### PR TITLE
[workers] Update Quick Start/Starters pages

### DIFF
--- a/products/workers/src/content/_partials/_tutorials-before-you-start.md
+++ b/products/workers/src/content/_partials/_tutorials-before-you-start.md
@@ -1,3 +1,3 @@
 ## Before you start
 
-All of the tutorials assume you’ve already gone through [Getting started](/learning/getting-started), which gets you set up with a Cloudflare Workers account, and the Workers CLI tool, [Wrangler](https://github.com/cloudflare/wrangler).
+All of the tutorials assume you’ve already gone through [Getting started](/get-started/guide), which gets you set up with a Cloudflare Workers account, and the Workers CLI tool, [Wrangler](https://github.com/cloudflare/wrangler).

--- a/products/workers/src/content/examples/index.md
+++ b/products/workers/src/content/examples/index.md
@@ -1,7 +1,7 @@
 ---
 type: overview
 hideChildren: true
-order: 1
+order: 2
 ---
 
 import DocsCodeExamplesOverview from "../../components/docs-code-examples-overview"

--- a/products/workers/src/content/get-started/guide.md
+++ b/products/workers/src/content/get-started/guide.md
@@ -1,8 +1,9 @@
 ---
 order: 0
+title: "Guide"
 ---
 
-# Getting started
+# Getting Started Guide
 
 Cloudflare Workers is a **serverless application platform** running on Cloudflare’s global cloud network in over 200 cities around the world, offering both [free and paid plans](/platform/pricing).
 

--- a/products/workers/src/content/get-started/index.md
+++ b/products/workers/src/content/get-started/index.md
@@ -1,0 +1,7 @@
+---
+order: 1
+---
+
+# Get Started
+
+<DirectoryListing path="/get-started"/>

--- a/products/workers/src/content/get-started/quickstarts.md
+++ b/products/workers/src/content/get-started/quickstarts.md
@@ -5,11 +5,11 @@ order: 2
 
 import WorkerStarter from "../../components/worker-starter"
 
-# Starters
+# Quickstarts
 
 <ContentColumn>
 
-Starters are essentially GitHub repos that are designed to be a starting point for building a new Cloudflare Workers project. For the projects below, you simply run:
+Quickstarts are GitHub repos that are designed to be a starting point for building a new Cloudflare Workers project. For the projects below, you simply run:
 
 ```sh
 $ wrangler generate <new-project-name> <github-repo-url>
@@ -29,17 +29,17 @@ $ wrangler generate <new-project-name> <github-repo-url>
 
 --------------------------------
 
-## JavaScript, TypeScript
+## Templates
 
 <WorkerStarter
-  title="Hello World"
-  description="A bare-bones starter in JavaScript."
+  title="JavaScript Starter"
+  description="A bare-bones Workers starter project, in JavaScript."
   repo="cloudflare/worker-template"
 />
 
 <WorkerStarter
-  title="Hello World (TypeScript)"
-  description="A bare-bones starter in TypeScript."
+  title="TypeScript Starter"
+  description="A bare-bones Workers starter project, in TypeScript."
   repo="cloudflare/worker-typescript-template"
 />
 
@@ -55,11 +55,25 @@ $ wrangler generate <new-project-name> <github-repo-url>
   repo="cloudflare/worker-template-router"
 />
 
+--------------------------------
+
+## Frameworks
+
 <WorkerStarter
   title="Apollo GraphQL Server"
   description="Lightning-fast, globally distributed Apollo GraphQL server, deployed at the edge using Cloudflare Workers."
   repo="signalnerve/workers-graphql-server"
 />
+
+<WorkerStarter
+  title="Flareact"
+  description="Flareact is an edge-rendered React framework built for Cloudflare Workers. It features file-based page routing with dynamic page paths and edge-side data fetching APIs."
+  repo="flareact/flareact"
+/>
+
+--------------------------------
+
+## Example Projects
 
 <WorkerStarter
   title="Speedtest"

--- a/products/workers/src/content/index.md
+++ b/products/workers/src/content/index.md
@@ -11,7 +11,7 @@ type: overview
 Cloudflare Workers provides a serverless execution environment that allows you to create entirely new applications or augment existing ones without configuring or maintaining infrastructure.
 
 <ButtonGroup>
-  <Button type="primary" href="/learning/getting-started">Get started</Button>
+  <Button type="primary" href="/get-started/guide">Get started</Button>
   <Button type="secondary" href="/tutorials">View the tutorials</Button>
 </ButtonGroup>
 

--- a/products/workers/src/content/platform/sites/start-from-existing.md
+++ b/products/workers/src/content/platform/sites/start-from-existing.md
@@ -39,7 +39,7 @@ Once you have a site generated, follow these steps:
     - Jekyll: `_site`
     - Eleventy: `_site`
 
-3. Add your `account_id` to your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` visit [Getting started](/learning/getting-started#6a-obtaining-your-account-id-and-zone-id).
+3. Add your `account_id` to your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` visit [Getting started](/get-started/guide#6a-obtaining-your-account-id-and-zone-id).
 
 4. You can preview your site by running:
 
@@ -47,7 +47,7 @@ Once you have a site generated, follow these steps:
   $ wrangler preview --watch
   ```
 
-5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/learning/getting-started#configure-for-deploying-to-workersdev) or your [personal domain](/learning/getting-started#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
+5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
 
   Then, update your `wrangler.toml`:
 
@@ -60,7 +60,7 @@ Once you have a site generated, follow these steps:
 
   **workers.dev**: Set `workers_dev` to true. This is the default.
 
-  Learn more about [configuring your project](/learning/getting-started#6-configure-your-project-for-deployment).
+  Learn more about [configuring your project](/get-started/guide#6-configure-your-project-for-deployment).
 
 6. Run:
 

--- a/products/workers/src/content/platform/sites/start-from-scratch.md
+++ b/products/workers/src/content/platform/sites/start-from-scratch.md
@@ -20,7 +20,7 @@ To start from scratch to create a Workers Site, follow these steps:
     - `workers-site`: The JavaScript for serving your assets. You don’t need to edit this- but if you want to see how it works or add more functionality to your Worker, you can edit `workers-site/index.js`.
     - `wrangler.toml`: Your configuration file. You’ll configure your account and project information here.
 
-3. Add your `account_id` your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` visit [Getting started](/learning/getting-started#6a-obtaining-your-account-id-and-zone-id).
+3. Add your `account_id` your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` visit [Getting started](/get-started/guide#6a-obtaining-your-account-id-and-zone-id).
 
 4. You can preview your site by running:
 
@@ -28,7 +28,7 @@ To start from scratch to create a Workers Site, follow these steps:
   $ wrangler preview --watch
   ```
 
-5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/learning/getting-started#configure-for-deploying-to-workersdev) or your [personal domain](/learning/getting-started#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
+5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
 
   Then, update your `wrangler.toml`:
 
@@ -47,7 +47,7 @@ To start from scratch to create a Workers Site, follow these steps:
 
   **workers.dev**: Set `workers_dev`  to true. This is the default.
 
-  Learn more about [configuring your project](/learning/getting-started#6-configure-your-project-for-deployment).
+  Learn more about [configuring your project](/get-started/guide#6-configure-your-project-for-deployment).
 
 6. Run:
   ```sh

--- a/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
+++ b/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
@@ -796,7 +796,7 @@ Given an example configuration and deployment of `https://my-auth.signalnerve.co
 
 2. Configure your `wrangler.toml` to associate your Workers script with a zone
 
-Associating a configured zone from your Cloudflare account is covered in the section [“Configure for deploying to a registered domain”](/learning/getting-started#optional-configure-for-deploying-to-a-registered-domain) section of [Getting started](/learning/getting-started). In the “Publish” section of this guide, we’ll cover how to configure the file `wrangler.toml` to deploy to workers.dev — make sure you read the [Getting started](/learning/getting-started#optional-configure-for-deploying-to-a-registered-domain) linked above so you can understand how these approaches differ.
+Associating a configured zone from your Cloudflare account is covered in the section [“Configure for deploying to a registered domain”](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) section of [Getting started](/get-started/guide). In the “Publish” section of this guide, we’ll cover how to configure the file `wrangler.toml` to deploy to workers.dev — make sure you read the [Getting started](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) linked above so you can understand how these approaches differ.
 
 In particular, you’ll need to ensure that you have `zone_id` and `route` keys in your `wrangler.toml`, and `workers_dev` disabled. You may also choose to entirely remove the `[site]` block from your `wrangler.toml`, which will stop `wrangler` from uploading the contents of your project’s `public` folder to Workers KV:
 
@@ -828,7 +828,7 @@ We’re finally ready to deploy our application to Workers. Before we can succes
 
 ### Configuring `wrangler.toml`
 
-The `wrangler.toml` generated as part of your application tells wrangler how and where to deploy your application. Using the [“Configuring your project” section of the Getting started](/learning/getting-started#6d-configuring-your-project) as a guide, populate `wrangler.toml` with your account ID, which will allow you to deploy your application to your Cloudflare account:
+The `wrangler.toml` generated as part of your application tells wrangler how and where to deploy your application. Using the [“Configuring your project” section of the Getting started](/get-started/guide#6d-configuring-your-project) as a guide, populate `wrangler.toml` with your account ID, which will allow you to deploy your application to your Cloudflare account:
 
 ```toml
 ---

--- a/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
@@ -52,7 +52,7 @@ The `init --site` command will provide the scaffolding necessary to deploy your 
 
 ## Configure and publish
 
-To prepare your application for deployment, open up the newly-created `wrangler.toml` file, which represents the configuration for your Workers application. Using the [“Configuring your project” section of Getting started](/learning/getting-started#6d-configuring-your-project) as a guide, populate `wrangler.toml` with your account ID, which will allow you to deploy your React application to your Cloudflare account.
+To prepare your application for deployment, open up the newly-created `wrangler.toml` file, which represents the configuration for your Workers application. Using the [“Configuring your project” section of Getting started](/get-started/guide#6d-configuring-your-project) as a guide, populate `wrangler.toml` with your account ID, which will allow you to deploy your React application to your Cloudflare account.
 
 The `bucket` key in your `wrangler.toml` indicates the “build” folder that Sites will deploy to Workers. While many front-end application and static site generators use the folder `public`, `create-react-app` uses the folder `build`. Let’s change the `bucket` key in `wrangler.toml` to `build`:
 

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -43,7 +43,7 @@ It’s time to do our first export! Select “Start static site export” (it mi
 
 ## Creating the Workers project
 
-With an export ready of our site, it’s time to get to work deploying it. To do this, we’ll use [Wrangler](https://github.com/cloudflare/wrangler), the command-line tool for Cloudflare Workers. If you haven’t yet installed and configured Wrangler, check out our [Getting started](/learning/getting-started) guide.
+With an export ready of our site, it’s time to get to work deploying it. To do this, we’ll use [Wrangler](https://github.com/cloudflare/wrangler), the command-line tool for Cloudflare Workers. If you haven’t yet installed and configured Wrangler, check out our [Getting started](/get-started/guide) guide.
 
 Once Wrangler is installed and configured, we can create a new project for deploying our static WordPress site to Workers. To generate a new project run:
 
@@ -96,11 +96,11 @@ $ tree wp-static
 
 ## Deploying
 
-To preview and deploy our application, we need to fill out `wrangler.toml` — the configuration file for this project. Most of the file has been pre-filled, but you need to specify your `account_id` and where you want to deploy your application. Fill out the [`account_id`](/learning/getting-started#6a-obtaining-your-account-id-and-zone-id) field in `wrangler.toml` with your Cloudflare account ID.
+To preview and deploy our application, we need to fill out `wrangler.toml` — the configuration file for this project. Most of the file has been pre-filled, but you need to specify your `account_id` and where you want to deploy your application. Fill out the [`account_id`](/get-started/guide#6a-obtaining-your-account-id-and-zone-id) field in `wrangler.toml` with your Cloudflare account ID.
 
 Using Wrangler’s preview feature, we can quickly upload a version of our site to the Cloudflare Workers preview service, and make sure that the static export looks like we’d expect. Running `wrangler preview` will upload your static site and preview it in a browser window.
 
-When your site looks correct in Wrangler’s preview, you can move onto publishing your project to a domain. For a guide on how to do this, check out [Getting started](/learning/getting-started#6-configure-your-project-for-deployment).
+When your site looks correct in Wrangler’s preview, you can move onto publishing your project to a domain. For a guide on how to do this, check out [Getting started](/get-started/guide#6-configure-your-project-for-deployment).
 
 [![Demo site](./media/wordpress--demo.png)](https://wp-static.signalnerve.workers.dev)
 
@@ -116,7 +116,7 @@ There are some features available in WordPress sites that will not be supported 
 
 Deploying your WordPress site to Workers has benefits for your site’s performance, security, and cost. With a static version of your site being served, you can do a number of things with your live WordPress installation:
 
-- Move your WordPress install to a private URL or subdomain, and serve the static version of your site by deploying the Workers application to your domain. See [Deploying to a Domain](/learning/getting-started#optional-configure-for-deploying-to-a-registered-domain) to learn more!
+- Move your WordPress install to a private URL or subdomain, and serve the static version of your site by deploying the Workers application to your domain. See [Deploying to a Domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) to learn more!
 - Run your WordPress instance locally, or put your now-hidden WP instance behind something like [Cloudflare Access](https://www.cloudflare.com/products/cloudflare-access/) to only give access to your contributors. This has a dramatic effect on the number of attack vectors for your WordPress site and its content.
 - Downgrade your WordPress hosting plan to a cheaper plan. Because the memory and bandwidth requirements for your WordPress instance are now much smaller, you can often get away with hosting it on a cheaper plan, or moving to shared hosting. Your Cloudflare Workers plan is priced per-request, and because you can host up to thirty sites on your account, serving a high number of static WordPress sites can be an order of magnitude cheaper on Workers.
 

--- a/products/workers/src/content/tutorials/localize-a-website/index.md
+++ b/products/workers/src/content/tutorials/localize-a-website/index.md
@@ -250,7 +250,7 @@ async function handleEvent(event) {
 
 Our simple i18n tool built on Cloudflare Workers is complete, and it’s time to deploy it to your domain!
 
-It’s super easy (and quick) to deploy sites to your Workers.dev subdomain, but the `wrangler.toml` configuration file in your project needs a little bit of setup before you can deploy your project. First, you’ll need to add your Cloudflare [account ID](/learning/getting-started#6a-obtaining-your-account-id-and-zone-id). Set this ID at the top part of your project’s `wrangler.toml`:
+It’s super easy (and quick) to deploy sites to your Workers.dev subdomain, but the `wrangler.toml` configuration file in your project needs a little bit of setup before you can deploy your project. First, you’ll need to add your Cloudflare [account ID](/get-started/guide#6a-obtaining-your-account-id-and-zone-id). Set this ID at the top part of your project’s `wrangler.toml`:
 
 ```toml
 ---


### PR DESCRIPTION
This PR updates the Quick Start guide and Starters page to both live under a new "Get Started" section in the docs. I also updated the hierarchy/titling on the Starters page to be a bit more clear. 

**Needed redirects while merging PR:**

- [ ] Redirect `/learning/getting-started` → `/get-started/guide`
- [ ] Redirect `/starters` → `/get-started/quickstarts`

<details>
<summary>Screenshots ⬇️ </summary>

<img width="1085" alt="Screen Shot 2021-03-22 at 3 43 33 PM" src="https://user-images.githubusercontent.com/922353/112056365-ec555c00-8b25-11eb-83c0-6e024e5c1023.png">
<img width="739" alt="Screen Shot 2021-03-22 at 3 43 41 PM" src="https://user-images.githubusercontent.com/922353/112056367-ecedf280-8b25-11eb-921e-52129748fd65.png">
<img width="1075" alt="Screen Shot 2021-03-22 at 3 43 47 PM" src="https://user-images.githubusercontent.com/922353/112056370-ed868900-8b25-11eb-96ca-7a7e61bc0998.png">
<img width="1078" alt="Screen Shot 2021-03-22 at 3 43 54 PM" src="https://user-images.githubusercontent.com/922353/112056373-ee1f1f80-8b25-11eb-8eb8-eb7317564adf.png">
<img width="814" alt="Screen Shot 2021-03-22 at 3 43 58 PM" src="https://user-images.githubusercontent.com/922353/112056378-eeb7b600-8b25-11eb-915e-cc03445b68cc.png">
<img width="809" alt="Screen Shot 2021-03-22 at 3 44 02 PM" src="https://user-images.githubusercontent.com/922353/112056382-ef504c80-8b25-11eb-83b5-9f83f157f9c9.png">
<img width="771" alt="Screen Shot 2021-03-22 at 3 44 06 PM" src="https://user-images.githubusercontent.com/922353/112056384-ef504c80-8b25-11eb-9f27-d9fcde8ecb1c.png">
</details>