### PR TITLE
Http3 redirects

### DIFF
--- a/products/http3/wrangler.toml
+++ b/products/http3/wrangler.toml
@@ -8,6 +8,9 @@ workers_dev = false
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99"
 zone_id = "351cf9fc660523187714fa772ad5ca49"
 route = "https://developers.cloudflare.com/http3*"
+kv_namespaces = [
+    { binding = "REDIRECTS", id = "dd91f8b73f5843b8b67d91df7ff3a613" }
+]
 
 [site]
 bucket = ".docs/public/"


### PR DESCRIPTION
Initial use case --> likely will be easier + quicker than fixing a link on the Cloudflare quic homepage
Additional use case --> Will be helpful if we do any content re-orgs in the future

Sorry for duplicate notifications related to https://github.com/cloudflare/cloudflare-docs/pull/1510. Figured it was easier to create a new branch than fix the older one