### PR TITLE
Add section to HTMLRewriter about async handlers

### DIFF
--- a/products/workers/src/content/runtime-apis/html-rewriter.md
+++ b/products/workers/src/content/runtime-apis/html-rewriter.md
@@ -91,6 +91,26 @@ class DocumentHandler {
 }
 ```
 
+#### Async Handlers
+
+All functions defined on both Element and Document handlers can return either `void` or a `Promise<void>`. Making your handler function `async` allows you to access external resources such as an API via fetch, Workers KV, Durable Objects, or the cache.
+
+```js
+class UserElementHandler {
+  async element(element) {
+    let response = await fetch(new Request("/user"));
+    
+    // fill in user info using response
+  }
+}
+
+async function handleRequest(req) {
+  const res = await fetch(req)
+
+  return new HTMLRewriter().on("div:user_info", new UserElementHandler()).transform(res)
+}
+```
+
 ### Element
 
 The `element` argument, used only in element handlers, is a representation of a DOM element. A number of methods exist on an element to query and manipulate it:


### PR DESCRIPTION
HTMLRewriter supports async handlers but *nothing in the docs says so*. This adds a short section under Element and Document handlers showing it's possible to have async element and document handlers.