### PR TITLE
Fix homebrew installation instructions

### DIFF
--- a/products/http3/src/content/curl-brew.md
+++ b/products/http3/src/content/curl-brew.md
@@ -24,7 +24,8 @@ Run the following commands to install required dependencies and to build curl wi
 - Build curl with quiche:
 
   ```sh
-  $ brew install --HEAD -s https://raw.githubusercontent.com/cloudflare/homebrew-cloudflare/master/curl.rb
+  $ curl -o curl.rb https://raw.githubusercontent.com/cloudflare/homebrew-cloudflare/master/curl.rb
+  $ brew install --HEAD -s curl.rb
   ```
 
 At the end curl binary will be installed on "/usr/local/opt/curl/bin",

--- a/products/http3/src/content/curl-brew.md
+++ b/products/http3/src/content/curl-brew.md
@@ -24,7 +24,7 @@ Run the following commands to install required dependencies and to build curl wi
 - Build curl with quiche:
 
   ```sh
-  $ curl -o curl.rb https://raw.githubusercontent.com/cloudflare/homebrew-cloudflare/master/curl.rb
+  $ curl -O https://raw.githubusercontent.com/cloudflare/homebrew-cloudflare/master/curl.rb
   $ brew install --HEAD -s curl.rb
   ```
 


### PR DESCRIPTION
Per https://dev.to/gjrdiesel/getting-around-brew-s-error-calling-non-checksummed-download-of-17fl

If you follow the existing instructions, homebrew will complain with
`Calling Non-checksummed download of curl formula file from an arbitrary
URL is disabled!`.  The workaround (from the URL above) is to fetch the
file locally and then run `brew install --HEAD -s ...` on that.