### PR TITLE
Add EventTarget, AbortController, and AbortSignal to web standard APIs

### DIFF
--- a/products/workers/src/content/runtime-apis/web-standards.md
+++ b/products/workers/src/content/runtime-apis/web-standards.md
@@ -68,6 +68,18 @@ __Note:__ Timers are only available inside of [the Request Context](/runtime-api
 
 </Aside>
 
+### EventTarget and Event
+
+The EventTarget and Event API allow objects to publish and subscribe to events.
+
+[Go to the docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+
+### AbortController and AbortSignal
+
+The AbortController and AbortSignal APIs provide a common model for canceling async operations.
+
+[Go to the docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+
 ### Fetch global
 
 <Definitions>

--- a/products/workers/src/content/runtime-apis/web-standards.md
+++ b/products/workers/src/content/runtime-apis/web-standards.md
@@ -70,15 +70,11 @@ __Note:__ Timers are only available inside of [the Request Context](/runtime-api
 
 ### EventTarget and Event
 
-The EventTarget and Event API allow objects to publish and subscribe to events.
-
-[Go to the docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+The [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) and [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) API allow objects to publish and subscribe to events.
 
 ### AbortController and AbortSignal
 
-The AbortController and AbortSignal APIs provide a common model for canceling async operations.
-
-[Go to the docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+The [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) and [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) APIs provide a common model for canceling asynchronous operations.
 
 ### Fetch global
 


### PR DESCRIPTION
`EventTarget` has recently been updated to match spec.

* `new EventTarget()` and `class Foo extends EventTarget {}` both now work.
* `addEventTarget()` now supports `EventHandler` objects in addition to functions; `once` listeners are also now supported.
* `Event` now exposes all of the standard property accessors and init options.

`AbortController` and `AbortSignal` have been added.