### PR TITLE
s/req/request

### DIFF
--- a/products/pages/src/content/platform/functions.md
+++ b/products/pages/src/content/platform/functions.md
@@ -309,7 +309,7 @@ filename: _worker.js
 ---
 export default {
   async fetch(request, env) {
-    if (req.url.startsWith('/api/')) {
+    if (request.url.startsWith('/api/')) {
       // TODO: Custom /api/* Worker logic
       return new Response('TODO: add logic')
     }

--- a/products/pages/src/content/platform/functions.md
+++ b/products/pages/src/content/platform/functions.md
@@ -309,14 +309,14 @@ filename: _worker.js
 ---
 export default {
   async fetch(request, env) {
-    if (request.url.startsWith('/api/')) {
-      // TODO: Custom /api/* Worker logic
-      return new Response('TODO: add logic')
+    const url = new URL(request.url);
+    if (url.pathname.startsWith('/api/')) {
+      // TODO: Add your custom /api/* logic here.
+      return new Response('Ok');
     }
-
-    // Otherwise, serve static asset(s).
-    // Without this, Worker will error and no assets will be served.
-    return env.ASSETS.fetch(request)
+    // Otherwise, serve the static assets.
+    // Without this, the Worker will error and no assets will be served.
+    return env.ASSETS.fetch(request);
   }
 }
 ```


### PR DESCRIPTION
This snippet generates an error when run because there's no object called `req`. This PR fixes the reference.

via https://github.com/cloudflare/wrangler2/issues/37