### PR TITLE
Fix broken link

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -48,7 +48,7 @@ Keys to configure per project in your `wrangler.toml`.
 
 <Aside>
 
-  **Note:** We will continue to support `rust` and `webpack` project types, but we recommend using the `javascript` project type and specifying a custom [`build`](configuration#build) section.
+  **Note:** We will continue to support `rust` and `webpack` project types, but we recommend using the `javascript` project type and specifying a custom [`build`](#build) section.
 
 </Aside>
 


### PR DESCRIPTION
Should point to

```diff
- https://developers.cloudflare.com/workers/cli-wrangler/configuration/configuration#build
+ https://developers.cloudflare.com/workers/cli-wrangler/configuration#build
```

Maybe missing from #1249 😉 