### PR TITLE
chore: bump "automatic-platform-optimization" site

### DIFF
--- a/products/automatic-platform-optimization/wrangler.toml
+++ b/products/automatic-platform-optimization/wrangler.toml
@@ -1,7 +1,7 @@
 name = "automatic-platform-optimization"
 type = "webpack"
-workers_dev = true
 account_id = "b54f07a6c269ecca2fa60f1ae4920c99" # cloudflare-docs.workers.dev
+workers_dev = true
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
This is a follow-up to #2603 and is the only failing deployment from [the batch](https://github.com/cloudflare/cloudflare-docs/runs/4049301245?check_suite_focus=true)

Rather than rerun all the jobs, this PR re-bumps the single site so that only it gets queued for redeployment.