### PR TITLE
WAF: Add content type information to topics

### DIFF
--- a/products/waf/src/content/about.md
+++ b/products/waf/src/content/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+pcx-content-type: concept
 order: 1
 ---
 

--- a/products/waf/src/content/change-log/index.md
+++ b/products/waf/src/content/change-log/index.md
@@ -1,5 +1,6 @@
 ---
 title: Change log
+pcx-content-type: concept
 order: 5
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/configure-api.md
+++ b/products/waf/src/content/exposed-credentials-check/configure-api.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: interim
 order: 3
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/configure-dashboard.md
+++ b/products/waf/src/content/exposed-credentials-check/configure-dashboard.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: how-to
 order: 2
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/how-checks-work.md
+++ b/products/waf/src/content/exposed-credentials-check/how-checks-work.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: concept
 order: 1
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/index.md
+++ b/products/waf/src/content/exposed-credentials-check/index.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: concept
 order: 3
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/monitor-events.md
+++ b/products/waf/src/content/exposed-credentials-check/monitor-events.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: concept
 order: 5
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/test-configuration.md
+++ b/products/waf/src/content/exposed-credentials-check/test-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Test your configuration
-pcx-content-type: concept
+pcx-content-type: reference
 order: 4
 ---
 

--- a/products/waf/src/content/exposed-credentials-check/test-configuration.md
+++ b/products/waf/src/content/exposed-credentials-check/test-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Test your configuration
+pcx-content-type: concept
 order: 4
 ---
 

--- a/products/waf/src/content/index.md
+++ b/products/waf/src/content/index.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome
+pcx-content-type: landing-page
 type: overview
 order: 0
 ---

--- a/products/waf/src/content/managed-rulesets/deploy-api.md
+++ b/products/waf/src/content/managed-rulesets/deploy-api.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: how-to
 order: 23
 ---
 

--- a/products/waf/src/content/managed-rulesets/deploy-zone-dashboard.md
+++ b/products/waf/src/content/managed-rulesets/deploy-zone-dashboard.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy Managed Rulesets for a zone
+pcx-content-type: how-to
 order: 21
 ---
 

--- a/products/waf/src/content/managed-rulesets/index.md
+++ b/products/waf/src/content/managed-rulesets/index.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: concept
 order: 2
 ---
 

--- a/products/waf/src/content/managed-rulesets/payload-logging/command-line/decrypt-payload.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/command-line/decrypt-payload.md
@@ -1,5 +1,6 @@
 ---
 title: Decrypt the payload content
+pcx-content-type: how-to
 order: 2
 type: overview
 ---

--- a/products/waf/src/content/managed-rulesets/payload-logging/command-line/generate-key-pair.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/command-line/generate-key-pair.md
@@ -1,5 +1,6 @@
 ---
 title: Generate a key pair
+pcx-content-type: how-to
 order: 1
 type: overview
 ---

--- a/products/waf/src/content/managed-rulesets/payload-logging/command-line/index.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/command-line/index.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: navigation
 order: 3
 ---
 

--- a/products/waf/src/content/managed-rulesets/payload-logging/configure.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/configure.md
@@ -1,5 +1,6 @@
 ---
 title: Configure payload logging
+pcx-content-type: how-to
 order: 1
 ---
 

--- a/products/waf/src/content/managed-rulesets/payload-logging/index.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/index.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: concept
 order: 25
 ---
 

--- a/products/waf/src/content/managed-rulesets/payload-logging/view.md
+++ b/products/waf/src/content/managed-rulesets/payload-logging/view.md
@@ -1,4 +1,5 @@
 ---
+pcx-content-type: how-to
 order: 2
 ---
 


### PR DESCRIPTION
These changes have no impact in the rendered docs. It's for internal purposes only.