### PR TITLE
fix variable naming

### DIFF
--- a/products/workers/src/content/tutorials/configure-your-cdn/index.md
+++ b/products/workers/src/content/tutorials/configure-your-cdn/index.md
@@ -143,11 +143,11 @@ filename: index.js
 highlight: [1, 2, 6]
 ---
 const BUCKET_NAME = "my-bucket"
-const BUCKET_URL = `http://storage.googleapis.com/${bucketName}`
+const BUCKET_URL = `http://storage.googleapis.com/${BUCKET_NAME}`
 
 function serveAsset(event) {
   const url = new URL(event.request.url)
-  return fetch(`${bucketUrl}${url.pathname}`)
+  return fetch(`${BUCKET_URL}${url.pathname}`)
 }
 ```
 


### PR DESCRIPTION
On the docs the variable names didn't match up: `BUCKET_URL` was `bucketUrl` and `BUCKET_NAME` was `bucketName` even though they were defined as their screaming snake case variant.