### PR TITLE
Add callout for DNS type field

### DIFF
--- a/products/spectrum/src/content/about/byoip.md
+++ b/products/spectrum/src/content/about/byoip.md
@@ -15,7 +15,7 @@ BYOIP does not come standard with Spectrum. To enable it, contact your account t
 
 ## Assign an IP address
 
-To use an IP, it must be assigned to a Spectrum app to create the appropriate A (IPv4) or AAAA (IPv6) records. This is done by specifying one or more IP addresses when creating an application through the API. In addition, the DNS "type" field must be updated to "ADDRESS" in order to create a spectrum app using BYOIP.
+To use an IP, it must be assigned to a Spectrum app to create the appropriate A (IPv4) or AAAA (IPv6) records. This is done by specifying one or more IP addresses when creating an application through the API. In addition, the DNS "type" field must be updated to "ADDRESS" in order to create a Spectrum app using BYOIP.
 
 ```json
 {

--- a/products/spectrum/src/content/about/byoip.md
+++ b/products/spectrum/src/content/about/byoip.md
@@ -15,7 +15,7 @@ BYOIP does not come standard with Spectrum. To enable it, contact your account t
 
 ## Assign an IP address
 
-To use an IP, it must be assigned to a Spectrum app to create the appropriate A (IPv4) or AAAA (IPv6) records. This is done by specifying one or more IP addresses when creating an application through the API:
+To use an IP, it must be assigned to a Spectrum app to create the appropriate A (IPv4) or AAAA (IPv6) records. This is done by specifying one or more IP addresses when creating an application through the API. In addition, the DNS "type" field must be updated to "ADDRESS" in order to create a spectrum app using BYOIP.
 
 ```json
 {


### PR DESCRIPTION
DNS type refers to the backend Cloudflare method of pointing to a spectrum app. ADDRESS is required when specifying an IP address in BYOIP.