### PR TITLE
[Workers] Fix handler parameters in module workers examples

### DIFF
--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -42,7 +42,7 @@ async function handleRequest(request, ctx) {
   return response;
 }
 export default {
-  fetch(request, ctx) {
+  fetch(request, env, ctx) {
     try {
       return handleRequest(request, ctx);
     } catch (e) {

--- a/products/workers/src/content/examples/cache-post-request.md
+++ b/products/workers/src/content/examples/cache-post-request.md
@@ -52,7 +52,7 @@ async function handlePostRequest(request, ctx) {
   return response;
 }
 export default {
-  fetch(request, ctx) {
+  fetch(request, env, ctx) {
     try {
       if (request.method.toUpperCase() === "POST") {
         return handlePostRequest(request, ctx);

--- a/products/workers/src/content/examples/cron-trigger.md
+++ b/products/workers/src/content/examples/cron-trigger.md
@@ -19,8 +19,8 @@ async function triggerEvent(event) {
   console.log("cron processed", event.scheduledTime);
 }
 export default {
-  async scheduled(event) {
-    event.waitUntil(triggerEvent(event));
+  async scheduled(controller, env, ctx) {
+    ctx.waitUntil(triggerEvent(event));
   },
 };
 ```

--- a/products/workers/src/content/examples/debugging-logs.md
+++ b/products/workers/src/content/examples/debugging-logs.md
@@ -49,7 +49,7 @@ async function handleRequest(request, ctx) {
   return response;
 }
 export default {
-  fetch(request, ctx) {
+  fetch(request, env, ctx) {
     ctx.passThroughOnException();
     return handleRequest(request, ctx);
   },


### PR DESCRIPTION
According to https://developers.cloudflare.com/workers/runtime-apis/fetch-event#syntax-module-worker and https://developers.cloudflare.com/workers/runtime-apis/scheduled-event, the signature for `fetch` and `scheduled` handlers is `fetch(request, env, ctx) { ... }` and `scheduled(controller, env, ctx) { ... }`.

This PR fixes the handler signatures used by some of the new module worker examples, so `ctx` is correct in each case.