### PR TITLE
Updating docs to indicate correct Authorization Header for Signed URL requests

### DIFF
--- a/products/stream/src/content/security/signed-urls.md
+++ b/products/stream/src/content/security/signed-urls.md
@@ -19,7 +19,7 @@ You can [revoke a key](#revoking-keys) anytime for any reason.
 Upon creation you will get a RSA private key in PEM and JWK formats. Keys are created, used and deleted independently of videos. Every key can sign any of your videos.
 
 ```javascript
-// curl -X POST -H "X-Auth-Email: ${EMAIL}" -H "X-Auth-Key: ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/keys"
+// curl -X POST -H "X-Auth-Email: ${EMAIL}" -H "Authorization: Bearer ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/keys"
 
 {
   "result": {
@@ -42,7 +42,7 @@ Restricting viewing can be done by updating the video's metadata.
 
 ```javascript
 
-// curl -X POST -H "X-Auth-Email: ${EMAIL}" -H "X-Auth-Key: ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{VIDEO-ID}" -H "Content-Type: application/json" -d '{"uid": "{VIDEO-ID}", "requireSignedURLs": true }'
+// curl -X POST -H "X-Auth-Email: ${EMAIL}" -H "Authorization: Bearer ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{VIDEO-ID}" -H "Content-Type: application/json" -d '{"uid": "{VIDEO-ID}", "requireSignedURLs": true }'
 
 {
   "result": {
@@ -137,7 +137,7 @@ You can create up to 1,000 keys and rotate them at your convenience.
 Once revoked all tokens created with that key will be invalidated.
 
 ```javascript
-// curl -X DELETE -H "X-Auth-Email: ${EMAIL}" -H "X-Auth-Key: ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/keys/{KEY-ID}"
+// curl -X DELETE -H "X-Auth-Email: ${EMAIL}" -H "Authorization: Bearer ${API-KEY}"  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/keys/{KEY-ID}"
 
 {
   "result": "Revoked",


### PR DESCRIPTION
While attempting to integrate our backend with Cloudflare Stream, I was consistently receiving the following error when supplying the `"X-Auth-Key: ${API-KEY}"` header as the docs indicate:

```
{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}
```

However, when supplying the same `API_KEY` as an `Authorization: Bearer ${API_KEY}` header, I'm able to get a successful request.

This PR updates the docs to reflect this.