### PR TITLE
Propose adding link to Fission setup guide

### DIFF
--- a/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
+++ b/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
@@ -24,3 +24,6 @@ hash. There are several tools that help with different parts of this:
 - [dnslink-cloudflare](https://github.com/ipfs-shipyard/dnslink-cloudflare) is a
   script to programmatically update DNSLink records. This can be run with the
   `-Q` flag of `ipfs add` that only outputs the top-level hash.
+- [fission ipns support](https://guide.fission.codes/developers/custom-domains/using-cloudflare-ipfs-gateway) 
+  lets you use the the Fission IPFS app publishing system from the CLI  
+  or Github Actions, while using Cloudflare-managed DNS and gateway

--- a/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
+++ b/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
@@ -25,5 +25,5 @@ hash. There are several tools that help with different parts of this:
   script to programmatically update DNSLink records. This can be run with the
   `-Q` flag of `ipfs add` that only outputs the top-level hash.
 - [fission ipns support](https://guide.fission.codes/developers/custom-domains/using-cloudflare-ipfs-gateway) 
-  lets you use the the Fission IPFS app publishing system from the CLI  
+  lets you use the Fission IPFS app publishing system from the CLI
   or from GitHub Actions, while using Cloudflare-managed DNS and gateway.

--- a/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
+++ b/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
@@ -26,4 +26,4 @@ hash. There are several tools that help with different parts of this:
   `-Q` flag of `ipfs add` that only outputs the top-level hash.
 - [fission ipns support](https://guide.fission.codes/developers/custom-domains/using-cloudflare-ipfs-gateway) 
   lets you use the the Fission IPFS app publishing system from the CLI  
-  or Github Actions, while using Cloudflare-managed DNS and gateway
+  or from GitHub Actions, while using Cloudflare-managed DNS and gateway.

--- a/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
+++ b/products/distributed-web/src/content/ipfs-gateway/automated-deployment.md
@@ -24,6 +24,6 @@ hash. There are several tools that help with different parts of this:
 - [dnslink-cloudflare](https://github.com/ipfs-shipyard/dnslink-cloudflare) is a
   script to programmatically update DNSLink records. This can be run with the
   `-Q` flag of `ipfs add` that only outputs the top-level hash.
-- [fission ipns support](https://guide.fission.codes/developers/custom-domains/using-cloudflare-ipfs-gateway) 
+- [Fission's IPNS support](https://guide.fission.codes/developers/custom-domains/using-cloudflare-ipfs-gateway) 
   lets you use the Fission IPFS app publishing system from the CLI
   or from GitHub Actions, while using Cloudflare-managed DNS and gateway.


### PR DESCRIPTION
hi all! We've got instructions on our guide on how to use a Cloudflare hosted DNS with the gateway and serve up an IPNS site from Fission. LMK if this looks OK.