### PR TITLE
Migrate wrangler preview to wrangler dev

### DIFF
--- a/products/workers/src/content/learning/playground.md
+++ b/products/workers/src/content/learning/playground.md
@@ -63,7 +63,7 @@ The console displays the output of any calls to `console.log` that were called f
 
 ### Sources
 
-The sources that make up your Workers script. Note that access KV, text, and secret bindings are only accessible when authenticated with an account. This means you must be logged in to the dashboard, or use `wrangler preview` with your account credentials.
+The sources that make up your Workers script. Note that access KV, text, and secret bindings are only accessible when authenticated with an account. This means you must be logged in to the dashboard, or use `wrangler dev` with your account credentials.
 
 <!--
 

--- a/products/workers/src/content/platform/sites/start-from-existing.md
+++ b/products/workers/src/content/platform/sites/start-from-existing.md
@@ -48,7 +48,7 @@ Once you have a site generated, follow these steps:
   $ wrangler dev
   ```
 
-5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
+5. Decide where you would like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
 
   Then, update your `wrangler.toml`:
 

--- a/products/workers/src/content/platform/sites/start-from-existing.md
+++ b/products/workers/src/content/platform/sites/start-from-existing.md
@@ -45,7 +45,7 @@ Once you have a site generated, follow these steps:
 4. You can preview your site by running:
 
   ```sh
-  $ wrangler preview --watch
+  $ wrangler dev
   ```
 
 5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.

--- a/products/workers/src/content/platform/sites/start-from-scratch.md
+++ b/products/workers/src/content/platform/sites/start-from-scratch.md
@@ -29,7 +29,7 @@ To start from scratch to create a Workers Site, follow these steps:
   $ wrangler dev
   ```
 
-5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
+5. Decide where you would like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.
 
   Then, update your `wrangler.toml`:
 

