### PR TITLE
mention API Shield on tlsClientAuth

### DIFF
--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -215,7 +215,7 @@ All plans have access to:
 
 - `tlsClientAuth` <Type>Object | null</Type>
 
-  - Only set when using Cloudflare Access. Object with the following properties: `certIssuerDNLegacy`, `certIssuerDN`, `certIssuerDNRFC2253`, `certSubjectDNLegacy`, `certVerified`, `certNotAfter`, `certSubjectDN`, `certFingerprintSHA1`, `certNotBefore`, `certSerial`, `certPresented`, `certSubjectDNRFC2253`.
+  - Only set when using Cloudflare Access or API Shield. Object with the following properties: `certIssuerDNLegacy`, `certIssuerDN`, `certIssuerDNRFC2253`, `certSubjectDNLegacy`, `certVerified`, `certNotAfter`, `certSubjectDN`, `certFingerprintSHA1`, `certNotBefore`, `certSerial`, `certPresented`, `certSubjectDNRFC2253`.
 
 - `tlsVersion` <Type>string</Type>
 


### PR DESCRIPTION
I was looking for info on how to check if the cert was verified on origin, `tlsClientAuth` is also set if there is a request validated by API Shield