### PR TITLE
Fix SvelteKit pages docs to use ESM config

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
@@ -79,28 +79,32 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 By default, SvelteKit prepares our project with the assumption that it will deployed to a Node.js server. This is not appropriate for this tutorial, but luckily SvelteKit is flexible and has a ready-made "adapter" for your needs. A few, easy changes have to be made.
 
-First, remove the [`@sveltejs/adapter-node`](https://www.npmjs.com/package/@sveltejs/adapter-node) dependency and install the [`@sveltejs/adapter-static`](https://www.npmjs.com/package/@sveltejs/adapter-static) package instead:
+First, install the [`@sveltejs/adapter-static`](https://www.npmjs.com/package/@sveltejs/adapter-static) package instead:
 
 ```sh
-$ npm uninstall @sveltejs/adapter-node
 $ npm install @sveltejs/adapter-static@next --save-dev
 ```
 
-Then, in the `svelte.config.cjs` file, update the adapter selection:
+Then, in the `svelte.config.js` file, update the adapter selection:
 
 ```diff
-const sveltePreprocess = require('svelte-preprocess');
---const node = require('@sveltejs/adapter-node');
-const pkg = require('./package.json');
+import preprocess from 'svelte-preprocess';
+++ import adapter from '@sveltejs/adapter-static';
 
-module.exports = {
-  // ... truncated ...
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	// Consult https://github.com/sveltejs/svelte-preprocess
+	// for more information about preprocessors
+	preprocess: preprocess(),
+
 	kit: {
---		adapter: node(),
-++		adapter: require('@sveltejs/adapter-static')(),
-		// ... truncated ...
+		// hydrate the <div id="svelte"> element in src/app.html
+++		adapter: adapter(),
+		target: '#svelte'
 	}
 };
+
+export default config;
 ```
 
 <Aside type="note">

--- a/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
@@ -93,14 +93,10 @@ import preprocess from 'svelte-preprocess';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://github.com/sveltejs/svelte-preprocess
-	// for more information about preprocessors
-	preprocess: preprocess(),
-
+	// ... truncated ...
 	kit: {
-		// hydrate the <div id="svelte"> element in src/app.html
 ++		adapter: adapter(),
-		target: '#svelte'
+		// ... truncated ...
 	}
 };
 

--- a/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-svelte-site.md
@@ -79,7 +79,7 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 By default, SvelteKit prepares our project with the assumption that it will deployed to a Node.js server. This is not appropriate for this tutorial, but luckily SvelteKit is flexible and has a ready-made "adapter" for your needs. A few, easy changes have to be made.
 
-First, install the [`@sveltejs/adapter-static`](https://www.npmjs.com/package/@sveltejs/adapter-static) package instead:
+First, install the [`@sveltejs/adapter-static`](https://www.npmjs.com/package/@sveltejs/adapter-static) package:
 
 ```sh
 $ npm install @sveltejs/adapter-static@next --save-dev
@@ -88,16 +88,15 @@ $ npm install @sveltejs/adapter-static@next --save-dev
 Then, in the `svelte.config.js` file, update the adapter selection:
 
 ```diff
-import preprocess from 'svelte-preprocess';
 ++ import adapter from '@sveltejs/adapter-static';
-
+++
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// ... truncated ...
-	kit: {
-++		adapter: adapter(),
-		// ... truncated ...
-	}
+  kit: {
+++  adapter: adapter(),
+    // ... truncated ...
+    target: '#svelte'  
+  }
 };
 
 export default config;


### PR DESCRIPTION
The [current instructions](https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-site#sveltekit-configuration) need updating for the current SvelteKit. The main reason is that SvelteKit changed the config to using ESM. See https://kit.svelte.dev/docs#configuration for the new style.

Also, the adapter-node is not included by default so cannot be removed.

This patch fixes both.