### PR TITLE
pages: adjust `redirects` phrasing

### DIFF
--- a/products/pages/src/content/platform/redirects.md
+++ b/products/pages/src/content/platform/redirects.md
@@ -3,9 +3,13 @@
 ## Creating redirects
 To use redirects on Cloudflare Pages, declare your redirects in a `_redirects` plain text file in the output folder of your project. The [build output folder](https://developers.cloudflare.com/pages/platform/build-configuration) is project-specific so the `_redirects` file should not always be in the root directory of the repo. Changes to redirects will be updated to your website at build time so make sure you commit and push the file to trigger a new build each time you update redirects.
 
-Redirects can be stated as such with one redirect per line in the form: 
+Only one redirect can be defined per line and must follow this format:
 
+```
 [source] [destination] [code]
+```
+
+A complete example with multiple redirects may look like the following:
 
 ```
 ---
@@ -14,12 +18,12 @@ filename: _redirects
 /home301 / 301
 /home302 / 302
 /querystrings /?query=string 301
-/twitch https://twitch.tv
+/twitch https://twitch.tv 301
 /trailing /trailing/ 301
 /notrailing/ /nottrailing 301
 ```
- 
-There is a limit of 100 redirects and a 1000 character limit per redirect line. Incorrectly formatted lines in the file are ignored. If there are multiple redirects for the same source, the topmost redirect is applied. 
+
+A project is limited to 100 total redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied. If the same `source` URL has multiple redirects, the topmost redirect is applied.
 
 We currently offer limited support for advanced redirects. More support will be added in the future.
 
@@ -32,7 +36,7 @@ We currently offer limited support for advanced redirects. More support will be 
 | Splats                          | No      | /blog/* /blog/:splat                                                     |
 | Placeholders                    | No      | /blog/:year/:month/:date/:slug /news/:year/:month/:date/:slug            |
 | Query Parameters                | No      | /shop id=:id /blog/:id 301                                               |
-| Force (shadowing)                | No      | /workers/ /workers/index.html 200!                                       |
+| Force (shadowing)               | No      | /workers/ /workers/index.html 200!                                       |
 | Domain-level redirects          | No      | workers.example.com/* workers.example.com/blog/:splat 301 |
 | Redirect by country or language | No      | / /us 302 Country=us                                                     |
 

--- a/products/pages/src/content/platform/redirects.md
+++ b/products/pages/src/content/platform/redirects.md
@@ -1,13 +1,20 @@
 # Redirects
 
 ## Creating redirects
+
 To use redirects on Cloudflare Pages, declare your redirects in a `_redirects` plain text file in the output folder of your project. The [build output folder](https://developers.cloudflare.com/pages/platform/build-configuration) is project-specific so the `_redirects` file should not always be in the root directory of the repo. Changes to redirects will be updated to your website at build time so make sure you commit and push the file to trigger a new build each time you update redirects.
 
 Only one redirect can be defined per line and must follow this format:
 
 ```
-[source] [destination] [code]
+[source] [destination] [code?]
 ```
+
+<Aside heading="Status Code">
+  
+  The `[code]` parameter is optional, and when not defined, will default to a `302` status code.
+  
+</Aside>
 
 A complete example with multiple redirects may look like the following:
 
@@ -18,7 +25,7 @@ filename: _redirects
 /home301 / 301
 /home302 / 302
 /querystrings /?query=string 301
-/twitch https://twitch.tv 301
+/twitch https://twitch.tv
 /trailing /trailing/ 301
 /notrailing/ /nottrailing 301
 ```


### PR DESCRIPTION
A customer was confused by some of the [Redirects](https://developers.cloudflare.com/pages/platform/redirects) documentation – specifically the limits. I noticed that the formatting demonstration wasn't rendering correctly:

<img width="564" alt="Screen Shot 2021-06-15 at 3 23 39 PM" src="https://user-images.githubusercontent.com/5855893/122131376-f4076280-cded-11eb-8b05-c2855a1a9928.png">


