### PR TITLE
Added stronger callouts for ScheduledEvent listener

### DIFF
--- a/products/workers/src/content/platform/cron-triggers/index.md
+++ b/products/workers/src/content/platform/cron-triggers/index.md
@@ -12,6 +12,12 @@ Cron Triggers allow users to map a cron expression to a Worker script using a [S
 
 Cron Triggers can be added to scripts with the Cloudflare API, or in the dashboard on a [Workers Triggers tab](https://dash.cloudflare.com/?to=/:account/workers) up to the [per-script limit](/platform/limits). If a script is managed with Wrangler, Cron Triggers should be exclusively managed through the **`wrangler.toml`** file.
 
+<Aside header="Requires a ScheduledEvent Listener">
+
+In order to respond to a Cron Trigger, a [ScheduledEvent](/runtime-apis/scheduled-event) listener must be added to the Workers script. Similar to the Fetch listener, add your code within the Scheduled listener to specify what the Worker should do under the condition that it was triggered by a Cron Trigger.
+
+</Aside>
+
 ![workers-schedule-editor](./media/workers-schedule-editor.png)
 
 ## Supported cron expressions

--- a/products/workers/src/content/runtime-apis/scheduled-event.md
+++ b/products/workers/src/content/runtime-apis/scheduled-event.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The event type for Scheduled requests to a Worker. The `Object` passed through as `event` in [`addEventListener()`](/runtime-apis/add-event-listener).
+A ScheduledEvent is an event type invoked by a [Cron Trigger](/platform/cron-triggers). `Scheduled` is the `Object` passed through as `event` in [`addEventListener()`](/runtime-apis/add-event-listener).
 
 ## Context
 

--- a/products/workers/src/content/runtime-apis/scheduled-event.md
+++ b/products/workers/src/content/runtime-apis/scheduled-event.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-A ScheduledEvent is the event type for scheduled requests to a Worker. It is the `Object` passed through as the `event` when a Worker's `scheduled` [`addEventListener()`](/runtime-apis/add-event-listener) is invoked by a Worker's [Cron Trigger](/platform/cron-triggers)
+A ScheduledEvent is the event type for scheduled requests to a Worker. It is the `Object` passed through as the `event` when a Worker's `scheduled` [`addEventListener()`](/runtime-apis/add-event-listener) is invoked by a Worker's [Cron Trigger](/platform/cron-triggers).
 
 
 ## Context

--- a/products/workers/src/content/runtime-apis/scheduled-event.md
+++ b/products/workers/src/content/runtime-apis/scheduled-event.md
@@ -2,7 +2,8 @@
 
 ## Background
 
-A ScheduledEvent is an event type invoked by a [Cron Trigger](/platform/cron-triggers). `Scheduled` is the `Object` passed through as `event` in [`addEventListener()`](/runtime-apis/add-event-listener).
+A ScheduledEvent is the event type for scheduled requests to a Worker. It is the `Object` passed through as the `event` when a Worker's `scheduled` [`addEventListener()`](/runtime-apis/add-event-listener) is invoked by a Worker's [Cron Trigger](/platform/cron-triggers)
+
 
 ## Context
 


### PR DESCRIPTION
Added an aside in Cron Triggers to create a stronger callout of this requirement that is easier to spot and reference than the background description.

Added small change to ScheduledEvent listener to callout earlier that it works with Cron Triggers.