--- a/products/workers/src/content/platform/sites/start-from-scratch.md
+++ b/products/workers/src/content/platform/sites/start-from-scratch.md
@@ -26,7 +26,7 @@ To start from scratch to create a Workers Site, follow these steps:
 4. You can preview your site by running:
 
   ```sh
-  $ wrangler preview --watch
+  $ wrangler dev
   ```
 
 5. Decide where you’d like to publish your site to: [a workers.dev subdomain](/get-started/guide#configure-for-deploying-to-workersdev) or your [personal domain](/get-started/guide#optional-configure-for-deploying-to-a-registered-domain) registered with Cloudflare.

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -105,9 +105,9 @@ $ tree wp-static
 
 To preview and deploy our application, we need to fill out `wrangler.toml` — the configuration file for this project. Most of the file has been pre-filled, but you need to specify your `account_id` and where you want to deploy your application. Fill out the [`account_id`](/get-started/guide#6a-obtaining-your-account-id-and-zone-id) field in `wrangler.toml` with your Cloudflare account ID.
 
-Using Wrangler’s preview feature, we can quickly upload a version of our site to the Cloudflare Workers preview service, and make sure that the static export looks like we’d expect. Running `wrangler dev` will upload your static site and preview it in a browser window.
+Using Wrangler’s preview feature, you can quickly upload a version of your site to the Cloudflare Workers preview service and check that the static export looks as expected. Running `wrangler dev` will upload your static site and preview it in a browser window.
 
-When your site looks correct in Wrangler’s preview, you can move onto publishing your project to a domain. For a guide on how to do this, check out [Getting started](/get-started/guide#6-configure-your-project-for-deployment).
+When your site looks correct in Wrangler’s preview, you can move onto publishing your project to a domain. For a guide on how to do this, check out [Get started](/get-started/guide#6-configure-your-project-for-deployment).
 
 [![Demo site](./media/wordpress--demo.png)](https://wp-static.signalnerve.workers.dev)
 

--- a/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
+++ b/products/workers/src/content/tutorials/deploy-a-static-wordpress-site/index.md
@@ -105,7 +105,7 @@ $ tree wp-static
 
 To preview and deploy our application, we need to fill out `wrangler.toml` — the configuration file for this project. Most of the file has been pre-filled, but you need to specify your `account_id` and where you want to deploy your application. Fill out the [`account_id`](/get-started/guide#6a-obtaining-your-account-id-and-zone-id) field in `wrangler.toml` with your Cloudflare account ID.
 
-Using Wrangler’s preview feature, we can quickly upload a version of our site to the Cloudflare Workers preview service, and make sure that the static export looks like we’d expect. Running `wrangler preview` will upload your static site and preview it in a browser window.
+Using Wrangler’s preview feature, we can quickly upload a version of our site to the Cloudflare Workers preview service, and make sure that the static export looks like we’d expect. Running `wrangler dev` will upload your static site and preview it in a browser window.
 
 When your site looks correct in Wrangler’s preview, you can move onto publishing your project to a domain. For a guide on how to do this, check out [Getting started](/get-started/guide#6-configure-your-project-for-deployment).
 

--- a/products/workers/src/content/tutorials/hello-world-rust/index.md
+++ b/products/workers/src/content/tutorials/hello-world-rust/index.md
@@ -121,7 +121,7 @@ async function handleRequest(request) {
 }
 ```
 
-If `wrangler preview --watch` is running, you'll see the output of your Rust program in your browser a few seconds after you save in your editor. Wrangler watches your project for changes then compiles your Rust to WebAssembly and outputs compiler errors.
+If `wrangler dev` is running, you'll see the output of your Rust program in your browser a few seconds after you save in your editor. Wrangler watches your project for changes then compiles your Rust to WebAssembly and outputs compiler errors.
 
 ## Publish
 

--- a/products/workers/src/content/tutorials/hello-world-rust/index.md
+++ b/products/workers/src/content/tutorials/hello-world-rust/index.md
@@ -121,7 +121,7 @@ async function handleRequest(request) {
 }
 ```
 
-If `wrangler dev` is running, you'll see the output of your Rust program in your browser a few seconds after you save in your editor. Wrangler watches your project for changes then compiles your Rust to WebAssembly and outputs compiler errors.
+If `wrangler dev` is running, you will see the output of your Rust program in your browser a few seconds after you save it in your editor. Wrangler watches your project for changes then compiles your Rust to WebAssembly and outputs compiler errors.
 
 ## Publish
 

--- a/products/workers/src/content/tutorials/localize-a-website/index.md
+++ b/products/workers/src/content/tutorials/localize-a-website/index.md
@@ -13,7 +13,7 @@ import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start
 
 ## Overview
 
-The [`HTMLRewriter`](/runtime-apis/html-rewriter) class (currently in beta) built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the edge, giving developers the ability to efficiently and transparently customize their Workers applications.
+The [`HTMLRewriter`](/runtime-apis/html-rewriter) class built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the edge, giving developers the ability to efficiently and transparently customize their Workers applications.
 
 In this tutorial, we’ll build an example internationalization and localization engine (commonly referred to as “i18n” and “l10n”) for your application, serve the content of your site, and automatically translate the content based your visitors’ location in the world.
 
@@ -155,7 +155,7 @@ class ElementHandler {
 }
 ```
 
-To check that everything looks like you’d expect, it could be a good time to use the preview functionality built into Wrangler. Call `wrangler preview --watch` to open up a live preview of your project, refreshed after every code change that you make.
+To check that everything looks like you’d expect, it could be a good time to use the preview functionality built into Wrangler. Call `wrangler dev` to open up a live preview of your project, refreshed after every code change that you make.
 
 We can expand on this simple translation functionality to provide country-specific translations, based on the incoming request’s `Accept-Language` header. By taking this header, parsing it, and passing the parsed language into our `ElementHandler`, we can retrieve a translated string in our user’s home language, provided that it’s defined in `strings`.
 

--- a/products/workers/src/content/tutorials/localize-a-website/index.md
+++ b/products/workers/src/content/tutorials/localize-a-website/index.md
@@ -13,7 +13,7 @@ import TutorialsBeforeYouStart from "../../_partials/_tutorials-before-you-start
 
 ## Overview
 
-The [`HTMLRewriter`](/runtime-apis/html-rewriter) class built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the edge, giving developers the ability to efficiently and transparently customize their Workers applications.
+The [`HTMLRewriter`](/runtime-apis/html-rewriter) class built into the Cloudflare Workers runtime allows for parsing and rewriting of HTML at the Cloudflare edge network, giving developers the ability to efficiently and transparently customize their Workers applications.
 
 In this tutorial, we’ll build an example internationalization and localization engine (commonly referred to as “i18n” and “l10n”) for your application, serve the content of your site, and automatically translate the content based your visitors’ location in the world.
 
@@ -155,7 +155,7 @@ class ElementHandler {
 }
 ```
 
-To check that everything looks like you’d expect, it could be a good time to use the preview functionality built into Wrangler. Call `wrangler dev` to open up a live preview of your project, refreshed after every code change that you make.
+To check that everything looks as expected, use the preview functionality built into Wrangler. Call `wrangler dev` to open up a live preview of your project. `wrangler dev` is refreshed after every code change that you make.
 
 We can expand on this simple translation functionality to provide country-specific translations, based on the incoming request’s `Accept-Language` header. By taking this header, parsing it, and passing the parsed language into our `ElementHandler`, we can retrieve a translated string in our user’s home language, provided that it’s defined in `strings`.
 


### PR DESCRIPTION
Switched some of the old tutorials and examples to recommend `wrangler dev` instead of `wrangler preview`. Since preview is **not** deprecated, it's still in all of the official docs. It's just that `dev` provides a better experience in most cases.

@deadlypants1973 we still refer to the functionality itself as "previewing" -- is that ok? Like is it ok to say "To preview your worker, run `wrangler dev`?" 

Also I think HTMLRewriter is not in beta any longer? I removed that too cc @signalnerve 