### PR TITLE
[Pages] Change incorrect language for Jekyll

### DIFF
--- a/products/pages/src/content/how-to/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/how-to/deploy-a-jekyll-site.md
@@ -1,6 +1,6 @@
 # Deploy a Jekyll site
 
-Jekyll is an open-source React framework for creating websites and apps. In this guide, you'll create a new Jekyll application and deploy it using Cloudflare Pages. We'll be the `jekyll` CLI to create a new Jekyll site.
+Jekyll is a simple, blog-aware, static site generator. In this guide, you'll create a new Jekyll application and deploy it using Cloudflare Pages. We'll be the `jekyll` CLI to create a new Jekyll site.
 
 ## Installing Jekyll
 


### PR DESCRIPTION
On the ["Deploy a Jekyll site"](https://developers.cloudflare.com/pages/how-to/deploy-a-jekyll-site) page in the Cloudflare Pages section, Jekyll is stated to be:

> an open-source React framework

However, Jekyll is neither. This MR fixes the description of what Jekyll is.
The used description is taken ad-verbatim from the [Jekyll page on Wikipedia](https://en.wikipedia.org/wiki/Jekyll_(software)).