### PR TITLE
refactor: use API token instead of legacy API key

### DIFF
--- a/products/analytics/src/content/graphql-api/getting-started/authentication/graphql-client-headers.md
+++ b/products/analytics/src/content/graphql-api/getting-started/authentication/graphql-client-headers.md
@@ -12,13 +12,13 @@ order: 40
    ![Edit HTTP Headers Window](../../../static/images/GraphiQL-edit-http-headers-window.png)
 1. Click **Add Header**.
    ![Click Add Header](../../../static/images/GraphiQL-add-header.png)
-1. Enter **X-AUTH-EMAIL** in the _Header name_ field and your email address registered with Cloudflare in the _Header value_ field, and click **Save**.
-1. To configure authentication, click **Add Header**. You can use Cloudflare Analytics API token authentication (recommended) or Cloudflare API key authentication.
+1. To configure authentication, click **Add Header**. You can use Cloudflare API token authentication (recommended) or Cloudflare API key authentication (legacy).
    * **Token authentication**:
    Enter **Authorization** in the _Header Name_ field, and enter **Bearer {your-analytics-token}**  in the _Header value_ field, then click **Save**.
    ![HTTP Headers](../../../static/images/GraphiQL-edit-http-headers-token.png)
-   * **Key authentication**:
-   Enter **X-AUTH-KEY** in the _Header Name_ field, and paste your Global API Key in the _Header value_ field, then click **Save**.
+   * **Key authentication (legacy)**:
+      1. Enter **X-AUTH-EMAIL** in the _Header name_ field and your email address registered with Cloudflare in the _Header value_ field.
+      1. Enter **X-AUTH-KEY** in the _Header Name_ field and paste your Global API Key in the _Header value_ field, then click **Save**.
    ![HTTP Headers](../../../static/images/GraphiQL-edit-http-headers-complete.png)
 1. Click anywhere outside the _Edit HTTP Headers_ window in _GraphiQL_ to close it and return to the main _GraphiQL_ display.
 1. Enter `https://api.cloudflare.com/client/v4/graphql` in the _GraphQL Endpoint_ field
@@ -30,4 +30,4 @@ The right-side response pane is empty when you enter your information correctly.
 
 </Aside>
 
-Now that you have configured authentication with a Cloudflare API key, you are ready to run queries using _GraphiQL_.
+Now that you have configured authentication, you are ready to run queries using _GraphiQL_.

--- a/products/analytics/src/content/graphql-api/getting-started/execute-graphql-query.md
+++ b/products/analytics/src/content/graphql-api/getting-started/execute-graphql-query.md
@@ -22,12 +22,11 @@ header: Example bash script that uses curl to query Analytics API
 #!/bin/bash
 #
 # This script fetches the last 24 hours of firewall events for the ZoneID passed
-# in as the first parameter using the global key passed in as the second parameter.
+# in as the first parameter using the API token passed in as the second parameter.
 ######################################################################################
- 
+
 ZoneID="$1"
-global_key="$2"
-Email="user@domain.com"
+api_token="$2"
 #
 # Calculate 24 hours back and produce the start and end times in the appropriate format.
 back_seconds=60*60*24  # 24 hours
@@ -35,7 +34,7 @@ end_epoch=$(date +'%s')
 let start_epoch=$end_epoch-$back_seconds
 start_date=$(date --date="@$start_epoch" +'%Y-%m-%dT%H:%m:%SZ')
 end_date=$(date --date="@$end_epoch" +'%Y-%m-%dT%H:%m:%SZ')
