### PR TITLE
Update robots.txt

### DIFF
--- a/developers.cloudflare.com/static/robots.txt
+++ b/developers.cloudflare.com/static/robots.txt
@@ -18,7 +18,7 @@ Sitemap: https://developers.cloudflare.com/events/sitemap.xml
 Sitemap: https://developers.cloudflare.com/firewall/sitemap.xml
 Sitemap: https://developers.cloudflare.com/fundamentals/sitemap.xml
 Sitemap: https://developers.cloudflare.com/http3/sitemap.xml
-Sitemap: https://developers.cloudflare.com/images/sitemap.xml
+Sitemap: https://developers.cloudflare.com/image-resizing/sitemap.xml
 Sitemap: https://developers.cloudflare.com/load-balancing/sitemap.xml
 Sitemap: https://developers.cloudflare.com/logs/sitemap.xml
 Sitemap: https://developers.cloudflare.com/magic-transit/sitemap.xml


### PR DESCRIPTION
Image Resizing docs has a new path; has gone from `/images` to `/image-resizing`