### PR TITLE
workers triggers issue

### DIFF
--- a/products/workers/src/content/platform/cron-triggers/index.md
+++ b/products/workers/src/content/platform/cron-triggers/index.md
@@ -21,8 +21,6 @@ We support all cron expressions, including special characters, that evaluate to 
 - Minimum interval is 1 minute
 - Maximum interval is 12 months
 
-![workers-cron-diagram](./media/workers-cron-diagram.png)
-
 ### Examples
 
 Here are some common time intervals that may be useful for setting up your Cron Trigger.
@@ -35,8 +33,11 @@ Here are some common time intervals that may be useful for setting up your Cron 
 - `*/30 * * * *`
   - Every 30 minutes
 
-- `0 17 * * fri`
-  - 5PM on Friday
+- `0 17 * * sun` or `0 17 * * 1`
+  - 5PM on Sunday
+
+- `10 7 * * mon-fri` or `10 7 * * 2-6`
+  - 7:10AM on weekdays
 
 - `0 15 1 * *`
   - 3PM on first day of the month


### PR DESCRIPTION
Fixing a docs error report and clarified in the [Community](https://community.cloudflare.com/t/workers-cron-triggers-triggering-wrong-days/212893/7). More examples added to clarify the Cron syntax used on worker triggers.

Diagram reference removed, but not delete.
