### PR TITLE
Update country in countryMap Object

### DIFF
--- a/products/workers/src/content/examples/country-code-redirect.md
+++ b/products/workers/src/content/examples/country-code-redirect.md
@@ -38,7 +38,7 @@ async function redirect(request) {
  */
 const countryMap = {
   US: "https://example.com/us",
-  EU: "https://eu.example.com/",
+  DE: "https://de.example.com/",
 }
 
 async function handleRequest(request) {


### PR DESCRIPTION
Accessing a Worker from the EU usually puts the actual country in the headers, like DE or FR but not EU. This change makes the example more clear and also works better as an example. EU is represented in `continent`. [See also](https://accessing-the-cloudflare-object.workers-sites-examples.workers.dev/).