### PR TITLE
[Teams] Fix codeblocks in ssh-cert-bastion.md

### DIFF
--- a/products/cloudflare-one/src/content/tutorials/ssh-cert-bastion.md
+++ b/products/cloudflare-one/src/content/tutorials/ssh-cert-bastion.md
@@ -56,7 +56,7 @@ First, [install and authenticate](/connections/connect-apps/install-and-setup) a
 Next, create a new Argo Tunnel with the following command. You can replace `ssh-pool` with any name.
 
 ```sh
-cloudflared tunnel create ssh-pool
+$ cloudflared tunnel create ssh-pool
 ```
 
 `cloudflared` will create the Tunneland generate a UUID and corresponding credentials file.
@@ -89,7 +89,7 @@ ingress:
 You can now run the Tunnel with the following command.
 
 ```sh
-cloudflared tunnel run ssh-pool
+$ cloudflared tunnel run ssh-pool
 ```
 
 ## Configure a DNS record and route to the server
@@ -98,7 +98,7 @@ You can now configure a DNS record for the Tunnel you have created. Navigate to 
 
 Open the `DNS` page and click **+Add record**. Select `CNAME` for `Type` and in the `Target` field input the UUID value of your Tunnel followed by `.cfargotunnel.com`. In this example, that value is:
 
-```sh
+```
 79a60ee2-9a98-4f5f-96c7-76c88b2075be.cfargotunnel.com
 ```
 
@@ -120,7 +120,7 @@ Cloudflare Access will display the public key and an audience tag for the genera
 
 You must now configure your SSH host to rely on the generated certificate. In your `sshd` configuration, set the following values:
 
-```sh
+```
 PubkeyAuthentication yes
 TrustedUserCAKeys /etc/ssh/ca.pub
 ```
@@ -134,12 +134,12 @@ Users can now modify their SSH configuration files to connect over SSH. This is 
 Instruct users to download `cloudflared` and run the following command, replacing the hostname in this example with the one that you created.
 
 ```sh
-cloudflared access ssh-config --hostname ssh-bastion.widgetcorp.tech --short-lived-cert
+$ cloudflared access ssh-config --hostname ssh-bastion.widgetcorp.tech --short-lived-cert
 ```
 
 `cloudflared` will generate the required lines to append to the SSH configuration file, similar to the example output below.
 
-```sh
+```
 Host ssh-bastion.widgetcorp.tech
   ProxyCommand bash -c '/usr/local/bin/cloudflared access ssh-gen --hostname %h; ssh -tt %r@cfpipe-ssh-bastion.widgetcorp.tech >&2 <&1' 
 


### PR DESCRIPTION
On the live site currently, a lot of the codeblocks in [SSH with short-lived certificates](https://developers.cloudflare.com/cloudflare-one/tutorials/ssh-cert-bastion) have `sh` as their language, which causes them to not be able to be highlighted or copied due to not being actual commands prefixed by `$`

There also are some which are actually shell commands but still cannot be copied because they are missing the `$` at the start of the block.

This PR fixes both of those issues by removing the language on the former and adding `$` to the start of the latter.

I did test this locally (After disabling thumbnail generation to save on CPU cycles) and it appears to work as intended.
Only thing I can see is despite having no language specificied, the ssh config and the example cfargotunnel.com URL have some interesting colours for some characters. I think these are things like slashes and numbers.
Not sure if a better language could be used for those blocks or not.