### PR TITLE
fix tables, more correct asides

### DIFF
--- a/products/firewall/src/content/api/cf-filters/endpoints.md
+++ b/products/firewall/src/content/api/cf-filters/endpoints.md
@@ -13,7 +13,7 @@ For authentication instructions, see [_Getting Started: Requests_](https://api.c
 
 For help with endpoints and pagination, see [_Getting Started: Endpoints_](https://api.cloudflare.com/#getting-started-endpoints).
 
-<Aside type='note'>
+<Aside type='warning'>
 
 The Filters API endpoints require a value for _{zone_id}_.
 

--- a/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
@@ -13,7 +13,7 @@ For authentication instructions, see [_Getting Started: Requests_](https://api.c
 
 For help with endpoints and pagination, see [_Getting Started: Endpoints_](https://api.cloudflare.com/#getting-started-endpoints).
 
-<Aside type='note'>
+<Aside type='warning'>
 
 The Firewall Rules API endpoints require a value for _{zone_id}_.
 

--- a/products/firewall/src/content/api/cf-lists/endpoints.md
+++ b/products/firewall/src/content/api/cf-lists/endpoints.md
@@ -13,7 +13,7 @@ For authentication instructions, see [_Getting Started: Requests_](https://api.c
 
 For help with endpoints and pagination, see [_Getting Started: Endpoints_](https://api.cloudflare.com/#getting-started-endpoints).
 
-<Aside type='note'>
+<Aside type='warning'>
 
 The Rules Lists endpoints require a value for _{account_id}_.
 

--- a/products/firewall/src/content/cf-dashboard/rules-lists/manage-items.md
+++ b/products/firewall/src/content/cf-dashboard/rules-lists/manage-items.md
@@ -16,7 +16,7 @@ The list of items displays sorted by IP address, ascending:
 
 ![View items in  a list](../../images/lists-view-items-in-list.png)
 
-<Aside type='note'>
+<Aside type='warning'>
 
 You cannot download a list in CSV format from the dashboard. If you need to download the contents of a list to your device, use the [Get Lists](https://api.cloudflare.com/#rules-lists-list-lists) operation in the [Lists API](/api/cf-firewall-rules/#manage-the-items-in-a-list) to fetch them.
 
@@ -60,7 +60,7 @@ To [add items in CSV format](/cf-dashboard/rules-lists/manage-items/#add-items-i
 
 ### Add items in CSV format
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Importing a CSV file to a list only updates descriptions or adds items to the list. It does not delete items from a list.
 
@@ -100,7 +100,7 @@ The **Add items to list** page updates to include the items from the CSV file:
 
    The updated list displays.
 
-<Aside type='note'>
+<Aside type='warning'>
 
 When uploading CSV data, keep in mind that duplicate data is treated as follows:
 

--- a/products/firewall/src/content/cf-firewall-language/fields.md
+++ b/products/firewall/src/content/cf-firewall-language/fields.md
@@ -266,7 +266,7 @@ The Cloudflare Firewall Rules language supports these standard fields:
 
 Dynamic fields represent computed or derived values, typically related to threat intelligence about an HTTP request.
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to the `cf.bot_management.verified_bot` field requires a Cloudflare Enterprise plan.
 
@@ -507,7 +507,7 @@ The Cloudflare Firewall Rules language supports these HTTP header fields:
 
 ## HTTP body fields
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to HTTP body fields requires a Cloudflare Enterprise plan.
 

--- a/products/firewall/src/content/cf-firewall-language/functions.md
+++ b/products/firewall/src/content/cf-firewall-language/functions.md
@@ -344,7 +344,7 @@ For details on generating a MessageMAC, see [_Implement token creation_](https:/
 
 ### Validation function examples
 
-<Aside type='note'>
+<Aside type='warning'>
 
 When you do not use the optional _flags_ argument for `_is_timed_hmac_valid()`, you must URL encode the base64 value for _mac_ in the _MessageMAC_ argument.
 

--- a/products/firewall/src/content/cf-firewall-language/operators.md
+++ b/products/firewall/src/content/cf-firewall-language/operators.md
@@ -14,7 +14,7 @@ The Cloudflare Firewall Rules language supports comparison and logical operators
 
 The Firewall Rules language supports the following comparison operators. Since some operators only support specific data types, the list is organized by data type.
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to the `matches` operator requires a Cloudflare Business or Enterprise plan.
 
@@ -211,7 +211,7 @@ Each logical operator is associate with an [order of precedence](#order-of-prece
 
 ### Order of precedence
 
-<Aside type='note'>
+<Aside type='warning'>
 
 To avoid ambiguity when working with logical operators, use grouping symbols so that the order of evaluation is explicit.
 
@@ -234,7 +234,7 @@ Since the logical `and` operator has precedence over logical `or`, the `and` ope
 
 ## Grouping symbols
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Only the [Expression Editor](/cf-dashboard/expression-preview-editor/) and the [Cloudflare API](/api/) support grouping symbols. The [Expression Builder](/cf-dashboard/create-edit-delete-rules/) does not.
 

--- a/products/firewall/src/content/cf-firewall-rules/api-shield.md
+++ b/products/firewall/src/content/cf-firewall-rules/api-shield.md
@@ -28,7 +28,7 @@ To protect your application with API Shield, use this workflow:
 
 1. [Configure your mobile app or IoT device](/ssl/client-certificates/configure-your-mobile-app-or-iot-device) to use your Cloudflare-issued client certificate.
 
-<Aside type='note'>
+<Aside type='warning'>
 
 API Shield requires Cloudflare-issued certificates. You can use API Shield with any fully managed certificate authority (CA) where Cloudflare issues the client certificates.
 

--- a/products/firewall/src/content/known-issues-and-faq/index.md
+++ b/products/firewall/src/content/known-issues-and-faq/index.md
@@ -246,7 +246,7 @@ Exclude multiple IP addresses from a blocking/challenging rule that assesses Thr
 <table style="width: 100%">
   <tbody>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong>Basic rule, with no <em>exclusion</em></strong>
       </td>
     </tr>
@@ -259,7 +259,7 @@ Exclude multiple IP addresses from a blocking/challenging rule that assesses Thr
       <td><em>(http.host eq "example.com" and cf.threat_score &gt; 5)</em></td>
     </tr>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong
           >Rule that excludes IP addresses from being blocked/challenged</strong
         >
@@ -279,7 +279,7 @@ Exclude multiple IP addresses from a blocking/challenging rule that assesses Thr
       </td>
     </tr>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong>Two rules to allow exceptions and block the rest</strong>
       </td>
     </tr>
@@ -310,7 +310,7 @@ Block Amazon Web Services (AWS) and Google Cloud Platform (GCP) because of large
 <table style="width: 100%">
   <tbody>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong>Basic rule, with no <em>exclusion</em></strong>
       </td>
     </tr>
@@ -323,7 +323,7 @@ Block Amazon Web Services (AWS) and Google Cloud Platform (GCP) because of large
       <td><em>(ip.geoip.asnum in {'{7224 15169}'})</em></td>
     </tr>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong>Rule that excludes known bots that Cloudflare validates</strong>
       </td>
     </tr>
@@ -338,7 +338,7 @@ Block Amazon Web Services (AWS) and Google Cloud Platform (GCP) because of large
       </td>
     </tr>
     <tr>
-      <td style="background: #ebedef" colspan="2">
+      <td colspan="2">
         <strong
           ><strong
             >Two rules to allow exceptions and block the rest</strong

--- a/products/firewall/src/content/recipes/block-ms-exchange-autodiscover.md
+++ b/products/firewall/src/content/recipes/block-ms-exchange-autodiscover.md
@@ -6,8 +6,8 @@ This example uses the `matches` [comparison operator](/cf-firewall-language/oper
 
 <TableWrap>
 
-| Expression                                          | Action   |
-| --------------------------------------------------- | -------- |
-| `http.request.uri.path matches "/autodiscover\.(xml | src)\$"` | Block |
+| Expression                                                      | Action |
+| --------------------------------------------------------------- | ------ |
+| `http.request.uri.path matches "/autodiscover\.(xml \| src)\$"` | Block  |
 
 </TableWrap>

--- a/products/firewall/src/content/recipes/challenge-bad-bots.md
+++ b/products/firewall/src/content/recipes/challenge-bad-bots.md
@@ -1,6 +1,6 @@
 # Challenge bad bots
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to [Bot Management](https://developers.cloudflare.com/logs/tutorials/bot-management-dashboard/) requires a Cloudflare Enterprise plan.
 

--- a/products/firewall/src/content/recipes/require-specific-headers.md
+++ b/products/firewall/src/content/recipes/require-specific-headers.md
@@ -1,6 +1,6 @@
 # Require specific HTTP headers
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to HTTP header and body fields require a Cloudflare Enterprise plan.
 

--- a/products/firewall/src/content/recipes/require-valid-hmac-token.md
+++ b/products/firewall/src/content/recipes/require-valid-hmac-token.md
@@ -1,6 +1,6 @@
 # Require a valid HMAC token
 
-<Aside type='note'>
+<Aside type='warning'>
 
 Access to the HMAC validation function requires a Cloudflare Pro, Business, or Enterprise plan.
 
@@ -52,7 +52,7 @@ then the token is valid and the function returns `true`.
 
 Since the expression in this example uses the `not` operator, it only matches when the HMAC token is _not_ valid. When the token is not valid, the Cloudflare triggers the action and blocks the request.
 
-<Aside type='note'>
+<Aside type='warning'>
 
 When you do not use the optional _flags_ argument for `_is_timed_hmac_valid()`, you must URL encode the base64 value for _mac_ in the _MessageMAC_ argument.
 


### PR DESCRIPTION
 - correctly escape a `|` in a table expression
 - more noticable asides `type='warning'`