### PR TITLE
Fixed proposed ruby version

### DIFF
--- a/products/pages/src/content/how-to/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/how-to/deploy-a-jekyll-site.md
@@ -9,7 +9,7 @@ Jekyll is written in Ruby, meaning that you'll need a functioning Ruby installat
 We recommend using [`rbenv`](https://github.com/rbenv/rbenv) to install Ruby on your computer. Follow the [`rbenv` install instructions](https://github.com/rbenv/rbenv#installation), and install a recent version of Ruby using `rbenv`:
 
 ```sh
-$ rbenv install 2.7
+$ rbenv install 2.7.2
 ```
 
 With Ruby installed, you can install the `jekyll` Ruby gem:


### PR DESCRIPTION
When running `rbenv install 2.7` I see this message:

```
hannes ~ % rbenv install 2.7                     
ruby-build: definition not found: 2.7

The following versions contain `2.7' in the name:
  2.2.7
  2.7.0-dev
  2.7.0-preview1
  2.7.0-preview2
  2.7.0-preview3
  2.7.0-rc1
  2.7.0-rc2
  2.7.0
  2.7.1
  2.7.2
  jruby-9.2.7.0
  rbx-2.2.7
  rbx-2.7
  rbx-2.71828182

See all available versions with `rbenv install --list'.

If the version you need is missing, try upgrading ruby-build:

  brew update && brew upgrade ruby-build
```