### PR TITLE
Clarify use of `fetch` here

### DIFF
--- a/products/pages/src/content/how-to/add-custom-http-headers.md
+++ b/products/pages/src/content/how-to/add-custom-http-headers.md
@@ -23,6 +23,7 @@ addEventListener('fetch', event => {
 })
 
 async function handleRequest(request) {
+  // This proxies your Pages app, as long as your Worker is deployed on the same custom domain as your Pages project
   const response = await fetch(request)
   
   // Clone the response so that it's no longer immutable


### PR DESCRIPTION
Correct me if I'm wrong, but this code relies on a very specific setup of your Pages/Workers routes, right? You need Pages to have a custom domain (e.g. `example.com`), then to deploy the worker with `example.com/*` route. There's no way to put this code in front of a `x.pages.dev` domain, since that doesn't route to your account.

You _can_, however, skip the custom domain step and deploy an originless worker that reverse-proxies your `x.pages.dev` site by changing the `hostname` of the incoming `request`. I think we should be clear that this _isn't_ the setup described here.

Ideally, I think we should add some screenshots of what your Pages custom domain setup, and Workers route setup should look like in the Dash for this to be correctly configured. I think that'd be useful for anyone approaching this completely new, or for people who usually set up Workers slightly differently.