### PR TITLE
Update DNS over Discord 1.1.1.1 supported DNS record types

### DIFF
--- a/products/1.1.1.1/src/content/fun-stuff/dns-over-discord.md
+++ b/products/1.1.1.1/src/content/fun-stuff/dns-over-discord.md
@@ -34,10 +34,21 @@ Returns:
 DNS over Discord supports the following record types, with `*` being supported to fetch them all:
 
     A
-    NS
-    CNAME
-    MX
-    TXT
     AAAA
-    SRV
     CAA
+    CERT
+    CNAME
+    DNSKEY
+    DS
+    LOC
+    MX
+    NAPTR
+    NS
+    PTR
+    SMIMEA
+    SPF
+    SRV
+    SSHFP
+    TLSA
+    TXT
+    URI


### PR DESCRIPTION
Updates supported DNS record types introduced in MattIPv4/1.1.1.1-Discord@1a6c11a14b8b1b90ed3023bf7be002cc38e1c04c.