### PR TITLE
[Teams] add one-tutorials component

### DIFF
--- a/products/cloudflare-one/src/content/components/code-block.js
+++ b/products/cloudflare-one/src/content/components/code-block.js
@@ -1,0 +1,121 @@
+import React from "react"
+
+import * as frontMatterParser from "gray-matter"
+
+import Highlight, { defaultProps } from "prism-react-renderer"
+
+import { languageMappings, prismLanguages, transformToken } from "./custom-syntax-highlighting"
+
+// Additional language support (See https://git.io/JJuZX)
+import Prism from "prism-react-renderer/prism"
+(typeof global !== "undefined" ? global : window).Prism = Prism
+require("prismjs/components/prism-toml")
+require("prismjs/components/prism-rust")
+Prism.languages.sh = prismLanguages.sh
+
+const codeBlockClassName = theme => {
+  const themeClassName = theme === "dark" ? "" : " CodeBlock-is-light-in-light-theme"
+  return `CodeBlock CodeBlock-with-rows CodeBlock-scrolls-horizontally${themeClassName}`
+}
+
+const addNewlineToEmptyLine = line => {
+  if (line && line.length === 1 && line[0].empty) {
+    // Improves copy/paste behavior
+    line[0].content = "\n"
+  }
+
+  return line
+}
+
+const CodeBlock = props => {
+  const { className, children } = props.children.props
+
+  if (props.className) {
+    return (<pre {...props}/>)
+  }
+
+  let language = className ? className.split("-")[1] : "js"
+  const mappedLanguage = languageMappings[language]
+  if (mappedLanguage) language = mappedLanguage
+
+  let code = children.trim()
+
+  const tokenProps = ({ children, className, key }) => {
+    const tokens = className.replace("token ", "").split(" ")
+
+    className = ""
+
+    tokens.forEach((token, i) => {
+      token = transformToken({ token, children, language })
+      if (token.indexOf("language-") !== 0) token = `token-${ token }`
+      className += ` CodeBlock--${ token }`
+    })
+
+    className = className.trim()
+
+    return {
+      key,
+      children,
+      className
+    }
+  }
+
+  let codeFrontmatter = {}
+
+  // For now, we don’t support code frontmatter
+  // in Markdown or YAML blocks because they
+  // themselves can contain frontmatter.
+
+  // TODO: find workaround for this limitation
+  if (language !== "markdown" && language !== "yaml") {
+    const parsed = frontMatterParser(code)
+
+    if (Object.keys(parsed.data).length) {
+      code = parsed.content
+      codeFrontmatter = parsed.data
+    }
+  }
+
+  const theme = codeFrontmatter.theme || "light"
+
+  return (
+    <Highlight {...defaultProps} code={code} language={language}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={codeBlockClassName(theme) + " CodeBlock--language-" + language} language={language}>
+          {codeFrontmatter.header && (
+            <span className="CodeBlock--header">{codeFrontmatter.header}</span>
+          )}
+          {codeFrontmatter.filename && !codeFrontmatter.header && (
+            <span className="CodeBlock--filename">{codeFrontmatter.filename}</span>
+          )}
+          <code>
+            <span className="CodeBlock--rows">
+              <span className="CodeBlock--rows-content">
+                {tokens.map((line, i) => (
+                  <span
+                    key={i}
+                    className={"CodeBlock--row" + (
+                      codeFrontmatter.highlight &&
+                      codeFrontmatter.highlight.length &&
+                      codeFrontmatter.highlight.includes(i + 1) ?
+                        " CodeBlock--row-is-highlighted" : ""
+                    )}
+                  >
+                    <span className="CodeBlock--row-indicator"></span>
+                    <span className="CodeBlock--row-content">
+                      {addNewlineToEmptyLine(line).map((token, key) => (
+                        <span key={key} {...tokenProps(getTokenProps({ token, key }))}/>
+                      ))}
+                    </span>
+                  </span>
+                ))}
+              </span>
+            </span>
+          </code>
+        </pre>
+      )}
+    </Highlight>
+  )
+}
+
+export default CodeBlock

--- a/products/cloudflare-one/src/content/components/get-page-title.js
+++ b/products/cloudflare-one/src/content/components/get-page-title.js
@@ -1,0 +1,5 @@
+export default ({ frontmatter, headings }) => {
+  if (!frontmatter) return "Not found"
+
+  return frontmatter.title || (headings.length && headings[0].value)
+}

