### PR TITLE
Add API reference links to Ruleset Engine docs

### DIFF
--- a/products/ruleset-engine/src/content/rulesets-api/add-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/add-rule.md
@@ -1,7 +1,7 @@
 ---
 pcx-content-type: reference
-alwaysopen: true
 order: 786
+type: overview
 ---
 
 # Add rule to ruleset
@@ -10,19 +10,12 @@ Adds a single rule to an existing ruleset. Use this endpoint to add a rule witho
 
 Use one of the following API endpoints to add a rule to a ruleset:
 
-```bash
----
-header: Account-level endpoint
----
-POST /accounts/{account-id}/rulesets/{ruleset-id}/rules
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Add an individual rule][ar-account] (account) | `POST /accounts/{account-id}/rulesets/{ruleset-id}/rules` |
+| Add an individual rule (zone) | `POST /zones/{zone-id}/rulesets/{ruleset-id}/rules` |
 
-```bash
----
-header: Zone-level endpoint
----
-POST /zones/{zone-id}/rulesets/{ruleset-id}/rules
-```
+[ar-account]: https://api.cloudflare.com/#account-rulesets-add-an-individual-rule
 
 Invoking this method creates a new version of the ruleset.
 
@@ -32,12 +25,13 @@ Include the rule definition in the request body. The rule will be added to the e
 
 The following example adds a rule to ruleset `{ruleset-id}` of zone `{zone-id}`. The ruleset ID was previously obtained using the [List rulesets](/rulesets-api/view#list-existing-rulesets) method, and corresponds to the entry point ruleset for the `http_request_firewall_custom` phase.
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X POST \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules" \
 -d '{
@@ -47,12 +41,16 @@ curl -X POST \
 }'
 ```
 
+</div>
+</details>
+
 The response includes the complete ruleset after adding the rule.
 
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -89,3 +87,6 @@ header: Response
   "messages": []
 }
 ```
+
+</div>
+</details>

--- a/products/ruleset-engine/src/content/rulesets-api/add-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/add-rule.md
@@ -8,9 +8,9 @@ type: overview
 
 Adds a single rule to an existing ruleset. Use this endpoint to add a rule without having to include all the existing ruleset rules in the request.
 
-Use one of the following API endpoints to add a rule to a ruleset:
+Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Add an individual rule][ar-account] (account) | `POST /accounts/{account-id}/rulesets/{ruleset-id}/rules` |
 | Add an individual rule (zone) | `POST /zones/{zone-id}/rulesets/{ruleset-id}/rules` |

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -11,7 +11,7 @@ Creates a ruleset of a given kind in the specified phase. Allows you to create p
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Create account ruleset][cr-account] | `POST accounts/{account-id}/rulesets` |
 | [Create zone ruleset][cr-zone] | `POST zones/{zone-id}/rulesets` |

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -68,7 +68,7 @@ Use the `rules` parameter to supply a list of rules for the ruleset. For an obje
 
 ## Example - Create a custom ruleset
 
-This example request creates a custom ruleset in the `http_request_firewall_custom` phase containing a single rule.
+The following example request creates a custom ruleset in the `http_request_firewall_custom` phase containing a single rule.
 
 <details open>
 <summary>Request</summary>
@@ -131,7 +131,7 @@ curl -X POST \
 
 ## Example - Create a zone-level phase entry point ruleset
 
-This example request creates a zone-level phase entry point ruleset at the `http_request_firewall_managed` phase with a single rule that executes a Managed Ruleset.
+The following example request creates a zone-level phase entry point ruleset at the `http_request_firewall_managed` phase with a single rule that executes a Managed Ruleset.
 
 <Aside type="note">
 

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -1,13 +1,15 @@
 ---
 title: Create ruleset
 pcx-content-type: reference
-type: overview
 order: 784
+type: overview
 ---
 
 # Create ruleset
 
 Creates a ruleset of a given kind in the specified phase. Allows you to create phase entry point rulesets.
+
+Use one of the following API endpoints:
 
 | Operation | Method + URL stub |
 |-----------|-------------------|
@@ -64,18 +66,17 @@ The following parameters are required:
 
 Use the `rules` parameter to supply a list of rules for the ruleset. For an object definition, refer to [Rulesets API: JSON Object](/rulesets-api/json-object).
 
-## Examples
+## Example - Create a custom ruleset
 
-### Create a custom ruleset
+This example request creates a custom ruleset in the `http_request_firewall_custom` phase containing a single rule.
 
-This example creates a custom ruleset in the `http_request_firewall_custom` phase containing a single rule.
+<details open>
+<summary>Request</summary>
+<div>
 
 ```json
