### PR TITLE
Removed whitespace to trigger build

### DIFF
--- a/products/automatic-platform-optimization/src/content/troubleshooting/index.md
+++ b/products/automatic-platform-optimization/src/content/troubleshooting/index.md
@@ -9,9 +9,9 @@ order: 14
 
 The WordPress plugin may go undetected on your Cloudflare dashboard for a few reasons.
 
-- Versions older than 3.8.2 of the WordPress plugin are installed. 
+- Versions older than 3.8.2 of the WordPress plugin are installed.
   - **Solution:** Install version 4.4.0 of the WordPress plugin.
-- Version 3.8.2 of the plugin is installed but existing cache plugins return stale responses, for example, without `cf-edge-cache` header. 
+- Version 3.8.2 of the plugin is installed but existing cache plugins return stale responses, for example, without `cf-edge-cache` header.
   - **Solution:** Enable APO from the WordPress plugin and purge the cache in the existing cache plugins.
 - WordPress only runs on a subdomain, but WordPress and the WordPress plugin check against the zone's root domain.
   - **Solution:** For additional information, see [Subdomains and subdirectories](/reference/subdomain-subdirectories)


### PR DESCRIPTION
Removed whitespace to trigger build after fixing the deploy for the APO docs