### PR TITLE
'datetimeMinute' doesn't exist but 'datetime'

### DIFF
--- a/products/analytics/src/content/graphql-api/tutorials/querying-workers-metrics/index.md
+++ b/products/analytics/src/content/graphql-api/tutorials/querying-workers-metrics/index.md
@@ -33,7 +33,7 @@ PAYLOAD='{ "query":
               cpuTimeP99
             }
             dimensions{
-              datetimeMinute
+              datetime
               scriptName
               status
             }


### PR DESCRIPTION
There is a minor error in this sample. `datetimeMinute` doesn't actually exist so the server will respond with an error. But `datetime` exists and in the sample response that is the key used as well.
For some reason someone used a wrong key in the sample request.

Documentation link
https://developers.cloudflare.com/analytics/graphql-api/tutorials/querying-workers-metrics

Error
![image](https://user-images.githubusercontent.com/4406639/129122011-a7d11bc8-0e77-4178-98fa-7167e5a1a504.png)

Success (partial view of response to hide sensitive data)
![image](https://user-images.githubusercontent.com/4406639/129122081-2a14068d-dfca-4113-a55b-21894d6d19db.png)
