### PR TITLE
Remove the reference to `worktop/cookie` in the cookie parsing example.

### DIFF
--- a/products/workers/src/content/examples/extract-cookie-value.md
+++ b/products/workers/src/content/examples/extract-cookie-value.md
@@ -15,8 +15,6 @@ pcx-content-type: configuration
 
 ```js
 import { parse } from "cookie"
-// OR
-import { parse } from "worktop/cookie"
 
 // The name of the cookie
 const COOKIE_NAME = "__uid"
@@ -39,6 +37,6 @@ addEventListener("fetch", event => {
 
 <Aside type="note" header="External Dependencies">
 
-This example is set up to depend on [`cookie@0.4.1`](https://www.npmjs.com/package/cookie/v/0.4.1) or [`worktop@0.7.1`](https://www.npmjs.com/package/worktop/v/0.7.1). You may pick either package, as they both work the same way.
+This example requires the npm package [`cookie`](https://www.npmjs.com/package/cookie) to be installed in your javascript project.
 
 </Aside>

--- a/products/workers/src/content/examples/extract-cookie-value.md
+++ b/products/workers/src/content/examples/extract-cookie-value.md
@@ -37,6 +37,6 @@ addEventListener("fetch", event => {
 
 <Aside type="note" header="External Dependencies">
 
-This example requires the npm package [`cookie`](https://www.npmjs.com/package/cookie) to be installed in your javascript project.
+This example requires the npm package [`cookie`](https://www.npmjs.com/package/cookie) to be installed in your JavaScript project.
 
 </Aside>


### PR DESCRIPTION
This doc gives a choice between 2 packages but isn't clear why one should be picked over the other (in fact, it claims they're the same). This confused a friend of mine who was looking at it, and I agreed it's confusing. This PR removes the reference to `worktop/cookie` in the example.