### PR TITLE
Add note to use the pem vs crt certificate.

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -346,7 +346,7 @@ export REQUESTS_CA_BUNDLE=${CERT_PATH}
 
 ### npm
 
-The command below will set the `cafile` configuration to use the Cloudflare certificate.
+The command below will set the `cafile` configuration to use the Cloudflare certificate. Note: Make sure to use the pem formatted certificate.
 
 ```
 npm config set cafile [PATH_TO_CLOUDFLARE_CERT]

--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -346,7 +346,7 @@ export REQUESTS_CA_BUNDLE=${CERT_PATH}
 
 ### npm
 
-The command below will set the `cafile` configuration to use the Cloudflare certificate. Note: Make sure to use the pem formatted certificate.
+The command below will set the `cafile` configuration to use the Cloudflare certificate. Make sure to use the certificate in the [`.pem`](../../../static/documentation/connections/Cloudflare_CA.pem) file type.
 
 ```
 npm config set cafile [PATH_TO_CLOUDFLARE_CERT]


### PR DESCRIPTION
It appears the crt certificate does not work and npm will still hang and timeout eventually. Whereas with the pem certificate things proceed along just as quickly as without Warp enabled.