### PR TITLE
Document support for viewing live stream via live input ID

### DIFF
--- a/products/stream/src/content/stream-live/start-stream-live.md
+++ b/products/stream/src/content/stream-live/start-stream-live.md
@@ -34,11 +34,13 @@ Within seconds of you pushing your live stream to Cloudflare Stream, you should 
 To start a live stream programmatically, make a `POST` request to the `/live_inputs` endpoint:
 
 ```bash
-curl -X POST \ -H "Authorization: Bearer $TOKEN" \https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/live_inputs \--data '{"meta": {"name":"test stream 1"},"recording": { "mode": "automatic", "timeoutSeconds": 10 }}'
+curl -X POST \ -H "Authorization: Bearer $TOKEN" \https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/stream/live_inputs \--data '{"meta": {"name":"test stream 1"},"recording": { "mode": "automatic", "timeoutSeconds": 10, "requireSignedURLs": false, "allowedOrigins": ["*.example.com"] }}'
 ```
 
 * When the mode property is set to `automatic`, it means the live stream will be automatically available for viewing using HLS/DASH. In addition, the live stream will be automatically recorded for later replays.
 * The `timeoutSeconds` property specifies how long a live feed can be disconnected before it results in a new video being created.
+* The `requireSignedURLs` property indicates if signed URLs are required to view the video. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
+* The `allowedOrigins` property can optionally be invoked to provide a list of allowed origins. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
 
 A successful response will return information about the live input:
 
@@ -57,7 +59,8 @@ A successful response will return information about the live input:
   "status": null,
   "live": {
     "mode": "automatic",
-    "requireSignedURLs": false
+    "requireSignedURLs": false,
+    "allowedOrigins": ["*.example.com"]
   }
 }
 ```

--- a/products/stream/src/content/stream-live/watch-live-stream.md
+++ b/products/stream/src/content/stream-live/watch-live-stream.md
@@ -7,6 +7,8 @@ pcx-content-type: tutorial
 
 When an input begins receiving the live stream, a new video with HLS and DASH URLs is automatically created as long as the mode property for the input is set to `automatic`.
 
+## View by video id
+
 One live input can have multiple video ids associated with it. In order to get the video id representing the current live stream for a given input, make a `GET` request to the `/stream` endpoint:
 
 ```bash
@@ -95,6 +97,43 @@ The response will contain the HLS/DASH URL that can be used to play the current 
   "messages": []
 }
 ```
+
+## View by live input uid
+
+By using the live input uid in place of a video id in the hls/dash manifest URL, you get a static URL that will return a 200 with the manifest of the active livestream, or a 204 status code with no content if there is no active live stream.
+
+Using the input ID in this manner is fully integrated in the Stream player, but may require some additional support for third party players. You can make a `GET` request to the `/lifecycle` endpoint to get additional data about a video id or live input uid for more information to make additional decisions.
+
+```bash
+GET https://videodelivery.net/34036a0695ab5237ce757ac53fd158a2/lifecycle
+```
+
+This is a response for an input ID with an active live stream:
+
+```json
+{
+      // indicates if the ID provided is for an input or a video
+    "isInput": true,
+    // returns the active video ID or null for an input ID, otherwise returns the provided video ID
+    "videoUID": "55b9b5ce48c3968c6b514c458959d6a",
+    // if isInput is true, indicates if the input is actively streaming or not
+    "live": true
+}
+```
+
+Or if the input ID does not have an active live stream:
+
+```json
+{
+    "isInput": true,
+    "videoUID": null,
+    "live": false
+}
+```
+
+### Live input level viewing options
+
+When viewing a livestream via the live input id, the `requireSignedURLs` and `allowedOrigins` options in the live input recording settings are used. These settings take are independent of the video-level settings.
 
 ## Replaying recordings
 

--- a/products/stream/src/content/stream-live/watch-live-stream.md
+++ b/products/stream/src/content/stream-live/watch-live-stream.md
@@ -133,7 +133,7 @@ Or if the input ID does not have an active live stream:
 
 ### Live input level viewing options
 
-When viewing a livestream via the live input id, the `requireSignedURLs` and `allowedOrigins` options in the live input recording settings are used. These settings take are independent of the video-level settings.
+When viewing a livestream via the live input id, the `requireSignedURLs` and `allowedOrigins` options in the live input recording settings are used. These settings are independent of the video-level settings.
 
 ## Replaying recordings
 


### PR DESCRIPTION
Document support for static manifest URLs via live input ID, and document
viewing information and relevant APIs.