### PR TITLE
Update 1.1.1.1 docs for DoH JSON API

### DIFF
--- a/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/make-api-requests/dns-json.md
+++ b/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/make-api-requests/dns-json.md
@@ -7,7 +7,7 @@ pcx-content-type: reference
 
 Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. For lack of an agreed upon JSON schema for DNS over HTTPS in the Internet Engineering Task Force (IETF), Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
 
-JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. An additional URL parameter of `ct` should indicate the MIME type (`application/dns-json`).
+JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. The client should include an HTTP `Accept` request header field with a MIME type of `application/dns-json` to indicate that the client is able to accept a JSON response from the DNS over HTTPS resolver.
 
 Supported Parameters:
 


### PR DESCRIPTION
Deprecates the use of "ct" parameter according to RFC-8484.