### PR TITLE
[Workers] Fix syntax in toml for DO migrations

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -298,13 +298,13 @@ new_classes = ["DurableObjectExample"] # Array of new classes
 
 [[migrations]]
 tag = "v2"
-renamed_classes = [{from: "DurableObjectExample", to: "UpdatedName" }] # Array of rename directives
+renamed_classes = [{from = "DurableObjectExample", to = "UpdatedName" }] # Array of rename directives
 deleted_classes = ["DeprecatedClass"] # Array of deleted class names
 ```
 
 <Aside type="note">
 
-Note that `.toml` files do not allow line breaks in inline tables (the `{key: "value"}` syntax), but line breaks
+Note that `.toml` files do not allow line breaks in inline tables (the `{key = "value"}` syntax), but line breaks
 in the surrounding inline array are acceptable.
 
 </Aside>


### PR DESCRIPTION
Fixed the syntax for the wrangler.toml in the DO migrations section