### PR TITLE
EIP-695 introduces `eth_chainId`

### DIFF
--- a/products/distributed-web/src/content/ethereum-gateway/interacting-with-the-eth-gateway.md
+++ b/products/distributed-web/src/content/ethereum-gateway/interacting-with-the-eth-gateway.md
@@ -152,6 +152,7 @@ supported.
 | eth_gasPrice | X |
 | eth_accounts | X |
 | eth_blockNumber | X |
+| eth_chainId | X |
 | eth_getBalance | X |
 | eth_getStorageAt | X |
 | eth_getTransactionCount | X |


### PR DESCRIPTION
Cloudflare Ethereum Gateway supports `eth_chainId`, as introduced by [EIP-695](https://eips.ethereum.org/EIPS/eip-695).

## Changes
+ Add `eth_chainId` as a supported JSON-RPC methods to [Cloudflare Ethereum Gateway](https://cloudflare-eth.com).