### PR TITLE
Fix to Python example since PyJWT 2.0.0

### DIFF
--- a/products/cloudflare-one/src/content/identity/users/validating-json.md
+++ b/products/cloudflare-one/src/content/identity/users/validating-json.md
@@ -183,7 +183,7 @@ def verify_token(f):
         for key in keys:
             try:
                 # decode returns the claims that has the email when needed
-                jwt.decode(token, key=key, audience=POLICY_AUD)
+                jwt.decode(token, key=key, audience=POLICY_AUD, algorithms=['RS256'])
                 valid_token = True
                 break
             except:


### PR DESCRIPTION
The Python example no long works since PyJWT 2.0.0. The code will run, but since we are catching all exceptions, devs will not notice that they must specify the `algorithms` parameter when decoding. The error will be hidden and hard to discover.

I have now included `algorithms` it in the example.