### PR TITLE
Cleanup Linux and Download pages

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/download-warp.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/download-warp.md
@@ -35,7 +35,9 @@ Alternatively, download the client from one of the following links after checkin
   </tbody>
 </table>
 
-__[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Cloudflare_WARP_Release-x64.msi)__
+__[Windows Release Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-windows-1/distribution_groups/release)__
+
+__[Windows Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-windows/distribution_groups/beta)__
 
 ## macOS
 <table>
@@ -63,7 +65,39 @@ __[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Clou
   </tbody>
 </table>
 
-__[Download Cloudflare_WARP.zip](https://www.cloudflarewarp.com/Cloudflare_WARP.zip)__
+__[macOS Release Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-macos-1/distribution_groups/release)__
+
+__[macOS Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-macos/distribution_groups/beta)__
+
+## Linux
+<table>
+  <tbody>
+    <tr>
+      <td><strong>OS Ver</strong></td>
+      <td>CentOS 8, RHEL, Ubuntu, Debian</td>
+    </tr>
+    <tr>
+      <td><strong>OS Type</strong></td>
+      <td>64bit only</td>
+    </tr>
+    <tr>
+      <td><strong>HD Space</strong></td>
+      <td>75MB</td>
+    </tr>
+    <tr>
+      <td><strong>Memory</strong></td>
+      <td>35MB</td>
+    </tr>
+    <tr>
+      <td><strong>Network Types</strong></td>
+      <td>WIFI or LAN</td>
+    </tr>
+  </tbody>
+</table>
+
+__[Package Download](https://pkg.cloudflareclient.com/packages/cloudflare-warp)__
+
+__[APT/YUM Repository Setup](https://pkg.cloudflareclient.com/install)__
 
 ## iOS
 <table>

--- a/products/warp-client/src/content/setting-up/linux.md
+++ b/products/warp-client/src/content/setting-up/linux.md
@@ -5,12 +5,6 @@ order: 6
 
 # Linux desktop client
 
-## Known Issues
-Thank you for using the intial release of the Linux client for WARP! Here is a list of known issues. Please check back frequently as we keep this updated.
-* Cloudflare for Teams is not yet fully supported
-* 1.1.1.1 Families blocks are not working
-
-
 ## Steps to install
 1. Find the [setup repository](https://pkg.cloudflareclient.com/).
 1. Install the `cloudflare-warp` package depending on your distro:


### PR DESCRIPTION
- Cleanup Linux release notes
- Add Linux to teams platform page
- Change Windows and Mac build pointers to be app center so admins can more easily find the specific build they are looking for