### PR TITLE
[Cache] Fixed API method

### DIFF
--- a/products/cache/src/content/how-to/enable-vary-for-images.md
+++ b/products/cache/src/content/how-to/enable-vary-for-images.md
@@ -10,7 +10,7 @@ Vary for Images is enabled through Cloudflare’s API by creating a variants rul
 ## Create a variants rule 
 
 ```json
-curl -X POST 
+curl -X PATCH 
 "https://api.cloudflare.com/client/v4/zones/023e105f4ecef8ad9ca31a8372d0 c353/cache/variants" \ 
 -H "X-Auth-Email: user@example.com" \ 
 -H "X-Auth-Key: 3xamp1ek3y1234" \ 


### PR DESCRIPTION
Fixing API method. Vary for Images content was already added, but this fix helps close out [PCX-805](https://jira.cfops.it/browse/PCX-805).