### PR TITLE
Update Durable Objects size limit

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -121,7 +121,7 @@ Refer to [KV pricing](/platform/pricing#workers-kv) to review the specific KV op
 | [Storage per class](#durable-objects)   | unlimited
 | [Storage per object](#durable-objects)  | unlimited
 | [Key size](#durable-objects)            | 2048 bytes
-| [Value size](#durable-objects)          | 32 KiB
+| [Value size](#durable-objects)          | 128 KiB
 | [CPU per request](#durable-objects)     | 30s
 
 </TableWrap>

--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -282,7 +282,7 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 
 - Storage keys of up to 2 KiB (2048 bytes)
 
-- Storage values of up to 32 KiB (32768 bytes)
+- Storage values of up to 128 KiB (131072 bytes)
 
 - 30s of CPU time per request, including websocket messages
 

--- a/products/workers/src/content/runtime-apis/durable-objects.md
+++ b/products/workers/src/content/runtime-apis/durable-objects.md
@@ -157,7 +157,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
 
 - <Code>put(key<ParamType>string</ParamType>, value<ParamType>any</ParamType>, options<ParamType>Object</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Promise</Type>
 
-  - Stores the value and associates it with the given key. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Keys are limited to a max size of 2048 bytes and values are limited to 32 KiB (32768 bytes).
+  - Stores the value and associates it with the given key. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Keys are limited to a max size of 2048 bytes and values are limited to 128 KiB (131072 bytes).
 
     __Supported options:__
 
@@ -187,7 +187,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
 
 - <Code>put(entries<ParamType>Object</ParamType>, options<ParamType>Object</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Promise</Type>
 
-  - Takes an Object and stores each of its keys and values to storage. Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Supports up to 128 key-value pairs at a time. Each key is limited to a max size of 2048 bytes and each value is limited to 32 KiB (32768 bytes).
+  - Takes an Object and stores each of its keys and values to storage. Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Supports up to 128 key-value pairs at a time. Each key is limited to a max size of 2048 bytes and each value is limited to 128 KiB (131072 bytes).
 
     __Supported options:__ Same as `put(key, value, options)`, above.
 

--- a/products/workers/src/content/runtime-apis/durable-objects.md
+++ b/products/workers/src/content/runtime-apis/durable-objects.md
@@ -187,7 +187,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
 
 - <Code>put(entries<ParamType>Object</ParamType>, options<ParamType>Object</ParamType><PropMeta>optional</PropMeta>)</Code> <Type>Promise</Type>
 
-  - Takes an Object and stores each of its keys and values to storage. Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Supports up to 128 key-value pairs at a time. Each key is limited to a max size of 2048 bytes and each value is limited to 128 KiB (131072 bytes).
+  - Takes an Object and stores each of its keys and values to storage. Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Supports up to 128 key-value pairs at a time. Each key is limited to a maximum size of 2048 bytes and each value is limited to 128 KiB (131072 bytes).
 
     __Supported options:__ Same as `put(key, value, options)`, above.
 


### PR DESCRIPTION
Copied over from @jbmanning 's #3040 to add an additional commit to it that fixes the remaining locations.