### PR TITLE
fix broken link for code block examples

### DIFF
--- a/products/docs-engine/src/content/reference/markdown.md
+++ b/products/docs-engine/src/content/reference/markdown.md
@@ -530,7 +530,7 @@ Custom tokenization can also be achieved by manually applying tokens. For exampl
 
 ### Examples
 
-Check out the dedicated [code block examples](/markdown/code-block-examples) page for more.
+Check out the dedicated [code block examples](/examples/code-block-examples) page for more.
 
 --------------------------------
 


### PR DESCRIPTION
on this page: https://developers.cloudflare.com/docs-engine/reference/markdown#examples the link to `code block examples` hits a 404. 

![image](https://user-images.githubusercontent.com/49507/98966584-72f39000-24d9-11eb-918b-01fb9c33772e.png)

this looks to fix it