### PR TITLE
Add binding for redirects KV namespace (Pages)

### DIFF
--- a/products/pages/wrangler.toml
+++ b/products/pages/wrangler.toml
@@ -8,6 +8,9 @@ workers_dev = false
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 zone_id = "351cf9fc660523187714fa772ad5ca49"
 route = "https://developers.cloudflare.com/pages*"
+kv_namespaces = [ 
+    { binding = "REDIRECTS", id = "153263ecbd3a436caf8c685ff3e26b93" }
+]
 
 [site]
 bucket = ".docs/public/"


### PR DESCRIPTION
Related changes outside this GitHub PR:
- Created new KV namespace for the redirects with the correct names (binding = `REDIRECTS`, Workers KV namespace name = `pages-REDIRECTS`
- Checked if there was an Access config entry for the redirects URL (it already existed)