### PR TITLE
Update publish-durable-object comment about chicken-and-egg problem

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -160,7 +160,7 @@ export class Counter {
 
 The following describes the raw HTTP API to upload your class definition, define a Durable Object namespace, and then bind another worker to be able to talk to it. This functionality is not yet available in Wrangler, but will be very soon, at which point these instructions will become much simpler.
 
-We've included a helper script that will handle creating configuring and uploading the script for you.  See the [configuration script](#configuration-script) section below.
+We've included a helper script that will handle configuring a namespace and uploading its script for you.  See the [configuration script](#configuration-script) section below.
 
 </Aside>
 


### PR DESCRIPTION
Now that you can actually create a durable object namespace without a
script assigned to it. I'm not bothering to modify the code, though,
since we still need 3 requests either way and it would make updating an
existing Worker using the script slightly more difficult.

Also fix a minor typo while I'm here.

@greg-mckeon @bretthoerner 