### PR TITLE
[Teams] hide learning folder

### DIFF
--- a/products/cloudflare-one/src/content/learning/index.md
+++ b/products/cloudflare-one/src/content/learning/index.md
@@ -1,5 +1,6 @@
 ---
 order: 2
+hidden: true
 ---
 
 # Learning
@@ -7,7 +8,3 @@ order: 2
 We're building this section to help you make the most of your experience with Cloudflare for Teams. We plan on having learning materials, readings, and technical deep-dives about what you can do with our products and features.
 
 Check back soon for more content!
-
-Available sections:
-
-<DirectoryListing path="/learning"/>


### PR DESCRIPTION
Policies page was buggy - will hide until we have more content for the learning section