### PR TITLE
[SSL] Correctly format origin pull cert

### DIFF
--- a/products/ssl/src/content/origin-configuration/authenticated-origin-pull.md
+++ b/products/ssl/src/content/origin-configuration/authenticated-origin-pull.md
@@ -67,7 +67,8 @@ Cloudflare uses the following CA to sign certificates for the Authenticated Orig
 <summary>Certificate value</summary>
 <div>
 
-`-----BEGIN CERTIFICATE-----
+```text
+-----BEGIN CERTIFICATE-----
 MIIGCjCCA/KgAwIBAgIIV5G6lVbCLmEwDQYJKoZIhvcNAQENBQAwgZAxCzAJBgNV
 BAYTAlVTMRkwFwYDVQQKExBDbG91ZEZsYXJlLCBJbmMuMRQwEgYDVQQLEwtPcmln
 aW4gUHVsbDEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzETMBEGA1UECBMKQ2FsaWZv
@@ -101,7 +102,8 @@ bA+JbyJeUMtU7KMsxvx82RmhqBEJJDBCJ3scVptvhDMRrtqDBW5JShxoAOcpFQGm
 iYWicn46nPDjgTU0bX1ZPpTpryXbvciVL5RkVBuyX2ntcOLDPlZWgxZCBp96x07F
 AnOzKgZk4RzZPNAxCXERVxajn/FLcOhglVAKo5H0ac+AitlQ0ip55D2/mf8o72tM
 fVQ6VpyjEXdiIXWUq/o=
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+```
 
 </div>
 </details>


### PR DESCRIPTION
Hello 🙂

As pointed out by @centminmod in the [internal Cloudflare Community section](https://community.cloudflare.com/t/cf-authenticated-origin-pull-ca-certificate-clarification/277621) (only accessible to Cloudflare employees and Community MVPs), the origin pull certificate is currently shown on the documentation page as a one-liner, so you can currently not copy-paste the certificate as the certificate is not correctly formatted, causing line breaks to not be included.

This PR swaps out the single ticks for triple backticks, which correctly showns the certificate now with it's line breaks included, so you can copy-paste the certificate and immediately use it.

https://user-images.githubusercontent.com/5787588/121790687-0b720000-cbe2-11eb-9e7d-801f51f822b1.mp4

