### PR TITLE
Add troubleshooting page pointing to Support KB

### DIFF
--- a/products/rules/src/content/transform/troubleshooting.md
+++ b/products/rules/src/content/transform/troubleshooting.md
@@ -1,0 +1,11 @@
+---
+title: Troubleshooting
+pcx-content-type: faq
+order: 6
+---
+
+# Troubleshoot Transform Rules
+
+After configuring a URL Rewrite Rule or an HTTP Request Header Modification Rule, you may get runtime errors related to the rule configuration.
+
+For more information on these errors, see [Troubleshooting Cloudflare 1XXX errors](https://support.cloudflare.com/hc/articles/360029779472).


### PR DESCRIPTION
New troubleshooting page that links to an updated Support KB page. Related to the following tickets:
* https://jira.cfops.it/browse/PCX-1646
* https://jira.cfops.it/browse/PCX-1647
* https://jira.cfops.it/browse/PCX-1678