### PR TITLE
Fix direct download link for macOS cloudflared

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/installation.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/installation.md
@@ -67,7 +67,7 @@ You can install `cloudflared` on macOS systems via Homebrew:
 $ brew install cloudflare/cloudflare/cloudflared
 ```
 
-Alternatively, you can download the latest Darwin amd64 release directly.
+Alternatively, you can [download the latest Darwin amd64 release directly](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-darwin-amd64.zip).
 
 ## Windows
 


### PR DESCRIPTION
I used `brew`, but I was confused by this sentence. Played around with filename of the other downloads until I found what appears to be the right link