### PR TITLE
Fix DO pricing table

### DIFF
--- a/products/workers/src/content/platform/pricing.md
+++ b/products/workers/src/content/platform/pricing.md
@@ -78,7 +78,7 @@ Total = ~$5.60 + Minimum $5/mo usage = $10.60
 Durable Objects are currently only available on the Workers Paid plan.
 
 <TableWrap>
-  
+
 |               | Paid plan                                                    |
 | ------------- | ------------------------------------------------------------ |
 | Requests      | 1 million, + $0.15/million                                   | 


### PR DESCRIPTION
Fixes the DO pricing table, it currently shows as broken due to a space instead of an empty line

Current:
![image](https://user-images.githubusercontent.com/8492901/141803534-9185824b-50f4-4709-befa-be625e9540a4.png)

After fix:
![image](https://user-images.githubusercontent.com/8492901/141803457-af9aa427-dc03-4eef-832f-35bbf966fd0d.png)
