### PR TITLE
Correct sampling percentage for Network Analytics

### DIFF
--- a/products/analytics/src/content/graphql-api/sampling/index.md
+++ b/products/analytics/src/content/graphql-api/sampling/index.md
@@ -46,7 +46,7 @@ The following data nodes are based on fixed sampling, where the sample rate does
 | Data set | Rate | Notes |
 | :-- | --: | :-- |
 | Firewall Rules Preview<br /><p><b>Nodes:</b><br />`firewallRulePreviewGroups`</p> | 1% | Use with caution. A 1% sample rate does not provide accurate estimates for data sets smaller than a certain threshold, a scenario the Cloudflare Dashboard calls out explicitly but the API does not. |
-| Network Analytics<br /><p><b>Nodes:</b><br />`ipFlows1mGroups`<br />`ipFlows1hGroups`<br />`ipFlows1dGroups`<br />`ipFlows1mAttacksGroups`</p> | 0.12% | Sampling rate is in terms of packet count (1 of every 8,192 packets).                                                                                                                                 |
+| Network Analytics<br /><p><b>Nodes:</b><br />`ipFlows1mGroups`<br />`ipFlows1hGroups`<br />`ipFlows1dGroups`<br />`ipFlows1mAttacksGroups`</p> | 0.012% | Sampling rate is in terms of packet count (1 of every 8,192 packets).                                                                                                                                 |
 
 </TableWrap>
 


### PR DESCRIPTION
1 in 8,192 packets is 1/8192*100 = 0.01220703125

So should be displayed in the docs as 0.012% not 0.12%