### PR TITLE
[Workers] Fix KV max value size

### DIFF
--- a/products/pages/src/content/platform/limits.md
+++ b/products/pages/src/content/platform/limits.md
@@ -23,7 +23,7 @@ Pages uploads each file on your site to Cloudflare's globally distributed networ
 
 ## File size
 
-The maximum file size for a single Cloudflare Pages site asset is 25MiB.
+The maximum file size for a single Cloudflare Pages site asset is 25MB.
 
 ## Preview deployments
 

--- a/products/pages/src/content/platform/limits.md
+++ b/products/pages/src/content/platform/limits.md
@@ -23,7 +23,7 @@ Pages uploads each file on your site to Cloudflare's globally distributed networ
 
 ## File size
 
-The maximum file size for a single Cloudflare Pages site asset is 25MB.
+The maximum file size for a single Cloudflare Pages site asset is 25MiB.
 
 ## Preview deployments
 

--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -284,7 +284,7 @@ You can also define your `site` using an [alternative TOML syntax](https://githu
 
 #### Storage Limits
 
-For exceptionally large pages, Workers Sites may not be ideal. There is a 25MiB limit per page or file. Additionally, Wrangler will create an asset manifest for your files that will count towards your script’s size limit. If you have too many files, you may not be able to use Workers Sites.
+For exceptionally large pages, Workers Sites may not be ideal. There is a 25 MiB limit per page or file. Additionally, Wrangler will create an asset manifest for your files that will count towards your script’s size limit. If you have too many files, you may not be able to use Workers Sites.
 
 #### Exclusively including files/directories
 

--- a/products/workers/src/content/cli-wrangler/configuration.md
+++ b/products/workers/src/content/cli-wrangler/configuration.md
@@ -284,7 +284,7 @@ You can also define your `site` using an [alternative TOML syntax](https://githu
 
 #### Storage Limits
 
-For exceptionally large pages, Workers Sites may not be ideal. There is a 25MB limit per page or file. Additionally, Wrangler will create an asset manifest for your files that will count towards your script’s size limit. If you have too many files, you may not be able to use Workers Sites.
+For exceptionally large pages, Workers Sites may not be ideal. There is a 25MiB limit per page or file. Additionally, Wrangler will create an asset manifest for your files that will count towards your script’s size limit. If you have too many files, you may not be able to use Workers Sites.
 
 #### Exclusively including files/directories
 

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -82,7 +82,7 @@ The Workers Unbound Usage Model has a significantly higher limit than the Bundle
 | [Keys/namespace](#kv)                 | unlimited  |
 | [Key size](#kv)                       | 512 bytes  |
 | [Key metadata](#kv)                   | 1024 bytes |
-| [Value size](#kv)                     | 25 MB      |
+| [Value size](#kv)                     | 25 MiB     |
 
 </TableWrap>
 
@@ -232,7 +232,7 @@ Workers KV supports:
 - Up to 100 Namespaces per account
 - Unlimited keys per namespace
 - Keys of up to 512 bytes
-- Values of up to 25 MB
+- Values of up to 25 MiB
 - Metadata of up to 1024 bytes per key
 - Unlimited reads per second
 - Unlimited writes per second, if they are to different keys

--- a/products/workers/src/content/platform/sites/configuration.md
+++ b/products/workers/src/content/platform/sites/configuration.md
@@ -90,7 +90,7 @@ route = "https://staging.example.com/docs*"
 
 ## Storage limits
 
-For very exceptionally large pages, Workers Sites might not work for you. There is a 25MiB limit per page or file.
+For very exceptionally large pages, Workers Sites might not work for you. There is a 25 MiB limit per page or file.
 
 ## Ignoring subsets of static assets
 

--- a/products/workers/src/content/platform/sites/configuration.md
+++ b/products/workers/src/content/platform/sites/configuration.md
@@ -90,7 +90,7 @@ route = "https://staging.example.com/docs*"
 
 ## Storage limits
 
-For very exceptionally large pages, Workers Sites might not work for you. There is a 25MB limit per page or file.
+For very exceptionally large pages, Workers Sites might not work for you. There is a 25MiB limit per page or file.
 
 ## Ignoring subsets of static assets
 

--- a/products/workers/src/content/runtime-apis/kv.md
+++ b/products/workers/src/content/runtime-apis/kv.md
@@ -38,7 +38,7 @@ await NAMESPACE.put(key, value)
 
 This method returns a `Promise` that you should `await` on in order to verify a successful update.
 
-The maximum size of a value is 25MiB.
+The maximum size of a value is 25 MiB.
 
 You can also [write key-value pairs from the command line with
 Wrangler](/cli-wrangler/commands#kvkey).

--- a/products/workers/src/content/runtime-apis/kv.md
+++ b/products/workers/src/content/runtime-apis/kv.md
@@ -38,7 +38,7 @@ await NAMESPACE.put(key, value)
 
 This method returns a `Promise` that you should `await` on in order to verify a successful update.
 
-The maximum size of a value is 25MB.
+The maximum size of a value is 25MiB.
 
 You can also [write key-value pairs from the command line with
 Wrangler](/cli-wrangler/commands#kvkey).


### PR DESCRIPTION
The max value size in KV is actually 25 MiB (26214400 bytes) not 25 MB (25000000).

Verified through the runtime:
> KV PUT failed: 413 Value length of 26214401 exceeds limit of 26214400.

---

Pages is incorrectly checking 25 MB not MiB:
![image](https://user-images.githubusercontent.com/8492901/143962151-e547ee0e-823a-4314-bec5-056a789d063d.png)
