### PR TITLE
Remove KV/Bundled reference in deploy button docs

### DIFF
--- a/products/workers/src/content/platform/deploy-button.md
+++ b/products/workers/src/content/platform/deploy-button.md
@@ -55,11 +55,3 @@ deploy:
 ```
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com)
-
-**Does your project use Workers KV or other features only available in a Workers paid plan?** Providing the `paid=true` query parameter to the `/button` and the deploy application paths will render a "Deploy to Workers Bundled" button, as seen below -- it will also render a notice in the UI that the project requires Workers Bundled:
-
-```md
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button?paid=true)](https://deploy.workers.cloudflare.com/?url=https://github.com/YOURUSERNAME/YOURREPO&paid=true)
-```
-
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button?paid=true)](https://deploy.workers.cloudflare.com/?url=https://github.com/YOURUSERNAME/YOURREPO&paid=true)


### PR DESCRIPTION
KV is now free, so the info in the Workers docs around specifying if a deploy button requires Workers Bundled or not is now out of date. Follows the work here → https://github.com/signalnerve/deploy.workers.cloudflare.com/pull/114