### PR TITLE
Clarify caching behavior for Cloudflare Pages

### DIFF
--- a/products/pages/src/content/platform/serving-pages.md
+++ b/products/pages/src/content/platform/serving-pages.md
@@ -22,4 +22,12 @@ If your project does not include a top-level `404.html` file, Pages assumes that
 
 ## Caching and performance
 
-Pages includes good caching defaults. That means that every time you deploy an asset to Pages, it remains cached on the Cloudflare CDN until your next deploy. As much as possible, Pages sets `ETag` and `If-None-Match` headers to allow clients to also cache content in their browsers — for more details on these behaviors, refer to the MDN [HTTP Caching page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching). Pages will also serve Gzip and Brotli responses whenever possible.
+Pages includes good caching defaults. That means that every time you deploy an asset to Pages, it remains cached on the Cloudflare CDN until your next deploy. 
+
+<Aside type="note" header="Purging the cache">
+
+If there are Page Rules or other cache settings already existing on your custom domain, that may lead to stale assets being served after a new build. You can resolve this quickly by clicking <a href="https://developers.cloudflare.com/cache/how-to/purge-cache#purge-everything">Purge Everything</a> in the "Caching" tab of your zone to ensure the latest build gets served."
+
+</Aside>
+
+As much as possible, Pages sets `ETag` and `If-None-Match` headers to allow clients to also cache content in their browsers — for more details on these behaviors, refer to the MDN [HTTP Caching page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching). Pages will also serve Gzip and Brotli responses whenever possible.

--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -18,8 +18,9 @@ pcx-content-type: configuration
 const DEFAULT_SECURITY_HEADERS = {
     /*
     Secure your application with Content-Security-Policy headers.
-    To avoid introducing breaking changes, these headers are not automatically set. 
-    Read more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+    Enabling these headers will permit content from a trusted domain and all its subdomains.
+    @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+    "Content-Security-Policy": "default-src 'self' example.com *.example.com",
     */
     /*
     You can also set Strict-Transport-Security headers. 
@@ -28,18 +29,22 @@ const DEFAULT_SECURITY_HEADERS = {
     "Strict-Transport-Security" : "max-age=63072000; includeSubDomains; preload",
     */
     /*
-    X-XSS-Protection header prevents a page from loading if an XSS attack is detected. 
-    Read more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    Permissions-Policy header provides the ability to allow or deny the use of browser features, such as opting out of FLoC - which you can use below:
+    "Permissions-Policy": "interest-cohort=()",
     */
-    "X-XSS-Protection": "1; mode=block",
+    /*
+    X-XSS-Protection header prevents a page from loading if an XSS attack is detected. 
+    @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    */
+    "X-XSS-Protection": "0; mode=block",
     /*
     X-Frame-Options header prevents click-jacking attacks. 
-    Read more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+    @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
     */
     "X-Frame-Options": "DENY",
     /*
     X-Content-Type-Options header prevents MIME-sniffing. 
-    Read more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+    @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
     */
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",


### PR DESCRIPTION
This describes what to do in zone settings if Pages users see stale assets served after a new build. Page Rules and other cache settings for a custom domain can lead to unexpected behavior after new builds complete.