### PR TITLE
[Workers] Fix typo: `colo-local` in how-the-cache-works.md

### DIFF
--- a/products/workers/src/content/learning/how-the-cache-works.md
+++ b/products/workers/src/content/learning/how-the-cache-works.md
@@ -5,7 +5,7 @@ pcx-content-type: concept
 
 # How the Cache works
 
-Since Workers was built atop Cloudflare’s network, since its early days, it was designed to allow developers to interact directly with the Cloudflare cache. The cache can provide ephemeral, colo-local storage, as a convenient way to frequently access static or dynamic content.
+Since Workers was built atop Cloudflare’s network, since its early days, it was designed to allow developers to interact directly with the Cloudflare cache. The cache can provide ephemeral, co-local storage, as a convenient way to frequently access static or dynamic content.
 
 By allowing developers to write to the cache, Workers provide a way to customize cache behavior on Cloudflare’s CDN. To learn about the benefits of caching see our Learning Center’s article on [What is Caching?](https://www.cloudflare.com/learning/cdn/what-is-caching/).
 


### PR DESCRIPTION
- fix typo: `colo-local` to `co-local`

Although I'm not a native speaker of English, I could not find a reasonable meaning of the prefix "colo-" or the word "colo-local". So I thought this was a typo for "co-local".

For that reason, I correct `colo-local` to `co-local` in this PR.