### PR TITLE
Update log values

### DIFF
--- a/products/analytics/src/content/graphql-api/getting-started/querying-basics.md
+++ b/products/analytics/src/content/graphql-api/getting-started/querying-basics.md
@@ -91,14 +91,14 @@ header: Query response from firewallEventsAdaptive
         {
           "firewallEventsAdaptive": [
             {
-              "action": "simulate",
+              "action": "log",
               "clientRequestHTTPHost": "cloudflare.guru",
               "datetime": "2020-08-03T17:07:03Z",
               "rayName": "5bd1a1fc584357ed",
               "userAgent": "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 08c774cde2f3c385)"
             },
             {
-              "action": "simulate",
+              "action": "log",
               "clientRequestHTTPHost": "cloudflare.guru",
               "datetime": "2020-08-03T17:07:01Z",
               "rayName": "5bd1a1ef3bb5d296",

--- a/products/analytics/src/content/graphql-api/tutorials/querying-firewall-events/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/querying-firewall-events/index.md
@@ -144,7 +144,7 @@ curl \
               "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"
             },
             {
-              "action": "drop",
+              "action": "block",
               "clientAsn": "5089",
               "clientCountryName": "GB",
               "clientIP": "203.0.113.69",

--- a/products/logs/src/content/log-fields/_partials/firewall_events.md
+++ b/products/logs/src/content/log-fields/_partials/firewall_events.md
@@ -1,11 +1,11 @@
 | Field | Value | Type |
 | -- | -- | -- |
-| Action | The code of the first-class action the Cloudflare Firewall took on this request, possible values are: <em>unknown</em> \| <em>allow</em> \| <em>drop</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>simulate</em> \| <em>connection_close</em> \| <em>log</em> \| <em>challenge_solved</em> \| <em>challenge_failed</em> \| <em>challenge_bypassed</em> \| <em>jschallenge_solved</em> \| <em>jschallenge_failed</em> \| <em>jschallenge_bypassed</em> \| <em>bypass</em> \| <em>managed_challenge</em> \| <em>managed_challenge_skipped</em> \| <em>managed_challenge_non_interactive_solved</em> \| <em>managed_challenge_interactive_solved</em> \| <em>managed_challenge_bypassed</em> | string |
+| Action | The code of the first-class action the Cloudflare Firewall took on this request, possible values are: <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connection_close</em> \| <em>challenge_solved</em> \| <em>challenge_failed</em> \| <em>challenge_bypassed</em> \| <em>jschallenge_solved</em> \| <em>jschallenge_failed</em> \| <em>jschallenge_bypassed</em> \| <em>bypass</em> \| <em>managed_challenge</em> \| <em>managed_challenge_skipped</em> \| <em>managed_challenge_non_interactive_solved</em> \| <em>managed_challenge_interactive_solved</em> \| <em>managed_challenge_bypassed</em> | string |
 | ClientASN | The ASN number of the visitor | int |
 | ClientASNDescription | The ASN of the visitor as string | string |
 | ClientCountry | Country from which request originated | string |
 | ClientIP | The visitor's IP address (IPv4 or IPv6) | string |
-| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>whitelist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
+| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
 | ClientRefererHost | The referer host | string |
 | ClientRefererPath | The referer path requested by visitor | string |
 | ClientRefererQuery | The referer query-string was requested by the visitor | string |
@@ -27,4 +27,4 @@
 | OriginatorRayID | The RayID of the request that issued the challenge/jschallenge | string |
 | RayID | The RayID of the request | string |
 | RuleID | The Cloudflare security product-specific RuleID triggered by this request | string |
-| Source | The Cloudflare security product triggered by this request, possible values are: <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>sanitycheck</em> \| <em>botFight</em> | string |
+| Source | The Cloudflare security product triggered by this request, possible values are: <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botFight</em> | string |

--- a/products/logs/src/content/log-fields/_partials/http_requests.md
+++ b/products/logs/src/content/log-fields/_partials/http_requests.md
@@ -10,7 +10,7 @@
 | ClientCountry | Country of the client IP address | string |
 | ClientDeviceType | Client device type | string |
 | ClientIP | IP address of the client | string |
-| ClientIPClass | <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>whitelist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
+| ClientIPClass | <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
 | ClientRequestBytes | Number of bytes in the client request | int |
 | ClientRequestHost | Host requested by the client | string |
 | ClientRequestMethod | HTTP method of client request | string |
@@ -30,7 +30,7 @@
 | EdgePathingSrc | Details how the request was classified based on security checks (unknown = no specific classification) | string |
 | EdgePathingStatus | Indicates what data was used to determine the handling of this request (unknown = no data) | string |
 | EdgeRateLimitAction | The action taken by the blocking rule; empty if no action taken | string |
-| EdgeRateLimitID | The internal rule ID of the rate-limiting rule that triggered a block (ban) or simulate action. 0 if no action taken. | int |
+| EdgeRateLimitID | The internal rule ID of the rate-limiting rule that triggered a block (ban) or log action. 0 if no action taken. | int |
 | EdgeRequestHost | Host header on the request from the edge to the origin | string |
 | EdgeResponseBytes | Number of bytes returned by the edge to the client | int |
 | EdgeResponseCompressionRatio | Edge response compression ratio | float |
@@ -38,9 +38,9 @@
 | EdgeResponseStatus | HTTP status code returned by Cloudflare to the client | int |
 | EdgeServerIP | IP of the edge server making a request to the origin | string |
 | EdgeStartTimestamp | Timestamp at which the edge received request from the client | int or string |
-| FirewallMatchesActions | Array of actions the Cloudflare firewall products performed on this request. The individual firewall products associated with this action be found in FirewallMatchesSources and their respective RuleIds can be found in FirewallMatchesRuleIDs. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesSources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>drop</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>simulate</em> \| <em>connection_close</em> \| <em>log</em> \| <em>challenge_solved</em> \| <em>challenge_failed</em> \| <em>challenge_bypassed</em> \| <em>jschallenge_solved</em> \| <em>jschallenge_failed</em> \| <em>jschallenge_bypassed</em> \| <em>bypass</em> \| <em>managed_challenge</em> \| <em>managed_challenge_skipped</em> \| <em>managed_challenge_non_interactive_solved</em> \| <em>managed_challenge_interactive_solved</em> \| <em>managed_challenge_bypassed</em> | array[string] |
+| FirewallMatchesActions | Array of actions the Cloudflare firewall products performed on this request. The individual firewall products associated with this action be found in FirewallMatchesSources and their respective RuleIds can be found in FirewallMatchesRuleIDs. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesSources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>connection_close</em> \| <em>log</em> \| <em>challenge_solved</em> \| <em>challenge_failed</em> \| <em>challenge_bypassed</em> \| <em>jschallenge_solved</em> \| <em>jschallenge_failed</em> \| <em>jschallenge_bypassed</em> \| <em>bypass</em> \| <em>managed_challenge</em> \| <em>managed_challenge_skipped</em> \| <em>managed_challenge_non_interactive_solved</em> \| <em>managed_challenge_interactive_solved</em> \| <em>managed_challenge_bypassed</em> | array[string] |
 | FirewallMatchesRuleIDs | Array of RuleIDs of the firewall product that has matched the request. The firewall product associated with the RuleID can be found in FirewallMatchesSources. The length of the array is the same as FirewallMatchesActions and FirewallMatchesSources. | array[string] |
-| FirewallMatchesSources | The firewall products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The RuleIDs can be found in FirewallMatchesRuleIDs, the actions can be found in FirewallMatchesActions. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>sanitycheck</em> \| <em>botFight</em> | array[string] |
+| FirewallMatchesSources | The firewall products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The RuleIDs can be found in FirewallMatchesRuleIDs, the actions can be found in FirewallMatchesActions. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botFight</em> | array[string] |
 | OriginIP | IP of the origin server | string |
 | OriginResponseBytes (deprecated) | Number of bytes returned by the origin server | int |
 | OriginResponseHTTPExpires | Value of the origin 'expires' header in RFC1123 format | string |
@@ -52,8 +52,8 @@
 | RayID | ID of the request | string |
 | SecurityLevel | The security level configured at the time of this request. This is used to determine the sensitivity of the IP Reputation system. | string |
 | WAFAction | Action taken by the WAF, if triggered | string |
-| WAFFlags | Additional configuration flags: <em>simulate (0x1)</em> \| <em>null</em> | string |
-| WAFMatchedVar | The full name of the most-recently matched variable | string |
+| WAFFlags | Deprecated | string |
+| WAFMatchedVar | Deprecated | string |
 | WAFProfile | <em>low</em> \| <em>med</em> \| <em>high</em> | string |
 | WAFRuleID | ID of the applied WAF rule | string |
 | WAFRuleMessage | Rule message associated with the triggered rule | string |

--- a/products/logs/src/content/reference/waf-fields.md
+++ b/products/logs/src/content/reference/waf-fields.md
@@ -19,7 +19,6 @@ The Web Application Firewall (WAF) contains rules managed by Cloudflare to block
 | <em><span style="font-weight: 400;">3</span></em> | Challenge Allow | Issue a CAPTCHA challenge |
 | <em><span style="font-weight: 400;">4</span></em> | Challenge Drop | Unused |
 | <em><span style="font-weight: 400;">5</span></em> | Simulate | Take no action other than logging the event |
-| <em><span style="font-weight: 400;">6</span></em> | Log | Increment the anomaly score for OWASP rules. Records actions only if the total anomaly score for all matching OWASP rules exceeds the overall trigger threshold for an OWASP action (challenge, block, simulate) |
 
 </TableWrap>
 

--- a/products/waf/src/content/change-log/2019-10-21.md
+++ b/products/waf/src/content/change-log/2019-10-21.md
@@ -34,14 +34,14 @@ order: 994
             <td>Cloudflare Specials</td>
             <td>100186</td>
             <td>Block vBulletin vulnerability CVE-2019-17132</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
             <td>Cloudflare Specials</td>
             <td>100187</td>
             <td>Block vBulletin vulnerability CVE-2019-17132</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
     </tbody>

--- a/products/waf/src/content/change-log/2019-11-12.md
+++ b/products/waf/src/content/change-log/2019-11-12.md
@@ -20,7 +20,7 @@ order: 989
             <td>Cloudflare Specials</td>
             <td>100148</td>
             <td>Disable outdated XSS rule by default.</td>
-            <td>Drop</td>
+            <td>Block</td>
             <td>Disable</td>
         </tr>
     </tbody>

--- a/products/waf/src/content/change-log/2020-07-27.md
+++ b/products/waf/src/content/change-log/2020-07-27.md
@@ -40,7 +40,7 @@ order: 964
                 N/A
             </td>
             <td>
-                Drop
+                Block
             </td>
         </tr>
         <tr>

--- a/products/waf/src/content/change-log/2020-09-15.md
+++ b/products/waf/src/content/change-log/2020-09-15.md
@@ -40,7 +40,7 @@ order: 958
                 N/A
             </td>
             <td>
-                Simulate
+                Log
             </td>
         </tr>
     </tbody>

--- a/products/waf/src/content/change-log/2020-09-21.md
+++ b/products/waf/src/content/change-log/2020-09-21.md
@@ -37,7 +37,7 @@ order: 957
                 Wordpress - Command Injection
             </td>
             <td>
-                Simulate
+                Log
             </td>
             <td>
                 Block

--- a/products/waf/src/content/change-log/historical.md
+++ b/products/waf/src/content/change-log/historical.md
@@ -152,7 +152,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>SQL Injection - Obfuscated SELECT expressions</td>
             <td>2019-06-17</td>
             <td>2019-09-09</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -200,7 +200,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -208,7 +208,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -216,7 +216,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -224,7 +224,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -232,7 +232,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -240,7 +240,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -248,7 +248,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -256,7 +256,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -264,7 +264,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -272,7 +272,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -280,7 +280,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -288,7 +288,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -296,7 +296,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -304,7 +304,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -312,7 +312,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -320,7 +320,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -328,7 +328,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -336,7 +336,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -344,7 +344,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -352,7 +352,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -360,7 +360,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -368,7 +368,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -376,7 +376,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -384,7 +384,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -392,7 +392,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -400,7 +400,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -408,7 +408,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -416,7 +416,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -424,7 +424,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -432,7 +432,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -440,7 +440,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -448,7 +448,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -456,7 +456,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -464,7 +464,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -472,7 +472,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -480,7 +480,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -488,7 +488,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -496,7 +496,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -504,7 +504,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -512,7 +512,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -520,7 +520,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -528,7 +528,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -536,7 +536,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -544,7 +544,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -552,7 +552,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -560,7 +560,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -568,7 +568,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -576,7 +576,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -584,7 +584,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -592,7 +592,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -600,7 +600,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -608,7 +608,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -616,7 +616,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -624,7 +624,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -632,7 +632,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -640,7 +640,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -648,7 +648,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -656,7 +656,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -664,7 +664,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -672,7 +672,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -680,7 +680,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -688,7 +688,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -696,7 +696,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -704,7 +704,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -712,7 +712,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -720,7 +720,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -728,7 +728,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -736,7 +736,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -744,7 +744,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -752,7 +752,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -760,7 +760,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -768,7 +768,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -776,7 +776,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Disable rule by default</td>
             <td>2019-07-22</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Disable</td>
         </tr>
         <tr>
@@ -816,7 +816,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve XSS Javascript Events detection and reduce false positives</td>
             <td>2019-07-01</td>
             <td>2019-07-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -888,7 +888,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Easy WP SMTP - Deserialization</td>
             <td>2019-06-10</td>
             <td>2019-06-17</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -896,7 +896,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>XSS, HTML Injection - Malicious HTML Encoding</td>
             <td>2019-06-10</td>
             <td>2019-06-17</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -921,7 +921,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-06-03</td>
             <td>2019-06-03</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100096BEVIL</td>
@@ -929,14 +929,14 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-06-03</td>
             <td>2019-06-03</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100155</td>
             <td>PHPCMS - Dangerous File Upload - <a href="https://nvd.nist.gov/vuln/detail/CVE-2018-14399">CVE-2018-14399</a></td>
             <td>2019-06-03</td>
             <td>2019-06-10</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1008,7 +1008,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Dangerous stream wrappers</td>
             <td>2019-05-13</td>
             <td>2019-05-20</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1016,7 +1016,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>WordPress Social Warfare RCE/XSS (<a href="https://nvd.nist.gov/vuln/detail/CVE-2019-9978">CVE-2019-9978</a>)</td>
             <td>2019-05-07</td>
             <td>2019-05-13</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1024,7 +1024,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Reduce OWASP false positives</td>
             <td>2019-05-07</td>
             <td>2019-05-13</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Allow</td>
         </tr>
         <tr>
@@ -1048,7 +1048,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve XSS detection and reduce false positives</td>
             <td>2019-04-29</td>
             <td>2019-05-07</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1088,7 +1088,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve inline XSS detection</td>
             <td>2019-04-29</td>
             <td>2019-05-07</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1104,7 +1104,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Potential SSRF attack</td>
             <td>2019-04-29</td>
             <td>2019-05-07</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1121,7 +1121,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-04-29</td>
             <td>2019-05-07</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100139B</td>
@@ -1160,7 +1160,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>NoSQL Injection attack (Expression vector)</td>
             <td>2019-04-22</td>
             <td>2019-04-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1168,7 +1168,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>NoSQL Injection attack (comparison vector)</td>
             <td>2019-04-22</td>
             <td>2019-04-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1208,7 +1208,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve SQLi blocking</td>
             <td>2019-04-15</td>
             <td>2019-04-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1232,7 +1232,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Blocks PHP CGI attack by default</td>
             <td>2019-04-15</td>
             <td>2019-04-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1248,7 +1248,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve XSS inline detection</td>
             <td>2019-04-15</td>
             <td>2019-04-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1256,7 +1256,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>NoSQL Injection attack (array vector)</td>
             <td>2019-04-08</td>
             <td>2019-04-15</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1344,7 +1344,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1352,7 +1352,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1360,7 +1360,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1368,7 +1368,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1376,7 +1376,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1384,7 +1384,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1392,7 +1392,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1400,7 +1400,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve blocking of SA-CORE-2019-003</td>
             <td>2019-04-01</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -1441,7 +1441,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-03-25</td>
             <td>2019-04-08</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
        <tr>
             <td>100135C</td>
@@ -1456,7 +1456,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Reduce 100120's false positives</td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1473,14 +1473,14 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-03-25</td>
             <td>2019-04-08</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>WP0032BETA</td>
             <td>Reduce false positives for WP0032</td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1488,7 +1488,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Block use of stream wrappers in all arguments</td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1496,7 +1496,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Protection for Apache Tika Command Injection <a href="https://nvd.nist.gov/vuln/detail/CVE-2018-1335">CVE-2018-1335</a></td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1504,7 +1504,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve PHP webshell attempt detection.</td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1536,7 +1536,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Ruby on Rails File Disclosure <a href="https://nvd.nist.gov/vuln/detail/CVE-2019-5418">CVE-2019-5418</a></td>
             <td>2019-03-25</td>
             <td>2019-04-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1544,7 +1544,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve 100120's coverage of SQLi</td>
             <td>2019-03-18</td>
             <td>2019-03-25</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1552,7 +1552,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Executable file upload attempt</td>
             <td>2019-03-18</td>
             <td>2019-04-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1560,7 +1560,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Executable file with fake extension upload attempt</td>
             <td>2019-03-18</td>
             <td>2019-03-25</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1568,7 +1568,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improves XSS event detection using alternate syntax `, brackets, and parenthesis.</td>
             <td>2019-03-11</td>
             <td>2019-03-18</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1616,7 +1616,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Block use of stream wrappers in GET arguments (RFI/RCE)</td>
             <td>2019-03-11</td>
             <td>2019-03-18</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1624,7 +1624,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Block AngularJS Sandbox attacks</td>
             <td>2019-03-11</td>
             <td>2019-03-18</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1672,7 +1672,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>UTF-8 Invalid Characters detection (URL)</td>
             <td>2019-02-18</td>
             <td>2019-03-04</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1704,7 +1704,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Reduce false positives for 100063</td>
             <td>2019-02-11</td>
             <td>2019-02-18</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1720,7 +1720,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve XSS</td>
             <td>2019-02-11</td>
             <td>2019-02-18</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1744,7 +1744,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Blocked SQLi with mysql comments</td>
             <td>2019-01-28</td>
             <td>2019-02-04</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1752,7 +1752,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Blocked SQLi with mysql comments</td>
             <td>2019-01-28</td>
             <td>2019-02-04</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1768,7 +1768,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Block <a href="https://nvd.nist.gov/vuln/detail/CVE-2017-5638">CVE-2017-5638</a> RCE attempts</td>
             <td>2019-01-28</td>
             <td>2019-02-04</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1817,7 +1817,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>2019-01-17</td>
             <td>2019-01-17</td>
             <td>N/A</td>
-            <td>Simulate</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100009J</td>
@@ -1832,7 +1832,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS probing detection</td>
             <td>2019-01-14</td>
             <td>2019-01-21</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1840,7 +1840,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved LFI detection</td>
             <td>2019-01-14</td>
             <td>2019-01-21</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1848,7 +1848,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved PHP code injection detection in URI and headers</td>
             <td>2019-01-07</td>
             <td>2019-01-14</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1880,7 +1880,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve SQLi detection</td>
             <td>2018-12-17</td>
             <td>2019-01-02</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1888,7 +1888,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improve XXS detection</td>
             <td>2018-12-17</td>
             <td>2019-01-02</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Challenge</td>
         </tr>
         <tr>
@@ -1896,7 +1896,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved sensitive directories access</td>
             <td>2018-12-06</td>
             <td>2018-12-11</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1904,7 +1904,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved Baidu bot detection</td>
             <td>2018-11-26</td>
             <td>2018-12-06</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1912,7 +1912,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved PHP injection detection</td>
             <td>2018-11-26</td>
             <td>2018-12-06</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1920,7 +1920,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-11-12</td>
             <td>2018-11-19</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1928,7 +1928,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-11-05</td>
             <td>2018-11-12</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1936,7 +1936,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>For <a href="https://nvd.nist.gov/vuln/detail/CVE-2018-9206">CVE-2018-9206</a>, vulnerable jQuery File Uploader</td>
             <td>2018-11-05</td>
             <td>2018-11-19</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1944,7 +1944,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>For <a href="https://nvd.nist.gov/vuln/detail/CVE-2018-9206">CVE-2018-9206</a>, vulnerable jQuery File Uploader</td>
             <td>2018-11-05</td>
             <td>2018-11-19</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1952,7 +1952,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>XSS probing detection</td>
             <td>2018-10-29</td>
             <td>2018-11-12</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1968,7 +1968,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>libinjection based SQLi detection rule.</td>
             <td>2018-10-22</td>
             <td>2018-10-29</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1984,7 +1984,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Block requests with invalid x-forwarded-for headers</td>
             <td>2018-10-15</td>
             <td>2018-10-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -1992,7 +1992,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Probing detection</td>
             <td>2018-10-15</td>
             <td>2018-10-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2000,7 +2000,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Detect large numbers of GET parameters in requests</td>
             <td>2018-10-15</td>
             <td>2018-10-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2008,7 +2008,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Detect large numbers of GET parameters in requests</td>
             <td>2018-10-15</td>
             <td>2018-10-22</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2016,8 +2016,8 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Detect large numbers of GET parameters in requests</td>
             <td>2018-10-15</td>
             <td>2018-10-22</td>
-            <td>Simulate</td>
-            <td>Simulate</td>
+            <td>Log</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100110</td>
@@ -2029,7 +2029,7 @@ summary: Changes that were completed before the change log was made publicly ava
         </tr>
         <tr>
             <td>WP0020</td>
-            <td>WP whitelist</td>
+            <td>WP allowlist</td>
             <td>2018-10-01</td>
             <td>2018-10-08</td>
             <td>Allow</td>
@@ -2037,7 +2037,7 @@ summary: Changes that were completed before the change log was made publicly ava
         </tr>
         <tr>
             <td>WP0004</td>
-            <td>WP whitelist</td>
+            <td>WP allowlist</td>
             <td>2018-10-01</td>
             <td>2018-10-08</td>
             <td>Allow</td>
@@ -2048,7 +2048,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XXE detection</td>
             <td>2018-09-24</td>
             <td>2018-10-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2072,7 +2072,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Probing detection</td>
             <td>2018-09-24</td>
             <td>2018-10-08</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2080,7 +2080,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi sleep probing</td>
             <td>2018-09-24</td>
             <td>2018-10-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2088,7 +2088,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-09-24</td>
             <td>2018-10-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2096,7 +2096,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-09-24</td>
             <td>2018-10-01</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2104,7 +2104,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-09-17</td>
             <td>2018-09-24</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2112,7 +2112,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Rules to stop file read and deletion vulnerabilities in GhostScript</td>
             <td>2018-09-17</td>
             <td>2018-09-24</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2120,7 +2120,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Rules to stop file read and deletion vulnerabilities in GhostScript</td>
             <td>2018-09-17</td>
             <td>2018-09-24</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2192,7 +2192,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-09-10</td>
             <td>2018-09-17</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Deleted</td>
         </tr>
         <tr>
@@ -2208,7 +2208,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XXE Detection</td>
             <td>2018-09-03</td>
             <td>2018-09-10</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2232,7 +2232,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2240,7 +2240,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2248,7 +2248,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2256,7 +2256,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2264,7 +2264,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2272,8 +2272,8 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved XSS Detection</td>
             <td>2018-08-20</td>
             <td>2018-08-28</td>
-            <td>Simulate</td>
-            <td>Simulate</td>
+            <td>Log</td>
+            <td>Log</td>
         </tr>
         <tr>
             <td>100063</td>
@@ -2408,7 +2408,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Blocks requests to /server_status, which g ives away information on how a server works.</td>
             <td>2018-08-30</td>
             <td>2018-08-06</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
         <tr>
@@ -2416,7 +2416,7 @@ summary: Changes that were completed before the change log was made publicly ava
             <td>Improved SQLi detection</td>
             <td>2018-07-16</td>
             <td>2018-07-30</td>
-            <td>Simulate</td>
+            <td>Log</td>
             <td>Block</td>
         </tr>
     </tbody>

--- a/products/waf/src/content/change-log/index.md
+++ b/products/waf/src/content/change-log/index.md
@@ -7,7 +7,7 @@ order: 1
 
 Cloudflare has a very regular cadence of releasing updates and new rules to our Managed Rulesets. The updates either improve a rule's accuracy, lower false positives rates or increase the protection due to a change in the threat landscape.
 
-The release cycle for new rules happens on a 7-day cycle. Every Monday, sometimes Tuesday depending on public holidays, Cloudflare will deploy the updated or new rules into logging only ("Simulate") mode. Logging only mode allows our customers to identify any increases in Firewall Event volumes which look like potential false positives. On the following Monday (or Tuesday) the rules will be transitioned from the logging only mode to the intended default action ("New Action").
+The release cycle for new rules happens on a 7-day cycle. Every Monday, sometimes Tuesday depending on public holidays, Cloudflare will deploy the updated or new rules into logging only ("Log") mode. Logging only mode allows our customers to identify any increases in Firewall Event volumes which look like potential false positives. On the following Monday (or Tuesday) the rules will be transitioned from the logging only mode to the intended default action ("New Action").
 
 Cloudflare is very proactive in responding to new vulnerabilities, which may need to be released outside of the 7-day cycle, defined as an Emergency Release.
 


### PR DESCRIPTION
Firewall Actions:
`simulate` -> `log`
`drop` -> `block`
Old `log` is removed.

Firewall Source:
`sanityCheck` -> `validation`

IP Class:
`whitelist` -> `allowlist`

Deprecates `WAFFlags` and `WAFMatchedVar`.