### PR TITLE
Added warning + awareness about wrangler secret

### DIFF
--- a/products/workers/src/content/platform/environments.md
+++ b/products/workers/src/content/platform/environments.md
@@ -263,7 +263,7 @@ vars = {FOO = "some text"}
 
 <Aside type="warning">
 
-\* __Warning:__ We do not recommend using text variables to store secrets. If possible use the `wrangler secret put` command instead.
+\* __Warning:__ We do not recommend using text variables to store secrets. If possible use the [`wrangler secret put`](/cli-wrangler/commands#secret) command instead.
 
 </Aside>
 

--- a/products/workers/src/content/platform/environments.md
+++ b/products/workers/src/content/platform/environments.md
@@ -261,6 +261,12 @@ kv_namespaces = [
 vars = {FOO = "some text"}
 ```
 
+<Aside type="warning">
+
+\* __Warning:__ Do **not** use text varibales to hold secrets like API keys, tokens etcetra, use the [`wrangler secret put`](/cli-wrangler/commands#secret) command instead.
+
+</Aside>
+
 <Aside>
 
 __Note:__ Secret variables can only be assigned to specific environments by passing the `-e/--env <environment_name>` flag while using the [`wrangler secret put`](/cli-wrangler/commands#secret) command.

--- a/products/workers/src/content/platform/environments.md
+++ b/products/workers/src/content/platform/environments.md
@@ -263,7 +263,7 @@ vars = {FOO = "some text"}
 
 <Aside type="warning">
 
-\* __Warning:__ Do **not** use text varibales to hold secrets like API keys, tokens etcetra, use the [`wrangler secret put`](/cli-wrangler/commands#secret) command instead.
+\* __Warning:__ We do not recommend using text variables to store secrets. If possible use the `wrangler secret put` command instead.
 
 </Aside>
 


### PR DESCRIPTION
Some users might think about adding environment variables to hold their secrets and might store it on their .toml file. 
A warning will add a layer of protection and it will also redirect people towards the right way to store secrets.