### PR TITLE
Updated documentation to reflect correct options.

### DIFF
--- a/products/terraform/src/content/advanced-topics/importing-cloudflare-resources.md
+++ b/products/terraform/src/content/advanced-topics/importing-cloudflare-resources.md
@@ -29,26 +29,26 @@ You can use `cf-terraforming` or `cf-terraforming -h` to view the help file, but
 
 The list of supported resources currently are:
 
-* [access_application](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application)
-* [access_policy](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy)
-* [access_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_rule)
-* [account_member](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/account_member)
-* [custom_pages](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/custom_pages)
-* [filter](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/filter)
-* [firewall_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/firewall_rule)
-* [load_balancer](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer)
-* [load_balancer_monitor](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_monitor)
-* [load_balancer_pool](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_pool)
-* [page_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/page_rule)
-* [rate_limit](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/rate_limit)
-* [record](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record)
-* [spectrum_application](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/spectrum_application)
-* [waf_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/waf_rule)
-* [worker_route](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/worker_route)
-* [worker_script](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/worker_script)
-* [zone](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone)
-* [zone_lockdown](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_lockdown)
-* [zone_settings_override](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_settings_override)
+* [cloudflare_access_application](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_application)
+* [cloudflare_access_policy](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_policy)
+* [cloudflare_access_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/access_rule)
+* [cloudflare_account_member](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/account_member)
+* [cloudflare_custom_pages](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/custom_pages)
+* [cloudflare_filter](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/filter)
+* [cloudflare_firewall_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/firewall_rule)
+* [cloudflare_load_balancer](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer)
+* [cloudflare_load_balancer_monitor](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_monitor)
+* [cloudflare_load_balancer_pool](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_pool)
+* [cloudflare_page_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/page_rule)
+* [cloudflare_rate_limit](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/rate_limit)
+* [cloudflare_record](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record)
+* [cloudflare_spectrum_application](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/spectrum_application)
+* [cloudflare_waf_rule](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/waf_rule)
+* [cloudflare_worker_route](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/worker_route)
+* [cloudflare_worker_script](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/worker_script)
+* [cloudflare_zone](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone)
+* [cloudflare_zone_lockdown](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_lockdown)
+* [cloudflare_zone_settings_override](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_settings_override)
 
 ## Importing existing Cloudflare resources
 
@@ -73,7 +73,7 @@ We start by making a call to Cf-Terraforming to enumerate the Terraform configur
 
 Note: The below command assumes you run the tool from `{GOPATH}/src/github.com/cloudflare/cf-terraforming`. If pulled with `go get` and if `$GOPATH/bin` is in your `$PATH` you should be able to just run the tool with `$ cf-terraforming <parameters>`.
 ```
-$ go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --token $CLOUDFLARE_API_TOKEN -z 1109d899a5ff5fd74bc01e581693685a record > importing-example.tf
+$ go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --token $CLOUDFLARE_API_TOKEN -z 1109d899a5ff5fd74bc01e581693685a --resource-type cloudflare_record > importing-example.tf
 ```
 
 If output to standard out, the result would look like the below. In this case we directly imported the configuration into our Terraform configuration file `importing-state.tf`.


### PR DESCRIPTION
Without these changes (using `--resource-type <resource_type>` and the resource types being prefixed with `cloudflare_`), you'll get ...
```
$ cf-terraforming --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY --zone $CLOUDFLARE_ZONE_ID --verbose generate record
DEBU[0000] initializing cloudflare-go                    account_id= email=********** zone_id=**********
DEBU[0004] initialising Terraform in .                  
DEBU[0005] reading Terraform schema for Cloudflare provider 
DEBU[0006] beginning to read and build  resources       
"" is not yet supported for automatic generation
```

This is using `cf-terraforming v0.2.0`.