### PR TITLE
Fix Access-Control-Allow-Origin on final response

### DIFF
--- a/products/workers/src/content/examples/cors-header-proxy.md
+++ b/products/workers/src/content/examples/cors-header-proxy.md
@@ -111,7 +111,7 @@ async function handleRequest(request) {
   response = new Response(response.body, response)
 
   // Set CORS headers
-  response.headers.set("Access-Control-Allow-Origin", url.origin)
+  response.headers.set("Access-Control-Allow-Origin", '*')
 
   // Append to/Add Vary header so browser will cache response correctly
   response.headers.append("Vary", "Origin")

--- a/products/workers/src/content/examples/cors-header-proxy.md
+++ b/products/workers/src/content/examples/cors-header-proxy.md
@@ -112,6 +112,8 @@ async function handleRequest(request) {
 
   // Set CORS headers
   response.headers.set("Access-Control-Allow-Origin", '*')
+  // Note: If you wish to serve the worker in front of an existing origin, 
+  // you may wish to change the above value fron `*` to `url.origin`
 
   // Append to/Add Vary header so browser will cache response correctly
   response.headers.append("Vary", "Origin")


### PR DESCRIPTION
I may be off-base here but I propose using `*` instead of `url.origin` because `url.origin` represents the worker's origin, not the user's. This means the user's origin won't match the response's, etc., which is contrary to the whole point of things, if the point is enabling your local machine's browser to fetch data from a CORS-restricted API.