### PR TITLE
Bugfix/pcx 1069 graphql fix typos

### DIFF
--- a/products/analytics/src/content/graphql-api/getting-started/index.md
+++ b/products/analytics/src/content/graphql-api/getting-started/index.md
@@ -8,6 +8,6 @@ order: 10
 Use these articles to get started with the Cloudflare GraphQL Analytics API:
 
 * [_Authentication_](/graphql-api/getting-started/authentication) walks you through the options and the steps required to successfully set up your access to Cloudflare API.
-* [_Querying basics_](/graphql-api/getting-started/querying-basics) brings you simple query examples for you to start exploring the GraphQl Analytics API.
+* [_Querying basics_](/graphql-api/getting-started/querying-basics) brings you simple query examples for you to start exploring the GraphQL Analytics API.
 
 For examples of how to build your own GraphQL Analytics dashboard and query specific information, such as Firewall and Workers events, see [_Tutorials_](/graphql-api/tutorials).

--- a/products/analytics/src/content/graphql-api/index.md
+++ b/products/analytics/src/content/graphql-api/index.md
@@ -3,7 +3,7 @@ title: GraphQL Analytics API
 order: 1
 ---
 
-# GraphQl Analytics API
+# GraphQL Analytics API
 
 The GraphQL Analytics API provides data regarding HTTP requests passing through Cloudflare’s network, as well as data from specific products, such as Firewall or Load Balancing. Network Analytics users also have access to packet-level data. Use the GraphQL Analytics API to select specific data sets and metrics of interest, filter and aggregate the data along various dimensions, and integrate the results with other applications.
 

--- a/products/analytics/src/content/migration-guides/zone-analytics/index.md
+++ b/products/analytics/src/content/migration-guides/zone-analytics/index.md
@@ -504,6 +504,6 @@ As you can see from the response, Zone Analytics returns metrics along many dime
 </div>
 </details>
 
-Notice that you can specify the request time period using a data set filter (_see [Filtering](/graphql-api/features/filtering/)_). The `continuous` parameter is no longer needed because GraphQL Analytics is designed to provide data as soon as it's available.
+Notice that you can specify the request time period using a data set filter see ( [_Filtering_](/graphql-api/features/filtering/)). The `continuous` parameter is no longer needed because GraphQL Analytics is designed to provide data as soon as it is available.
 
 Also, if you want to get the totals for a particular period, rather than a breakdown by time period, simply remove the `datetimeMinute` field under `dimensions`.

--- a/products/analytics/src/content/migration-guides/zone-analytics/index.md
+++ b/products/analytics/src/content/migration-guides/zone-analytics/index.md
@@ -504,6 +504,6 @@ As you can see from the response, Zone Analytics returns metrics along many dime
 </div>
 </details>
 
-Notice that you can specify the request time period using a data set filter see ( [_Filtering_](/graphql-api/features/filtering/)). The `continuous` parameter is no longer needed because GraphQL Analytics is designed to provide data as soon as it is available.
+Notice that you can specify the request time period using a data set filter (see [_Filtering_](/graphql-api/features/filtering/)). The `continuous` parameter is no longer needed because GraphQL Analytics is designed to provide data as soon as it is available.
 
 Also, if you want to get the totals for a particular period, rather than a breakdown by time period, simply remove the `datetimeMinute` field under `dimensions`.


### PR DESCRIPTION
## User story

Find and replace "GraphQl" with "GraphQL" typos so that the proper product name is used in product documentation.

