### PR TITLE
[BYOIP & Magic Transit] Adding explanation of LOA purpose

### DIFF
--- a/products/byoip/src/content/loa/index.md
+++ b/products/byoip/src/content/loa/index.md
@@ -6,7 +6,7 @@ pcx-content-type: concept
 
 # Letter of Authorization (LOA)
 
-A letter of authorization (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they accept the routes Cloudflare advertises on behalf of another entity.
+A letter of authorization (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on behalf of another entity.
 
 The letter must contain both the prefixes you are authorizing Cloudflare to announce, and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you are welcome to use ours. If you want Cloudflare to use our ASN, just let us know and we will provide the AS number to put in the LOA document.
 

--- a/products/byoip/src/content/loa/index.md
+++ b/products/byoip/src/content/loa/index.md
@@ -6,7 +6,7 @@ pcx-content-type: concept
 
 # Letter of Authorization (LOA)
 
-A letter of authorization (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. Some backbone and transit providers require that Cloudflare provide them with an LOA whenever Cloudflare starts to announce a customer prefix.
+A letter of authorization (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they accept the routes Cloudflare advertises on behalf of another entity.
 
 The letter must contain both the prefixes you are authorizing Cloudflare to announce, and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you are welcome to use ours. If you want Cloudflare to use our ASN, just let us know and we will provide the AS number to put in the LOA document.
 

--- a/products/magic-transit/src/content/set-up/requirements.md
+++ b/products/magic-transit/src/content/set-up/requirements.md
@@ -20,7 +20,7 @@ Magic Transit relies on Generic Routing Encapsulation (GRE) tunnels to transmit 
 
 ## Draft Letter of Authorization
 
-Draft a [Letter of Authorization (LOA)](https://developers.cloudflare.com/byoip/loa) that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. See this [LOA template](https://developers.cloudflare.com/byoip/loa/loa-template) for an example.
+Draft a [Letter of Authorization (LOA)](https://developers.cloudflare.com/byoip/loa) that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. The LOA is required by Cloudflare's transit providers so they can accept routes Cloudflare advertises on your behalf. See this [LOA template](https://developers.cloudflare.com/byoip/loa/loa-template) for an example.
 
 ## Verify Internet Routing Registry entries
 

--- a/products/magic-transit/src/content/set-up/requirements.md
+++ b/products/magic-transit/src/content/set-up/requirements.md
@@ -20,7 +20,7 @@ Magic Transit relies on Generic Routing Encapsulation (GRE) tunnels to transmit 
 
 ## Draft Letter of Authorization
 
-Draft a [Letter of Authorization (LOA)](https://developers.cloudflare.com/byoip/loa) that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. The LOA is required by Cloudflare's transit providers so they can accept routes Cloudflare advertises on your behalf. See this [LOA template](https://developers.cloudflare.com/byoip/loa/loa-template) for an example.
+Draft a [Letter of Authorization (LOA)](https://developers.cloudflare.com/byoip/loa) that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on your behalf. See this [LOA template](https://developers.cloudflare.com/byoip/loa/loa-template) for an example.
 
 ## Verify Internet Routing Registry entries
 


### PR DESCRIPTION
Adding explanation of why LOAs are required for Magic Transit prefixes to LOA section of BYOIP and LOA Requirements section of Magic Transit.

Addresses [PCX-1790](https://github.com/cloudflare/cloudflare-docs/compare/byoip-loa-purpose?expand=1)