### PR TITLE
[Identity] fix heading in teams-authentication-faq.md

### DIFF
--- a/products/cloudflare-one/src/content/faq/teams-authentication-faq.md
+++ b/products/cloudflare-one/src/content/faq/teams-authentication-faq.md
@@ -15,7 +15,7 @@ Yes. Your team can simultaneously use multiple providers, reducing friction when
 
 You can add your preferred identity providers to Cloudflare Access even if you do not see them listed on the Teams dashboard, as long as these providers support SAML 2.0 or [OpenID Connect (OIDC)](/identity/idp-integration/generic-oidc). 
 
-## How do end users log out of an application protected by Access?
+## How do end users log out of an application protected by Access?
 
 Access provides a URL that will end a user's current session. To force log out of an Access application, use the following URL:
 


### PR DESCRIPTION
- Heading "How do end users log out of an application protected by Access?" was unrecognised.
- A non-breaking space was changed to a regular space.