### PR TITLE
Pages known issues

### DIFF
--- a/products/pages/src/content/platform/known-issues.md
+++ b/products/pages/src/content/platform/known-issues.md
@@ -15,7 +15,7 @@ Here are some known bugs and issues that we're aware of with Cloudflare Pages:
 - For users migrating from Netlify, Cloudflare does not support Netlify's Forms and Serverless Functions features.
 - It is currently not possible to add a custom domain with a wildcard, for example, `*.domain.com`.
 - Cloudflare Pages is not supported with Cloudflare Apps; you may see a `1014` error if you use both in a deployment.
-- Cloudflare's Load Balancer will not work on your `*.pages.dev` project because it will serve a Error 1000: DNS points to prohibited IP.
-- You cannot add your GitHub or GitLab account to more than one Cloudflare account.
+- Cloudflare's Load Balancer does not work with `*.pages.dev` projects; an `Error 1000: DNS points to prohibited IP` will appear.
+- A GitHub or GitLab account cannot be attached to more than one Cloudflare account.
 
 If you have an issue that you do not see listed, let the team know in the Cloudflare Workers Discord. Get your invite at [discord.gg/cloudflaredev](https://discord.gg/cloudflaredev), and share your bug report in the #pages-help channel.

--- a/products/pages/src/content/platform/known-issues.md
+++ b/products/pages/src/content/platform/known-issues.md
@@ -15,5 +15,7 @@ Here are some known bugs and issues that we're aware of with Cloudflare Pages:
 - For users migrating from Netlify, Cloudflare does not support Netlify's Forms and Serverless Functions features.
 - It is currently not possible to add a custom domain with a wildcard, for example, `*.domain.com`.
 - Cloudflare Pages is not supported with Cloudflare Apps; you may see a `1014` error if you use both in a deployment.
+- Cloudflare's Load Balancer will not work on your `*.pages.dev` project because it will serve a Error 1000: DNS points to prohibited IP.
+- You cannot add your GitHub or GitLab account to more than one Cloudflare account.
 
 If you have an issue that you do not see listed, let the team know in the Cloudflare Workers Discord. Get your invite at [discord.gg/cloudflaredev](https://discord.gg/cloudflaredev), and share your bug report in the #pages-help channel.

--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -36,7 +36,7 @@ const DEFAULT_SECURITY_HEADERS = {
     X-XSS-Protection header prevents a page from loading if an XSS attack is detected. 
     @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
     */
-    "X-XSS-Protection": "0; mode=block",
+    "X-XSS-Protection": "0",
     /*
     X-Frame-Options header prevents click-jacking attacks. 
     @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options


### PR DESCRIPTION
Updating with known issues for Pages:
- Cannot use load balancer with .pages.dev projects
- GitLab/GitHub accounts can only be added to a single Cloudflare account (regardless if it's within an organization)