### PR TITLE
[WIP] - feat(CI): create a Markdown link checker GitHub Action

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,0 +1,28 @@
+name: Check Markdown links
+
+on: [pull_request]
+
+jobs:
+  markdown-link-check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        node_version:
+          - 14
+        architecture:
+          - x64
+    name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install
+        run: npm install -g markdown-link-check
+      - name: Run
+        # run: git ls-files . -m | xargs markdown-link-check -q -v  # modified files only, quiet mode, verbose mode
+        run: find . -name \*.md -exec markdown-link-check -q -v {} \;


### PR DESCRIPTION
Check for broken links in Markdown files.
This first run will check all docs to find all broken links.
Then when we do merge we set up this check to only check modified files or files in each PR only.

You can install the npm package locally and run a full scan on the docs and fix all at once. Also needs a config file sometimes to map link paths etc.

https://github.com/tcort/markdown-link-check

For a full scan run from repo root:

find . -name \*.md -exec markdown-link-check {} \;