### PR TITLE
Typo?

### DIFF
--- a/products/workers/src/content/platform/scripts.md
+++ b/products/workers/src/content/platform/scripts.md
@@ -46,7 +46,7 @@ All bindings have the following properties:
 - `type`
   - The type of binding, can be one of:
 
-    - `namespace_id`
+    - `kv_namespace`
     - `secret`
     - `wasm_module`
     - `plain_text`


### PR DESCRIPTION
Is that 'type' a typo? Should it read `kv_namespace`?