### PR TITLE
Add Remix to framework presets

### DIFF
--- a/products/pages/src/content/platform/build-configuration.md
+++ b/products/pages/src/content/platform/build-configuration.md
@@ -42,6 +42,7 @@ If you are not using a framework, you may input `exit 0` into the **Build comman
 | Quasar                       | `quasar build`                       | `dist/spa`                  |
 | React (create-react-app)     | `npm run build`                      | `build`                     |
 | React Static                 | `react-static build`                 | `dist`                      |
+| Remix                        | `npm run build`                      | `public`                    |
 | Slate                        | `./deploy.sh`                        | `build`                     |
 | Svelte                       | `npm run build`                      | `public`                    |
 | Umi                          | `umi build`                          | `dist`                      |


### PR DESCRIPTION
Remix is already supported but was missing from this list. I've added the build command and directory to match how Cloudflare configures it when you choose Remix as a preset