### PR TITLE
Pages build configuration: Add HUGO_VERSION to table

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -70,7 +70,7 @@ Many common tools have been pre-installed as well. The environment variable avai
 | Doxygen     | Version 1.8.6                   |                      |
 | Emacs       | 25                              |                      |
 | Gutenberg   |                                 |                      |
-| Hugo        | Version 0.54                    |                      |
+| Hugo        | Version 0.54                    | `HUGO_VERSION`       |
 | GNU Make    | Version 3.8.1                   |                      |
 | ImageMagick | Version 6.7.7                   |                      |
 | jq          | Version 1.5                     |                      |


### PR DESCRIPTION
While `HUGO_VERSION` is mentioned in the documentation for making a Hugo site and for Known issues, it's not listed in the table of environment variables.
This change adds it to the table.