### PR TITLE
[Workers] Change WebsocketPair to WebSocketPair in runtime-apis/websockets.md

### DIFF
--- a/products/workers/src/content/runtime-apis/websockets.md
+++ b/products/workers/src/content/runtime-apis/websockets.md
@@ -8,15 +8,15 @@ WebSockets allow you to communicate in real-time with your Cloudflare Workers se
 
 ```js
 // { 0: <WebSocket>, 1: <WebSocket> }
-let websocketPair = new WebsocketPair()
+let websocketPair = new WebSocketPair()
 ```
 
-The WebsocketPair returned from this constructor is an Object, with two WebSockets at keys `0` and `1`. 
+The WebSocketPair returned from this constructor is an Object, with two WebSockets at keys `0` and `1`. 
 
 These WebSockets are commonly referred to as `client` and `server`. In the below example, we combine `Object.values` and ES6 destructuring to retrieve the WebSockets as `client` and `server`:
 
 ```js
-let [client, server] = Object.values(new WebsocketPair())
+let [client, server] = Object.values(new WebSocketPair())
 ```
 
 ## Methods


### PR DESCRIPTION
- Based on trial/error & other documentation, it seems WebSocketPair is correct and attempting to use WebsocketPair causes an exception.
- Replaced instances of WebsocketPair with WebSocketPair in all code examples
- Replaced one instance of WebsocketPair in the body of the documentation to keep consistency.