### PR TITLE
Add macOS minimum version as semver 10.13

### DIFF
--- a/products/warp-client/src/content/setting-up/requirements.md
+++ b/products/warp-client/src/content/setting-up/requirements.md
@@ -38,7 +38,7 @@ __[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Clou
   <tbody>
     <tr>
       <td><strong>OS Ver</strong></td>
-      <td>High Sierra+</td>
+      <td>High Sierra+ (10.13+)</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>


### PR DESCRIPTION
It currently says "High Sierra+" and I didn't know which version number that was. So, I looked it up on [Wikipedia](https://en.wikipedia.org/wiki/MacOS_High_Sierra) and it says 10.13. So, I added it in parenthesis after the name.