### PR TITLE
Stream: Start using API Tokens instead of API Keys

### DIFF
--- a/products/stream/src/content/faq/index.md
+++ b/products/stream/src/content/faq/index.md
@@ -38,6 +38,8 @@ If the frame rate is variable we will drop frames (e.g. if there are more than 1
 
 The Stream player can be successfully embedded on the following platforms:
 
+<TableWrap>
+
 Browser         | Version
 ----------------|-----------------------------------
 Chrome          | Supported since Chrome version 30+
@@ -46,6 +48,10 @@ Internet Explorer | Supported since IE 11 (Windows 8+ only)
 Safari          | Supported since Safari version 8+
 Opera           | Supported since Opera version 15+
 
+</TableWrap>
+
+<TableWrap>
+
 Mobile Platform   | Version
 ------------------|-----------------------------------------------------------------------------------
 Chrome on Android | Supported on Chrome and Firefox for Android 4.0+ and all browsers for Android 4.1+
@@ -53,6 +59,8 @@ UC Browser on Android | Supported on version 11.8+
 Samsung Internet | Supported on 5+
 iOS               | Supported on iOS 8+
 Windows           | Supported on Windows Phone 8+
+
+</TableWrap>
 
 ## What are the recommended upload settings for video uploads?
 
@@ -68,9 +76,13 @@ If you're producing a brand new file for Cloudflare Stream, we recommend you use
 
 Below are bitrate reccomendations for encoding new videos for Stream:
 
+<TableWrap>
+
 Resolution  |  Recommended bitrate
 ------------|---------
 1080p  |	8 Mbps
 720p  |	4.8 Mbps
 480p  |	2.4 Mbps
 360p | 1 Mbps
+
+</TableWrap>

--- a/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
+++ b/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
@@ -78,8 +78,7 @@ Here is the exact cURL request:
 curl --request POST \
 --url https://api.cloudflare.com/client/v4/graphql \
 --header 'content-type: application/json' \
---header 'x-auth-email: $EMAIL' \
---header 'x-auth-key: $CF_KEY' \
+--header 'Authorization: Bearer $TOKEN' \
 --data '{"query":"query {\n  viewer {\n    accounts(filter:{\n      accountTag:\"$ACCOUNT_ID\"\n\n    }) {\n      videoPlaybackEventsAdaptiveGroups(\n        filter: {\n          date_geq: \"2020-09-01\"\n          date_lt: \"2020-09-25\"\n        }\n        orderBy:[uid_ASC]\n        limit: 10000\n      ) {\n        count\n        sum {\n          timeViewedMinutes\n        }\n        dimensions{\n          uid\n        }\n      }\n    }\n  }\n}\n\n"}'
 ```
 

--- a/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
+++ b/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
@@ -40,7 +40,7 @@ Please refer to [Cloudflare GraphQL analytics for HTTP requests](https://develop
 Here is how you would get the view count and minutes viewed for the videos in your Stream account:
 
 1. Make a query to https://api.cloudflare.com/client/v4/graphql
-1. Include your Cloudflare email and key in the headers (see cURL example included on this page)
+1. Include your Cloudflare API token in the headers (see cURL example included on this page)
 1. It is important that you change the $ACCOUNT_ID with your account ID and the date range
 1. The body of the query should contain the following GraphQL Query:
 

--- a/products/stream/src/content/index.md
+++ b/products/stream/src/content/index.md
@@ -17,25 +17,21 @@ To get started with Stream, simply visit the Stream Dashboard in your Cloudflare
 
 ## Make your first API request
 
-To make your first request to the Stream API, you must obtain three pieces of information:
+To make your first request to the Stream API, you must obtain these pieces of information:
 
 1. Your Cloudflare Account ID
-2. Email address associated with the account
-3. Your Cloudflare Account API Token
-
-Alternatively, you can also use [bearer tokens](https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys).
+1. A Cloudflare Account API Token
 
 ### Step 1: Uploading your first video
 Stream provides multiple ways to upload videos. For this example, we will upload an MP4 file that is stored in a storage bucket onto Stream. The MP4 file can be found here: 
 
-To make your first request, simply take the cURL command below and replace the API Key, email and account id placeholders with your credentials. 
+To make your first request, simply take the cURL command below and replace the API token, and account id placeholders with your credentials.
 
 ```bash
 curl \
 -X POST \
 -d '{"url":"https://storage.googleapis.com/stream-example-bucket/video.mp4","meta":{"name":"My First Stream Video"}}' \
--H "X-Auth-Key: $API_KEY" \
--H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUND_ID/stream/copy
 ```
 
@@ -73,8 +69,7 @@ Use the video UID from the first step to poll the video:
 
 ```bash
 curl \
--H "X-Auth-Key: $API_KEY" \
--H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUND_ID/stream/$VIDEO_UID
 ```
 

--- a/products/stream/src/content/index.md
+++ b/products/stream/src/content/index.md
@@ -137,3 +137,10 @@ https://github.com/cloudflare/cloudflare-docs-engine/issues/281
       allowFullScreen></iframe>
   </div>
 </figure>
+
+### Next steps
+
+ - [Securing your Stream](/viewing-videos/securing-your-stream)
+ - [Displaying thumbnails to your video](/viewing-videos/securing-your-stream)
+ - [Programatically controling the video player](/viewing-videos/using-the-player-api)
+ - [Uploading without a API token](/uploading-videos/direct-creator-uploads)

--- a/products/stream/src/content/uploading-videos/adding-captions.md
+++ b/products/stream/src/content/uploading-videos/adding-captions.md
@@ -8,9 +8,7 @@ Adding captions and subtitles to your video library.
 
 ## Add or modify a caption
 
-To create or modify a caption on a video, you will need your
-[Cloudflare API key](https://www.cloudflare.com/a/account/my-account)
-and your email address.
+To create or modify a caption on a video a [Cloudflare API Token](https://www.cloudflare.com/a/account/my-account) is required.
 
 The `$LANGUAGE` must adhere to the [BCP 47 format](http://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers).  For convenience, the most common
 language codes are provided [at the bottom of this document](#most-common-language-codes).
@@ -38,8 +36,7 @@ be created; if sent `de`, the label `Deutsch` will be created.
 
 ```bash
 curl -X PUT \
- -H 'X-Auth-Key:$APIKEY' \
- -H 'X-Auth-Email:$EMAIL' \
+ -H 'Authorization: Bearer $TOKEN' \
  -F file=@/Users/mickie/Desktop/example_caption.vtt \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID/captions/$LANGUAGE
 ```
@@ -63,7 +60,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID/captions/
 To view captions associated with a video:
 
 ```bash
-curl -H 'X-Auth-Key:$APIKEY' -H 'X-Auth-Email:$EMAIL'
+curl -H 'Authorization: Bearer $TOKEN' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEO/captions
 ```
 
@@ -93,8 +90,7 @@ To remove a caption associated with your video:
 
 ```bash
 curl -X DELETE \
- -H 'X-Auth-Key:$APIKEY' \
- -H 'X-Auth-Email:$EMAIL' \
+ -H 'Authorization: Bearer $TOKEN' \
  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEO/captions/$LANGUAGE
 ```
 

--- a/products/stream/src/content/uploading-videos/applying-watermarks.md
+++ b/products/stream/src/content/uploading-videos/applying-watermarks.md
@@ -16,7 +16,7 @@ Watermark profile has many customizable options. However, the default parameters
 ### Step 1: Create a profile
 
 ```bash
-curl -X POST -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X POST -H 'Authorization: Bearer $TOKEN' \
 -F file=@/Users/rchen/cloudflare.png \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks
 ```
@@ -25,8 +25,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks
 
 ```bash
 tus-upload --chunk-size 5242880 \
---header X-Auth-Key $APIKEY \
---header X-Auth-Email $EMAIL \
+--header Authentication 'Bearer $TOKEN' \
 --metadata watermark $WATERMARKUID \
 /Users/rchen/cat.mp4 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
 ```
@@ -37,8 +36,7 @@ tus-upload --chunk-size 5242880 \
 ## Profiles
 
 To create, list, delete, or get information about the profile, you will need your
-[Cloudflare API key](https://www.cloudflare.com/a/account/my-account)
-and your email address.
+[Cloudflare API token](https://www.cloudflare.com/a/account/my-account).
 
 ### Optional parameters
 
@@ -82,7 +80,7 @@ and your email address.
 
 To upload the image directly, please send a POST request using `multipart/form-data` as the content-type and specify the file under the `file` key. All other fields are optional.
 ```bash
-curl -X POST -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X POST -H "Authorization: Bearer $TOKEN" \
 -F file=@{path-to-image-locally} \
 -F name='marketing videos' \
 -F opacity=1.0 \
@@ -96,7 +94,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks
 
 To specify a URL for upload, please send a POST request using `application/json` as the content-type and specify the file location using the `url` key. All other fields are optional.
 ```bash
-curl -X POST -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X POST -H "Authorization: Bearer $TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "url": "{url-to-image}",
@@ -144,7 +142,7 @@ Unfortunately, Stream does not currently support specifying watermark profile at
 ### Upload video with a link
 
 ```bash
-curl -X POST -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X POST -H "Authorization: Bearer $TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "url": "{url-to-video}",
@@ -191,8 +189,7 @@ highlight: [10,11,12,13,14,15,16,17,18,19,20,21,22]
 
 ```bash
 tus-upload --chunk-size 5242880 \
---header X-Auth-Key $APIKEY \
---header X-Auth-Email $EMAIL \
+--header Authentication 'Bearer $TOKEN' \
 --metadata watermark $WATERMARKUID \
 $PATH_TO_VIDEO https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
 ```
@@ -201,7 +198,7 @@ $PATH_TO_VIDEO https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
 The video uploaded with the generated unique one-time URL will be watermarked with the profile specified.
 
 ```bash
-curl -X POST -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X POST -H "Authorization: Bearer $TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
   "maxDurationSeconds": 3600,
@@ -246,7 +243,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/direct_upload
 To view a watermark profile that you created:
 
 ```bash
-curl -X GET -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -H "Authorization: Bearer $TOKEN" \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks/$WATERMARKUID
 ```
 
@@ -278,7 +275,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks/$WATERM
 To list watermark profiles that you created:
 
 ```bash
-curl -X GET -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -H "Authorization: Bearer $TOKEN" \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks/
 ```
 
@@ -325,7 +322,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks/
 To delete a watermark profile that you created:
 
 ```bash
-curl -X DELETE -H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+curl -X DELETE -H 'Authorization: Bearer $TOKEN' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/watermarks/$WATERMARKUID
 ```
 

--- a/products/stream/src/content/uploading-videos/direct-creator-uploads.md
+++ b/products/stream/src/content/uploading-videos/direct-creator-uploads.md
@@ -4,7 +4,7 @@ order: 3
 
 # Direct creator uploads
 
-Direct creator uploads allow users to upload videos without API keys. A common place to
+Direct creator uploads allow users to upload videos without API tokens. A common place to
 use Direct creator uploads is on web apps, client side applications, or on mobile apps
 where users upload content directly to Stream.
 
@@ -13,8 +13,7 @@ where users upload content directly to Stream.
 To give users the ability to directly upload their videos, first generate and
 provide them with a unique one-time upload URL with the following API request.
 
-To make API requests you will need your [Cloudflare API key](https://www.cloudflare.com/a/account/my-account)
-your email address and your Cloudflare [account ID](https://www.cloudflare.com/a/overview/).
+To make API requests you will need your [Cloudflare API token](https://www.cloudflare.com/a/account/my-account) and your Cloudflare [account ID](https://www.cloudflare.com/a/overview/).
 
 ### Upload constraints
 
@@ -58,8 +57,7 @@ any other additional arbitrary keys for metadata to be stored.
 
 ```bash
 curl -X POST \
- -H 'X-Auth-Key:$APIKEY' \
- -H 'X-Auth-Email:$EMAIL' \
+ -H 'Authorization: Bearer $TOKEN' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/direct_upload \
  --data '{
     "maxDurationSeconds": 3600,

--- a/products/stream/src/content/uploading-videos/searching.md
+++ b/products/stream/src/content/uploading-videos/searching.md
@@ -4,7 +4,7 @@ You can search for videos by name through the Stream API by adding a `search` qu
 
 ## What you will need
 
-To make API requests you will need your [Cloudflare API key](https://www.cloudflare.com/a/account/my-account), your email address and your Cloudflare [account ID](https://www.cloudflare.com/a/overview/).
+To make API requests you will need a [Cloudflare API token](https://www.cloudflare.com/a/account/my-account) and your Cloudflare [account ID](https://www.cloudflare.com/a/overview/).
 
 ## cURL example
 
@@ -12,7 +12,6 @@ This example lists media where the name matches `puppy.mp4`.
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream?search=puppy" \
-     -H "X-Auth-Email: $EMAIL" \
-     -H "X-Auth-Key: $APIKEY" \
+     -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json"
 ```

--- a/products/stream/src/content/uploading-videos/upload-via-link.md
+++ b/products/stream/src/content/uploading-videos/upload-via-link.md
@@ -16,8 +16,7 @@ Make a HTTP request to the Stream API with the URL of the video.
 curl \
 -X POST \
 -d '{"url":"https://storage.googleapis.com/zaid-test/Watermarks%20Demo/cf-ad-original.mp4","meta":{"name":"My First Stream Video"}}' \
--H "X-Auth-Key: $API_KEY" \
--H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUND_ID/stream/copy
 ```
 

--- a/products/stream/src/content/uploading-videos/upload-video-file.md
+++ b/products/stream/src/content/uploading-videos/upload-video-file.md
@@ -14,8 +14,7 @@ Make an HTTP request with content-type header set to `multipart/form-data` and i
 
 ```bash
 curl -X POST \
--H "X-Auth-Key: $APIKEY" \
--H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 -F file=@/Users/kyle/Desktop/video.mp4 \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
 ```
@@ -79,7 +78,7 @@ pip install -U tus.py
 ```
 
 ```bash
-tus-upload --chunk-size 5242880 --header X-Auth-Key $APIKEY --header X-Auth-Email $EMAIL $PATH_TO_VIDEO https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
+tus-upload --chunk-size 5242880 --header Authorization "Bearer $TOKEN" $PATH_TO_VIDEO https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream
 ```
 
 In the beginning of the response from tus, you’ll see the endpoint for getting information about your newly uploaded video.
@@ -119,8 +118,7 @@ func main() {
 	defer f.Close()
 
 	headers := make(http.Header)
-	headers.Add("X-Auth-Email", "$EMAIL")
-	headers.Add("X-Auth-Key", "$APIKEY")
+	headers.Add("Authorization", "Bearer $TOKEN")
 
 	config := &tus.Config{
 		ChunkSize:           5 * 1024 * 1024, // Cloudflare Stream requires a minimum chunk size of 5MB.
@@ -170,7 +168,7 @@ npm install tus-js-client
 Set up an index.js and configure:
 
 * API endpoint with your Cloudflare Account ID
-* Request headers to include your Cloudflare Email and API Key
+* Request headers to include a API token
 
 ```javascript
 var fs = require("fs");
@@ -184,8 +182,7 @@ var size = fs.statSync(path).size;
 var options = {
   endpoint: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT ID}/stream",
   headers: {
-    'X-Auth-Email': '$EMAIL',
-    'X-Auth-Key': '$APIKEY',
+    'Authorization': 'Bearer $TOKEN',
   },
   chunkSize: 5 * 1024 * 1024, // Cloudflare Stream requires a minimum chunk size of 5MB.
   resume: true,

--- a/products/stream/src/content/uploading-videos/using-webhooks.md
+++ b/products/stream/src/content/uploading-videos/using-webhooks.md
@@ -10,19 +10,15 @@ A tool to notify your service when videos successfully finish processing and are
 
 ### Create or modify the webhook subscription
 
-To subscribe to receive webhook notifications on your service, or modify an
-existing subscription, you will need your
-[Cloudflare API key](https://www.cloudflare.com/a/account/my-account)
-and your email address.
+To subscribe to receive webhook notifications on your service, or modify an existing subscription, you will need a [Cloudflare API token](https://www.cloudflare.com/a/account/my-account).
 
 ```bash
-curl -X PUT --header 'X-Auth-Key:$APIKEY' --header 'X-Auth-Email:$EMAIL'
+curl -X PUT --header 'Authorization: Bearer $TOKEN'
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/webhook
 --data '{"notificationUrl":"$WEBHOOK_NOTIFICATION_URL}'
 ```
 
-The webhook notification URL must include the protocol. Only `http://`
-or `https://` is supported.
+The webhook notification URL must include the protocol. Only `http://` or `https://` is supported.
 
 #### Example response to create or modify the webhook subscription
 
@@ -41,8 +37,7 @@ or `https://` is supported.
 
 ## Notifications
 
-When a video on your account finishes processing, you will receive a `POST`
-request notification with information about the video.
+When a video on your account finishes processing, you will receive a `POST` request notification with information about the video.
 
 Note the `status` field indicates whether the video processing finished successfully.
 

--- a/products/stream/src/content/viewing-videos/displaying-thumbnails.md
+++ b/products/stream/src/content/viewing-videos/displaying-thumbnails.md
@@ -51,7 +51,7 @@ You can change this default value by setting the "thumbnailTimestampPct" value u
 
 ```bash
 curl -X POST \
--H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 -d '{"uid": "$VIDEOID", "thumbnailTimestampPct": <pct>}' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID
 ```
@@ -61,7 +61,7 @@ https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID
 The example will yield a request:
 ```bash
 curl -X POST \
--H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 -d '{"uid": "$VIDEOID", "thumbnailTimestampPct": 0.5}' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID
 ```

--- a/products/stream/src/content/viewing-videos/securing-your-stream.md
+++ b/products/stream/src/content/viewing-videos/securing-your-stream.md
@@ -25,7 +25,7 @@ You can [revoke a key](#revoking-keys) anytime for any reason.
 Upon creation you will get a RSA private key in PEM and JWK formats. Keys are created, used and deleted independently of videos. Every key can sign any of your videos.
 
 ```javascript
-// curl -X POST -H "X-Auth-Email: $EMAIL" -H "X-Auth-Key: $APIKEY"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/keys"
+// curl -X POST -H "Authorization: Bearer $TOKEN"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/keys"
 
 {
   "result": {
@@ -48,7 +48,7 @@ Restricting viewing can be done by updating the video's metadata.
 
 ```javascript
 
-// curl -X POST -H "X-Auth-Email: $EMAIL" -H "X-Auth-Key: $APIKEY"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID" -H "Content-Type: application/json" -d '{"uid": "$VIDEOID", "requireSignedURLs": true }'
+// curl -X POST -H "Authorization: Bearer $TOKEN"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID" -H "Content-Type: application/json" -d '{"uid": "$VIDEOID", "requireSignedURLs": true }'
 
 {
   "result": {
@@ -148,7 +148,7 @@ You can create up to 1,000 keys and rotate them at your convenience.
 Once revoked all tokens created with that key will be invalidated.
 
 ```javascript
-// curl -X DELETE -H "X-Auth-Email: $EMAIL" -H "X-Auth-Key: $APIKEY"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/keys/$KEYID"
+// curl -X DELETE -H "Authorization: Bearer $TOKEN"  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/keys/$KEYID"
 
 {
   "result": "Revoked",
@@ -336,7 +336,7 @@ You can also control embed limitation programmatically using the Stream API. `ui
 
 ```bash
 curl -X POST \
--H "X-Auth-Key: $APIKEY" -H "X-Auth-Email: $EMAIL" \
+-H "Authorization: Bearer $TOKEN" \
 -d '{"uid": "$VIDEOID", "allowedOrigins": ["example.com"]}' \
 https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/$VIDEOID
 


### PR DESCRIPTION
Applies the change mentioned in https://github.com/cloudflare/cloudflare-docs/pull/2 across the entire Stream documentation.