### PR TITLE
[Cloudflare-One] Add better documentation regarding Linux + other changes

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-useful-terms.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-useful-terms.md
@@ -23,7 +23,7 @@ Users can create and configure a tunnel once and run it as multiple different `c
 | OS | Path to default directory |
 | -- | ---- |
 | Windows | `%USERPROFILE%\.cloudflared` |
-| MacOS and Unix-like systems | `~/.cloudflared`, `/etc/cloudflared`, and `/usr/local/etc/cloudflared`, in this order. |
+| macOS and Unix-like systems | `~/.cloudflared`, `/etc/cloudflared`, and `/usr/local/etc/cloudflared`, in this order. |
 
 ## Configuration file
 This is a `.yaml` file that functions as the operating manual for `cloudflared`. `cloudflared` will automatically look for the configuration file in the [default `cloudflared` directory](/connections/connect-apps/install-and-setup/tunnel-useful-terms#default-cloudflared-directory), but you can store your configuration file in any directory. It is recommended to always specify the file path for your configuration file whenever you reference it. By creating a configuration file, you can have fine-grained control over how their instance of `cloudflared` will operate. This includes operations like what you want `cloudflared` to do with traffic (for example, proxy websockets to port `xxxx`, or ssh to port `yyyy`), where `cloudflared` should search for authorization (credentials file, tunnel token), and what mode it should run in (for example, [`warp-routing`](/connections/connect-networks/private-net/create-tunnel#configure-the-tunnel)). In the absence of a configuration file, cloudflared will proxy outbound traffic through port `8080`. For more information on how to create, store, and structure a configuration file, refer to the [dedicated instructions](/connections/connect-apps/configuration/configuration-file).

--- a/products/cloudflare-one/src/content/connections/connect-devices/agentless/native-os.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/agentless/native-os.md
@@ -21,22 +21,20 @@ Alternatively, you can look into using the [WARP client](/connections/connect-de
 ### Ubuntu
 
 #### IPv4
-1. Click **System** > **Preferences** > **Network Connections**.
-2. Click on the **Wireless** tab, then choose the Wi-Fi network you are currently connected to.
-3. Click **Edit**.
-4. Click **IPv4**.  
-Remove any IP addresses that may already be listed.
-6. Add the following IP addresses:
-    * **172.64.36.1**
-    * **172.64.36.2**
-7. Click **Apply**.
+1. Open **Settings**
+2. Click **Wi-Fi** (or **Network** for wired connections), then click the gear icon next to the network you are currently connected to.
+3. Click the **IPv4** tab.
+4. Under **DNS** settings, disable *Automatic*.
+5. Under **DNS** settings, enter the following custom IP addresses: `172.64.36.1,172.64.36.2`
+6. Click **Apply**.
 
 #### IPv6
-1. Click **System** > **Preferences** > **Network Connections**.
-2. Click on the **Wireless** tab, then choose the Wi-Fi network you are currently connected to.
-3. Click **IPv6**.
-4. Add the IPv6 address from that we listed based on your location configuration
-5. Click **Apply**.
+1. Open **Settings**
+2. Click **Wi-Fi** (or **Network** for wired connections), then click the gear icon next to the network you are currently connected to.
+3. Click the **IPv4** tab.
+4. Under **DNS** settings, disable *Automatic*.
+5. Add the IPv6 address from that we listed based on your location configuration
+6. Click **Apply**.
 
 ### Debian
 

--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/mdm-deployment/intune.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/mdm-deployment/intune.md
@@ -70,7 +70,7 @@ To proceed with the installation, here is an example of the XML code you will ne
 
 Refer to the [deployment parameters](/connections/connect-devices/warp/deployment/mdm-deployment/parameters) for a description of each value.
 
-## MacOS
+## macOS
 
 The Cloudflare WARP client allows for an automated install via tools like Jamf, Intune, Kandji, or JumpCloud or any script or management tool that can place a `com.cloudflare.warp.plist` file in `/Library/Managed Preferences` on a supported macOS device. Additionally, this `plist` can be wrapped in a `.mobileconfig`.
 

--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/mdm-deployment/jamf.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/deployment/mdm-deployment/jamf.md
@@ -5,7 +5,7 @@ hidden: true
 
 # Jamf
 
-## MacOS
+## macOS
 
 The Cloudflare WARP client allows for an automated install via tools like Jamf, Intune, Kandji, or JumpCloud or any script or management tool that can place a `com.cloudflare.warp.plist` file in `/Library/Managed Preferences` on a supported macOS device. Additionally, this plist can be wrapped in a `.mobileconfig`.
 

--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/download-warp.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/download-warp.md
@@ -14,14 +14,14 @@ Alternatively, download the client from one of the following links after checkin
   <tbody>
     <tr>
       <td><strong>OS Ver</strong></td>
-      <td>Windows 8, Windows 10</td>
+      <td>Windows 8, Windows 10+</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>
-      <td>64bit only</td>
+      <td>64-bit only</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
+      <td><strong>Disk Space</strong></td>
       <td>184MB</td>
     </tr>
     <tr>
@@ -30,7 +30,7 @@ Alternatively, download the client from one of the following links after checkin
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>
@@ -44,14 +44,14 @@ __[Windows Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.
   <tbody>
     <tr>
       <td><strong>OS Ver</strong></td>
-      <td>Big Sur, High Sierra, Catalina</td>
+      <td>High Sierra+ (10.13+)</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>
-      <td>64bit only</td>
+      <td>Intel & M1</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
+      <td><strong>Disk Space</strong></td>
       <td>75MB</td>
     </tr>
     <tr>
@@ -60,7 +60,7 @@ __[Windows Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>
@@ -73,16 +73,16 @@ __[macOS Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-
 <table>
   <tbody>
     <tr>
-      <td><strong>OS Ver</strong></td>
-      <td>CentOS 8, RHEL, Ubuntu, Debian</td>
+      <td><strong>Distributions</strong></td>
+      <td>CentOS 8, RHEL, Ubuntu (Focal and Xenial), Debian 9+</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>
-      <td>64bit only</td>
+      <td>64-bit only</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
-      <td>75MB</td>
+      <td><strong>Disk Space</strong></td>
+      <td>200MB</td>
     </tr>
     <tr>
       <td><strong>Memory</strong></td>
@@ -90,7 +90,7 @@ __[macOS Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>

--- a/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -48,7 +48,7 @@ sha256 Fingerprint=F5:E1:56:C4:89:78:77:AD:79:3A:1E:83:FA:77:83:F1:9C:B0:C6:1B:5
 
 ## Add the certificate to your system
 
-### MacOS
+### macOS
 
 You will need to install the root certificate in the **Keychain Access** application. In the application, you can choose the keychain in which you want to install the certificate. macOS offers three options, each having a different impact on which users will be affected by trusting the root certificate.
 
@@ -257,6 +257,45 @@ The root certificate is now installed and ready to be used.
 7. Enter anything you want for the certificate name and click **OK**.
 
 ![Name the certificate with anything](../../../static/documentation/connections/chromeOS8_cert.png)
+
+### Linux
+
+Depending on your Linux distribution, the commands for trusting new certificates can vary.
+
+#### Ubuntu, Debian
+
+1. Go to `/usr/local/share/ca-certificates/`:
+ ```bash
+ cd /usr/local/share/ca-certificates/
+ ```
+
+1. Download the Cloudflare Certificate, pasting the **.crt** from [here](#download-the-cloudflare-root-certificate) into the following command:
+ ```bash
+ curl <Cloudflare_CA.crt link> -O 
+ ```
+
+1. Update the certificate store.
+ ```bash
+ sudo update-ca-certificates
+ ```
+
+Refer to the [update-ca-certficates man page](https://manpages.debian.org/jessie/ca-certificates/update-ca-certificates.8.en.html) for information on Ubuntu/Debian installations.
+
+#### CentOS, RHEL
+
+1. Download the Cloudflare Certificate, pasting the **.pem** from [here](#download-the-cloudflare-root-certificate) into the following command:
+ ```bash
+ curl <Cloudflare_CA.pem link> -O 
+ ```
+
+1. Copy the certificate into `/etc/pki/ca-trust/source/anchors/`
+ ```bash
+ cp Cloudflare_CA.pem /etc/pki/ca-trust/source/anchors/Cloudflare_CA.pem
+ ```
+
+1. Run `update-ca-trust` to update the certificate store.
+
+Refer to the [update-ca-trust man page](https://www.unix.com/man-page/centos/8/update-ca-trust/) for information on CentOS/RHEL installations.
 
 ## Adding to Applications
 

--- a/products/cloudflare-one/src/content/identity/devices/mutual-tls-authentication.md
+++ b/products/cloudflare-one/src/content/identity/devices/mutual-tls-authentication.md
@@ -214,9 +214,9 @@ $ curl -v --cert client.pem --key client-key.pem https://iot.widgetcorp.tech
 
 ### Testing in the browser
 
-The instructions here cover usage with a computer running MacOS.
+The instructions here cover usage with a computer running macOS.
 
-1. In the same working directory, run the following command to add the client certificate into the MacOS Keychain.
+1. In the same working directory, run the following command to add the client certificate into the macOS Keychain.
 
 <Aside type='warning' header='Important'>
 

--- a/products/cloudflare-one/src/content/tutorials/rdp.md
+++ b/products/cloudflare-one/src/content/tutorials/rdp.md
@@ -226,7 +226,7 @@ At this point the shortcut will appear on the desktop, and users can launch with
 
 * Ensure that RDP is enabled on the target Windows machine. If not, you may encounter an error: `No connection could be made because the target machine actively refused it`.
 
-### MacOS
+### macOS
 
 <Aside type="note">
   
@@ -234,7 +234,7 @@ At this point the shortcut will appear on the desktop, and users can launch with
   
 </Aside>
 
-MacOS users can save a command shortcut that will launch the RDP flow.
+macOS users can save a command shortcut that will launch the RDP flow.
 
 1. The command below can be saved as a `.command` file that can be launched on login:
 
@@ -263,4 +263,4 @@ MacOS users can save a command shortcut that will launch the RDP flow.
 
 1. Double click on the previously created `CF-RDP-Tunnel.command` file.
 
-The default behavior in MacOS is for the Terminal window to stay open. You can configure it to close automatically.
+The default behavior in macOS is for the Terminal window to stay open. You can configure it to close automatically.

--- a/products/http3/src/content/tutorials/curl-brew.md
+++ b/products/http3/src/content/tutorials/curl-brew.md
@@ -4,7 +4,7 @@ pcx-content-type: how-to
 
 # Curl + Quiche
 
-Follow the guidelines below to build and test HTTP/3 on MacOS.
+Follow the guidelines below to build and test HTTP/3 on macOS.
 
 ## Requirements
 

--- a/products/ssl/src/content/keyless-ssl/hardware-security-modules/azure-managed-hsm.md
+++ b/products/ssl/src/content/keyless-ssl/hardware-security-modules/azure-managed-hsm.md
@@ -33,7 +33,7 @@ Follow [these instructions](/keyless-ssl/configuration##step-3--set-up-and-activ
 
 Set up the Azure CLI (used to access the private key).
 
-For example, if you were using MacOS:
+For example, if you were using macOS:
 
 ```
 brew install azure-cli

