### PR TITLE
Fix desktop download links

### DIFF
--- a/products/warp-client/src/content/setting-up/index.md
+++ b/products/warp-client/src/content/setting-up/index.md
@@ -12,7 +12,7 @@ Review [Installation Requirements](/setting-up/requirements/) to ensure your dev
 * [Teams Deployment for Windows](/teams/Windows-Teams/)
 
 ## macOS
-* [Download macOS Installer](https://www.cloudflarewarp.com/Cloudflare%20WARP.zip)
+* [Download macOS Installer](https://www.cloudflarewarp.com/Cloudflare_WARP.zip)
 * [macOS Installation Instruction](/setting-up/macOS/)
 * [Teams Deployment for macOS](/teams/macOS-Teams/)
 

--- a/products/warp-client/src/content/setting-up/macOS.md
+++ b/products/warp-client/src/content/setting-up/macOS.md
@@ -32,8 +32,8 @@ order: 3
 </table>
 
 ## Steps to download
-1. [Download __Cloudflare WARP.zip__](https://1.1.1.1/Cloudflare%20WARP.zip).
-1. Navigate to the downloads folder and double-click on `Cloudflare WARP.zip`.
+1. [Download __Cloudflare_WARP.zip__](https://www.cloudflarewarp.com/Cloudflare_WARP.zip).
+1. Navigate to the downloads folder and double-click on `Cloudflare_WARP.zip`.
 1. Double click on the `Cloudflare_WARP.pkg` file that is extracted.
 1. Follow instructions in the installer to complete installation.
    * Cloudflare WARP will automatically launch and appear in your menu bar with the Cloudflare logo.

--- a/products/warp-client/src/content/setting-up/requirements.md
+++ b/products/warp-client/src/content/setting-up/requirements.md
@@ -31,7 +31,7 @@ order: 1
   </tbody>
 </table>
 
-__[Download Cloudflare_WARP_Release-x64.msi](https://1.1.1.1/Cloudflare_WARP_Release-x64.msi)__
+__[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Cloudflare_WARP_Release-x64.msi)__
 
 ## macOS
 <table>
@@ -59,7 +59,7 @@ __[Download Cloudflare_WARP_Release-x64.msi](https://1.1.1.1/Cloudflare_WARP_Rel
   </tbody>
 </table>
 
-__[Download Cloudflare WARP.zip](https://1.1.1.1/Cloudflare%20WARP.zip)__
+__[Download Cloudflare_WARP.zip](https://www.cloudflarewarp.com/Cloudflare_WARP.zip)__
 
 ## iOS
 <table>

--- a/products/warp-client/src/content/setting-up/windows.md
+++ b/products/warp-client/src/content/setting-up/windows.md
@@ -32,7 +32,7 @@ order: 2
 </table>
 
 ## Steps to download
-1. [Download __Cloudflare_WARP_Release-x64.msi__](https://1.1.1.1/Cloudflare_WARP_Release-x64.msi).
+1. [Download __Cloudflare_WARP_Release-x64.msi__](https://www.cloudflarewarp.com/Cloudflare_WARP_Release-x64.msi).
 1. Navigate to Downloads folder and double-click on `Cloudflare_WARP_Release-x64.msi`.
 1. Follow the instructions in the installer to complete installation.
   - Cloudflare WARP will automatically launch and appear in your menu bar with the Cloudflare logo.


### PR DESCRIPTION
- Replace 1.1.1.1 URLs with cloudflarewarp.com so IPv6 folks can download too
- Fix macOS download so it points to product zip instead of the beta zip.