### PR TITLE
edit preview yml

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -100,6 +100,8 @@ jobs:
               fi
               echo "
               [env.preview]
+              # Opt into backwards-incompatible changes through September 17, 2021.
+              compatibility_date = "2021-09-17"
               name = \"pr-$prnumber\"
               type = \"webpack\"
               route = \"https://pr-$prnumber.cloudflare-docs.workers.dev/*\"
@@ -115,6 +117,8 @@ jobs:
               fi
               echo "
               [env.preview]
+              # Opt into backwards-incompatible changes through September 17, 2021.
+              compatibility_date = "2021-09-17"
               name = \"pr-$prnumber-$tile\"
               type = \"webpack\"
               account_id = \"b54f07a6c269ecca2fa60f1ae4920c99\"

--- a/get-products-from-file-paths.js
+++ b/get-products-from-file-paths.js
@@ -11,7 +11,7 @@ process.stdin.on("end", () => {
     let splittedStr = product.split("/");
     const productName = splittedStr[1];
 
-    if (!changedProducts.has(splittedStr[0] === "developers.cloudflare.com")) {
+    if (splittedStr[0] === "developers.cloudflare.com" && !changedProducts.has(splittedStr[0])) {
       changedProducts.add("developers.cloudflare.com");
     }
 

--- a/products/spectrum/wrangler.toml
+++ b/products/spectrum/wrangler.toml
@@ -2,6 +2,7 @@ name = "spectrum"
 type = "webpack"
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
 workers_dev = true
+compatibility_date = "2021-09-17"
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
This addresses warnings that were shown in preview link for compatibility date for wrangler.

Added `compatibility_date = "2021-09-17"` to preview.yml 
Going forward when there is a warning aded to the bot where the preview should be, the solution is to add:
compatibility_date = "2021-09-17" replace 09-17 with the current date in the wrangler.toml of the product folder.
*This warning has been reported to workers team and they said they will try to remove this warning in the future from the `wrangler subdomain` command

This also fixes bug that was creating preview links for developers.cloudflare folder even though no changes were made for that folder