### PR TITLE
URL typo in Creating API tokens via the API

### DIFF
--- a/products/api/src/content/tokens/advanced/api.md
+++ b/products/api/src/content/tokens/advanced/api.md
@@ -99,7 +99,7 @@ The last piece to defining a policy is what Permission Groups should be applied.
 
 ### Define the restrictions
 
-Last in defining the token is setting up any limitations on how the token can be used. Currently, API Tokens allow for IP filtering and TTLs. You can find general info in [Restricting Token Use](../restrictions).
+Last in defining the token is setting up any limitations on how the token can be used. Currently, API Tokens allow for IP filtering and TTLs. You can find general info in [Restricting Token Use](./restrictions).
 
 When defining TTLs you can set the time at which a token becomes active, `not_before` and the time when it expires, `expires_on`. Both of these fields take timestamps in UTC in the following format: `"2018-07-01T05:20:00Z"`.
 


### PR DESCRIPTION
Fix link to "restrictions" page