### PR TITLE
Update run-as-service.md

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/run-as-service.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/run-as-service.md
@@ -202,7 +202,7 @@ C:\> sc start cloudflared tunnel run
 If you are a Powershell user, run this command instead:
 
 ```
-PS C:> Start-Service cloudflared tunnel run
+PS C:> $Service = Get-Service cloudflared ; $Service.start(@('tunnel','run'))
 ```
 
 <Aside>


### PR DESCRIPTION
`sc start cloudflared tunnel run` and `Start-Service cloudflared tunnel run` are not equivalent.

https://stackoverflow.com/questions/37337718/powershell-start-windows-service-with-a-parameter

Although it may also be pertinent to note that neither ensures that the parameters are passed each time.