### PR TITLE
Update categorization of Examples

### DIFF
--- a/products/workers/src/content/examples/ab-testing.md
+++ b/products/workers/src/content/examples/ab-testing.md
@@ -3,7 +3,6 @@ order: 1000
 type: example
 summary: Set up an A/B test by controlling what response is served based on cookies.
 tags:
-  - JAMstack
   - Originless
 ---
 

--- a/products/workers/src/content/examples/accessing-the-cloudflare-object.md
+++ b/products/workers/src/content/examples/accessing-the-cloudflare-object.md
@@ -4,12 +4,10 @@ type: example
 summary: Access custom Cloudflare properties and control how Cloudflare features are applied to every request.
 demo: https://accessing-the-cloudflare-object.workers-sites-examples.workers.dev
 tags:
-  - API
-  - JSON
   - Originless
 ---
 
-# Accessing the Cloudflare object
+# Accessing the `cf` object
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/examples/aggregate-requests.md
+++ b/products/workers/src/content/examples/aggregate-requests.md
@@ -3,8 +3,7 @@ order: 1000
 type: example
 summary: Send two GET request to two urls and aggregates the responses into one response.
 tags:
-  - JSON
-  - HTML
+  - Originless
 ---
 
 # Aggregate requests

--- a/products/workers/src/content/examples/alter-headers.md
+++ b/products/workers/src/content/examples/alter-headers.md
@@ -3,7 +3,8 @@ order: 1000
 type: example
 summary: Change the headers sent in a request or returned in a response.
 tags:
-  - Security
+  - Headers
+  - Middleware
 ---
 
 # Alter headers

--- a/products/workers/src/content/examples/auth-with-headers.md
+++ b/products/workers/src/content/examples/auth-with-headers.md
@@ -3,7 +3,8 @@ order: 1000
 type: example
 summary: Allow or deny a request based on a known pre-shared key in a header. This is not meant to replace the WebCrypto API.
 tags:
-  - Security
+  - Authentication
+  - WebCrypto
 ---
 
 # Auth with headers

--- a/products/workers/src/content/examples/basic-auth.md
+++ b/products/workers/src/content/examples/basic-auth.md
@@ -5,6 +5,7 @@ summary: Shows how to restrict access using the HTTP "Basic" schema.
 tags:
   - Security
   - Originless
+  - Authentication
 ---
 
 # HTTP "Basic" Authentication

--- a/products/workers/src/content/examples/block-on-tls.md
+++ b/products/workers/src/content/examples/block-on-tls.md
@@ -3,8 +3,8 @@ order: 1000
 type: example
 summary: Inspects the incoming request's TLS version and blocks if under TLSv1.2.
 tags:
-  - Originless
   - Security
+  - Middleware
 ---
 
 # Block on TLS

--- a/products/workers/src/content/examples/bulk-origin-proxy.md
+++ b/products/workers/src/content/examples/bulk-origin-proxy.md
@@ -3,10 +3,10 @@ order: 1000
 type: example
 summary: Resolve requests to your domain to a set of proxy third-party origin URLs.
 tags:
-  - Proxy
+  - Middleware
 ---
 
-# Bulk origin proxy
+# Bulk origin override
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/examples/bulk-redirects.md
+++ b/products/workers/src/content/examples/bulk-redirects.md
@@ -3,8 +3,7 @@ order: 1000
 type: example
 summary: Redirect requests to certain URLs based on a mapped object to the request's URL.
 tags:
-  - Security
-  - Proxy
+  - Middleware
 ---
 
 # Bulk redirects

--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -3,7 +3,7 @@ order: 1000
 type: example
 summary: Use the Cache API to store responses in Cloudflare's cache.
 tags:
-  - API
+  - Cache API
   - Middleware
   - Caching
 ---

--- a/products/workers/src/content/examples/cache-post-request.md
+++ b/products/workers/src/content/examples/cache-post-request.md
@@ -5,6 +5,7 @@ summary: Cache POST requests using the Cache API.
 tags:
   - Middleware
   - Caching
+  - Cache API
 ---
 
 # Cache POST requests

--- a/products/workers/src/content/examples/cache-using-fetch.md
+++ b/products/workers/src/content/examples/cache-using-fetch.md
@@ -3,8 +3,9 @@ order: 1000
 type: example
 summary: Determine how to cache a resource by setting TTLs, custom cache keys, and cache headers in a fetch request.
 tags:
-  - API
-  - JAMstack
+  - Caching
+  - Cache API
+  - Middleware
 ---
 
 # Cache using fetch

--- a/products/workers/src/content/examples/conditional-response.md
+++ b/products/workers/src/content/examples/conditional-response.md
@@ -3,8 +3,7 @@ order: 1000
 type: example
 summary: Return a response based on the incoming request's URL, HTTP method, User Agent, IP address, ASN or device type.
 tags:
