### PR TITLE
[workers/pages] Chat notif on failing builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1054,7 +1054,7 @@ jobs:
           environment: 'production'
           wranglerVersion: '1.13.0'
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@releases/v1
+        uses: signalnerve/google-chat-notification@master
         with:
           name: Build
           url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}
@@ -1601,7 +1601,7 @@ jobs:
           environment: "production"
           wranglerVersion: '1.13.0'
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@releases/v1
+        uses: signalnerve/google-chat-notification@master
         with:
           name: Build
           url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1059,7 +1059,7 @@ jobs:
           name: Build
           url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}
           status: ${{ job.status }}
-        if: job.status == "failure"
+        if: ${{ failure() }}
   
   deploy-page-shield:
     runs-on: ubuntu-latest
@@ -1606,4 +1606,4 @@ jobs:
           name: Build
           url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}
           status: ${{ job.status }}
-        if: job.status == "failure"
+        if: ${{ failure() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1053,6 +1053,13 @@ jobs:
           workingDirectory: 'products/pages'
           environment: 'production'
           wranglerVersion: '1.13.0'
+      - name: Google Chat Notification
+        uses: Co-qn/google-chat-notification@releases/v1
+        with:
+          name: Build
+          url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}
+        if: job.status == "failure"
   
   deploy-page-shield:
     runs-on: ubuntu-latest
@@ -1593,3 +1600,10 @@ jobs:
           workingDirectory: "products/workers"
           environment: "production"
           wranglerVersion: '1.13.0'
+      - name: Google Chat Notification
+        uses: Co-qn/google-chat-notification@releases/v1
+        with:
+          name: Build
+          url: ${{ secrets.WDC_TEAM_GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}
+        if: job.status == "failure"


### PR DESCRIPTION
Notify the team internally when Workers/Pages docs builds fail.