### PR TITLE
[Logs] PCX-1815: Add account-scoped example for Logpush API fields endpoint

### DIFF
--- a/products/logs/src/content/reference/log-fields/index.md
+++ b/products/logs/src/content/reference/log-fields/index.md
@@ -7,9 +7,9 @@ pcx-content-type: navigation
 # Log fields
 
 The data sets below describe the fields available by log category. The list of fields is also accessible directly from the API:
-`https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields`, where the `dataset` argument indicates the log category (such as `http_requests`, `spectrum_events`, `firewall_events`, etc). 
+`https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields` for zone-scoped data set, or `https://api.cloudflare.com/client/v4/accounts/<account_id>/logpush/datasets/<dataset>/fields` for account-scoped data set, where the `dataset` argument indicates the log category (such as `http_requests`, `spectrum_events`, `firewall_events`, etc).
 
-HTTP requests are available in both Logpush and Logpull. All other data sets are only available through Logpush.
+Zone-scoped HTTP requests are available in both Logpush and Logpull. All other data sets are only available through Logpush.
 
 Unless otherwise noted, fields are available in both Logpush v1 (Logpush prior to mid-2020) and Logpush v2 (all Logpush jobs after mid-2020).
 

--- a/products/logs/src/content/reference/log-fields/index.md
+++ b/products/logs/src/content/reference/log-fields/index.md
@@ -7,7 +7,7 @@ pcx-content-type: navigation
 # Log fields
 
 The data sets below describe the fields available by log category. The list of fields is also accessible directly from the API:
-`https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields` for zone-scoped data set, or `https://api.cloudflare.com/client/v4/accounts/<account_id>/logpush/datasets/<dataset>/fields` for account-scoped data set, where the `dataset` argument indicates the log category (such as `http_requests`, `spectrum_events`, `firewall_events`, etc).
+`https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields` for zone-scoped data sets or `https://api.cloudflare.com/client/v4/accounts/<account_id>/logpush/datasets/<dataset>/fields` for account-scoped data sets, where the `dataset` argument indicates the log category (such as `http_requests`, `spectrum_events`, `firewall_events`, etc).
 
 Zone-scoped HTTP requests are available in both Logpush and Logpull. All other data sets are only available through Logpush.
 


### PR DESCRIPTION
This adds account-scoped example for Logpush API `fields` endpoint, since account-scoped data sets are added here: https://github.com/cloudflare/cloudflare-docs/pull/1861