### PR TITLE
Update docs to aviod using "simple"

### DIFF
--- a/products/workers/src/content/learning/playground.md
+++ b/products/workers/src/content/learning/playground.md
@@ -4,7 +4,7 @@ order: 1
 
 # Playground
 
-The quickest way to experiment with Cloudflare Workers is in the [Playground](https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank). It doesn’t require _any_ setup. It’s just a simple, instant way to preview and test a Workers script directly in the browser against any site.
+The quickest way to experiment with Cloudflare Workers is in the [Playground](https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank). It doesn’t require _any_ setup. It’s just a sandbox which gives an instant way to preview and test a Workers script directly in the browser against any site.
 
 <p><Button type="primary" href="https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank">Launch playground</Button></p>
 
@@ -24,7 +24,7 @@ async function handleRequest(request) {
 }
 ```
 
-It’s essentially the simplest Worker script you can write.
+Yay! You have written your first Worker script.
 
 Essentially what’s going on here is that when the Worker receives a request, `handleRequest` is called, and it responds with a text [response](/runtime-apis/response) of `"Hello world"`.
 

--- a/products/workers/src/content/learning/playground.md
+++ b/products/workers/src/content/learning/playground.md
@@ -4,7 +4,7 @@ order: 1
 
 # Playground
 
-The quickest way to experiment with Cloudflare Workers is in the [Playground](https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank). It doesn’t require _any_ setup. It’s just a sandbox which gives an instant way to preview and test a Workers script directly in the browser against any site.
+The quickest way to experiment with Cloudflare Workers is in the [Playground](https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank). It doesn’t require _any_ setup. It’s just a simple sandbox which gives an instant way to preview and test a Workers script directly in the browser against any site.
 
 <p><Button type="primary" href="https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank">Launch playground</Button></p>
 
@@ -24,11 +24,9 @@ async function handleRequest(request) {
 }
 ```
 
-Yay! You have written your first Worker script.
+This is the least complex Worker you can write. When the Worker receives a request, the `fetch` event is dispatched. [RespondWith](/learning/fetch-event-lifecycle#respondwith) intercepts the event, promising to return the result of the `handleRequest` function to the client. Finally, `handleRequest` is actually called, and it returns a text [response](/runtime-apis/response) of `"Hello world"` which bubbles up and is delivered back to the client.
 
-Essentially what’s going on here is that when the Worker receives a request, `handleRequest` is called, and it responds with a text [response](/runtime-apis/response) of `"Hello world"`.
-
-Check out the reference for [addEventListener](/runtime-apis/add-event-listener) and [FetchEvent](/runtime-apis/fetch-event) to learn more.
+Check out the reference for [addEventListener](/runtime-apis/add-event-listener), [FetchEvent](/runtime-apis/fetch-event) and [FetchEvent lifecycle](/learning/fetch-event-lifecycle) to learn more.
 
 --------------------------------
 


### PR DESCRIPTION
I think it's great to avoid using words like “easy”, “simple” and “basic” in docs, especially when Introducing a new method of a thing, because if users have a hard time completing the task that is supposedly “easy,” they will question their abilities. And we want people to feel comfortable learning.