### PR TITLE
Improve proxy template

### DIFF
--- a/products/workers/src/content/examples/respond-with-another-site.md
+++ b/products/workers/src/content/examples/respond-with-another-site.md
@@ -14,11 +14,22 @@ tags:
 </ContentColumn>
 
 ```js
-addEventListener("fetch", event => {
-  return event.respondWith(
-    fetch("https://example.com")
-  )
+addEventListener('fetch', function(event) {
+  event.respondWith(handleRequest(event.request))
 })
+async function handleRequest(request) {
+  // Only GET requests work with this proxy.
+  if (request.method !== 'GET') return MethodNotAllowed(request)
+  return fetch(`https://example.com`)
+}
+function MethodNotAllowed(request) {
+  return new Response(`Method ${request.method} not allowed.`, {
+    status: 405,
+    headers: {
+      'Allow': 'GET'
+    }
+  })
+}
 ```
 
 ## Demo


### PR DESCRIPTION
The previous example turns POSTs into GETs, causing the loss of POST data. Also, the previous example returned HTML when requesting /favicon.ico
or /robots.txt.