### PR TITLE
DDoS: API supports only token-based authentication

### DIFF
--- a/products/ddos-protection/src/content/managed-rulesets/tcp-protection/configure-api.md
+++ b/products/ddos-protection/src/content/managed-rulesets/tcp-protection/configure-api.md
@@ -8,7 +8,7 @@ order: 2
 
 You can configure Advanced TCP Protection using the Advanced TCP Protection API.
 
-For authentication instructions, refer to [Getting Started: Requests](https://api.cloudflare.com/#getting-started-requests) in the Cloudflare API documentation.
+The Advanced TCP Protection API only supports API token authentication. For more information on API authentication, refer to [Getting Started: Requests](https://api.cloudflare.com/#getting-started-requests) in the Cloudflare API documentation.
 
 ## Endpoints
 


### PR DESCRIPTION
Add a note about the supported authentication method.