### PR TITLE
Typo: --env production > --env staging

### DIFF
--- a/products/workers/src/content/platform/environments.md
+++ b/products/workers/src/content/platform/environments.md
@@ -318,7 +318,7 @@ workers_dev = true
 type = "rust"
 ```
 
-With this configuration, no errors will be thrown. However, only `type = "webpack"` will be used, even in an `--env production` setting.
+With this configuration, no errors will be thrown. However, only `type = "webpack"` will be used, even in an `--env staging` setting.
 
 ### Same name for multiple environments
 


### PR DESCRIPTION
I think this is a typo, the example shows a config `type` for "staging" but the note mentions that this will be ignored for `--env production`.