### PR TITLE
Update durable-objects.md - s/`await`/`ctx.waitUntil`

### DIFF
--- a/products/workers/src/content/runtime-apis/durable-objects.md
+++ b/products/workers/src/content/runtime-apis/durable-objects.md
@@ -90,7 +90,7 @@ export default {
 }
 ```
 
-The same functionality can be achieved in a Durable Object, simply by omitting the `await` for the POST request. The request will complete before the Durable Object exits:
+The same functionality can be achieved in a Durable Object, simply by omitting the call to `ctx.waitUntil()` for the POST request. The request will complete before the Durable Object exits:
 
 ```js
 ---


### PR DESCRIPTION
The docs say that the different between the two code samples is an await statement, but there's no await statement in either of the samples. I think it meant to say that you can omit the call the `ctx.waitUntil`, because that _is_ the difference between the two.