### PR TITLE
Fix root wildcard example

### DIFF
--- a/products/cloudflare-one/src/content/policies/zero-trust/app-paths.md
+++ b/products/cloudflare-one/src/content/policies/zero-trust/app-paths.md
@@ -37,13 +37,13 @@ Using a wildcard in the *subdomain* field **does not cover the apex domain**.
 
 ### Protect all paths of an apex domain
 
-Using a wildcard in the *path* field **does not cover the apex domain**.
+Using a wildcard in the *path* field **does cover the apex domain**.
 
 <TableWrap>
 
 | Wildcard | Covers | Doesn't cover |
 | -------- | ------ | ------------- |
-| `example.com/*` | `example.com/alpha`, `example.com/beta` | `example.com`,`alpha.example.com` |
+| `example.com/*` | `example.com`, `example.com/alpha`, `example.com/beta` | `alpha.example.com` |
 
 </TableWrap>
 


### PR DESCRIPTION
I'm unsure if this is a bug or is intended, but the documented behaviour isn't accurate. I noticed this when trying to have an application for `/` and an application for `/*`, and the `/*` policy still took precedence. After removing the `/` application I noticed the application name used for `/*` was still being shown on the login page (for `/`) and the policy was still being used.

## Steps to reproduce

1. Create an orange cloud record for `test.example.com`
2. Create an application for `test.example.com/*`
    - Name it `Test Application`
    - Disable instant auth
3. Go to `test.example.com/` and notice you are taken to the identity provider selection page and `Test Application` is shown