### PR TITLE
Add redirects to Dev Docs homepage

### DIFF
--- a/developers.cloudflare.com/wrangler.toml
+++ b/developers.cloudflare.com/wrangler.toml
@@ -8,6 +8,9 @@ workers_dev = false
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 zone_id = "351cf9fc660523187714fa772ad5ca49"
 route = "https://developers.cloudflare.com/*"
+kv_namespaces = [
+    { binding = "REDIRECTS", id = "42719e2c4502479e9145f347015e5b34" }
+]
 
 [site]
 bucket = "./public"


### PR DESCRIPTION
Adding redirects at this level to be able to delete doc folders for old products and keep redirecting readers to the correct URLs.