### PR TITLE
Remove documentation of dashboard durable object bugs

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -365,6 +365,10 @@ In particular, a Durable Object may be superseded in this way in the event of a 
 
 [Wrangler tail](/cli-wrangler/commands#tail) logs from requests that are upgraded to WebSockets are delayed until the WebSocket is closed.  Wrangler tail should not be connected to a script that you expect will receive heavy volumes of traffic.
 
+[Wrangler dev](/cli-wrangler/commands#dev) establishes a tunnel from your local development environment to Cloudflare's edge, allowing you to test your Worker and Durable Objects as they are developed.
+
+The Workers editor in [the Cloudflare dashboard](https://dash.cloudflare.com/) allows you to interactively edit and preview your Worker and Durable Objects. Note that in the editor Durable Objects can only be talked to by a preview request if the Worker being previewed both exports the Durable Object class and binds to it. Durable Objects exported by other Workers cannot be talked to in the editor preview.
+
 ### Object Location
 
 Not all Cloudflare locations host Durable Objects, so objects may not be created in the same point-of-presence where they are first requested.

--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -365,12 +365,6 @@ In particular, a Durable Object may be superseded in this way in the event of a 
 
 [Wrangler tail](/cli-wrangler/commands#tail) logs from requests that are upgraded to WebSockets are delayed until the WebSocket is closed.  Wrangler tail should not be connected to a script that you expect will receive heavy volumes of traffic.
 
-While the Workers dashboard does support editing Workers that use modules syntax:
-* If you edit a script in the editor that is bound to Durable Objects and save it, the Durable Objects bindings will be lost.
-* Previewing scripts that bind Durable Objects does not work in the editor.
-
-These are both bugs that will be fixed soon.
-
 ### Object Location
 
 Not all Cloudflare locations host Durable Objects, so objects may not be created in the same point-of-presence where they are first requested.


### PR DESCRIPTION
The bindings being deleted is fixed, and the DO previews will be as well as soon as my API server release goes out.

Replace the deleted bugs with documentation of `wrangler dev` and the workers editor as development tools.