### PR TITLE
Update hello-world.md

### DIFF
--- a/products/terraform/src/content/tutorial/hello-world.md
+++ b/products/terraform/src/content/tutorial/hello-world.md
@@ -17,7 +17,7 @@ First we'll create a initial Terraform config file. Any files ending in `.tf` wi
 $ cat > cloudflare.tf <<'EOF'
 provider "cloudflare" {
   email = "you@example.com"
-  token = "your-api-key"
+  api_key = "your-api-key"
 }
 
 variable "domain" {
@@ -25,7 +25,7 @@ variable "domain" {
 }
 
 resource "cloudflare_record" "www" {
-  domain  = "${var.domain}"
+  domain  = var.domain
   name    = "www"
   value   = "203.0.113.10"
   type    = "A"


### PR DESCRIPTION
`token` updated to `api_key` or `api_token` per Cloudflare Terraform Provider 2.11.0 release:

https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs

`"${var.domain}"` updated to `var.domain` per Terraform 0.12.14 release:

>Interpolation-only expressions are deprecated: an expression like `"${foo}"` should be rewritten as just `foo`.

https://discuss.hashicorp.com/t/terraform-0-12-14-released/3898