### PR TITLE
Add Ember.js to build config table

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -16,6 +16,7 @@ Below are some standard build commands and directories for popular frameworks an
 | Brunch                       | `brunch build --production`         | `public`                                       |
 | Docusaurus                   | `npm run build`                     | `build`                                        |
 | Eleventy                     | `eleventy`                          | `_site`                                        |
+| Ember.js                     | `ember build`                       | `dist`                                         |
 | Gatsby                       | `gatsby build`                      | `public`                                       |
 | GitBook                      | `gitbook build`                     | `_book`                                        |
 | Gridsome                     | `gridsome build`                    | `dist`                                         |


### PR DESCRIPTION
This PR adds Ember.js to the Build Configuration page.