### PR TITLE
[Workers] Add missing property isEUCountry to IncomingRequestCfProperties

### DIFF
--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -209,6 +209,10 @@ All plans have access to:
 
   - Country of the incoming request. The two-letter country code in the request. This is the same value as that provided in the `CF-IPCountry` header, e.g. `"US"`.
 
+- `isEUCountry` <Type>string | null</Type>
+
+  - If the country of the incoming request is in the EU, this will return `"1"`. Otherwise, this property will be omitted.
+
 - `httpProtocol` <Type>string</Type>
 
   - HTTP Protocol, e.g. `"HTTP/2"`.


### PR DESCRIPTION
In an EU country:
![eu-country](https://user-images.githubusercontent.com/8492901/133673504-cf0e29a4-b24f-4638-a61c-599cd9f23900.png)

In a non-EU country:
![non-eu](https://user-images.githubusercontent.com/8492901/133673537-6c17e6d1-1830-4330-a478-30a9447b5c71.png)