### PR TITLE
Document client reconnect requirement of live inputs

### DIFF
--- a/products/stream/src/content/stream-live/start-stream-live.md
+++ b/products/stream/src/content/stream-live/start-stream-live.md
@@ -86,6 +86,7 @@ curl -X DELETE \ -H "Authorization: Bearer $TOKEN" \https://api.cloudflare.com/c
 * Stream Live requires input GOP duration (keyframe interval) to be between 4 to 10 seconds.
 * Closed GOPs required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoder software such as OBS.
 * Stream Live only supports H.264 video and AAC audio codecs as inputs. This requirement does not apply to inputs that are relayed to Stream Connect outputs.
+* Clients must be configured to reconnect when a disconnection occurs. Stream Live is designed to handle reconnection gracefully by continuing the live stream.
 
 ### Known limitations (will be solved in coming weeks without any changes required from you): 
 


### PR DESCRIPTION
We included the entry in our faq regarding reconnection but never
explicitly included it as a recommendation or requirement.