### PR TITLE
Update Argo Tunnel cloudflared link

### DIFF
--- a/products/1.1.1.1/src/content/dns-over-https/cloudflared-proxy.md
+++ b/products/1.1.1.1/src/content/dns-over-https/cloudflared-proxy.md
@@ -10,7 +10,7 @@ There are several DNS over HTTPS (DoH) clients you can use to connect to 1.1.1.1
 
 We've open sourced a Golang DoH client you can use to get started. Follow this quick guide to start a DNS over HTTPS proxy to 1.1.1.1.
 
-Step 1: Download the cloudflared daemon. You can [find it here](https://developers.cloudflare.com/argo-tunnel/downloads/).
+Step 1: Download the cloudflared daemon. You can [find it here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation).
 
 Step 2: Verify that the `cloudflared` daemon is installed
 

--- a/products/cloudflare-one/src/content/applications/non-HTTP/SMB-file-shares.md
+++ b/products/cloudflare-one/src/content/applications/non-HTTP/SMB-file-shares.md
@@ -28,7 +28,7 @@ This section will cover:
 
 The Cloudflare daemon, `cloudflared`, will maintain a secure, persistent, outbound-only connection from the machine to Cloudflare. SMB traffic will be proxied over this connection using [Cloudflare Argo Tunnel](https://www.cloudflare.com/products/argo-tunnel/).
 
-Follow [these instructions](https://developers.cloudflare.com/argo-tunnel/downloads/) to download and install `cloudflared` on the machine hosting the file share.
+Follow [these instructions](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation) to download and install `cloudflared` on the machine hosting the file share.
 
 For example, on a Windows server, the following Powershell example can be used.
 

--- a/products/cloudflare-one/src/content/applications/non-HTTP/ssh/putty-clients.md
+++ b/products/cloudflare-one/src/content/applications/non-HTTP/ssh/putty-clients.md
@@ -8,7 +8,7 @@ order: 2
 
 ## Before you begin
 
-* [Download](https://developers.cloudflare.com/argo-tunnel/downloads/) the cloudflared.exe file from the options available.
+* [Download](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation) the cloudflared.exe file from the options available.
 * Ensure you have the hostname of the Host Machine you are reaching.
 * Download and install the [PuTTY client](https://www.chiark.greenend.org.uk/~sgtatham/putty/).
 


### PR DESCRIPTION
The page at /argo-tunnel has a warning that it will be deleted soon.  The download is now in /cloudflare-one.