### PR TITLE
Add package-lock.json to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .docs
 node_modules
+package-lock.json
 dist/worker.js
 products/*/dist/worker.js


### PR DESCRIPTION
It looks like lock files aren't being tracked in this repo, so to avoid confusion and accidental tracking of them, I've added `package-lock.json` to the git ignore file.