### PR TITLE
fix: use absolute URL for Workers Route docs

### DIFF
--- a/products/pages/src/content/how-to/add-custom-http-headers.md
+++ b/products/pages/src/content/how-to/add-custom-http-headers.md
@@ -47,7 +47,7 @@ async function handleRequest(request) {
 
 The easiest way to start deploying your Workers function is by typing [workers.new](https://workers.new/) in the browser. Log into your account to be automatically directed to the Workers dashboard. From the Workers dashboard, write your function or use one of the [examples from the Workers documentation](/workers/examples/). 
 
-Click "Save and Deploy" when your script is ready and set a [route](/workers/platform/routes/) in your domain's zone settings.
+Click "Save and Deploy" when your script is ready and set a [route](https://developers.cloudflare.com/workers/platform/routes/) in your domain's zone settings.
 
 For example, [here is a Workers script](https://developers.cloudflare.com/workers/examples/security-headers) you can copy and paste into the Workers dashboard that sets common security headers whenever a request hits your Pages URL, such as X-XSS-Protection, X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security, Content-Security-Policy (CSP), and more.
 


### PR DESCRIPTION
The relative URL `/workers/platform/routes/` resolved to the invalid URL `https://developers.cloudflare.com/pages/workers/platform/routes/` because the docs is hosted on `https://developers.cloudflare.com/pages/`.

I didn't look for more such relative URLs. Might be worth to do a quick search through the repo. I'm happy if you close this PR in favor of a more general PR fixing all such relative URLs.