### PR TITLE
Update WebCrypto conformance table

### DIFF
--- a/products/workers/src/content/runtime-apis/web-crypto.md
+++ b/products/workers/src/content/runtime-apis/web-crypto.md
@@ -271,30 +271,46 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
 
 ### Supported algorithms
 
-Workers implements a subset of the most common cryptographic algorithms, as shown in the following table. We are happy to add support for more algorithms — [let us know about your use case](https://community.cloudflare.com/c/developers/workers).
+Workers implements all operation of the [WebCrypto standard](https://www.w3.org/TR/WebCryptoAPI), as shown in the following table.
+We are happy to add support for more algorithms — [let us know about your use case](https://community.cloudflare.com/c/developers/workers).
+
+A checkmark (✓) indicates that this feature is believed to be fully supported according to the spec.
+[//]: #  An x (✘) indicates that this feature is part of the specification but not implemented.
+[//]: #  If a feature only implements the operation partially, details are listed.
 
 <TableWrap>
 
-| Algorithm                                 | sign()<br/>verify() | encrypt()<br/>decrypt() | digest() | deriveBits()<br/>deriveKey() | generateKey() | wrapKey()<br/>unwrapKey() | exportKey() |
-| :---------------------------------------- | :------------------ | :---------------------- | :------- | :--------------------------- | :------------ | :------------------------ | ----------- |
-| RSASSA-PKCS1-v1_5                         | ✓                   |                         |          |                              | ✓             |                           | ✓           |
-| RSA-PSS                                   | ✓                   |                         |          |                              | ✓             |                           | ✓           |
-| ECDSA                                     | ✓                   |                         |          |                              |               |                           | ✓           |
-| HMAC                                      | ✓                   |                         |          |                              | ✓             |                           |             |
-| AES-CBC                                   |                     | ✓                       |          |                              |               | ✓                         |             |
-| AES-GCM                                   |                     | ✓                       |          |                              | ✓             | ✓                         |             |
-| SHA-1                                     |                     |                         | ✓        |                              |               |                           |             |
-| SHA-256                                   |                     |                         | ✓        |                              |               |                           |             |
-| SHA-384                                   |                     |                         | ✓        |                              |               |                           |             |
-| SHA-512                                   |                     |                         | ✓        |                              |               |                           |             |
-| MD5<sup><a href="#footnote-1">1</a></sup> |                     |                         | ✓        |                              |               |                           |             |
-| PBKDF2                                    |                     |                         |          | ✓                            |               |                           |             |
+| Algorithm                                         | sign()<br/>verify()  | encrypt()<br/>decrypt()   | digest() | deriveBits()<br/>deriveKey() | generateKey() | wrapKey()<br/>unwrapKey() | exportKey() | importKey() |
+| :------------------------------------------------ | :------------------- | :------------------------ | :------- | :--------------------------- | :------------ | :------------------------ | :---------- | :---------- |
+| RSASSA PKCS1 v1.5                                 | ✓                    |                           |          |                              | ✓             |                           | ✓           | ✓           |
+| RSA PSS                                           | ✓                    |                           |          |                              | ✓             |                           | ✓           | ✓           |
+| RSA OAEP                                          |                      | ✓                         |          |                              | ✓             | ✓                         | ✓           | ✓           |
+| ECDSA                                             | ✓                    |                           |          |                              | ✓             |                           | ✓           | ✓           |
+| ECDH                                              |                      |                           |          | ✓                            | ✓             |                           | ✓           | ✓           |
+| NODE ED25519<sup><a href="#footnote 1">1</a></sup>| ✓                    |                           |          |                              | ✓             |                           | ✓           | ✓           |
+| AES CTR                                           |                      | ✓                         |          |                              | ✓             | ✓                         | ✓           | ✓           |
+| AES CBC                                           |                      | ✓                         |          |                              | ✓             | ✓                         | ✓           | ✓           |
+| AES GCM                                           |                      | ✓                         |          |                              | ✓             | ✓                         | ✓           | ✓           |
+| AES KW                                            |                      |                           |          |                              | ✓             | ✓                         | ✓           | ✓           |
+| HMAC                                              | ✓                    |                           |          |                              | ✓             |                           | ✓           | ✓           |
+| SHA 1                                             |                      |                           | ✓        |                              |               |                           |             |             |
+| SHA 256                                           |                      |                           | ✓        |                              |               |                           |             |             |
+| SHA 384                                           |                      |                           | ✓        |                              |               |                           |             |             |
+| SHA 512                                           |                      |                           | ✓        |                              |               |                           |             |             |
+| MD5<sup><a href="#footnote 2">2</a></sup>         |                      |                           | ✓        |                              |               |                           |             |             |
+| HKDF                                              |                      |                           |          | ✓                            |               |                           |             | ✓           |
+| PBKDF2                                            |                      |                           |          | ✓                            |               |                           |             | ✓           |
 
 </TableWrap>
 
 __Footnotes:__
 
-1. <a name="footnote-1"></a> MD5 is not part of the WebCrypto standard, but is supported in Cloudflare Workers for interacting with legacy systems that require MD5. MD5 is considered a weak algorithm. Do not rely upon MD5 for security.
+1. <a name="footnote-1"></a> Non-standard EdDSA is supported for the Ed25519 curve. Since this algorithm is non-standard, a few things to keep in mind while using it:
+* Use <Code>NODE-ED25519</Code> as the algorithm and namedCurve parameters.
+* Unlike NodeJS, we will not support "raw" import of private keys.
+* Since this algorithm is non-standard, the implementation may change over time. While we cannot guarantee it at this time, we will strive to maintain backward compatabilityand compatability with NodeJS's behavior.
+Any notable compatability notes will be communicated in release notes and via this developer document.
+2. <a name="footnote-2"></a> MD5 is not part of the WebCrypto standard, but is supported in Cloudflare Workers for interacting with legacy systems that require MD5. MD5 is considered a weak algorithm. Do not rely upon MD5 for security.
 
 --------------------------------
 


### PR DESCRIPTION
Use `-` to indicate function is invalid for that algorithm.
Use `✘` to indicate when the function isn't implemented at all.
For partial implementation, document the caveats.
Add missing `importKey` column.

Document that the following additions have been made to the runtime:
* AES-CTR
* AES import/export for JWK format
* HMAC JWK import
* ECDH (generateKey, import, export, & deriveBits/deriveKey). JWK import not implemented.
* ECDSA generateKey added. Fully supported except for missing JWK import.