### PR TITLE
[Pages]: Fix grammatical error and minor formatting inconsistency

### DIFF
--- a/products/pages/src/content/platform/deploy-hooks.md
+++ b/products/pages/src/content/platform/deploy-hooks.md
@@ -7,7 +7,7 @@ pcx-content-type: concept
 
 With Deploy Hooks, you can trigger deployments using event sources beyond commits in your source repository. Each event source may obtain its own unique URL, which will receive HTTP POST requests in order to initiate new deployments. This feature allows you to integrate Pages with new or existing workflows. For example, you may:
 
-- Automatically deploy new builds whenever content in a Headless CMS system changes
+- Automatically deploy new builds whenever content in a Headless CMS changes
 - Implement a fully customized CI/CD pipeline, deploying only under desired conditions 
 - Schedule a CRON trigger to update your website on a fixed timeline
 
@@ -23,7 +23,8 @@ To configure your Deploy Hook, you must enter two key parameters:
 ![deploy hooks](deploy-hooks-configure.png)
 
 ## Using your Deploy Hook
-Once your configuration is complete, the Deploy Hook’s unique URL is ready to be used. You will see both the URL as well as the POST request snippet available to copy. 
+Once your configuration is complete, the Deploy Hook’s unique URL is ready to be used. You will see both the URL as well as the POST request snippet available to copy.
+
 ![deploy hooks](deploy-hooks-details.png)
 
 Every time a request is sent to your Deploy Hook, a new build will be triggered. Review the **Source** column of your deployment log to see which deployment were triggered by a Deploy Hook.  


### PR DESCRIPTION
* Removed extra "system" after CMS
* Lack of a blank line between text & image in markdown leads to lack of spacing on deployed site
  - Normal formatting (see vertical gap between end of paragraph and top of image)

      ![Properly formatted text + image](https://user-images.githubusercontent.com/33403762/131565629-e5cbb39c-4a9f-461b-86e5-bef4aa4857fa.png)

  -  Problem instance

      ![Improperly formatted text + image](https://user-images.githubusercontent.com/33403762/131565736-d89ff85a-f147-4879-8af4-be90299cd3f2.png)
