### PR TITLE
1.1.1.1: typos in network-operators.md

### DIFF
--- a/products/1.1.1.1/src/content/network-operators.md
+++ b/products/1.1.1.1/src/content/network-operators.md
@@ -7,7 +7,7 @@ pcx-content-type: reference
 
 Network operators, including Internet Service Providers (ISPs), device manufacturers, public WiFi networks, municipal broadband providers, and security scanning services can use [1.1.1.1](/setup-1.1.1.1) and [1.1.1.1 for Families](/1.1.1.1-for-families) in place of operating their own recursive DNS infrastructure.
 
-Using 1.1.1.1 can improve performance for end-users due to Cloudflare's extensive [global network](https://www.cloudflare.com/network/), as well as higher overall cache hit rates due to our regional caches.
+Using 1.1.1.1 can improve performance for end-users due to Cloudflare's extensive [global network](https://www.cloudflare.com/network/), as well as provide higher overall cache hit rates due to our regional caches.
 
 The 1.1.1.1 resolver was designed with a privacy-first approach. Refer to our [data and privacy policies](/privacy/public-dns-resolver) for what is logged and retained by 1.1.1.1.
 
@@ -43,7 +43,7 @@ Families (Adult Content + Malware) | 1.1.1.3 / 1.0.0.3  | `https://family.cloudf
 
 </TableWrap>
 
-You may wish to provide end-users options to change from the default 1.1.1.1 resolver to one of the [/1.1.1.1-for-families) endpoints.
+You may wish to provide end-users options to change from the default 1.1.1.1 resolver to one of the [1.1.1.1 for Families](https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families) endpoints.
 
 ## Rate Limiting
 


### PR DESCRIPTION
Fixed a broken link and a typo. 