### PR TITLE
Adding a secondary note to better describe the example parameters

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/routing-to-tunnel/lb.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/routing-to-tunnel/lb.md
@@ -35,7 +35,7 @@ To do so, run the following command:
 $ cloudflared tunnel route lb <tunnel ID or NAME> <load balancer name> <load balancer pool>
 ```
 
-**Note**: this command requires the `cert.pem` file.
+**Note**: this command requires the `cert.pem` file, and `<load balancer name>` is a hostname with the suffix of this zone (even though this suffix is not shown in the dashboard UI). 
 
 ## Optional: Configure additional Cloudflare settings
 


### PR DESCRIPTION
In the user interface of the load balancer page (`/traffic/load-balancing`) the suffix of a load balancer name is never shown even though that column is titled 'hostname'. In the CF API call to list load balancers the zone suffix *is* included in the "name" key, and to get the command on this page to work the full hostname is required. For example, for load balancer "hello" in zone "you.com", we need to use "hello.you.com" as the load balancer name in the `cloudflared tunnel route lb <tunnel ID or NAME> <load balancer name> <load balancer pool>` for it to work.