### PR TITLE
Fix Durable Object initializePromise example

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -371,23 +371,23 @@ export class Counter {
     }
 
     async initialize() {
-        try {
-            let stored = await this.state.storage.get("value");
-            this.value = stored || 0;
-        } catch (err) {
-            // If anything throws during initialization then we
-            // need to be sure that a future request will retry by
-            // creating another `initializePromise` below.
-            this.initializePromise = undefined;
-            throw err;
-        }
+        let stored = await this.state.storage.get("value");
+        this.value = stored || 0;
     }
 
     // Handle HTTP requests from clients.
     async fetch(request) {
         // Make sure we're fully initialized from storage.
         if (!this.initializePromise) {
-            this.initializePromise = this.initialize();
+            this.initializePromise = this.initialize().catch((err) => {
+                // If anything throws during initialization then we need to be
+                // sure sure that a future request will retry initialize().
+                // Note that the concurrency involved in resetting this shared
+                // promise on an error can be tricky to get right -- we don't
+                // recommend customizing it.
+                this.initializePromise = undefined;
+                throw err
+            });
         }
         await this.initializePromise;
 


### PR DESCRIPTION
In the previous version of the code, if the initialize() method throws
an exception synchronously (e.g.  because the `get()` isn't allowed due
to an ongoing `deleteAll()` operation), it could cause
`initializePromise` to get stuck with an exception in it due to the
order of assignments -- the assignment of `undefined` to
`initializePromise` would actually happen before the assignment of the
result of `initialize()` to `initializePromise`.

This formulation avoids that problem -- according to the relevant MDN
docs on Promise.then and Promise.catch, they're guaranteed to run
asynchronously.