### PR TITLE
Edge Cache TTL can work without Cache Everything

### DIFF
--- a/products/cache/src/content/about/edge-browser-cache-ttl.md
+++ b/products/cache/src/content/about/edge-browser-cache-ttl.md
@@ -8,7 +8,7 @@ pcx-content-type: concept
 
 ## Edge Cache TTL
 
-Edge Cache TTL (Time to Live) specifies how long to cache a resource in the Cloudflare edge network. Edge Cache TTL only takes effect when included in a page rule setting that sets **Cache Level** to **Cache Everything**. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
+Edge Cache TTL (Time to Live) specifies how long to cache a resource in the Cloudflare edge network.  Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
 
 - Free - 2 hours
 - Pro - 1 hour


### PR DESCRIPTION
I would like this to be fixed because Edge Cache TTL of Page Rules can work now without Cache Everything.
I have confirmed it works in my test env and most people have recognized this behavior.