### PR TITLE
Removed references and visibility from bot management dashboard tutorial

### DIFF
--- a/products/logs/src/content/tutorials/bot-management-dashboard.md
+++ b/products/logs/src/content/tutorials/bot-management-dashboard.md
@@ -1,6 +1,7 @@
 ---
 order: 90
 pcx-content-type: tutorial
+hidden: true
 ---
 
 # Bot Management Dashboard

--- a/products/logs/src/content/tutorials/index.md
+++ b/products/logs/src/content/tutorials/index.md
@@ -10,7 +10,3 @@ Learn to manage and analyze your Cloudflare Logs with the following resources. F
 ### Logpull and Logpsuh
 
 - [Parsing Cloudflare Logs JSON data](/tutorials/parsing-json-log-data/)
-
-### Logpush
-
-- [Bot management dashboard](/tutorials/bot-management-dashboard/)


### PR DESCRIPTION
Talked with Ben S and we decided to:

- Remove references to the bot management dashboard tutorial
- Set up a redirect to [Bot analytics](https://developers.cloudflare.com/bots/bot-analytics)
- Re-eval in ~ a month based on #'s of redirects and complaints as to whether we kill tutorial or replace with better log field examples