### PR TITLE
Updating create-react-app instructions

### DIFF
--- a/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
@@ -50,6 +50,17 @@ $ wrangler init --site
 
 The `init --site` command will provide the scaffolding necessary to deploy your React application. For the majority of static sites, you shouldn’t need to change the Workers script: by default, the script will look at an incoming request, and will serve a corresponding asset from [Workers KV](https://www.cloudflare.com/products/workers-kv/) based on that route. For instance, if my static site is deployed at `mystaticsite.com`, requesting `mystaticsite.com/about.html` will look for a file in KV called `about.html`, and serve it back to the client. In addition, if the asset being returned from KV is cacheable, it will automatically be cached with Cloudflare’s CDN, making subsequent requests even faster.
 
+To serve a single page application, update `workers-site/index.js` with the following code to so that all html requests are pointed at your root `index.html` file.
+
+```js
+import { getAssetFromKV, serveSinglePageApp } from '@cloudflare/kv-asset-handler';
+
+async function handleEvent(event) {
+   ...
+   const asset = await getAssetFromKV(event, { mapRequestToAsset: serveSinglePageApp });
+}
+```
+
 ## Configure and publish
 
 To prepare your application for deployment, open up the newly-created `wrangler.toml` file, which represents the configuration for your Workers application. Using the [“Configuring your project” section of Getting started](/get-started/guide#6d-configuring-your-project) as a guide, populate `wrangler.toml` with your account ID, which will allow you to deploy your React application to your Cloudflare account.


### PR DESCRIPTION
`create-react-app` creates a single page application with a root index.html, but the default worker script generated by `init --site`, as documented in the CF workers `create-react-app` guide, will attempt to serve a non-existent html file by default if you are accessing any path that isn't the root `index.html`.

This change amends the documentation so folks starting a new project are aware of this and have the small code change necessary to point all of their html page requests at the root html file 😃 