### PR TITLE
PCX-554 SSL: Custom cert expiry notification

### DIFF
--- a/products/ssl/src/content/custom-certificates/renewing.md
+++ b/products/ssl/src/content/custom-certificates/renewing.md
@@ -5,3 +5,5 @@ order: 2
 # Renewing
 
 Uploaded Certificates cannot be renewed by Cloudflare. You must ensure that you replace an expiring certificate before it expires, otherwise your visitors may not be able to connect.
+
+Cloudflare automatically sends email notification 30 and 14 days before your custom certificate expires. Email is sent to users who have the SSL/TLS, Administrator, or Super Administrator roles.


### PR DESCRIPTION
## User story

Update existing development docs for custom certificates with Expiration information so that users know that they have to renew their own certificates but will receive automatic notice of expiry from Cloudflare via email.

Email is automatic and sent 30 days and 14 days before the custom cert is about to expire. 

Notifications are sent to users with SSL/TLS roles, Admin/SuperAdmins.


