### PR TITLE
Update deploy-button.md with latest release number

### DIFF
--- a/products/workers/src/content/platform/deploy-button.md
+++ b/products/workers/src/content/platform/deploy-button.md
@@ -33,7 +33,7 @@ deploy:
   steps:
     - uses: actions/checkout@v2
     - name: Publish
-      uses: cloudflare/wrangler-action@1.2.0
+      uses: cloudflare/wrangler-action@1.3.0
 ```
 
 2. **Add support for `CF_API_TOKEN` and `CF_ACCOUNT_ID` in your workflow**:
@@ -41,7 +41,7 @@ deploy:
 ```yaml
 # Update "Publish" step from last code snippet
 - name: Publish
-  uses: cloudflare/wrangler-action@1.2.0
+  uses: cloudflare/wrangler-action@1.3.0
   with:
     apiToken: ${{ secrets.CF_API_TOKEN }}
   env:


### PR DESCRIPTION
This change updates the values for the [cloudflare/wrangler-action](https://github.com/cloudflare/wrangler-action) from `1.2.0` to the latest release `1.3.0`.