### PR TITLE
Kubectl guide to includes a link to the dashboard

### DIFF
--- a/products/cloudflare-one/src/content/tutorials/kubectl.md
+++ b/products/cloudflare-one/src/content/tutorials/kubectl.md
@@ -25,7 +25,7 @@ You can connect to machines over `kubectl` using Cloudflare's Zero Trust platfor
 
 ## Create a Zero Trust policy
 
-First, navigate to the Cloudflare for Teams dashboard to create a new application. Select the `Applications` page from the sidebar. Click **Add application**.
+First, navigate to the [Cloudflare for Teams dashboard](https://dash.teams.cloudflare.com/) to create a new application. Select the `Applications` page from the sidebar. Click **Add application**.
 
 ![App List](../static/zero-trust-security/ssh/app-list.png)
 


### PR DESCRIPTION
This directs the user to the proper page instead of having to find the URL manually or finding it in the images listed below.