### PR TITLE
remove duplicate information in kv doc and add preview id command

### DIFF
--- a/products/workers/src/content/cli-wrangler/commands.md
+++ b/products/workers/src/content/cli-wrangler/commands.md
@@ -328,7 +328,7 @@ Default values indicated by <Type>=value</Type>.
 
 If you are using [kv_namespaces](/cli-wrangler/configuration#kv_namespaces) with `wrangler preview`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.
 
-To create a `preview_id` run 
+To create a `preview_id` run:
 ``` 
 wrangler kv:namespace create --preview "NAMESPACE"
 ```

--- a/products/workers/src/content/cli-wrangler/commands.md
+++ b/products/workers/src/content/cli-wrangler/commands.md
@@ -258,9 +258,6 @@ $ wrangler dev
 
 From here you can send HTTP requests to `localhost:8787` and your Worker should execute as expected. You will also see console.log messages and exceptions appearing in your terminal. If either of these things _don’t_ happen, or you think the output is incorrect, please [file an issue](https://github.com/cloudflare/wrangler).
 
-### kv_namespaces
-
-If you are using [kv_namespaces](/cli-wrangler/configuration#kv_namespaces) with `wrangler dev`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.
 
 --------------------------------
 
@@ -330,6 +327,11 @@ Default values indicated by <Type>=value</Type>.
 ### kv_namespaces
 
 If you are using [kv_namespaces](/cli-wrangler/configuration#kv_namespaces) with `wrangler preview`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.
+
+To create a `preview_id` run 
+``` 
+wrangler kv:namespace create --preview "NAMESPACE"
+```
 
 ### Previewing on Windows Subsystem for Linux (WSL 1/2)
 


### PR DESCRIPTION
I realized that generating a preview_id wasn’t explicitly pointed out and the doc had duplicate information. 

Ref: #1458  https://github.com/cloudflare/wrangler/issues/1458