### PR TITLE
Remove URL.createObjectURL from example script for reading POST data

### DIFF
--- a/products/workers/src/content/examples/read-post.md
+++ b/products/workers/src/content/examples/read-post.md
@@ -58,7 +58,7 @@ async function readRequestBody(request) {
   else {
     // Perhaps some other type of data was submitted in the form
     // like an image, or some other binary data. 
-    return "a file". 
+    return 'a file';
   }
 }
 

--- a/products/workers/src/content/examples/read-post.md
+++ b/products/workers/src/content/examples/read-post.md
@@ -56,9 +56,9 @@ async function readRequestBody(request) {
     return JSON.stringify(body)
   }
   else {
-    const myBlob = await request.blob()
-    const objectURL = URL.createObjectURL(myBlob)
-    return objectURL
+    // Perhaps some other type of data was submitted in the form
+    // like an image, or some other binary data. 
+    return "a file". 
   }
 }
 


### PR DESCRIPTION
Workers doesn't support URL.createObjectURL, so this example doesn't actually work on our platform.
Further, the example form doesn't actually accept a file upload, so this condition isn't useful on its own. 

This PR removes the line which uses that api, replacing it with a simple string return. Later, we might want a crack at rewriting this page altogether to be a more useful example.