### PR TITLE
The name vars is too ambigous and not prominent

### DIFF
--- a/products/workers/src/content/platform/environments.md
+++ b/products/workers/src/content/platform/environments.md
@@ -258,7 +258,7 @@ kv_namespaces = [
 kv_namespaces = [
   { binding = "KV", id = "bd46d6484b665e6bd134b0496ad97760" }
 ]
-vars = {FOO = "some text"}
+vars = {FOO = "some text"} # Creates & Sets Environment Variable FOO to "some text"
 ```
 
 <Aside>


### PR DESCRIPTION
I wanted to find a way to set an Environment variable for my Cloudflare worker via the wrangler cli / wrangler.toml and ended up looking at this block of example code.

This block of example code is too ambiguous for a simple task of setting an environment variable in the cloudflare. 

To create ONE basic environment variable,  I am presented with `kv_namespaces` and `[env.production]` and the ambiguous variable name `vars` does not help either.

Ideally the KV names spaces shouldn't be in this snippet, but cloudflare needs more users to adapt KV namespaces as it is a key part of their monetization strategy.

Hence, the least we could do is add a comment to make it more clear as to how to create environment variable.