### PR TITLE
update cf-terraforming installation

### DIFF
--- a/products/terraform/src/content/advanced-topics/importing-cloudflare-resources.md
+++ b/products/terraform/src/content/advanced-topics/importing-cloudflare-resources.md
@@ -13,7 +13,7 @@ If you've configured Cloudflare through other means, e.g., by logging into the C
 
 To help with this process, we have published a library called [cf-terraforming](https://github.com/cloudflare/cf-terraforming). Our goal with cf-terraforming is to make it easy for existing Cloudflare customers to get going with Terraform. Currently, cf-terraforming helps to generate terraform config state by fetching all the resources of a specified type from the account and/or zone of your choosing. Let's try it out.
 
-First, `go get` cf-terraforming with `go get -u github.com/cloudflare/cf-terraforming/...`
+First, `go get` cf-terraforming with `GO111MODULE=on go get -u github.com/cloudflare/cf-terraforming/...`
 
 You can use `cf-terraforming` or `cf-terraforming -h` to view the help file, but to use cf-terraforming there are 4 things to specify:
 


### PR DESCRIPTION
The README on the GitHub page describes how to properly install cf-terraforming, the Cloudflare docs are missing the `GO111MODULE=on` part making the installation fail