### PR TITLE
Added await to example for generateKey as it returns a Promise

### DIFF
--- a/products/workers/src/content/runtime-apis/web-crypto.md
+++ b/products/workers/src/content/runtime-apis/web-crypto.md
@@ -134,7 +134,7 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
     example, to generate a new AES-GCM key:
 
     ```js
-    let keyPair = crypto.subtle.generateKey(
+    let keyPair = await crypto.subtle.generateKey(
       {
         name: "AES-GCM",
         length: "256"


### PR DESCRIPTION
```js
    let keyPair = await crypto.subtle.generateKey(
      {
        name: "AES-GCM",
        length: "256"
      },
      true,
      ["encrypt", "decrypt"]
    )
    ```