### PR TITLE
Update terraform-provider-cloudflare URL

### DIFF
--- a/products/api/src/content/index.md
+++ b/products/api/src/content/index.md
@@ -27,4 +27,4 @@ For specific guidance on making API calls, see the following:
 
 * The specific [Developer Docs section](https://developers.cloudflare.com) for a service for how to guides.
 * [API schema docs](https://api.cloudflare.com) for request and response payloads for each endpoint.
-* If you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/terraform-providers/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.
+* If you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/cloudflare/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.


### PR DESCRIPTION
Terraform's provider is now at https://github.com/cloudflare/terraform-provider-cloudflare