### PR TITLE
[pages] Re-format build config table to better show how to override versions

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -42,50 +42,44 @@ If your project make use of environment variables to build your site, you can pr
 
 ## Language support and tools
 
-Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, PHP, and Go (and many more):
+Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, PHP, and Go (and many more). 
 
-| Framework | Default version |
-| --------- | --------------- |
-| Elixir    | 1.7             |
-| Emacs     | 25              |
-| Erlang    | 21              |
-| Go        | 1.12            |
-| Java      | 8               |
-| Node.js   | 10              |
-| PHP       | 5.6             |
-| Python    | 2.7             |
-| Ruby      | 2.6.2           |
+If you need to use a specific version of a language, e.g. Node.js or Ruby, you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code. 
 
-Many common tools have been pre-installed as well:
+Here are the pinned versions for tools included in the Cloudflare Workers build environment, and how to override them as relevant:
 
-| Tools       | Notes                           |
-| ----------- | ------------------------------- |
-| Boot        |                                 |
-| Cask        |                                 |
-| Composer    |                                 |
-| Doxygen     | Version 1.8.6                   |
-| Gutenberg   |                                 |
-| Hugo        | Version 0.54                    |
-| GNU Make    | Version 3.8.1                   |
-| ImageMagick | Version 6.7.7                   |
-| jq          | Version 1.5                     |
-| Leiningen   |                                 |
-| OptiPNG     | Version 0.6.4                   |
-| NPM         | Corresponds with NPM version    |
-| pip         | Corresponds with Python version |
-| Pipenv      | Latest version                  |
-| Yarn        | Version 1.13.0                  |
-| Zola        |                                 |
 
-If you need to use a specific version of a language, e.g. Node.js or Ruby, you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code. Below are some examples:
+| Framework | Default version | Environment variable | File                      |
+| --------- | --------------- | -------------------- | ------------------------- |
+| Elixir    | 1.7             |                      |                           |
+| Erlang    | 21              |                      |                           |
+| Go        | 1.12            | `GO_VERSION`         |                           |
+| Java      | 8               |                      |                           |
+| Node.js   | 10              | `NODE_VERSION`       | `.nvmrc`, `.node-version` |
+| PHP       | 5.6             | `PHP_VERSION`        |                           |
+| Python    | 2.7             | `PYTHON_VERSION`     | `runtime.txt`, `Pipfile`  |
+| Ruby      | 2.6.2           | `RUBY_VERSION`       | `.ruby-version`           |
 
-| Language/tool | Environment variable | File                      |
-| ------------- | -------------------- | ------------------------- |
-| Go            | `GO_VERSION`         |                           |
-| Node.js       | `NODE_VERSION`       | `.nvmrc`, `.node-version` |
-| NPM           | `NPM_VERSION`        |                           |
-| Python        | `PYTHON_VERSION`     | `runtime.txt`, `Pipfile`  |
-| Ruby          | `RUBY_VERSION`       | `.ruby-version`           |
-| Yarn          | `YARN_VERSION`       |                           |
+Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
+
+| Tools       | Notes                           | Environment variable |
+| ----------- | ------------------------------- | -------------------- |
+| Boot        |                                 |                      |
+| Cask        |                                 |                      |
+| Composer    |                                 |                      |
+| Doxygen     | Version 1.8.6                   |                      |
+| Emacs       | 25                              |                      |
+| Gutenberg   |                                 |                      |
+| Hugo        | Version 0.54                    |                      |
+| GNU Make    | Version 3.8.1                   |                      |
+| ImageMagick | Version 6.7.7                   |                      |
+| jq          | Version 1.5                     |                      |
+| Leiningen   |                                 |                      |
+| OptiPNG     | Version 0.6.4                   |                      |
+| NPM         | Corresponds with NPM version    | `NPM_VERSION`        |
+| pip         | Corresponds with Python version |                      |
+| Pipenv      | Latest version                  |                      |
+| Yarn        | Version 1.13.0                  | `YARN_VERSION`       |
+| Zola        |                                 |                      |
 
 If you're looking to set a specific version of a framework your Cloudflare Pages project is using, note that Pages will respect your package manager of choice during your build process. For instance, if you use Gatsby.js, your `package.json` should indicate a version of the `gatsby` NPM package, which will be installed using `npm install` as your project builds on Cloudflare Pages.


### PR DESCRIPTION
Reformats some of the tables on this page, to better indicate how to override default versions of tools that are installed with Pages

<img width="460" alt="Capture" src="https://user-images.githubusercontent.com/922353/110006008-b8350b00-7cde-11eb-8eb8-f8198cb59dc5.PNG">