### PR TITLE
Format /pages intro actions with a <ButtonGroup>

### DIFF
--- a/products/pages/src/content/index.md
+++ b/products/pages/src/content/index.md
@@ -13,7 +13,11 @@ Deploy your dynamic frontend applications using Cloudflare Pages. Pages are supe
 
 Get started deploying your first site using our starter guide below, or check out our examples page to explore the vast ecosystem of tools and framework that we support on the platform.
 
-<Link to="/getting-started" className="Button Button-is-docs-primary">Get started</Link> &nbsp;&nbsp; <Link to="/how-to" className="Button Button-is-docs-secondary">See what you can build</Link> &nbsp;&nbsp; <Link to="https://pages.dev" className="Button Button-is-docs-secondary">Your Cloudflare Pages dashboard</Link>
+<ButtonGroup>
+  <Button type="primary" href="/getting-started">Get started</Button>
+  <Button type="secondary" href="/how-to">See what you can build</Button>
+  <Button type="secondary" href="https://pages.dev">Your Cloudflare Pages dashboard</Button>
+</ButtonGroup>
 
 ## Popular pages
 


### PR DESCRIPTION
Fixes the awkward spacing that occurs when the third buttons wraps (typically on mobile devices):

<img width="320" src="https://user-images.githubusercontent.com/154613/123901490-04185980-d939-11eb-9f85-2cdc56aea956.png">

@rita3ko @signalnerve Please double check I preserved the link `href`s properly, but otherwise I think this should be good to go.
