### PR TITLE
fixes #965 Replace 'create-react-app' with 'hugo x.xx.x' reference in Cloudflare pages docs for Hugo

### DIFF
--- a/products/pages/src/content/how-to/deploy-a-hugo-site.md
+++ b/products/pages/src/content/how-to/deploy-a-hugo-site.md
@@ -167,7 +167,7 @@ You can deploy your site to Cloudflare Pages by going to the dashboard, and crea
 
 </TableLayout>
 
-Once you've configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `create-react-app`, your project dependencies, and building your site, before deploying it.
+Once you've configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `Hugo x.xx.x`, your project dependencies, and building your site, before deploying it.
 
 <Aside>
 


### PR DESCRIPTION
The Hugo docs for Cloudflare pages reference 'create-react-app' instead of 'Hugo x.xx.x'. This will fix that.

Here is what the logs look like for a Hugo project in Cloudflare pages.
![image](https://user-images.githubusercontent.com/62220614/111719110-35a56300-8829-11eb-8a1f-ac5a29ff5074.png)
