### PR TITLE
Add FSharp Worker Starter

### DIFF
--- a/products/workers/src/content/starters/index.md
+++ b/products/workers/src/content/starters/index.md
@@ -134,6 +134,12 @@ Other languages may require you to install additional tools beyond wrangler. See
 />
 
 <WorkerStarter
+  title="Hello World (FSharp)"
+  description="A bare-bones starter in FSharp/Fable."
+  repo="fable-compiler/cfworker-hello-world"
+/>
+
+<WorkerStarter
   title="Hello World (Dart)"
   description="A bare-bones starter in Dart."
   repo="cloudflare/dart-worker-hello-world"


### PR DESCRIPTION
This PR adds a FSharp Worker Starter. It is a replacement for https://github.com/cloudflare/template-registry/pull/49