### PR TITLE
Updated "Caching Ports"

### DIFF
--- a/products/fundamentals/src/content/get-started/network-ports.md
+++ b/products/fundamentals/src/content/get-started/network-ports.md
@@ -75,7 +75,7 @@ Ports 80 and 443 are the only ports compatible with:
 
 - HTTP/HTTPS traffic within China data centers for domains that have the **China Network** enabled, and
 - Proxying of [Cloudflare Apps](https://www.cloudflare.com/apps/developer/docs/getting-started)
-- [Cloudflare Caching](https://support.cloudflare.com/hc/en-us/articles/360021806811)
+- [Cloudflare Caching](https://support.cloudflare.com/hc/en-us/articles/360021806811) (plus Port 8080)
 
 <Aside type="note">
 


### PR DESCRIPTION
According to this: https://support.cloudflare.com/hc/articles/218411427

> Ports 80, 443, and 8080 are the only ports where Cloudflare Caching is available.

But this page states:

> **Ports 80 and 443** are the only ports compatible with:
> 
> HTTP/HTTPS traffic within China data centers for domains that have the China Network enabled, and
> Proxying of Cloudflare Apps
> **Cloudflare Caching**

According to this page itself, Port 8080 MUST be able to cache as it is listed as "HTTP ports supported by Cloudflare":

> HTTP ports supported by Cloudflare
> - 80
> - 8080
> - 8880
> - 2052
> - 2082
> - 2086
> - 2095

and not in the "Caching is disabled for the following ports" section.

> Caching is disabled for the following ports
> - 2052
> - 2053
> - 2082
> - 2083
> - 2086
> - 2087
> - 2095
> - 2096
> - 8880
> - 8443


So should be pretty clear that the statement "Ports 80 and 443 are the only ports compatible with:" (Cloudflare Caching) cant be right, as they are not the only ones for "Cloudflare Caching". Please doublecheck and fix this as this can cause confusion.