### PR TITLE
Add more options to the Sec heads example

### DIFF
--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -71,7 +71,6 @@ const DEFAULT_SECURITY_HEADERS = {
 }
 
 const BLOCKED_HEADERS = [
-    "Public-Key-Pins",
     "X-Powered-By",
     "X-AspNet-Version",
 ]

--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -55,7 +55,7 @@ const DEFAULT_SECURITY_HEADERS = {
     'Cross-Origin-Opener-Policy': 'same-site; report-to="default";',
     "Cross-Origin-Resource-Policy": "same-site",
     "Cache-Control": "no-cache, no-store, must-revalidate, private",
-    "Set-Cookie": "__Host-ID=123; Secure; HttpOnly; SameSite=None; Path=/",
+    "Set-Cookie": "__Host-ID=123; Secure; HttpOnly; SameSite=strict; Path=/",
     /*
     Feature-Policy will be renamed into Permissions-Policy and will be deprectated.
     Using both will give a warning and the Permissions-Policy will be used instead.

--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -20,13 +20,15 @@ const DEFAULT_SECURITY_HEADERS = {
     Secure your application with Content-Security-Policy headers.
     Enabling these headers will permit content from a trusted domain and all its subdomains.
     @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-    "Content-Security-Policy": "default-src 'self' example.com *.example.com",
+    "Content-Security-Policy": "default-src 'none'; script-src 'unsafe-inline' 'report-sample' 'self'; style-src 'report-sample' 'self' https://fonts.googleapis.com; object-src 'none'; base-uri 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none'; form-action 'none'; frame-ancestors 'none'; require-trusted-types-for 'script';",
     */
     /*
     You can also set Strict-Transport-Security headers. 
     These are not automatically set because your website might get added to Chrome's HSTS preload list.
+    If you want to submit your website to be HSTS preloaded.
+    @see https://hstspreload.org
     Here's the code if you want to apply it:
-    "Strict-Transport-Security" : "max-age=63072000; includeSubDomains; preload",
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
     */
     /*
     Permissions-Policy header provides the ability to allow or deny the use of browser features, such as opting out of FLoC - which you can use below:
@@ -36,7 +38,7 @@ const DEFAULT_SECURITY_HEADERS = {
     X-XSS-Protection header prevents a page from loading if an XSS attack is detected. 
     @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
     */
-    "X-XSS-Protection": "0; mode=block",
+    "X-XSS-Protection": "1; mode=block",
     /*
     X-Frame-Options header prevents click-jacking attacks. 
     @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
@@ -48,18 +50,36 @@ const DEFAULT_SECURITY_HEADERS = {
     */
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
     'Cross-Origin-Embedder-Policy': 'require-corp; report-to="default";',
     'Cross-Origin-Opener-Policy': 'same-site; report-to="default";',
     "Cross-Origin-Resource-Policy": "same-site",
+    "Cache-Control": "no-cache, no-store, must-revalidate, private",
+    "Set-Cookie": "__Host-ID=123; Secure; HttpOnly; SameSite=None; Path=/",
+    /*
+    Feature-Policy will be renamed into Permissions-Policy and will be deprectated.
+    Using both will give a warning and the Permissions-Policy will be used instead.
+    @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+    //"Feature-Policy": "camera 'none'; fullscreen 'self'; geolocation 'none'; microphone 'none';",
+    */
+    "X-Permitted-Cross-Domain-Policies": "none",
+    /* SRI/Subresource Integrity can be implemented at the html level.
+    @see https://infosec.mozilla.org/guidelines/web_security#subresource-integrity
+    HPKP isn't something you should do when using the Dedicated & Universal SSL on Cloudflare.
+    @see https://developers.cloudflare.com/ssl/edge-certificates/additional-options/certificate-transparency-monitoring#:~:text=Cloudflare%20does%20not%20offer%20or%20support%20HPKP%20and%20advises%20against%20using%20it%20with%20Dedicated%20%26%20Universal%20SSL.
+    */
 }
+
 const BLOCKED_HEADERS = [
     "Public-Key-Pins",
     "X-Powered-By",
     "X-AspNet-Version",
 ]
+
 addEventListener('fetch', event => {
     event.respondWith(addHeaders(event.request))
 })
+
 async function addHeaders(req) {
     let response = await fetch(req)
     let newHeaders = new Headers(response.headers)
@@ -74,18 +94,19 @@ async function addHeaders(req) {
         })
     }
 
-    Object.keys(DEFAULT_SECURITY_HEADERS).map(function (name) {
+    Object.keys(DEFAULT_SECURITY_HEADERS).map(function(name, index) {
         newHeaders.set(name, DEFAULT_SECURITY_HEADERS[name]);
     })
 
-    BLOCKED_HEADERS.forEach(function (name) {
+    BLOCKED_HEADERS.forEach(function(name){
         newHeaders.delete(name)
     })
 
     if (tlsVersion != "TLSv1.2" && tlsVersion != "TLSv1.3") {
         return new Response("You need to use TLS version 1.2 or higher.", { status: 400 })
-    } else {
-        return new Response(response.body, {
+    }
+    else {
+        return new Response(response.body , {
             status: response.status,
             statusText: response.statusText,
             headers: newHeaders


### PR DESCRIPTION
This PR is based on the previous/current example how to implement security-headers with CF workers.
I've tested the headers on the following site and they all seem to be working as intended:
https://observatory.mozilla.org/analyze/rockraidersx.com
https://securityheaders.com/?q=https%3A%2F%2Frockraidersx.com&followRedirects=on
https://csp-evaluator.withgoogle.com/?csp=https://rockraidersx.com

I found some conflicting/oudated information about Feature-Policy and added a comment about that.
I also left comments about the using SRI and HPKP. I do understand if you want this part to be removed.

To clarify. While I do understand mostly what's going on with workers adding the HTTP headers, and how CSP/Security Headers do their magic. I'm only following warnings and applying solutions so I don't have the right experience/background to justify all the decisions made/set here.

I also believe it's not possible to make the Content-Security-Policy and Permissions-Policy multi-lined is there? Given the highlighting that changes in the workers editor i assume not. But correct me if i'm wrong! It would certainly make reading alot easier.

If some parts don't make sense or should be changed i can do so. For example: 
Here: https://github.com/cloudflare/cloudflare-docs/compare/production...Macleykun:patch-2#diff-177479fe4766ecf9cd4083ff3629016752dc2264f53387955636689e737f4701R97 index was added. But i'm not sure if that really matters.

Also, technically i could add this to the script-src part:
https://observatory.mozilla.org/analyze/rockraidersx.com#:~:text=Uses%20CSP3%27s,Google%27s%20CSP%20Evaluator!
Which would technically check that one off too.