### PR TITLE
Add a dollar to command on Next.js docs for pages

### DIFF
--- a/products/pages/src/content/how-to/deploy-a-nextjs-site.md
+++ b/products/pages/src/content/how-to/deploy-a-nextjs-site.md
@@ -6,7 +6,7 @@ Next.js is an open-source React framework for creating websites and apps. In thi
 
 Create a new project using npx
 ```sh
-npx create-next-app
+$ npx create-next-app
 ```
 
 ## Creating a GitHub repository


### PR DESCRIPTION
When I created the original PR I didn't realize that the dollar had special meaning, and now you can't copy the text for the first codeblock on the Next.js guide, so this adds a dollar in, so you can do that