### PR TITLE
[Magic Transit] Fixed broken link to Magic Firewall

### DIFF
--- a/products/magic-transit/src/content/set-up/index.md
+++ b/products/magic-transit/src/content/set-up/index.md
@@ -10,4 +10,4 @@ Magic Transit setup is straightforward but involves significant configuration of
 - __[Onboarding](/set-up/onboarding/)__ outlines the onboarding process, from scoping to going live, which typically takes about 10 business days. Cloudflare can significantly accelerate this timeline in active-attack scenarios.
 - __[Requirements](/set-up/requirements)__ covers router compatibility, letters of authorization (LOA), internet routing registry (IRR) verification, and maximum segment size (MSS) settings.
 - __[Provide configuration data](/set-up/provide-configuration-data/)__ defines customer configuration data required for Cloudflare to set up Magic Transit for your organization.
-- __[Configure Magic Transit firewall](/configure-magic-transit-firewall/)__ outlines recommended Magic Transit firewall policies and customization.
+- __[Configure Magic Transit firewall](/magic-firewall/)__ outlines recommended Magic Transit firewall policies and customization.


### PR DESCRIPTION
Fixed link pointing to Magic Firewall docs. 
Addresses [PCX-1551](https://jira.cfops.it/browse/PCX-1551)