----
-header: Request
----
 curl -X POST \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets" \
 -d '{
@@ -92,10 +93,14 @@ curl -X POST \
 }'
 ```
 
+</div>
+</details>
+
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -121,9 +126,12 @@ header: Response
 }
 ```
 
-### Create a zone-level phase entry point ruleset
+</div>
+</details>
 
-This example creates a zone-level phase entry point ruleset at the `http_request_firewall_managed` phase with a single rule that executes a Managed Ruleset.
+## Example - Create a zone-level phase entry point ruleset
+
+This example request creates a zone-level phase entry point ruleset at the `http_request_firewall_managed` phase with a single rule that executes a Managed Ruleset.
 
 <Aside type="note">
 
@@ -131,12 +139,13 @@ You do not have to use this method to create a phase entry point ruleset — Clo
 
 </Aside>
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X POST \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets" \
 -d '{
@@ -156,10 +165,14 @@ curl -X POST \
 }'
 ```
 
+</div>
+</details>
+
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -187,3 +200,6 @@ header: Response
   "messages": []
 }
 ```
+
+</div>
+</details>

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -13,8 +13,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Create account ruleset][cr-account] | `POST accounts/{account-id}/rulesets` |
-| [Create zone ruleset][cr-zone] | `POST zones/{zone-id}/rulesets` |
+| [Create account ruleset][cr-account] | `POST /accounts/{account-id}/rulesets` |
+| [Create zone ruleset][cr-zone] | `POST /zones/{zone-id}/rulesets` |
 
 [cr-account]: https://api.cloudflare.com/#account-rulesets-create-account-ruleset
 [cr-zone]: https://api.cloudflare.com/#zone-rulesets-create-zone-ruleset

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -1,7 +1,7 @@
 ---
 title: Create ruleset
 pcx-content-type: reference
-alwaysopen: true
+type: overview
 order: 784
 ---
 
@@ -9,21 +9,13 @@ order: 784
 
 Creates a ruleset of a given kind in the specified phase. Allows you to create phase entry point rulesets.
 
-Use one of the following endpoints when creating a ruleset:
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Create account ruleset][cr-account] | `POST accounts/{account-id}/rulesets` |
+| [Create zone ruleset][cr-zone] | `POST zones/{zone-id}/rulesets` |
 
-```bash
----
-header: Account-level endpoint
----
-POST accounts/{account-id}/rulesets
-```
-
-```bash
----
-header: Zone-level endpoint
----
-POST zones/{zone-id}/rulesets
-```
+[cr-account]: https://api.cloudflare.com/#account-rulesets-create-account-ruleset
+[cr-zone]: https://api.cloudflare.com/#zone-rulesets-create-zone-ruleset
 
 The following parameters are required:
 
@@ -72,7 +64,9 @@ The following parameters are required:
 
 Use the `rules` parameter to supply a list of rules for the ruleset. For an object definition, refer to [Rulesets API: JSON Object](/rulesets-api/json-object).
 
-## Example - Create a custom ruleset
+## Examples
+
+### Create a custom ruleset
 
 This example creates a custom ruleset in the `http_request_firewall_custom` phase containing a single rule.
 
@@ -127,9 +121,15 @@ header: Response
 }
 ```
 
-## Example - Create a zone-level phase entry point ruleset
+### Create a zone-level phase entry point ruleset
 
 This example creates a zone-level phase entry point ruleset at the `http_request_firewall_managed` phase with a single rule that executes a Managed Ruleset.
+
+<Aside type="note">
+
+You do not have to use this method to create a phase entry point ruleset — Cloudflare automatically creates the entry point ruleset when you add a rule to it, if it does not exist. Refer to [Add rules to phase entry point rulesets](/basic-operations/add-rule-phase-rulesets) for more information.
+
+</Aside>
 
 ```json
 ---

--- a/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
@@ -10,7 +10,7 @@ Deletes a single rule in a ruleset at the account or zone level.
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Delete an individual rule][dr-account] (account) | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
 | Delete an individual rule (zone) | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |

--- a/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
@@ -1,27 +1,21 @@
 ---
 pcx-content-type: reference
 order: 787
