### PR TITLE
[Spectrum] Update Spectrum link to get started page

### DIFF
--- a/products/spectrum/src/content/index.md
+++ b/products/spectrum/src/content/index.md
@@ -11,4 +11,4 @@ Spectrum provides security and acceleration for any TCP or UDP based application
 Spectrum is available on all paid plans. Pro and Business support selected protocols only, and Enterprise supports all TCP and UDP based traffic. For information on how billing is calculated, refer to [Billing for Spectrum](https://support.cloudflare.com/hc/articles/360041721872) for an in-depth breakdown.
 
 
-<p><Button type="primary" href="/getting-started">Get started</Button></p>
+<p><Button type="primary" href="/get-started">Get started</Button></p>


### PR DESCRIPTION
Currently, the link points to `/getting-started`, which does not exist since the page in this document is called `/get-started` (Get Started)

![image](https://user-images.githubusercontent.com/25812029/130858786-28a5eaa8-bdcb-4319-a72e-f03399dda989.png)

Referenced Links: 
Contains the wrong link: https://developers.cloudflare.com/spectrum/
Current link: https://developers.cloudflare.com/spectrum/getting-started
Correct link: https://developers.cloudflare.com/spectrum/get-started

An alternative fix here would be to change `/get-started` to `/getting-started`, however I see that we've moved away from this practice.