### PR TITLE
[Pages] Fix get started links

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -62,7 +62,7 @@ After configuring your site, you can begin your first deploy. You should see Clo
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, refer to the [Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, refer to the [Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-gatsby-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-gatsby-site.md
@@ -50,7 +50,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-hugo-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-hugo-site.md
@@ -176,7 +176,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-jekyll-site.md
@@ -77,7 +77,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-nextjs-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-nextjs-site.md
@@ -51,7 +51,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-react-application.md
+++ b/products/pages/src/content/framework-guides/deploy-a-react-application.md
@@ -44,7 +44,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-sphinx-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-sphinx-site.md
@@ -153,7 +153,7 @@ your project dependencies, and building your site, before deploying it.
 <Aside>
 
 For the complete guide to deploying your first site to Cloudflare Pages, check
-out [our Getting Started guide](/getting-started).
+out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-vue-application.md
+++ b/products/pages/src/content/framework-guides/deploy-a-vue-application.md
@@ -45,7 +45,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-a-zola-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-zola-site.md
@@ -96,7 +96,7 @@ Once you've configured your site, you can begin your first deploy. You should se
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-an-angular-application.md
+++ b/products/pages/src/content/framework-guides/deploy-an-angular-application.md
@@ -108,7 +108,7 @@ You'll see your first deploy pipeline in progress. Pages installs all dependenci
 
 <Aside>
 
-**Note:** For the complete guide to deploying your first site to Cloudflare Pages, check out [our Getting Started guide](/getting-started).
+**Note:** For the complete guide to deploying your first site to Cloudflare Pages, check out [our Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/framework-guides/deploy-anything.md
+++ b/products/pages/src/content/framework-guides/deploy-anything.md
@@ -36,7 +36,7 @@ Once you have configured your site, you can begin your first deploy. Your custom
 
 <Aside>
 
-For the complete guide to deploying your first site to Cloudflare Pages, refer to [the Get Started guide](/getting-started).
+For the complete guide to deploying your first site to Cloudflare Pages, refer to [the Get Started guide](/get-started).
 
 </Aside>
 

--- a/products/pages/src/content/migrations/migrating-from-firebase.md
+++ b/products/pages/src/content/migrations/migrating-from-firebase.md
@@ -33,7 +33,7 @@ If you haven't pushed your static site to GitHub before, you should do so before
 
 You can create a new repo by visiting [repo.new](https://repo.new) and following the instructions to push your project up to GitHub.
 
-You can use the ["Getting started" guide](/getting-started) to add your project to Cloudflare Pages, using the **build command** and **build directory** that you saved earlier.
+You can use the ["Getting started" guide](/get-started) to add your project to Cloudflare Pages, using the **build command** and **build directory** that you saved earlier.
 
 ## Cleaning up your old application and assigning the domain
 

--- a/products/pages/src/content/migrations/migrating-from-netlify/index.md
+++ b/products/pages/src/content/migrations/migrating-from-netlify/index.md
@@ -36,7 +36,7 @@ In the **Build & Deploy** tab, find the **Build settings** panel, which will hav
 
 Once you have found your build directory and build command, you can move your project to Cloudflare Pages.
 
-The [Getting started guide](/getting-started) will show you how to add your GitHub project to Cloudflare Pages.
+The [Getting started guide](/get-started) will show you how to add your GitHub project to Cloudflare Pages.
 
 If you choose to use a custom domain for your Pages, you can set it to the same custom domain as your currently deployed Netlify application. When Pages finishes the initial deploy of your site, you will need to delete the Workers application to start sending requests to Cloudflare Pages.
 

--- a/products/pages/src/content/migrations/migrating-from-vercel/index.md
+++ b/products/pages/src/content/migrations/migrating-from-vercel/index.md
@@ -32,7 +32,7 @@ Find the "Build & Development settings" panel, which will have the **Build Comma
 
 Once you've found your build directory and build command, you can move your project to Cloudflare Pages.
 
-The [Getting started guide](/getting-started) will show you how to add your GitHub project to Cloudflare Pages.
+The [Getting started guide](/get-started) will show you how to add your GitHub project to Cloudflare Pages.
 
 If you choose to use a custom domain for your Pages, you can set it to the same custom domain as your currently deployed Vercel application. When Pages finishes the initial deploy of your site, you will need to delete the Workers application to start sending requests to Cloudflare Pages.
 

--- a/products/pages/src/content/migrations/migrating-from-workers/index.md
+++ b/products/pages/src/content/migrations/migrating-from-workers/index.md
@@ -26,7 +26,7 @@ When moving to Cloudflare Pages, you can remove the Workers application, and any
 
 ## Creating a new Pages project
 
-Once you have these written down, you can remove everything else from your application, and push the new version of your project up to GitHub. You can use the ["Getting started" guide](/getting-started) to add your project to Cloudflare Pages, using the **build command** and **build directory** that you saved earlier.
+Once you have these written down, you can remove everything else from your application, and push the new version of your project up to GitHub. You can use the ["Getting started" guide](/get-started) to add your project to Cloudflare Pages, using the **build command** and **build directory** that you saved earlier.
 
 If you choose to use a custom domain for your Pages, you can set it to the same custom domain as your currently deployed Workers application. When Pages finishes the initial deploy of your site, you will need to delete the Workers application to start sending requests to Cloudflare Pages.
 


### PR DESCRIPTION
The getting started page changed its link from /getting-started to /get-started. This broke a lot of pages. I have gone through all of them and believe I have fixed them all. Apologies for all the commits, you can't modify multiple files in one commit from phone :NotLikeThis:

## Expected Behaviour
"Get Started" links to https://developers.cloudflare.com/pages/get-started which is a valid link

## Actual Behaviour
"Getting Started" links to https://developers.cloudflare.com/pages/getting-started which returns 404