### PR TITLE
Remove RUM Browser Insights Resource  Beta data set from GraphQL API …

### DIFF
--- a/products/analytics/src/content/graphql-api/features/data-sets/index.md
+++ b/products/analytics/src/content/graphql-api/features/data-sets/index.md
@@ -45,7 +45,7 @@ Beta data sets are available to Enterprise customers for testing and exploration
 
 | Data set (product) | Node                                                                                                        |
 | :----------------- | :---------------------------------------------------------------------------------------------------------- |
-| Browser Insights   | `browserInsightsAdaptiveGroups` `browserInsightsResourceAdaptiveGroups` `webVitalsAdaptiveGroups`           |
+| Browser Insights   | `browserInsightsAdaptiveGroups` `webVitalsAdaptiveGroups`                                                   |
 | Web Analytics      | `rumPageloadEventsAdaptiveGroups` `rumPerformanceEventsAdaptiveGroups` `rumWebVitalsEventsAdaptiveGroups`   |
 
 </TableWrap>


### PR DESCRIPTION
…docs (preparation for migration to Web Analytics)