### PR TITLE
Fix broken link to install cloudflared

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/setup.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/setup.md
@@ -9,7 +9,7 @@ order: 2
 | 1. [Add a website to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-Creating-a-Cloudflare-account-and-adding-a-website) |
 | 2. [Change your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/205195708) |
 | 3. [Enable Argo Smart Routing for your account](https://support.cloudflare.com/hc/articles/115000224552-Configuring-Argo-through-the-UI) |
-| 4. [Install `cloudflared`](/connections/connect-apps/installation/) |
+| 4. [Install `cloudflared`](/connections/connect-apps/install-and-setup/installation) |
 
 Follow these steps to authenticate `cloudflared`:
 


### PR DESCRIPTION
https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/setup has a broken link "4. Install cloudflared" to
`https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/installation/`, but should be
`https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation`.