### PR TITLE
Fixed tunnel run command with config parameter

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/configuration/configuration-file/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/configuration/configuration-file/index.md
@@ -66,5 +66,5 @@ $ cat config.yaml
 Before you run a tunnel, ensure you have created a configuration file for `cloudflared` to know what configuration to follow when routing traffic through the tunnel. When running a tunnel, make sure you specify the path to your configuration file:
 
 ```sh
-$ cloudflared tunnel run --config /path/your-config-file.yaml run tunnel-name
+$ cloudflared tunnel --config /path/your-config-file.yaml run tunnel-name
 ```


### PR DESCRIPTION
The first 'run' caused the tunnel run command to fail because the config parameter is a tunnel command option, not a subcommand option. 

![image](https://user-images.githubusercontent.com/45736619/147943800-bb49c598-add7-4879-be38-701bc9ac8fbd.png)

The correct usage is displayed here: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide#6-run-the-tunnel