### PR TITLE
Update links to TOML docs

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -165,7 +165,7 @@ kv_namespaces = [
 
 **Note:** Creating your KV Namespaces can be handled using Wrangler’s [KV Commands](/cli-wrangler/commands#kv).
 
-You can also define your `kv_namespaces` using [alternative TOML syntax](https://github.com/toml-lang/toml#user-content-table).
+You can also define your `kv_namespaces` using [alternative TOML syntax](https://github.com/toml-lang/toml/blob/master/toml.md#user-content-table).
 
 </Aside>
 
@@ -202,7 +202,7 @@ entry-point = "workers-site"
 
 To learn more about the optional `include` and `exclude` fields, visit [Ignoring Subsets of Static Assets](#ignoring-subsets-of-static-assets).
 
-You can also define your `site` using [alternative TOML syntax](https://github.com/toml-lang/toml#user-content-inline-table).
+You can also define your `site` using [alternative TOML syntax](https://github.com/toml-lang/toml/blob/master/toml.md#user-content-inline-table).
 
 #### Storage Limits
 


### PR DESCRIPTION
The linked content in the TOML repository was moved from the README to a separate Markdown file.