+type: overview
 ---
 
 # Delete a rule in a ruleset
 
-Deletes a single rule in a ruleset.
+Deletes a single rule in a ruleset at the account or zone level.
 
 Use one of the following API endpoints:
 
-```bash
----
-header: Account-level endpoint
----
-DELETE /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Delete an individual rule][dr-account] (account) | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
+| Delete an individual rule (zone) | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
 
-```bash
----
-header: Zone-level endpoint
----
-DELETE /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}
-```
+[dr-account]: https://api.cloudflare.com/#account-rulesets-delete-an-individual-rule
 
 If the delete operation succeeds, the API method call returns a `200 OK` HTTP status code with the complete ruleset in the response body.
 
@@ -29,22 +23,25 @@ If the delete operation succeeds, the API method call returns a `200 OK` HTTP st
 
 The following example deletes rule `{rule-id-1}` belonging to ruleset `{ruleset-id}`.
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X DELETE \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id-1}"
+  -H "X-Auth-Email: user@example.com" \
+  -H "X-Auth-Key: REDACTED" \
+  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id-1}"
 ```
 
-The response includes the complete ruleset after deleting the rule.
+</div>
+</details>
+
+<details>
+<summary>Response</summary>
+<div>
 
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -72,3 +69,8 @@ header: Response
   "messages": []
 }
 ```
+
+</div>
+</details>
+
+The response includes the complete ruleset after deleting the rule.

--- a/products/ruleset-engine/src/content/rulesets-api/delete.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete.md
@@ -37,7 +37,7 @@ To delete the ruleset, update or delete any rules that reference the ruleset and
 
 ### Example
 
-This example request deletes an existing ruleset.
+The following example request deletes an existing ruleset.
 
 ```json
 ---
@@ -77,7 +77,7 @@ To delete the ruleset version, update or delete any rules that reference the rul
 
 ### Example
 
-This example request deletes a version of an existing ruleset.
+The following example request deletes a version of an existing ruleset.
 
 ```json
 ---

--- a/products/ruleset-engine/src/content/rulesets-api/delete.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete.md
@@ -1,6 +1,7 @@
 ---
 pcx-content-type: reference
 order: 788
+type: overview
 ---
 
 # Delete rulesets
@@ -12,21 +13,17 @@ You can use the API to delete all the versions of a ruleset or delete a specific
 
 ## Delete ruleset
 
-To delete all the versions of an existing ruleset at the account or zone level, use one of the following API endpoints:
+Deletes all the versions of an existing ruleset at the account or zone level.
 
-```bash
----
-header: Account-level endpoint
----
-DELETE /accounts/{account-id}/rulesets/{ruleset-id}
-```
+Use one of the following API endpoints:
 
-```bash
----
-header: Zone-level endpoint
----
-DELETE /zones/{zone-id}/rulesets/{ruleset-id}
-```
+| Operation                            | Method + URL stub                                     |
+|--------------------------------------|-------------------------------------------------------|
+| [Delete account ruleset][dr-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}` |
+| [Delete zone ruleset][dr-zone]       | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}`       |
+
+[dr-account]: https://api.cloudflare.com/#account-rulesets-delete-account-ruleset
+[dr-zone]: https://api.cloudflare.com/#zone-rulesets-delete-zone-ruleset
 
 If the delete operation succeeds, the API method call returns a `204 No Content` HTTP status code.
 
@@ -40,32 +37,31 @@ To delete the ruleset, update or delete any rules that reference the ruleset and
 
 ### Example
 
-The following example request deletes an existing ruleset.
+This example request deletes an existing ruleset.
 
 ```json
+---
+header: Request
+---
 curl -X DELETE \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}"
+  -H "X-Auth-Email: user@example.com" \
+  -H "X-Auth-Key: REDACTED" \
+  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}"
 ```
 
 ## Delete ruleset version
 
-To delete a specific version of a ruleset, use one of the following API endpoints:
+Deletes a specific version of a ruleset.
 
-```bash
----
-header: Account-level endpoint
----
-DELETE /accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}
-```
+Use one of the following API endpoints:
 
-```bash
----
-header: Zone-level endpoint
----
-DELETE /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Delete a version of an account ruleset][drv-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
+| [Delete a version of a zone ruleset][drv-zone] | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}` |
+
+[drv-account]: https://api.cloudflare.com/#account-rulesets-delete-a-version-of-an-account-ruleset
+[drv-zone]: https://api.cloudflare.com/#zone-rulesets-delete-a-version-of-a-zone-ruleset
 
 If the delete operation succeeds, the method call returns a `204 No Content` HTTP status code.
 
@@ -81,11 +77,14 @@ To delete the ruleset version, update or delete any rules that reference the rul
 
 ### Example
 
-The following example request deletes a version of an existing ruleset.
+This example request deletes a version of an existing ruleset.
 
 ```json
