### PR TITLE
[Workers] Fix syntax in example/multiple-cron-triggers

### DIFF
--- a/products/workers/src/content/examples/multiple-cron-triggers.md
+++ b/products/workers/src/content/examples/multiple-cron-triggers.md
@@ -14,13 +14,13 @@ pcx-content-type: configuration
 </ContentColumn>
 
 ```js
-addEventListener('scheduled', event => {
-  event.waitUntil(triggerEvent(event.cron))
-})
+addEventListener("scheduled", (event) => {
+  event.waitUntil(triggerEvent(event));
+});
 
-async function triggerEvent(event.cron) {
-  // Write code for updating your API 
-  switch (event.cron) {
+async function triggerEvent({ cron }) {
+  // Write code for updating your API
+  switch (cron) {
     // You can set up to three schedules maximum.
     case "*/3 * * * *":
       // Every three minutes
@@ -35,6 +35,6 @@ async function triggerEvent(event.cron) {
       await updateAPI3();
       break;
   }
-  console.log("cron processed")
+  console.log("cron processed");
 }
 ```

--- a/products/workers/src/content/examples/multiple-cron-triggers.md
+++ b/products/workers/src/content/examples/multiple-cron-triggers.md
@@ -18,9 +18,9 @@ addEventListener("scheduled", (event) => {
   event.waitUntil(triggerEvent(event));
 });
 
-async function triggerEvent({ cron }) {
+async function triggerEvent(event) {
   // Write code for updating your API
-  switch (cron) {
+  switch (event.cron) {
     // You can set up to three schedules maximum.
     case "*/3 * * * *":
       // Every three minutes


### PR DESCRIPTION
- Fix JS syntax error
  - `function triggerEvent(event.cron) {` is syntax error
- Unify code styles
  - always semi;, "double quote", etc