### PR TITLE
Browser Isolation: Corrected regex expressions

### DIFF
--- a/products/browser-isolation/src/content/usage/isolated-traffic.md
+++ b/products/browser-isolation/src/content/usage/isolated-traffic.md
@@ -35,16 +35,15 @@ Here is the `browser-beta` configuration:
 | URL Path | Is | `/cf-simulate-block` | Block
 
 ### Bypass common cert pinning sites
-| Selector | Operator | Value | Action |
-| - | - | - | - |
-| Host | matches regex | `.*whispersystems.org\|.*signal.org\|.*zoom.us\|.*zoomgov.com\|.*wellsfargo.com\|.*usaa.com\|.*apple.com\|.*icloud.com` | Bypass
+
+See [Gateway recommeded rules](https://developers.cloudflare.com/gateway/connecting-to-gateway/Troubleshooting#im-using-a-common-application-and-it-seems-unable-to-connect-when-i-inspect-http-traffic-or-presents-an-untrusted-certificate-error)
 
 ### Isolate Google Search
 This rule is placed above bypass Google Workspace to ensure all Google Search endpoints are isolated.
 
 | Selector | Operator | Value | Action |
 | - | - | - | - |
-| Host | matches regex | `www\.google\.co.*\|www\.google\.com.*` | Isolate
+| Host | matches regex | www\.google\.co.\*\|www\.google\.com.\* | Isolate
 
 ### Bypass Google Workspace
 This rule is defined to avoid isolating Google Meet as Microphones / Webcams are not available in isolated browsers.
@@ -53,7 +52,7 @@ Google Single Sign On does not work across isolated and non-isolated sessions.
 
 | Selector | Operator | Value | Action |
 | - | - | - | - |
-| Host | matches regex | `.*\.google\.com\|.*\.gstatic\.com\|accounts\.youtube\.com\|.*googleusercontent\.com\|.*\.googleapis\.com` | Bypass
+| Host | matches regex | .\*\.google\.com\|.\*\.gstatic\.com\|accounts\.youtube\.com\|.\*googleusercontent\.com\|.\*\.googleapis\.com | Bypass
 
 ### Isolate everything
 | Selector | Operator | Value | Action |


### PR DESCRIPTION
Issue with markdown / tables caused regular expressions to get mangled.