### PR TITLE
Revert "fix: use short sha version"

### DIFF
--- a/developers.cloudflare.com/package.json
+++ b/developers.cloudflare.com/package.json
@@ -12,7 +12,7 @@
     "@mdx-js/react": "1.6.6",
     "@reach/skip-nav": "0.10.5",
     "animejs": "3.2.0",
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3e",
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git",
     "focus-group": "0.3.1",
     "focus-visible-polyfill": "1.0.0",
     "gatsby": "^2.32.12",

--- a/products/email-routing/package.json
+++ b/products/email-routing/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3e"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",

--- a/products/email-routing/package.json
+++ b/products/email-routing/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",

--- a/products/fundamentals/package.json
+++ b/products/fundamentals/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3e"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",

--- a/products/fundamentals/package.json
+++ b/products/fundamentals/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",

--- a/products/workers/package.json
+++ b/products/workers/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3e"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",

--- a/products/workers/package.json
+++ b/products/workers/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git#1a796d3eaaa018da4c6ca4106bf369a2017bc4ec"
+    "cloudflare-docs-engine": "git+https://github.com/cloudflare/cloudflare-docs-engine.git"
   },
   "scripts": {
     "bootstrap": "node_modules/cloudflare-docs-engine/bin/commands.sh bootstrap",


### PR DESCRIPTION
Reverts cloudflare/cloudflare-docs#2805
Also removes the previous long SHA from the URL.