### PR TITLE
Use updated Rust worker template

### DIFF
--- a/products/workers/src/content/tutorials/hello-world-rust/index.md
+++ b/products/workers/src/content/tutorials/hello-world-rust/index.md
@@ -105,13 +105,15 @@ addEventListener('fetch', (event) => {
   event.respondWith(handleRequest(event.request))
 })
 
+const { parse } = wasm_bindgen;
+const instance =  wasm_bindgen(wasm);
+
 /**
  * Fetch and log a request
  * @param {Request} request
  */
 async function handleRequest(request) {
-  const { parse } = wasm_bindgen
-  await wasm_bindgen(wasm)
+  await instance;
   const output = parse()
   let res = new Response(output, { status: 200 })
   res.headers.set('Content-type', 'text/html')


### PR DESCRIPTION
See <https://community.cloudflare.com/t/a-hanging-promise-was-canceled-rust-wasm-worker/282471/8> for the reasoning behind this change.

(The change was [already pushed as the template](https://github.com/cloudflare/rustwasm-worker-template/commit/ba67ffa532f5c8fffb9bfcbeab56277a0ea7fe75>) so this PR merely updates the tutorial to reflect that update.)