### PR TITLE
Fix the links to the examples for 1.1.1.1 UDP and JSON formats.

### DIFF
--- a/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/make-api-requests/index.md
+++ b/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/make-api-requests/index.md
@@ -24,7 +24,7 @@ When making requests using `GET`, the DNS query is encoded into the URL. An addi
 
 If you use JSON format, set `application/dns-json` URL parameter, and if you use DNS wireformat, use `application/dns-message` as either the URL parameter of `ct` or a `Content-Type` header for `POST` requests.
 
-See also curl examples for [UDP wireformat](/encrypted-dns/dns-over-https/dns-wireformat) and [JSON](/encrypted-dns/dns-over-https/json).
+See also curl examples for [UDP wireformat](/encrypted-dns/dns-over-https/make-api-requests/dns-wireformat) and [JSON](/encrypted-dns/dns-over-https/make-api-requests/dns-json).
 
 ## Send multiple questions in a query
 


### PR DESCRIPTION
Quick fix to the URLs for the UDP and JSON formats for the using the API for 1.1.1.1.