### PR TITLE
STREAM-2706 Update TUS docs with 256KiB multiple requirement

### DIFF
--- a/products/stream/src/content/uploading-videos/upload-video-file.md
+++ b/products/stream/src/content/uploading-videos/upload-video-file.md
@@ -43,7 +43,7 @@ We recommend increasing the chunk size to 52,428,800 bytes for better performanc
 
 <Aside>
 
-Important: Cloudflare Stream requires a chunk size divisible by 256KiB(256x1024 bytes). Please round your desired chunk size to the nearest multiple of 256KiB.
+Important: Cloudflare Stream requires a chunk size divisible by 256KiB (256x1024 bytes). Please round your desired chunk size to the nearest multiple of 256KiB.
 
 The final chunk of an upload or uploads that fit within a single chunk are exempt from this requirement.
 

--- a/products/stream/src/content/uploading-videos/upload-video-file.md
+++ b/products/stream/src/content/uploading-videos/upload-video-file.md
@@ -33,10 +33,6 @@ Note that cURL `-F` flag automatically configures the content-type header and ma
 
 [tus protocol](https://tus.io) is the recommended method for uploading large files to Cloudflare Stream from a computer. Popular programming languages have [tus client implementations](https://tus.io/implementations.html).
 
-### Chunk sizes
-
-tus clients allow you to configure them with a `ChunkSize`. Stream has requirements for the `ChunkSize` it will accept:
-
 <Aside>
 
 Important: Cloudflare Stream requires a minimum chunk size of 5,242,880 bytes when using TUS, unless the entire file is less than this amount.
@@ -225,4 +221,3 @@ upload.start();
 ```
 
 </Example>
-

--- a/products/stream/src/content/uploading-videos/upload-video-file.md
+++ b/products/stream/src/content/uploading-videos/upload-video-file.md
@@ -33,11 +33,23 @@ Note that cURL `-F` flag automatically configures the content-type header and ma
 
 [tus protocol](https://tus.io) is the recommended method for uploading large files to Cloudflare Stream from a computer. Popular programming languages have [tus client implementations](https://tus.io/implementations.html).
 
+### Chunk sizes
+
+tus clients allow you to configure them with a `ChunkSize`. Stream has requirements for the `ChunkSize` it will accept:
+
 <Aside>
 
 Important: Cloudflare Stream requires a minimum chunk size of 5,242,880 bytes when using TUS, unless the entire file is less than this amount.
 
 We recommend increasing the chunk size to 52,428,800 bytes for better performance when the client connection is expected to be reliable.
+
+</Aside>
+
+<Aside>
+
+Important: Cloudflare Stream requires a chunk size divisible by 256KiB(256x1024 bytes). Please round your desired chunk size to the nearest multiple of 256KiB.
+
+The final chunk of an upload or uploads that fit within a single chunk are exempt from this requirement.
 
 </Aside>
 


### PR DESCRIPTION
A new constraint is being applied to our TUS backend, this
documents that requirement before it takes effect.

Customers detected to be using incompatible ChunkSizes are
scheduled to be emailed.

Preview:
![image](https://user-images.githubusercontent.com/2524459/98578519-139c4280-2283-11eb-92aa-6bf3fe71561a.png)

