### PR TITLE
Mention workarounds for 25MB file size limit

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -73,6 +73,12 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 After deploying your site, you will receive a unique subdomain for your project on `*.pages.dev`. 
 Every time you commit new code to your Blazor site, Cloudflare Pages will automatically rebuild your project and deploy it. You will also get access to [preview deployments](/platform/preview-deployments) on new pull requests, so you can preview how changes look to your site before deploying them to production.
 
+## Troubleshooting
+
+### A file is over the 25MB limit
+
+If you get error like *"Error: Asset "/opt/buildhome/repo/output/wwwroot/_framework/dotnet.wasm" is over the 25MB limit"* then you have two options. Either you try to reduce size of your assets with following [guide](https://docs.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#minimize-app-download-size) **or** remove the _*.wasm_ files from the output (e.g. `rm output/wwwroot/_framework/*.wasm`) and modify your Blazor app to [load the Brotli compressed files](https://docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?view=aspnetcore-6.0#compression) instead. 
+
 ## Learn more
 
 By completing this guide, you have successfully deployed your Blazor site to Cloudflare Pages. To get started with other frameworks, [refer to the list of Framework guides](/framework-guides).

--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -77,7 +77,13 @@ Every time you commit new code to your Blazor site, Cloudflare Pages will automa
 
 ### A file is over the 25MB limit
 
-If you get error like *"Error: Asset "/opt/buildhome/repo/output/wwwroot/_framework/dotnet.wasm" is over the 25MB limit"* then you have two options. Either you try to reduce size of your assets with following [guide](https://docs.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#minimize-app-download-size) **or** remove the _*.wasm_ files from the output (e.g. `rm output/wwwroot/_framework/*.wasm`) and modify your Blazor app to [load the Brotli compressed files](https://docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?view=aspnetcore-6.0#compression) instead. 
+If you receive the error message `Error: Asset "/opt/buildhome/repo/output/wwwroot/_framework/dotnet.wasm" is over the 25MB limit`, you have two options:
+
+1. Reduce the size of your assets with the following [guide](https://docs.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#minimize-app-download-size).
+
+Or
+
+2. Remove the `*.wasm` files from the output (`rm output/wwwroot/_framework/*.wasm`) and modify your Blazor application to [load the Brotli compressed files](https://docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?view=aspnetcore-6.0#compression) instead. 
 
 ## Learn more
 


### PR DESCRIPTION
Since this can be a very common issue with apps that have many dependencies