### PR TITLE
Add mentions about eligibility to use bot score field

### DIFF
--- a/products/firewall/src/content/cf-firewall-language/fields.md
+++ b/products/firewall/src/content/cf-firewall-language/fields.md
@@ -245,7 +245,7 @@ Dynamic fields represent computed or derived values, typically related to threat
 
 <Aside type='warning' header='Important'>
 
-Access to the `cf.bot_management.verified_bot` field requires a Cloudflare Enterprise plan with [Bot Management](/bots/get-started/bm-subscription) enabled.
+Access to `cf.bot_management.verified_bot` and `cf.bot_management.score` fields require a Cloudflare Enterprise plan with [Bot Management](/bots/get-started/bm-subscription) enabled.
 
 </Aside>
 


### PR DESCRIPTION
cf.bot_management.score field is also only available in Enterprise plan.