### PR TITLE
[Workers] Unindent code block to fix it not showing up

### DIFF
--- a/products/workers/src/content/platform/environment-variables.md
+++ b/products/workers/src/content/platform/environment-variables.md
@@ -55,21 +55,21 @@ console.log(STRIPE_TOKEN);
 
 Secrets are defined by running [`wrangler secret put <NAME>`](/cli-wrangler/commands#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by re-running the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`. Keep a list of the secrets used in your code in your `wrangler.toml` file, like the example under `[secrets]`:
 
-    ```toml
-    ---
-    filename: wrangler.toml
-    ---
-    name = "my-worker-dev"
-    type = "javascript"
+```toml
+---
+filename: wrangler.toml
+---
+name = "my-worker-dev"
+type = "javascript"
 
-    account_id = "<YOUR ACCOUNTID>"
-    workers_dev = true
+account_id = "<YOUR ACCOUNTID>"
+workers_dev = true
 
-    # [secrets]
-    # SPARKPOST_KEY
-    # GTOKEN_PRIVKEY
-    # GTOKEN_KID
-    ```
+# [secrets]
+# SPARKPOST_KEY
+# GTOKEN_PRIVKEY
+# GTOKEN_KID
+```
 
 <Aside type="warning">
 


### PR DESCRIPTION
How it currently looks (https://developers.cloudflare.com/workers/platform/environment-variables#adding-secrets-via-wrangler):
![broken_code_block](https://user-images.githubusercontent.com/8492901/132135717-31edda41-a3bd-4e78-b939-f0437801204b.png)

