### PR TITLE
Fix module reference in build modules

### DIFF
--- a/products/pages/src/content/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
+++ b/products/pages/src/content/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
@@ -108,7 +108,7 @@ filename: nuxt.config.js
 ---
 {
   buildModules: [
-    "@nuxtjs/sanity"
+    "@nuxtjs/sanity/module"
   ]
 }
 ```


### PR DESCRIPTION
I found the issue in this [tutorial](https://developers.cloudflare.com/pages/tutorials/build-a-blog-using-nuxt-and-sanity#integrating-sanityio) and looking in the sanity [docs](https://sanity.nuxtjs.org/quick-start) i could figure out that the tutorial is out of date.

https://discord.com/channels/595317990191398933/827054336566624266/831546711888625715