### PR TITLE
Fix typo in "Require a specific cookie" page

### DIFF
--- a/products/firewall/src/content/recipes/require-specific-cookie.md
+++ b/products/firewall/src/content/recipes/require-specific-cookie.md
@@ -23,7 +23,7 @@ Since the _Allow_ action has precedence over _Block_, Cloudflare grants access t
     <tr>
       <td>1</td>
       <td><code>(http.cookie contains "devaccess=james" or http.cookie contains "devaccess=matt" or http.cookie contains "devaccess=michael") and http.host eq "dev.www.example.com")</code></td>
-      <td><em>Block</em></td>
+      <td><em>Allow</em></td>
     </tr>
     <tr>
       <td>2</td>


### PR DESCRIPTION
The page cites an example where 3 developers should be allowed to access a dev website.
But the table describes 2 rules that block requests.
This PR replaces "Block" with "Allow" in the first line of the table.