### PR TITLE
Update Durable Objects size limit

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -282,7 +282,7 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 
 - Storage keys of up to 2 KiB (2048 bytes)
 
-- Storage values of up to 32 KiB (32768 bytes)
+- Storage values of up to 128 KiB (131072 bytes)
 
 - 30s of CPU time per request, including websocket messages
 


### PR DESCRIPTION
- Increase from 32 KiB to 128 KiB per release notes: https://community.cloudflare.com/t/2021-12-10-workers-runtime-release-notes/334982

#3039 