### PR TITLE
Remove failing KV namespace IDs from products

### DIFF
--- a/products/byoip/wrangler.toml
+++ b/products/byoip/wrangler.toml
@@ -2,7 +2,6 @@ name = "byoip"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
-kv_namespaces = [{ binding = "REDIRECTS", id = "b393a548b93e4c36936e9276dedf5f5a", preview_id = "b393a548b93e4c36936e9276dedf5f5a" }]
 
 [env.production]
 workers_dev = false

--- a/products/registrar/wrangler.toml
+++ b/products/registrar/wrangler.toml
@@ -2,7 +2,6 @@ name = "registrar"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
-kv-namespaces = [{ binding = "REDIRECTS", id = "a08297023fa44f369c9828b0e7674960", preview_id = "a08297023fa44f369c9828b0e7674960" }]
 
 [env.production]
 workers_dev = false

--- a/products/ssl/wrangler.toml
+++ b/products/ssl/wrangler.toml
@@ -2,7 +2,6 @@ name = "ssl"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
-kv-namespaces = [{ binding = "REDIRECTS_DEV", id = "59ccb75f5e064cd78291ad48c8c4bad0", preview_id = "59ccb75f5e064cd78291ad48c8c4bad0" }]
 
 [env.production]
 workers_dev = false

--- a/products/stream/wrangler.toml
+++ b/products/stream/wrangler.toml
@@ -2,9 +2,7 @@ name = "stream"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
-kv_namespaces = [
-  { binding = "REDIRECTS", id = "0f8c3cc688e140c08ca2d02b45a372ed", preview_id = "0f8c3cc688e140c08ca2d02b45a372ed" }
-]
+
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
Since we recently hit our KV namespace limit on the developer docs, some of these KV namespaces were deleted, but the corresponding reference in some product docs (BYOIP, Registrar, SSL, and Stream) still exist. This causes staging builds to fail. This PR removes the KV namespace references from the wrangler.toml for these files, just in the staging deployment.