### PR TITLE
Don't treat 3xx responses as errors in examples

### DIFF
--- a/products/images/src/content/faq/index.md
+++ b/products/images/src/content/faq/index.md
@@ -83,7 +83,7 @@ Yes, the uploaded image file must be less than or equal to 10 MB.
 
 ### Which file formats does Cloudflare Images support?
 
-Cloudflare Images supports common Web-compatible file formats as input files: JPEG, PNG, GIF (including animations), and WebP.
+Cloudflare Images supports common web-compatible file formats as input files: JPEG, PNG, GIF (including animations), and WebP.
 
 ### Can Cloudflare Images convert my images to AVIF?
 

--- a/products/images/src/content/faq/index.md
+++ b/products/images/src/content/faq/index.md
@@ -83,7 +83,7 @@ Yes, the uploaded image file must be less than or equal to 10 MB.
 
 ### Which file formats does Cloudflare Images support?
 
-Cloudflare Images supports most common file formats as input files. These include JPEG, GIF, PNG, and WebP.
+Cloudflare Images supports common Web-compatible file formats as input files: JPEG, PNG, GIF (including animations), and WebP.
 
 ### Can Cloudflare Images convert my images to AVIF?
 

--- a/products/images/src/content/image-resizing/resize-with-workers.md
+++ b/products/images/src/content/image-resizing/resize-with-workers.md
@@ -83,7 +83,7 @@ The `fetch()` function accepts parameters in the second argument inside the `{cf
     To automatically serve WebP or AVIF formats to browsers that support them, check if the `Accept` header contains `image/webp` or `image/avif`, and set the format option accordingly.
 
 - **`anim`**
-  - Whether to preserve animation frames from input files. Default is `true`. Setting it to `false` reduces animations to still images. This setting is recommended when enlarging images or processing arbitrary user content, because large GIF animations can weigh tens or even hundreds of megabytes. It's also useful to set `anim:false` when using `format:"json"` to get the response quicker without the number of frames.
+  - Whether to preserve animation frames from input files. Default is `true`. Setting it to `false` reduces animations to still images. This setting is recommended when enlarging images or processing arbitrary user content, because large GIF animations can weigh tens or even hundreds of megabytes. It is also useful to set `anim:false` when using `format:"json"` to get the response quicker without the number of frames.
 
 - **`metadata`**
   - What EXIF data should be preserved in the output image. Note that EXIF rotation and embedded color profiles are always applied ("baked in" into the image), and are not affected by this option. Note that if the Polish feature is enabled, all metadata may have been removed already and this option may have no effect.

--- a/products/images/src/content/image-resizing/resize-with-workers.md
+++ b/products/images/src/content/image-resizing/resize-with-workers.md
@@ -177,7 +177,7 @@ By default, the error will be forwarded to the browser, but you can decide how t
 ```js
 const response = await fetch(imageURL, options)
 
