### PR TITLE
Correct an incorrect TOML Format

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -330,15 +330,14 @@ Usage:
 
 ```toml
 [build]
-upload.format = "service-worker"
 command = "npm install && npm run build"
+[build.upload]
+format = "service-worker"
 ```
 
+#### `[build]`
+
 <Definitions>
-
-- `upload.format` <PropMeta>required</PropMeta>
-
-  - The format of the Worker script, must be "service-worker"
 
 - `command` <PropMeta>optional</PropMeta>
 
@@ -352,6 +351,16 @@ command = "npm install && npm run build"
 
   - The directory to watch for changes while using `wrangler dev`, defaults to "src" relative to the project root directory
 
+</Definitions>
+
+#### `[build.upload]`
+
+<Definitions>
+  
+  - `format` <PropMeta>required</PropMeta>
+
+    - The format of the Worker script, must be "service-worker"
+  
 </Definitions>
 
 <Aside>
@@ -520,7 +529,8 @@ kv_namespaces = [
 
 [build]
 command = "webpack"
-upload.format = "service-worker"
+[build.upload]
+format = "service-worker"
 
 [site]
 bucket = "./public"


### PR DESCRIPTION
A direct copy/paste of these results in an invalid TOML error, but the correct format is used elsewhere and is valid.

We ran across this earlier today and this was the fix.

Issue: https://github.com/cloudflare/cloudflare-docs/issues/1384