### PR TITLE
PyJWT[crypto] is required for RSAAlgorithm

### DIFF
--- a/products/cloudflare-one/src/content/identity/users/validating-json.md
+++ b/products/cloudflare-one/src/content/identity/users/validating-json.md
@@ -136,7 +136,7 @@ func main() {
 
 * flask
 * requests
-* PyJWT
+* PyJWT[crypto]
 
 ```python
 from flask import Flask, request


### PR DESCRIPTION
The PyJWT package doesn't contain the RSA Algorithm without the `cryptography` package, using `pip install pyjwt[crypto]` fixes this:

```
python AttributeError: module 'jwt.algorithms' has no attribute 'RSAAlgorithm'
```