### PR TITLE
[Images] Improve the deleting images docs

### DIFF
--- a/products/images/src/content/deleting-images.md
+++ b/products/images/src/content/deleting-images.md
@@ -4,12 +4,12 @@ order: 4
 
 # Deleting Images
 
-If you want to remove an image from your Cloudflare storage that is associated with your account, you have two options:
+If you want to remove an image from the Cloudflare Images storage, you have two options:
 
-- API to delete an image
-- API to delete a variant
+* Delete from the [dashboard](https://dash.cloudflare.com?to=/:account/images/images)
+* Call the [API endpoint](https://api.cloudflare.com/#cloudflare-images-delete-image)
 
-To delete an image simply make a call via API:
+To delete an image through the API simply make a call like so:
 
 ```bash
 curl -X DELETE https://api.cloudflare.com/client/v4/account/:account_id/images/v1/:image_id \


### PR DESCRIPTION
In [Deleting Images](https://developers.cloudflare.com/images/deleting-images) it states:
```
If you want to remove an image from your Cloudflare storage that is associated with your account, you have two options:

* API to delete an image
* API to delete a variant
```

Now, there are a few issues that I see here:
* Deleting a variant does not remove any images from storage (which is what the sentence states).
* The wording is a little strange "API to delete an image" - this should probably be "Call the API endpoint" instead (it should also really link to the docs)
* It does not mention the fact you can just delete images on the dashboard.

I have suggested changes which in my opinion improve the wording here a lot and clear the docs up.