### PR TITLE
Enable redirects in WAF

### DIFF
--- a/products/waf/wrangler.toml
+++ b/products/waf/wrangler.toml
@@ -8,6 +8,9 @@ workers_dev = false
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99"
 zone_id = "351cf9fc660523187714fa772ad5ca49"
 route = "https://developers.cloudflare.com/waf*"
+kv_namespaces = [
+    { binding = "REDIRECTS", id = "c28577c67f74468b918e7684c94802c0" }
+]
 
 [site]
 bucket = ".docs/public/"


### PR DESCRIPTION
Redirects are required for the WAF in the context of https://jira.cfops.it/browse/PCX-2178.
