### PR TITLE
Add cron to ScheduledEvent

### DIFF
--- a/products/workers/src/content/runtime-apis/scheduled-event.md
+++ b/products/workers/src/content/runtime-apis/scheduled-event.md
@@ -16,6 +16,9 @@ addEventListener("scheduled", event => {
 
 <Definitions>
 
+- `event.cron` <Type>string</Type>
+    - The value of the [Cron Trigger](/platform/cron-triggers) that started the the `ScheduledEvent`.
+
 - `event.type` <Type>string</Type>
     - The type of event. This will always return `"scheduled"`.
 


### PR DESCRIPTION
The value of the cron trigger is now passed to the event as well, example:

```json
{"cron":"*/3 * * * *","scheduledTime":1618909249000,"type":"scheduled"}
```

Types PR: <https://github.com/cloudflare/workers-types/pull/86>