### PR TITLE
Update with real workspace one instructions

### DIFF
--- a/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
+++ b/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
@@ -5,37 +5,41 @@ hidden: true
 ---
  
 # Workspace ONE
-Posture with Workspace ONE requires that the Workspace ONE agent and the Cloudflare WARP client are deployed on your devices. Our service-to-service posture check relies on the **serial_number** being the same in both clients for this integration to function.
 
+Device posture with Workspace ONE requires that the Workspace ONE agent and the Cloudflare WARP client are deployed on your devices. For this integration to function, our service-to-service posture check relies on the **serial_number** being the same in both clients. Follow the instructions below to set up the check.
 
 ## Obtain Workspace ONE Settings
-To successfully set up the Workspace ONE posture check, you need to obtain the following Workspace ONE values:
+
+The following Workspace ONE values are needed to set up the Workspace ONE posture check:
+
 - ClientID
 - Client Secret
 - Region-Specific token URL
 - REST API URL
 
-To obtain those values:
+To retrieve those values:
 
 1. Log in to your Workspace ONE dashboard.
-1. Navigate to **Groups & Settings > Configurations.**
-1. Enter "OAuth" in the search bar labeled **Enter a name or category**.
-1. Select **OAuth Client Management** that appears in the results. The OAuth Client Management screen displays.
-1. Select the **Add** button.
+1. Navigate to **Groups & Settings** > **Configurations**.
+1. Enter `OAuth` in the search bar labeled **Enter a name or category**.
+1. Select **OAuth Client Management** in the results. The OAuth Client Management screen displays.
+1. Click **Add**.
 1. Enter values for the **Name**, **Description**, **Organization Group**, and **Role**.
 1. Ensure that the **Status** is **Enabled**.
-1. Select **Save**.
-1. Copy the `Client ID` and `Client Secret` to a safe place. 
-1. Retrieve the correct **Region-Specific Token URL** from here: https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/services/UEM_ConsoleBasics/GUID-BF20C949-5065-4DCF-889D-1E0151016B5A.html. Copy the `Region-specific token URL` to a safe place.
-1. Obtain your `REST API URL` by going to the WS1 dashboard and navigating to Groups & Settings > All Settings > System > Advance > Site URLs > REST API URL.
+1. Click **Save**.
+1. Copy the Client ID and Client Secret to a safe place. 
+1. Retrieve the correct Region-Specific Token URL from the [VMware documentation](https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/services/UEM_ConsoleBasics/GUID-BF20C949-5065-4DCF-889D-1E0151016B5A.html). Copy the Region-specific token URL to a safe place.
+1. Obtain your REST API URL by going to the WS1 dashboard and navigating to **Groups & Settings** > **All Settings** > **System** > **Advance** > **Site URLs** > **REST API URL**.
 
-## Configure provider on the Teams dashboard
+## Configure the provider on the Teams dashboard
+
 1. Give your provider a name. This name will be used throughout the dashboard to reference this connection.
-1. Enter in the `Client ID` and `Client Secret` you noted down above
-1. Select a **polling frequency** for how often teams should query Workspace ONE for information.
-1. Enter the `Region-specific token URL` and `REST API URL` you noted down above.
-1. Select **Save**.
-1. Select the **Test Provider** button to ensure the values have been entered correctly.
+1. Enter the Client ID and Client Secret you noted down above.
+1. Select a **polling frequency** for how often Cloudflare for Teams should query Workspace ONE for information.
+1. Enter the Region-specific token URL and REST API URL you noted down above.
+1. Click **Save**.
+1. Click **Test Provider** to ensure the values have been entered correctly.
 
 ## Configure Compliance Settings
+
 Workspace ONE integrated posture checks work with the Compliance flags in Workspace ONE. All compliance tests must pass for the device to be considered compliant.

--- a/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
+++ b/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
@@ -5,25 +5,37 @@ hidden: true
 ---
  
 # Workspace ONE
-
-<details>
-<summary>Feature availability</summary>
-<div>
-
-| Operating Systems | [WARP mode required](/connections/connect-devices/warp#warp-client-modes) | Minimum WARP version required | [Teams plans](https://www.cloudflare.com/teams-pricing/) |
-| ----------------- | --------- | ---------- | ---- |
-| macOS, Windows | WARP with Gateway | macOS: 1.4.34, Windows: 1.4.33.0 | All plans | 
-
-</div>
-</details>
-
-Placeholder text to talk about how to setup WorkSapce one configre
-
-## Configure Workspace ONE
-
-You'll need to configure workspace one so Cloudflare can talk to it can get credentails
+Posture with Workspace ONE requires that the Workspace ONE agent and the Cloudflare WARP client are deployed on your devices. Our service-to-service posture check relies on the **serial_number** being the same in both clients for this integration to function.
 
 
-## Configuring the Cloudflare integration
+## Obtain Workspace ONE Settings
+To successfully set up the Workspace ONE posture check, you need to obtain the following Workspace ONE values:
+- ClientID
+- Client Secret
+- Region-Specific token URL
+- REST API URL
 
-You'll need to then configure  Workspace One as a posture provider and create a posture rule
+To obtain those values:
+
+1. Log in to your Workspace ONE dashboard.
+1. Navigate to **Groups & Settings > Configurations.**
+1. Enter "OAuth" in the search bar labeled **Enter a name or category**.
+1. Select **OAuth Client Management** that appears in the results. The OAuth Client Management screen displays.
+1. Select the **Add** button.
+1. Enter values for the **Name**, **Description**, **Organization Group**, and **Role**.
+1. Ensure that the **Status** is **Enabled**.
+1. Select **Save**.
+1. Copy the `Client ID` and `Client Secret` to a safe place. 
+1. Retrieve the correct **Region-Specific Token URL** from here: https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/services/UEM_ConsoleBasics/GUID-BF20C949-5065-4DCF-889D-1E0151016B5A.html. Copy the `Region-specific token URL` to a safe place.
+1. Obtain your `REST API URL` by going to the WS1 dashboard and navigating to Groups & Settings > All Settings > System > Advance > Site URLs > REST API URL.
+
+## Configure provider on the Teams dashboard
+1. Give your provider a name. This name will be used throughout the dashboard to reference this connection.
+1. Enter in the `Client ID` and `Client Secret` you noted down above
+1. Select a **polling frequency** for how often teams should query Workspace ONE for information.
+1. Enter the `Region-specific token URL` and `REST API URL` you noted down above.
+1. Select **Save**.
+1. Select the **Test Provider** button to ensure the values have been entered correctly.
+
+## Configure Compliance Settings
+Workspace ONE integrated posture checks work with the Compliance flags in Workspace ONE. All compliance tests must pass for the device to be considered compliant.

--- a/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
+++ b/products/cloudflare-one/src/content/identity/idp-integration/workspace-one.md
@@ -40,6 +40,6 @@ To retrieve those values:
 1. Click **Save**.
 1. Click **Test Provider** to ensure the values have been entered correctly.
 
-## Configure Compliance Settings
+## Configure compliance settings
 
-Workspace ONE integrated posture checks work with the Compliance flags in Workspace ONE. All compliance tests must pass for the device to be considered compliant.
+Workspace ONE posture checks work with the Compliance flags in Workspace ONE. All compliance tests must pass for the device to be considered compliant.


### PR DESCRIPTION
- Update content with real instructions for Workspace ONE service to service posture
- Remove customer header HTML that talks about compatibility because that is not supported with embedded teams dash help content.