### PR TITLE
Migration Guide: Jekyll on GitHub Pages -> Cloudflare Pages

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
@@ -7,9 +7,10 @@ pcx-content-type: how-to
 Jekyll is an open-source framework for creating websites, based around Markdown with Liquid templates. In this guide, you will create a new Jekyll application and deploy it using Cloudflare Pages. You will be using the `jekyll` CLI to create a new Jekyll site.
 
 <Aside type="note">
-If you have an existing Jekyll site on GitHub Pages, see [our migration guide](/pages/migrating-jekyll-from-github-pages/)
-</Aside>
 
+If you have an existing Jekyll site on GitHub Pages, refer to [the Jekyll migration guide](/pages/migrating-jekyll-from-github-pages/).
+
+</Aside>
 ## Installing Jekyll
 
 Jekyll is written in Ruby, meaning that you'll need a functioning Ruby installation in order to install Jekyll.

--- a/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
@@ -13,7 +13,7 @@ If you have an existing Jekyll site on GitHub Pages, refer to [the Jekyll migrat
 </Aside>
 ## Installing Jekyll
 
-Jekyll is written in Ruby, meaning that you'll need a functioning Ruby installation in order to install Jekyll.
+Jekyll is written in Ruby, meaning that you will need a functioning Ruby installation in order to install Jekyll.
 
 We recommend using [`rbenv`](https://github.com/rbenv/rbenv) to install Ruby on your computer. Follow the [`rbenv` install instructions](https://github.com/rbenv/rbenv#installation), and install a recent version of Ruby using `rbenv`:
 

--- a/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
@@ -6,6 +6,10 @@ pcx-content-type: how-to
 
 Jekyll is an open-source framework for creating websites, based around Markdown with Liquid templates. In this guide, you will create a new Jekyll application and deploy it using Cloudflare Pages. You will be using the `jekyll` CLI to create a new Jekyll site.
 
+<Aside type="note">
+If you have an existing Jekyll site on GitHub Pages, see [our migration guide](/pages/migrating-jekyll-from-github-pages/)
+</Aside>
+
 ## Installing Jekyll
 
 Jekyll is written in Ruby, meaning that you'll need a functioning Ruby installation in order to install Jekyll.

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -120,7 +120,7 @@ You can deploy your site to Cloudflare Pages by going to the dashboard and creat
 
 Once you've configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `jekyll`, your project dependencies, and building your site, before deploying it.
 
-<Aside>
+<Aside type="note">
 
 For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -83,9 +83,9 @@ $ bundle update
 # Bundler will show a lot of output as it fetches the dependencies
 ```
 
-This should complete successfully. If not, make sure you've copied the `github-pages` line above exactly, and have *not* commented it out with a leading `#`.
+This should complete successfully. If not, verify that you have copied the `github-pages` line above exactly, and have not commented it out with a leading `#`.
 
-You'll now need to commit these files to your repository so that Cloudflare Pages can reference them in the following steps:
+You will now need to commit these files to your repository so that Cloudflare Pages can reference them in the following steps:
 
 ```sh
 ---
@@ -98,11 +98,11 @@ $ git push origin main
 
 ## Configuring your Pages project
 
-With your GitHub Pages project now explicitly specifying its dependencies, we can now configure Cloudflare Pages. The process is almost identical to [deploying a Jekyll site](/framework-guides/deploy-a-jekyll-site).
+With your GitHub Pages project now explicitly specifying its dependencies, you can start configuring Cloudflare Pages. The process is almost identical to [deploying a Jekyll site](/framework-guides/deploy-a-jekyll-site).
 
-<Aside>
+<Aside type="note">
 
-Configuring Cloudflare Pages for the first time? Refer to the [Getting started guide](/getting-started), which covers how to connect your existing GitHub repository to Cloudflare Pages.
+If you are configuring your Cloudflare Pages site for the first time, refer to the [Getting started guide](/getting-started#connect-to-github), which explains how to connect your existing GitHub repository to Cloudflare Pages.
 
 </Aside>
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -73,7 +73,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem "github-pages", "~> 215", group: :jekyll_plugins
 ```
 
-We can now run `bundle update`, which will install the `github-pages` gem for us, and create a `Gemfile.lock` file with the resolved dependency versions.
+Run `bundle update`, which will install the `github-pages` gem for you, and create a `Gemfile.lock` file with the resolved dependency versions.
 
 ```sh
 ---

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -23,7 +23,7 @@ This tutorial assumes:
 
 1. You have an existing GitHub Pages site using [Jekyll](https://jekyllrb.com/)
 2. You have some familiarity with running Ruby's command-line tools, and have both `gem` and `bundle` installed.
-3. You know how to use a few basic Git operations, including `add`, `commit`, `push`, `pull`.
+3. You know how to use a few basic Git operations, including `add`, `commit`, `push`, and `pull`.
 4. You have read the [Get Started](/getting-started) guide for Cloudflare Pages.
 
 If you do not have Rubygems (`gem`) or Bundler (`bundle`) installed on your machine, refer to the installation guides for [Rubygems](https://rubygems.org/pages/download) and [Bundler](https://bundler.io/).

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -134,7 +134,7 @@ If you're using a [custom domain with GitHub Pages](https://docs.github.com/en/p
 
 Note that it may take some time for DNS caches to expire and for this change to be reflected, depending on the DNS TTL (time-to-live) value you set when you originally created the record.
 
-Refer to the [adding a custom domain](/getting-started#adding-a-custom-domain) section of the Getting Started guide for a list of detailed steps.
+Refer to the [adding a custom domain](/getting-started#adding-a-custom-domain) section of the Get started guide for a list of detailed steps.
 
 ## What's next?
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -32,7 +32,7 @@ If you do not have Rubygems (`gem`) or Bundler (`bundle`) installed on your mach
 
 <Aside type="note">
 
-**If your GitHub Pages repo already has a `Gemfile` and `Gemfile.lock` present, you can skip this step entirely.** The GitHub Pages environment assumes a default set of Jekyll plugins that aren't explicitly specified in a `Gemfile`.
+If your GitHub Pages repository already has a `Gemfile` and `Gemfile.lock` present, you can skip this step entirely. The GitHub Pages environment assumes a default set of Jekyll plugins that are not explicitly specified in a `Gemfile`.
 
 </Aside>
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -30,7 +30,7 @@ If you do not have Rubygems (`gem`) or Bundler (`bundle`) installed on your mach
 
 ## Preparing your GitHub Pages repository
 
-<Aside>
+<Aside type="note">
 
 **If your GitHub Pages repo already has a `Gemfile` and `Gemfile.lock` present, you can skip this step entirely.** The GitHub Pages environment assumes a default set of Jekyll plugins that aren't explicitly specified in a `Gemfile`.
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -6,7 +6,7 @@ pcx-content-type: tutorial
 
 # Migrating from GitHub Pages
 
-This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages. Jekyll has been one of the most popular static site generators used with GitHub Pages, and migrating it to Cloudflare Pages only takes a few steps.
+This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages. Jekyll has been one of the most popular static site generators used with GitHub Pages, and migrating your GitHub Pages site to Cloudflare Pages will take a few short steps.
 
 This tutorial will guide you through:
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -38,7 +38,7 @@ If your GitHub Pages repository already has a `Gemfile` and `Gemfile.lock` prese
 
 Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependency configuration file) to allow Cloudflare Pages to fetch and install those dependencies during the [build step](/platform/build-configuration).
 
-Specifically, we need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
+Specifically, you will need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
 
 ```sh
 ---

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -122,7 +122,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside type="note">
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, refer to [the Get started guide](/getting-started).
 
 </Aside>
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -130,7 +130,7 @@ Once you've deployed your site, you'll receive a unique subdomain for your proje
 
 ## Migrating your custom domain
 
-If you're using a [custom domain with GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site), you'll need to update your DNS record(s) to point at your new Cloudflare Pages deployment. This will require you to update the `CNAME` record at the DNS provider for your domain to point to `<your-pages-site>.pages.dev`, replacing `<your-username>.github.io`.
+If you are using a [custom domain with GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site), you must update your DNS record(s) to point at your new Cloudflare Pages deployment. This will require you to update the `CNAME` record at the DNS provider for your domain to point to `<your-pages-site>.pages.dev`, replacing `<your-username>.github.io`.
 
 Note that it may take some time for DNS caches to expire and for this change to be reflected, depending on the DNS TTL (time-to-live) value you set when you originally created the record.
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -118,7 +118,7 @@ You can deploy your site to Cloudflare Pages by going to the dashboard and creat
 
 </TableLayout>
 
-Once you've configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `jekyll`, your project dependencies, and building your site, before deploying it.
+After you have configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `jekyll`, your project dependencies, and building your site, before deploying it.
 
 <Aside type="note">
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -33,20 +33,15 @@ If you don't have Rubygems (`gem`) or Bundler (`bundle`) installed on your machi
 
 </Aside>
 
-Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependency configuration file) to allow Cloudflare Pages to fetch and install those dependencies during the [build step](/platform/build-configuration). Specifically, we need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
+Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependency configuration file) to allow Cloudflare Pages to fetch and install those dependencies during the [build step](/platform/build-configuration).
+
+Specifically, we need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
 
 ```sh
 ---
 header: Create a Gemfile
 ---
 $ cd my-github-pages-repo
-$ bundle init
-```
-
-```sh
----
-header: Add the github-pages gem
----
 $ bundle init
 ```
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -6,19 +6,22 @@ pcx-content-type: tutorial
 
 # Migrating from GitHub Pages
 
