### PR TITLE
CNAME manual validation is actually a post method

### DIFF
--- a/products/ssl/src/content/ssl-for-saas/common-tasks/certificate-validation-methods.md
+++ b/products/ssl/src/content/ssl-for-saas/common-tasks/certificate-validation-methods.md
@@ -232,7 +232,7 @@ $ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hos
 The last DCV method available is via a CNAME record. First, make a request using `"method":"cname"`:
 
 ```bash
-$ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
+$ curl -sXPOST "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames" \
        -H "X-Auth-Email: {email}" -H "X-Auth-Key: {key}" \
        -H "Content-Type: application/json" \
        -d '{"hostname":"cname.example.com", "ssl":{"method":"cname","type":"dv"}}'


### PR DESCRIPTION
Documentation said that it should be a patch but actual method mirrors the others and is a post.