### PR TITLE
Firewall language: Fix http version field

### DIFF
--- a/products/firewall/src/content/cf-firewall-language/fields.md
+++ b/products/firewall/src/content/cf-firewall-language/fields.md
@@ -136,7 +136,7 @@ The Cloudflare Firewall Rules language supports these standard fields:
       </td>
    </tr>
    <tr>
-      <td valign="top"><code>http.version</code><br /><Type>Number</Type></td>
+      <td valign="top"><code>http.request.version</code><br /><Type>Number</Type></td>
       <td>
          <p>Represents the version of the HTTP protocol used. Use this field when you require different checks for different versions.
          </p>


### PR DESCRIPTION
## User story

Update the _Fields_ article in Firewall Rules dev docs so that the name of the http version field is correctly rendered as `http.request.version`