### PR TITLE
[pages] Fixed section id in pricing URL

### DIFF
--- a/products/pages/src/content/platform/limits.md
+++ b/products/pages/src/content/platform/limits.md
@@ -4,7 +4,7 @@ Below, we've listed the limits for users using the Cloudflare Pages free plan. F
 
 ## Builds
 
-Each time you push new code to your GitHub repository, we'll build and deploy your site. You can deploy up to 500 times per month on the free plan. Check out the Pro and Business plans on our [pricing page](https://pages.cloudflare.com/#plans) if you need to deploy more frequently!
+Each time you push new code to your GitHub repository, we'll build and deploy your site. You can deploy up to 500 times per month on the free plan. Check out the Pro and Business plans on our [pricing page](https://pages.cloudflare.com/#pricing) if you need to deploy more frequently!
 
 ## Custom domains
 


### PR DESCRIPTION
This fixes the section id that's in the pricing URL, so clicking on it now will show the pricing section immediately.