### PR TITLE
Clarify Cache API storage limit is per request

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -110,7 +110,7 @@ The following limits apply regardless of the plan used.
 | ------------------------------------- | ------ | ------- |
 | [Max object size](#cache-api)         | 512 MB | 512 MB  |
 | [Calls/request](#cache-api)           | 50     | 50      |
-| [Storage limit/request](#cache-api)   | 5 GB   | 5 GB    |
+| [Storage/request](#cache-api)         | 5 GB   | 5 GB    |
 
 </TableWrap>
 

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -106,11 +106,11 @@ The following limits apply regardless of the plan used.
 
 <TableWrap>
 
-| Feature                       | Free   | Bundled |
-| ----------------------------- | ------ | ------- |
-| [Max object size](#cache-api) | 512 MB | 512 MB  |
-| [Calls/request](#cache-api)   | 50     | 50      |
-| [Storage limit](#cache-api)   | 5 GB   | 5 GB    |
+| Feature                               | Free   | Bundled |
+| ------------------------------------- | ------ | ------- |
+| [Max object size](#cache-api)         | 512 MB | 512 MB  |
+| [Calls/request](#cache-api)           | 50     | 50      |
+| [Storage limit/request](#cache-api)   | 5 GB   | 5 GB    |
 
 </TableWrap>
 


### PR DESCRIPTION
As it stands, [the storage limit for the Cache API can be read as it applying to an account](https://discord.com/channels/595317990191398933/779390076219686943/874340364700483614).

In fact, [it is per request](https://developers.cloudflare.com/workers/platform/limits#cache-api).