### PR TITLE
add jobs to workers deploy button example

### DIFF
--- a/products/workers/src/content/platform/deploy-button.md
+++ b/products/workers/src/content/platform/deploy-button.md
@@ -26,14 +26,15 @@ on:
   push:
   pull_request:
   repository_dispatch:
-deploy:
-  runs-on: ubuntu-latest
-  timeout-minutes: 60
-  needs: test
-  steps:
-    - uses: actions/checkout@v2
-    - name: Publish
-      uses: cloudflare/wrangler-action@1.3.0
+jobs:
+    deploy:
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      needs: test
+      steps:
+        - uses: actions/checkout@v2
+        - name: Publish
+          uses: cloudflare/wrangler-action@1.3.0
 ```
 
 2. **Add support for `CF_API_TOKEN` and `CF_ACCOUNT_ID` in your workflow**:


### PR DESCRIPTION
Issue: #1082 

as far as I can tell this is required by github: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs