### PR TITLE
[pages] Add Expo to list of framework/tool

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -17,6 +17,7 @@ Below are some standard build commands and directories for popular frameworks an
 | Docusaurus                   | `npm run build`                     | `build`                     |
 | Eleventy                     | `eleventy`                          | `_site`                     |
 | Ember.js                     | `ember build`                       | `dist`                      |
+| Expo                         | `expo build:web`                    | `web-build`                 |
 | Gatsby                       | `gatsby build`                      | `public`                    |
 | GitBook                      | `gitbook build`                     | `_book`                     |
 | Gridsome                     | `gridsome build`                    | `dist`                      |


### PR DESCRIPTION
reference: https://docs.expo.io/distribution/publishing-websites/