### PR TITLE
Correct HMAC example

### DIFF
--- a/products/firewall/src/content/cf-firewall-language/functions.md
+++ b/products/firewall/src/content/cf-firewall-language/functions.md
@@ -270,7 +270,7 @@ is_timed_hmac_valid_v0(
         http.request.uri,
         http.request.headers["timestamp"][0],
         "-",
-        http.request.headers["MAC"]),
+        http.request.headers["mac"][0]),
     100000,
     http.request.timestamp.sec,
     0


### PR DESCRIPTION
Stated in the [fields documentation](https://developers.cloudflare.com/firewall/cf-firewall-language/fields#http-header-fields):

> The keys convert to lowercase.

From my testing, using the uppercase header name to index `http.request.headers` always fails.

Also added `[0]` to get the first element.