### PR TITLE
[Automatic Platform Optimization] fix query parameter names for campaignid and adgroupid

### DIFF
--- a/products/automatic-platform-optimization/src/content/reference/query-parameters.md
+++ b/products/automatic-platform-optimization/src/content/reference/query-parameters.md
@@ -28,8 +28,8 @@ APO serves cached content as long as the query parameters in the URL are one of 
 - `gclid`
 - `dclid`
 - `_ga`
-- `campaigni`
-- `adgroupi`
+- `campaignid`
+- `adgroupid`
 - `_ke`
 - `cn-reloaded`
 - `age-verified`


### PR DESCRIPTION
Reference:
- https://developers.google.com/adwords/api/docs/appendix/reports/click-performance-report#campaignid
- https://developers.google.com/adwords/api/docs/appendix/reports/click-performance-report#adgroupid