### PR TITLE
[Workers] fetch-event.md: Fix casing of link anchor names

### DIFF
--- a/products/workers/src/content/runtime-apis/fetch-event.md
+++ b/products/workers/src/content/runtime-apis/fetch-event.md
@@ -37,15 +37,15 @@ addEventListener("fetch", event => {
 
 -  <Code>event.respondWith(response<TypeLink href="/runtime-apis/response">Response</TypeLink>|<span style={{marginLeft:"-6px"}}><ParamType>Promise</ParamType></span>)</Code> <Type>void</Type>
 
-    - See [`respondWith`](#respondWith).
+    - See [`respondWith`](#respondwith).
 
 - <Code>event.waitUntil(promise<ParamType>Promise</ParamType>)</Code> <Type>void</Type>
 
-    - See [`waitUntil`](#waitUntil).
+    - See [`waitUntil`](#waituntil).
 
 - <Code>event.passThroughOnException()</Code> <Type>void</Type>
 
-    - See [`passThroughOnException`](#passThroughOnException).
+    - See [`passThroughOnException`](#passthroughonexception).
 
 </Definitions>
 
@@ -80,11 +80,11 @@ export default {
 
 - <Code>context.waitUntil(promise<ParamType>Promise</ParamType>)</Code> <Type>void</Type>
 
-    - See [`waitUntil`](#waitUntil).
+    - See [`waitUntil`](#waituntil).
 
 - <Code>context.passThroughOnException()</Code> <Type>void</Type>
 
-    - See [`passThroughOnException`](#passThroughOnException).
+    - See [`passThroughOnException`](#passthroughonexception).
 
 </Definitions>
 


### PR DESCRIPTION
It looks like gatsby generates lowercase named anchors for headings, so the named anchors in links also need to be lowercase for the links to work correctly.