### PR TITLE
Add example for logpush/logpull CVE-2021-44228 redaction

### DIFF
--- a/products/logs/src/content/reference/logpush-api-configuration/examples/example-logpush-curl/index.md
+++ b/products/logs/src/content/reference/logpush-api-configuration/examples/example-logpush-curl/index.md
@@ -305,3 +305,73 @@ curl -s -X GET https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logpush/jobs
       "error_message": null
     },
 ```
+
+## Step 6 - Updating `logpull_options`
+
+If you want to add (or remove) fields, change the timestamp format, or enable protection against the `Log4j - CVE-2021-44228` vulnerability, first retrieve the current `logpull_options` for your zone.
+
+```bash
+curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logpush/jobs/<JOB_ID>' \
+    -H 'X-Auth-Key: <YOUR_AUTH_KEY>' \
+    -H 'X-Auth-Email: <YOUR_EMAIL>' | jq .
+```
+
+### Response 
+
+```json
+{
+    "errors": [],
+    "messages": [],
+    "result": {
+        "id": 146,
+        "dataset": "http_requests",
+        "logstream": true,
+        "frequency": "high",
+        "kind": "",
+        "enabled": true,
+        "name": "<DOMAIN_NAME>",
+        "logpull_options": "fields=ClientIP,ClientRequestHost,ClientRequestMethod,ClientRequestURI,EdgeEndTimestamp,EdgeResponseBytes,EdgeResponseStatus,EdgeStartTimestamp,RayID&timestamps=rfc3339",
+        "destination_conf": "s3://<BUCKET_PATH_HTTP_REQUESTS>?region=us-west-2",
+        "last_complete": "2021-12-14T19:56:49Z",
+        "last_error": null,
+        "error_message": null
+    },
+    "success": true
+}
+```
+
+Next, edit the `logpull_options` as desired and create a `PUT` request. The following example enables the `CVE-2021-44228` redaction CVE-2021-44228 option.
+
+```bash
+curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/${ZONE_TAG}/logpush/jobs/${JOB_ID}/' \
+    -H 'X-Auth-Key: <YOUR_AUTH_KEY>' \
+    -H 'X-Auth-Email: <YOUR_EMAIL>' \
+    -H 'Content-Type: application/json' \
+    --data-raw '{
+    "logpull_options": "fields=ClientIP,ClientRequestHost,ClientRequestMethod,ClientRequestURI,EdgeEndTimestamp,EdgeResponseBytes,EdgeResponseStatus,EdgeStartTimestamp,RayID&timestamps=rfc3339&CVE-2021-44228=true"
+}'
+```
+
+### Response 
+
+```json
+{
+    "errors": [],
+    "messages": [],
+    "result": {
+        "id": 146,
+        "dataset": "http_requests",
+        "logstream": true,
+        "frequency": "high",
+        "kind": "",
+        "enabled": true,
+        "name": null,
+        "logpull_options": "fields=ClientIP,ClientRequestHost,ClientRequestMethod,ClientRequestURI,EdgeEndTimestamp,EdgeResponseBytes,EdgeResponseStatus,EdgeStartTimestamp,RayID&timestamps=rfc3339&CVE-2021-44228=true",
+        "destination_conf": "s3://<BUCKET_PATH_HTTP_REQUESTS>?region=us-west-2",
+        "last_complete": "2021-12-14T20:02:19Z",
+        "last_error": null,
+        "error_message": null
+    },
+    "success": true
+}
+```

--- a/products/logs/src/content/reference/logpush-api-configuration/index.md
+++ b/products/logs/src/content/reference/logpush-api-configuration/index.md
@@ -148,7 +148,7 @@ The four options that you can customize are:
 1. Fields: See *[Log fields](/reference/log-fields/)* for the currently available fields. The list of fields is also accessible directly from the API: `https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields`. Default fields: `https://api.cloudflare.com/client/v4/zones/<zone_id>/logpush/datasets/<dataset>/fields/default`.
 1. Sampling rate: Value can range from 0.001 to 1.0 (inclusive). `sample=0.1` means return 10% (1 in 10) of all records.
 1. Timestamp format: The format in which timestamp fields will be returned. Value options: unixnano (default), unix, rfc3339.
-1. Optional redaction for CVE-2021-44228: This option will replace every occurrence of `${` with `x{`.  To enable it, set "CVE-2021-44228=true".
+1. Optional redaction for CVE-2021-44228: This option will replace every occurrence of `${` with `x{`.  To enable it, set `CVE-2021-44228=true`.
 
 To check if `logpull_options` are valid:
 


### PR DESCRIPTION
Adding an example for editing `logpull_options` to enable CVE-2021-44228 redaction in logs.