### PR TITLE
PCX-1635: add content types for tenant, image resizing, and docs engine

### DIFF
--- a/products/docs-engine/src/content/contributing/content/accessibility.md
+++ b/products/docs-engine/src/content/contributing/content/accessibility.md
@@ -1,6 +1,7 @@
 ---
 title: Accessibility
 order: 3
+pcx-content-type: best-practices
 ---
 
 # Writing accessible content

--- a/products/docs-engine/src/content/contributing/content/content-framework.md
+++ b/products/docs-engine/src/content/contributing/content/content-framework.md
@@ -1,5 +1,6 @@
 ---
 order: 0
+pcx-content-type: configuration
 ---
 
 # Content framework

--- a/products/docs-engine/src/content/contributing/content/formatting.md
+++ b/products/docs-engine/src/content/contributing/content/formatting.md
@@ -1,5 +1,6 @@
 ---
 order: 2
+pcx-content-type: best-practices
 ---
 
 # Formatting

--- a/products/docs-engine/src/content/contributing/content/index.md
+++ b/products/docs-engine/src/content/contributing/content/index.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: navigation
 ---
 
 # Content

--- a/products/docs-engine/src/content/contributing/content/working-with-github.md
+++ b/products/docs-engine/src/content/contributing/content/working-with-github.md
@@ -1,5 +1,6 @@
 ---
 order: 4
+pcx-content-type: best-practices
 ---
 
 # Working with GitHub

--- a/products/docs-engine/src/content/contributing/content/writing-style.md
+++ b/products/docs-engine/src/content/contributing/content/writing-style.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: interim
 ---
 
 # Writing style

--- a/products/docs-engine/src/content/contributing/development-setup.md
+++ b/products/docs-engine/src/content/contributing/development-setup.md
@@ -1,5 +1,6 @@
 ---
 order: 0
+pcx-content-type: how-to
 ---
 
 # Development setup

--- a/products/docs-engine/src/content/contributing/index.md
+++ b/products/docs-engine/src/content/contributing/index.md
@@ -1,6 +1,7 @@
 ---
 type: overview
 order: 3
+pcx-content-type: navigation
 ---
 
 # Contributing

--- a/products/docs-engine/src/content/contributing/to-cloudflare-docs.md
+++ b/products/docs-engine/src/content/contributing/to-cloudflare-docs.md
@@ -1,6 +1,7 @@
 ---
 title: To Cloudflare’s docs
 order: 2
+pcx-content-type: configuration
 ---
 
 # Contribute to Cloudflare’s docs

--- a/products/docs-engine/src/content/contributing/to-docs-engine.md
+++ b/products/docs-engine/src/content/contributing/to-docs-engine.md
@@ -1,6 +1,7 @@
 ---
 title: To Docs Engine
 order: 3
+pcx-content-type: how-to
 ---
 
 # Contribute to the Docs Engine

--- a/products/docs-engine/src/content/examples/code-block-examples.md
+++ b/products/docs-engine/src/content/examples/code-block-examples.md
@@ -1,3 +1,7 @@
+---
+pcx-content-type: reference
+---
+
 # Code block examples
 
 Code blocks inside [Docs Engine Markdown](/reference/markdown) offer a variety of custom presentation mechanisms. This page contains practical examples for inspiration.

--- a/products/docs-engine/src/content/examples/index.md
+++ b/products/docs-engine/src/content/examples/index.md
@@ -1,6 +1,6 @@
 ---
-type: overview
 order: 5
+pcx-content-type: navigation
 ---
 
 # Examples

--- a/products/docs-engine/src/content/examples/pages/class.md
+++ b/products/docs-engine/src/content/examples/pages/class.md
@@ -1,3 +1,7 @@
+---
+pcx-content-type: interim
+---
+
 # Class
 
 ## Background

--- a/products/docs-engine/src/content/examples/pages/example.md
+++ b/products/docs-engine/src/content/examples/pages/example.md
@@ -1,11 +1,11 @@
 ---
-type: example
 summary: A short summary of the example. Should be no more than 100 characters or so.
 demo: https://example.com
 tags:
   - Tag1
   - Tag2
   - Tag3
+pcx-content-type: interim
 ---
 
 # Example

--- a/products/docs-engine/src/content/examples/pages/index.md
+++ b/products/docs-engine/src/content/examples/pages/index.md
@@ -1,5 +1,6 @@
 ---
 order: 3
+pcx-content-type: navigation
 ---
 
 # Example pages

--- a/products/docs-engine/src/content/faq.md
+++ b/products/docs-engine/src/content/faq.md
@@ -1,6 +1,7 @@
 ---
 type: overview
 order: 6
+pcx-content-type: faq
 ---
 
 # FAQ

--- a/products/docs-engine/src/content/how-it-works.md
+++ b/products/docs-engine/src/content/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: interim
 ---
 
 # How it works

--- a/products/docs-engine/src/content/index.md
+++ b/products/docs-engine/src/content/index.md
@@ -1,10 +1,10 @@
 ---
-title: Home
-type: overview
+title: Overview
 order: 0
+pcx-content-type: landing-page
 ---
 
-# Docs Engine docs
+# Docs Engine
 
 <ContentColumn>
 

