### PR TITLE
Note Perl requirement for installing Wrangler on Windows via Cargo

### DIFF
--- a/products/workers/src/content/cli-wrangler/install-update.md
+++ b/products/workers/src/content/cli-wrangler/install-update.md
@@ -48,6 +48,8 @@ Wrangler can be installed both through [npm](https://www.npmjs.com/get-npm) and 
     ```
 
     Additional installation methods are available [on the Rust site](https://forge.rust-lang.org/other-installation-methods.html).
+    
+    Windows users will need to install Perl as a dependency for `openssl-sys`. We recommmend [Strawberry Perl](https://www.perl.org/get.html).
 
 2. Install `wrangler`:
 


### PR DESCRIPTION
This issue has been reported (https://github.com/cloudflare/wrangler/issues/1601) and resolved (https://github.com/cloudflare/wrangler/pull/1629) but only in the Wrangler readme, not on the installation page page where it would be more useful for new users.