--- a/products/time-services/src/content/ntp/usage.md
+++ b/products/time-services/src/content/ntp/usage.md
@@ -19,7 +19,7 @@ Here is an example of how to configure your Mac to synchronize time from time.cl
 4. Enter your password
 5. Next to Set date and time automatically, enter `time.cloudflare.com`
 
-![MacOS](../static/mactime.png)
+![macOS](../static/mactime.png)
 
 ... and you're all set!
 

--- a/products/warp-client/src/content/setting-up/requirements.md
+++ b/products/warp-client/src/content/setting-up/requirements.md
@@ -10,14 +10,14 @@ order: 3
   <tbody>
     <tr>
       <td><strong>OS Ver</strong></td>
-      <td>Windows 8+</td>
+      <td>Windows 8, Windows 10+</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>
-      <td>64bit only</td>
+      <td>64-bit only</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
+      <td><strong>Disk Space</strong></td>
       <td>184MB</td>
     </tr>
     <tr>
@@ -26,7 +26,7 @@ order: 3
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>
@@ -45,7 +45,7 @@ __[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Clou
       <td>Intel & M1</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
+      <td><strong>Disk Space</strong></td>
       <td>75MB</td>
     </tr>
     <tr>
@@ -54,7 +54,7 @@ __[Download Cloudflare_WARP_Release-x64.msi](https://www.cloudflarewarp.com/Clou
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>
@@ -66,14 +66,14 @@ __[Download Cloudflare_WARP.zip](https://www.cloudflarewarp.com/Cloudflare_WARP.
   <tbody>
     <tr>
       <td><strong>Distributions</strong></td>
-      <td>Ubuntu, Redhat Enterprise Linux, Centos</td>
+      <td>CentOS 8, RHEL, Ubuntu (Focal and Xenial), Debian 9+</td>
     </tr>
     <tr>
       <td><strong>OS Type</strong></td>
-      <td>x64</td>
+      <td>64-bit only</td>
     </tr>
     <tr>
-      <td><strong>HD Space</strong></td>
+      <td><strong>Disk Space</strong></td>
       <td>200MB</td>
     </tr>
     <tr>
@@ -82,7 +82,7 @@ __[Download Cloudflare_WARP.zip](https://www.cloudflarewarp.com/Cloudflare_WARP.
     </tr>
     <tr>
       <td><strong>Network Types</strong></td>
-      <td>WIFI or LAN</td>
+      <td>Wi-Fi or LAN</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
I've added some changes to the Cloudflare One documentation, specifically regarding Linux instructions. Whilst trying to write that, I came across a few other inconsistencies and made those changes accordingly. Because this is a reasonably random pull request, I've listed all the changes that I've made here (since a lot of the services around WARP is closed-source, I've made some educated guesses here and there, but I've listed the assumptions all down below as well):

- Change "HD Space" to "Disk Space" (products\cloudflare-one\src\content\connections\connect-devices\warp\download-warp.md, products\warp-client\src\content\setting-up\requirements.md)
- Change "WIFI" to "Wi-Fi" (products\cloudflare-one\src\content\connections\connect-devices\warp\download-warp.md, products\warp-client\src\content\setting-up\requirements.md)
    - WIFI isn't usually considered correct, and should be either Wi-Fi (when referring to Wi-Fi devices) or WLAN (including both Wi-Fi and other wireless connections including Bluetooth). I'm not sure if they support other wireless connections (especially the Linux client), so I've left it at Wi-Fi, although this should really be WLAN if it supports other network adapters.
- Change "MacOS" to "macOS" (in a lot of files)
- Write up documentation on CA Certificates for Linux (products\cloudflare-one\src\content\connections\connect-devices\warp\install-cloudflare-cert.md)
    - I tested this on Ubuntu / Debian, and it worked out fine. Whilst I assume the instructions for CentOS and Red Hat probably work, I didn't have time to test this.
- Make the requirements pages for the WARP client more consistent (products\cloudflare-one\src\content\connections\connect-devices\warp\download-warp.md, products\warp-client\src\content\setting-up\requirements.md)
    - For Linux distros, the requirements were _very_ inconsistent across pages. I updated them based on [this page](https://pkg.cloudflareclient.com/packages/cloudflare-warp) which made the most sense to me.
    - I updated the Disk Space requirement to 200MB, because the page under `warp-client` was 200MB, and the `cloudflare-one` page was 75MB. Made the most sense to use the larger one, because I have a feeling that the 75MB was copied at pasted from the macOS requirements, but I may be wrong there.
- Change "64bit" to "64-bit" (products\cloudflare-one\src\content\connections\connect-devices\warp\download-warp.md, products\warp-client\src\content\setting-up\requirements.md)
    - Changed "64bit" to "Intel & M1" for macOS devices (I assume someone only updated one bit of documentation and forgot about the other page), just because it's simpler to understand for most people.
- Fixed Native OS DNS setup for Ubuntu (products\cloudflare-one\src\content\connections\connect-devices\agentless\native-os.md)
    - Instructions were old, and I couldn't figure out which version this was for. New instructions are suitable for Ubuntu 20.04LTS installations.