### PR TITLE
[Workers] Document streams_byob_reader_detaches_buffer compatibility flag

### DIFF
--- a/products/workers/src/content/platform/compatibility-dates.md
+++ b/products/workers/src/content/platform/compatibility-dates.md
@@ -52,7 +52,7 @@ Newest changes are listed first.
   <tr><td><strong>Flag to disable</strong></td><td><code>streams_byob_reader_does_not_detach_buffer</code></td></tr>
 </tbody></table>
 
-Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change brings us in line with the spec.
+Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change makes Workers conform to the spec.
 
 User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). Instead, user code can re-use the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
 

--- a/products/workers/src/content/platform/compatibility-dates.md
+++ b/products/workers/src/content/platform/compatibility-dates.md
@@ -52,7 +52,7 @@ Newest changes are listed first.
   <tr><td><strong>Flag to disable</strong></td><td><code>streams_byob_reader_does_not_detach_buffer</code></td></tr>
 </tbody></table>
 
-Originally, the Workers runtime did not detach the ArrayBuffers from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently re-use the same buffer for multiple `read()` calls. This change brings us in line with the spec.
+Originally, the Workers runtime did not detach the ArrayBuffers from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change brings us in line with the spec.
 
 User code should never try to re-use an ArrayBuffer that has been passed in to a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). The more recently added extension method `readAtLeast()` will always detach the ArrayBuffer and is unaffected by this feature flag setting.
 

--- a/products/workers/src/content/platform/compatibility-dates.md
+++ b/products/workers/src/content/platform/compatibility-dates.md
@@ -44,6 +44,18 @@ Most developers will not need to use `compatibility_flags`; instead, we recommen
 
 Newest changes are listed first.
 
+### Streams BYOB reader detaches buffer
+
+<table><tbody>
+  <tr><td><strong>Default as of</strong></td><td>2021-11-10</td></tr>
+  <tr><td><strong>Flag to enable early</strong></td><td><code>streams_byob_reader_detaches_buffer</code></td></tr>
+  <tr><td><strong>Flag to disable</strong></td><td><code>streams_byob_reader_does_not_detach_buffer</code></td></tr>
+</tbody></table>
+
+Originally, the Workers runtime did not detach the ArrayBuffers from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently re-use the same buffer for multiple `read()` calls. This change brings us in line with the spec.
+
+User code should never try to re-use an ArrayBuffer that has been passed in to a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). The more recently added extension method `readAtLeast()` will always detach the ArrayBuffer and is unaffected by this feature flag setting.
+
 ### Durable Object `stub.fetch()` requires a full URL
 
 <table><tbody>

--- a/products/workers/src/content/platform/compatibility-dates.md
+++ b/products/workers/src/content/platform/compatibility-dates.md
@@ -52,9 +52,9 @@ Newest changes are listed first.
   <tr><td><strong>Flag to disable</strong></td><td><code>streams_byob_reader_does_not_detach_buffer</code></td></tr>
 </tbody></table>
 
-Originally, the Workers runtime did not detach the ArrayBuffers from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change brings us in line with the spec.
+Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change brings us in line with the spec.
 
-User code should never try to re-use an ArrayBuffer that has been passed in to a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). The more recently added extension method `readAtLeast()` will always detach the ArrayBuffer and is unaffected by this feature flag setting.
+User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). The more recently added extension method `readAtLeast()` will always detach the `ArrayBuffer` and is unaffected by this feature flag setting.
 
 ### Durable Object `stub.fetch()` requires a full URL
 

--- a/products/workers/src/content/platform/compatibility-dates.md
+++ b/products/workers/src/content/platform/compatibility-dates.md
@@ -54,7 +54,23 @@ Newest changes are listed first.
 
 Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change brings us in line with the spec.
 
-User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). The more recently added extension method `readAtLeast()` will always detach the `ArrayBuffer` and is unaffected by this feature flag setting.
+User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](/runtime-apis/streams/readablestreambyobreader#methods). Instead, user code can re-use the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
+
+```js
+  // Consume and discard `readable` using a single 4KiB buffer.
+  let reader = readable.getReader({ mode: "byob" })
+  let arrayBufferView = new Uint8Array(4096)
+  while (true) {
+    let result = await reader.read(arrayBufferView)
+    if (result.done) break
+    // Optionally something with `result` here.
+    // Re-use the same memory for the next `read()` by creating
+    // a new Uint8Array backed by the result's ArrayBuffer.
+    arrayBufferView = new Uint8Array(result.value.buffer)
+  }
+```
+
+The more recently added extension method `readAtLeast()` will always detach the `ArrayBuffer` and is unaffected by this feature flag setting.
 
 ### Durable Object `stub.fetch()` requires a full URL
 


### PR DESCRIPTION
This compatibility flag is new as of this week.

Note that the text references a relatively new, non-standard method that we added to ReadableStream: `readAtLeast()`. Unfortunately, this method is not yet documented.

/cc @jasnell 