--- a/products/cloudflare-one/src/content/components/one-tutorials.js
+++ b/products/cloudflare-one/src/content/components/one-tutorials.js
@@ -1,0 +1,116 @@
+import React from "react"
+import { Link, useStaticQuery, graphql } from "gatsby"
+import TimeAgo from "react-timeago"
+
+import getPageTitle from "./get-page-title"
+import css from "../css/one-tutorials.css"
+
+
+const tenDaysInMS = 10 * 24 * 60 * 60 * 1000
+
+const OneTutorials = () => {
+  const query = useStaticQuery(graphql`
+    query {
+      allMdx {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              updated
+              difficulty
+              category
+            }
+            headings(depth: h1) {
+              value
+            }
+            wordCount {
+              words
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const tutorials = query.allMdx.edges
+    .map(({ node }) => node)
+    .filter(page => page.fields.slug.match(/^\/tutorials\/.+/))
+    .map(page => ({
+      title: getPageTitle(page),
+      url: page.fields.slug,
+      updated: page.frontmatter.updated,
+      difficulty: page.frontmatter.difficulty,
+      category: page.frontmatter.category,
+      wordCount: page.wordCount.words,
+      new: (+new Date() - +new Date(page.frontmatter.updated)) < tenDaysInMS
+    }))
+    .sort((a, b) => +new Date(b.updated) - +new Date(a.updated))
+
+  let i = 0
+  let longestWordCount = 0
+
+  for (i = 0; i < tutorials.length; i += 1) {
+    if (tutorials[i].wordCount > longestWordCount) {
+      longestWordCount = tutorials[i].wordCount
+    }
+  }
+
+  for (i = 0; i < tutorials.length; i += 1) {
+    tutorials[i].length = ((tutorials[i].wordCount / longestWordCount) * 100) + "%"
+  }
+
+  return (
+    <div className="OneTutorials">
+      <div className="OneTutorials--header">
+        <div className="OneTutorials--row">
+          <div className="OneTutorials--column" data-column="name">
+            <span className="OneTutorials--column-text">Name</span>
+          </div>
+          <div className="OneTutorials--column" data-column="updated">
+            <span className="OneTutorials--column-text">Updated</span>
+          </div>
+          <div className="OneTutorials--column" data-column="difficulty">
+            <span className="OneTutorials--column-text">Difficulty</span>
+          </div>
+          <div className="OneTutorials--column" data-column="length">
+            <span className="OneTutorials--column-text">Length</span>
+          </div>
+           <div className="OneTutorials--column" data-column="category">
+            <span className="OneTutorials--column-text">Category</span>
+          </div> 
+        </div>
+      </div>
+
+      <div className="OneTutorials--body">
+        {tutorials.map(tutorial => (
+          <div key={tutorial.url} className={"OneTutorials--row" + (tutorial.new ? " OneTutorials--row-is-new" : "")}>
+            <div className="OneTutorials--column" data-column="name">
+              <Link className="OneTutorials--link" to={tutorial.url}>
+                {tutorial.title}
+              </Link>
+            </div>
+            <div className="OneTutorials--column" data-column="updated">
+              <TimeAgo date={tutorial.updated} formatter={(value, unit) => (
+                <React.Fragment>
+                  {value} {unit}{value > 1 ? "s" : ""}<span className="OneTutorials--ago-text"> ago</span>
+                </React.Fragment>
+              )} minPeriod={60}/>
+            </div>
+            <div className="OneTutorials--column" data-column="difficulty">{tutorial.difficulty}</div>
+            <div className="OneTutorials--column" data-column="length">
+              <div className="OneTutorials--length-bar">
+                <div className="OneTutorials--length-bar-inner" style={{width: tutorial.length}}></div>
+              </div>
+            </div>
+            <div className="OneTutorials--column" data-column="category">{tutorial.category}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default OneTutorials

--- a/products/cloudflare-one/src/content/css/one-tutorials.css
+++ b/products/cloudflare-one/src/content/css/one-tutorials.css
@@ -1,0 +1,169 @@
+.OneTutorials {
+  margin: 2em 0;
+  width: 53em;
+  max-width: 100%;
+}
+
+[theme="dark"] .OneTutorials {
+  color: var(--gray-7);
+}
+
+.OneTutorials--row {
+  display: flex;
+  align-items: baseline;
+  --gap: 1.5em;
+  padding-bottom: .5em;
+  border-bottom: 1px solid rgba(var(--color-rgb), .1);
+  margin-bottom: .5em;
+}
+
+.OneTutorials--body .OneTutorials--row:last-child {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+
+.OneTutorials--header .OneTutorials--column-text {
+  font-size: .9em;
+  font-weight: bold;
+}
+
+.OneTutorials--header .OneTutorials--row {
+  border-bottom-width: .125em;
+  padding-bottom: .1875em;
+}
+
+.OneTutorials--body .OneTutorials--column:not([data-column="name"]) {
+  position: relative;
+  top: -.1em;
+}
+
+.OneTutorials--body .OneTutorials--column[data-column="length"] {
+  top: -.2em;
+}
+
+.OneTutorials--column[data-column="name"] {
+  flex: 1;
+  padding-right: calc(var(--gap) / 2);
+}
+
+.OneTutorials--link {
+  position: relative;
+  font-size: 1.2em;
+  color: inherit;
+  --underline-opacity: .75;
+  text-decoration-color: rgba(var(--orange-rgb), var(--underline-opacity));
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+
+[theme="dark"] .OneTutorials--link {
+  --underline-opacity: .5;
+}
+
+.OneTutorials--row-is-new .OneTutorials--link::after {
+  content: "";
+  position: absolute;
+  top: .45em;
+  right: 100%;
+  margin-right: .625em;
+  height: 8px;
+  width: 8px;
+  border-radius: 999em;
+  background: var(--orange);
+}
+
+@media (max-width: 1280px) {
+  .OneTutorials--link {
+    text-decoration: none;
+    box-shadow: inset 0 -2px rgba(var(--orange-rgb), var(--underline-opacity));
+  }
+
+  .OneTutorials--row-is-new .OneTutorials--link::after {
+    top: .375em;
+  }
+}
+
+@media (max-width: 768px) {
+  .OneTutorials--link {
+    font-size: 1.1em;
+  }
+
+  .OneTutorials--row-is-new .OneTutorials--link::after {
+    display: none;
+  }
+}
+
+@media (max-width: 414px) {
+  .OneTutorials--link {
+    font-size: 1em;
+  }
+
+  .OneTutorials--ago-text {
+    display: none;
+  }
+}
+
+[js-focus-visible-polyfill-available] .OneTutorials--link:focus {
+  outline: none;
+}
+
+.OneTutorials--link[is-focus-visible] {
+  --underline-size: 0;
+}
+
+.OneTutorials--link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+
+.OneTutorials--column[data-column="updated"] {
+  padding-left: calc(var(--gap) / 2);
+  text-align: "center";
+  padding-right: calc(var(--gap) / 2);
+}
+
+.OneTutorials--column[data-column="difficulty"] {
+  width: 7.5em;
+  padding-left: calc(var(--gap) / 2);
+  padding-right: calc(var(--gap) / 2);
+  text-align: "center";
+  flex-shrink: 0;
+}
+
+.OneTutorials--column[data-column="category"] {
+  width: 13.5em;
+  padding-left: calc(var(--gap) / 2);
+  padding-right: calc(var(--gap) / 2);
+  flex-shrink: 0;
+}
+
+.OneTutorials--column[data-column="length"] {
+  width: 4.5em;
+  padding-left: calc(var(--gap) / 2);
+  flex-shrink: 0;
+}
+
+.OneTutorials--length-bar {
+  width: 100%;
+  height: .5em;
+  border-radius: 1em;
+  background: rgba(var(--color-rgb), .1);
+  overflow: hidden;
+}
+
+.OneTutorials--length-bar-inner {
+  background: rgba(var(--color-rgb), .5);
+  border-radius: 1em;
+  min-width: .6em;
+  height: 100%;
+}
+
+@media (max-width: 1024px) {
+  .OneTutorials--column[data-column="updated"] {
+    padding-right: 0;
+  }
+
+  .OneTutorials--column[data-column="difficulty"],
+  .OneTutorials--column[data-column="category"],
+  .OneTutorials--column[data-column="length"] {
+    display: none;
+  }
+}

--- a/products/cloudflare-one/src/content/glossary/index.md
+++ b/products/cloudflare-one/src/content/glossary/index.md
@@ -2,7 +2,7 @@
 order: 10
 ---
 
-# Teams Glossary
+# Teams glossary
 
 ## [Cloudflare for Teams](https://www.cloudflare.com/teams-home/)
 Cloudflare for Teams brings the power of Cloudflare’s global network to your internal teams and infrastructure. Teams empowers users with secure, fast and seamless access to any device on the Internet.

--- a/products/cloudflare-one/src/content/index.md
+++ b/products/cloudflare-one/src/content/index.md
@@ -14,10 +14,7 @@ Your employees, partners, and customers need a network that is secure, fast and 
 
 Cloudflare for Teams provides seamless access to any application and the Internet from any device, anywhere.
 
-If you want to learn more about Teams, you can explore our:
-
-* [Tutorials](/tutorials) on how to make the most out of your Teams subscription
-* [Learning materials](/learning) to get accustomed to our products
+If you want to learn more about Teams, you can explore our [tutorials](/tutorials) on how to make the most out of your Teams subscription.
 
 If you want to learn more about a specific Teams product, navigate to each product's developer documentation:
 

--- a/products/cloudflare-one/src/content/learning/index.md
+++ b/products/cloudflare-one/src/content/learning/index.md
@@ -1,5 +1,6 @@
 ---
 order: 2
+hidden: true
 ---
 
 # Learning

--- a/products/cloudflare-one/src/content/secure-origin-connections/credentials-only.md
+++ b/products/cloudflare-one/src/content/secure-origin-connections/credentials-only.md
@@ -1,0 +1,95 @@
+---
+order: 2
+---
+
+# Connect without long-lived API keys
+
+You can use [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to connect applications and servers to Cloudflare's network without leaving sensitive API keys lingering in your environment. These applications can be both public-facing or protected by [Cloudflare Access](https://developers.cloudflare.com/access/).
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from a server to Cloudflare
+* Keep that connection running after deleting the initial authentication file
+* Give that application a hostname where users can reach the resource
+
+**⏲️Time to complete: ~20 minutes**
+
+## Install `cloudflared`
+
+In this example, the resource being connected is a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313` - an address only available currently on the same machine as the server.
+
+![New Hugo](../../static/secure-origin-connections/share-new-site/hugo-new.png)
+
+To share this work-in-progress with an audience on the Internet, start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file, called `cert.pem` to authenticate this instance of `cloudflared`. The `cert.pem` file uses a certificate to authenticate your instance of `cloudflared` and includes an API key for your account to perform actions like DNS record changes.
+
+You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose. This command requires the `cert.pem` file.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Delete the `cert.pem` file
+
+The credentials file is separate from the `cert.pem` file. Unlike the `cert.pem` file, the credentials file consists of a token that authenticates only the Named Tunnel you just created. Formatted as `JSON`, the file cannot make changes to your Cloudflare account or create additional Tunnels.
+
+If you are done creating Tunnels, you can delete the `cert.pem` file, leave only the credentials file, and continue to manage DNS records directly in the Cloudflare dashboard or API. For additional information on the different functions of the two files, see the table in [this section](https://developers.cloudflare.com/argo-tunnel/create-tunnel#create-a-tunnel).
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to your local development environment. You can use a configuration file to do so, which makes it easier to start `cloudflared` in the future.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `url` value is the destination where the new website is available locally. The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+url: http://localhost:1313
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/username/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+```
+
+If you are using the credentials file without the `cert.pem` file, you must specify the Tunnel ID in the `tunnel:` value. You cannot use the Name alone with the credentials file.
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to your local server, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/share-new-site/add-dns.png)
+
+Alternatively, you can create a DNS record from `cloudflared` directly.
+
+Once saved, you can share the subdomain created and visitors can reach your local web server environment.

--- a/products/cloudflare-one/src/content/secure-origin-connections/index.md
+++ b/products/cloudflare-one/src/content/secure-origin-connections/index.md
@@ -1,0 +1,8 @@
+---
+order: 3
+hidden: true
+---
+
+# Secure Origin Connections
+
+<DirectoryListing path="/tutorials/secure-origin-connections"/>

--- a/products/cloudflare-one/src/content/secure-origin-connections/multi-origin.md
+++ b/products/cloudflare-one/src/content/secure-origin-connections/multi-origin.md
@@ -1,0 +1,101 @@
+---
+order: 3
+---
+
+# Connect multiple HTTP origins
+
+You can use [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to connect applications and servers to Cloudflare's network. Argo Tunnel relies on a piece of software, `cloudflared`, to create those connections. You can deploy a single instance of `cloudflared` to proxy traffic to multiple destinations for multiple hostnames.
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from a machine to Cloudflare for multiple applications
+* Give those applications hostnames where users can connect
+
+**⏲️Time to complete: ~10 minutes**
+
+## Install `cloudflared`
+
+In this example, two resources are running and need to be connected to the Internet:
+
+* a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313`.
+* Grafana, a charting application. Grafana is available at `localhost:3000`
+
+Start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file, called `cert.pem` to authenticate this instance of `cloudflared`. The `cert.pem` file uses a certificate to authenticate your instance of `cloudflared` and includes an API key for your account to perform actions like DNS record changes.
+
+You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose. This command requires the `cert.pem` file.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel. This Tunnel will represent both applications and both hostnames.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to both applications for multiple hostnames using [ingress rules](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel/ingress). You must use a configuration file to do so.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/samrhea/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+
+ingress:
+  - hostname: grafana.widgetcorp.tech
+    service: http://localhost:3000
+  - hostname: blog.widgetcorp.tech
+    service: http://localhost:1313
+  # Catch-all rule, which just responds with 404 if traffic doesn't match any of
+  # the earlier rules
+  - service: http_status:404
+```
+
+The configuration above will send traffic received for `grafana` to the Grafana address and traffic bound for `blog` to the Hugo address. The last service rule specifies a catch-all which will respond to requests that do not meet the previous rules. You must include a catch-all. In this case, the catch-all returns a 404.
+
+You can run the following command to validate the configuration file before you start your tunnel. If an error is present, `cloudflared` will alert you first.
+
+`$ cloudflared tunnel validate`
+
+If you are using the credentials file without the `cert.pem` file, you must specify the Tunnel ID in the `tunnel:` value. You cannot use the Name alone with the credentials file.
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to both applications, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`. Repeat this process for the second subdomain - they will both share the same Tunnel address.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/multi-origin/multi-origin-dns.png)
+
+Once saved, you can share the subdomain created and visitors can reach both applications.

--- a/products/cloudflare-one/src/content/secure-origin-connections/share-new-site.md
+++ b/products/cloudflare-one/src/content/secure-origin-connections/share-new-site.md
@@ -1,0 +1,121 @@
+---
+order: 1
+---
+
+# Share development environments
+
+You can use Cloudflare's reverse proxy and [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to share local development environments with team members or customers.
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from an application running locally on a Mac laptop
+* Give that application a hostname where users can reach the resource
+* Optionally require a simple login to reach the application with Cloudflare Access
+
+**⏲️Time to complete: ~30 minutes**
+
+Instead of pointing DNS records to the external IP of a web service, you can connect that service to Cloudflare's network using Argo Tunnel. Argo Tunnel relies on a lightweight service, `cloudflared`, that you run in your infrastructure. `cloudflared` makes outbound-only connections to Cloudflare's network, so that you do not need to open holes in your firewall.
+
+You can use Argo Tunnel to quickly share projects you are working on with team members. In this example, you can use Argo Tunnel to give users a preview of a new website. At the end, as an optional step, you'll be able to add a Cloudflare Access policy to only allow certain people to reach the site.
+
+| Before you start |
+|---|
+| 1. [Add a website to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-Creating-a-Cloudflare-account-and-adding-a-website) |
+| 2. [Change your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/205195708) |
+| 3. [Enable Argo Smart Routing for your account](https://support.cloudflare.com/hc/articles/115000224552-Configuring-Argo-through-the-UI)  |
+
+## Install `cloudflared`
+
+In this example, the new website is a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313` - an address only available currently on the same machine as the server.
+
+![New Hugo](../../static/secure-origin-connections/share-new-site/hugo-new.png)
+
+To share this work-in-progress with an audience on the Internet, start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file to authenticate this instance of `cloudflared`. You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to your local development environment. You can use a configuration file to do so, which makes it easier to start `cloudflared` in the future.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `url` value is the destination where the new website is available locally. The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+url: http://localhost:1313
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/username/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+```
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to your local server, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/share-new-site/add-dns.png)
+
+Alternatively, you can create a DNS record from `cloudflared` directly.
+
+Once saved, you can share the subdomain created and visitors can reach your local web server environment.
+
+## Optional: Add an Access policy
+
+When you create the DNS record, any visitor will be able to view that new site. You can restrict the audience to certain users by adding a rule in Cloudflare Access. You can also build this Access rule before creating the DNS record so that the site is never accessible to the rest of the Internet.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+Once enabled, navigate to the `Applications` page in the Cloudflare for Teams dashboard. Click `Add an application`.
+
+![Applications Page](../../static/secure-origin-connections/share-new-site/applications.png)
+
+Choose self-hosted from the options presented.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/self-hosted.png)
+
+In the policy builder, add the subdomain of your new DNS record that represents your Argo Tunnel connection.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/configure-app.png)
+
+You can then add rules to determine who can reach the site.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/add-rules.png)
+
+## Additional Materials
+
+* You can use this model to [share more complex development environments](https://blog.cloudflare.com/how-argo-tunnel-engineering-uses-argo-tunnel/) with other team members.

--- a/products/cloudflare-one/src/content/secure-web-gateway/block-uploads.md
+++ b/products/cloudflare-one/src/content/secure-web-gateway/block-uploads.md
@@ -1,0 +1,112 @@
+---
+order: 3
+---
+
+# Block file uploads to Google Drive
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to prevent enrolled devices from uploading files to an unapproved cloud storage provider.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a Gateway policy to block file uploads to a specific provider
+* Enroll devices into a Cloudflare for Teams account where this rule will be enforced
+* Log file type upload attempts
+
+**⏲️Time to complete: ~45 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform file type control, you will need one of the following subscriptions:
+
+* Teams Standard
+* Gateway
+
+## Determine which devices can enroll
+
+To block file types from corporate devices, those devices must run the Cloudflare WARP client and [be enrolled in your Teams account](https://developers.cloudflare.com/gateway/connecting-to-gateway). When devices enroll, users will be prompted to authenticate with your identity provider or a consumer identity service. You can also deploy via MDM.
+
+First, you will need to determine which devices can enroll. To begin, you will need to enable Cloudflare Access for your account. Cloudflare Access provides the identity integration to enroll users. This feature of Cloudflare Access is available in the Teams Free plan or in the Gateway plan at no additional cost. Follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to add Access and integrate a free identity option or a specific provider.
+
+Next, build a rule to decide which devices can enroll into your Gateway account. Navigate to the `Devices` page in the `My Teams` section of the sidebar.
+
+![Device List](../../static/secure-web-gateway/secure-dns-devices/device-page.png)
+
+Click `Device Settings` to build the enrollment rule. In the policy, define who should be allowed to enroll a device and click `Save`.
+
+![Enroll Rule](../../static/secure-web-gateway/secure-dns-devices/enroll-rule.png)
+
+## Enroll a device
+
+You can use the WARP client to enroll a device into your security policies. Follow the [instructions here](https://developers.cloudflare.com/warp-client/setting-up) to install the client depending on your device type. Cloudflare Gateway does not need a special version of the client.
+
+Once installed, click the gear icon.
+
+![WARP](../../static/secure-web-gateway/secure-dns-devices/warp.png)
+
+Under the `Account` tab, click `Login with Cloudflare for Teams`.
+
+![Account View](../../static/secure-web-gateway/secure-dns-devices/account-view.png)
+
+Input your Cloudflare for Teams org name. You will have created this during the Cloudflare Access setup flow. You can find it under the `Authentication` tab in the `Access` section of the sidebar.
+
+![Org Name](../../static/secure-web-gateway/secure-dns-devices/org-name.png)
+
+The user will be prompted to login with the identity provider configured in Cloudflare Access. Once authenticated, the client will update to `Teams` mode. You can click the gear to toggle between DNS filtering or full proxy. In this use case, you must toggle to `Gateway with WARP`.
+
+![Confirm WARP](../../static/secure-web-gateway/block-uploads/with-warp.png)
+
+## Configure the Cloudflare certificate
+
+To inspect traffic, Cloudflare Gateway requires that a [certificate be installed](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert) on enrolled devices. You can also distribute this certificate through an MDM provider. The example below follows a manual distribution flow.
+
+Download the Cloudflare certificate provided in the [instructions here](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert). You can also find the certificate in the Cloudflare for Teams dashboard. Navigate to the `Account` page in the `Settings` section of the sidebar and scroll to the bottom.
+
+Next, follow [these instructions](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert) to install the certificate on your system.
+
+Once the certificate has been installed, you can configure Gateway to inspect HTTP traffic. To do so, navigate to the `Policies` page in the Gateway section. Scroll to the bottom and toggle `Proxy Settings` to enabled.
+
+![Add Policy](../../static/secure-web-gateway/block-uploads/filter-toggle.png)
+
+## Create a Gateway HTTP policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-http-policy) that will block file uploads to Google Drive. Navigate to the `Policies` page. On the HTTP tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/block-uploads/add-policy.png)
+
+Uploading files to Google Drive consists of `POST` and `PUT` methods made to `clients6.google.com`. To block Google Drive uploads, block these methods to that host.
+
+In the rule builder, add `Host is drive.google.com` and a second rule where `HTTP Method is POST`. Choose the Block action. Click `Save`.
+
+![Block POST](../../static/secure-web-gateway/block-uploads/block-post.png)
+
+Add a second policy, replacing `POST` with `PUT`.
+
+![Block PUT](../../static/secure-web-gateway/block-uploads/block-put.png)
+
+You should now see both policies in the `Policies` view.
+
+![All Policies](../../static/secure-web-gateway/block-uploads/all-policies.png)
+
+<Aside>
+
+Alternatively, you can block all POST and PUT methods to `google.com` subdomains in the event that the `clients6` subdomain changes. However, this may block other Google functionality.
+
+</Aside>
+
+## Test policy
+
+You can test the policy by attempting to upload a file to Google Drive. Google Drive should return an error message when blocked.
+
+![Block Action](../../static/secure-web-gateway/block-uploads/block-result.png)
+
+## View Logs
+
+Once enabled, if a user attempts to upload a file you can view logs of the block.
+
+Navigate to the `Logs` section of the sidebar and choose `Gateway`. Open the Filter action and select `Block` from the dropdown under `Decision`.
+
+![Block Action](../../static/secure-web-gateway/block-uploads/block-logs.png)
+
+## Optional: Deploy via MDM
+
+You can deploy the WARP client on corporate devices in a way that does not require users to configure the Org Name. To do so, [follow these instructions](https://developers.cloudflare.com/warp-client/teams).

--- a/products/cloudflare-one/src/content/secure-web-gateway/index.md
+++ b/products/cloudflare-one/src/content/secure-web-gateway/index.md
@@ -1,0 +1,8 @@
+---
+order: 2
+hidden: true
+---
+
+# Secure Web Gateway
+
+<DirectoryListing path="/tutorials/secure-web-gateway"/>

--- a/products/cloudflare-one/src/content/secure-web-gateway/review-gateway-block.md
+++ b/products/cloudflare-one/src/content/secure-web-gateway/review-gateway-block.md
@@ -1,0 +1,63 @@
+---
+order: 1
+---
+
+# Review Gateway blocks
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to filter and log DNS queries from devices on any network. You can also use Cloudflare Radar to review why a site has been blocked.
+
+**🗺️ This tutorial covers how to:**
+
+* Review DNS filtering logs in Cloudflare Gateway
+* Review the reason a domain was blocked in Cloudflare Radar
+* Submit categorization feedback
+
+**⏲️Time to complete: ~5 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+You can follow [these instructions](/secure-web-gateway/secure-dns-devices) to configure Gateway DNS filtering on roaming devices and [these instructions](/secure-web-gateway/secure-dns-network) for home or office networks.
+
+## Review Gateway events
+
+Once deployed, you can review which policies apply to which locations in the `Policies` page of the `Gateway` section in the Cloudflare for Teams dashboard.
+
+![Policies](../../static/secure-web-gateway/review-gateway-block/policies.png)
+
+To see how these impact real traffic, navigate to the `Gateway` page in the `Logs` section.
+
+![Logs](../../static/secure-web-gateway/review-gateway-block/logs-unfiltered.png)
+
+You can filter by date and by decision type. Select `Block` as the type to review blocked events.
+
+![Blocks Filter](../../static/secure-web-gateway/review-gateway-block/blocks-filter.png)
+
+## Review block reason
+
+You can select any of the events in the logs view to review the initial reason for the block. In this example, the policy configured blocks Social Media, which is the category that `facebook.com` belongs to.
+
+![Blocks Filter](../../static/secure-web-gateway/review-gateway-block/facebook-row.png)
+
+You can review more information in Cloudflare Radar, Cloudflare's Internet security and trends tool. Click `View domain details` to launch the Radar page for the hostname selected.
+
+![Radar](../../static/secure-web-gateway/review-gateway-block/facebook-row.png)
+
+You can review information like site ranking, certificate history, and WHOIS information. If you believe the site was not categorized appropriately, click `Submit Categorization Feedback` beneath the `Content Categories` section.
+
+## Override a rule
+
+If you need to allow a specific hostname immediately, you can override a hostname in a rule that takes precedence over content or security categories.
+
+Navigate to the policy being applied and click `Edit`. Select the `Custom` tab of the policy.
+
+![Custom](../../static/secure-web-gateway/review-gateway-block/custom.png)
+
+Click `Add a destination`. In the next screen, select the `Allow` button and input the hostname that should override the category-based policies. Click save. This hostname will now resolve even if blocked by a content or security policy.
+
+![Custom](../../static/secure-web-gateway/review-gateway-block/override.png)

--- a/products/cloudflare-one/src/content/secure-web-gateway/secure-dns-devices.md
+++ b/products/cloudflare-one/src/content/secure-web-gateway/secure-dns-devices.md
@@ -1,0 +1,92 @@
+---
+order: 1
+---
+
+# Filter DNS on devices
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to filter and log DNS queries from devices on any network.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a DNS filtering policy that secures devices by blocking malicious hostnames
+* Apply that policy to devices on any network
+
+**⏲️Time to complete: ~45 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+## Create a Default Location
+
+When you [enable Cloudflare Gateway](https://developers.cloudflare.com/gateway/getting-started) for the first time, you will be prompted to configure your first location. You can use that Location to represent a physical office and/or roaming users.
+
+Start by navigating to the `Locations` page in the `Gateway` section of the sidebar. You will see the first location that you added has been set as the Default. Any device that enrolls into your Gateway account will follow the policies set for the Default location by using the `DNS over HTTPS` address.
+
+![Add DNS](../../static/secure-web-gateway/secure-dns-devices/locations.png)
+
+If you wish to [use a different Location](https://developers.cloudflare.com/gateway/getting-started/configuring-locations) as your Default, and subsequently the one used for roaming devices, click `Add a location`. During location creation, toggle the `Default location` toggle and the new location will be the Default.
+
+![New Default](../../static/secure-web-gateway/secure-dns-devices/new-default.png)
+
+## Create a Gateway policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-dns-policy) that will filter DNS queries for known malicious hostnames and other types of threats. Navigate to the `Policies` page. On the DNS tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/secure-dns-devices/add-policy.png)
+
+Assign the policy a name and choose which locations will adhere to this policy. In this example, `Austin Office` is the only location and also the Default. Any devices which enroll will be grouped into this location using its `DNS over HTTPS` hostname.
+
+![Apply Policy](../../static/secure-web-gateway/secure-dns-devices/apply-policy.png)
+
+Under the `Security threats` tab you can toggle which types of threats to block. In this case, choosing `Block all` will toggle all threats to be blocked.
+
+![Block Rules](../../static/secure-web-gateway/secure-dns-devices/block-rules.png)
+
+You can also configure content or custom blocks. Once complete, click `Save`.
+
+## Determine which devices can enroll
+
+Now that you have a Default location and DNS filtering policy, you can [begin to enroll devices](https://developers.cloudflare.com/gateway/connecting-to-gateway). When devices enroll, users will be prompted to authenticate with your identity provider or a consumer identity service. By authenticating, you can attribute devices and DNS queries to users while also limiting who can enroll.
+
+To begin, you will need to enable Cloudflare Access for your account. Cloudflare Access provides the identity integration to enroll users. This feature of Cloudflare Access is available in the Teams Free plan or in the Gateway plan at no additional cost. Follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to add Access and integrate a free identity option or a specific provider.
+
+Next, build a rule to decide which devices can enroll into your Gateway account. Navigate to the `Devices` page in the `My Teams` section of the sidebar.
+
+![Device List](../../static/secure-web-gateway/secure-dns-devices/device-page.png)
+
+Click `Device Settings` to build the enrollment rule. In the policy, define who should be allowed to enroll a device and click `Save`.
+
+![Enroll Rule](../../static/secure-web-gateway/secure-dns-devices/enroll-rule.png)
+
+## Enroll a device
+
+You can use the WARP client to enroll a device into your security policies. Follow the [instructions here](https://developers.cloudflare.com/warp-client/setting-up) to install the client depending on your device type. Cloudflare Gateway does not need a special version of the client.
+
+Once installed, click the gear icon.
+
+![WARP](../../static/secure-web-gateway/secure-dns-devices/warp.png)
+
+Under the `Account` tab, click `Login with Cloudflare for Teams`.
+
+![Account View](../../static/secure-web-gateway/secure-dns-devices/account-view.png)
+
+Input your Cloudflare for Teams org name. You will have created this during the Cloudflare Access setup flow. You can find it under the `Authentication` tab in the `Access` section of the sidebar.
+
+![Org Name](../../static/secure-web-gateway/secure-dns-devices/org-name.png)
+
+The user will be prompted to login with the identity provider configured in Cloudflare Access. Once authenticated, the client will update to `Teams` mode. You can click the gear to toggle between DNS filtering or full proxy. In this use case, you only need DNS filtering.
+
+![DoH](../../static/secure-web-gateway/secure-dns-devices/with-doh.png)
+
+You can confirm that the device is using the default location under the `Connection` tab. The DoH address will match that of the Default location.
+
+![Confirm DoH](../../static/secure-web-gateway/secure-dns-devices/doh-subdomain.png)
+
+## Optional: Deploy via MDM
+
+You can deploy the WARP client on corporate devices in a way that does not require users to configure the Org Name. To do so, [follow these instructions](https://developers.cloudflare.com/warp-client/teams).

--- a/products/cloudflare-one/src/content/secure-web-gateway/secure-dns-network.md
+++ b/products/cloudflare-one/src/content/secure-web-gateway/secure-dns-network.md
@@ -1,0 +1,64 @@
+---
+order: 2
+---
+
+# Filter DNS on home or office network
+
+You can use Cloudflare Gateway to filter and log DNS queries from any device using your network without installing client software.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a DNS filtering policy that secures a home or office network by blocking malicious hostnames
+* Review logs and events that occur on that network
+
+**⏲️Time to complete: ~15 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+## Add a location
+
+During the Gateway onboarding flow, the dashboard will prompt you to configure a location for the IP you are currently using. Gateway will automatically detect the IP of your current network and assign it to the location being created.
+
+If you want to create a different location, one that you are not currently using, you can add a new location from the `Locations` page in the `Gateway` Section.
+
+![Add Location](../../static/secure-web-gateway/secure-dns-network/add-location.png)
+
+## Create a Gateway policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-dns-policy) that will filter DNS queries for known malicious hostnames and other types of threats. Navigate to the `Policies` page. On the DNS tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/secure-dns-devices/add-policy.png)
+
+Assign the policy a name and choose which locations will adhere to this policy. In this example, `Austin Office` is the only location and also the Default.
+
+![Apply Policy](../../static/secure-web-gateway/secure-dns-devices/apply-policy.png)
+
+Under the `Security threats` tab you can toggle which types of threats to block. In this case, choosing `Block all` will toggle all threats to be blocked.
+
+![Block Rules](../../static/secure-web-gateway/secure-dns-devices/block-rules.png)
+
+You can also configure content or custom blocks. Once complete, click `Save`. The policy will now filter DNS queries from that location once you have configured your router.
+
+## Configure your router
+
+You will need to make a one-time change to your router to use Cloudflare Gateway for DNS filtering for all devices in your network.
+
+Instructions to change your router's DNS settings are available in the Cloudflare for Teams dashboard. Navigate to the `Locations` page and expand the location you want to configure. Click `Setup instructions`.
+
+![Expand Location](../../static/secure-web-gateway/secure-dns-network/expand-location.png)
+
+The default toggle presented will be `Router`. Follow the instructions on the page to change your router settings. Additional instructions are available for routers from specific manufacturers in the [documentation here](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/router).
+
+![Expand Location](../../static/secure-web-gateway/secure-dns-network/router-instructions.png)
+
+## Review events
+
+Once configured, you can review DNS queries made from your network in the Gateway overview page.
+
+![Gateway Overview](../../static/secure-web-gateway/secure-dns-network/gateway-overview.png)

--- a/products/cloudflare-one/src/content/tutorials/block-uploads/index.md
+++ b/products/cloudflare-one/src/content/tutorials/block-uploads/index.md
@@ -1,0 +1,114 @@
+---
+updated: 2020-11-17
+difficulty: Beginner
+category: Secure Web Gateway
+---
+
+# Block file uploads to Google Drive
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to prevent enrolled devices from uploading files to an unapproved cloud storage provider.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a Gateway policy to block file uploads to a specific provider
+* Enroll devices into a Cloudflare for Teams account where this rule will be enforced
+* Log file type upload attempts
+
+**⏲️Time to complete: ~45 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform file type control, you will need one of the following subscriptions:
+
+* Teams Standard
+* Gateway
+
+## Determine which devices can enroll
+
+To block file types from corporate devices, those devices must run the Cloudflare WARP client and [be enrolled in your Teams account](https://developers.cloudflare.com/gateway/connecting-to-gateway). When devices enroll, users will be prompted to authenticate with your identity provider or a consumer identity service. You can also deploy via MDM.
+
+First, you will need to determine which devices can enroll. To begin, you will need to enable Cloudflare Access for your account. Cloudflare Access provides the identity integration to enroll users. This feature of Cloudflare Access is available in the Teams Free plan or in the Gateway plan at no additional cost. Follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to add Access and integrate a free identity option or a specific provider.
+
+Next, build a rule to decide which devices can enroll into your Gateway account. Navigate to the `Devices` page in the `My Teams` section of the sidebar.
+
+![Device List](../../static/secure-web-gateway/secure-dns-devices/device-page.png)
+
+Click `Device Settings` to build the enrollment rule. In the policy, define who should be allowed to enroll a device and click `Save`.
+
+![Enroll Rule](../../static/secure-web-gateway/secure-dns-devices/enroll-rule.png)
+
+## Enroll a device
+
+You can use the WARP client to enroll a device into your security policies. Follow the [instructions here](https://developers.cloudflare.com/warp-client/setting-up) to install the client depending on your device type. Cloudflare Gateway does not need a special version of the client.
+
+Once installed, click the gear icon.
+
+![WARP](../../static/secure-web-gateway/secure-dns-devices/warp.png)
+
+Under the `Account` tab, click `Login with Cloudflare for Teams`.
+
+![Account View](../../static/secure-web-gateway/secure-dns-devices/account-view.png)
+
+Input your Cloudflare for Teams org name. You will have created this during the Cloudflare Access setup flow. You can find it under the `Authentication` tab in the `Access` section of the sidebar.
+
+![Org Name](../../static/secure-web-gateway/secure-dns-devices/org-name.png)
+
+The user will be prompted to login with the identity provider configured in Cloudflare Access. Once authenticated, the client will update to `Teams` mode. You can click the gear to toggle between DNS filtering or full proxy. In this use case, you must toggle to `Gateway with WARP`.
+
+![Confirm WARP](../../static/secure-web-gateway/block-uploads/with-warp.png)
+
+## Configure the Cloudflare certificate
+
+To inspect traffic, Cloudflare Gateway requires that a [certificate be installed](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert) on enrolled devices. You can also distribute this certificate through an MDM provider. The example below follows a manual distribution flow.
+
+Download the Cloudflare certificate provided in the [instructions here](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert). You can also find the certificate in the Cloudflare for Teams dashboard. Navigate to the `Account` page in the `Settings` section of the sidebar and scroll to the bottom.
+
+Next, follow [these instructions](https://developers.cloudflare.com/gateway/connecting-to-gateway/install-cloudflare-cert) to install the certificate on your system.
+
+Once the certificate has been installed, you can configure Gateway to inspect HTTP traffic. To do so, navigate to the `Policies` page in the Gateway section. Scroll to the bottom and toggle `Proxy Settings` to enabled.
+
+![Add Policy](../../static/secure-web-gateway/block-uploads/filter-toggle.png)
+
+## Create a Gateway HTTP policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-http-policy) that will block file uploads to Google Drive. Navigate to the `Policies` page. On the HTTP tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/block-uploads/add-policy.png)
+
+Uploading files to Google Drive consists of `POST` and `PUT` methods made to `clients6.google.com`. To block Google Drive uploads, block these methods to that host.
+
+In the rule builder, add `Host is drive.google.com` and a second rule where `HTTP Method is POST`. Choose the Block action. Click `Save`.
+
+![Block POST](../../static/secure-web-gateway/block-uploads/block-post.png)
+
+Add a second policy, replacing `POST` with `PUT`.
+
+![Block PUT](../../static/secure-web-gateway/block-uploads/block-put.png)
+
+You should now see both policies in the `Policies` view.
+
+![All Policies](../../static/secure-web-gateway/block-uploads/all-policies.png)
+
+<Aside>
+
+Alternatively, you can block all POST and PUT methods to `google.com` subdomains in the event that the `clients6` subdomain changes. However, this may block other Google functionality.
+
+</Aside>
+
+## Test policy
+
+You can test the policy by attempting to upload a file to Google Drive. Google Drive should return an error message when blocked.
+
+![Block Action](../../static/secure-web-gateway/block-uploads/block-result.png)
+
+## View Logs
+
+Once enabled, if a user attempts to upload a file you can view logs of the block.
+
+Navigate to the `Logs` section of the sidebar and choose `Gateway`. Open the Filter action and select `Block` from the dropdown under `Decision`.
+
+![Block Action](../../static/secure-web-gateway/block-uploads/block-logs.png)
+
+## Optional: Deploy via MDM
+
+You can deploy the WARP client on corporate devices in a way that does not require users to configure the Org Name. To do so, [follow these instructions](https://developers.cloudflare.com/warp-client/teams).

--- a/products/cloudflare-one/src/content/tutorials/credentials-only/index.md
+++ b/products/cloudflare-one/src/content/tutorials/credentials-only/index.md
@@ -1,0 +1,97 @@
+---
+updated: 2020-11-17
+difficulty: Intermediate
+category: Secure Origin Connections
+---
+
+# Connect without long-lived API keys
+
+You can use [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to connect applications and servers to Cloudflare's network without leaving sensitive API keys lingering in your environment. These applications can be both public-facing or protected by [Cloudflare Access](https://developers.cloudflare.com/access/).
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from a server to Cloudflare
+* Keep that connection running after deleting the initial authentication file
+* Give that application a hostname where users can reach the resource
+
+**⏲️Time to complete: ~20 minutes**
+
+## Install `cloudflared`
+
+In this example, the resource being connected is a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313` - an address only available currently on the same machine as the server.
+
+![New Hugo](../../static/secure-origin-connections/share-new-site/hugo-new.png)
+
+To share this work-in-progress with an audience on the Internet, start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file, called `cert.pem` to authenticate this instance of `cloudflared`. The `cert.pem` file uses a certificate to authenticate your instance of `cloudflared` and includes an API key for your account to perform actions like DNS record changes.
+
+You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose. This command requires the `cert.pem` file.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Delete the `cert.pem` file
+
+The credentials file is separate from the `cert.pem` file. Unlike the `cert.pem` file, the credentials file consists of a token that authenticates only the Named Tunnel you just created. Formatted as `JSON`, the file cannot make changes to your Cloudflare account or create additional Tunnels.
+
+If you are done creating Tunnels, you can delete the `cert.pem` file, leave only the credentials file, and continue to manage DNS records directly in the Cloudflare dashboard or API. For additional information on the different functions of the two files, see the table in [this section](https://developers.cloudflare.com/argo-tunnel/create-tunnel#create-a-tunnel).
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to your local development environment. You can use a configuration file to do so, which makes it easier to start `cloudflared` in the future.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `url` value is the destination where the new website is available locally. The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+url: http://localhost:1313
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/username/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+```
+
+If you are using the credentials file without the `cert.pem` file, you must specify the Tunnel ID in the `tunnel:` value. You cannot use the Name alone with the credentials file.
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to your local server, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/share-new-site/add-dns.png)
+
+Alternatively, you can create a DNS record from `cloudflared` directly.
+
+Once saved, you can share the subdomain created and visitors can reach your local web server environment.

--- a/products/cloudflare-one/src/content/tutorials/gitlab/index.md
+++ b/products/cloudflare-one/src/content/tutorials/gitlab/index.md
@@ -1,0 +1,296 @@
+---
+updated: 2020-11-17
+difficulty: Intermediate
+category: Zero-Trust Security
+---
+
+# Secure GitLab with Zero Trust Rules for SSH and HTTP
+
+You can use Cloudflare Access to add Zero Trust rules to a self-hosted instance of GitLab. Combined with Argo Tunnel, users can connect through HTTP and SSH and authenticate with your team's identity provider.
+
+**🗺️ This walkthrough covers how to:**
+
+* Deploy an instance of GitLab
+* Lock down all inbound connections to that instance and use Argo Tunnel to set outbound connections to Cloudflare
+* Build policies with Cloudflare Access to control who can reach GitLab
+* Connect over HTTP and SSH through Cloudflare
+
+**⏲️Time to complete: 1 hour**
+
+---
+
+## Deploying GitLab
+
+This section walks through deploying GitLab in Digital Ocean. If you have already deployed GitLab, you can skip this section.
+
+Create a Droplet that has 16 GB of RAM and 6 CPUs. This should make it possible to support 500 users, based on [GitLab's resource recommendations](https://docs.gitlab.com/ee/install/requirements.html).
+
+![Create Droplet](../../static/zero-trust-security/gitlab/create-droplet.png)
+
+GitLab will provide an external IP that is exposed to the Internet (for now). You will need to connect to the deployed server using this external IP for the initial configuration. You can secure connections to the IP by [adding SSH keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2) to your Digital Ocean account.
+
+This example uses a macOS machine to configure the Droplet. Copy the IP address assigned to the machine from Digital Ocean.
+
+![Machine IP](../../static/zero-trust-security/gitlab/show-ip.png)
+
+Open Terminal and run the following command, replacing the IP address with the IP assigned by Digital Ocean.
+
+```bash
+$ ssh root@134.209.124.123
+```
+
+Next, install GitLab. This example uses the [Ubuntu package](https://about.gitlab.com/install/#ubuntu) and the steps in the GitLab documentation, with a few exceptions called out below.
+
+Run the following commands to begin.
+
+```bash
+sudo apt-get update
+
+sudo apt-get install -y curl openssh-server ca-certificates
+curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | sudo bash
+```
+
+The commands above download the GitLab software to this machine. You must now install it. This is the first place this tutorial will diverge from the operations in the GitLab documentation. The next step in the GitLab-provided tutorial sets an external hostname. Instead, you can just install the software.
+
+```bash
+sudo apt-get install gitlab-ee
+```
+
+After a minute or so, GitLab will be installed.
+
+![Install GitLab](../../static/zero-trust-security/gitlab/install-gitlab.png)
+
+However, the application is not running yet. You can check to see what ports are listening to confirm by installing and using `netstat`.
+
+```bash
+sudo apt-get install net-tools
+sudo netstat -tulpn | grep LISTEN
+```
+
+The result should be only the services currently active on the machine:
+
+![Just Services](../../static/zero-trust-security/gitlab/just-services.png)
+
+To start GitLab, run the software's reconfigure command.
+
+```bash
+sudo gitlab-ctl reconfigure
+```
+
+GitLab will launch its component services. Once complete, confirm that GitLab is running and listening on both ports 22 and 80.
+
+![GitLab Services](../../static/zero-trust-security/gitlab/gitlab-services.png)
+
+Users connect to GitLab over SSH (port 22 here) and HTTP for the web app (port 80). In the next step, you will make it possible for users to try both through Cloudflare Access. I'll leave this running and head over to the Cloudflare dashboard.
+
+## Securing GitLab with Zero Trust rules
+
+### Building Access policies
+
+You can use Cloudflare Access to build Zero Trust rules to determine who can connect to both the web application of GitLab (HTTP) and who can connect over SSH.
+
+When a user makes a request to a site protected by Access, that request hits Cloudflare's network first. Access can then check if the user is allowed to reach the application. When integrated with Argo Tunnel, the zero-trust architecture looks like this:
+
+![GitLab Services](../../static/zero-trust-security/gitlab/teams-diagram.png)
+
+To determine who can reach the application, Cloudflare Access relies on integration with identity providers like Okta or AzureAD or Google to issue the identity cards that get checked at the door. While a VPN allows users free range on a private network unless someone builds an active rule to stop them, Access enforces that identity check on every request (and at any granularity configured).
+
+For GitLab, start by building two policies. Users will connect to GitLab in a couple of methods: in the web app and over SSH. Create policies to secure a subdomain for each. First, the web app.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+Once enabled, navigate to the `Applications` page in the Cloudflare for Teams dashboard. Click `Add an application`.
+
+![Applications Page](../../static/secure-origin-connections/share-new-site/applications.png)
+
+Choose self-hosted from the options presented.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/policy.png)
+
+In the policy builder, you will be prompted to add a subdomain that will represent the resource. This must be a subdomain of a domain in your Cloudflare account. You will need separate subdomains for the web application and SSH flows.
+
+This example uses `gitlab.widgetcorp.tech` for the web application and `gitlab-ssh.widgetcorp.tech` for SSH connectivity.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/configure-app.png)
+
+While on this page, you can decide which identity providers will be allowed to authenticate. By default, all configured providers are allowed. Click `Next` to build rules to determine who can reach the application.
+
+You can then add rules to determine who can reach the site.
+
+![Add Rules](../../static/secure-origin-connections/share-new-site/add-rules.png)
+
+Click `Next` and `Next` again on the `Setup` page - this example does not require advanced CORS configuration. Repeat these steps for the second application, `gitlab-ssh.widgetcorp.tech`.
+
+![App List](../../static/secure-origin-connections/gitlab/app-list.png)
+
+
+## Cloudflare Argo Tunnel
+
+Cloudflare Argo Tunnel creates a secure, outbound-only, connection between this machine and Cloudflare's network. With an outbound-only model, you can  prevent any direct access to this machine and lock down any externally exposed points of ingress. And with that, no open firewall ports.
+
+Argo Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the Digital Ocean machine with the two commands below.
+
+```bash
+sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
+sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+```
+
+Once installed, authenticate the instance of `cloudflared` with the following command.
+
+`cloudflared login`
+
+The command will print a URL that you must visit to login with your Cloudflare account.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/leave-running.png)
+
+Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file to authenticate this instance of `cloudflared`. You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+### Connecting to Cloudflare
+
+You can now connect GitLab to Cloudflare using Argo Tunnel.
+
+First, create a new Tunnel by running the following command.
+
+```bash
+cloudflared tunnel create gitlab
+```
+
+`cloudflared` will generate a unique ID for this Tunnel. You can use this Tunnel both for SSH and HTTP traffic.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/tunnel-create.png)
+
+Next, you will need to configure Argo Tunnel to proxy traffic to both destinations. The configuration below will take traffic bound for the DNS record that will be created for the web app and the DNS record to represent SSH traffic to the right port.
+
+You use the text editor of your choice to edit the configuration file. The example relies on `Vi`.
+
+```bash
+vim ~/.cloudflared/config.yml
+```
+
+Next,
+
+```yml
+tunnel: 6ff42ae2-765d-4adf-8112-31c55c1551ef
+credentials-file: /root/.cloudflared/6ff42ae2-765d-4adf-8112-31c55c1551ef.json
+
+ingress:
+  - hostname: gitlab.widgetcorp.tech
+    service: http://localhost:80
+  - hostname: gitlab-ssh.widgetcorp.tech
+    service: ssh://localhost:22
+  # Catch-all rule, which just responds with 404 if traffic doesn't match any of
+  # the earlier rules
+  - service: http_status:404
+```
+
+![Self Hosted](../../static/zero-trust-security/gitlab/config-file.png)
+
+You can test that the configuration file is set correctly with the following command.
+
+```bash
+cloudflared tunnel ingress validate
+```
+
+`cloudflared` should indicate the Tunnel is okay. You can now begin running the Tunnel.
+
+```bash
+cloudflared tunnel run
+```
+
+![Tunnel Run](../../static/zero-trust-security/gitlab/tunnel-run.png)
+
+<Aside>
+
+This command should be run as a `systemd` service for long-term use; if it terminates, GitLab will be unavailable.
+
+</Aside>
+
+### Configure DNS records
+
+You can now create DNS records for GitLab in the Cloudflare dashboard. Remember, you will still need two records - one for the web application and one for SSH traffic.
+
+In the DNS tab, choose the website where you built your Access policies. Click `+Add record` and select `CNAME` from type. In the `Name` field, input `gitlab`. In the `Target` field, input the ID of the Tunnel created followed by `cfargotunnel.com`. In this example, that value is:
+
+```
+6ff42ae2-765d-4adf-8112-31c55c1551ef.cfargotunnel.com
+```
+
+![Add DNS](../../static/zero-trust-security/gitlab/add-dns.png)
+
+Click `Save`. Repeat the process again by creating a second `CNAME` record, with the same `Target`, but input `gitlab-ssh` for the `Name`. Both records should then appear, pointing to the same Tunnel. The ingress rules defined in the configuration file above will direct traffic to the appropriate port.
+
+![View DNS](../../static/zero-trust-security/gitlab/view-dns.png)
+
+### Connecting to the web application
+
+You can now test the end-to-end configuration for the web application. Visit the subdomain created for the web application. Cloudflare Access will prompt you to authenticate. Login with your provider.
+
+![Access Login](../../static/zero-trust-security/gitlab/access-login.png)
+
+Once authenticated, you should see the GitLab web application.
+
+![GitLab Web](../../static/zero-trust-security/gitlab/gitlab-web.png)
+
+Register your own account and create a Blank project to test SSH in the next step.
+
+![Blank Project](../../static/zero-trust-security/gitlab/blank-project.png)
+
+GitLab will create a new project and repository.
+
+![New Project](../../static/zero-trust-security/gitlab/new-project.png)
+
+<Aside>
+
+To pull or push code, you must also add an SSH key to your profile in GitLab.
+
+</Aside>
+
+### Configuring SSH
+
+To push and pull code over SSH, you will need to install `cloudflared` on the client machine as well. This example uses a macOS laptop. On macOS, you can install `cloudflared` with the following command.
+
+```
+$ brew install cloudflare/cloudflare/cloudflared
+```
+
+While you need to install `cloudflared`, you do not need to wrap your SSH commands in any unique way. Instead, you will need to make a one-time change to your SSH configuration file.
+
+```bash
+vim /Users/samrhea/.ssh/config
+```
+
+Input the following values; replacing `gitlab-ssh.widgetcorp.tech` with the hostname you created.
+
+```bash
+Host gitlab-ssh.widgetcorp.tech
+  ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
+```
+You can now test the SSH flow by attempting to clone the project created earlier.
+
+```bash
+$ git clone git@gitlab-ssh.widgetcorp.tech:samrhea/demo
+```
+
+`cloudflared` will prompt you to login with my identity provider and, once successful, issue a token to your device to allow you to authenticate.
+
+![GitLab Clone](../../static/zero-trust-security/gitlab/git-clone.png)
+
+### Lock down exposed ports
+
+You can now configure your Digital Ocean firewall with a single rule, block any inbound traffic, to prevent direct access.
+
+![Download Cert](../../static/zero-trust-security/gitlab/disable-ingress.png)
+
+Argo Tunnel will continue to run outbound-only connections and I can avoid this machine getting caught up in a crypto mining operation, or something worse.
+
+## View logs
+
+You can also view logs of the events that are allowed and blocked. Open the `Access` page of the `Logs` section in the Cloudflare for Teams dashboard.
+
+![View Logs](../../static/zero-trust-security/gitlab/view-logs.png)

--- a/products/cloudflare-one/src/content/tutorials/index.md
+++ b/products/cloudflare-one/src/content/tutorials/index.md
@@ -1,7 +1,12 @@
 ---
+type: overview
 order: 0
+hideChildren: true
 ---
 
 # Teams tutorials
 
-<DirectoryListing path="/tutorials"/>
+import OneTutorials from "../components/one-tutorials.js"
+
+<OneTutorials/>
+

--- a/products/cloudflare-one/src/content/tutorials/multi-origin/index.md
+++ b/products/cloudflare-one/src/content/tutorials/multi-origin/index.md
@@ -1,0 +1,103 @@
+---
+updated: 2020-11-17
+difficulty: Intermediate
+category: Secure Origin Connections
+---
+
+# Connect multiple HTTP origins
+
+You can use [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to connect applications and servers to Cloudflare's network. Argo Tunnel relies on a piece of software, `cloudflared`, to create those connections. You can deploy a single instance of `cloudflared` to proxy traffic to multiple destinations for multiple hostnames.
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from a machine to Cloudflare for multiple applications
+* Give those applications hostnames where users can connect
+
+**⏲️Time to complete: ~10 minutes**
+
+## Install `cloudflared`
+
+In this example, two resources are running and need to be connected to the Internet:
+
+* a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313`.
+* Grafana, a charting application. Grafana is available at `localhost:3000`
+
+Start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file, called `cert.pem` to authenticate this instance of `cloudflared`. The `cert.pem` file uses a certificate to authenticate your instance of `cloudflared` and includes an API key for your account to perform actions like DNS record changes.
+
+You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose. This command requires the `cert.pem` file.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel. This Tunnel will represent both applications and both hostnames.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to both applications for multiple hostnames using [ingress rules](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel/ingress). You must use a configuration file to do so.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/samrhea/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+
+ingress:
+  - hostname: grafana.widgetcorp.tech
+    service: http://localhost:3000
+  - hostname: blog.widgetcorp.tech
+    service: http://localhost:1313
+  # Catch-all rule, which just responds with 404 if traffic doesn't match any of
+  # the earlier rules
+  - service: http_status:404
+```
+
+The configuration above will send traffic received for `grafana` to the Grafana address and traffic bound for `blog` to the Hugo address. The last service rule specifies a catch-all which will respond to requests that do not meet the previous rules. You must include a catch-all. In this case, the catch-all returns a 404.
+
+You can run the following command to validate the configuration file before you start your tunnel. If an error is present, `cloudflared` will alert you first.
+
+`$ cloudflared tunnel validate`
+
+If you are using the credentials file without the `cert.pem` file, you must specify the Tunnel ID in the `tunnel:` value. You cannot use the Name alone with the credentials file.
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to both applications, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`. Repeat this process for the second subdomain - they will both share the same Tunnel address.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/multi-origin/multi-origin-dns.png)
+
+Once saved, you can share the subdomain created and visitors can reach both applications.

--- a/products/cloudflare-one/src/content/tutorials/require-specific-country/index.md
+++ b/products/cloudflare-one/src/content/tutorials/require-specific-country/index.md
@@ -1,0 +1,56 @@
+---
+updated: 2020-11-17
+difficulty: Beginner
+category: Zero-Trust Security
+---
+
+# Require specific countries
+
+You can use Cloudflare Access to require team members to connect to self-hosted or SaaS applications from a list of approved countries.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+**🗺️ This walkthrough covers how to:**
+
+* Create a list of approved countries where a team operates
+* Require that users connecting to self-hosted or SaaS applications connect from those countries
+
+**⏲️Time to complete: ~5 minutes**
+
+## Create an approved country list
+
+Navigate to the `Groups` page in the `My Teams` section of the Cloudflare for Teams dashboard. Click `Add a Group`.
+
+Groups contain criteria that you can reuse in Access policies. Additionally, groups can allow you to nest certain operators inside of rules in the Access policy.
+
+For example, `Include` rules work like `OR` operators - anything in the list will meet the criteria. However, if you include values in the Require field, these work like `AND` operators. Since you cannot connect from multiple countries at the same time, you must use a group to define a list of options that can be used inside of a `Require` rule in the policy.
+
+![Initial Groups](../../static/zero-trust-security/country-rules/starter-groups.png)
+
+Click `Add a Group`. In the next page, select `Country` from the `Include` dropdown and add two or more countries.
+
+![Add Countries](../../static/zero-trust-security/country-rules/country-list.png)
+
+Click `Save`.
+
+![Full Groups](../../static/zero-trust-security/country-rules/later-groups.png)
+
+## Build a policy
+
+You can now build Access policies that will require at least one country in the approved countries list. Navigate to the `Applications` page in the `Access` section of the Cloudflare for Teams dashboard.
+
+![Apps](../../static/zero-trust-security/country-rules/app-list.png)
+
+You can build this rule for SaaS or self-hosted applications. This example will add the requirement to an existing application, but you can also add it when creating a new application.
+
+Choose an application and click `Edit`.
+
+![Edit](../../static/zero-trust-security/country-rules/before-rules.png)
+
+Select the existing rule and click `Edit`.
+
+Click `+ Add require`. In the dropdown, select `Access groups`. The existing groups will display and choose the name of the group with the approved countries list.
+
+![Edit](../../static/zero-trust-security/country-rules/add-rule.png)
+
+Cloudflare Access will follow the nesting of the group created. In this case, the `Require` rule will require that all of the conditions be met - like an `AND` operator. Since the group has multiple country options,because it was constructed with an `Include` rule like an `OR` operator, meeting at least one of them will be true and allow the user to proceed.

--- a/products/cloudflare-one/src/content/tutorials/review-gateway-blocks/index.md
+++ b/products/cloudflare-one/src/content/tutorials/review-gateway-blocks/index.md
@@ -1,0 +1,65 @@
+---
+updated: 2020-12-01
+difficulty: Beginner
+category: Secure Web Gateway
+---
+
+# Review Gateway blocks
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to filter and log DNS queries from devices on any network. You can also use Cloudflare Radar to review why a site has been blocked.
+
+**🗺️ This tutorial covers how to:**
+
+* Review DNS filtering logs in Cloudflare Gateway
+* Review the reason a domain was blocked in Cloudflare Radar
+* Submit categorization feedback
+
+**⏲️Time to complete: ~5 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+You can follow [these instructions](/secure-web-gateway/secure-dns-devices) to configure Gateway DNS filtering on roaming devices and [these instructions](/secure-web-gateway/secure-dns-network) for home or office networks.
+
+## Review Gateway events
+
+Once deployed, you can review which policies apply to which locations in the `Policies` page of the `Gateway` section in the Cloudflare for Teams dashboard.
+
+![Policies](../../static/secure-web-gateway/review-gateway-block/policies.png)
+
+To see how these impact real traffic, navigate to the `Gateway` page in the `Logs` section.
+
+![Logs](../../static/secure-web-gateway/review-gateway-block/logs-unfiltered.png)
+
+You can filter by date and by decision type. Select `Block` as the type to review blocked events.
+
+![Blocks Filter](../../static/secure-web-gateway/review-gateway-block/blocks-filter.png)
+
+## Review block reason
+
+You can select any of the events in the logs view to review the initial reason for the block. In this example, the policy configured blocks Social Media, which is the category that `facebook.com` belongs to.
+
+![Blocks Filter](../../static/secure-web-gateway/review-gateway-block/facebook-row.png)
+
+You can review more information in Cloudflare Radar, Cloudflare's Internet security and trends tool. Click `View domain details` to launch the Radar page for the hostname selected.
+
+![Radar](../../static/secure-web-gateway/review-gateway-block/facebook-row.png)
+
+You can review information like site ranking, certificate history, and WHOIS information. If you believe the site was not categorized appropriately, click `Submit Categorization Feedback` beneath the `Content Categories` section.
+
+## Override a rule
+
+If you need to allow a specific hostname immediately, you can override a hostname in a rule that takes precedence over content or security categories.
+
+Navigate to the policy being applied and click `Edit`. Select the `Custom` tab of the policy.
+
+![Custom](../../static/secure-web-gateway/review-gateway-block/custom.png)
+
+Click `Add a destination`. In the next screen, select the `Allow` button and input the hostname that should override the category-based policies. Click save. This hostname will now resolve even if blocked by a content or security policy.
+
+![Custom](../../static/secure-web-gateway/review-gateway-block/override.png)

--- a/products/cloudflare-one/src/content/tutorials/secure-dns-network/index.md
+++ b/products/cloudflare-one/src/content/tutorials/secure-dns-network/index.md
@@ -1,0 +1,66 @@
+---
+updated: 2020-11-17
+difficulty: Beginner
+category: Secure Web Gateway
+---
+
+# Filter DNS on home or office network
+
+You can use Cloudflare Gateway to filter and log DNS queries from any device using your network without installing client software.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a DNS filtering policy that secures a home or office network by blocking malicious hostnames
+* Review logs and events that occur on that network
+
+**⏲️Time to complete: ~15 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+## Add a location
+
+During the Gateway onboarding flow, the dashboard will prompt you to configure a location for the IP you are currently using. Gateway will automatically detect the IP of your current network and assign it to the location being created.
+
+If you want to create a different location, one that you are not currently using, you can add a new location from the `Locations` page in the `Gateway` Section.
+
+![Add Location](../../static/secure-web-gateway/secure-dns-network/add-location.png)
+
+## Create a Gateway policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-dns-policy) that will filter DNS queries for known malicious hostnames and other types of threats. Navigate to the `Policies` page. On the DNS tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/secure-dns-devices/add-policy.png)
+
+Assign the policy a name and choose which locations will adhere to this policy. In this example, `Austin Office` is the only location and also the Default.
+
+![Apply Policy](../../static/secure-web-gateway/secure-dns-devices/apply-policy.png)
+
+Under the `Security threats` tab you can toggle which types of threats to block. In this case, choosing `Block all` will toggle all threats to be blocked.
+
+![Block Rules](../../static/secure-web-gateway/secure-dns-devices/block-rules.png)
+
+You can also configure content or custom blocks. Once complete, click `Save`. The policy will now filter DNS queries from that location once you have configured your router.
+
+## Configure your router
+
+You will need to make a one-time change to your router to use Cloudflare Gateway for DNS filtering for all devices in your network.
+
+Instructions to change your router's DNS settings are available in the Cloudflare for Teams dashboard. Navigate to the `Locations` page and expand the location you want to configure. Click `Setup instructions`.
+
+![Expand Location](../../static/secure-web-gateway/secure-dns-network/expand-location.png)
+
+The default toggle presented will be `Router`. Follow the instructions on the page to change your router settings. Additional instructions are available for routers from specific manufacturers in the [documentation here](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/router).
+
+![Expand Location](../../static/secure-web-gateway/secure-dns-network/router-instructions.png)
+
+## Review events
+
+Once configured, you can review DNS queries made from your network in the Gateway overview page.
+
+![Gateway Overview](../../static/secure-web-gateway/secure-dns-network/gateway-overview.png)

--- a/products/cloudflare-one/src/content/tutorials/secure-dns-services/index.md
+++ b/products/cloudflare-one/src/content/tutorials/secure-dns-services/index.md
@@ -1,0 +1,94 @@
+---
+updated: 2020-11-24
+difficulty: Beginner
+category: Secure Web Gateway
+---
+
+# Filter DNS on devices
+
+You can use Cloudflare Gateway and the Cloudflare WARP client application to filter and log DNS queries from devices on any network.
+
+**🗺️ This tutorial covers how to:**
+
+* Create a DNS filtering policy that secures devices by blocking malicious hostnames
+* Apply that policy to devices on any network
+
+**⏲️Time to complete: ~45 minutes**
+
+## Configure Cloudflare Gateway
+
+Before you begin, you'll need to follow [these instructions](https://developers.cloudflare.com/gateway/getting-started/onboarding-gateway) to set up Cloudflare Gateway in your account. To perform DNS filtering, you need one of the following subscriptions:
+
+* Teams Free
+* Teams Standard
+* Gateway
+
+## Create a Default Location
+
+When you [enable Cloudflare Gateway](https://developers.cloudflare.com/gateway/getting-started) for the first time, you will be prompted to configure your first location. You can use that Location to represent a physical office and/or roaming users.
+
+Start by navigating to the `Locations` page in the `Gateway` section of the sidebar. You will see the first location that you added has been set as the Default. Any device that enrolls into your Gateway account will follow the policies set for the Default location by using the `DNS over HTTPS` address.
+
+![Add DNS](../../static/secure-web-gateway/secure-dns-devices/locations.png)
+
+If you wish to [use a different Location](https://developers.cloudflare.com/gateway/getting-started/configuring-locations) as your Default, and subsequently the one used for roaming devices, click `Add a location`. During location creation, toggle the `Default location` toggle and the new location will be the Default.
+
+![New Default](../../static/secure-web-gateway/secure-dns-devices/new-default.png)
+
+## Create a Gateway policy
+
+Next, you can [build a policy](https://developers.cloudflare.com/gateway/getting-started/configuring-dns-policy) that will filter DNS queries for known malicious hostnames and other types of threats. Navigate to the `Policies` page. On the DNS tab, click `Add a policy`.
+
+![Add Policy](../../static/secure-web-gateway/secure-dns-devices/add-policy.png)
+
+Assign the policy a name and choose which locations will adhere to this policy. In this example, `Austin Office` is the only location and also the Default. Any devices which enroll will be grouped into this location using its `DNS over HTTPS` hostname.
+
+![Apply Policy](../../static/secure-web-gateway/secure-dns-devices/apply-policy.png)
+
+Under the `Security threats` tab you can toggle which types of threats to block. In this case, choosing `Block all` will toggle all threats to be blocked.
+
+![Block Rules](../../static/secure-web-gateway/secure-dns-devices/block-rules.png)
+
+You can also configure content or custom blocks. Once complete, click `Save`.
+
+## Determine which devices can enroll
+
+Now that you have a Default location and DNS filtering policy, you can [begin to enroll devices](https://developers.cloudflare.com/gateway/connecting-to-gateway). When devices enroll, users will be prompted to authenticate with your identity provider or a consumer identity service. By authenticating, you can attribute devices and DNS queries to users while also limiting who can enroll.
+
+To begin, you will need to enable Cloudflare Access for your account. Cloudflare Access provides the identity integration to enroll users. This feature of Cloudflare Access is available in the Teams Free plan or in the Gateway plan at no additional cost. Follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to add Access and integrate a free identity option or a specific provider.
+
+Next, build a rule to decide which devices can enroll into your Gateway account. Navigate to the `Devices` page in the `My Teams` section of the sidebar.
+
+![Device List](../../static/secure-web-gateway/secure-dns-devices/device-page.png)
+
+Click `Device Settings` to build the enrollment rule. In the policy, define who should be allowed to enroll a device and click `Save`.
+
+![Enroll Rule](../../static/secure-web-gateway/secure-dns-devices/enroll-rule.png)
+
+## Enroll a device
+
+You can use the WARP client to enroll a device into your security policies. Follow the [instructions here](https://developers.cloudflare.com/warp-client/setting-up) to install the client depending on your device type. Cloudflare Gateway does not need a special version of the client.
+
+Once installed, click the gear icon.
+
+![WARP](../../static/secure-web-gateway/secure-dns-devices/warp.png)
+
+Under the `Account` tab, click `Login with Cloudflare for Teams`.
+
+![Account View](../../static/secure-web-gateway/secure-dns-devices/account-view.png)
+
+Input your Cloudflare for Teams org name. You will have created this during the Cloudflare Access setup flow. You can find it under the `Authentication` tab in the `Access` section of the sidebar.
+
+![Org Name](../../static/secure-web-gateway/secure-dns-devices/org-name.png)
+
+The user will be prompted to login with the identity provider configured in Cloudflare Access. Once authenticated, the client will update to `Teams` mode. You can click the gear to toggle between DNS filtering or full proxy. In this use case, you only need DNS filtering.
+
+![DoH](../../static/secure-web-gateway/secure-dns-devices/with-doh.png)
+
+You can confirm that the device is using the default location under the `Connection` tab. The DoH address will match that of the Default location.
+
+![Confirm DoH](../../static/secure-web-gateway/secure-dns-devices/doh-subdomain.png)
+
+## Optional: Deploy via MDM
+
+You can deploy the WARP client on corporate devices in a way that does not require users to configure the Org Name. To do so, [follow these instructions](https://developers.cloudflare.com/warp-client/teams).

--- a/products/cloudflare-one/src/content/tutorials/share-new-site/index.md
+++ b/products/cloudflare-one/src/content/tutorials/share-new-site/index.md
@@ -1,0 +1,123 @@
+---
+updated: 2020-11-17
+difficulty: Intermediate
+category: Secure Origin Connections
+---
+
+# Share development environments
+
+You can use Cloudflare's reverse proxy and [Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/) to share local development environments with team members or customers.
+
+**🗺️ This tutorial covers how to:**
+
+* Start a secure, outbound-only, connection from an application running locally on a Mac laptop
+* Give that application a hostname where users can reach the resource
+* Optionally require a simple login to reach the application with Cloudflare Access
+
+**⏲️Time to complete: ~30 minutes**
+
+Instead of pointing DNS records to the external IP of a web service, you can connect that service to Cloudflare's network using Argo Tunnel. Argo Tunnel relies on a lightweight service, `cloudflared`, that you run in your infrastructure. `cloudflared` makes outbound-only connections to Cloudflare's network, so that you do not need to open holes in your firewall.
+
+You can use Argo Tunnel to quickly share projects you are working on with team members. In this example, you can use Argo Tunnel to give users a preview of a new website. At the end, as an optional step, you'll be able to add a Cloudflare Access policy to only allow certain people to reach the site.
+
+| Before you start |
+|---|
+| 1. [Add a website to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-Creating-a-Cloudflare-account-and-adding-a-website) |
+| 2. [Change your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/205195708) |
+| 3. [Enable Argo Smart Routing for your account](https://support.cloudflare.com/hc/articles/115000224552-Configuring-Argo-through-the-UI)  |
+
+## Install `cloudflared`
+
+In this example, the new website is a [Hugo site](https://gohugo.io/getting-started/quick-start/). Hugo, a static site generator, provides a built-in server that can be used for testing changes. That server is available at `localhost:1313` - an address only available currently on the same machine as the server.
+
+![New Hugo](../../static/secure-origin-connections/share-new-site/hugo-new.png)
+
+To share this work-in-progress with an audience on the Internet, start by [downloading and installing](https://developers.cloudflare.com/argo-tunnel/getting-started/installation) the Argo Tunnel daemon, `cloudflared`. On Mac, you can do so by running the following `brew` command. If you do not have Homebrew, follow the [documentation here](https://docs.brew.sh/Installation) to install it.
+
+`$ brew install cloudflare/cloudflare/cloudflared`
+
+Once installed, run the following command in your Terminal to authenticate this instance of `cloudflared` into your Cloudflare account.
+
+`$ cloudflared login`
+
+The command will launch a browser window and prompt you to login with your Cloudflare account. Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file to authenticate this instance of `cloudflared`. You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+## Create a Tunnel
+
+You can now [create an Argo Tunnel](https://developers.cloudflare.com/argo-tunnel/create-tunnel) that will connect `cloudflared` to Cloudflare's edge. You'll configure the details of that Tunnel in the next step.
+
+Run the following command to create a Tunnel. You can replace `new-website` with any name that you choose.
+
+`$ cloudflared tunnel create new-website`
+
+Cloudflare will create the Tunnel with that name and generate an ID and credentials file for that Tunnel.
+
+![New Tunnel](../../static/secure-origin-connections/share-new-site/create.png)
+
+## Configure `cloudflared`
+
+You can now [configure](https://developers.cloudflare.com/argo-tunnel/configuration) `cloudflared` to route traffic to your local development environment. You can use a configuration file to do so, which makes it easier to start `cloudflared` in the future.
+
+By default, `cloudflared` expects the configuration file at a specific location: `~/.cloudflared/config.yml`. You can modify this location if you want. For this example, we'll keep the default. Create or edit your configuration file using a text editor.
+
+`$ vim ~/.cloudflared/config.yml`
+
+The `url` value is the destination where the new website is available locally. The `tunnel` and `credentials-file` value can be copied from the output of the last command.
+
+```yml
+url: http://localhost:1313
+tunnel: 5157d321-5933-4b30-938b-d889ca87e11b
+credentials-file: /Users/username/.cloudflared/5157d321-5933-4b30-938b-d889ca87e11b.json
+```
+
+## Run Argo Tunnel
+
+At this point, you have created and configured your Argo Tunnel connection. You can now [run that](https://developers.cloudflare.com/argo-tunnel/create-tunnel) Tunnel. Running it will create connections to Cloudflare's edge. Those connections will not respond to traffic, yet. You'll add DNS records in the next step to share the resource across the Internet.
+
+`$ cloudflared tunnel run`
+
+## Create DNS records
+
+You can now [route traffic](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel) to your Tunnel, and on to your local server, using Cloudflare DNS. Visit the [Cloudflare dashboard](https://dash.cloudflare.com), select a website, and click on the `DNS` tab.
+
+Click `+Add record` and choose `CNAME`. In the `Name` field, add the name of the subdomain of your new site. In the `Content` field, paste the ID of your Tunnel created earlier and append `cfargotunnel.com`.
+
+`5157d321-5933-4b30-938b-d889ca87e11b.cfargotunnel.com`
+
+![Add DNS](../../static/secure-origin-connections/share-new-site/add-dns.png)
+
+Alternatively, you can create a DNS record from `cloudflared` directly.
+
+Once saved, you can share the subdomain created and visitors can reach your local web server environment.
+
+## Optional: Add an Access policy
+
+When you create the DNS record, any visitor will be able to view that new site. You can restrict the audience to certain users by adding a rule in Cloudflare Access. You can also build this Access rule before creating the DNS record so that the site is never accessible to the rest of the Internet.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+Once enabled, navigate to the `Applications` page in the Cloudflare for Teams dashboard. Click `Add an application`.
+
+![Applications Page](../../static/secure-origin-connections/share-new-site/applications.png)
+
+Choose self-hosted from the options presented.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/self-hosted.png)
+
+In the policy builder, add the subdomain of your new DNS record that represents your Argo Tunnel connection.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/configure-app.png)
+
+You can then add rules to determine who can reach the site.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/add-rules.png)
+
+## Additional Materials
+
+* You can use this model to [share more complex development environments](https://blog.cloudflare.com/how-argo-tunnel-engineering-uses-argo-tunnel/) with other team members.

--- a/products/cloudflare-one/src/content/zero-trust-security/country-rules.md
+++ b/products/cloudflare-one/src/content/zero-trust-security/country-rules.md
@@ -1,0 +1,54 @@
+---
+order: 2
+---
+
+# Require specific countries
+
+You can use Cloudflare Access to require team members to connect to self-hosted or SaaS applications from a list of approved countries.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+**🗺️ This walkthrough covers how to:**
+
+* Create a list of approved countries where a team operates
+* Require that users connecting to self-hosted or SaaS applications connect from those countries
+
+**⏲️Time to complete: ~5 minutes**
+
+## Create an approved country list
+
+Navigate to the `Groups` page in the `My Teams` section of the Cloudflare for Teams dashboard. Click `Add a Group`.
+
+Groups contain criteria that you can reuse in Access policies. Additionally, groups can allow you to nest certain operators inside of rules in the Access policy.
+
+For example, `Include` rules work like `OR` operators - anything in the list will meet the criteria. However, if you include values in the Require field, these work like `AND` operators. Since you cannot connect from multiple countries at the same time, you must use a group to define a list of options that can be used inside of a `Require` rule in the policy.
+
+![Initial Groups](../../static/zero-trust-security/country-rules/starter-groups.png)
+
+Click `Add a Group`. In the next page, select `Country` from the `Include` dropdown and add two or more countries.
+
+![Add Countries](../../static/zero-trust-security/country-rules/country-list.png)
+
+Click `Save`.
+
+![Full Groups](../../static/zero-trust-security/country-rules/later-groups.png)
+
+## Build a policy
+
+You can now build Access policies that will require at least one country in the approved countries list. Navigate to the `Applications` page in the `Access` section of the Cloudflare for Teams dashboard.
+
+![Apps](../../static/zero-trust-security/country-rules/app-list.png)
+
+You can build this rule for SaaS or self-hosted applications. This example will add the requirement to an existing application, but you can also add it when creating a new application.
+
+Choose an application and click `Edit`.
+
+![Edit](../../static/zero-trust-security/country-rules/before-rules.png)
+
+Select the existing rule and click `Edit`.
+
+Click `+ Add require`. In the dropdown, select `Access groups`. The existing groups will display and choose the name of the group with the approved countries list.
+
+![Edit](../../static/zero-trust-security/country-rules/add-rule.png)
+
+Cloudflare Access will follow the nesting of the group created. In this case, the `Require` rule will require that all of the conditions be met - like an `AND` operator. Since the group has multiple country options,because it was constructed with an `Include` rule like an `OR` operator, meeting at least one of them will be true and allow the user to proceed.

--- a/products/cloudflare-one/src/content/zero-trust-security/gitlab.md
+++ b/products/cloudflare-one/src/content/zero-trust-security/gitlab.md
@@ -1,0 +1,293 @@
+---
+order: 1
+---
+# Secure GitLab with Zero Trust Rules for SSH and HTTP
+
+You can use Cloudflare Access to add Zero Trust rules to a self-hosted instance of GitLab. Combined with Argo Tunnel, users can connect through HTTP and SSH and authenticate with your team's identity provider.
+
+**🗺️ This walkthrough covers how to:**
+
+* Deploy an instance of GitLab
+* Lock down all inbound connections to that instance and use Argo Tunnel to set outbound connections to Cloudflare
+* Build policies with Cloudflare Access to control who can reach GitLab
+* Connect over HTTP and SSH through Cloudflare
+
+**⏲️Time to complete: 1 hour**
+
+---
+
+## Deploying GitLab
+
+This section walks through deploying GitLab in Digital Ocean. If you have already deployed GitLab, you can skip this section.
+
+Create a Droplet that has 16 GB of RAM and 6 CPUs. This should make it possible to support 500 users, based on [GitLab's resource recommendations](https://docs.gitlab.com/ee/install/requirements.html).
+
+![Create Droplet](../../static/zero-trust-security/gitlab/create-droplet.png)
+
+GitLab will provide an external IP that is exposed to the Internet (for now). You will need to connect to the deployed server using this external IP for the initial configuration. You can secure connections to the IP by [adding SSH keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2) to your Digital Ocean account.
+
+This example uses a macOS machine to configure the Droplet. Copy the IP address assigned to the machine from Digital Ocean.
+
+![Machine IP](../../static/zero-trust-security/gitlab/show-ip.png)
+
+Open Terminal and run the following command, replacing the IP address with the IP assigned by Digital Ocean.
+
+```bash
+$ ssh root@134.209.124.123
+```
+
+Next, install GitLab. This example uses the [Ubuntu package](https://about.gitlab.com/install/#ubuntu) and the steps in the GitLab documentation, with a few exceptions called out below.
+
+Run the following commands to begin.
+
+```bash
+sudo apt-get update
+
+sudo apt-get install -y curl openssh-server ca-certificates
+curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | sudo bash
+```
+
+The commands above download the GitLab software to this machine. You must now install it. This is the first place this tutorial will diverge from the operations in the GitLab documentation. The next step in the GitLab-provided tutorial sets an external hostname. Instead, you can just install the software.
+
+```bash
+sudo apt-get install gitlab-ee
+```
+
+After a minute or so, GitLab will be installed.
+
+![Install GitLab](../../static/zero-trust-security/gitlab/install-gitlab.png)
+
+However, the application is not running yet. You can check to see what ports are listening to confirm by installing and using `netstat`.
+
+```bash
+sudo apt-get install net-tools
+sudo netstat -tulpn | grep LISTEN
+```
+
+The result should be only the services currently active on the machine:
+
+![Just Services](../../static/zero-trust-security/gitlab/just-services.png)
+
+To start GitLab, run the software's reconfigure command.
+
+```bash
+sudo gitlab-ctl reconfigure
+```
+
+GitLab will launch its component services. Once complete, confirm that GitLab is running and listening on both ports 22 and 80.
+
+![GitLab Services](../../static/zero-trust-security/gitlab/gitlab-services.png)
+
+Users connect to GitLab over SSH (port 22 here) and HTTP for the web app (port 80). In the next step, you will make it possible for users to try both through Cloudflare Access. I'll leave this running and head over to the Cloudflare dashboard.
+
+## Securing GitLab with Zero Trust rules
+
+### Building Access policies
+
+You can use Cloudflare Access to build Zero Trust rules to determine who can connect to both the web application of GitLab (HTTP) and who can connect over SSH.
+
+When a user makes a request to a site protected by Access, that request hits Cloudflare's network first. Access can then check if the user is allowed to reach the application. When integrated with Argo Tunnel, the zero-trust architecture looks like this:
+
+![GitLab Services](../../static/zero-trust-security/gitlab/teams-diagram.png)
+
+To determine who can reach the application, Cloudflare Access relies on integration with identity providers like Okta or AzureAD or Google to issue the identity cards that get checked at the door. While a VPN allows users free range on a private network unless someone builds an active rule to stop them, Access enforces that identity check on every request (and at any granularity configured).
+
+For GitLab, start by building two policies. Users will connect to GitLab in a couple of methods: in the web app and over SSH. Create policies to secure a subdomain for each. First, the web app.
+
+Before you build the rule, you'll need to follow [these instructions](https://developers.cloudflare.com/access/getting-started/access-setup) to set up Cloudflare Access in your account.
+
+Once enabled, navigate to the `Applications` page in the Cloudflare for Teams dashboard. Click `Add an application`.
+
+![Applications Page](../../static/secure-origin-connections/share-new-site/applications.png)
+
+Choose self-hosted from the options presented.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/policy.png)
+
+In the policy builder, you will be prompted to add a subdomain that will represent the resource. This must be a subdomain of a domain in your Cloudflare account. You will need separate subdomains for the web application and SSH flows.
+
+This example uses `gitlab.widgetcorp.tech` for the web application and `gitlab-ssh.widgetcorp.tech` for SSH connectivity.
+
+![App Picker](../../static/secure-origin-connections/share-new-site/configure-app.png)
+
+While on this page, you can decide which identity providers will be allowed to authenticate. By default, all configured providers are allowed. Click `Next` to build rules to determine who can reach the application.
+
+You can then add rules to determine who can reach the site.
+
+![Add Rules](../../static/secure-origin-connections/share-new-site/add-rules.png)
+
+Click `Next` and `Next` again on the `Setup` page - this example does not require advanced CORS configuration. Repeat these steps for the second application, `gitlab-ssh.widgetcorp.tech`.
+
+![App List](../../static/secure-origin-connections/gitlab/app-list.png)
+
+
+## Cloudflare Argo Tunnel
+
+Cloudflare Argo Tunnel creates a secure, outbound-only, connection between this machine and Cloudflare's network. With an outbound-only model, you can  prevent any direct access to this machine and lock down any externally exposed points of ingress. And with that, no open firewall ports.
+
+Argo Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the Digital Ocean machine with the two commands below.
+
+```bash
+sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
+sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+```
+
+Once installed, authenticate the instance of `cloudflared` with the following command.
+
+`cloudflared login`
+
+The command will print a URL that you must visit to login with your Cloudflare account.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/leave-running.png)
+
+Choose a website that you have added into your account.
+
+![Choose Site](../../static/secure-origin-connections/share-new-site/pick-site.png)
+
+Once you click one of the sites in your account, Cloudflare will download a certificate file to authenticate this instance of `cloudflared`. You can now use `cloudflared` to control Argo Tunnel connections in your Cloudflare account.
+
+![Download Cert](../../static/secure-origin-connections/share-new-site/cert-download.png)
+
+### Connecting to Cloudflare
+
+You can now connect GitLab to Cloudflare using Argo Tunnel.
+
+First, create a new Tunnel by running the following command.
+
+```bash
+cloudflared tunnel create gitlab
+```
+
+`cloudflared` will generate a unique ID for this Tunnel. You can use this Tunnel both for SSH and HTTP traffic.
+
+![Self Hosted](../../static/zero-trust-security/gitlab/tunnel-create.png)
+
+Next, you will need to configure Argo Tunnel to proxy traffic to both destinations. The configuration below will take traffic bound for the DNS record that will be created for the web app and the DNS record to represent SSH traffic to the right port.
+
+You use the text editor of your choice to edit the configuration file. The example relies on `Vi`.
+
+```bash
+vim ~/.cloudflared/config.yml
+```
+
+Next,
+
+```yml
+tunnel: 6ff42ae2-765d-4adf-8112-31c55c1551ef
+credentials-file: /root/.cloudflared/6ff42ae2-765d-4adf-8112-31c55c1551ef.json
+
+ingress:
+  - hostname: gitlab.widgetcorp.tech
+    service: http://localhost:80
+  - hostname: gitlab-ssh.widgetcorp.tech
+    service: ssh://localhost:22
+  # Catch-all rule, which just responds with 404 if traffic doesn't match any of
+  # the earlier rules
+  - service: http_status:404
+```
+
+![Self Hosted](../../static/zero-trust-security/gitlab/config-file.png)
+
+You can test that the configuration file is set correctly with the following command.
+
+```bash
+cloudflared tunnel ingress validate
+```
+
+`cloudflared` should indicate the Tunnel is okay. You can now begin running the Tunnel.
+
+```bash
+cloudflared tunnel run
+```
+
+![Tunnel Run](../../static/zero-trust-security/gitlab/tunnel-run.png)
+
+<Aside>
+
+This command should be run as a `systemd` service for long-term use; if it terminates, GitLab will be unavailable.
+
+</Aside>
+
+### Configure DNS records
+
+You can now create DNS records for GitLab in the Cloudflare dashboard. Remember, you will still need two records - one for the web application and one for SSH traffic.
+
+In the DNS tab, choose the website where you built your Access policies. Click `+Add record` and select `CNAME` from type. In the `Name` field, input `gitlab`. In the `Target` field, input the ID of the Tunnel created followed by `cfargotunnel.com`. In this example, that value is:
+
+```
+6ff42ae2-765d-4adf-8112-31c55c1551ef.cfargotunnel.com
+```
+
+![Add DNS](../../static/zero-trust-security/gitlab/add-dns.png)
+
+Click `Save`. Repeat the process again by creating a second `CNAME` record, with the same `Target`, but input `gitlab-ssh` for the `Name`. Both records should then appear, pointing to the same Tunnel. The ingress rules defined in the configuration file above will direct traffic to the appropriate port.
+
+![View DNS](../../static/zero-trust-security/gitlab/view-dns.png)
+
+### Connecting to the web application
+
+You can now test the end-to-end configuration for the web application. Visit the subdomain created for the web application. Cloudflare Access will prompt you to authenticate. Login with your provider.
+
+![Access Login](../../static/zero-trust-security/gitlab/access-login.png)
+
+Once authenticated, you should see the GitLab web application.
+
+![GitLab Web](../../static/zero-trust-security/gitlab/gitlab-web.png)
+
+Register your own account and create a Blank project to test SSH in the next step.
+
+![Blank Project](../../static/zero-trust-security/gitlab/blank-project.png)
+
+GitLab will create a new project and repository.
+
+![New Project](../../static/zero-trust-security/gitlab/new-project.png)
+
+<Aside>
+
+To pull or push code, you must also add an SSH key to your profile in GitLab.
+
+</Aside>
+
+### Configuring SSH
+
+To push and pull code over SSH, you will need to install `cloudflared` on the client machine as well. This example uses a macOS laptop. On macOS, you can install `cloudflared` with the following command.
+
+```
+$ brew install cloudflare/cloudflare/cloudflared
+```
+
+While you need to install `cloudflared`, you do not need to wrap your SSH commands in any unique way. Instead, you will need to make a one-time change to your SSH configuration file.
+
+```bash
+vim /Users/samrhea/.ssh/config
+```
+
+Input the following values; replacing `gitlab-ssh.widgetcorp.tech` with the hostname you created.
+
+```bash
+Host gitlab-ssh.widgetcorp.tech
+  ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
+```
+You can now test the SSH flow by attempting to clone the project created earlier.
+
+```bash
+$ git clone git@gitlab-ssh.widgetcorp.tech:samrhea/demo
+```
+
+`cloudflared` will prompt you to login with my identity provider and, once successful, issue a token to your device to allow you to authenticate.
+
+![GitLab Clone](../../static/zero-trust-security/gitlab/git-clone.png)
+
+### Lock down exposed ports
+
+You can now configure your Digital Ocean firewall with a single rule, block any inbound traffic, to prevent direct access.
+
+![Download Cert](../../static/zero-trust-security/gitlab/disable-ingress.png)
+
+Argo Tunnel will continue to run outbound-only connections and I can avoid this machine getting caught up in a crypto mining operation, or something worse.
+
+## View logs
+
+You can also view logs of the events that are allowed and blocked. Open the `Access` page of the `Logs` section in the Cloudflare for Teams dashboard.
+
+![View Logs](../../static/zero-trust-security/gitlab/view-logs.png)

--- a/products/cloudflare-one/src/content/zero-trust-security/index.md
+++ b/products/cloudflare-one/src/content/zero-trust-security/index.md
@@ -1,0 +1,8 @@
+---
+order: 1
+hidden: true
+---
+
+# Zero Trust Security
+
+<DirectoryListing path="/tutorials/zero-trust-security"/>


### PR DESCRIPTION
@adamschwartz I added a new component to `cloudflare-one` (`one-tutorials.js`). 
Had to tweak `gatsby-node.js` to add a field ( `category: String` ) to `type Frontmatter`. Everything works locally, but of course this change is outside `src/content` so it doesn't show up when I commit/push. Something might break?