### PR TITLE
Put the link to the Cloudflare Pages dashboard in the docs!

### DIFF
--- a/products/pages/src/content/getting-started/index.md
+++ b/products/pages/src/content/getting-started/index.md
@@ -16,7 +16,7 @@ You'll be signing up for a Cloudflare account. You may also want a custom domain
 
 ### Sign in to Cloudflare Pages
 
-To begin, go to https://pages.dev and sign in with your Cloudflare account. If you don't have one yet, you can sign up for an account as you get started deploying your new site.
+To begin, go to the [Cloudflare Pages site](https://pages.dev) and sign in with your Cloudflare account. If you don't have one yet, you can sign up for an account as you get started deploying your new site.
 
 ### Connect to GitHub
 

--- a/products/pages/src/content/getting-started/index.md
+++ b/products/pages/src/content/getting-started/index.md
@@ -16,11 +16,11 @@ You'll be signing up for a Cloudflare account. You may also want a custom domain
 
 ### Sign in to Cloudflare Pages
 
-To begin, sign in with your Cloudflare account. If you don't have one yet, you can sign up for an account as you get started deploying your new site.
+To begin, go to https://pages.dev and sign in with your Cloudflare account. If you don't have one yet, you can sign up for an account as you get started deploying your new site.
 
 ### Connect to GitHub
 
-Signing in with GitHub allows Cloudflare Pages to deploy your projects, update your GitHub PRs with [preview deployments](/platform/preview-deployments), and more. When you sign in, you'll also have the option of specifying any GitHub organizations that you'd like to connect to Cloudflare Pages. This allows you to deploy both public and private repositories for your own account, as well as repositories for your company or organization.
+Signing in with GitHub allows [Cloudflare Pages](https://pages.dev) to deploy your projects, update your GitHub PRs with [preview deployments](/platform/preview-deployments), and more. When you sign in, you'll also have the option of specifying any GitHub organizations that you'd like to connect to Cloudflare Pages. This allows you to deploy both public and private repositories for your own account, as well as repositories for your company or organization.
 
 ## Configuration and deployment
 

--- a/products/pages/src/content/index.md
+++ b/products/pages/src/content/index.md
@@ -12,7 +12,7 @@ Deploy your dynamic frontend applications using Cloudflare Pages! Pages are supe
 
 Get started deploying your first site using our starter guide below, or check out our examples page to explore the vast ecosystem of tools and framework that we support on the platform.
 
-<Link to="/getting-started" className="Button Button-is-docs-primary">Get started</Link> &nbsp;&nbsp; <Link to="/how-to" className="Button Button-is-docs-secondary">See what you can build</Link>
+<Link to="/getting-started" className="Button Button-is-docs-primary">Get started</Link> &nbsp;&nbsp; <Link to="/how-to" className="Button Button-is-docs-secondary">See what you can build</Link> &nbsp;&nbsp; <Link to="https://pages.dev" className="Button Button-is-docs-secondary">Your Cloudflare Pages dashboard</Link>
 
 ## Popular pages
 


### PR DESCRIPTION
For an embarrassingly long amount of time I was reading and re-reading the CloudFlare Pages docs and tearing my hair out trying to figure out how to access Pages.

<img src="https://user-images.githubusercontent.com/511499/111017227-149fc680-8380-11eb-9118-816c2172535b.png" width="400px"/>

On every tweet I've seen by the cloudflare team about pages I've replied asking how in the world we're supposed to access the supposedly "public beta".

The docs just say "sign into to CloudFlare Pages" as if it's supposed to be obvious where that is, and yet the is no UI anywhere in the standard CloudFlare dashboard to access Pages.
(worse yet, there is a section called Custom Pages that has absolutely nothing to do with CloudFlare Pages, and no info disambiguating the two)

<img src="https://user-images.githubusercontent.com/511499/111017217-ffc33300-837f-11eb-92fd-c30fb955a4f3.png" width="400px"/>

This PR adds the link front-and-center at the top, and I encourage you to make it even bigger / give it a nice themed orange button if you want!

I'm sorry if this PR comes across as cranky, I love CF overall, and cant wait to use pages, it looks awesome. Hopefully it'll save other people the pain of having to find this mysteriously elusive https://pages.dev domain via word-of-mouth.

Edit: Apparently there is also `https://pages.cloudflare.com` and `https://dash.cloudflare.com/<zone>/pages`, which one is the canonical one?