### PR TITLE
1.1.1.1: show DoH on Families index page

### DIFF
--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/setup-instructions/dns-over-https.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/setup-instructions/dns-over-https.md
@@ -1,6 +1,6 @@
 ---
 order: 5
-pcx-content: interim
+pcx-content: how-to
 ---
 # DNS over HTTPS
 


### PR DESCRIPTION
The 1.1.1.1 for Families setup page does not show the DNS over HTTPS setup instructions on the index page, only in the sidebar.

This commit should fix that.