### PR TITLE
[Cache] Adjuste inline block around the max-age

### DIFF
--- a/products/cache/src/content/about/cache-control.md
+++ b/products/cache/src/content/about/cache-control.md
@@ -41,7 +41,7 @@ Expiration refers to how long a resource should remain in the cache, and the dir
 
 <Aside type="note" header="Note">
 
-Cloudflare respects whichever value is higher: the [Browser Cache TTL](/about/edge-browser-cache-ttl) in Cloudflare or the `max-age` header. You can also simultaneously specify a Cloudflare Edge Cache TTL different than a Browser’s Cache TTL respectively via the `s-maxage` and `max-age Cache-Control` headers.
+Cloudflare respects whichever value is higher: the [Browser Cache TTL](/about/edge-browser-cache-ttl) in Cloudflare or the `max-age` header. You can also simultaneously specify a Cloudflare Edge Cache TTL different than a Browser’s Cache TTL respectively via the `s-maxage` and `max-age` Cache-Control headers.
 
 When using Origin Cache-Control and setting `max-age=0`, Cloudflare prefers to cache and revalidate. With Origin Cache-Control off and `max-age=0`, Cloudflare settings bypass cache. Setting `no-cache` also bypasses cache.
 


### PR DESCRIPTION
Should be `max-age` and not `max-age Cache-Control` since there is no header called `max-age Cache-Control`