### PR TITLE
DWeb gateways have moved to a private beta

### DIFF
--- a/products/distributed-web/src/content/ethereum-gateway/connecting-your-website.md
+++ b/products/distributed-web/src/content/ethereum-gateway/connecting-your-website.md
@@ -5,6 +5,10 @@ pcx-content-type: tutorial
 
 # Connecting your Website
 
+> To improve our service, the Ethereum gateway has moved to a Private Beta.
+> During this period, we are not offering self-provisioning of SSL cerificates.
+> You [can register](https://forms.gle/3c2xAzawnDcqWzgN7) to get notified once this service opens up.
+
 You can connect your own domain name to <https://cloudflare-eth.com> to allow
 Ethereum network access from your own domain. This means that anyone can send
 the HTTP (JSON RPC) queries as given in [Interacting with the Ethereum
@@ -13,24 +17,3 @@ to your own domain. To do this, you should replace `https://cloudflare-eth.com`
 with your domain, e.g. `myethereumgateway.xyz`, as the target of the HTTP
 query.
 
-To connect your domain to the Cloudflare Ethereum gateway, follow the instructions
-at <https://cloudflare.com/distributed-web-gateway> on the 'Ethereum' tab. Essentially,
-you need to:
-
-1. Go to your DNS settings for your domain. If your website is on Cloudflare,
-   the DNS settings are accessible from your dashboard. If your website is not
-on Cloudflare, and you need help finding the DNS records, you can use
-[DomainTools](https://whois.domaintools.com/) to identify your registrar.
-2. Add a CNAME record from your domain (e.g. www.example.com) to
-cloudflare-eth.com. Note: if your website is on Cloudflare, the little cloud
-next to this record will automatically turn grey. Because you’ve CNAME’d to
-our gateway, you’ll automatically receive Cloudflare's enterprise-level
-performance and security enhancements, but you won’t be able to control those
-settings yourself.
-3. Send an email to [ask-research@cloudflare.com](mailto:ask-research@cloudflare.com?subject=%5BDistributed%20Web%20Gateway%5D%20Create%20Ethereum%20certificate).
-
-Following these instructions will CNAME your domain to the Cloudflare Ethereum
-Gateway, which will allow you to access the Ethereum network via your domain
-name. Submitting your your domain name in the form launches a process that
-provisions an SSL certificate for your website so that you can access the
-Gateway over HTTPS.

--- a/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
+++ b/products/distributed-web/src/content/ipfs-gateway/connecting-website.md
@@ -133,6 +133,10 @@ recommended course.
 
 ## Make It All Secure
 
+> To improve our service, the IPFS gateway has moved to a Private Beta.
+> During this period, we are not offering self-provisioning of SSL cerificates.
+> You [can register](https://forms.gle/3c2xAzawnDcqWzgN7) to get notified once this service opens up.
+
 Now your content is on IPFS and your website is connected to Cloudflare's
 gateway. There's just one more step to make this secure. If you've followed all
 the steps until now, you'll notice that your website works fine when loaded over
@@ -142,8 +146,7 @@ Cloudflare's gateway doesn't have an SSL certificate for `your.website`. The
 good news is that Cloudflare can fix that.
 
 Cloudflare will issue you a free SSL certificate for `your.website`, which
-allows users to load `https://your.website`. All you have to do is send an email
-to [ask-research@cloudflare.com](mailto:ask-research@cloudflare.com?subject=%5BDistributed%20Web%20Gateway%5D%20Create%IPFS%20certificate). These certificates will
+allows users to load `https://your.website`. These certificates will
 auto-renew, so once you’ve completed this step, you’ll never need to worry about
 certificates again.
 


### PR DESCRIPTION
Inform customer that dweb gateways have moved to a private beta, and are
not provisioning SSL certificates during this interval.