### PR TITLE
Fix small typo in ssh-cert-bastion.md

### DIFF
--- a/products/cloudflare-one/src/content/tutorials/ssh-cert-bastion.md
+++ b/products/cloudflare-one/src/content/tutorials/ssh-cert-bastion.md
@@ -62,7 +62,7 @@ Next, create a new Tunnel with the following command. You can replace `ssh-pool`
 $ cloudflared tunnel create ssh-pool
 ```
 
-`cloudflared` will create the Tunneland generate a UUID and corresponding credentials file.
+`cloudflared` will create the Tunnel and generate a UUID and corresponding credentials file.
 
 You can now configure your Tunnel. The example configuration file below uses the UUID value of the Tunnel, adds the path to the credentials file, and sets an optional logging location.
 


### PR DESCRIPTION
This adds a missing space, the sentence as a whole could be worded differently but adding this space should be good for now 🙂 