### PR TITLE
lacking 'as=style' in the Link preload header

### DIFF
--- a/products/workers/src/content/examples/http2-server-push.md
+++ b/products/workers/src/content/examples/http2-server-push.md
@@ -44,7 +44,7 @@ async function handleRequest(request) {
     return new Response(HTML, {
       headers: {
         "content-type": "text/html",
-        Link: "</http2_push/h2p/test.css>; rel=preload;",
+        Link: "</http2_push/h2p/test.css>; rel=preload; as=style",
       },
     })
   }


### PR DESCRIPTION
https://www.w3.org/TR/preload/#example-3:~:text=Link%3A%20%3C%2Fapp%2Fstyle.css%3E%3B%20rel%3Dpreload%3B%20as%3Dstyle