### PR TITLE
Fix broken kubernetes link

### DIFF
--- a/products/cloudflare-one/src/content/tutorials/migrate-lb-tunnel.md
+++ b/products/cloudflare-one/src/content/tutorials/migrate-lb-tunnel.md
@@ -18,7 +18,7 @@ If you are using Legacy Argo Tunnel today you can migrate to Named Argo Tunnel d
 
 **⏲️ Time to complete: 10 minutes**
 
-See additional documentation for working with [Kubernetes](/cloudflare-one/connections/connect-apps/routing-to-tunnel/kubernetes).
+See additional documentation for working with [Kubernetes](/connections/connect-apps/routing-to-tunnel/kubernetes).
 
 ## Creating a Legacy Argo Tunnel with Cloudflare Load Balancer
 


### PR DESCRIPTION
The current link (from my last PR) results in `/cloudflare-one/cloudflare-one/...` which is not a valid route - this removes the duplicate `/cloudflare-one`.