### PR TITLE
Update command to fetch and display Magic Firewall rules

### DIFF
--- a/products/magic-transit/src/content/magic-firewall/updating-rules.md
+++ b/products/magic-transit/src/content/magic-firewall/updating-rules.md
@@ -55,7 +55,7 @@ curl https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets/437635
 
 <Aside type='note' header='Note'>
 
-The API response has quite a bit of extra information, e.g. the last updated timestamp, that will ignored if sent back to the API when making a PUT request. You can pipe curl's output through jq as shown below, to only display fields that are relevant to the update request.
+The API response has quite a bit of extra information, e.g. the last updated timestamp, that will be ignored if sent back to the API when making a PUT request. You can pipe curl's output through jq as shown below to only display fields that are relevant to the update request.
 ```
 curl ... | jq '.result | {description: .description, rules: [ .rules[] | {id: .id, description: .description, action: .action, action_parameters: .action_parameters, expression: .expression} ]}'
 ```

--- a/products/magic-transit/src/content/magic-firewall/updating-rules.md
+++ b/products/magic-transit/src/content/magic-firewall/updating-rules.md
@@ -50,13 +50,15 @@ We'll use this to fetch the existing rules to help us construct the call to upda
 curl https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets/4376358e00ec4c42b0450b1afed120bf/versions/1 \
 -H 'Content-Type: application/json' \
 -H 'X-Auth-Email: user@example.com' \
--H 'X-Auth-Key: 00000000000' | jq '.result | {description: .description, rules: [ .rules[] | {id: .id, description: .description, action: .action, action_parameters: .action_parameters, expression: .expression} ]}'
+-H 'X-Auth-Key: 00000000000'
 ```
 
 <Aside type='note' header='Note'>
 
-What's up with that jq command? The API response has quite a bit of extra information, e.g. the last updated timestamp, that cannot be sent back to the API when making a PUT request. You do not need to use jq, but make sure you only send fields that are relevant to the update request.
-
+The API response has quite a bit of extra information, e.g. the last updated timestamp, that will ignored if sent back to the API when making a PUT request. You can pipe curl's output through jq as shown below, to only display fields that are relevant to the update request.
+```
+curl ... | jq '.result | {description: .description, rules: [ .rules[] | {id: .id, description: .description, action: .action, action_parameters: .action_parameters, expression: .expression} ]}'
+```
 </Aside>
 
 Example response:


### PR DESCRIPTION
* Any additional fields received from the rulesets endpoints will be
  ignored if sent using the PUT request, so piping the output to jq
  is no longer necessary. Its still good to have, so move the command
  into the note below.