### PR TITLE
Update Worker subdomain DNS record instructions

### DIFF
--- a/products/workers/src/content/platform/routes.md
+++ b/products/workers/src/content/platform/routes.md
@@ -107,4 +107,4 @@ If a route pattern path ends with `*`, then it matches all suffixes of that path
 
 All subdomains must have a [DNS record](https://support.cloudflare.com/hc/en-us/articles/360019093151#h_60566325041543261564371) to be proxied on Cloudflare and used to invoke a Worker. For example, if you want to put a worker on `myname.example.com`, and you've added `example.com` to Cloudflare but have not added any DNS records for `example.com`, any request to `myname.example.com` will result in the error `ERR_NAME_NOT_RESOLVED`.
 
-To support this, you should use the Cloudflare dashboard to add an `AAAA` record for `myname` to `example.com`, pointing to `100::` (the [reserved IPv6 discard prefix](https://tools.ietf.org/html/rfc6666)).
+To support this, you should use the Cloudflare dashboard to add an `A` record for `myname` to `example.com`, pointing to `192.0.2.1` (a reserved example IP), with proxying turned on.


### PR DESCRIPTION
Updates the "Subdomains must have a DNS Record" instructions to match the instructions found on the forum [here](https://community.cloudflare.com/t/should-i-proxy-a-cname-record-pointing-to-my-cloudflare-workers-site/193763/3). If this is incorrect, feel free to close. I was unable to get a Worker route working using the `AAAA` record instructions.