-  - Security
-  - Originless
+  - Middleware
 ---
 
 # Conditional response

--- a/products/workers/src/content/examples/cors-header-proxy.md
+++ b/products/workers/src/content/examples/cors-header-proxy.md
@@ -3,9 +3,8 @@ order: 1000
 type: example
 summary: Add the necessary CORS headers to a third party API response.
 tags:
-  - Originless
   - Security
-  - API
+  - Headers
 ---
 
 # CORS header proxy

--- a/products/workers/src/content/examples/country-code-redirect.md
+++ b/products/workers/src/content/examples/country-code-redirect.md
@@ -3,7 +3,6 @@ order: 1000
 type: example
 summary: Redirect a response based on the country code in the header of a visitor.
 tags:
-  - Security
   - Originless
 ---
 

--- a/products/workers/src/content/examples/debugging-logs.md
+++ b/products/workers/src/content/examples/debugging-logs.md
@@ -3,10 +3,8 @@ order: 1000
 type: example
 summary: Send debugging information in an errored response to a logging service.
 tags:
-  - API
-  - JSON
-  - Middleware
-  - Originless
+  - Debugging
+  - Logging
 ---
 
 # Debugging logs

--- a/products/workers/src/content/examples/extract-cookie-value.md
+++ b/products/workers/src/content/examples/extract-cookie-value.md
@@ -3,12 +3,10 @@ order: 1000
 type: example
 summary: Given the cookie name, get the value of a cookie. You can also use cookies for A/B testing.
 tags:
-  - Security
-  - JAMstack
-  - Originless
+  - Headers
 ---
 
-# Extract cookie value
+# Cookie parsing
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/examples/fetch-html.md
+++ b/products/workers/src/content/examples/fetch-html.md
@@ -3,8 +3,7 @@ order: 2
 type: example
 summary: Send a request to a remote server, read HTML from the response, and serve that HTML.
 tags:
-  - JSON
-  - API
+  - Originless
 ---
 
 # Fetch HTML

--- a/products/workers/src/content/examples/fetch-json.md
+++ b/products/workers/src/content/examples/fetch-json.md
@@ -3,8 +3,7 @@ order: 3
 type: example
 summary: Send a GET request and read in JSON from the response. Use to fetch external data.
 tags:
-  - JSON
-  - API
+  - Originless
 ---
 
 # Fetch JSON

--- a/products/workers/src/content/examples/geolocation-app-weather.md
+++ b/products/workers/src/content/examples/geolocation-app-weather.md
@@ -3,7 +3,7 @@ order: 1000
 type: example
 summary: Fetch weather data from an API using the user's geolocation data.
 tags:
-  - HTML
+  - Originless
   - Geolocation
 ---
 

--- a/products/workers/src/content/examples/geolocation-custom-styling.md
+++ b/products/workers/src/content/examples/geolocation-custom-styling.md
@@ -3,7 +3,7 @@ order: 1000
 type: example
 summary: Personalize website styling based on localized user time.
 tags:
-  - HTML
+  - Originless
   - Geolocation
 ---
 

--- a/products/workers/src/content/examples/geolocation-hello-world.md
+++ b/products/workers/src/content/examples/geolocation-hello-world.md
@@ -3,7 +3,7 @@ order: 1000
 type: example
 summary: Get all geolocation data fields and display them in HTML.
 tags:
-  - HTML
+  - Originless
   - Geolocation
 ---
 

--- a/products/workers/src/content/examples/hot-link-protection.md
+++ b/products/workers/src/content/examples/hot-link-protection.md
@@ -4,7 +4,7 @@ type: example
 summary: Block other websites from linking to your content. This is useful for protecting images.
 tags:
   - Security
-  - JAMstack
+  - Headers
 ---
 
 # Hot-link protection

--- a/products/workers/src/content/examples/http2-server-push.md
+++ b/products/workers/src/content/examples/http2-server-push.md
@@ -3,9 +3,8 @@ order: 1000
 type: example
 summary: Push static assets to a client's browser without waiting for HTML to render.
 tags:
-  - Originless
-  - JAMstack
-  - HTML
+  - Middleware
+  - Headers
 ---
 
 # HTTP2 server push

--- a/products/workers/src/content/examples/logging-headers.md
+++ b/products/workers/src/content/examples/logging-headers.md
@@ -3,11 +3,10 @@ order: 1000
 type: example
 summary: Examine the contents of a Headers object by logging to console with a Map.
 tags:
-  - Middleware
-  - Originless
+  - Debugging
 ---
 
