### PR TITLE
Add whitespace to force redeploy

### DIFF
--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -332,3 +332,4 @@ async function eventHandler(event){..}
 
 This code snippet will throw during script startup, and the `"fetch"` event
 listener will never be registered.
+


### PR DESCRIPTION
Yesterday's deploy failed due to API outage.