### PR TITLE
Custom Cache Key should use template literals

### DIFF
--- a/products/workers/src/content/examples/cache-using-fetch.md
+++ b/products/workers/src/content/examples/cache-using-fetch.md
@@ -19,7 +19,7 @@ async function handleRequest(request) {
 
   // Only use the path for the cache key, removing query strings
   // and always store using HTTPS e.g. https://www.example.com/file-uri-here
-  const someCustomKey = "https://${url.hostname}${url.pathname}"
+  const someCustomKey = `https://${url.hostname}${url.pathname}`
 
   let response = await fetch(request, {
     cf: {


### PR DESCRIPTION
I think the idea here was to use string interpolation via template literals