+---
+header: Request
+---
 curl -X DELETE \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}"
+  -H "X-Auth-Email: user@example.com" \
+  -H "X-Auth-Key: REDACTED" \
+  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}"
 ```

--- a/products/ruleset-engine/src/content/rulesets-api/delete.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete.md
@@ -17,7 +17,7 @@ Deletes all the versions of an existing ruleset at the account or zone level.
 
 Use one of the following API endpoints:
 
-| Operation                            | Method + URL stub                                     |
+| Operation                            | Method + Endpoint                                     |
 |--------------------------------------|-------------------------------------------------------|
 | [Delete account ruleset][dr-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}` |
 | [Delete zone ruleset][dr-zone]       | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}`       |
@@ -55,7 +55,7 @@ Deletes a specific version of a ruleset.
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Delete a version of an account ruleset][drv-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
 | [Delete a version of a zone ruleset][drv-zone] | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}` |

--- a/products/ruleset-engine/src/content/rulesets-api/endpoints.md
+++ b/products/ruleset-engine/src/content/rulesets-api/endpoints.md
@@ -24,7 +24,7 @@ PUT /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint
 To invoke a Cloudflare Rulesets API operation, append the endpoint to the Cloudflare API base URL:
 
 ```bash
-https://api.cloudflare.com/client/v4/
+https://api.cloudflare.com/client/v4
 ```
 
 For authentication instructions, see [Getting Started: Requests](https://api.cloudflare.com/#getting-started-requests) in the Cloudflare API documentation.

--- a/products/ruleset-engine/src/content/rulesets-api/endpoints.md
+++ b/products/ruleset-engine/src/content/rulesets-api/endpoints.md
@@ -1,7 +1,6 @@
 ---
 title: Endpoints
 pcx-content-type: reference
-alwaysopen: true
 order: 782
 ---
 

--- a/products/ruleset-engine/src/content/rulesets-api/endpoints.md
+++ b/products/ruleset-engine/src/content/rulesets-api/endpoints.md
@@ -41,7 +41,7 @@ To retrieve a list of zones you have access to, use the [List Zones](https://api
 
 </Aside>
 
-The Cloudflare Rulesets API supports the operations outlined below. Visit the associated links for examples.
+The Cloudflare Rulesets API supports the operations outlined below. Visit the associated links for API endpoints and examples.
 
 ## List and view rulesets
 

--- a/products/ruleset-engine/src/content/rulesets-api/index.md
+++ b/products/ruleset-engine/src/content/rulesets-api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Rulesets API
 pcx-content-type: navigation
-alwaysopen: false
 order: 780
 ---
 

--- a/products/ruleset-engine/src/content/rulesets-api/json-object.md
+++ b/products/ruleset-engine/src/content/rulesets-api/json-object.md
@@ -1,7 +1,6 @@
 ---
 title: JSON object
 pcx-content-type: reference
-alwaysopen: true
 order: 781
 ---
 

--- a/products/ruleset-engine/src/content/rulesets-api/update-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update-rule.md
@@ -1,29 +1,22 @@
 ---
 title: Update a rule in a ruleset
 pcx-content-type: reference
-alwaysopen: true
 order: 786
+type: overview
 ---
 
 # Update a rule in a ruleset
 
-Applies one or more changes to an existing rule in a ruleset.
+Applies one or more changes to an existing rule in a ruleset at the account or zone level.
 
-Use one of the following API endpoints to update a single rule in a ruleset:
+Use one of the following API endpoints:
 
-```bash
----
-header: Account-level endpoint
----
-PATCH /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Patch an individual rule][ur-account] (account) | `PATCH /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
+| Patch an individual rule (zone) | `PATCH /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
 
-```bash
----
-header: Zone-level endpoint
----
-PATCH /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}
-```
+[ur-account]: https://api.cloudflare.com/#account-rulesets-patch-an-individual-rule
 
 You can update the definition of the rule, changing its fields, or change the order of the rule in the ruleset. Invoking this method creates a new version of the ruleset.
 
@@ -31,12 +24,13 @@ You can update the definition of the rule, changing its fields, or change the or
 
 To update the definition of a rule, include the new rule definition in the request body. You must include all the rule fields that you want to be part of the new rule definition, even if you are not changing their values.
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X PATCH \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id-1}" \
 -d '{
@@ -46,12 +40,16 @@ curl -X PATCH \
 }'
 ```
 
+</div>
+</details>
+
 The response includes the complete ruleset after updating the rule.
 
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -89,6 +87,9 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 ## Change the order of a rule in a ruleset
 
 To reorder a rule in a list of ruleset rules, include a `position` field in the request, containing one of the following arguments:
@@ -125,8 +126,11 @@ The following examples build upon the following (abbreviated) ruleset:
 The following request with the `position` field places rule `{rule-id-2}` as the first rule:
 
 ```json
+---
+header: Request
+---
 curl -X PATCH \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-2}" \
 -d '{
@@ -144,8 +148,11 @@ In this case, the new rule order would be:
 The following request with the `position` field places rule `{rule-id-2}` after rule 3:
 
 ```json
+---
+header: Request
+---
 curl -X PATCH \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-2}" \
 -d '{
