### PR TITLE
TUN-3510: Argo Tunnel docs now use ingress rules (not CLI) to configure origins

### DIFF
--- a/products/argo-tunnel/src/content/configuration/arguments.md
+++ b/products/argo-tunnel/src/content/configuration/arguments.md
@@ -9,37 +9,37 @@ order: 1
 All tunnel-related commands are prefixed with `tunnel`. For example:
 
 ```sh
-$ cloudflared tunnel --url localhost:5555 --hostname x.example.com
+$ cloudflared tunnel --origincert ~/cert.pem --config ~/tunnel.yaml run mytunnel
+```
+
+Tunnel-related commands include creating, deleting and running tunnels with
+
+```sh
+$ cloudflared tunnel create <TUNNELNAME>
+$ cloudflared tunnel delete <TUNNELNAME>
+$ cloudflared tunnel run    <TUNNELNAME>
+```
+
+You can also list all tunnels with
+
+```sh
+$ cloudflared tunnel list
 ```
 
 - [Tunnel commands](#tunnel-commands)
   - [`--config`](#--config)
-  - [`--url`](#--url)
-  - [`--hostname`](#--hostname)
-  - [`--lb-pool`](#--lb-pool)
   - [`--autoupdate-freq`](#--autoupdate-freq)
   - [`--no-autoupdate`](#--no-autoupdate)
   - [`--origincert`](#--origincert)
   - [`--no-tls-verify`](#--no-tls-verify)
-  - [`--origin-ca-pool`](#--origin-ca-pool)
-  - [`--origin-server-name`](#--origin-server-name)
   - [`--metrics`](#--metrics)
   - [`--metrics-update-freq`](#--metrics-update-freq)
   - [`--tag`](#--tag)
   - [`--loglevel`](#--loglevel)
   - [`--proto-loglevel`](#--proto-loglevel)
   - [`--retries`](#--retries)
-  - [`--no-chunked-encoding`](#--no-chunked-encoding)
-  - [`--hello-world`](#--hello-world)
   - [`--pidfile`](#--pidfile)
   - [`--logfile`](#--logfile)
-  - [`--proxy-connect-timeout`](#--proxy-connect-timeout)
-  - [`--proxy-tls-timeout`](#--proxy-tls-timeout)
-  - [`--proxy-tcp-keepalive`](#--proxy-tcp-keepalive)
-  - [`--proxy-no-happy-eyeballs`](#--proxy-no-happy-eyeballs)
-  - [`--proxy-keepalive-connections`](#--proxy-keepalive-connections)
-  - [`--proxy-keepalive-timeout`](#--proxy-keepalive-timeout)
-  - [`--socks5`](#--socks5)
   - [`--help`](#--help)
   - [`--version`](#--version)
 - [Login command](#login-command)
@@ -53,30 +53,6 @@ $ cloudflared tunnel --url localhost:5555 --hostname x.example.com
 | `--config value` | `~/.cloudflared/config.yml` |
 
 Specifies a config file in YAML format.
-
-### `--url`
-
-| Syntax | Default | Environment Variable |
-|--|--|--|
-| `--url URL` | `http://localhost:8080` | `TUNNEL_URL` |
-
-Connects to the local webserver at `URL`.
-
-### `--hostname`
-
-| Syntax | Environment Variable |
-|--|--|
-| `--hostname value` | `TUNNEL_HOSTNAME` |
-
-Sets a hostname on a Cloudflare zone to route traffic through this tunnel.
-
-### `--lb-pool`
-
-| Syntax |
-|--|
-| `--lb-pool POOL_NAME` |
-
-Add this tunnel to a Load Balancer pool. If it doesn’t already exist a load balancer will be created for the hostname of your tunnel, and a pool will be created with the pool name you specify. Traffic destined to that pool will be load balanced across this tunnel and any other tunnels which share its pool name.
 
 ### `--autoupdate-freq`
 
@@ -110,22 +86,6 @@ Specifies the Tunnel certificate for one of your zones, authorizing the client t
 
 Disables TLS verification of the certificate presented by your origin. Will allow any certificate from the origin to be accepted.
 The connection from your machine to Cloudflare's Edge is still encrypted and verified using TLS.
-
-### `--origin-ca-pool`
-
-| Syntax |
-|--|
-| `--origin-ca-pool value` |
-
-Path to the CA for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
-
-
-### `--origin-server-name`
-
-| Syntax | Environment Variable |
-|--|--|
-| `--origin-server-name value` | `TUNNEL_ORIGIN_SERVER_NAME` |
-
 
 ### `--metrics`
 
@@ -178,22 +138,6 @@ Specifies the verbosity of the HTTP/2 protocol logging. Any value below `warn` i
 Maximum number of retries for connection/protocol errors. Retries use exponential backoff (retrying at 1, 2, 4, 8, 16 seconds by default) so increasing this value significantly is not recommended.
 
 
-### `--no-chunked-encoding`
-
-| Syntax | Default |
-|--|--|
-| `--no-chunked-encoding` | `false` |
-
-Disables chunked transfer encoding; useful if you are running a WSGI server.
-
-### `--hello-world`
-
-| Syntax | Environment Variable |
-|--|--|
-| `--hello-world` | `TUNNEL_HELLO_WORLD` |
-
-Use the established tunnel to expose a `Hello world` HTTP server for testing Argo Tunnel. Mutually exclusive with the `--url argument`.
-
 ### `--pidfile`
 
 | Syntax | Environment Variable |
@@ -209,62 +153,6 @@ Write the application's PID to this file after the first successful connection. 
 | `--logfile value` | `TUNNEL_LOGFILE` |
 
 Save application log to this file. Mainly useful for reporting issues.
-
-### `--proxy-connect-timeout`
-
-| Syntax | Default |
-|--|--|
-| `--proxy-connect-timeout value` | `30s` |
-
-Timeout for establishing a new TCP connection to your origin server. This excludes the time taken to establish TLS, which is controlled by [--proxy-tls-timeout](#proxy-tls-timeout).
-
-### `--proxy-tls-timeout`
-
-| Syntax | Default |
-|--|--|
-| `--proxy-tls-timeout value` | `10s` |
-
-Timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
-
-### `--proxy-tcp-keepalive`
-
-| Syntax | Default |
-|--|--|
-| `--proxy-tcp-keepalive value` | `30s` |
-
-The timeout after which a TCP keepalive packet is sent on a connection between Tunnel and the origin server.
-
-### `--proxy-no-happy-eyeballs`
-
-| Syntax |
-|--|
-| `--proxy-no-happy-eyeballs` |
-
-Disable the "happy eyeballs" algorithm for IPv4/IPv6 fallback if your local network has misconfigured one of the protocols.
-
-### `--proxy-keepalive-connections`
-
-| Syntax | Default |
-|--|--|
-| `--proxy-keepalive-connections value` | `100` |
-
-Maximum number of idle keepalive connections between Tunnel and your origin. This does not restrict the total number of concurrent connections.
-
-### `--proxy-keepalive-timeout`
-
-| Syntax | Default |
-|--|--|
-| `--proxy-keepalive-timeout value` | `1m30s` |
-
-Timeout after which an idle keepalive connection can be discarded.
-
-### `--socks5`
-
-| Syntax | Default |
-|--|--|
-| `--socks5=value` | `true` |
-
-See [kubectl](https://developers.cloudflare.com/access/other-protocols/kubectl) for example usage.
 
 ### `--help`
 

--- a/products/argo-tunnel/src/content/configuration/config.md
+++ b/products/argo-tunnel/src/content/configuration/config.md
@@ -18,7 +18,7 @@ hostname: [hostname]
 
 ## Default behavior
 
-You can specify a particular Tunnel in the config file by name or ID. When the following stanza is present in the file, the command `cloudflaredtunnl run` will be treated as if `cloudflared tunnel run NAME-OR-ID` was run.
+You can specify a particular Tunnel in the config file by name or ID. When the following stanza is present in the file, the command `cloudflared tunnel run` will be treated as if `cloudflared tunnel run NAME-OR-ID` was run.
 
 ```yml
 tunnel: NAME-OR-ID

--- a/products/argo-tunnel/src/content/configuration/origins-via-cli.md
+++ b/products/argo-tunnel/src/content/configuration/origins-via-cli.md
@@ -1,0 +1,138 @@
+---
+order: 11
+---
+
+# Legacy: Configuring Origins via CLI
+
+`cloudflared` proxies traffic to local services running on your origin. You can configure the exact properties of each
+origin by adding stanzas to the [Ingress Rules](/configuration/origins-via-ingress). However, if you only want to proxy
+traffic to a single local service, you can use CLI flags instead of YAML to configure that service.
+
+- [`--url`](#--url)
+- [`--hostname`](#--hostname)
+- [`--lb-pool`](#--lb-pool)
+- [`--origin-ca-pool`](#--origin-ca-pool)
+- [`--origin-server-name`](#--origin-server-name)
+- [`--no-chunked-encoding`](#--no-chunked-encoding)
+- [`--hello-world`](#--hello-world)
+- [`--proxy-connect-timeout`](#--proxy-connect-timeout)
+- [`--proxy-tls-timeout`](#--proxy-tls-timeout)
+- [`--proxy-tcp-keepalive`](#--proxy-tcp-keepalive)
+- [`--proxy-no-happy-eyeballs`](#--proxy-no-happy-eyeballs)
+- [`--proxy-keepalive-connections`](#--proxy-keepalive-connections)
+- [`--proxy-keepalive-timeout`](#--proxy-keepalive-timeout)
+- [`--socks5`](#--socks5)
+
+### `--url`
+
+| Syntax | Default | Environment Variable |
+|--|--|--|
+| `--url URL` | `http://localhost:8080` | `TUNNEL_URL` |
+
+Connects to the local webserver at `URL`.
+
+
+### `--hostname`
+
+| Syntax | Environment Variable |
+|--|--|
+| `--hostname value` | `TUNNEL_HOSTNAME` |
+
+Sets a hostname on a Cloudflare zone to route traffic through this tunnel.
+
+### `--lb-pool`
+
+| Syntax |
+|--|
+| `--lb-pool POOL_NAME` |
+
+Add this tunnel to a Load Balancer pool. If it doesn’t already exist a load balancer will be created for the hostname of your tunnel, and a pool will be created with the pool name you specify. Traffic destined to that pool will be load balanced across this tunnel and any other tunnels which share its pool name.
+
+### `--origin-ca-pool`
+
+| Syntax |
+|--|
+| `--origin-ca-pool value` |
+
+Path to the CA for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
+
+
+### `--origin-server-name`
+
+| Syntax | Environment Variable |
+|--|--|
+| `--origin-server-name value` | `TUNNEL_ORIGIN_SERVER_NAME` |
+
+
+
+### `--no-chunked-encoding`
+
+| Syntax | Default |
+|--|--|
+| `--no-chunked-encoding` | `false` |
+
+Disables chunked transfer encoding; useful if you are running a WSGI server.
+
+### `--hello-world`
+
+| Syntax | Environment Variable |
+|--|--|
+| `--hello-world` | `TUNNEL_HELLO_WORLD` |
+
+Use the established tunnel to expose a `Hello world` HTTP server for testing Argo Tunnel. Mutually exclusive with the `--url argument`.
+
+### `--proxy-connect-timeout`
+
+| Syntax | Default |
+|--|--|
+| `--proxy-connect-timeout value` | `30s` |
+
+Timeout for establishing a new TCP connection to your origin server. This excludes the time taken to establish TLS, which is controlled by [--proxy-tls-timeout](#proxy-tls-timeout).
+
+### `--proxy-tls-timeout`
+
+| Syntax | Default |
+|--|--|
+| `--proxy-tls-timeout value` | `10s` |
+
+Timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
+
+### `--proxy-tcp-keepalive`
+
+| Syntax | Default |
+|--|--|
+| `--proxy-tcp-keepalive value` | `30s` |
+
+The timeout after which a TCP keepalive packet is sent on a connection between Tunnel and the origin server.
+
+### `--proxy-no-happy-eyeballs`
+
+| Syntax |
+|--|
+| `--proxy-no-happy-eyeballs` |
+
+Disable the "happy eyeballs" algorithm for IPv4/IPv6 fallback if your local network has misconfigured one of the protocols.
+
+### `--proxy-keepalive-connections`
+
+| Syntax | Default |
+|--|--|
+| `--proxy-keepalive-connections value` | `100` |
+
+Maximum number of idle keepalive connections between Tunnel and your origin. This does not restrict the total number of concurrent connections.
+
+### `--proxy-keepalive-timeout`
+
+| Syntax | Default |
+|--|--|
+| `--proxy-keepalive-timeout value` | `1m30s` |
+
+Timeout after which an idle keepalive connection can be discarded.
+
+### `--socks5`
+
+| Syntax | Default |
+|--|--|
+| `--socks5=value` | `true` |
+
+See [kubectl](https://developers.cloudflare.com/access/other-protocols/kubectl) for example usage.

--- a/products/argo-tunnel/src/content/configuration/origins-via-ingress.md
+++ b/products/argo-tunnel/src/content/configuration/origins-via-ingress.md
@@ -1,0 +1,189 @@
+---
+order: 10
+---
+
+# Configuring Origins via Ingress Rules
+
+`cloudflared` proxies incoming traffic to one or multiple services running locally on your origin. You can configure the
+way that `cloudflared` sends requests to these servers by setting a key in your config file. For example, to set a 30
+second connection timeout for all origins except one:
+
+```yaml
+originRequest: # Root-level configuration
+  connectTimeout: 30s
+ingress:
+  # This service inherits all configuration from the root-level config, i.e.
+  # it will use a connectTimeout of 30 seconds.
+  - hostname: example.com
+    service: localhost:8000
+  - hostname: example2.com
+    service: localhost:8001
+  # This service overrides some root-level config.
+  - service: localhost:8002
+    originRequest:
+      connectTimeout: 10s
+      disableChunkedEncoding: true
+```
+
+You can [validate](/routing-to-tunnel/ingress#validating-your-configuration) and [test](/routing-to-tunnel/ingress#testing-your-configuration)
+your ingress rules using `cloudflared`.
+
+You can use the following YAML keys to configure how cloudflared communicates with each local service:
+
+- [connectTimeout](#connectTimeout)
+- [tlsTimeout](#tlsTimeout)
+- [tcpKeepAlive](#tcpKeepAlive)
+- [noHappyEyeballs](#noHappyEyeballs)
+- [keepAliveConnections](#keepAliveConnections)
+- [keepAliveTimeout](#keepAliveTimeout)
+- [httpHostHeader](#httpHostHeader)
+- [originServerName](#originServerName)
+- [caPool](#caPool)
+- [noTLSVerify](#noTLSVerify)
+- [disableChunkedEncoding](#disableChunkedEncoding)
+- [bastionMode](#bastionMode)
+- [proxyAddress](#proxyAddress)
+- [proxyPort](#proxyPort)
+- [proxyType](#proxyType)
+
+<div id="connectTimeout">
+
+## connectTimeout
+</div>
+
+Default: `30s`
+
+Timeout for establishing a new TCP connection to your origin server. This excludes the time taken to
+establish TLS, which is controlled by [tlsTimeout]({{< ref "#tlsTimeout" >}}).
+
+<div id="tlsTimeout">
+
+## tlsTimeout
+</div>
+
+Default: `10s`
+
+Timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
+
+<div id="tcpKeepAlive">
+
+## tcpKeepAlive
+</div>
+
+Default: `30s`
+
+The timeout after which a TCP keepalive packet is sent on a connection between Tunnel and the origin server.
+
+<div id="noHappyEyeballs">
+
+## noHappyEyeballs
+</div>
+
+Default: `false`
+
+Disable the "happy eyeballs" algorithm for IPv4/IPv6 fallback if your local network has misconfigured one of the protocols.
+
+<div id="keepAliveConnections">
+
+## keepAliveConnections
+</div>
+
+Default: `100`
+
+Maximum number of idle keepalive connections between Tunnel and your origin. This does not restrict the total number of concurrent connections.
+
+<div id="keepAliveTimeout">
+
+## keepAliveTimeout
+</div>
+
+Default: `1m30s`
+
+Timeout after which an idle keepalive connection can be discarded.
+
+<div id="httpHostHeader">
+
+## httpHostHeader
+</div>
+
+Default: `""`
+
+Sets the HTTP Host header on requests sent to the local service.
+
+<div id="originServerName">
+
+## originServerName
+</div>
+
+Default: `""`
+
+Hostname that `cloudflared` should expect from your origin server certificate.
+
+<div id="caPool">
+
+## caPool
+</div>
+
+Default: `""`
+
+Path to the CA for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
+
+<div id="noTLSVerify">
+
+## noTLSVerify
+</div>
+
+Default: `false`
+
+Disables TLS verification of the certificate presented by your origin. Will allow any certificate from the origin to be accepted.
+
+<div id="disableChunkedEncoding">
+
+## disableChunkedEncoding
+</div>
+
+Default: `false`
+
+Disables TLS verification of the certificate presented by your origin. Will allow any certificate from the origin to be accepted.
+
+<div id="bastionMode">
+
+## bastionMode
+</div>
+
+Default: `false`
+
+Runs as jump host.
+
+<div id="proxyAddress">
+
+## proxyAddress
+</div>
+
+Default: `127.0.0.1`
+
+`cloudflared` starts a proxy server to translate HTTP traffic into TCP when proxying e.g. SSH or RDP.
+This configures the listen address for that proxy.
+
+<div id="proxyPort">
+
+## proxyPort
+</div>
+
+Default: `0`
+
+`cloudflared` starts a proxy server to translate HTTP traffic into TCP when proxying e.g. SSH or RDP.
+This configures the listen port for that proxy. If set to zero, an unused port will randomly be chosen.
+
+<div id="proxyType">
+
+## proxyType
+</div>
+
+Default: `""`
+
+`cloudflared` starts a proxy server to translate HTTP traffic into TCP when proxying e.g. SSH or RDP.
+This configures what type of proxy will be started. Valid options are
+
+ - "" for the regular proxy
+ - "socks" for a SOCKS5 proxy. See [kubectl](https://developers.cloudflare.com/access/other-protocols/kubectl) for more.

--- a/products/argo-tunnel/src/content/create-tunnel/index.md
+++ b/products/argo-tunnel/src/content/create-tunnel/index.md
@@ -40,11 +40,7 @@ Creating a Tunnel generates a credentials file for that specific Tunnel. This fi
 
 ## Run a Tunnel
 
-Once created, you can use Argo Tunnel to proxy traffic from the Tunnel to a locally available URL in your environment. You can specify configuration details for your tunnel in a configuration file.
-
-If you do not specify a configuration file location, `cloudflared` will attempt to read a configuration file in `~/.cloudflared/config.yml`.
-
-To begin, run the Tunnel with the following command.
+Once created, you can run the Argo Tunnel to proxy incoming traffic from the Tunnel to any number of services running locally on your origin. To begin, run the Tunnel with the following command.
 
 `cloudflared tunnel --config path/config.yaml run <NAME>`
 
@@ -56,7 +52,11 @@ You can also specify the Tunnel name or UUID inside of the configuration file, i
 
 `cloudflared tunnel --config path/config.yaml run`
 
-You can also run the Tunnel without a configuration file by appending the flags after the `run` command and before the name or UUID.
+If you do not specify a configuration file location, `cloudflared` will attempt to read a configuration file in `~/.cloudflared/config.yml`.
+
+When `cloudflared` receives a HTTP request from the internet it matches the incoming request to an ingress rule from the config file. The ingress rules specify which traffic should go to which local services. See the section on [Ingress Rules](/routing-to-tunnel/ingress).
+
+You can also run the Tunnel without a configuration file by appending the flags after the `run` command and before the name or UUID. Running your tunnel this way will route _all_ traffic to the given URL.
 
 `cloudflared tunnel run --url localhost:3000 <NAME or UUID>`
 

--- a/products/argo-tunnel/src/content/reference/arguments.md
+++ b/products/argo-tunnel/src/content/reference/arguments.md
@@ -5,7 +5,7 @@ order: 100
 # Command-line arguments
 
 * [Tunnel command](#tunnel-command)
-  * [Login command](#login-command)
+* [Login command](#login-command)
 * [Service command](#service-command)
 * [Update command](#update-command)
 

--- a/products/argo-tunnel/src/content/routing-to-tunnel/ingress.md
+++ b/products/argo-tunnel/src/content/routing-to-tunnel/ingress.md
@@ -1,0 +1,137 @@
+---
+order: 20
+---
+
+# Ingress rules
+
+| Before you start |
+|---|
+| 1. [Add a website to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-Creating-a-Cloudflare-account-and-adding-a-website) |
+| 2. [Change your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/205195708) |
+| 3. [Enable Argo Smart Routing for your account](https://support.cloudflare.com/hc/articles/115000224552-Configuring-Argo-through-the-UI) |
+| 4. [Install `cloudflared` and authenticate the software](/getting-started) |
+| 5. [Create an Argo Tunnel](/create-tunnel) |
+
+`cloudflared` can accept traffic from many different domains, and proxy it to many different local services. Ingress
+rules let you specify which local services a request should be proxied to. You can configure ingress rules in the
+configuration file.
+
+## Matching traffic
+
+When `cloudflared` gets an incoming request, it evaluates each ingress rule from top to bottom to find which one matches
+the request. Rules can match the hostname and/or path of an incoming request. The last rule you list in the config file
+must be a catch-all rule that matches all traffic. If a rule doesn't specify a hostname, all hostnames will be matched.
+If a rule doesn't specify a path, all paths will be matched.
+
+This is an example config file that specifies several different rules:
+
+
+```yaml
+ingress:
+  # Rules map traffic from a hostname to a local service
+  - hostname: example.com
+    service: https://localhost:8000
+  # Rules can can optionally match the request's path to a regular expression.
+  - hostname: static.example.com
+    path: /*.(jpg|png|css|js)
+    service: https://localhost:8001
+  # You can use a wildcard subdomain in the hostname
+  - hostname: "*.example.com"
+    service: https://localhost:8002
+  # The last rule must match all traffic (a "catch-all" rule).
+  # This ensures ingress rules are exhaustive -- otherwise cloudflared wouldn't
+  # be able to respond to all requests.
+  - service: https://localhost:8003
+```
+
+To summarize: ingress rules match the URL of incoming traffic and proxy it to a given local service. Rules can match the
+hostname and/or path of an incoming request. The last rule must be a catch-all rule that matches all traffic. If a rule
+doesn't specify a hostname, all hostnames will be matched. If a rule doesn't specify a path, all paths will be matched.
+
+## Types of local service
+
+`cloudflared` supports more than just proxying traffic to an HTTP service running on localhost. Other options include
+SSH, RDP, arbitrary TCP services, and unix sockets. You can also route traffic to the built-in Hello World test server,
+or configure `cloudflared` to just respond with a certain HTTP status code.
+
+```yaml
+ingress:
+  # Services don't have to use HTTP. List of other supported protocols here:
+  # https://developers.cloudflare.com/access/protocols-and-connections
+  - hostname: example.com
+    service: tcp://localhost:8000
+  # You can accept HTTP over a Unix socket too.
+  - hostname: staging.example.com
+    service: unix:/home/production/echo.sock
+  # Traffic can be mapped to the built-in Hello World test server.
+  # This could be useful for testing your Argo Tunnel deployment.
+  - hostname: test.example.com
+    service: hello_world
+  # You can also respond to traffic with a HTTP status. This is particularly
+  # useful for the catch-all rule -- you can just respond with e.g. HTTP 404.
+  - service: http_status:404
+```
+
+For a complete list of non-HTTP protocols `cloudflared` supports, see [here](https://developers.cloudflare.com/access/protocols-and-connections).
+
+## Configuring each origin
+
+Each incoming request `cloudflared` receives causes `cloudflared` to send a request to a local service. You can configure
+various properties of the requests `cloudflared` makes -- for example, setting a specific Host header or using a specific
+number of keep-alive connections. You can configure these requests with the `originRequest` key in the root of your
+configuration file. Each local service will inherit this root-level config, and can override it with their own
+service-specific configuration. For example,
+
+```yaml
+originRequest: # Root-level configuration
+  connectTimeout: 30s
+ingress:
+  # This service inherits all configuration from the root-level config, i.e.
+  # it will use a connectTimeout of 30 seconds.
+  - hostname: example.com
+    service: localhost:8000
+  # This service overrides some root-level config.
+  - service: localhost:8001
+    originRequest:
+      connectTimeout: 10s
+      disableChunkedEncoding: true
+```
+
+For a complete list of configuration options, see the [configuration](/configuration) page.
+
+## Validating your configuration
+
+To validate the ingress rules in your configuration file, simply run
+
+```bash
+$ cloudflared tunnel ingress validate
+```
+
+This will ensure your config file specifies a valid set of ingress rules.
+
+## Testing your configuration
+
+`cloudflared` can check which rule matches a given URL. Just use `cloudflared tunnel ingress rule`. For example:
+
+```bash
+$ cloudflared tunnel ingress rule https://foo.example.com
+Using rules from /usr/local/etc/cloudflared/config.yml
+Matched rule #3
+	hostname: *.example.com
+	service: https://localhost:8000
+```
+
+This checks the URL against every rule, from first to last, and shows the first rule that matches. This helps you verify
+that `cloudflared` is going to proxy the right traffic to the right local service.
+
+## Single-service configuration
+
+To proxy traffic to _only one_ local service, you can:
+ - Configure the service using the *configuration file* (the scenario covered so far)
+ - Configure the service using the *command-line flags*, for example:
+
+```bash
+cloudflared tunnel --url localhost:8000 --no-chunked-encoding run mytunnel
+```
+
+For a complete list of configuration options, see the [configuration](/configuration) page.


### PR DESCRIPTION
The docs now tell users to configure the local services running on their origin via Ingress Rules, not via the CLI. I've added a new page explaining how ingress rules work, and another new page with all the various ingress rule config options. 

Origin-related CLI arguments have been moved into their own page and marked as legacy. This PR should not result in any broken links.