-This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages.
+This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages. Jekyll has been one of the most popular static site generators used with GitHub Pages, and migrating it to Cloudflare Pages only takes a few steps.
 
-We will:
+This tutorial will guide you through:
 
-1. Add the list of dependencies used by our existing Jekyll-based repository on GitHub Pages 
-2. Create a new Cloudflare Pages site, connected to our GitHub repository
-3. Build and deploy our site on Cloudflare Pages.
+1. Adding the necessary dependencies used by GitHub Pages to your project configuration.
+2. Creating a new Cloudflare Pages site, connected to your existing GitHub repository.
+3. Building and deploying your site on Cloudflare Pages.
+4. (Optional) Migrating your custom domain.
+
+Including build times, this tutorial should take you less than 15 minutes to complete.
 
 ## Before you begin
 
 This tutorial assumes:
 
-1. You have an existing GitHub Pages site using Jekyll
+1. You have an existing GitHub Pages site using [Jekyll](https://jekyllrb.com/)
 2. You have some familiarity with running Ruby's command-line tools, and have both `gem` and `bundle` installed.
 3. You know how to use a few basic Git operations, including `add`, `commit`, `push`, `pull`.
 4. You have read the [Get Started](/getting-started) guide for Cloudflare Pages.

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -126,7 +126,7 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 
 </Aside>
 
-Once you've deployed your site, you'll receive a unique subdomain for your project on `pages.dev`. Every time you commit new code to your Jekyll site, Cloudflare Pages will automatically rebuild your project and deploy it. You'll also get access to [preview deployments](/platform/preview-deployments) on new pull requests, so you can preview how changes look to your site before deploying them to production.
+After you have deployed your site, you will receive a unique subdomain for your project on `pages.dev`. Every time you commit new code to your Jekyll site, Cloudflare Pages will automatically rebuild your project and deploy it. You will also get access to [preview deployments](/platform/preview-deployments) on new pull requests, so you can preview how changes look to your site before deploying them to production.
 
 ## Migrating your custom domain
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -106,7 +106,7 @@ Configuring Cloudflare Pages for the first time? Refer to the [Getting started g
 
 </Aside>
 
-You can deploy your site to Cloudflare Pages by going to the dashboard and creating a new site. Select the *existing* GitHub repository you use for your GitHub Pages site, and in the configuration section, provide the following information:
+Begin deployment of your site to Cloudflare Pages by going to your Pages dashboard through the account home and select **Create a project**. Choose the existing GitHub repository you use for your GitHub Pages site, and select **Install & Authorize** and **Begin setup** to continue. Next, on the **Set up builds and deployments** page, provide the following information:
 
 <TableLayout>
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -26,7 +26,7 @@ This tutorial assumes:
 3. You know how to use a few basic Git operations, including `add`, `commit`, `push`, `pull`.
 4. You have read the [Get Started](/getting-started) guide for Cloudflare Pages.
 
-If you don't have Rubygems (`gem`) or Bundler (`bundle`) installed on your machine, refer to the installation guides for [Rubygems](https://rubygems.org/pages/download) and [Bundler](https://bundler.io/).
+If you do not have Rubygems (`gem`) or Bundler (`bundle`) installed on your machine, refer to the installation guides for [Rubygems](https://rubygems.org/pages/download) and [Bundler](https://bundler.io/).
 
 ## Preparing your GitHub Pages repository
 

--- a/products/pages/src/content/migrations/migrating-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-from-github-pages.md
@@ -1,0 +1,145 @@
+---
+updated: 2021-07-16
+difficulty: Beginner
+pcx-content-type: tutorial
+---
+
+# Migrating from GitHub Pages
+
+This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages.
+
+We will:
+
+1. Add the list of dependencies used by our existing Jekyll-based repository on GitHub Pages 
+2. Create a new Cloudflare Pages site, connected to our GitHub repository
+3. Build and deploy our site on Cloudflare Pages.
+
+## Before you begin
+
+This tutorial assumes:
+
+1. You have an existing GitHub Pages site using Jekyll
+2. You have some familiarity with running Ruby's command-line tools, and have both `gem` and `bundle` installed.
+3. You know how to use a few basic Git operations, including `add`, `commit`, `push`, `pull`.
+4. You have read the [Get Started](/getting-started) guide for Cloudflare Pages.
+
+If you don't have Rubygems (`gem`) or Bundler (`bundle`) installed on your machine, refer to the installation guides for [Rubygems](https://rubygems.org/pages/download) and [Bundler](https://bundler.io/).
+
+## Preparing your GitHub Pages repository
+
+<Aside>
+
+**If your GitHub Pages repo already has a `Gemfile` and `Gemfile.lock` present, you can skip this step entirely.** The GitHub Pages environment assumes a default set of Jekyll plugins that aren't explicitly specified in a `Gemfile`.
+
+</Aside>
+
+Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependency configuration file) to allow Cloudflare Pages to fetch and install those dependencies during the [build step](/platform/build-configuration). Specifically, we need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
+
+```sh
+---
+header: Create a Gemfile
+---
+$ cd my-github-pages-repo
+$ bundle init
+```
+
+```sh
+---
+header: Add the github-pages gem
+---
+$ bundle init
+```
+
+Open the `Gemfile` that was created for you, and add the following line to the bottom of the file:
+
+```ruby
+---
+header: Specifying the github-pages version
+---
+gem "github-pages", "~> 215", group: :jekyll_plugins
+```
+
+Your `Gemfile` should resemble the below:
+
+```ruby
+---
+filename: Gemfile
+---
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+gem "github-pages", "~> 215", group: :jekyll_plugins
+```
+
+We can now run `bundle update`, which will install the `github-pages` gem for us, and create a `Gemfile.lock` file with the resolved dependency versions.
+
+```sh
+---
+header: Running bundle update
+---
+$ bundle update
+# Bundler will show a lot of output as it fetches the dependencies
+```
+
+This should complete successfully. If not, make sure you've copied the `github-pages` line above exactly, and have *not* commented it out with a leading `#`.
+
+You'll now need to commit these files to your repository so that Cloudflare Pages can reference them in the following steps:
+
+```sh
+---
+header: Commit Gemfile and Gemfile.lock
+---
+$ git add Gemfile Gemfile.lock
+$ git commit -m "deps: added Gemfiles"
+$ git push origin main
+```
+
+## Configuring your Pages project
+
+With your GitHub Pages project now explicitly specifying its dependencies, we can now configure Cloudflare Pages. The process is almost identical to [deploying a Jekyll site](/framework-guides/deploy-a-jekyll-site).
+
+<Aside>
+
+Configuring Cloudflare Pages for the first time? Refer to the [Getting started guide](/getting-started), which covers how to connect your existing GitHub repository to Cloudflare Pages.
+
+</Aside>
+
+You can deploy your site to Cloudflare Pages by going to the dashboard and creating a new site. Select the *existing* GitHub repository you use for your GitHub Pages site, and in the configuration section, provide the following information:
+
+<TableLayout>
+
+| Configuration option | Value          |
+| -------------------- | -------------- |
+| Production branch    | `main`         |
+| Build command        | `jekyll build` |
+| Build directory      | `_site`        |
+
+</TableLayout>
+
+Once you've configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `jekyll`, your project dependencies, and building your site, before deploying it.
+
+<Aside>
+
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+
+</Aside>
+
+Once you've deployed your site, you'll receive a unique subdomain for your project on `pages.dev`. Every time you commit new code to your Jekyll site, Cloudflare Pages will automatically rebuild your project and deploy it. You'll also get access to [preview deployments](/platform/preview-deployments) on new pull requests, so you can preview how changes look to your site before deploying them to production.
+
+## Migrating your custom domain
+
+If you're using a [custom domain with GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site), you'll need to update your DNS record(s) to point at your new Cloudflare Pages deployment. This will require you to update the `CNAME` record at the DNS provider for your domain to point to `<your-pages-site>.pages.dev`, replacing `<your-username>.github.io`.
+
+Note that it may take some time for DNS caches to expire and for this change to be reflected, depending on the DNS TTL (time-to-live) value you set when you originally created the record.
+
+Refer to the [adding a custom domain](/getting-started#adding-a-custom-domain) section of the Getting Started guide for a list of detailed steps.
+
+## What's next?
+
+* Learn how to [customize HTTP response headers](/how-to/add-custom-http-headers) for your Pages site using Cloudflare Workers.
+* Understand how to [rollback a potentially broken deployment](/platform/rollbacks) to a previously working version.
+* [Configure redirects](/platform/redirects) so that visitors are always directed to your 'canonical' custom domain.

--- a/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
@@ -1,10 +1,10 @@
 ---
-updated: 2021-07-16
+updated: 2021-07-27
 difficulty: Beginner
 pcx-content-type: tutorial
 ---
 
-# Migrating from GitHub Pages
+# Migrating a Jekyll-based site from GitHub Pages
 
 This tutorial shows how to migrate an existing [GitHub Pages site using Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll) to Cloudflare Pages. Jekyll has been one of the most popular static site generators used with GitHub Pages, and migrating your GitHub Pages site to Cloudflare Pages will take a few short steps.
 
@@ -16,6 +16,10 @@ This tutorial will guide you through:
 4. (Optional) Migrating your custom domain.
 
 Including build times, this tutorial should take you less than 15 minutes to complete.
+
+<Aside type="note">
+If you have a Jekyll-based site **not** deployed on GitHub Pages, refer to [the Jekyll framework guide](/pages/deploy-a-jekyll-site).
+</Aside>
 
 ## Before you begin
 

--- a/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
@@ -106,7 +106,7 @@ With your GitHub Pages project now explicitly specifying its dependencies, you c
 
 <Aside type="note">
 
-If you are configuring your Cloudflare Pages site for the first time, refer to the [Getting started guide](/getting-started#connect-to-github), which explains how to connect your existing GitHub repository to Cloudflare Pages.
+If you are configuring your Cloudflare Pages site for the first time, refer to the [Get started guide](/getting-started#connect-to-github), which explains how to connect your existing GitHub repository to Cloudflare Pages.
 
 </Aside>
 

--- a/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
+++ b/products/pages/src/content/migrations/migrating-jekyll-from-github-pages.md
@@ -18,9 +18,10 @@ This tutorial will guide you through:
 Including build times, this tutorial should take you less than 15 minutes to complete.
 
 <Aside type="note">
-If you have a Jekyll-based site **not** deployed on GitHub Pages, refer to [the Jekyll framework guide](/pages/deploy-a-jekyll-site).
-</Aside>
 
+If you have a Jekyll-based site not deployed on GitHub Pages, refer to [the Jekyll framework guide](/pages/deploy-a-jekyll-site).
+
+</Aside>
 ## Before you begin
 
 This tutorial assumes:


### PR DESCRIPTION
Provides a migration guide for migrating an existing Jekyll-based (the most common framework) site on GitHub Pages to Cloudflare Pages.

I recently ran through this myself (https://twitter.com/elithrar/status/1415733165641986049?s=20) after realizing that Cloudflare Pages wasn't successfully building my GitHub Pages repo out-of-the-box - due to the missing `Gemfile`(s).

First draft and open to further feedback!