### PR TITLE
Fix default $TEMPLATE value for wrangler generate command

### DIFF
--- a/products/workers/src/content/cli-wrangler/commands.md
+++ b/products/workers/src/content/cli-wrangler/commands.md
@@ -23,7 +23,7 @@ Default values indicated by <Type>=value</Type>.
 - `$NAME` <Type>=worker</Type> <PropMeta>optional</PropMeta>
   - Name of the Workers project, setting both the directory name and `name` property in the generated `wrangler.toml` [configuration](/cli-wrangler/configuration) file.
 
-- `$TEMPLATE` <Type>=github.com/cloudflare/worker-template</Type> <PropMeta>optional</PropMeta>
+- `$TEMPLATE` <Type>=https://github.com/cloudflare/worker-template</Type> <PropMeta>optional</PropMeta>
   - GitHub URL of the [repo to use as the template](https://github.com/cloudflare/worker-template) for generating the project.
 
 - `--type=$TYPE` <Type>=webpack</Type> <PropMeta>optional</PropMeta>


### PR DESCRIPTION
The default value of `$TEMPLATE` is `https://github.com/cloudflare/worker-template`, and in fact it does not work at all without the `https://` prefix (it instead tries to resolve it as a local path.

See: https://github.com/cloudflare/wrangler/blob/f2d083dd01a656e22322db9e5117f00193c71649/src/main.rs#L697

<img width="987" alt="Screen Shot 2021-02-19 at 8 19 34 PM" src="https://user-images.githubusercontent.com/353790/108577690-c9017c00-72ef-11eb-9105-306fc2957fca.png">
