### PR TITLE
Fix docs to include that Workers KV is now also included in the free plan

### DIFF
--- a/products/workers/src/content/learning/how-kv-works.md
+++ b/products/workers/src/content/learning/how-kv-works.md
@@ -12,6 +12,6 @@ KV achieves this performance by being eventually-consistent. Changes may take up
 
 All values are encrypted at rest with 256-bit AES-GCM, and only decrypted by the process executing your Worker scripts or responding to your API requests.
 
-Workers KV comes with both the free and the bundled plan.
+Workers KV is free to try, with additional usage available as part of the Workers Bundled plan.
 
 Learn more at the [Workers KV API reference](/runtime-apis/kv).

--- a/products/workers/src/content/learning/how-kv-works.md
+++ b/products/workers/src/content/learning/how-kv-works.md
@@ -12,6 +12,6 @@ KV achieves this performance by being eventually-consistent. Changes may take up
 
 All values are encrypted at rest with 256-bit AES-GCM, and only decrypted by the process executing your Worker scripts or responding to your API requests.
 
-Workers KV is an account-level feature, and comes with your Workers Bundled subscription.
+Workers KV comes with both the free and the bundled plan.
 
 Learn more at the [Workers KV API reference](/runtime-apis/kv).


### PR DESCRIPTION
Was a small change to say that it's included in both the free and the bundled plan. Wasn't sure about adding the numbers included in the free tier so I just excluded them for now.