### PR TITLE
Update ordering of Platform content in Pages docs

### DIFF
--- a/products/pages/src/content/platform/api.md
+++ b/products/pages/src/content/platform/api.md
@@ -1,4 +1,9 @@
-# API
+---
+order: 7
+pcx-content-type: concept
+---
+
+# REST API
 
 The [Pages API](https://api.cloudflare.com/#pages-project-properties) empowers you to build automations and integrate Pages with your development workflow. At a high level, the API endpoints let you manage deployments and builds and configure projects. We plan to support prebuilt deployments and hooks soon. Refer to the [API documentation](https://api.cloudflare.com/) for a full breakdown of object types and endpoints.
 

--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -1,3 +1,8 @@
+---
+order: 2
+pcx-content-type: concept
+---
+
 # Build configuration
 
 ## Build commands and directories

--- a/products/pages/src/content/platform/github-integration.md
+++ b/products/pages/src/content/platform/github-integration.md
@@ -1,3 +1,8 @@
+---
+order: 1
+pcx-content-type: concept
+---
+
 # GitHub integration
 
 We support connecting Cloudflare Pages to your GitHub repositories to look for new changes to your project.

--- a/products/pages/src/content/platform/known-issues.md
+++ b/products/pages/src/content/platform/known-issues.md
@@ -1,3 +1,8 @@
+---
+order: 9
+pcx-content-type: concept
+---
+
 # Known issues
 
 Here are some known bugs and issues that we're aware of with Cloudflare Pages:

--- a/products/pages/src/content/platform/limits.md
+++ b/products/pages/src/content/platform/limits.md
@@ -1,3 +1,8 @@
+---
+order: 8
+pcx-content-type: concept
+---
+
 # Limits
 
 Below, we've listed the limits for users using the Cloudflare Pages free plan. For more details on removing these limits, check out our [Cloudflare plans](https://www.cloudflare.com/plans) page.

--- a/products/pages/src/content/platform/preview-deployments.md
+++ b/products/pages/src/content/platform/preview-deployments.md
@@ -1,3 +1,8 @@
+---
+order: 3
+pcx-content-type: concept
+---
+
 # Preview deployments
 
 Preview deployments allow you to preview new versions of your project without deploying it to production.

--- a/products/pages/src/content/platform/redirects.md
+++ b/products/pages/src/content/platform/redirects.md
@@ -1,3 +1,8 @@
+---
+order: 6
+pcx-content-type: concept
+---
+
 # Redirects
 
 ## Creating redirects

--- a/products/pages/src/content/platform/rollbacks.md
+++ b/products/pages/src/content/platform/rollbacks.md
@@ -1,3 +1,8 @@
+---
+order: 5
+pcx-content-type: concept
+---
+
 # Rollbacks
 
 Rollbacks allow you to instantly revert your project to a previous production deployment.

--- a/products/pages/src/content/platform/serving-pages.md
+++ b/products/pages/src/content/platform/serving-pages.md
@@ -1,3 +1,8 @@
+---
+order: 4
+pcx-content-type: concept
+---
+
 # Serving Pages
 
 Cloudflare Pages includes a number of "good defaults" for serving your Pages sites. This page details some of those decisions, so you can understand how Pages works, and how you might want to override some of the default behaviors.


### PR DESCRIPTION
New ordering (in this PR):
<img width="294" alt="Screen Shot 2021-07-08 at 8 34 17 AM" src="https://user-images.githubusercontent.com/2414910/124950497-50156f00-dfc7-11eb-9d13-088c5e5ff496.png">

Current ordering (in Docs):
<img width="299" alt="Screen Shot 2021-07-08 at 8 34 43 AM" src="https://user-images.githubusercontent.com/2414910/124950556-5e638b00-dfc7-11eb-8956-3eede3418faf.png">
