### PR TITLE
[Terraform] Fix config spacing

### DIFF
--- a/products/terraform/src/content/tutorial/initialize-terraform.md
+++ b/products/terraform/src/content/tutorial/initialize-terraform.md
@@ -26,8 +26,8 @@ terraform {
 }
 
 provider "cloudflare" {
-      email = "you@example.com"
-      api_token = "your-api-token"
+  email = "you@example.com"
+  api_token = "your-api-token"
 }
 
 variable "zone_id" {


### PR DESCRIPTION
Per the Terraform Style Conventions (https://www.terraform.io/docs/language/syntax/style.html) indentation should be 2 spaces. The rest of the file follows this except this one section