### PR TITLE
Update example for client certificate in an Android app

### DIFF
--- a/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
+++ b/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
@@ -310,15 +310,15 @@ private OkHttpClient setUpClient() {
         keyStore.setKeyEntry("client", keyFactory.generatePrivate(keySpec), SECRET.toCharArray(), new Certificate[]{certificate});
         certificateInputStream.close();
 
-        // Set up Trust Managers
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trustManagerFactory.init((KeyStore) null);
-        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-
         // Set up Key Managers
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(keyStore, SECRET.toCharArray());
         KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+
+        // Set up Trust Managers
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore) null);
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
 
         // Obtain SSL Socket Factory
         SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -327,7 +327,7 @@ private OkHttpClient setUpClient() {
 
         // Finally, return the client, which will then be used to make HTTP calls.
         OkHttpClient client = new OkHttpClient.Builder()
-                .sslSocketFactory(sslSocketFactory)
+                .sslSocketFactory(sslSocketFactory, (X509TrustManager) trustManagers[0])
                 .build();
 
         return client;

--- a/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
+++ b/products/ssl/src/content/client-certificates/configure-your-mobile-app-or-iot-device.md
@@ -310,15 +310,15 @@ private OkHttpClient setUpClient() {
         keyStore.setKeyEntry("client", keyFactory.generatePrivate(keySpec), SECRET.toCharArray(), new Certificate[]{certificate});
         certificateInputStream.close();
 
-        // Set up Key Managers
-        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, SECRET.toCharArray());
-        KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
-
         // Set up Trust Managers
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init((KeyStore) null);
         TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+
+        // Set up Key Managers
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, SECRET.toCharArray());
+        KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
 
         // Obtain SSL Socket Factory
         SSLContext sslContext = SSLContext.getInstance("TLS");


### PR DESCRIPTION
The method `OkHttpClient.Builder().sslSocketFactory` has been updated with new signature, so the example should be updated as well: https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/ssl-socket-factory/