### PR TITLE
The remove() and removeAndKeepContent() don't take any parameters

### DIFF
--- a/products/workers/src/content/runtime-apis/html-rewriter.md
+++ b/products/workers/src/content/runtime-apis/html-rewriter.md
@@ -177,11 +177,11 @@ The `element` argument, used only in element handlers, is a representation of a 
 
   - Replaces content of the element.
 
-- <Code>remove(content<ParamType>Content</ParamType>, contentOptions<ParamType>ContentOptions</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Element</Type>
+- <Code>remove()</Code> <Type>Element</Type>
 
   - Removes the element with all its content.
 
-- <Code>removeAndKeepContent(content<ParamType>Content</ParamType>, contentOptions<ParamType>ContentOptions</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Element</Type>
+- <Code>removeAndKeepContent()</Code> <Type>Element</Type>
 
   - Removes the start tag and end tag of the element, but keeps its inner content intact.
 


### PR DESCRIPTION
As pointed out by someone on Discord (where I can't find the post for some extremely obscure reason), the remove (and also the removeAndKeepContent) method doesn't take any parameters.