### PR TITLE
Remove 'REDIRECTS' KV namespace for staging

### DIFF
--- a/products/images/wrangler.toml
+++ b/products/images/wrangler.toml
@@ -2,7 +2,6 @@ name = "images"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
-kv_namespaces = [{ binding = "REDIRECTS", id = "fa21f9d866a14296b2d53f4ee161ab11", preview_id = "fa21f9d866a14296b2d53f4ee161ab11" }]
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
We no longer have redirects in the staging environment.

The configured non-Prod KV namespace no longer exists. Additionally, this configuration is preventing us from publishing updates to the `/images` tile in production.