### PR TITLE
Fix broken links

### DIFF
--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/setup-instructions/index.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/setup-instructions/index.md
@@ -4,18 +4,18 @@ order: 1
 
 # Setup instructions
 
-## [Router](./setup-instructions/router/)
+## [Router](./router/)
 
 See how you can send DNS queries to 1.1.1.1 for Families from a router.
 
-## [Mac](./setup-instructions/mac/)
+## [Mac](./mac/)
 
 See how you can send DNS queries to 1.1.1.1 for Families from a Mac.
 
-## [Windows](./setup-instructions/windows/)
+## [Windows](./windows/)
 
 See how you can send DNS queries to 1.1.1.1 for Families from Windows.
 
-## [Linux](./setup-instructions/linux/)
+## [Linux](./linux/)
 
 See how you can send DNS queries to 1.1.1.1 for Families from a Linux distro.


### PR DESCRIPTION
Hope this is correct. Apologies if not.

This page:
https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions
links to: 
https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions/setup-instructions/router

but the drop down navigate points to: https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions/router

Problem appears to be duplication of the folder path 'setup-instructions'