### PR TITLE
[Pages] remove non working private packages section npm-private-registry.md

### DIFF
--- a/products/pages/src/content/how-to/npm-private-registry.md
+++ b/products/pages/src/content/how-to/npm-private-registry.md
@@ -65,30 +65,3 @@ Here, all packages under the `@foobar` scope are directed towards the GitHub Pac
 
 Your Pages project must then have the matching [Environment Variables](/platform/build-configuration#environment-variables) defined for all environments. In our example, that means `TOKEN_FOR_NPM` must contain [the read-only npm token](#registry-access-token) value and `TOKEN_FOR_GITHUB` must contain its own [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token).
 
-
-### Managing Multiple Environments
-
-In the event that your local development no longer works with your new `.npmrc` file, you will need to add some additional changes:
-
-1. Rename the Pages-compliant `.npmrc` file to `.npmrc.pages`. This should be referencing environment variables.
-
-2. Restore your previous `.npmrc` file – the version that was previously working for you and your teammates.
-
-3. Create a new `is-pages.js` file in your project's root directory:
-
-    ```js
-    // Pages always has `NODE_VERSION` defined
-    if (process.env.NODE_VERSION == null) process.exit(1);
-    ```
-
-4. In your `package.json` file, create a new `"preinstall"` script, which will rename the `.npmrc.pages` file to `.npmrc` **only** during the Pages build process:
-
-    ```js
-    // package.json
-    {
-      "scripts": {
-        "preinstall": "node is-pages && mv .npmrc.pages .npmrc || echo \"Not Pages\"",
-        // your existing scripts
-      }
-    }
-    ```


### PR DESCRIPTION
* While this section does work when testing locally, it does not appear to work correctly when actually deploying with CloudFlare Pages.
* Since this does not function correctly, I've removed it from the documentation to avoid further confusion.


## Steps to Reproduce

* Create the `.npmrc.pages` file following the guide here, and modified the `preinstall` script for the `package.json` according to the guide.

Here's the `.npmrc.pages` file that I used. `my_org` was actually the organization that I have private packages installed.
```
//npm.pkg.github.com/:_authToken=${TOKEN_FOR_GITHUB}
@my_org:registry=https://npm.pkg.github.com/my_org
```

* Create the token used for `TOKEN_FOR_GITHUB` and load it into CloudFlare Pages. 

* Verify running this locally correctly moes the `.npmrc.pages` file and installs packages.

* Deploy to CloudFlare pages 
I  received this error during the Building Application process
```
13:05:36.876	npm ERR! code E401
13:05:36.878	npm ERR! Unable to authenticate, need: Basic realm="GitHub Package Registry"
```

I manually copied over the  `.npmrc.pages` file to `.npmrc`, committed the results, and re-deployed. This time the deployment was successful. 

The conclusion here is that modifying the `.npmrc` in CloudFlare Pages using the `preinstall` is not a functional way to authenticate private registries, and CloudFlare Pages will need to make some changes on their side to support private registries. 

Using `//npm.pkg.github.com/:_authToken=${TOKEN_FOR_GITHUB}` in the `.npmrc` currently is not tenable due to the fact that it breaks all local development environments.