### PR TITLE
new: workers bot management properties

### DIFF
--- a/products/bots/src/content/get-started/bm-subscription.md
+++ b/products/bots/src/content/get-started/bm-subscription.md
@@ -13,7 +13,7 @@ Bot Management for Enterprise is a paid add-on that provides sophisticated bot p
 This Enterprise product provides the most flexibility to customers by:
 
 - Generating a [bot score](/concepts/bot-score) of 1-99 for every request. Scores below 30 are commonly associated with bot traffic.
-- Allowing customers to take action on this score with Firewall Rules or Workers.
+- Allowing customers to take action on this score with Firewall Rules or [`Workers`](/workers/runtime-apis/request#incomingrequestcfproperties).
 - Allowing customers to view this score in Bot Analytics or Logs.
 
 ---

--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -201,6 +201,10 @@ All plans have access to:
 
   - The organisation which owns the ASN of the incoming request, e.g. `Google Cloud`.
 
+- `botManagement` <Type>Object | null</Type>
+
+  - Only set when using Cloudflare Bot Management. Object with the following properties: `score`, `verifiedBot`, `staticResource`. See the [`Bot Management Variables`](/bots/reference/bot-management-variables) for more details.
+
 - `colo` <Type>string</Type>
 
   - The three-letter [`IATA`](https://en.wikipedia.org/wiki/IATA_airport_code) airport code of the data center that the request hit, e.g. `"DFW"`.

--- a/products/workers/src/content/runtime-apis/request.md
+++ b/products/workers/src/content/runtime-apis/request.md
@@ -203,7 +203,7 @@ All plans have access to:
 
 - `botManagement` <Type>Object | null</Type>
 
-  - Only set when using Cloudflare Bot Management. Object with the following properties: `score`, `verifiedBot`, `staticResource`. See the [`Bot Management Variables`](/bots/reference/bot-management-variables) for more details.
+  - Only set when using Cloudflare Bot Management. Object with the following properties: `score`, `verifiedBot`, `staticResource`. Refer to the [`Bot Management Variables`](/bots/reference/bot-management-variables) for more details.
 
 - `colo` <Type>string</Type>
 


### PR DESCRIPTION
BM properties are documented on https://developers.cloudflare.com/bots/reference/bot-management-variables, so decided to just reference that page

Kate:
closes: https://jira.cfops.it/browse/WDC-224