### PR TITLE
Update tutorials type to "Tutorial"

### DIFF
--- a/products/workers/src/content/tutorials/postgres/index.md
+++ b/products/workers/src/content/tutorials/postgres/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2021-06-10
 difficulty: Intermediate
-content_type: 📝 Tutorial"
+content_type: "📝 Tutorial"
 pcx-content-type: tutorial
 ---
 

--- a/products/workers/src/content/tutorials/postgres/index.md
+++ b/products/workers/src/content/tutorials/postgres/index.md
@@ -1,7 +1,7 @@
 ---
 updated: 2021-06-10
 difficulty: Intermediate
-content_type: "💾 Storage"
+content_type: 📝 Tutorial"
 pcx-content-type: tutorial
 ---
 


### PR DESCRIPTION
This is currently "Storage", which is more about the content than medium, so changing to make it consistent with the rest until we have something for indicating content category.