@@ -164,8 +171,11 @@ In this case, the new rule order would be:
 The following request with the `position` field places rule `{rule-id-1}` in position 3, becoming the third rule in the ruleset:
 
 ```json
+---
+header: Request
+---
 curl -X PATCH \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-1}" \
 -d '{

--- a/products/ruleset-engine/src/content/rulesets-api/update-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update-rule.md
@@ -11,7 +11,7 @@ Applies one or more changes to an existing rule in a ruleset at the account or z
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Patch an individual rule][ur-account] (account) | `PATCH /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
 | Patch an individual rule (zone) | `PATCH /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |

--- a/products/ruleset-engine/src/content/rulesets-api/update.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update.md
@@ -10,7 +10,7 @@ You can use the API to update **basic properties** of a ruleset (currently only 
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Update account ruleset][ur-account] | `PUT /accounts/{account-id}/rulesets/{ruleset-id}` |
 | [Update zone ruleset][ur-zone] | `PUT /zones/{zone-id}/rulesets/{ruleset-id}` |

--- a/products/ruleset-engine/src/content/rulesets-api/update.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update.md
@@ -1,44 +1,26 @@
 ---
 pcx-content-type: reference
-alwaysopen: true
 order: 785
+type: overview
 ---
 
 # Update and deploy rulesets
 
 You can use the API to update **basic properties** of a ruleset (currently only the description) and the **list of rules** in the ruleset.
 
-To update a ruleset at the account or zone level, use one of the following API endpoints:
+Use one of the following API endpoints:
 
-```bash
----
-header: Account-level endpoint
----
-PUT /accounts/{account-id}/rulesets/{ruleset-id}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Update account ruleset][ur-account] | `PUT /accounts/{account-id}/rulesets/{ruleset-id}` |
+| [Update zone ruleset][ur-zone] | `PUT /zones/{zone-id}/rulesets/{ruleset-id}` |
+| [Update account entry point ruleset][uep-account] | `PUT /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint` |
+| [Update zone entry point ruleset][uep-zone] | `PUT /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint` |
 
-```bash
----
-header: Zone-level endpoint
----
-PUT /zones/{zone-id}/rulesets/{ruleset-id}
-```
-
-Alternatively, you can use one of the following endpoints when updating a phase entry point ruleset:
-
-```bash
----
-header: Account-level phase endpoint
----
-PUT /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint
-```
-
-```bash
----
-header: Zone-level phase endpoint
----
-PUT /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint
-```
+[ur-account]: https://api.cloudflare.com/#account-rulesets-update-account-ruleset
+[ur-zone]: https://api.cloudflare.com/#zone-rulesets-update-a-zone-ruleset
+[uep-account]: https://api.cloudflare.com/#account-rulesets-update-entrypoint-ruleset
+[uep-zone]: https://api.cloudflare.com/#zone-rulesets-update-entrypoint-ruleset
 
 <Aside type='warning' header='Important'>
 
@@ -50,12 +32,13 @@ You cannot update the name of the ruleset or its type. Do not include these fiel
 
 Use this API method to set the rules of a ruleset. You must include all the rules you want to associate with the ruleset in every request.
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
 -d '{