--- a/products/docs-engine/src/content/reference/configuration.md
+++ b/products/docs-engine/src/content/reference/configuration.md
@@ -1,5 +1,6 @@
 ---
 order: 0
+pcx-content-type: configuration
 ---
 
 # Configuration

--- a/products/docs-engine/src/content/reference/index.md
+++ b/products/docs-engine/src/content/reference/index.md
@@ -1,6 +1,7 @@
 ---
 type: overview
 order: 4
+pcx-content-type: navigation
 ---
 
 # Reference

--- a/products/docs-engine/src/content/reference/markdown.md
+++ b/products/docs-engine/src/content/reference/markdown.md
@@ -1,5 +1,6 @@
 ---
 order: 2
+pcx-content-type: best-practices
 ---
 
 # Markdown

--- a/products/docs-engine/src/content/reference/pages.md
+++ b/products/docs-engine/src/content/reference/pages.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: configuration
 ---
 
 # Pages

--- a/products/images/src/content/cloudflare-images-beta.md
+++ b/products/images/src/content/cloudflare-images-beta.md
@@ -1,6 +1,7 @@
 ---
 title: Images (beta)
 order: 7
+pcx-content-type: how-to
 ---
 
 # Cloudflare Images API (beta)

--- a/products/images/src/content/controlling-origin-access.md
+++ b/products/images/src/content/controlling-origin-access.md
@@ -1,5 +1,6 @@
 ---
 order: 5
+pcx-content-type: interim
 ---
 
 # Controlling origin access

--- a/products/images/src/content/drawing-overlays.md
+++ b/products/images/src/content/drawing-overlays.md
@@ -1,6 +1,7 @@
 ---
 title: Drawing overlays
 order: 4
+pcx-content-type: configuration
 ---
 
 # Drawing overlays & watermarks

--- a/products/images/src/content/index.md
+++ b/products/images/src/content/index.md
@@ -1,7 +1,7 @@
 ---
-type: overview
-title: Welcome
+title: Overview
 order: 0
+pcx-content-type: landing-page
 ---
 
 # Cloudflare Image Resizing docs

--- a/products/images/src/content/integration-with-frameworks.md
+++ b/products/images/src/content/integration-with-frameworks.md
@@ -1,6 +1,7 @@
 ---
 title: Integration with frameworks
 order: 7
+pcx-content-type: interim
 ---
 
 # Integration with frameworks

--- a/products/images/src/content/resizing-with-workers.md
+++ b/products/images/src/content/resizing-with-workers.md
@@ -1,6 +1,7 @@
 ---
 title: Resizing with Workers
 order: 3
+pcx-content-type: configuration
 ---
 
 # Resizing with Cloudflare Workers

--- a/products/images/src/content/responsive-images.md
+++ b/products/images/src/content/responsive-images.md
@@ -1,5 +1,6 @@
 ---
 order: 2
+pcx-content-type: configuration
 ---
 
 # Responsive images

--- a/products/images/src/content/troubleshooting.md
+++ b/products/images/src/content/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 order: 6
+pcx-content-type: faq
 ---
 
 # Troubleshooting

--- a/products/images/src/content/url-format.md
+++ b/products/images/src/content/url-format.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: configuration
 ---
 
 # URL format

--- a/products/tenant/src/content/getting-started.md
+++ b/products/tenant/src/content/getting-started.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: interim
 ---
 
 # Getting started

--- a/products/tenant/src/content/index.md
+++ b/products/tenant/src/content/index.md
@@ -1,6 +1,7 @@
 ---
-title: Welcome
+title: Overview
 order: 0
+pcx-content-type: landing-page
 ---
 
 # Cloudflare Tenant docs

--- a/products/tenant/src/content/tutorial/enabling-services.md
+++ b/products/tenant/src/content/tutorial/enabling-services.md
@@ -1,6 +1,7 @@
 ---
 title: "3: Enabling services"
 order: 2
+pcx-content-type: tutorial
 ---
 
 # Step 3: Enabling services

--- a/products/tenant/src/content/tutorial/index.md
+++ b/products/tenant/src/content/tutorial/index.md
@@ -1,5 +1,6 @@
 ---
 order: 1
+pcx-content-type: navigation
 ---
 
 # Tutorial

--- a/products/tenant/src/content/tutorial/provisioning-resources.md
+++ b/products/tenant/src/content/tutorial/provisioning-resources.md
@@ -1,6 +1,7 @@
 ---
 title: "1: Provisioning resources"
 order: 0
+pcx-content-type: tutorial
 ---
 
 # Step 1: Provisioning resources

--- a/products/tenant/src/content/tutorial/service-configuration.md
+++ b/products/tenant/src/content/tutorial/service-configuration.md
@@ -1,6 +1,7 @@
 ---
 title: "4: Service configuration"
 weight: 40
+pcx-content-type: reference
 ---
 
 # Step 4: Service configuration

--- a/products/tenant/src/content/tutorial/user-access.md
+++ b/products/tenant/src/content/tutorial/user-access.md
@@ -1,6 +1,7 @@
 ---
 title: "2: User access"
 order: 1
+pcx-content-type: tutorial
 ---
 
 # Step 2: User access


### PR DESCRIPTION
part 2 of content type labelling: for tenant, image resizing, and docs engine