### PR TITLE
Fix code selection in load balancer tutorial

### DIFF
--- a/products/cloudflare-one/src/content/tutorials/migrate-lb-tunnel.md
+++ b/products/cloudflare-one/src/content/tutorials/migrate-lb-tunnel.md
@@ -33,7 +33,7 @@ Next, create an origin pool for the load balancer. This will be a group of origi
 In Legacy mode, adding a new instance of `cloudflared` into a Load Balancer pool must be done from the command line tool itself. The `cloudflared` agent will start and create 4 separate connections, enrolling each of these into a load balancer pool.
 
 ```sh
-cloudflared tunnel --hostname app.widgetcorp.tech --url http://localhost:8000 --lb-pool lisbon-data-center
+$ cloudflared tunnel --hostname app.widgetcorp.tech --url http://localhost:8000 --lb-pool lisbon-data-center
 ```
 
 ![Create LB](../static/secure-origin-connections/migrate-lb-tunnel/classic-tunnel-lb-ui.png)
@@ -52,7 +52,7 @@ To migrate to the Named Tunnel model, first [download and authenticate](/connect
 To begin, create a Named Tunnel with the following command.
 
 ```sh
-cloudflared tunnel create lisbon-app
+$ cloudflared tunnel create lisbon-app
 ```
 
 ![Create LB](../static/secure-origin-connections/migrate-lb-tunnel/tunnel-create.png)
@@ -76,7 +76,7 @@ You can now run the Tunnel. Running the Tunnel will connect `cloudflared` to Clo
 Run the following command, replacing `lisbon-app` with the name of your Tunnel.
 
 ```sh
-cloudflared tunnel run lisbon-app
+$ cloudflared tunnel run lisbon-app
 ```
 
 ![Create LB](../static/secure-origin-connections/migrate-lb-tunnel/tunnel-run.png)


### PR DESCRIPTION
Add `$` to beginning of code prompts to make them selectable.

See https://github.com/cloudflare/cloudflare-docs-engine/pull/274 for explanation about why this happens