### PR TITLE
Fix service worker section headings to match module headings

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -410,7 +410,7 @@ command = "npm install && npm run build"
 format = "service-worker"
 ```
 
-#### `[build]`
+##### `[build]`
 
 <Definitions>
 
@@ -428,7 +428,7 @@ format = "service-worker"
 
 </Definitions>
 
-#### `[build.upload]`
+##### `[build.upload]`
 
 <Definitions>
 


### PR DESCRIPTION
Felt weird to have the build sections for service worker in the sidebar without modules. We could go one way or the other, I just chose to remove the existing ones.