@@ -71,10 +54,14 @@ curl -X PUT \
 }'
 ```
 
+</div>
+</details>
+
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -103,18 +90,22 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 ## Example - Deploy a ruleset
 
 To deploy a ruleset, create a rule with `"action": "execute"` that executes the ruleset, and add the ruleset ID to the `action_parameters` field in the `id` parameter.
 
 The following example deploys a Managed Ruleset to the zone-level `http_request_firewall_managed` phase of a zone (`{zone-id}`).
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
 -d '{
@@ -131,10 +122,14 @@ curl -X PUT \
 }'
 ```
 
+</div>
+</details>
+
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{phase-ruleset-id}",
@@ -167,6 +162,9 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 For more information on deploying rulesets, check [Deploy rulesets](/basic-operations/deploy-rulesets).
 
 ## Example - Update ruleset description
@@ -179,12 +177,13 @@ You cannot update the description or the rules in a Managed Ruleset. You can onl
 
 </Aside>
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```json
----
-header: Request
----
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
+-H "X-Auth-Email: user@example.com" \
 -H "X-Auth-Key: REDACTED" \
 "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
 -d '{ 
@@ -192,10 +191,16 @@ curl -X PUT \
 }'
 ```
 
+</div>
+</details>
+
+The response includes the complete ruleset definition, including all the rules.
+
+<details>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -215,4 +220,5 @@ header: Response
 }
 ```
 
-The response includes the complete ruleset definition, including all the rules.
+</div>
+</details>

--- a/products/ruleset-engine/src/content/rulesets-api/view.md
+++ b/products/ruleset-engine/src/content/rulesets-api/view.md
@@ -19,7 +19,7 @@ Returns the list of existing rulesets at the account level or at the zone level.
 
 Use one of the following API endpoints:
 
-| Operation                           | Method + URL stub                     |
+| Operation                           | Method + Endpoint                     |
 |-------------------------------------|---------------------------------------|
 | [List account rulesets][lr-account] | `GET /accounts/{account-id}/rulesets` |
 | [List zone rulesets][lr-zone]       | `GET /zones/{zone-id}/rulesets`       |
@@ -87,7 +87,7 @@ Returns the properties of the most recent version of the ruleset with the specif
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Get an account ruleset][gr-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}` |
 | [Get a zone ruleset][gr-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}` |
@@ -168,7 +168,7 @@ Returns a list of all the versions of a ruleset.
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [List versions of an account ruleset][lv-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}/versions` |
 | List versions of a zone ruleset | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions` |
@@ -242,7 +242,7 @@ Returns the configuration of a specific version of a ruleset, including its rule
 
 Use one of the following API endpoints:
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | [Get an account ruleset version][grv-account] | `GET /account/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
 | [Get a zone ruleset version][grv-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}`
@@ -320,7 +320,7 @@ When you view a specific version of a Managed Ruleset, each rule listed in the r
 
 Returns a list of all the rules in a Managed Ruleset with a specific tag.
 
-| Operation | Method + URL stub |
+| Operation | Method + Endpoint |
 |-----------|-------------------|
 | List rules in ruleset by tag | `GET /accounts/{account-id}/rulesets/{managed-ruleset-id}/{version-number}/by_tag/{tag-name}` |
 

--- a/products/ruleset-engine/src/content/rulesets-api/view.md
+++ b/products/ruleset-engine/src/content/rulesets-api/view.md
@@ -1,8 +1,8 @@
 ---
 title: List and view rulesets
 pcx-content-type: reference
-alwaysopen: true
 order: 783
+type: overview
 ---
 
 # List and view rulesets
@@ -17,19 +17,15 @@ order: 783
 
 Returns the list of existing rulesets at the account level or at the zone level.
 
-```bash
----
-header: Account-level endpoint
----
-GET /accounts/{account-id}/rulesets
-```
+Use one of the following API endpoints:
 
-```bash
----
-header: Zone-level endpoint
----
-GET /zones/{zone-id}/rulesets
-```
+| Operation                           | Method + URL stub                     |
+|-------------------------------------|---------------------------------------|
+| [List account rulesets][lr-account] | `GET /accounts/{account-id}/rulesets` |
+| [List zone rulesets][lr-zone]       | `GET /zones/{zone-id}/rulesets`       |
+
+[lr-account]: https://api.cloudflare.com/#account-rulesets-list-account-rulesets
+[lr-zone]: https://api.cloudflare.com/#zone-rulesets-list-zone-rulesets
 
 The result includes rulesets across all phases at a given level (account or zone). The `phase` field in each result element indicates the phase where that ruleset is defined.
 
@@ -45,20 +41,25 @@ The result does not include the list of rules in the ruleset. Check [View a spec
 
 ### Example
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```bash
----
-header: Request
----
 curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
