### PR TITLE
Remove Workers Bundled requirement for using Sites

### DIFF
--- a/products/workers/src/content/platform/sites/configuration.md
+++ b/products/workers/src/content/platform/sites/configuration.md
@@ -4,7 +4,7 @@ order: 3
 
 # Configuration
 
-Workers Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler).
 
 ## Commands
 
@@ -93,7 +93,7 @@ For very exceptionally large pages, Workers Sites might not work for you. There 
 
 ## Ignoring subsets of static assets
 
-Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/cli-wrangler/install-update#update) - and the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/cli-wrangler/install-update#update).
 
 There are cases where users may not want to upload certain static assets to their Workers Sites.
 In this case, Workers Sites can also be configured to ignore certain files or directories using logic

--- a/products/workers/src/content/platform/sites/index.md
+++ b/products/workers/src/content/platform/sites/index.md
@@ -1,11 +1,5 @@
 # Workers Sites
 
-<Aside>
-
-__Note:__ Workers Sites requires the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans). As Workers Sites depend on both Workers and Workers KV, their usage is taken into account when calculating your monthly bill.
-
-</Aside>
-
 Workers Sites enables developers to deploy __static applications__ directly to Workers.
 
 It’s perfect for deploying applications built with static site generators like [Hugo](https://gohugo.io) and [Gatsby](https://www.gatsbyjs.org), or frontend frameworks like [Vue](https://vuejs.org) and [React](https://reactjs.org).
@@ -35,3 +29,9 @@ If you’re ready to start a brand new project, starting from scratch with Worke
 If you already have an application deployed to Workers, this guide will show you how to use Workers Sites in your existing codebase, allowing you to deploy your entire application as a single Workers project.
 
 <p><Button type="primary" href="/platform/sites/start-from-worker">Start from a worker</Button></p>
+
+<Aside>
+
+__Note:__ Workers Sites is built on Workers KV, and usage rates may apply. See the [Pricing page](/platform/pricing) to learn more.
+
+</Aside>

--- a/products/workers/src/content/platform/sites/start-from-existing.md
+++ b/products/workers/src/content/platform/sites/start-from-existing.md
@@ -4,7 +4,7 @@ order: 0
 
 # Start from existing
 
-Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) — make sure to be on the [latest version](/cli-wrangler/install-update#update) — and the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) — make sure to be on the [latest version](/cli-wrangler/install-update#update).
 
 To deploy a pre-existing static site project, you’ll need to start with a pre-generated site. Workers Sites works well with all static site generators! For a quick-start, check out the following projects:
 

--- a/products/workers/src/content/platform/sites/start-from-scratch.md
+++ b/products/workers/src/content/platform/sites/start-from-scratch.md
@@ -6,7 +6,7 @@ order: 1
 
 To start from scratch to create a Workers Site, follow these steps:
 
-1. Ensure you have the latest version of [Wrangler](/cli-wrangler/install-update#update) and Node.js installed. Workers Sites require the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans).
+1. Ensure you have the latest version of [Wrangler](/cli-wrangler/install-update#update) and Node.js installed.
 
 2. In your terminal run `wrangler generate --site <project-name>`, replacing `<project-name>` with the name of your project. For example, I’ll create a project called my-site by running this command:
 

--- a/products/workers/src/content/platform/sites/start-from-worker.md
+++ b/products/workers/src/content/platform/sites/start-from-worker.md
@@ -4,7 +4,7 @@ order: 2
 
 # Start from worker
 
-Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) — make sure to be on the [latest version](/cli-wrangler/install-update#update) — and the Workers [Bundled plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) — make sure to be on the [latest version](/cli-wrangler/install-update#update).
 
 Make sure to be on the latest version.
 


### PR DESCRIPTION
Because KV is now free, I made a quick pass through the Workers Sites docs to confirm that we don't mention needing Workers Bundled to use it.