### PR TITLE
Update DWeb gateway X.509 provisioning URLs

### DIFF
--- a/products/distributed-web/src/content/ethereum-gateway/connecting-your-website.md
+++ b/products/distributed-web/src/content/ethereum-gateway/connecting-your-website.md
@@ -26,10 +26,7 @@ next to this record will automatically turn grey. Because you’ve CNAME’d to
 our gateway, you’ll automatically receive Cloudflare's enterprise-level
 performance and security enhancements, but you won’t be able to control those
 settings yourself.
-3. Navigate to the 'Ethereum' tab of <https://cloudflare.com/distributed-web-gateway>
-and enter your website domain name into the text box at the bottom of the page.
-4. You should receive a message indicating that the domain name setup completed
-successfully.
+3. Send an email to [ask-research@cloudflare.com](mailto:ask-research@cloudflare.com?subject=%5BDistributed%20Web%20Gateway%5D%20Create%20Ethereum%20certificate).
 
 Following these instructions will CNAME your domain to the Cloudflare Ethereum
 Gateway, which will allow you to access the Ethereum network via your domain

--- a/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
+++ b/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
@@ -143,12 +143,8 @@ Cloudflare's gateway doesn't have an SSL certificate for `your.website`. The
 good news is that Cloudflare can fix that.
 
 Cloudflare will issue you a free SSL certificate for `your.website`, which
-allows users to load `https://your.website`. All you have to do is go to
-[cloudflare-ipfs.com](https://cloudflare-ipfs.com) and scroll to the bottom,
-where it says "Connecting Your Website." Enter your domain into the text box and
-click `Submit`. When you click `Submit` the certificate issuance will
-begin. When it’s done, a message will appear indicating that the process has
-been completed and your certificate is in place. These certificates will
+allows users to load `https://your.website`. All you have to do is send an email
+to [ask-research@cloudflare.com](mailto:ask-research@cloudflare.com?subject=%5BDistributed%20Web%20Gateway%5D%20Create%IPFS%20certificate). These certificates will
 auto-renew, so once you’ve completed this step, you’ll never need to worry about
 certificates again.
 


### PR DESCRIPTION
We are making changes to the way X.509 certificates are provisioned on the IPFS and Ethereum gateway. In the meantime, we want to point people to ask-research@ which is a link that works.