### PR TITLE
[workers] Remove Aside re: modules/Durable Objects

### DIFF
--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -454,14 +454,6 @@ Modules receive all bindings (KV Namespaces, Environment Variables, and Secrets)
 
 An uploaded module may `import` other uploaded ES Modules. If using the CommonJS format, you may `require` other uploaded CommonJS modules.
 
-<Aside>
-
-  **Note:** You currently need to opt-in to the [Durable Objects](/learning/using-durable-objects)
-  open beta to be able to use the `modules` format. This restriction will be removed as modules are
-  better supported in the Workers Dashboard.
-
-</Aside>
-
 ```js
 import html from './index.html'
 


### PR DESCRIPTION
It's no longer required to have Durable Objects access on your account to deploy modules, so this Aside is out of date