### PR TITLE
Update with proper link.

### DIFF
--- a/products/workers/src/content/examples/logging-headers.md
+++ b/products/workers/src/content/examples/logging-headers.md
@@ -87,7 +87,7 @@ This works because:
 
 The Map trick works great for simple calls to `console.log()`, but if we need to actually stringify our headers, we quickly find out that stringifying a Map yields nothing more than `[object Map]`, which isn’t very helpful.
 
-The JSON stringifier can’t help us, either: even though our Map stores its data in an enumerable property, that property is [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)-keyed, and `JSON.stringify()` [ignores Symbol-keyed properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) — we end up with an empty `{}` again.
+The JSON stringifier can’t help us, either: even though our Map stores its data in an enumerable property, that property is [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)-keyed, and `JSON.stringify()` [ignores Symbol-keyed properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#symbols_and_json.stringify) — we end up with an empty `{}` again.
 
 Instead, we can take advantage of the iterability of the Headers object in a new way by applying the [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator) (`...`) to it.
 


### PR DESCRIPTION
- Previously the link did point to `JSON.stringify`'s Description section but with the ID of **#Description** whereas the ID of the section is **#description**.
- There's a section within [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#symbols_and_json.stringify) Docs which explains the same thing so I've linked to that instead.