### PR TITLE
[workers] Add type/external URL to tutorials

### DIFF
--- a/products/workers/src/content/components/content-table.css
+++ b/products/workers/src/content/components/content-table.css
@@ -1,0 +1,5 @@
+.DocsTutorials--column[data-column="type"] {
+  width: 8em;
+  padding-left: calc(var(--gap) / 2);
+  padding-right: calc(var(--gap) / 2);
+}

--- a/products/workers/src/content/components/content-table.js
+++ b/products/workers/src/content/components/content-table.js
@@ -1,0 +1,114 @@
+import React from "react";
+import { Link, useStaticQuery, graphql } from "gatsby";
+import TimeAgo from "react-timeago";
+import "./content-table.css"
+
+const getPageTitle = ({ frontmatter, headings }) => {
+  if (!frontmatter) return "Not found";
+
+  return frontmatter.title || (headings.length && headings[0].value);
+};
+
+const tenDaysInMS = 10 * 24 * 60 * 60 * 1000;
+
+const DocsTutorials = () => {
+  const query = useStaticQuery(graphql`
+    query {
+      allMdx {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              updated
+              type
+              url
+            }
+            headings(depth: h1) {
+              value
+            }
+            wordCount {
+              words
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const tutorials = query.allMdx.edges
+    .map(({ node }) => node)
+    .filter(page => page.fields.slug.match(/^\/tutorials\/.+/))
+    .map(page => ({
+      title: getPageTitle(page),
+      url: page.frontmatter.url || page.fields.slug,
+      updated: page.frontmatter.updated,
+      type: page.frontmatter.type,
+      wordCount: page.wordCount.words,
+      new: (+new Date() - +new Date(page.frontmatter.updated)) < tenDaysInMS
+    }))
+    .sort((a, b) => +new Date(b.updated) - +new Date(a.updated))
+
+  let i = 0
+  let longestWordCount = 0
+
+  for (i = 0; i < tutorials.length; i += 1) {
+    if (tutorials[i].wordCount > longestWordCount) {
+      longestWordCount = tutorials[i].wordCount
+    }
+  }
+
+  for (i = 0; i < tutorials.length; i += 1) {
+    tutorials[i].length = ((tutorials[i].wordCount / longestWordCount) * 100) + "%"
+  }
+
+  return (
+    <div className="DocsTutorials">
+      <div className="DocsTutorials--header">
+        <div className="DocsTutorials--row">
+          <div className="DocsTutorials--column" data-column="name">
+            <span className="DocsTutorials--column-text">Name</span>
+          </div>
+          <div className="DocsTutorials--column" data-column="updated">
+            <span className="DocsTutorials--column-text">Updated</span>
+          </div>
+          <div className="DocsTutorials--column" data-column="type">
+            <span className="DocsTutorials--column-text">Type</span>
+          </div>
+          <div className="DocsTutorials--column" data-column="length">
+            <span className="DocsTutorials--column-text">Length</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="DocsTutorials--body">
+        {tutorials.map(tutorial => (
+          <div key={tutorial.url} className={"DocsTutorials--row" + (tutorial.new ? " DocsTutorials--row-is-new" : "")}>
+            <div className="DocsTutorials--column" data-column="name">
+              <Link className="DocsTutorials--link" to={tutorial.url}>
+                {tutorial.title}
+              </Link>
+            </div>
+            <div className="DocsTutorials--column" data-column="updated">
+              <TimeAgo date={tutorial.updated} formatter={(value, unit) => (
+                <React.Fragment>
+                  {value} {unit}{value > 1 ? "s" : ""}<span className="DocsTutorials--ago-text"> ago</span>
+                </React.Fragment>
+              )} minPeriod={60} />
+            </div>
+            <div className="DocsTutorials--column" data-column="type">{tutorial.type}</div>
+            <div className="DocsTutorials--column" data-column="length">
+              <div className="DocsTutorials--length-bar">
+                <div className="DocsTutorials--length-bar-inner" style={{ width: tutorial.length }}></div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default DocsTutorials;

--- a/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
+++ b/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-07-25
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-jamstack-app/index.md
+++ b/products/workers/src/content/tutorials/build-a-jamstack-app/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-03-09
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-qr-code-generator/index.md
+++ b/products/workers/src/content/tutorials/build-a-qr-code-generator/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-03-09
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-slackbot/index.md
+++ b/products/workers/src/content/tutorials/build-a-slackbot/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-03-10
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/configure-your-cdn/index.md
+++ b/products/workers/src/content/tutorials/configure-your-cdn/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-04-15
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-06-01
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-07-25
 difficulty: Intermediate
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/products/workers/src/content/tutorials/github-sms-notifications-using-twilio/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-08-25
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/hello-world-rust/index.md
+++ b/products/workers/src/content/tutorials/hello-world-rust/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-06-29
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/index.md
+++ b/products/workers/src/content/tutorials/index.md
@@ -4,7 +4,7 @@ hideChildren: true
 order: 3
 ---
 
-import DocsTutorials from "../../components/docs-tutorials"
+import DocsTutorials from "../components/content-table"
 
 # Tutorials
 

--- a/products/workers/src/content/tutorials/introduction-to-cloudflare-workers/index.md
+++ b/products/workers/src/content/tutorials/introduction-to-cloudflare-workers/index.md
@@ -1,0 +1,8 @@
+---
+updated: 2021-01-25
+difficulty: Beginner
+type: "🎥 Video"
+url: "https://egghead.io/playlists/introduction-to-cloudflare-workers-5aa3"
+---
+
+# Introduction to Cloudflare Workers

--- a/products/workers/src/content/tutorials/localize-a-website/index.md
+++ b/products/workers/src/content/tutorials/localize-a-website/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-08-03
 difficulty: Intermediate
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/manage-projects-with-lerna/index.md
+++ b/products/workers/src/content/tutorials/manage-projects-with-lerna/index.md
@@ -1,6 +1,7 @@
 ---
 updated: 2020-08-13
 difficulty: Beginner
+type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"


### PR DESCRIPTION
Adds the type column in tutorials. In addition, since we're experimenting with adding the new "Video" category (linking to our egghead course), this PR also includes support for setting a URL for a Markdown file, which will cause it to link directly to external URLs.

<img width="685" alt="tuts" src="https://user-images.githubusercontent.com/922353/105751519-bb80ee00-5f0b-11eb-9b5e-5a0ac0caa6c7.PNG">
