### PR TITLE
Correct “Gigabytes per sec” to “Gigabyte-seconds”

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -156,7 +156,7 @@ There is no limit on the real runtime for a Workers script. As long as the clien
 
 ## Duration
 
-Duration is the measurement of wall-clock time. This is measured in Gigabytes per second (GB-s). When a Worker is executed, it is allocated 128mb of [memory](/platform/limits#memory). As the Worker continues to execute that memory remains allocated, even during network IO requests.
+Duration is the measurement of wall-clock time. This is measured in Gigabyte-seconds (GB-s). When a Worker is executed, it is allocated 128mb of [memory](/platform/limits#memory). As the Worker continues to execute that memory remains allocated, even during network IO requests.
 
 For example, when a Worker executes via a [scheduled event](/runtime-apis/scheduledevent), it executes for 4 seconds, including network-bound IO time: `4s x 0.125GB (or 128Mb) = .5 GB-s`.
 


### PR DESCRIPTION
Gb-s is appropriate for this, as the meaning is “the amount of memory used, multiplied by (or _over_) the total duration.” Thus in the example given, the memory used can be correctly expressed as *0.125 GB/s* (gigabytes per second) because the average amount of memory used in each second is 0.125GB. By contrast, what is intended is to communicate not the memory used per second, but instead the cumulative memory used, over the whole execution time, adding each second of time together. Gigabyte-seconds expresses this concept.