### PR TITLE
Set PCX as code owner of Rules docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,9 @@ products/randomness-beacon/ @lukevalenta @armfazh @cloudflare/PCX
 # Registrar
 products/registrar/ @TownLake @cloudflare/PCX
 
+# Rules
+products/rules/ @cloudflare/PCX
+
 # Spectrum
 products/spectrum/ @ConzorKingKong @cloudflare/PCX
 


### PR DESCRIPTION
Purpose: Get the PCX team auto-assigned to Rules PRs as a reviewer.