### PR TITLE
Remove URL.hash from Workers redirect example

### DIFF
--- a/products/workers/src/content/examples/redirect.md
+++ b/products/workers/src/content/examples/redirect.md
@@ -36,9 +36,9 @@ const statusCode = 301
 
 async function handleRequest(request) {
   const url = new URL(request.url)
-  const { pathname, search, hash } = url
+  const { pathname, search } = url
 
-  const destinationURL = base + pathname + search + hash
+  const destinationURL = base + pathname + search
 
   return Response.redirect(destinationURL, statusCode)
 }


### PR DESCRIPTION
URL.hash (URL fragment) is always blank in worker context. Otherwise there is potential for confusion when new developers will try to match against URL.hash or will expect to receive it on the server side.