### PR TITLE
[workers] fix incorrect getCookie function in extract-cookie-value.md 

### DIFF
--- a/products/workers/src/content/examples/extract-cookie-value.md
+++ b/products/workers/src/content/examples/extract-cookie-value.md
@@ -23,13 +23,13 @@ const COOKIE_NAME = "__uid"
  * @returns {string|void} value of the cookie if found
  */
 function getCookie(request, key) {
-  const cookie = request.headers.get('Cookie')
+  const cookie = ' '+request.headers.get('Cookie')
   
   // No cookie found
   if (!cookie) return
 
   // Search for the cookie key in the header.
-  const search = `${key}=`
+  const search = ` ${key}=`
   const starts = cookie.indexOf(search)
 
   // The cookie could not be found.

--- a/products/workers/src/content/examples/extract-cookie-value.md
+++ b/products/workers/src/content/examples/extract-cookie-value.md
@@ -23,7 +23,7 @@ const COOKIE_NAME = "__uid"
  * @returns {string|void} value of the cookie if found
  */
 function getCookie(request, key) {
-  const cookie = ' '+request.headers.get('Cookie')
+  const cookie = ' ' + request.headers.get('Cookie')
   
   // No cookie found
   if (!cookie) return


### PR DESCRIPTION
fix for correct cookie find. for example, if cookie values are aaaa=triple; aa=double;
call getCookie(request, 'aa')   will return first occurance of "aa=", which leads to wrong value of "triple"

I fix searching phrase by leading space, and to all cookie string add leading space