### PR TITLE
Use Rules icon from the brand assets repository

### DIFF
--- a/products/rules/docs-config.js
+++ b/products/rules/docs-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   product: "Rules",
   pathPrefix: "/rules",
-//  productIconKey: "rules",
-  productLogoPathD: "m9.2446 4.7416-1.5 1.5v35.85l1.5 1.5h30l1.5-1.5v-35.85l-1.5-1.5zm1.5 3h27v32.85h-27zm3.3897 3.5332v3h10.005v-3zm0 6.2696v3h20.139v-3zm0 6.2696v3h20.139v-3z",
+  productIconKey: "rules",
   contentRepo: "cloudflare/cloudflare-docs",
   contentRepoFolder: "products/rules",
   externalLinks: [


### PR DESCRIPTION
The Rules icon is now available in the brand assets repository. Removing the initial workaround.