### PR TITLE
[workers] Fix Table of Contents rendering on tutorials

### DIFF
--- a/products/workers/src/content/components/content-table.js
+++ b/products/workers/src/content/components/content-table.js
@@ -23,7 +23,7 @@ const DocsTutorials = () => {
             frontmatter {
               title
               updated
-              type
+              content_type
               url
             }
             headings(depth: h1) {
@@ -45,7 +45,7 @@ const DocsTutorials = () => {
       title: getPageTitle(page),
       url: page.frontmatter.url || page.fields.slug,
       updated: page.frontmatter.updated,
-      type: page.frontmatter.type,
+      content_type: page.frontmatter.content_type,
       wordCount: page.wordCount.words,
       new: (+new Date() - +new Date(page.frontmatter.updated)) < tenDaysInMS
     }))
@@ -98,7 +98,7 @@ const DocsTutorials = () => {
                 </React.Fragment>
               )} minPeriod={60} />
             </div>
-            <div className="DocsTutorials--column" data-column="type">{tutorial.type}</div>
+            <div className="DocsTutorials--column" data-column="type">{tutorial.content_type}</div>
             <div className="DocsTutorials--column" data-column="length">
               <div className="DocsTutorials--length-bar">
                 <div className="DocsTutorials--length-bar-inner" style={{ width: tutorial.length }}></div>

--- a/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
+++ b/products/workers/src/content/tutorials/authorize-users-with-auth0/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-07-25
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-jamstack-app/index.md
+++ b/products/workers/src/content/tutorials/build-a-jamstack-app/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-03-09
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-qr-code-generator/index.md
+++ b/products/workers/src/content/tutorials/build-a-qr-code-generator/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-03-09
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/build-a-serverless-api/index.md
+++ b/products/workers/src/content/tutorials/build-a-serverless-api/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2021-06-03
 difficulty: Intermediate
-type: "🎥 Video"
+content_type: "🎥 Video"
 url: "https://egghead.io/courses/build-a-serverless-api-with-cloudflare-workers-d67ca551?af=a54gwi"
 ---
 

--- a/products/workers/src/content/tutorials/build-a-slackbot/index.md
+++ b/products/workers/src/content/tutorials/build-a-slackbot/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-03-10
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/configure-your-cdn/index.md
+++ b/products/workers/src/content/tutorials/configure-your-cdn/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-04-15
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-react-app-with-create-react-app/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-06-01
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-07-25
 difficulty: Intermediate
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/products/workers/src/content/tutorials/github-sms-notifications-using-twilio/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-08-25
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/hello-world-rust/index.md
+++ b/products/workers/src/content/tutorials/hello-world-rust/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-06-29
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/introduction-to-cloudflare-workers/index.md
+++ b/products/workers/src/content/tutorials/introduction-to-cloudflare-workers/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2021-01-25
 difficulty: Beginner
-type: "🎥 Video"
+content_type: "🎥 Video"
 url: "https://egghead.io/playlists/introduction-to-cloudflare-workers-5aa3?af=a54gwi"
 ---
 

--- a/products/workers/src/content/tutorials/localize-a-website/index.md
+++ b/products/workers/src/content/tutorials/localize-a-website/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-08-03
 difficulty: Intermediate
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"

--- a/products/workers/src/content/tutorials/manage-projects-with-lerna/index.md
+++ b/products/workers/src/content/tutorials/manage-projects-with-lerna/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2020-08-13
 difficulty: Beginner
-type: "📝 Tutorial"
+content_type: "📝 Tutorial"
 ---
 
 import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start.md"


### PR DESCRIPTION
This PR fixes an issue where tutorial pages in the Workers docs weren't correctly rendering the Table of Contents. This occurs because we overloaded the `type` value for tutorials in the YAML frontmatter, which is used by the `docs-page` component to [conditionally render the ToC for any page](https://github.com/cloudflare/cloudflare-docs-engine/blob/c8377533fa49b60d7f0fc4a3255376763216f1ab/src/components/docs-page.js#L60).

To solve this, the Markdown files for each tutorial/video now use the `content_type` YAML frontmatter key, which is now parsed inside of our `content-table` component instead of `type`.