### PR TITLE
Update IP Addresses for Teams ingress

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/firewall.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/firewall.md
@@ -9,16 +9,8 @@ If your organization uses a firewall or other policies to restrict Internet traf
 
 ## WARP Ingress IP
 These are the IP addresses that the WARP client will connect to. All traffic from your device to the Cloudflare edge will go through these IP addresses.
-- IPv4 Range: 162.159.192.0/24
-- IPv6 Range: 2606:4700:d0::/48
-
-
-<Aside>
-
-**Ingress IP addresses changing**
-In the future, we plan to change ingress IP addresses for Cloudflare for Teams WARP customers. The new ranges will be `162.159.193.0/24` and `2606:4700:100::/48`.
-
-</Aside>
+- IPv4 Range: 162.159.193.0/24
+- IPv6 Range: 2606:4700:100::/48
 
 ## UDP Ports
 WARP utilizes UDP for all of its communications. By default, the UDP Port required for WARP is: UDP 2408. WARP can fallback to: UDP 500, UDP 1701, or UDP 4500.


### PR DESCRIPTION
The IP Address change is now live. When connecting to a Teams organizations the client will use the following ingress IP's