+  -H "X-Auth-Email: user@example.com" \
   -H "X-Auth-Key: REDACTED" \
   "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets"
 ```
 
+</div>
+</details>
+
+<details open>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": [
     {
@@ -77,69 +78,59 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 ## View a specific ruleset
 
-Returns the properties of the most recent version of a specific ruleset.
+Returns the properties of the most recent version of the ruleset with the specified ruleset ID.
 
-```bash
----
-header: Account-level endpoint
----
-GET /accounts/{account-id}/rulesets/{ruleset-id}
-```
+Use one of the following API endpoints:
 
-```bash
----
-header: Zone-level endpoint
----
-GET /zones/{zone-id}/rulesets/{ruleset-id}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Get an account ruleset][gr-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}` |
+| [Get a zone ruleset][gr-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}` |
+| [Get account entry point ruleset][gep-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint` |
+| [Get zone entry point ruleset][gep-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint` |
+
+[gr-account]: https://api.cloudflare.com/#account-rulesets-get-an-account-ruleset
+[gr-zone]: https://api.cloudflare.com/#zone-rulesets-get-a-zone-ruleset
+[gep-account]: https://api.cloudflare.com/#account-rulesets-get-entrypoint-ruleset
+[gep-zone]: https://api.cloudflare.com/#zone-rulesets-get-entrypoint-ruleset
 
 <Aside type='warning' header='Important'>
 
-Note: You can only use the zone-level endpoint for zone-level phase entry points, that is, entry points where `kind` is set to `zone`.
+Note: You can only use the _Get a zone ruleset_ operation for zone-level phase entry points, that is, entry points where `kind` is set to `zone`.
 
 </Aside>
 
-You can also use the following specific endpoints for viewing the ruleset of a phase entry point:
-
-```bash
----
-header: Account-level phase endpoint
----
-GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint
-```
-
-```bash
----
-header: Zone-level phase endpoint
----
-GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint
-```
-
-Returns the ruleset with the specified Ruleset ID.
-
-The API returns a 404 HTTP Status Code under these conditions:
+The API returns a `404 Not Found` HTTP status code under these conditions:
 
 * When a ruleset cannot be found.
 * When the specified ruleset is not a Managed Ruleset the calling account is entitled to execute.
 
 ### Example
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```bash
----
-header: Request
----
 curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
+  -H "X-Auth-Email: user@example.com" \
   -H "X-Auth-Key: REDACTED" \
   "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}"
 ```
 
+</div>
+</details>
+
+<details open>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -168,62 +159,53 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 ## List all versions of a ruleset
 
 Returns a list of all the versions of a ruleset.
 
-For Managed Rulesets, this method returns a list with one item with the information about the most recent version of the ruleset.
+Use one of the following API endpoints:
 
-```bash
----
-header: Account-level endpoint
----
-GET /accounts/{account-id}/rulesets/{ruleset-id}/versions
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [List versions of an account ruleset][lv-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}/versions` |
+| List versions of a zone ruleset | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions` |
+| [List versions of an account entry point ruleset][lvep-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions`|
+| [List versions of a zone entry point ruleset][lvep-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions` |
 
-```bash
----
-header: Zone-level endpoint
----
-GET /zones/{zone-id}/rulesets/{ruleset-id}/versions
-```
+[lv-account]: https://api.cloudflare.com/#account-rulesets-list-versions-of-an-account-ruleset
+[lvep-account]: https://api.cloudflare.com/#account-rulesets-list-versions-of-an-entrypoint-ruleset
+[lvep-zone]: https://api.cloudflare.com/#zone-rulesets-list-versions-of-an-entrypoint-ruleset
 
 The result contains the ruleset properties of each version, but it does not include the list of rules. Check [View a specific version of a ruleset](#view-a-specific-version-of-a-ruleset) to get this information.
 
-You can also use the following specific endpoints to obtain all the versions of a phase entry point:
-
-```bash
----
-header: Account-level phase endpoint
----
-GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions
-```
-
-```bash
----
-header: Zone-level phase endpoint
----
-GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions
-```
+For Managed Rulesets, this method returns a list with one item with the information about the most recent version of the ruleset.
 
 When the specified phase entry point ruleset does not exist, this API method returns an empty array in the `result` field.
 
 ### Example
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```bash
----
-header: Request
----
 curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
+  -H "X-Auth-Email: user@example.com" \
   -H "X-Auth-Key: REDACTED" \
   "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/versions"
 ```
 
+</div>
+</details>
+
+<details open>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": [
     {
@@ -251,60 +233,52 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 ## View a specific version of a ruleset
 
 Returns the configuration of a specific version of a ruleset, including its rules.
 
+Use one of the following API endpoints:
+
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| [Get an account ruleset version][grv-account] | `GET /account/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
+| [Get a zone ruleset version][grv-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}`
+| [Get account entry point ruleset version][gepv-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}` |
+| [Get zone entry point ruleset version][gepv-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}` |
+
+[grv-account]: https://api.cloudflare.com/#account-rulesets-get-an-account-ruleset-version
+[grv-zone]: https://api.cloudflare.com/#zone-rulesets-get-a-zone-ruleset-version
+[gepv-account]: https://api.cloudflare.com/#account-rulesets-get-an-entrypoint-ruleset-version
+[gepv-zone]: https://api.cloudflare.com/#zone-rulesets-get-an-entrypoint-ruleset-version
+
 You can view the rules in all the versions of a custom ruleset. However, you can only view the rules of the latest version of a Managed Ruleset.
 
-```bash
----
-header: Account-level endpoint
----
-GET /account/{account-id}/rulesets/{ruleset-id}/versions/{version-number}
-```
-
-```bash
----
-header: Zone-level endpoint
----
-GET /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}
-```
-
-You can also use the following endpoints for viewing a specific version of a phase entry point:
-
-```bash
----
-header: Account-level phase endpoint
----
-GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}
-```
-
-```bash
----
-header: Zone-level phase endpoint
----
-GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}
-```
-
-When the specified phase entry point ruleset does not exist, this API method returns a 404 HTTP Status Code.
+When the specified phase entry point ruleset does not exist, this API method returns a `404 Not Found` HTTP status code.
 
 ### Example
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```bash
----
-header: Request
----
 curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
