### PR TITLE
Fix the 1.1.1.1 bot username

### DIFF
--- a/products/1.1.1.1/src/content/fun-stuff/dns-over-telegram.md
+++ b/products/1.1.1.1/src/content/fun-stuff/dns-over-telegram.md
@@ -6,7 +6,7 @@ order: 4
 
 To perform DNS over Telegram, you will need the Telegram app. For the unfamiliar, Telegram is an end-to-end encrypted messaging app. You can download it on [telegram.org](https://telegram.org/).
 
-First, you will need to add the 1.1.1.1 bot to your friends list in Telegram. Open the Telegram app, click on 'contacts' and search for `onedotonedotonedotonebot`.
+First, you will need to add the 1.1.1.1 bot to your friends list in Telegram. Open the Telegram app, click on 'contacts' and search for `onedotonedotonedotonedotbot`.
 
 ![search](../static/search.png)
 


### PR DESCRIPTION
The username of the 1.1.1.1 bot is `onedotonedotonedotonedotbot` instead of `onedotonedotonedotonebot`.
See https://t.me/onedotonedotonedotonedotBot
Note that https://t.me/onedotonedotonedotonebot points to the `1111Resalver` channel.