### PR TITLE
PCX-990 SSL: Remove SNI browser support option

### DIFF
--- a/products/ssl/src/content/ssl-tls/browser-compatibility.md
+++ b/products/ssl/src/content/ssl-tls/browser-compatibility.md
@@ -4,9 +4,7 @@ order: 5
 
 # Browser compatibility
 
-Cloudflare attempts to provide compatability for as wide a range of user agents (browsers, API clients, etc.) as possible. The specific set of supported browsers differs by SSL product, however. See below for specific details.
-
---------
+Cloudflare attempts to provide compatibility for as wide a range of user agents (browsers, API clients, etc.) as possible. The specific set of supported browsers differs by SSL product, however. See below for specific details.
 
 ## Universal SSL
 
@@ -14,10 +12,15 @@ Feature/Zone Plan | Free | Pro | Business | Enterprise
 ------|-------------|---------------|---------------|---------------
 Clients using ECDSA key exchange|✅|✅|✅|✅
 Clients using RSA key exchange|❌|✅|✅|✅
-Clients without SNI [^1]|❌|✅|✅|✅
+
+<Aside type='warning' header='Important'>
+
+Cloudflare no longer supports SSL certificates under any plan for clients without Server Name Indication (SNI) extensions to the TLS protocol.
+
+</Aside>
 
 ### Free plan
-Universal SSL certificates issued for Free plan zones require user agents that i) send Server Name Indication (SNI) and ii) support the Elliptic Curve Digital Signature Algorithm (ECDSA). SNI and ECDSA certificates work with the following modern browsers:
+Universal SSL certificates issued for Free plan zones require user agents that send Server Name Indication (SNI) and support the Elliptic Curve Digital Signature Algorithm (ECDSA). SNI and ECDSA certificates work with these modern browsers:
 
 **Desktop Browsers installed on Windows Vista or OS X 10.6 or later**:
 
@@ -43,8 +46,12 @@ Paid plans provide additional compatibility with older browsers/operating system
 
 Feature/Product | Custom (Legacy IP) | Custom Certificates | Dedicated Certificates | SSL for SaaS
 ------|-------------|---------------|---------------|---------------
-Clients using ECDSA key exchange [^1]|✅|✅|✅|✅
-Clients using RSA key exchange [^1]|✅|✅|✅|✅
-Clients without SNI [^1]|✅|❌|❌|❌|❌
+Clients using ECDSA key exchange|✅|✅|✅|✅
+Clients using RSA key exchange|✅|✅|✅|✅
+Clients without SNI |✅|❌|❌|❌|❌
 
-[^1]: *Server Name Indication (SNI) is an extension to the TLS protocol that was standardized in 2003. However, some browsers and operating systems waited until TLS 1.1 was released in 2006 to implement this extension (or 2011 for mobile browsers). If your visitors are using devices that have not been updated since 2011, they may not have SNI support.*
+<Aside type='note' header='Note'>
+
+SNI extensions to the TLS protocol were standardized in 2003. However some browsers and operating systems only implemented this extension when TLS 1.1 was released in 2006 (or 2011 for mobile browsers). If your visitors use devices that have not been updated since 2011, they may not have SNI support.
+
+</Aside>

--- a/products/ssl/src/content/ssl-tls/browser-compatibility.md
+++ b/products/ssl/src/content/ssl-tls/browser-compatibility.md
@@ -15,7 +15,7 @@ Clients using RSA key exchange|❌|✅|✅|✅
 
 <Aside type='warning' header='Important'>
 
-Cloudflare no longer supports SSL certificates under any plan for clients without [Server Name Indication (SNI) extensions](https://www.cloudflare.com/learning/ssl/what-is-sni/) to the TLS protocol.
+Cloudflare Universal SSL only supports browsers and API clients that use the [Server Name Indication (SNI)](https://www.cloudflare.com/learning/ssl/what-is-sni/) extension to the TLS protocol.
 
 </Aside>
 

--- a/products/ssl/src/content/ssl-tls/browser-compatibility.md
+++ b/products/ssl/src/content/ssl-tls/browser-compatibility.md
@@ -15,7 +15,7 @@ Clients using RSA key exchange|❌|✅|✅|✅
 
 <Aside type='warning' header='Important'>
 
-Cloudflare no longer supports SSL certificates under any plan for clients without Server Name Indication (SNI) extensions to the TLS protocol.
+Cloudflare no longer supports SSL certificates under any plan for clients without [Server Name Indication (SNI) extensions](https://www.cloudflare.com/learning/ssl/what-is-sni/) to the TLS protocol.
 
 </Aside>
 
@@ -52,6 +52,6 @@ Clients without SNI |✅|❌|❌|❌|❌
 
 <Aside type='note' header='Note'>
 
-SNI extensions to the TLS protocol were standardized in 2003. However some browsers and operating systems only implemented this extension when TLS 1.1 was released in 2006 (or 2011 for mobile browsers). If your visitors use devices that have not been updated since 2011, they may not have SNI support.
+SNI extensions to the TLS protocol were standardized in 2003. However, some browsers and operating systems only implemented this extension when TLS 1.1 was released in 2006 (or 2011 for mobile browsers). If your visitors use devices that have not been updated since 2011, they may not have SNI support.
 
 </Aside>


### PR DESCRIPTION
## User story

Remove reference to the Server Name Indication (SNI) browser option under the Universal SSL heading in the SSL> SSL-TLS documentation and insert a note indicating that Cloudflare no longer supports this option under any plan so that content is clear to users on this point. 