### PR TITLE
Remove waitUntil from Durable Object counter example

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -416,12 +416,6 @@ export class Counter {
         // Make sure we're fully initialized from storage.
         if (!this.initializePromise) {
             this.initializePromise = this.initialize();
-
-            // `state.waitUntil` ensures that the `initializePromise`
-            // will run to completion even if the request that created
-            // it ends (e.g. the client disconnects before the `await`
-            // below completes).
-            this.state.waitUntil(this.initializePromise);
         }
         await this.initializePromise;
 


### PR DESCRIPTION
This becomes unnecessary after the weekly release completes. (Not to be
merged until then.)