### PR TITLE
Update firewall.md

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/firewall.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/firewall.md
@@ -18,7 +18,7 @@ In late May 2021 the ingress change for Cloudflare for Teams WARP Customers will
 </Aside>
 
 ## UDP Ports
-WARP utilizes UDP for all of its communications. UDP Port required for WARP: UDP 2408. 
+WARP utilizes UDP for all of its communications. By default, the UDP Port required for WARP is: UDP 2408. WARP can fallback to: UDP 500, UDP 1701, or UDP 4500.
 
 ## Creating firewall rules
 If your organization does not currently allow Inbound/Outbound communication over the IP addresses and ports described above you must manually add an exception. The rule at a minimum needs to be scoped to the following process based on your platform:


### PR DESCRIPTION
WARP uses port 2408 by default, but does fallback to ports 500, 1701, and 4500.