- 
+
 PAYLOAD='{ "query":
   "query {
     viewer {
@@ -67,5 +66,5 @@ PAYLOAD="$PAYLOAD
 
 # Run query to GraphQL API endpoint
 
-curl -s -X POST -H "Content-Type: application/json" -H "X-Auth-Email: $Email" -H  "X-Auth-Key: $global_key" --data "$(echo $PAYLOAD)" https://api.cloudflare.com/client/v4/graphql/
+curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $api_token" --data "$(echo $PAYLOAD)" https://api.cloudflare.com/client/v4/graphql/
 ```

--- a/products/analytics/src/content/graphql-api/tutorials/build-your-own-analytics/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/build-your-own-analytics/index.md
@@ -9,7 +9,7 @@ In this example, we're going to see how to use the GraphQL Analytics API to buil
 
 ![GraphQL recipe](../static/graphQL-recipe-cacheVisual.gif)
 
-The following code will build a page with all the requirement to fetch from GraphQL and plot the cached and uncached bandwidth for the given zone. You'll just need to enter your API token and your zone ID, and then push the `Fetch analytics` button.
+The following code will build a page with all the requirements to fetch from GraphQL and plot the cached and uncached bandwidth for the given zone. You'll need to enter your API token and your zone ID, then push the `Fetch analytics` button.
 
 ## Code
 

--- a/products/analytics/src/content/graphql-api/tutorials/build-your-own-analytics/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/build-your-own-analytics/index.md
@@ -9,7 +9,7 @@ In this example, we're going to see how to use the GraphQL Analytics API to buil
 
 ![GraphQL recipe](../static/graphQL-recipe-cacheVisual.gif)
 
-The following code will build a page with all the requirement to fetch from GraphQL and plot the cached and uncached bandwidth for the given zone. You'll just need to enter your email address, API token, and your zone ID, and then push the `Fetch analytics` button.
+The following code will build a page with all the requirement to fetch from GraphQL and plot the cached and uncached bandwidth for the given zone. You'll just need to enter your API token and your zone ID, and then push the `Fetch analytics` button.
 
 ## Code
 
@@ -34,8 +34,7 @@ The following code will build a page with all the requirement to fetch from Grap
         <br />
         <div>
             <form><label for="site" class=""><span>Enter your API details:</span></label>
-                    <input placeholder= "Email" id="email"></textarea>
-                    <input placeholder= "API Token" id= "apiKey" ></textarea></form>
+                    <input placeholder= "API Token" id= "apiToken" ></textarea></form>
         </div>
         <label for="site" class=""><span>Choose the zone tag you want to fetch for:</span></label>
         <div><input placeholder= "Zone Tag" id="zoneTag"></textarea></div>
@@ -119,7 +118,7 @@ The following code will build a page with all the requirement to fetch from Grap
 
         };
 
-        function fetchAPI(url, email, apiKey, zoneTag) {
+        function fetchAPI(url, apiToken, zoneTag) {
             let request = new Request(url)
             let query = {"query":"{\n  viewer {\n    zones(filter: { zoneTag: " + zoneTag + " }) {\n      httpRequests1dGroups(\n        orderBy: [date_ASC]\n        limit: 1000\n        filter: { date_gt: \"2019-07-15\" }\n      ) {\n        date: dimensions {\n          date\n        }\n        sum {\n          cachedBytes\n          bytes\n        }\n      }\n    }\n  }\n}","variables":{}}
 
@@ -127,23 +126,21 @@ The following code will build a page with all the requirement to fetch from Grap
                 method: 'POST',
                 body: JSON.stringify(query)
             }
-            request.headers.set('x-auth-key', apiKey)
-            request.headers.set('x-auth-email', email)
+            request.headers.set('Authorization', `Bearer ${apiToken}`)
 
             return fetch(request, init)
         }
 
         document.getElementById('fetch').addEventListener('click', async function() {
-            var email = document.getElementById('email').value
-            var apiKey = document.getElementById('apiKey').value
+            var apiToken = document.getElementById('apiToken').value
             var zoneTag = document.getElementById('zoneTag').value
             var ctx = document.getElementById('canvas').getContext('2d');
             var beforeGraph = document.getElementById('canvas')
 
-            if (email && apiKey) {
+            if (apiToken) {
                 document.getElementById('error').innerHTML = ""
 
-                let response = await fetchAPI('https://api.cloudflare.com/client/v4/graphql', email, apiKey, zoneTag)
+                let response = await fetchAPI('https://api.cloudflare.com/client/v4/graphql', apiToken, zoneTag)
                 let json = await response.json()
 
                 if (response.status == 200) {
@@ -168,7 +165,7 @@ The following code will build a page with all the requirement to fetch from Grap
 
             }
             else {
-                document.getElementById('error').innerHTML = "Please fill the form with your key and email"
+                document.getElementById('error').innerHTML = "Please fill the form with your API token"
                 document.getElementById('error').style.color = "Red"
                 ctx.clearRect(0, 0, canvas.width, canvas.height);
             }

--- a/products/analytics/src/content/graphql-api/tutorials/querying-firewall-events/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/querying-firewall-events/index.md
@@ -6,7 +6,7 @@ title: Querying Firewall Events with GraphQL
 
 In this example, we're going to use the GraphQL Analytics API to query for Firewall Events over a specified time period.
 
-The following API call will request Firewall Events over a one hour period, and output the requested fields. Be sure to replace CLOUDFLARE_ZONE_ID, CLOUDFLARE_EMAIL, and CLOUDFLARE_API_KEY with your zone tag and API credentials, and adjust the datetime_geg and datetime_leq values to your liking.
+The following API call will request Firewall Events over a one hour period, and output the requested fields. Be sure to replace CLOUDFLARE_ZONE_ID and CLOUDFLARE_API_TOKEN with your zone tag and API token, and adjust the datetime_geg and datetime_leq values to your liking.
 
 ## API Call
 
@@ -45,8 +45,7 @@ PAYLOAD='{ "query":
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```
@@ -56,8 +55,7 @@ The results returned will be in JSON (as requested), so piping the output to `jq
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN"\
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 {

--- a/products/analytics/src/content/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
@@ -6,15 +6,13 @@ title: Querying Magic Transit Tunnel Health Check Results with GraphQL
 
 In this example, we're going to use the GraphQL Analytics API to query Magic Transit Health check results which are aggregated from individual health checks carried out by Cloudflare servers to GRE tunnels you've set up to work with Magic Transit during the [onboarding process](https://developers.cloudflare.com/magic-transit/set-up/onboarding). We can query up to one week of data for dates up to three months ago.
 
-The following API call will request a particular account's tunnel health checks over a one day period for a particular Cloudflare colo, and outputs the requested fields. Be sure to replace `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetimeStart`, `datetimeEnd` and `accountTag` variables as needed.
+The following API call will request a particular account's tunnel health checks over a one day period for a particular Cloudflare colo, and outputs the requested fields. Be sure to replace `CLOUDFLARE_API_TOKEN` with your API token, and adjust the `datetimeStart`, `datetimeEnd` and `accountTag` variables as needed.
 
 It will return the tunnel health check results by Cloudflare colo. The result for each colo is aggregated from the healthchecks conducted on individual servers. The tunnel state field in the value represents the [state of the tunnel](https://developers.cloudflare.com/magic-transit/about/health-checks/tunnel#health-state-and-prioritization). These states are used by Magic Transit for [routing](https://developers.cloudflare.com/magic-transit/about/health-checks/tunnel#failure). The value 0 for the tunnel state represents it being down, the value 0.5 being degraded and the value 1 as healthy.
 
 ## API Call
 
 ```
-CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
-CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
 PAYLOAD='{ "query":
   "query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
     {
@@ -49,8 +47,7 @@ PAYLOAD='{ "query":
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```
@@ -61,8 +58,7 @@ The results returned will be in JSON (as requested), so piping the output to `jq
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
   {

--- a/products/analytics/src/content/graphql-api/tutorials/querying-workers-metrics/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/querying-workers-metrics/index.md
@@ -6,13 +6,11 @@ title: Querying Workers Metrics with GraphQL
 
 In this example, we're going to use the GraphQL Analytics API to query for Workers Metrics over a specified time period. We can query up to one week of data for dates up to three months ago.
 
-The following API call will request a Worker script's metrics over a one day period, and output the requested fields. Be sure to replace `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetimeStart`, `datetimeEnd`, `accountTag`, and `scriptName` variables as needed.
+The following API call will request a Worker script's metrics over a one day period, and output the requested fields. Be sure to replace `CLOUDFLARE_API_TOKEN` with your API token, and adjust the `datetimeStart`, `datetimeEnd`, `accountTag`, and `scriptName` variables as needed.
 
 ## API Call
 
 ```
-CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
-CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
 PAYLOAD='{ "query":
   "query GetWorkersAnalytics($accountTag: string, $datetimeStart: string, $datetimeEnd: string, $scriptName: string) {
       viewer {
@@ -51,8 +49,7 @@ PAYLOAD='{ "query":
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```
@@ -63,8 +60,7 @@ The results returned will be in JSON (as requested), so piping the output to `jq
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "Authorization: Bearer CLOUDFLARE_API_TOKEN" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 {

--- a/products/analytics/src/content/migration-guides/zone-analytics/index.md
+++ b/products/analytics/src/content/migration-guides/zone-analytics/index.md
@@ -9,7 +9,7 @@ The [Zone Analytics API](https://api.cloudflare.com/#zone-analytics-properties) 
 
 For example, here is a sample curl call to get data for a two minute period:
 ```bash
-curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" -X GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/analytics/dashboard?since=2019-09-08T20:00:00Z&until=2019-09-08T20:02:00Z&continuous=false" | jq .
+curl -s -H "Authorization: Bearer $API_TOKEN" -X GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/analytics/dashboard?since=2019-09-08T20:00:00Z&until=2019-09-08T20:02:00Z&continuous=false" | jq .
 ```
 
 <details>

--- a/products/firewall/src/content/api/call-sequence.md
+++ b/products/firewall/src/content/api/call-sequence.md
@@ -27,8 +27,7 @@ Below is an example call and response using this method:
 
 ```bash
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '[
 {"filter":{"expression":"http.request.uri.path contains \"/api/\" and ip.src eq 93.184.216.34"}, "action": "block"}

--- a/products/firewall/src/content/api/cf-filters/delete.md
+++ b/products/firewall/src/content/api/cf-filters/delete.md
@@ -17,7 +17,7 @@ DELETE zones/{zone_id}/filters
 ### Request
 
 ```bash
-curl -X DELETE -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters?id=60ee852f9cbb4802978d15600c7f3110"
+curl -X DELETE -H "Authorization: Bearer $API_TOKEN" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters?id=60ee852f9cbb4802978d15600c7f3110"
 ```
 
 ### Response
@@ -40,7 +40,7 @@ DELETE zones/{zone_id}/filters/{id}
 ### Request
 
 ```bash
-curl -X DELETE -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110"
+curl -X DELETE -H "Authorization: Bearer $API_TOKEN" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110"
 ```
 
 ### Response

--- a/products/firewall/src/content/api/cf-filters/get.md
+++ b/products/firewall/src/content/api/cf-filters/get.md
@@ -18,8 +18,7 @@ GET zones/{zone_id}/filters
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters"
 ```
 
@@ -81,8 +80,7 @@ GET zones/{zone_id}/filters/{id}
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
 "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/b7ff25282d394be7b945e23c7106ce8a"
 ```
 

--- a/products/firewall/src/content/api/cf-filters/post.md
+++ b/products/firewall/src/content/api/cf-filters/post.md
@@ -15,8 +15,7 @@ Creates one or more filters.
 
 ```bash
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '[
 {"expression": "ip.src eq 93.184.216.0"},

--- a/products/firewall/src/content/api/cf-filters/put.md
+++ b/products/firewall/src/content/api/cf-filters/put.md
@@ -18,8 +18,7 @@ PUT zones/{zone_id}/filters
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '[
 {
@@ -59,8 +58,7 @@ PUT zones/{zone_id}/filters/{id}
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
     "id": "b7ff25282d394be7b945e23c7106ce8a",

--- a/products/firewall/src/content/api/cf-filters/validation.md
+++ b/products/firewall/src/content/api/cf-filters/validation.md
@@ -44,7 +44,7 @@ The Cloudflare Filters API supports an endpoint for validating expressions.
 #### Request
 
 ```bash
-curl -X GET -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" 'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34'
+curl -X GET -H "Authorization: Bearer $API_TOKEN" 'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34'
 ```
 
 #### Response
@@ -76,8 +76,7 @@ Filter parsing error:
 
 ```bash
 curl -X POST \
-    -H "X-Auth-Email: user@cloudflare.com" \
-    -H "X-Auth-Key: REDACTED" \
+    -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
     "expression": "ip.src in {2400:cb00::/32 2405:8100::/2000 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29}"

--- a/products/firewall/src/content/api/cf-firewall-rules/delete.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/delete.md
@@ -18,8 +18,7 @@ DELETE zones/{zone_id}/firewall/rules
 
 ```bash
 curl -X DELETE \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules?id=cbf4b7a5a2a24e59a03044d6d44ceb09"
 ```
 
@@ -50,8 +49,7 @@ DELETE zones/{zone_id}/firewall/rules/{id}
 
 ```bash
 curl -X DELETE \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/cbf4b7a5a2a24e59a03044d6d44ceb09"
 ```
 

--- a/products/firewall/src/content/api/cf-firewall-rules/get.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/get.md
@@ -18,8 +18,7 @@ GET zones/{zone_id}/firewall/rules
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules"
 ```
 
@@ -104,8 +103,7 @@ GET zones/{zone_id}/firewall/rules/{id}
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
   "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd"
 ```
 

--- a/products/firewall/src/content/api/cf-firewall-rules/post.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/post.md
@@ -15,8 +15,7 @@ Creates one or more firewall rules.
 
 ```bash
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '[
   {

--- a/products/firewall/src/content/api/cf-firewall-rules/put.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/put.md
@@ -19,8 +19,7 @@ You can include up to 25 rules in the JSON object array (_-d_ flag) to update as
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '[
   {
@@ -100,8 +99,7 @@ To preserve existing values, issue a `GET` request and based on the response, de
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
   "id": "f2d427378e7542acb295380d352e2ebd",

--- a/products/firewall/src/content/cf-rulesets/rulesets-api/get.md
+++ b/products/firewall/src/content/cf-rulesets/rulesets-api/get.md
@@ -30,8 +30,7 @@ Results are sorted by Ruleset ID in ascending order.
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
      "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets"
 ```
 
@@ -75,8 +74,7 @@ The API returns a HTTP Status Code 404 under these conditions:
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
   "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}"
 ```
 
@@ -111,8 +109,7 @@ Returns the version of a ruleset with the specified Ruleset ID and version numbe
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
+     -H "Authorization: Bearer $API_TOKEN" \
   "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset-id}/versions/1"
 ```
 
@@ -151,8 +148,7 @@ Fetches a list of rules in a managed ruleset tagged with a specific category. Th
 
 ```bash
 curl -X GET \
-      -H "X-Auth-Email: user@cloudflare.com" \
-      -H "X-Auth-Key: REDACTED" \
+      -H "Authorization: Bearer $API_TOKEN" \
     "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset-id}/versions/2/by_category/drupal"
 
 ```

--- a/products/load-balancing/src/content/create-load-balancer-api/index.md
+++ b/products/load-balancing/src/content/create-load-balancer-api/index.md
@@ -368,8 +368,7 @@ This command returns a list of zones, each with an associated hostname and Cloud
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/zones?name=example.com&status=active&account.id=01a7362d577a6c3019a474fd6f485823&account.name=Demo Account&page=1&per_page=20&order=status&direction=desc&match=all" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json"
 
 ```

--- a/products/load-balancing/src/content/understand-basics/session-affinity.md
+++ b/products/load-balancing/src/content/understand-basics/session-affinity.md
@@ -88,8 +88,7 @@ You can configure session affinity as part of your request to the Create Load Ba
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/zones/699d98642c564d2e855e9661899b7252/load_balancers" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '   "description":"Load Balancer for www.example.com",
    "name":"www.example.com",
@@ -192,8 +191,7 @@ PUT zones/:identifier/load_balancers/:identifier
 
 ```bash
 curl -X PUT "https://api.cloudflare.com/client/v4/zones/699d98642c564d2e855e9661899b7252/load_balancers" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '   "description":"Load Balancer for www.example.com",
    "name":"www.example.com",

--- a/products/load-balancing/src/content/understand-basics/weighted-load-balancing.md
+++ b/products/load-balancing/src/content/understand-basics/weighted-load-balancing.md
@@ -62,8 +62,7 @@ The example below uses the Update Pools command—`POST /user/load_balancers/poo
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/user/load_balancers/pools" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
 --data '{
    "description":"Primary data center - Provider XYZ",

--- a/products/logs/src/content/logpull-api/additional-details/index.md
+++ b/products/logs/src/content/logpull-api/additional-details/index.md
@@ -11,8 +11,7 @@ To estimate the amount of data for a zone per day (the number of log lines and t
 
 ```bash
 curl -s \
-    -H "X-Auth-Email: <REDACTED>" \
-    -H "X-Auth-Key: <REDACTED>" \
+    -H "Authorization: Bearer $API_TOKEN" \
     "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received?start=2018-12-15T00:00:00Z&end=2018-12-15T01:00:00Z&sample=0.1" \
     >sample.log
 ...

--- a/products/logs/src/content/logpull-api/enabling-log-retention/index.md
+++ b/products/logs/src/content/logpull-api/enabling-log-retention/index.md
@@ -24,7 +24,7 @@ To make a `POST` call, you must have a Cloudflare account role with "edit" permi
 ### Check whether log retention is turned on:
 
 ```bash
-curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" | jq .
+curl -s -H "Authorization: Bearer $API_TOKEN" -X GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" | jq .
 ```
 
 #### Response
@@ -43,7 +43,7 @@ curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" GET "https://a
 ### Turn on log retention:
 
 ```bash
-curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" POST "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" -d'{"flag":true}' | jq .
+curl -s -H "Authorization: Bearer $API_TOKEN" -X POST "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" -d'{"flag":true}' | jq .
 ```
 
 #### Parameters

--- a/products/logs/src/content/logpull-api/requesting-logs/index.md
+++ b/products/logs/src/content/logpull-api/requesting-logs/index.md
@@ -17,8 +17,7 @@ The three endpoints the Logpull API supports are:
 
 The following headers are required for all endpoint calls:
 
-* `X-Auth-Email` - the Cloudflare account email address associated with the domain
-* `X-Auth-Key` - the Cloudflare API key
+* `Authorization` - a Cloudflare API Token with `#logs:read` permissions for the zone
 
 ## Parameters
 
@@ -66,8 +65,7 @@ The overlap will be handled correctly.
 
 ```bash
 curl -s \
-    -H "X-Auth-Email: <REDACTED>" \
-    -H "X-Auth-Key: <REDACTED>" \
+    -H "Authorization: Bearer $API_TOKEN" \
     "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received?start=2017-07-18T22:00:00Z&end=2017-07-18T22:01:00Z&count=1&fields=RayID,ClientIP"
 ```
 
@@ -75,8 +73,7 @@ curl -s \
 
 ```bash
 curl -s \
-    -H "X-Auth-Email: <REDACTED>" \
-    -H "X-Auth-Key: <REDACTED>" \
+    -H "Authorization: Bearer $API_TOKEN" \
     "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/rayids/47ff6e2c812d3ccb?timestamps=rfc3339"
 ```
 
@@ -97,9 +94,8 @@ Using <em>Bash</em> subshell and <em>jq</em>, you can download the logs with all
 
 ```bash
 curl -s \
-    -H "X-Auth-Email: <REDACTED>" \
-    -H "X-Auth-Key: <REDACTED>" \
-    "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received?start=2017-07-18T22:00:00Z&end=2017-07-18T22:01:00Z&count=1&fields=$(curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received/fields" | jq '. | to_entries[] | .key' -r | paste -sd "," -)"
+    -H "Authorization: Bearer $API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received?start=2017-07-18T22:00:00Z&end=2017-07-18T22:01:00Z&count=1&fields=$(curl -s -H "Authorization: Bearer $API_TOKEN" "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received/fields" | jq '. | to_entries[] | .key' -r | paste -sd "," -)"
 ```
 
 *See [HTTP request fields](/log-fields/#http-requests)* for the currently available fields.

--- a/products/logs/src/content/logpush/logpush-configuration-api/index.md
+++ b/products/logs/src/content/logpush/logpush-configuration-api/index.md
@@ -23,8 +23,7 @@ To get started:
 
 2. Have your Cloudflare API credentials and other information handy, including:
 
-   - Email address
-   - Cloudflare API key
+   - Cloudflare API token
    - Zone ID
    - Destination access details for your cloud service provider
 

--- a/products/logs/src/content/logpush/logpush-configuration-api/understanding-logpush-api.md
+++ b/products/logs/src/content/logpush/logpush-configuration-api/understanding-logpush-api.md
@@ -38,7 +38,7 @@ For concrete examples, see the tutorial [Manage Logpush with cURL](/tutorials/tu
 The Logpush API requires credentials like any other Cloudflare API.
 
 ```bash
-$ curl -s -H "X-Auth-Email: <REDACTED>" -H "X-Auth-Key: <REDACTED>" \
+$ curl -s -H "Authorization: Bearer $API_TOKEN" \
     'https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logpush/jobs'
 ```
 
@@ -130,8 +130,7 @@ Log options, such as fields or sampling rate, are configured in the `logpull_opt
 
 ```bash
 curl -sv \
-    -H'X-Auth-Email: <REDACTED>' \
-    -H'X-Auth-Key: <REDACTED>' \
+    -H "Authorization: Bearer $API_TOKEN" \
     "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/received?start=2018-08-02T10:00:00Z&end=2018-08-02T10:01:00Z&fields=RayID,EdgeStartTimestamp"
 ```
 

--- a/products/logs/src/content/tutorials/example-logpush-python.md
+++ b/products/logs/src/content/tutorials/example-logpush-python.md
@@ -7,12 +7,12 @@ order: 88
 
 ```python
 import json
+import os
 import requests
 
 url = "https://api.cloudflare.com/client/v4/"
 
-x_auth_email = "EMAIL_REDACTED"
-x_auth_key = "KEY_REDACTED"
+api_token = os.environ["API_TOKEN"]
 
 zone_id = "ZONE_REDACTED"
 destination_conf = "s3://BUCKET_REDACTED/logs?region=us-west-1"
@@ -20,8 +20,7 @@ destination_conf = "s3://BUCKET_REDACTED/logs?region=us-west-1"
 logpush_url = url + "/zones/%s/logpush" % zone_id
 
 headers = {
-  'X-Auth-Email': x_auth_email,
-  'X-Auth-Key': x_auth_key,
+  'Authorization': f'Bearer {api_token}',
   'Content-Type': 'application/json'
 }
 

--- a/products/magic-transit/src/content/magic-firewall/adding-rules.md
+++ b/products/magic-transit/src/content/magic-firewall/adding-rules.md
@@ -15,8 +15,7 @@ API Example:
 ```
 curl https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000'
+-H "Authorization: Bearer $API_TOKEN"
 ```
 
 <Aside type='note' header='Note'>
@@ -43,8 +42,7 @@ API Example:
 ```
 curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' \
+-H "Authorization: Bearer $API_TOKEN" \
 --data '{
   "name": "Example ruleset",
   "kind": "root",

--- a/products/magic-transit/src/content/magic-firewall/examples.md
+++ b/products/magic-transit/src/content/magic-firewall/examples.md
@@ -13,8 +13,7 @@ by using the skip action.
 ```
 curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' \
+-H "Authorization: Bearer $API_TOKEN" \
 --data '{
     "name": "Example ruleset",
     "kind": "root",

--- a/products/magic-transit/src/content/magic-firewall/updating-rules.md
+++ b/products/magic-transit/src/content/magic-firewall/updating-rules.md
@@ -12,8 +12,7 @@ API Example:
 ```
 curl -X GET https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000'
+-H "Authorization: Bearer $API_TOKEN"
 ```
 
 Example data:
@@ -49,8 +48,7 @@ We'll use this to fetch the existing rules to help us construct the call to upda
 ```
 curl https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets/4376358e00ec4c42b0450b1afed120bf/versions/1 \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' | jq '.result | {description: .description, rules: [ .rules[] | {id: .id, description: .description, action: .action, action_parameters: .action_parameters, expression: .expression} ]}'
+-H "Authorization: Bearer $API_TOKEN" | jq '.result | {description: .description, rules: [ .rules[] | {id: .id, description: .description, action: .action, action_parameters: .action_parameters, expression: .expression} ]}'
 ```
 
 <Aside type='note' header='Note'>
@@ -81,8 +79,7 @@ Now, we have enough to make the call to update the ruleset:
 ```
 curl -X PUT https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets/${ruleset_id} \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' \
+-H "Authorization: Bearer $API_TOKEN" \
 --data '{
   "description": "block traffic with known bad patterns",
   "rules": [

--- a/products/spectrum/src/content/analytics.md
+++ b/products/spectrum/src/content/analytics.md
@@ -78,7 +78,6 @@ The AND operator is defined using a semicolon (;) or AND keyword surrounded by w
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/spectrum/analytics/events/summary?metrics=count&dimensions=event,appID&since=2018-01-01T16:57:00Z" \
-   -H "X-Auth-Email: you@email.com" \
-   -H "X-Auth-Key: 0000" \
+   -H "Authorization: Bearer $API_TOKEN" \
    -H "Content-Type: application/json"
 ```

--- a/products/spectrum/src/content/byoip.md
+++ b/products/spectrum/src/content/byoip.md
@@ -44,8 +44,7 @@ Full example of creating an application that routes traffic through Cloudflareâ€
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/zones/ZONEID/spectrum/apps" \
-     -H "X-Auth-Email: USER_EMAIL" \
-     -H "X-Auth-Key: API_KEY" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '{
       "protocol": "tcp/80",

--- a/products/spectrum/src/content/cname-origins.md
+++ b/products/spectrum/src/content/cname-origins.md
@@ -17,8 +17,7 @@ You will need to create a record on your Cloudflare hosted zone that points to y
 ```bash
 curl 'https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/dns_records'  \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' \
+-H "Authorization: Bearer $API_TOKEN" \
 -X POST --data '{"type":"CNAME", "name":"cname-to-origin.example.com", "content":"origin.domain.com", "proxied":true}'
 ```
 
@@ -42,8 +41,7 @@ You will then need to create the Spectrum application that will point to the dom
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/spectrum/apps' \
 -H "Content-Type: application/json" \
--H "X-Auth-Email: email" \
--H "X-Auth-Key: key" \
+-H "Authorization: Bearer $API_TOKEN" \
 --data '{"dns":{"type":"CNAME","name":"spectrum-cname.example.com"},"ip_firewall":false,"protocol":"tcp/22","proxy_protocol":"off","tls":"off","origin_dns": {"name": "cname-to-origin.example.com", "ttl": 1200}, "origin_port": 22}'
 ```
 

--- a/products/spectrum/src/content/load-balancer.md
+++ b/products/spectrum/src/content/load-balancer.md
@@ -31,8 +31,7 @@ The below image will configure a TCP health check for an application running on 
 ```bash
 curl 'https://api.cloudflare.com/client/v4/organizations/{ORG_ID}/load_balancers/monitors'  \
 -H 'Content-Type: application/json' \
--H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' \
+-H "Authorization: Bearer $API_TOKEN" \
 -X POST --data '{"description":"Spectrum Health Check","type":"tcp","port":2048,"interval":30,"retries":2,"timeout":5,"method":"connection_established"}'
 ```
 
@@ -105,8 +104,7 @@ Navigate to the Spectrum tab in the dashboard and select the `Add an Application
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/spectrum/apps' \
 -H "Content-Type: application/json" \
--H "X-Auth-Email: email" \
--H "X-Auth-Key: key" \
+-H "Authorization: Bearer $API_TOKEN" \
 --data '{"dns":{"type":"CNAME","name":"spectrum-cname.example.com"},"ip_firewall":false,"protocol":"tcp/22","proxy_protocol":false,"tls":"off","origin_dns": {"name": "cname-to-origin.example.com", "ttl": 1200}, "origin_port": 22}'
 ```
 

--- a/products/ssl/src/content/advanced-certificate-manager/index.md
+++ b/products/ssl/src/content/advanced-certificate-manager/index.md
@@ -30,7 +30,7 @@ Selecting Let’s Encrypt as a CA limits a certificate to txt validation_method,
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificate_packs/order" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+-H "Authorization: Bearer $API_TOKEN" \
 -H "Content-Type: application/json" \
 --data'{"Type":"advanced","hosts":["example.com","*.example.com","www.example.com"],"Validation_method":"txt","Validity_days":365,"Certificate_authority":"digicert","Cloudflare_branding":false}'
 
@@ -63,7 +63,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificate
 
 ```bash
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+-H "Authorization: Bearer $API_TOKEN" \
 -H "Content-Type: application/json"
 
 {
@@ -95,7 +95,7 @@ curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificat
 
 ```bash
 curl -X DELETE "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+-H "Authorization: Bearer $API_TOKEN" \
 -H "Content-Type: application/json"
 
 {
@@ -122,7 +122,7 @@ To [list all Advanced Certificates on the zone via API](https://api.cloudflare.c
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/zones/:zoneid/ssl/certificate_packs?status=all" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+-H "Authorization: Bearer $API_TOKEN"\
 -H "Content-Type: application/json"
 ```
 
@@ -134,7 +134,7 @@ To [change the Cipher Suite Settings on the zone via the API](https://api.cloudf
 
 ```bash
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zoneid/settings/ciphers" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+-H "Authorization: Bearer $API_TOKEN"\
 -H "Content-Type: application/json" \
 --data '{"value":["ECDHE-RSA-AES128-GCM-SHA256","AES128-SHA"]}'
 ```
@@ -147,7 +147,7 @@ To [list the Cipher Suite Settings on the zone via the API](https://api.cloudfla
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/zones/:zoneid/settings/ciphers" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+-H "Authorization: Bearer $API_TOKEN" \
 -H "Content-Type: application/json"
 ```
 
@@ -159,7 +159,7 @@ To [change the Cipher Suite Settings on the zone via the API](https://api.cloudf
 
 ```bash
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zoneid/settings/ciphers" \
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+-H "Authorization: Bearer $API_TOKEN" \
 -H "Content-Type: application/json" \
 --data '{"value":[]}'
 ```

--- a/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
+++ b/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
@@ -206,7 +206,7 @@ EOF
 ))
 
 // save the response so we can view it and then extra the certificate
-$ curl -H 'X-Auth-Email: YOUR_EMAIL' -H 'X-Auth-Key: YOUR_API_KEY' -H 'Content-Type: application/json' -d “$request_body” https://api.cloudflare.com/client/v4/zones/YOUR_ZONE_ID/client_certificates > response.json
+$ curl -H "Authorization: Bearer $API_TOKEN" -H 'Content-Type: application/json' -d “$request_body” https://api.cloudflare.com/client/v4/zones/YOUR_ZONE_ID/client_certificates > response.json
 
 $ cat response.json | jq .
 {
@@ -250,7 +250,7 @@ $ request_body=$(< <(cat <<EOF
 EOF
 ))
 
-$ curl -H 'X-Auth-Email: YOUR_EMAIL' -H 'X-Auth-Key: YOUR_API_KEY' -H 'Content-Type: application/json' -d "$request_body" https://api.cloudflare.com/client/v4/zones/YOUR_ZONE_ID/client_certificates | perl -npe 's/\\n/\n/g; s/"//g' > sensor.pem
+$ curl -H "Authorization: Bearer $API_TOKEN" -H 'Content-Type: application/json' -d "$request_body" https://api.cloudflare.com/client/v4/zones/YOUR_ZONE_ID/client_certificates | perl -npe 's/\\n/\n/g; s/"//g' > sensor.pem
 
 ```
 

--- a/products/ssl/src/content/custom-certificates/uploading.md
+++ b/products/ssl/src/content/custom-certificates/uploading.md
@@ -86,12 +86,12 @@ $ request_body=$(< <(cat <<EOF
 }
 ))
 ```
-`sni_custom` is recommended by Cloudflare. Use `legacy_custom` when a specific client requires non-SNI support. The Cloudflare API treats all Custom SSL certificates as Legacy by default.  
+`sni_custom` is recommended by Cloudflare. Use `legacy_custom` when a specific client requires non-SNI support. The Cloudflare API treats all Custom SSL certificates as Legacy by default.
 
 ### 2. With the payload built, make the API call to upload your certificate and key
 
 ```bash
 $ curl -sX POST https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_certificates \
-     -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" -d "$request_body"
 ```

--- a/products/ssl/src/content/origin-configuration/authenticated-origin-pull.md
+++ b/products/ssl/src/content/origin-configuration/authenticated-origin-pull.md
@@ -86,7 +86,7 @@ To enable Authenticated Origin Pull globally on a zone:
 
     ```bash
     curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zone/settings/tls_client_auth" \
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+    -H "Authorization: Bearer $API_TOKEN" \
     -H "Content-Type: application/json" \
     --data '{"value":"on"}'
 
@@ -144,7 +144,7 @@ To enable Authenticated Origin Pull globally on a zone:
 
     ```bash
     curl -sX POST https://api.cloudflare.com/client/v4/zones/:zone/origin_tls_client_auth \
- 	-H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+    -H "Authorization: Bearer $API_TOKEN" \
     -H Content-Type: application/json' \
     -d "$request_body"
 
@@ -174,7 +174,7 @@ The following [API call enables Authenticated origin pull at zone level](https:/
     curl -X PUT https://api.cloudflare.com/client/v4/zones/:zone/origin_tls_client_auth/settings
 
     \
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+    -H "Authorization: Bearer $API_TOKEN" \
     -H "Content-Type: application/json" \
     --data '{"enabled":true}'
     {
@@ -234,7 +234,7 @@ To upload a client certificate in Cloudflare:
 
   ```bash
   curl -sX POST https://api.cloudflare.com/client/v4/zones/:zone/origin_tls_client_auth/hostnames/certificates \
-  -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+  -H "Authorization: Bearer $API_TOKEN" \
   -H Content-Type: application/json' \
   -d "$request_body"
 
@@ -266,7 +266,7 @@ Link the client certificate to a specific hostname:
 
     ```bash
     curl -sX PUT https://api.cloudflare.com/client/v4/zones/:zone/origin_tls_client_auth/hostnames \
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+    -H "Authorization: Bearer $API_TOKEN" \
     -H Content-Type: application/json' \
     -d '{"config":[{"hostname":"app.example.com","cert_id":"2458ce5a-0c35-4c7f-82c7-8e9487d3ff60","enabled":true}]}'
 

--- a/products/ssl/src/content/ssl-for-saas/certificate-signing-requests.md
+++ b/products/ssl/src/content/ssl-for-saas/certificate-signing-requests.md
@@ -43,7 +43,7 @@ EOF
 
 ```bash
 $ curl -sXPOST https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_csrs\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json' -d "$request_body"
 
 {
@@ -72,7 +72,7 @@ Note that the ‘\n’ strings should be replaced with actual newline before pas
 
 ```bash
 $ curl -sXPOST https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_csrs\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json' -d "$request_body" | jq .result.csr |\
     perl -npe s'/\\n/\n/g; s/"//g' > csr.txt
 ```
@@ -109,7 +109,7 @@ With the request body built, create the Custom Hostname with the supplied custom
 
 ```bash
 $ curl -sXPOST https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json'\
     -d "$request_body"
 
@@ -202,7 +202,7 @@ You may delete a CSR provided there are no custom certificates using the private
 
 ```bash
 $ curl -sXDELETE https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_csrs/{csr_id}\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"
+    -H "Authorization: Bearer $API_TOKEN"
 
 {
     "result": null,

--- a/products/ssl/src/content/ssl-for-saas/certificate-validation-methods.md
+++ b/products/ssl/src/content/ssl-for-saas/certificate-validation-methods.md
@@ -38,7 +38,7 @@ This validation method allows your customer to add a TXT record to prove control
 
 ```bash
 $ curl -sX POST "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"another.example.com", "ssl":{"method":"txt","type":"dv"}}'
 
@@ -61,7 +61,7 @@ After a few seconds, i.e., once the state has transition from `initializing` to 
 
 ```bash
 $ curl -sX GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/46f8849a-72c9-49e0-9e42-857297d89306" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"
+       -H "Authorization: Bearer $API_TOKEN"
 {
   "result": {
     "id": "46f8849a-72c9-49e0-9e42-857297d89306",
@@ -85,7 +85,7 @@ If you’d like to request an immediate recheck, [rather than wait for the next 
 
 ```bash
 $ curl -X PATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/46f8849a-72c9-49e0-9e42-857297d89306" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"another.example.com", "ssl":{"method":"txt","type":"dv"}}'
 ```
@@ -98,7 +98,7 @@ First, create a new hostname using `"method":"email"`:
 
 ```bash
 $ curl -sX POST "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"emailval.example.com", "ssl":{"method":"email","type":"dv"}}'
 
@@ -121,7 +121,7 @@ Then, request the status to see the email addresses to which the approval email 
 
 ```bash
 $ curl -sX GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/16798830-42c1-4e4f-82b4-4695ee8b62e4" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"
+       -H "Authorization: Bearer $API_TOKEN"
 {
   "result": {
     "id": "16798830-42c1-4e4f-82b4-4695ee8b62e4",
@@ -163,7 +163,7 @@ First, make a request using `"method":"http"`:
 
 ```bash
 $ curl -sXPOST "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"http-preval.example.com", "ssl":{"method":"http","type":"dv"}}'
 {
@@ -184,7 +184,7 @@ $ curl -sXPOST "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_host
 Next, wait a few seconds for the status to transition from `initializing` to `pending_validation`, the step that obtains the random path and token from the CA, and then request status:
 
 ```bash
-$ curl -sXGET -H "X-Auth-Key: $MYAPIKEY" -H "X-Auth-Email: $MYEMAIL" https://api.cloudflare.com/client/v4/zones/$MYZONETAG/custom_hostnames/3aa0e60f-7622-47a4-8519-7a5fd7eb7145
+$ curl -sXGET -H "Authorization: Bearer $API_TOKEN" https://api.cloudflare.com/client/v4/zones/$MYZONETAG/custom_hostnames/3aa0e60f-7622-47a4-8519-7a5fd7eb7145
 {
   "result": {
     "id": "3aa0e60f-7622-47a4-8519-7a5fd7eb7145",
@@ -223,7 +223,7 @@ On the next check cycle, Cloudflare will ask the CA to recheck the URL, complete
 
 ```bash
 $ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"http-preval.example.com", "ssl":{"method":"http","type":"dv"}}'
 ```
@@ -234,7 +234,7 @@ The last DCV method available is via a CNAME record. First, make a request using
 
 ```bash
 $ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+       -H "Authorization: Bearer $API_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"cname.example.com", "ssl":{"method":"cname","type":"dv"}}'
 

--- a/products/ssl/src/content/ssl-for-saas/common-api-calls.md
+++ b/products/ssl/src/content/ssl-for-saas/common-api-calls.md
@@ -12,7 +12,7 @@ View all certificates on a zone using a GET to the *custom_hostnames* endpoint. 
 
 ```bash
 $ curl -sX GET https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames?page=1\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json'
 {
   "result": [
@@ -55,7 +55,7 @@ To search for a certificate by *hostname*, add the hostname parameter to your qu
 
 ```bash
 $ curl -sX GET https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames?hostname=app.example.com\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" -H 'Content-Type: application/json'
+    -H "Authorization: Bearer $API_TOKEN" -H 'Content-Type: application/json'
 
 {
   "result": [
@@ -119,8 +119,7 @@ Standard response structure, with the following result value:
 
 ```bash
 $ curl --location --request GET 'https://api.cloudflare.com/client/v4/zones/:zone_id/custom_hostnames/fallback_origin' \
---header 'X-Auth-Email: EMAIL' \
---header 'X-Auth-Key: APIKEY' \
+--header "Authorization: Bearer $API_TOKEN" \
 --header 'Content-Type: application/json' \
 
 {
@@ -150,7 +149,7 @@ Response schema: same as GET response for success. If the request failed, includ
 
 ```bash
 $ curl -X PUT "https://api.cloudflare.com/client/v4/zones/:zone_id/custom_hostnames/fallback_origin"\
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+-H "Authorization: Bearer $API_TOKEN"\
 -H "Content-Type: application/json"\
 -d '{"origin":"proxy-fallback.saasprovider.com"}'
 

--- a/products/ssl/src/content/ssl-for-saas/getting-started.md
+++ b/products/ssl/src/content/ssl-for-saas/getting-started.md
@@ -21,7 +21,7 @@ The fallback origin is used to route the traffic of your Custom Hostnames.  The 
 ```bash
 $ curl -XPUT
 "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/custom_hostnames/fallback_origin"\
--H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+-H "Authorization: Bearer $API_TOKEN"\
 -H "Content-Type: application/json"\
 -d '{"origin":"proxy-fallback.saasprovider.com"}'
 ```
@@ -60,7 +60,7 @@ In this example, HTTP based validation is used ("method":"http") to issue this c
 
 ```bash
 $ curl -XPOST "https://api.cloudflare.com/client/v4/zones/:zone_id/custom_hostnames"\
-       -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+       -H "Authorization: Bearer $API_TOKEN"\
        -H "Content-Type: application/json"\
        -d '{"hostname":"app.example.com", "ssl":{"method":"http","type":"dv"}}'
 ```

--- a/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/custom-metadata.md
+++ b/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/custom-metadata.md
@@ -24,7 +24,7 @@ You may add custom metadata to Cloudflare via the Custom Hostnames API. This dat
 
 ```bash
 $ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id} /custom_hostnames/{hostname_id}"\
-     -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+     -H "Authorization: Bearer $API_TOKEN"\
      -H "Content-Type: application/json"\
      -d '{"ssl":{"method":"http","type":"dv"},"custom_metadata":{"customer_id":"12345","redirect_to_https": true}}'
 ```

--- a/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/index.md
+++ b/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/index.md
@@ -31,7 +31,7 @@ If your zone has been granted the Custom Origin Server entitlement, you have the
 
 ```bash
 $ curl -sX PATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{hostname_id}" \
-     -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"ssl":{"method":"http","type":"dv"},"custom_origin_server":"origin2.example.com"}'
 ```
@@ -48,7 +48,7 @@ In this API example, we PATCH an existing custom hostname to enable HTTP/2 (spec
 
 ```bash
 $ curl -sX PATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{hostname_id}" \
-     -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"ssl":{"method":"http","type":"dv","settings":{"http2":"on","min_tls_version":"1.1","tls_1_3":"on"}}}'
 ```

--- a/products/ssl/src/content/ssl-for-saas/issuing-certificates.md
+++ b/products/ssl/src/content/ssl-for-saas/issuing-certificates.md
@@ -28,7 +28,7 @@ Once a certificate has been ordered or uploaded, you can make API calls to check
 
 ```bash
 curl -XGET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{hostname_id}"\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H "Content-Type: application/json"\
 ```
 
@@ -38,7 +38,7 @@ Alternatively, if you have not stored the hostname identifier, you can look the 
 
 ```bash
 curl -XGET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames?hostname=app.example.com"\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H "Content-Type: application/json"
 ```
 

--- a/products/ssl/src/content/ssl-for-saas/troubleshooting.md
+++ b/products/ssl/src/content/ssl-for-saas/troubleshooting.md
@@ -55,7 +55,7 @@ You can send a `PATCH` request to request an immediate validation check on any c
 
 ```bash
 $ curl -sXPATCH https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/7f09bb24-9ee0-49b3-98bb-11cccd664edb\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json' -d '{"ssl":{"method":"cname", "type":"dv"}}'
 
 {
@@ -81,7 +81,7 @@ Granularly remove one or more files from Cloudflare’s cache either by specifyi
 
 ```bash
 $ curl -sXDELETE "https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache"\
-     -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"\
+     -H "Authorization: Bearer $API_TOKEN"\
      -H "Content-Type: application/json"\
      -d '{"hosts":["www.customer.com", "www.customer2.com"]}'
 ```

--- a/products/ssl/src/content/ssl-for-saas/uploading-certificates.md
+++ b/products/ssl/src/content/ssl-for-saas/uploading-certificates.md
@@ -64,7 +64,7 @@ Note that the serial number returned is unique to the issuer, but not globally u
 
 ```bash
 $ curl -sX POST https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames\
-    -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}"
+    -H "Authorization: Bearer $API_TOKEN"\
     -H 'Content-Type: application/json' -d "$request_body"
 
 {

--- a/products/ssl/src/content/universal-ssl/changing-dcv-method.md
+++ b/products/ssl/src/content/universal-ssl/changing-dcv-method.md
@@ -55,8 +55,7 @@ To begin, find the `cert_pack_uuid` of the order that you would like to change v
 ```bash
 curl -sX GET \
 "https://api.cloudflare.com/client/v4/zones/:zone_id/ssl/verification/" \
--H 'X-Auth-Email: YOUR_EMAIL' \
--H 'X-Auth-Key: API_KEY'
+-H "Authorization: Bearer $API_TOKEN"
 
 {
     "result": [
@@ -90,8 +89,7 @@ This endpoint will modify the validation method of a selected certificate order.
 
 ```bash
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/:zone_id/ssl/verification/<cert_pack_uuid>" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: API_KEY" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '{"validation_method":"cname"}'
 
@@ -127,8 +125,7 @@ Once that is validated by the Certificate Authority, the “Get Validation Metho
 ```bash
 curl -sX GET \
 "https://api.cloudflare.com/client/v4/zones/:zone_id/ssl/verification/" \
--H 'X-Auth-Email: YOUR_EMAIL' \
--H 'X-Auth-Key: API_KEY'
+-H "Authorization: Bearer $API_TOKEN"
 
 {
     "result": [

--- a/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
+++ b/products/stream/src/content/getting-analytics/fetching-bulk-analytics.md
@@ -232,6 +232,5 @@ Here are the steps to implementing pagination:
   1. Call next query by specifying uid_gt property and set it to the last video ID. This will return the next set of videos
 
 ## Limitations
- - Only Cloudflare API keys, not API tokens can be used with the Stream GraphQL API for now
  - Maximum query interval in a single query is 31 days
  - Maximum data retention period is 90 days

--- a/products/stream/src/content/getting-analytics/fetching-per-video-analytics.md
+++ b/products/stream/src/content/getting-analytics/fetching-per-video-analytics.md
@@ -69,8 +69,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/analytics/vie
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/analytics/views?metrics=totalImpressions,totalTimeViewedMs&dimensions=videoId&filters=videoId==$VIDEOID&since=2018-01-01T16:57:00Z" \
-    -H "X-Auth-Email: $EMAIL" \
-    -H "X-Auth-Key: $APIKEY" \
+    -H "Authorization: Bearer $API_TOKEN" \
     -H "Content-Type: application/json"
 ```
 

--- a/products/tenant/src/content/tutorial/enabling-services.md
+++ b/products/tenant/src/content/tutorial/enabling-services.md
@@ -16,7 +16,7 @@ Creating a zone is no different the Client V4 API, but be sure to specify the cu
 Example - Create Zone
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/zones -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' -d '{ "name": "example.com", "account": { "id": "<customer account id>" } }'
+curl -X POST https://api.cloudflare.com/client/v4/zones -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" -d '{ "name": "example.com", "account": { "id": "<customer account id>" } }'
 ```
 
 ## Create a zone subscription
@@ -28,7 +28,7 @@ Now that you have a zone provisioned for the customer, you can add the appropria
 Example - Create Zone Subscription
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/zones/<zone id>/subscription -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' -d '{"rate_plan": {"id": "<rate plan identifier>"}}'
+curl -X POST https://api.cloudflare.com/client/v4/zones/<zone id>/subscription -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" -d '{"rate_plan": {"id": "<rate plan identifier>"}}'
 ```
 
 Allowed rate plans are:
@@ -64,7 +64,7 @@ Depending on your agreement, you may be allowed to resell other add-on services.
 Example - Create Account Subscription
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/accounts/<account id>/subscriptions -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' -d '{ "rate_plan": {"id": "<rate plan id>"} }'
+curl -X POST https://api.cloudflare.com/client/v4/accounts/<account id>/subscriptions -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" -d '{ "rate_plan": {"id": "<rate plan id>"} }'
 ```
 
 Once you have added the necessary features, you or your customer can move on to configuring the various services and fine-tuning settings.

--- a/products/tenant/src/content/tutorial/provisioning-resources.md
+++ b/products/tenant/src/content/tutorial/provisioning-resources.md
@@ -5,7 +5,7 @@ order: 0
 
 # Step 1: Provisioning resources
 
-All the API calls described in this tutorial use the Cloudflare client v4 interface at `https://api.cloudflare.com/client/v4`. API requests are authenticated in the same manner using a Cloudflare user's email and API key as the `x-auth-email` and `x-auth-key` headers. Your Cloudflare user must be active, verified, and enabled by Cloudflare to use these provisioning specific endpoints.
+All the API calls described in this tutorial use the Cloudflare client v4 interface at `https://api.cloudflare.com/client/v4`. API requests are authenticated in the same manner providing a Cloudflare API token in the `Authorization` header. Your Cloudflare user must be active, verified, and enabled by Cloudflare to use these provisioning specific endpoints.
 
 More details about making Cloudflare API calls can be found in our general api docs [here](https://api.cloudflare.com/#getting-started-endpoints).
 
@@ -23,7 +23,7 @@ Type (enum): Valid values are `standard` (default) and `enterprise`. For self-se
 
 Example:
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/accounts -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' \
+curl -X POST https://api.cloudflare.com/client/v4/accounts -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" \
 -d '{ "name": "<Account Name>", \
       "type": "standard" }'
 ```
@@ -51,7 +51,7 @@ A successful request will return with an HTTP status of 200 and the following re
 You own the account lifecycle from creation, ongoing management, and finally deletion. To see the newly created account, make a `GET /accounts` request:
 
 ```bash
-curl -X GET https://api.cloudflare.com/client/v4/accounts -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>'
+curl -X GET https://api.cloudflare.com/client/v4/accounts -H "Authorization: Bearer $API_TOKEN"
 ```
 <Aside type="note">
 
@@ -101,7 +101,7 @@ If for any reason you need to delete an account you created, then call `DELETE /
 **WARNING:** Account deletion is permanent and will delete any zones or other resources under the account.
 
 ```bash
-curl -X DELETE https://api.cloudflare.com/client/v4/accounts/<account_id> -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>'
+curl -X DELETE https://api.cloudflare.com/client/v4/accounts/<account_id> -H "Authorization: Bearer $API_TOKEN"
 ```
 
 A successful request will return the id to confirm the operation:

--- a/products/tenant/src/content/tutorial/user-access.md
+++ b/products/tenant/src/content/tutorial/user-access.md
@@ -17,7 +17,7 @@ The first method gives customers control over all aspects of Cloudflare, while t
 If you want to give customers access to their individual accounts then its no different then if you were inviting a teammate to help manage your account. This can be done in our dashboard through the members tab in the account management area or by making the below API call.
 
 ```bash
-curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<customer_account_id>/members' -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' -d '{ "email": "<customer-email>", "roles": ["<user-role>"] }'
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<customer_account_id>/members' -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" -d '{ "email": "<customer-email>", "roles": ["<user-role>"] }'
 ```
 
 In most cases the user-role to use is that of the `Administrator` role which is id `05784afa30c1afe1440e79d9351c7430`. A full list of available roles can be fetched by making a call to `GET https://api.cloudflare.com/client/v4/accounts/<account_id>/roles` in the case of ENT customers whom have access to our full set of user roles.
@@ -33,7 +33,7 @@ If you want to have greater control over how customers use Cloudflare or integra
 Creating a user works as follows:
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/users -H 'Content-Type: application/json' -H 'x-auth-email: <x-auth-email>' -H 'x-auth-key: <x-auth-key>' -d '{ "email": "<identifier>@youremaildomain.com>" }'
+curl -X POST https://api.cloudflare.com/client/v4/users -H 'Content-Type: application/json' -H "Authorization: Bearer $API_TOKEN" -d '{ "email": "<identifier>@youremaildomain.com>" }'
 ```
 
 In these cases these users are service users as no one will log into the dashboard with them. If you are planning to use this method we will enable you to see the API key for this user in order to make API calls as this user.

--- a/products/waiting-room/src/content/how-to/create-waiting-room/create-waiting-room-api.md
+++ b/products/waiting-room/src/content/how-to/create-waiting-room/create-waiting-room-api.md
@@ -44,8 +44,7 @@ The following example API request configures a waiting room with the same settin
 
 ```shell
 curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: xxxxxxxx" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '{"name":"shop_waiting_room",
               "description":"Waiting room for webshop",
@@ -89,8 +88,7 @@ In the following PATCH request, the `custom_page_html` field contains the HTML c
 
 ```shell
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/{waiting-room-id}" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: xxxxxxxx" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '{"custom_page_html":"<p>Include custom HTML here</p>"}'
 ```
@@ -142,8 +140,7 @@ Example request:
 
 ```shell
 curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/preview" \
-     -H "X-Auth-Email: user@example.com" \
-     -H "X-Auth-Key: xxxxxxxx" \
+     -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
      --data '{"custom_html":"<p>Include custom HTML here</p>"}'
 ```

--- a/products/waiting-room/src/content/how-to/create-waiting-room/create-waiting-room-api.md
+++ b/products/waiting-room/src/content/how-to/create-waiting-room/create-waiting-room-api.md
@@ -88,10 +88,10 @@ You can use the Waiting Room API to customize the web page served to visitors wh
 In the following PATCH request, the `custom_page_html` field contains the HTML code for the customized waiting room:
 
 ```shell
-curl -X PATCH "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/{waiting-room-id}"
-     -H "X-Auth-Email: user@example.com"
-     -H "X-Auth-Key: xxxxxxxx"
-     -H "Content-Type: application/json"
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/{waiting-room-id}" \
+     -H "X-Auth-Email: user@example.com" \
+     -H "X-Auth-Key: xxxxxxxx" \
+     -H "Content-Type: application/json" \
      --data '{"custom_page_html":"<p>Include custom HTML here</p>"}'
 ```
 
@@ -141,10 +141,10 @@ Note that you pass HTML content to the preview endpoint in the `custom_html` fie
 Example request:
 
 ```shell
-curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/preview"
-     -H "X-Auth-Email: user@example.com"
-     -H "X-Auth-Key: xxxxxxxx"
-     -H "Content-Type: application/json"
+curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone-id}/waiting_rooms/preview" \
+     -H "X-Auth-Email: user@example.com" \
+     -H "X-Auth-Key: xxxxxxxx" \
+     -H "Content-Type: application/json" \
      --data '{"custom_html":"<p>Include custom HTML here</p>"}'
 ```
 


### PR DESCRIPTION
Some products provides usage examples for the legacy API keys authorization scheme.  Where possible, the documentation and usage examples should direct users to use the recommended API tokens authorization scheme.