### PR TITLE
Fix s-maxage expiry header

### DIFF
--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -40,7 +40,7 @@ async function handleRequest(event) {
     // will limit the response to be in cache for 10 seconds max
 
     // Any changes made to the response here will be reflected in the cached value
-    response.headers.append("Cache-Control", "s-max-age=10")
+    response.headers.append("Cache-Control", "s-maxage=10")
 
     // Store the fetched response as cacheKey
     // Use waitUntil so you can return the response without blocking on


### PR DESCRIPTION
According to https://support.cloudflare.com/hc/en-us/articles/115003206852-Understanding-Origin-Cache-Control the correct directive is s-maxage, not s-max-age. I thought maybe it was an alias but s-max-age does not work at all.