### PR TITLE
Fix token API documentation

### DIFF
--- a/products/api/src/content/tokens/advanced/api.md
+++ b/products/api/src/content/tokens/advanced/api.md
@@ -135,7 +135,6 @@ curl -X POST "https://api.cloudflare.com/client/v4/user/tokens" \
   "name": "readonly token",
   "policies": [
     {
-      "id": "f267e341f3dd4697bd3b9f71dd96247f",
       "effect": "allow",
       "resources": {
         "com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4": "*",


### PR DESCRIPTION
If you include the ID parameter, the request fails with this error : 

```
#curl -v -X POST https://api.cloudflare.com/client/v4/user/tokens --header 'Content-Type: application/json' --header 'Authorization: Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXX' --data '{"name":"session_test","not_before":"2020-11-24T18:13:27Z","expires_on":"2020-11-24T19:13:27Z","condition":{},"policies":[{"id":"beefcafe1337beefcafe1337beefcafe","effect":"allow","resources":{"com.cloudflare.api.account.zone.*":"*"},"permission_groups":[{"id":"e6d2666161e84845a636613608cee8d5","name":"Zone Write"},{"id":"4755a26eedb94da69e1066d98aa820be","name":"DNS Write"}]}]}'
[...]
HTTP/2 400
[...]
{"success":false,"errors":[{"code":1001,"message":"Reusing existing policies is not supported by token creation"}],"messages":[],"result":null}
```

Without it, the call works