-if (response.ok) {
+if (response.ok || response.redirected) { // fetch() may respond with status 304
   return response
 } else {
   return response.redirect(imageURL, 307)
@@ -190,7 +190,7 @@ You can also replace failed images with a placeholder image:
 
 ```js
 const response = await fetch(imageURL, options)
-if (response.ok) {
+if (response.ok || response.redirected) {
   return response
 } else {
   // Change to a URL on your server

--- a/products/images/src/content/image-resizing/responsive-images.md
+++ b/products/images/src/content/image-resizing/responsive-images.md
@@ -84,7 +84,7 @@ In this example, `sizes` says that for screens smaller than 640 pixels the image
 
 `srcset` is useful for pixel-based formats such as PNG, JPEG, and WebP. It is unnecessary for vector-based SVG images.
 
-HTML also [supports the `<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) that can optionally request an image in the WebP format, but you do not need it. Cloudflare can serve WebP images automatically whenever you use `/cdn-cgi/image/…` URLs in `src` or `srcset`.
+HTML also [supports the `<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) that can optionally request an image in the WebP format, but you do not need it. Cloudflare can serve WebP images automatically whenever you use `/cdn-cgi/image/format=auto,…` URLs in `src` or `srcset`.
 
 If you want to use WebP images, but do not need resizing, you have two options:
 

--- a/products/images/src/content/image-resizing/troubleshooting.md
+++ b/products/images/src/content/image-resizing/troubleshooting.md
@@ -9,6 +9,7 @@ pcx-content-type: interim
 
 Does the response have a `Cf-Resized` header? If **not**, then resizing has not been attempted. Possible causes:
 
+  * Image Resizing feature is not enabled in the Cloudflare Dashboard.
   * There is another Worker running on the same request. Resizing is "forgotten" as soon as one Worker calls another. Do not use Workers scoped to the entire domain `/*`.
   * Preview in the Editor in Cloudflare Dashboard does not simulate image resizing. You must deploy the Worker and test from another browser tab instead.
 
@@ -36,7 +37,7 @@ When resizing fails, the response body contains an error message explaining the 
 
 ## Limits
 
-Maximum image size is 100 megapixels (e.g. 10000&times;10000 pixels large). Maximum file size is 70 MB.
+Maximum image size is 100 megapixels (e.g. 10000&times;10000 pixels large). Maximum file size is 70 MB. GIF animations are limited to 100 megapixels total (sum of sizes of all frames).
 
 ## Authorization and cookies are not supported
 
@@ -46,9 +47,9 @@ You can use unguessable URLs for images (e.g. with long random IDs) and/or handl
 
 ## Caching and purging
 
-Changes to image dimensions or other resizing options should always take effect immediately — no purging necessary.
+Changes to image dimensions or other resizing options always take effect immediately — no purging necessary.
 
-Image requests consists of two parts: running Worker code, and image processing. The Worker code is always executed and uncached. Results of image processing are cached for one hour or longer if origin server's `Cache-Control` header allows.
+Image requests consists of two parts: running Worker code, and image processing. The Worker code is always executed and uncached. Results of image processing are cached for one hour or longer if origin server's `Cache-Control` header allows. Source image is cached using regular caching rules. Resizing follows redirects internally, so the redirects are cached too.
 
 Because responses from Workers themselves are not cached at the edge, purging of *Worker URLs* does nothing. Resized image variants are cached together under their source’s URL. When purging, use the (full-size) source image’s URL, rather than URLs of the Worker that requested resizing.
 

--- a/products/images/src/content/image-resizing/url-format.md
+++ b/products/images/src/content/image-resizing/url-format.md
@@ -19,7 +19,7 @@ Here is a breakdown of each part of the URL:
   - Your domain name on Cloudflare. Unlike other third-party image resizing services, we do not use a separate domain name for an API. Every Cloudflare zone with image resizing enabled can handle resizing itself. In URLs used on your website this part can be omitted, so that URLs start with `/cdn-cgi/image/`.
 
 - `/cdn-cgi/image/`
-  - A fixed prefix that identifies that this is a special path handled by Cloudflare.
+  - A fixed prefix that identifies that this is a special path handled by Cloudflare's built-in Worker.
 
 - `options`
   - A comma-separated list of options such as `width`, `height`, and `quality`.
@@ -89,16 +89,19 @@ At least one option must be specified. Options are comma-separated (spaces are n
   - Specifies quality for images in JPEG, WebP, and AVIF formats. The quality is in 1-100 scale, but useful values are between `50` (low quality, small file size) and `90` (high quality, large file size). `85` is the default. When using the PNG format, an explicit quality setting allows use of PNG8 (palette) variant of the format.
 
 - **`format=auto`** or **`f=auto`**
-  - Allows serving of the WebP format to browsers that support it. If this option is not specified, a standard format like JPEG or PNG will be used.
+  - Allows serving of the WebP or AVIF format to browsers that support it. If this option is not specified, a standard format like JPEG or PNG will be used.
 
 - **`anim=false`**
-  - Reduces animations to still images. This setting is recommended to avoid large animGIF files, or flashing images.
+  - Reduces animations to still images. This setting is recommended to avoid large animated GIF files, or flashing images.
 
 - **`sharpen=x`**
   - Specifies strength of sharpening filter. The value is a floating-point number between `0` (no sharpening) and `10` (maximum). `1` is a recommended value.
 
+- **`blur=x`**
+  - Blur radius between `1` (slight blur) and `250` (maximum). Please beware that you can't use this option to reliably obscure image content, because savvy users can modify image's URL and remove the blur option. Use Workers to control which options can be set.
+
 - **`onerror=redirect`**
-  - In case of a fatal error that prevents the image from being resized, redirects to the unresized source image URL. This may be useful in case some images require user authentication and cannot be fetched anonymously via Worker. This option should not be used if there is a change the source images is very large. This option is ignored if the image is from another domain, but you can use with subdomains.
+  - In case of a fatal error that prevents the image from being resized, redirects to the unresized source image URL. This may be useful in case some images require user authentication and cannot be fetched anonymously via Worker. This option should not be used if there is a change the source images is very large. This option is ignored if the image is from another domain, but you can use it with subdomains.
 
 - **`metadata`**
   - Controls amount of invisible metadata (EXIF data) that should be preserved. Color profiles and EXIF rotation are applied to the image even if the metadata is discarded. Note that if the Polish feature is enabled, all metadata may have been removed already and this option may have no effect.
@@ -124,11 +127,13 @@ At least one option must be specified. Options are comma-separated (spaces are n
 
 Cloudflare Image resizing can:
 
+* Read JPEG, PNG, GIF (including animations), and WebP images. SVG is not supported (this format is inherently scalable, and doesn't need resizing).
 * Generate JPEG and PNG images, and optionally AVIF or WebP.
 * Save animations as GIF or animated WebP.
-* Read JPEG, PNG, GIF (including animations), and WebP images.
 * Support ICC color profiles in JPEG and PNG images. 
 * Preserve JPEG metadata. Metadata of other formats is discarded.
+
+AVIF format is supported on a best-effort basis. Images that can't be compressed as AVIF will be served as WebP instead.
 
 ## Recommended image sizes
 
@@ -152,7 +157,7 @@ You can detect device type by enabling the `CF-Device-Type` header [via Page Rul
 
 ## Image optimization and interaction with Polish
 
-Polish will not be applied to URLs using Image Resizing. Resized images already have lossy compression applied where possible, so they do not need the optimizations provided by Polish.
+Polish will not be applied to URLs using Image Resizing. Resized images already have lossy compression applied where possible, so they do not need the optimizations provided by Polish. Use `format=auto` option to allow use of WebP and AVIF formats.
 
 ## Caching
 

--- a/products/images/src/content/image-resizing/url-format.md
+++ b/products/images/src/content/image-resizing/url-format.md
@@ -133,7 +133,7 @@ Cloudflare Image resizing can:
 * Support ICC color profiles in JPEG and PNG images. 
 * Preserve JPEG metadata. Metadata of other formats is discarded.
 
-AVIF format is supported on a best-effort basis. Images that can't be compressed as AVIF will be served as WebP instead.
+AVIF format is supported on a best-effort basis. Images that cannot be compressed as AVIF will be served as WebP instead.
 
 ## Recommended image sizes
 

--- a/products/workers/src/content/examples/debugging-logs.md
+++ b/products/workers/src/content/examples/debugging-logs.md
@@ -30,7 +30,7 @@ async function handleRequest(event) {
 
   try {
     response = await fetch(event.request)
-    if (!response.ok) {
+    if (!response.ok && !response.redirected) {
       const body = await response.text()
       throw new Error(
         "Bad response at origin. Status: " +


### PR DESCRIPTION
Documents new `blur` param and updates docs in general.