### PR TITLE
[Workers] Add max upload size to limits.md + Fix toml in configuration.md

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -340,6 +340,7 @@ Usage:
 ```toml
 [build]
 command = "npm install && npm run build"
+
 [build.upload]
 format = "service-worker"
 ```
@@ -365,11 +366,11 @@ format = "service-worker"
 #### `[build.upload]`
 
 <Definitions>
-  
+
   - `format` <PropMeta>required</PropMeta>
 
     - The format of the Worker script, must be "service-worker"
-  
+
 </Definitions>
 
 <Aside>

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -22,6 +22,21 @@ pcx-content-type: concept
 
 </TableWrap>
 
+## Cloudflare plan limits
+
+Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PATCH requests) which depend on your Cloudflare plan (this is seperate from your workers plan). All uploads larger than your plan limit will be rejected with an HTTP 413 error code ("Request entity too large"). Cloudflare Enterprise customers can [contact support](https://support.cloudflare.com/hc/en-us/articles/200172476) to request a larger upload limit. Learn more about [Cloudflare plans](https://www.cloudflare.com/plans/).
+
+<TableWrap>
+
+| Cloudflare Plan | Maximum body size |
+| --------------- | ----------------- |
+| Free            | 100MB             |
+| Pro             | 100MB             |
+| Business        | 200MB             |
+| Enterprise      | 500MB+            |
+
+</TableWrap>
+
 ## Worker limits
 
 <TableWrap>

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -22,7 +22,7 @@ pcx-content-type: concept
 
 </TableWrap>
 
-##  Upload size limits
+## Upload size limits
 
 Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PATCH requests) which depend on your Cloudflare plan (this is separate from your Workers plan). All uploads larger than your plan limit will be rejected with an HTTP 413 error code ("Request entity too large"). Cloudflare Enterprise customers can [contact Cloudflare support](https://support.cloudflare.com/hc/en-us/articles/200172476) to request a larger upload limit. Learn more about [Cloudflare plans](https://www.cloudflare.com/plans/).
 

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -24,7 +24,7 @@ pcx-content-type: concept
 
 ## Cloudflare plan limits
 
-Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PATCH requests) which depend on your Cloudflare plan (this is seperate from your workers plan). All uploads larger than your plan limit will be rejected with an HTTP 413 error code ("Request entity too large"). Cloudflare Enterprise customers can [contact support](https://support.cloudflare.com/hc/en-us/articles/200172476) to request a larger upload limit. Learn more about [Cloudflare plans](https://www.cloudflare.com/plans/).
+Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PATCH requests) which depend on your Cloudflare plan (this is separate from your Workers plan). All uploads larger than your plan limit will be rejected with an HTTP 413 error code ("Request entity too large"). Cloudflare Enterprise customers can [contact Cloudflare support](https://support.cloudflare.com/hc/en-us/articles/200172476) to request a larger upload limit. Learn more about [Cloudflare plans](https://www.cloudflare.com/plans/).
 
 <TableWrap>
 

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -22,7 +22,7 @@ pcx-content-type: concept
 
 </TableWrap>
 
-## Cloudflare plan limits
+##  Upload size limits
 
 Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PATCH requests) which depend on your Cloudflare plan (this is separate from your Workers plan). All uploads larger than your plan limit will be rejected with an HTTP 413 error code ("Request entity too large"). Cloudflare Enterprise customers can [contact Cloudflare support](https://support.cloudflare.com/hc/en-us/articles/200172476) to request a larger upload limit. Learn more about [Cloudflare plans](https://www.cloudflare.com/plans/).
 

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -33,7 +33,7 @@ Cloudflare has network-wide limits on the body size of uploads (HTTP POST/PUT/PA
 | Free            | 100MB             |
 | Pro             | 100MB             |
 | Business        | 200MB             |
-| Enterprise      | 500MB+            |
+| Enterprise      | 500MB             |
 
 </TableWrap>
 


### PR DESCRIPTION
Requested by https://github.com/cloudflare/cloudflare-docs/issues/1361
 
 - Noted the network-wide upload limits Cloudflare has in place
 - Noted all requests larger than your plan's limit will be rejected with HTTP 413
 - Noted that enterprise customers may lift the upload size as needed
 - Linked to [https://cloudflare.com/plans](https://cloudflare.com/plans) so people may find more information if needed. (Might change to a support article instead)
 - Added table which contained current upload limits per-plan (from [this support article](https://support.cloudflare.com/hc/en-us/articles/200172516-Understanding-Cloudflare-s-CDN))