### PR TITLE
[SSL] Removed "three" since there are 4 pre-val methods

### DIFF
--- a/products/ssl/src/content/ssl-for-saas/certificate-validation-methods.md
+++ b/products/ssl/src/content/ssl-for-saas/certificate-validation-methods.md
@@ -31,7 +31,7 @@ If you would like to complete the issuance process before asking your customer t
 
 For your customers that already have HTTPS on their custom domain, e.g., they’re self-hosted or you’ve manually provisioned, and cannot tolerate a couple minutes of downtime during cutover, additional “pre-validation” methods are available.
 
-The three validation methods below can be used to obtain a certificate in advance of setting the CNAME to your `$CNAME_TARGET`.
+The validation methods below can be used to obtain a certificate in advance of setting the CNAME to your `$CNAME_TARGET`.
 
 ### 1. TXT record
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25812029/131044271-7bb895d7-6c98-4a3e-9f6a-13964b915831.png)

Alternative, instead of removing `three`, replace `three` with `four`. 
I just find that removing is a bit more future-proof, and writing out distinct counts over three may sound odd. 