### PR TITLE
Fix "Setup a logging service" example snippet

### DIFF
--- a/products/workers/src/content/learning/debugging-workers.md
+++ b/products/workers/src/content/learning/debugging-workers.md
@@ -136,12 +136,16 @@ When logging using this strategy, remember that outstanding asynchronous tasks a
 
 ```js
 addEventListener("fetch", event => {
+  event.respondWith(handleEvent(event))
+}
+
+async function handleEvent(event) {
   // ...
 
   // Without event.waitUntil(), our fetch() to our logging service may
   // or may not complete.
   event.waitUntil(postLog(stack))
-  return fetch(request)
+  return fetch(event.request)
 }
 
 function postLog(data) {


### PR DESCRIPTION
`event.respondWith()` must be called, or else the runtime will attempt to forward the request to the origin. However, since the event listener called `fetch(request)`, that forward attempt will probably fail, and the worker would return an 1101 error.