### PR TITLE
fix typo webpack.staging.js

### DIFF
--- a/products/workers/src/content/cli-wrangler/webpack.md
+++ b/products/workers/src/content/cli-wrangler/webpack.md
@@ -79,7 +79,7 @@ webpack_config = "webpack.development.js"
 
 [env.staging]
 name = "my-worker-staging"
-webpack_config = "webpack.production.js"
+webpack_config = "webpack.staging.js"
 
 [env.production]
 name = "my-worker-production"


### PR DESCRIPTION
The `webpack.production.js` seems to be a typo for `webpack.staging.js`.