### PR TITLE
Add Sunder Cloudflare Workers starter template

### DIFF
--- a/products/workers/src/content/starters/index.md
+++ b/products/workers/src/content/starters/index.md
@@ -56,6 +56,12 @@ $ wrangler generate <new-project-name> <github-repo-url>
 />
 
 <WorkerStarter
+  title="Sunder Starter (Typescript)"
+  description="A batteries-included starter template using Sunder, Typescript, ESBuild, Jest and Sass. Uses Worker Sites for static assets."
+  repo="gzuidhof/sunder-worker-template"
+/>
+
+<WorkerStarter
   title="Apollo GraphQL Server"
   description="Lightning-fast, globally distributed Apollo GraphQL server, deployed at the edge using Cloudflare Workers."
   repo="signalnerve/workers-graphql-server"


### PR DESCRIPTION
Hi Cloudflare 👋 

This PR adds a non-barebones starter template for Cloudflare workers using modern tech.  

I created it mostly to scratch my own itch as setting up a Workers project that goes beyond hello world and is actually test-friendly gets tiring after 5 times :). I think others will also benefit from this.

Here's an [**example deployment**](https://sunder-starter.sunderjs.com/).



