### PR TITLE
Removed onboarding screenshots

### DIFF
--- a/products/magic-transit/src/content/set-up/onboarding.md
+++ b/products/magic-transit/src/content/set-up/onboarding.md
@@ -5,8 +5,6 @@ order: 1
 
 # Magic Transit onboarding
 
-![Onboarding timeline](../static/mt-onboarding-timeline.png)
-
 The onboarding process, from scoping to going live, typically takes about 10 business days, and Cloudflare can significantly accelerate this timeline in active-attack scenarios.
 
 Throughout the onboarding process, Cloudflare partners closely with your organization to accomplish the following tasks:
@@ -31,7 +29,7 @@ Cloudflare sets up Anycast tunnels for Magic Transit based on configuration deta
 
 Once Cloudflare has staged the tunnels, we validate tunnel connectivity, LOA, IRR, and maximum segment size (MSS) configurations.
 
-To ensure that the integration is ready to go live the following week, complete this step by close of business Friday.
+To ensure that the integration is ready to go live the following week, complete this step by close of business Thursday.
 
 *Duration:* ~4 business days
 
@@ -59,7 +57,7 @@ When using [Cloudflare Network Interconnect](/network-interconnect/) with Magic 
 
 </Aside>
 
-*Duration:* ~2 business days
+*Duration:* ~5 business days
 
 ## Go live and announce prefixes
 

--- a/products/network-interconnect/src/content/set-up-cni/index.md
+++ b/products/network-interconnect/src/content/set-up-cni/index.md
@@ -7,13 +7,11 @@ order: 2
 
 Cloudflare Network Interconnect setup requires a few steps: onboarding, configuring the cross-connection, configuring the Cloudflare Border Gateway Protocol (BGP), and go live. The entire process from onboarding to go live typically takes 10-15 days.
 
-![Onboarding diagram](../static/cni-onboarding.png)
-
 # Onboarding
 
 During onboarding, Cloudflare works closely with your organization to accomplish the onboarding tasks.
 
-* [Scope your configuration](/set-up-cni/scope-config)
-* [Configure the network cross-connect](/set-up-cni/configure-x-connect)
-* [Configure Cloudflare Border Gateway Protocol (BGP) and Generic Route Encapsulation (GRE)](/set-up-cni/configure-bgp)
-* [Go live](/set-up-cni/configure-bgp#go-live)
+* [Scope your configuration](/set-up-cni/scope-config) (Kickoff call)
+* [Configure the network cross-connect](/set-up-cni/configure-x-connect) (Duration: 1-2 weeks)
+* [Configure Cloudflare Border Gateway Protocol (BGP) and Generic Route Encapsulation (GRE)](/set-up-cni/configure-bgp) (Duration: ~1 week)
+* [Go live](/set-up-cni/configure-bgp#go-live) (Duration: 1-2 days)


### PR DESCRIPTION
- Removed out-of-date onboarding screenshots for Magic Transit and CNI
- Added duration times from old image to CNI onboarding list
- Updated duration times for Magic transit

Addresses [PCX-1654](https://jira.cfops.it/browse/PCX-1654)