### PR TITLE
[Logs] Fix a typo in Datadog's ingestion webhook attributes description

### DIFF
--- a/products/logs/src/content/logpush/datadog/index.md
+++ b/products/logs/src/content/logpush/datadog/index.md
@@ -25,7 +25,7 @@ To create a job, make a `POST` request to the Logpush jobs endpoint with the fol
 
   * `<DATADOG-ENDPOINT-URL>`: The Datadog http logs intake endpoint, which is 'http-intake.logs.datadoghq.com/v1/input' 
   * `<DATADOG-API-KEY>`: The Datadog API token. For example, '20e6d94e8c57924ad1be3c29bcaee0197d"
-  * `service`, `hostname`, `ddsource`, `ddtags`: Optional parameters allowed by Datadog
+  * `service`, `host`, `ddsource`, `ddtags`: Optional parameters allowed by Datadog
 
 ```bash
 "datadog://<DATADOG-ENDPOINT-URL>?header_DD-API-KEY=<DATADOG-API-KEY>&service=<SERVICE>&host=<HOST>&ddsource=<SOURCE>"

--- a/products/logs/src/content/logpush/datadog/index.md
+++ b/products/logs/src/content/logpush/datadog/index.md
@@ -25,7 +25,7 @@ To create a job, make a `POST` request to the Logpush jobs endpoint with the fol
 
   * `<DATADOG-ENDPOINT-URL>`: The Datadog http logs intake endpoint, which is 'http-intake.logs.datadoghq.com/v1/input' 
   * `<DATADOG-API-KEY>`: The Datadog API token. For example, '20e6d94e8c57924ad1be3c29bcaee0197d"
-  * `service`, `host`, `ddsource`, `dtags`: Optional parameters allowed by Datadog
+  * `service`, `hostname`, `ddsource`, `ddtags`: Optional parameters allowed by Datadog
 
 ```bash
 "datadog://<DATADOG-ENDPOINT-URL>?header_DD-API-KEY=<DATADOG-API-KEY>&service=<SERVICE>&host=<HOST>&ddsource=<SOURCE>"


### PR DESCRIPTION
[As per Datadog docs](https://docs.datadoghq.com/api/latest/logs/#send-logs):
- `host` should be `hostname`
- `dtags` should be `ddtags`