### PR TITLE
Add .well-known bugs to Pages Known Bugs section

### DIFF
--- a/products/pages/src/content/platform/known-issues.md
+++ b/products/pages/src/content/platform/known-issues.md
@@ -8,6 +8,7 @@
 - Source code hosting tools besides GitHub—for instance, BitBucket or Gitlab—are not currently supported.
 - Pages currently only supports a single project per repository. Monorepos or repositories with multiple codebases/applications currently can't deploy more than one project to Pages at a time.
 - Once you've selected a GitHub repository for your Pages application, it can't be changed. Please remove/delete your Pages project and create a new one pointing at a different repository if you need to update it.
+- Pages cannot serve files located in a [`.well-known`](https://tools.ietf.org/html/rfc5785) folder.
 - pages.dev subdomains currently can't be changed. If you need to change your pages.dev subdomain, delete your project and create a new one.
 - Hugo builds automatically run an old version. To run the latest version of Hugo (for instance, 0.80.0), you'll need to set an environment variable. Set `HUGO_VERSION` to `0.80.0` or the Hugo version of your choice.
 - By default, we use Node 10 in the Pages build environment. If you need to use a newer Node version, see our [Build configuration page](https://developers.cloudflare.com/pages/platform/build-configuration) for configuration options.


### PR DESCRIPTION
Pages cannot serve files in a `.well-known` folder right now. This has been discussed quite a bit on the Workers Discord server, but codifying this into the Known Bugs section will help those who are not members on the community.

Example repository: https://github.com/jb3/pages-test-bed
Example (not working) URL: https://pages-test-bed.pages.dev/.well-known/dnt-policy.txt