### PR TITLE
[Logs] PCX-2746: Update Logs fields

### DIFF
--- a/products/logs/src/content/reference/log-fields/zone/firewall_events.md
+++ b/products/logs/src/content/reference/log-fields/zone/firewall_events.md
@@ -17,7 +17,7 @@ The descriptions below detail the fields available for `firewall_events`.
 | ClientASNDescription | The ASN of the visitor as string | string |
 | ClientCountry | Country from which request originated | string |
 | ClientIP | The visitor's IP address (IPv4 or IPv6) | string |
-| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
+| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em> | string |
 | ClientRefererHost | The referer host | string |
 | ClientRefererPath | The referer path requested by visitor | string |
 | ClientRefererQuery | The referer query-string was requested by the visitor | string |

--- a/products/logs/src/content/reference/log-fields/zone/http_requests.md
+++ b/products/logs/src/content/reference/log-fields/zone/http_requests.md
@@ -15,7 +15,7 @@ The descriptions below detail the fields available for `http_requests`.
 | BotScore | Cloudflare Bot Score. Scores below 30 are commonly associated with automated traffic. Available for Bot Management customers (please contact your account team to enable). | int |
 | BotScoreSrc | Detection engine responsible for generating the Bot Score. <br />Possible values are <em>Not Computed</em> \| <em>Heuristics</em> \| <em>Machine Learning</em> \| <em>Behavioral Analysis</em> \| <em>Verified Bot</em> \| <em>JS Fingerprinting</em> \| <em>Cloudflare Service</em> | string |
 | BotTags | Type of bot traffic (if available). See [Bot Tags](https://developers.cloudflare.com/bots/about/cloudflare-bot-tags) for the list of potential values. Available in Logpush v2 only. | array[string] |
-| CacheCacheStatus | <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> | string |
+| CacheCacheStatus | <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> | string |
 | CacheResponseBytes | Number of bytes returned by the cache | int |
 | CacheResponseStatus (deprecated) | HTTP status code returned by the cache to the edge. All requests (including non-cacheable ones) go through the cache. Also see CacheCacheStatus field. | int |
 | CacheTieredFill | Tiered Cache was used to serve this request | bool |
@@ -23,7 +23,7 @@ The descriptions below detail the fields available for `http_requests`.
 | ClientCountry | Country of the client IP address | string |
 | ClientDeviceType | Client device type | string |
 | ClientIP | IP address of the client | string |
-| ClientIPClass | <em>unknown</em> \| <em>clean</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>greylist</em> \| <em>monitoringService</em> \| <em>securityScanner</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>backupService</em> \| <em>mobilePlatform</em> \| <em>tor</em> | string |
+| ClientIPClass | <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em> | string |
 | ClientMTLSAuthCertFingerprint | The SHA256 fingerprint of the certificate presented by the client during mTLS authentication. Only populated on the first request on an mTLS connection. Available in Logpush v2 only. | string |
 | ClientMTLSAuthStatus | The status of mTLS authentication. Only populated on the first request on an mTLS connection. Available in Logpush v2 only. <br />Possible values are <em>unknown</em> \| <em>ok</em> \| <em>absent</em> \| <em>untrusted</em> \| <em>notyetvalid</em> \| <em>expired</em> | string |
 | ClientRequestBytes | Number of bytes in the client request | int |


### PR DESCRIPTION
This updates Logs fields, syncing from internal repo (`logshare-api` fields templates).

`gateway_dns.md` is excluded, as there are manual changes made directly, and requires update on the internal repo first.