-# Logging headers
+# Logging headers to console
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/examples/modify-request-property.md
+++ b/products/workers/src/content/examples/modify-request-property.md
@@ -3,9 +3,8 @@ order: 1000
 type: example
 summary: Create a modified request with edited properties based off of an incoming request.
 tags:
-  - Originless
-  - API
-  - JSON
+  - Middleware
+  - Headers
 ---
 
 # Modify request property

--- a/products/workers/src/content/examples/modify-response.md
+++ b/products/workers/src/content/examples/modify-response.md
@@ -3,9 +3,8 @@ order: 1000
 type: example
 summary: Fetch and modify response properties which are immutable by creating a copy first.
 tags:
-  - Originless
-  - API
-  - JSON
+  - Middleware
+  - Headers
 ---
 
 # Modify response

--- a/products/workers/src/content/examples/post-json.md
+++ b/products/workers/src/content/examples/post-json.md
@@ -4,8 +4,6 @@ type: example
 summary: Send a POST request with JSON data. Use to share data with external servers.
 tags:
   - Originless
-  - JSON
-  - API
 ---
 
 # Post JSON

--- a/products/workers/src/content/examples/read-post.md
+++ b/products/workers/src/content/examples/read-post.md
@@ -3,7 +3,6 @@ order: 1000
 type: example
 summary: Serve an HTML form, then read POST requests. Use also to read JSON or POST data from an incoming request.
 tags:
-  - HTML
   - JSON
   - Originless
 ---

--- a/products/workers/src/content/examples/redirect.md
+++ b/products/workers/src/content/examples/redirect.md
@@ -3,8 +3,7 @@ order: 5
 type: example
 summary: Redirect requests from one URL to another, or from one set of URLs to another set.
 tags:
-  - Originless
-  - Proxy
+  - Middleware
 ---
 
 # Redirect

--- a/products/workers/src/content/examples/respond-with-another-site.md
+++ b/products/workers/src/content/examples/respond-with-another-site.md
@@ -4,7 +4,7 @@ type: example
 summary: Respond to the Worker request with the response from another website (example.com in this example).
 demo: https://respond-with-another-site.workers-sites-examples.workers.dev
 tags:
-  - Proxy
+  - Middleware
 ---
 
 # Respond with another site

--- a/products/workers/src/content/examples/return-html.md
+++ b/products/workers/src/content/examples/return-html.md
@@ -4,12 +4,10 @@ type: example
 summary: Deliver an HTML page from an HTML string directly inside the Worker script.
 demo: https://returning-html.workers-sites-examples.workers.dev
 tags:
-  - HTML
-  - JAMstack
   - Originless
 ---
 
-# Return HTML
+# Return small HTML page
 
 <ContentColumn>
   <p>{props.frontmatter.summary}</p>

--- a/products/workers/src/content/examples/return-json.md
+++ b/products/workers/src/content/examples/return-json.md
@@ -5,7 +5,6 @@ summary: Return JSON directly from a Worker script, useful for building APIs and
 demo: https://returning-json.workers-sites-examples.workers.dev
 tags:
   - JSON
-  - API
   - Originless
 ---
 

--- a/products/workers/src/content/examples/rewrite-links.md
+++ b/products/workers/src/content/examples/rewrite-links.md
@@ -3,8 +3,6 @@ order: 1000
 type: example
 summary: Rewrite URL links in HTML using the HTMLRewriter. This is useful for JAMstack websites.
 tags:
-  - HTML
-  - JAMstack
   - HTMLRewriter
 ---
 

--- a/products/workers/src/content/examples/signing-requests.md
+++ b/products/workers/src/content/examples/signing-requests.md
@@ -4,6 +4,7 @@ type: example
 summary: Sign and verify a request using the HMAC and SHA-256 algorithms or return a 403.
 tags:
   - Security
+  - WebCrypto
 ---
 
 # Sign requests


### PR DESCRIPTION
Updated some of the categories for examples to make it easier to find content.

Old:
<img width="1000" alt="Screen Shot 2021-06-28 at 9 44 23 AM" src="https://user-images.githubusercontent.com/2414910/123673783-b8a96280-d7f5-11eb-83f3-73ad04783a3d.png">

Updated:
<img width="939" alt="Screen Shot 2021-06-28 at 9 44 06 AM" src="https://user-images.githubusercontent.com/2414910/123673760-b47d4500-d7f5-11eb-92cc-5cc32fa85e6f.png">


New categories: 
- Logging (things like Sentry, Honeycomb, etc can go here in the future)
- Debugging 
- Headers (we have lots of examples, and this is something customers often look for)
- Cache API (ideally, would love to be able to group the categories themselves, and have a Runtime APIs one). 
- WebCrypto (same as above)

Deprecated: 
- Proxy (feels too close to middleware, difference was unclear)
- API (unclear whether this means building an API or example of a runtime API)
- HTML (too ambiguous)