+  -H "X-Auth-Email: user@example.com" \
   -H "X-Auth-Key: REDACTED" \
   "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}"
 ```
 
+</div>
+</details>
+
+<details open>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{ruleset-id}",
@@ -333,6 +307,9 @@ header: Response
 }
 ```
 
+</div>
+</details>
+
 <Aside type='note' header='Note'>
 
 When you view a specific version of a Managed Ruleset, each rule listed in the result can have one or more associated categories/tags, and it will not contain an expression.
@@ -343,26 +320,31 @@ When you view a specific version of a Managed Ruleset, each rule listed in the r
 
 Returns a list of all the rules in a Managed Ruleset with a specific tag.
 
-```bash
-GET /accounts/{account-id}/rulesets/{managed-ruleset-id}/{version-number}/by_tag/{tag-name}
-```
+| Operation | Method + URL stub |
+|-----------|-------------------|
+| List rules in ruleset by tag | `GET /accounts/{account-id}/rulesets/{managed-ruleset-id}/{version-number}/by_tag/{tag-name}` |
 
 ### Example
 
+<details open>
+<summary>Request</summary>
+<div>
+
 ```bash
----
-header: Request
----
 curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
+  -H "X-Auth-Email: user@example.com" \
   -H "X-Auth-Key: REDACTED" \
   "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/versions/2/by_tag/wordpress"
 ```
 
+</div>
+</details>
+
+<details open>
+<summary>Response</summary>
+<div>
+
 ```json
----
-header: Response
----
 {
   "result": {
     "id": "{managed-ruleset-id}",
@@ -412,3 +394,6 @@ header: Response
   "messages": []
 }
 ```
+
+</div>
+</details>


### PR DESCRIPTION
Addresses https://jira.cfops.it/browse/PCX-2055.

Endpoints are now listed at the beginning of a section in a table, linking to the corresponding API reference section (at https://api.cloudflare.com). 

Note: We're still missing a few methods in the API reference website.