### PR TITLE
Update Workers examples

### DIFF
--- a/products/workers/src/content/examples/cache-post-request.md
+++ b/products/workers/src/content/examples/cache-post-request.md
@@ -1,0 +1,72 @@
+---
+order: 1000
+type: example
+summary: Cache POST requests using the Cache API.
+tags:
+  - Middleware
+  - Caching
+---
+
+# Cache POST requests
+
+<ContentColumn>
+  <p>{props.frontmatter.summary}</p>
+</ContentColumn>
+
+```js
+async function sha256(message) {
+  // encode as UTF-8
+  const msgBuffer = new TextEncoder().encode(message)
+
+  // hash the message
+  const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer)
+
+  // convert ArrayBuffer to Array
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+
+  // convert bytes to hex string
+  const hashHex = hashArray.map(b => ("00" + b.toString(16)).slice(-2)).join("")
+  return hashHex
+}
+
+async function handlePostRequest(event) {
+  const request = event.request
+  const body = await request.clone().text()
+
+  // Hash the request body to use it as a part of the cache key
+  const hash = await sha256(body)
+  const cacheUrl = new URL(request.url)
+
+  // Store the URL in cache by prepending the body's hash
+  cacheUrl.pathname = "/posts" + cacheUrl.pathname + hash
+
+  // Convert to a GET to be able to cache
+  const cacheKey = new Request(cacheUrl.toString(), {
+    headers: request.headers,
+    method: "GET",
+  })
+
+  const cache = caches.default
+
+  // Find the cache key in the cache
+  let response = await cache.match(cacheKey)
+
+  // Otherwise, fetch response to POST request from origin
+  if (!response) {
+    response = await fetch(request)
+    event.waitUntil(cache.put(cacheKey, response.clone()))
+  }
+  return response
+}
+
+addEventListener("fetch", event => {
+  try {
+    const request = event.request
+    if (request.method.toUpperCase() === "POST")
+      return event.respondWith(handlePostRequest(event))
+    return event.respondWith(fetch(request))
+  } catch (e) {
+    return event.respondWith(new Response("Error thrown " + e.message))
+  }
+})
+```

--- a/products/workers/src/content/examples/country-code-redirect.md
+++ b/products/workers/src/content/examples/country-code-redirect.md
@@ -19,8 +19,9 @@ tags:
  * @param {Request} request
  */
 async function redirect(request) {
-  // The `cf-ipcountry` header is not supported in the preview
-  const country = request.headers.get("cf-ipcountry")
+  // Use the cf object to obtain the country of the request
+  // more on the cf object: https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties
+  const country = request.cf.country
 
   if (country != null && country in countryMap) {
     const url = countryMap[country]

--- a/products/workers/src/content/examples/rewrite-links.md
+++ b/products/workers/src/content/examples/rewrite-links.md
@@ -5,6 +5,7 @@ summary: Rewrite URL links in HTML using the HTMLRewriter. This is useful for JA
 tags:
   - HTML
   - JAMstack
+  - HTMLRewriter
 ---
 
 # Rewrite links

--- a/products/workers/src/content/examples/signing-requests.md
+++ b/products/workers/src/content/examples/signing-requests.md
@@ -4,10 +4,9 @@ type: example
 summary: Sign and verify a request using the HMAC and SHA-256 algorithms or return a 403.
 tags:
   - Security
-  - Originless
 ---
 
-# Signing requests
+# Sign requests
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/runtime-apis/cache.md
+++ b/products/workers/src/content/runtime-apis/cache.md
@@ -176,3 +176,5 @@ Deletes the `Response` object from the cache and returns a `Promise` for a Boole
 
 - [How the Cache works](/learning/how-the-cache-works)
 - [Configure your CDN](/tutorials/configure-your-cdn)
+- [Example: using the Cache API](/examples/cache-api)
+- [Example: caching POST requests](/examples/cache-post-request)

--- a/products/workers/src/content/runtime-apis/fetch.md
+++ b/products/workers/src/content/runtime-apis/fetch.md
@@ -57,7 +57,7 @@ async function eventHandler(event) {
 
 ## See also
 
-- [Respond with another site](/examples/respond-with-another-site)
-- [Fetch HTML](/examples/fetch-html)
-- [Fetch JSON](/examples/fetch-json)
-- [Cache using Fetch](/examples/cache-using-fetch)
+- [Example: use `fetch` to respond with another site](/examples/respond-with-another-site)
+- [Example: Fetch HTML](/examples/fetch-html)
+- [Example: Fetch JSON](/examples/fetch-json)
+- [Example: cache using Fetch](/examples/cache-using-fetch)

--- a/products/workers/src/content/runtime-apis/html-rewriter.md
+++ b/products/workers/src/content/runtime-apis/html-rewriter.md
@@ -430,3 +430,4 @@ async function handle(request) {
 
 - [Introducing `HTMLRewriter`](https://blog.cloudflare.com/introducing-htmlrewriter/)
 - [Tutorial: Localize a Website](/tutorials/localize-a-website)
+- [Example: rewrite links](/examples/rewrite-links)

--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -340,3 +340,11 @@ async function eventHandler(event){..}
 
 This code snippet will throw during script startup, and the `"fetch"` event
 listener will never be registered.
+
+--------------------------------
+
+## See also
+
+- [Examples: Modify request property](examples/modify-request-property)
+- [Examples: Accessing the `cf` object](/examples/accessing-the-cloudflare-object)
+- [Reference: `Response`](/runtime-apis/response)

--- a/products/workers/src/content/runtime-apis/web-crypto.md
+++ b/products/workers/src/content/runtime-apis/web-crypto.md
@@ -298,3 +298,4 @@ __Footnotes:__
 
 - [SubtleCrypto documentation on MDN.](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
 - [SubtleCrypto documentation as part of the W3C Web Crypto API specification.](https://www.w3.org/TR/WebCryptoAPI/#subtlecrypto-interface)
+- [Example: signing requests](/examples/signing-requests)


### PR DESCRIPTION
- Split out Cache API example into two distinct examples for Cache API and caching POST requests
- Updated some examples tags
- Added examples to See Also of a few reference docs
- Updated country example to use cf object