### PR TITLE
Fix deploy a static WordPress site WP2Static plugin link and info

### DIFF
--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -11,7 +11,7 @@ import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start
 
 <Aside type="warning" header="Warning">
 
-As of August 2020, the WP2Static plugin is closed for downloads on WordPress.org but is still available on their GitHub repo. [WP2Static](https://github.com/leonstafford/wp2static), try [Simply Static](https://wordpress.org/plugins/simply-static/). 
+As of August 2020, the WP2Static plugin is closed for downloads on WordPress.org but is still available [on GitHub](https://github.com/leonstafford/wp2static).
 
 </Aside>
 

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -11,7 +11,7 @@ import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start
 
 <Aside type="warning" header="Warning">
 
-This tutorial is outdated. As of August 2020, the WP2Static plugin is no longer available. For a free alternative to [WP2Static](https://wordpress.org/plugins/static-html-output-plugin/), try [Simply Static](https://wordpress.org/plugins/simply-static/). 
+As of August 2020, the WP2Static plugin is closed for downloads on WordPress.org but is still available on their GitHub repo. [WP2Static](https://github.com/leonstafford/wp2static), try [Simply Static](https://wordpress.org/plugins/simply-static/). 
 
 </Aside>
 


### PR DESCRIPTION
Update the wording and WP2Static link.