### PR TITLE
IPFS Gateway: Add `Connecting your website` section

### DIFF
--- a/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
+++ b/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
@@ -1,5 +1,5 @@
 ---
-order: 4
+order: 5
 ---
 
 # Automated Deployment

--- a/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
+++ b/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
@@ -1,6 +1,5 @@
 ---
 order: 3
-hidden: true
 ---
 
 # Connecting Your Website
@@ -101,7 +100,7 @@ We'll go over how to do that now.
 First, go to the DNS settings for your domain. When you're there, add the
 following two records:
 
-1. CNAME for `your.website` pointing to `www.cloudflare-ipfs.com`
+1. CNAME for `your.website` pointing to `cloudflare-ipfs.com`
 2. TXT record for `_dnslink.your.website` with the value `dnslink=/ipfs/<your_hash_here>`
 
 Now any request to `your.website` will resolve to

--- a/products/distributed-web/src/content/ipfs-gateway/index.md
+++ b/products/distributed-web/src/content/ipfs-gateway/index.md
@@ -9,7 +9,7 @@ the InterPlanetary File System \(IPFS\) quickly and easily, without downloading
 any special software or giving up any storage space on your computer.
 
 Cloudflare's gateway is hosted at https://cloudflare-ipfs.com/. You can find the
-basics on IPFS and how to serve your website through our gateway there. These
+basics on IPFS and [how to serve your website](/ipfs-gateway/connecting-website) through our gateway there. These
 docs are going to get further into the weeds.
 
 

--- a/products/distributed-web/src/content/ipfs-gateway/updating-for-ipfs.md
+++ b/products/distributed-web/src/content/ipfs-gateway/updating-for-ipfs.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 ---
 
 # Updating your Website for IPFS


### PR DESCRIPTION
`Connecting your website` section was hidden. The page is useful to
describe how customers can connect their domains to Cloudflare.