### PR TITLE
Add .NET to list of language support/frameworks

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -79,6 +79,7 @@ Here are the pinned versions for tools included in the Cloudflare Workers build 
 | PHP       | 5.6             | `PHP_VERSION`        |                           |
 | Python    | 2.7             | `PYTHON_VERSION`     | `runtime.txt`, `Pipfile`  |
 | Ruby      | 2.6.2           | `RUBY_VERSION`       | `.ruby-version`           |
+| .NET      | 3.1.302         |                      |                           |
 
 Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
 


### PR DESCRIPTION
We noticed that the build environment now comes with .NET out of the box, but the documentation does not list it.
I added .NET to the table with the version I saw from running `dotnet --info` during Cloudflare pages build.
Not sure if .NET should be at the top or bottom when sorting alphabetically, but I put it at the bottom.