### PR TITLE
Deprecation Asides for Mobile SDK

### DIFF
--- a/products/mobile-sdk/src/content/faq/index.md
+++ b/products/mobile-sdk/src/content/faq/index.md
@@ -4,6 +4,15 @@ order: 5
 
 # FAQ
 
+<Aside type='warning' header='Important'>
+
+Cloudflare is deprecating the Mobile SDK. You will no longer be able to log in to the portal or view stats about your mobile app after February 22, 2021.
+
+While your mobile app will continue working with the SDK even after the portal is removed, we encourage you to remove the Mobile SDK as soon as possible.
+
+For more, see [_Deprecation notice: Cloudflare Mobile SDK_](https://support.cloudflare.com/hc/en-us/articles/360054452251-Deprecation-notice-Cloudflare-Mobile-SDK).
+</Aside>
+
 ## Where do I sign up?
 Visit [this page](https://mobilesdk.cloudflare.com) to sign up for the SDK and get started on Metrics Mode.
 

--- a/products/mobile-sdk/src/content/getting-started/index.md
+++ b/products/mobile-sdk/src/content/getting-started/index.md
@@ -4,6 +4,15 @@ order: 2
 
 # Getting started
 
+<Aside type='warning' header='Important'>
+
+Cloudflare is deprecating the Mobile SDK. You will no longer be able to log in to the portal or view stats about your mobile app after February 22, 2021.
+
+While your mobile app will continue working with the SDK even after the portal is removed, we encourage you to remove the Mobile SDK as soon as possible.
+
+For more, see [_Deprecation notice: Cloudflare Mobile SDK_](https://support.cloudflare.com/hc/en-us/articles/360054452251-Deprecation-notice-Cloudflare-Mobile-SDK).
+</Aside>
+
 You can easily integrate Cloudflare's Mobile SDK by going through the following steps.
 
 ![SDK installation](../images/sdk-installation-gif.gif)

--- a/products/mobile-sdk/src/content/index.md
+++ b/products/mobile-sdk/src/content/index.md
@@ -5,7 +5,16 @@ order: 1
 
 # Cloudflare Mobile SDK
 
-Cloudflare Mobile SDK let’s mobile app developers understand how poor network performance on mobile apps can affect end-user engagement. With our Metrics Mode dashboard, developers can identify what carriers, networks and APIs are suffering the most and take actions based on that.
+<Aside type='warning' header='Important'>
+
+Cloudflare is deprecating the Mobile SDK. You will no longer be able to log in to the portal or view stats about your mobile app after February 22, 2021.
+
+While your mobile app will continue working with the SDK even after the portal is removed, we encourage you to remove the Mobile SDK as soon as possible.
+
+For more, see [_Deprecation notice: Cloudflare Mobile SDK_](https://support.cloudflare.com/hc/en-us/articles/360054452251-Deprecation-notice-Cloudflare-Mobile-SDK).
+</Aside>
+
+Cloudflare Mobile SDK lets mobile app developers understand how poor network performance on mobile apps can affect end-user engagement. With our Metrics Mode dashboard, developers can identify what carriers, networks and APIs are suffering the most and take actions based on that.
 
 Using Mobile NX Metrics, you can identify top N requests, slow requests, and requests most likely to fail. You’re also able to understand all the third party calls your app is making through included libraries. You always suspected that ad network you’re calling out to kills performance. Now you know.
 


### PR DESCRIPTION
## User story

Add Asides to the Mobile SDK dev docs to announce the deprecation of the product so that users who visit the docs are aware that they will no longer be able to access the portal after Feb 22, 2021.


