### PR TITLE
Add RUM Web Analytics Beta data sets to GraphQL API docs

### DIFF
--- a/products/analytics/src/content/graphql-api/features/data-sets/index.md
+++ b/products/analytics/src/content/graphql-api/features/data-sets/index.md
@@ -43,9 +43,10 @@ Beta data sets are available to Enterprise customers for testing and exploration
 
 <TableWrap>
 
-| Data set (product) | Node                                                                                                   |
-| :----------------- | :----------------------------------------------------------------------------------------------------- |
-| Browser Insights   | `browserInsightsAdaptiveGroups` `browserInsightsResourceAdaptiveGroups` `webVitalsAdaptiveGroups`      |
+| Data set (product) | Node                                                                                                        |
+| :----------------- | :---------------------------------------------------------------------------------------------------------- |
+| Browser Insights   | `browserInsightsAdaptiveGroups` `browserInsightsResourceAdaptiveGroups` `webVitalsAdaptiveGroups`           |
+| Web Analytics      | `rumPageloadEventsAdaptiveGroups` `rumPerformanceEventsAdaptiveGroups` `rumWebVitalsEventsAdaptiveGroups`   |
 
 </TableWrap>
 


### PR DESCRIPTION
Adding Web Analytics beta data sets to GraphQL API docs