### PR TITLE
fix code blocks to allow copying of text

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-guide.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-guide.md
@@ -57,14 +57,14 @@ Next, install `cloudflared`.
 Use the deb package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` is used in this example.
 
 ```sh
-wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb dpkg -i cloudflared-linux-amd64.deb
+$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb dpkg -i cloudflared-linux-amd64.deb
 ```
 
-### ​.rpm install
+### .rpm install
 Use the rpm package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` is used in this example.
 
 ```sh
-wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-x86_64.rpm
+$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-x86_64.rpm
 ```
 
 </div>


### PR DESCRIPTION
This fixes the Linux install instructions for Tunnel Guide: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide

Using the instructions for code blocks: https://developers.cloudflare.com/docs-engine/reference/markdown#terminals