### PR TITLE
Updated POST command

### DIFF
--- a/products/terraform/src/content/tutorial/track-history.md
+++ b/products/terraform/src/content/tutorial/track-history.md
@@ -67,8 +67,7 @@ First, create the GitHub repository to store the config. This can be done via th
 $ export GITHUB_USER=your-github-user
 $ export GITHUB_TOKEN=your-github-token
 
-$ export GITHUB_URL=$(curl -sSXPOST https://api.github.com/user/repos?access_token=$GITHUB_TOKEN -H 'Content-Type: application/json' \
--d '{"name": "cf-config", "private":"true"}' 2>/dev/null | jq -r .ssh_url)
+$ export GITHUB_URL=$(curl -H "Authorization: token $GITHUB_TOKEN" -d '{"name": "cf-config", "private": true}' "https://api.github.com/user/repos" 2> /dev/null | jq -r .ssh_url)
 
 $ echo $GITHUB_URL
 git@github.com:$GITHUB_USER/cf-config.git


### PR DESCRIPTION
Correct command to use auth token:

$ export GITHUB_URL=$(curl -H "Authorization: token $GITHUB_TOKEN" -d '{"name": "cf-config", "private": true}' "https://api.github.com/user/repos" 2> /dev/null | jq -r .ssh_url)