### PR TITLE
[TEAMS] Links now point to github instead of equinox

### DIFF
--- a/products/access/src/content/common-access-configurations/gitlab.md
+++ b/products/access/src/content/common-access-configurations/gitlab.md
@@ -48,8 +48,8 @@ Cloudflare Argo Tunnel creates a secure, outbound-only, connection between this 
 Argo Tunnel can be installed on the machine with the following commands.
 
 ```sh
-$ sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-$ sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+$ sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 Once installed, you will need to authenticate `cloudflared`. The following command will print a URL that can be visited in another machine with a browser.

--- a/products/access/src/content/other-protocols/smb-guide.md
+++ b/products/access/src/content/other-protocols/smb-guide.md
@@ -37,8 +37,7 @@ For example, on a Windows server, the following Powershell example can be used.
 ```bash
 New-Item -Path "C:\cloudflared" -ItemType "directory"
 Set-Location "C:\cloudflared"
-(New-Object System.Net.WebClient).DownloadFile("https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-windows-amd64.zip","c:\cloudflared\cloudflared.zip")
-Expand-Archive -LiteralPath c:\cloudflared\cloudflared.zip -DestinationPath c:\cloudflared
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe","c:\cloudflared\cloudflared.exe")
 ```
 
 ## 2. Authenticate the Cloudflare daemon

--- a/products/access/src/content/protocols-and-connections/SMB-file-shares.md
+++ b/products/access/src/content/protocols-and-connections/SMB-file-shares.md
@@ -41,8 +41,7 @@ For example, on a Windows server, the following Powershell example can be used.
 ```bash
 New-Item -Path "C:\cloudflared" -ItemType "directory"
 Set-Location "C:\cloudflared"
-(New-Object System.Net.WebClient).DownloadFile("https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-windows-amd64.zip","c:\cloudflared\cloudflared.zip")
-Expand-Archive -LiteralPath c:\cloudflared\cloudflared.zip -DestinationPath c:\cloudflared
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe","c:\cloudflared\cloudflared.exe")
 ```
 ### 2. Authenticate `cloudflared`
 

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/installation.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/installation.md
@@ -15,11 +15,11 @@ Detailed release notes can be found on the [GitHub RELEASE_NOTES file](https://g
 
 <TableWrap>
 
-Type   | amd64 / x86-64 | x86 (32-bit) | ARMv6 | ARM64 |
--------|----------------|--------------|------|------|
-Binary | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.tgz) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-386.tgz) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.tgz) | [Download from GitHub](https://github.com/cloudflare/cloudflared/releases) |
-.deb   | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-386.deb) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.deb) | - |
-.rpm   | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.rpm) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-386.rpm) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.rpm) | - |
+Type   | amd64 / x86-64 | x86 (32-bit) | ARM64|
+-------|----------------|--------------|------|
+Binary | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-386) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64) |
+.deb   | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-386.deb) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm.deb) |
+.rpm   | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-x86_64.rpm) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-386.rpm) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm.rpm) |
 
 </TableWrap>
 
@@ -28,8 +28,8 @@ Binary | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux
 Use the `deb` package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` package in this example.
 
 ```bash
-wget -q https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-dpkg -i cloudflared-stable-linux-amd64.deb
+wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+dpkg -i cloudflared-linux-amd64.deb
 ```
 
 ### `.rpm` install
@@ -37,8 +37,8 @@ dpkg -i cloudflared-stable-linux-amd64.deb
 Use the `rpm` package manager to install `cloudflared` on compatable machines. `amd64 / x86-64` is used in this example.
 
 ```bash
-wget -q https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.rpm
-rpm -ivh cloudflared-stable-linux-amd64.rpm
+wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-x86_64.rpm
+rpm -ivh cloudflared-linux-x86_64.rpm
 ```
 
 ### Build from source
@@ -70,13 +70,13 @@ You can install `cloudflared` on macOS systems via Homebrew:
 $ brew install cloudflare/cloudflare/cloudflared
 ```
 
-Alternatively, you can [download the latest Darwin amd64 release directly](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-darwin-amd64.zip).
+Alternatively, you can [download the latest Darwin amd64 release directly](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz).
 
 ## Windows
 
 Type   | 32-bit | 64-bit |
 -------|----------------|-----|
-ZIP | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-windows-386.zip) | [Download](https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-windows-amd64.zip) |
+ZIP | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-386.exe) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe) |
 
 Once `cloudflared` is installed:
 1. Navigate to the **Downloads** folder.

--- a/products/cloudflare-one/src/content/tutorials/gitlab.md
+++ b/products/cloudflare-one/src/content/tutorials/gitlab.md
@@ -130,8 +130,8 @@ Cloudflare Tunnel creates a secure, outbound-only, connection between this machi
 Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the Digital Ocean machine with the two commands below.
 
 ```bash
-sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 Once installed, authenticate the instance of `cloudflared` with the following command.

--- a/products/cloudflare-one/src/content/tutorials/kubectl.md
+++ b/products/cloudflare-one/src/content/tutorials/kubectl.md
@@ -53,8 +53,8 @@ Cloudflare Tunnel creates a secure, outbound-only connection between this machin
 Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install `cloudflared` with the commands below. You can find releases for other operating systems [here](https://github.com/cloudflare/cloudflared/releases).
 
 ```sh
-sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 ## Authenticate `cloudflared`

--- a/products/cloudflare-one/src/content/tutorials/ssh-browser.md
+++ b/products/cloudflare-one/src/content/tutorials/ssh-browser.md
@@ -54,8 +54,8 @@ Cloudflare Tunnel creates a secure, outbound-only, connection between this machi
 Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install `cloudflared` with the commands below. You can find releases for other operating systems [here](https://github.com/cloudflare/cloudflared/releases).
 
 ```sh
-$ sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-$ sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+$ sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 ## Authenticate `cloudflared`

--- a/products/cloudflare-one/src/content/tutorials/ssh.md
+++ b/products/cloudflare-one/src/content/tutorials/ssh.md
@@ -55,8 +55,8 @@ Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare 
 For example, `cloudflared` can be installed on Debian and its derivatives with these commands:
 
 ```sh
-$ sudo wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
-$ sudo dpkg -i ./cloudflared-stable-linux-amd64.deb
+$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+$ sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 ## Authenticate `cloudflared`


### PR DESCRIPTION
We now have all assets uploaded to github.com/cloudflared/cloudflared
and therefore point the links that previously pointed to equinox to
github release's `latest` links.