### PR TITLE
Add missing info to os version posture check

### DIFF
--- a/products/cloudflare-one/src/content/identity/devices/os-version.md
+++ b/products/cloudflare-one/src/content/identity/devices/os-version.md
@@ -4,20 +4,20 @@ pcx-content-type: how-to
 title: OS Version 
 ---
 
-# OS Version (beta)
+# OS Version
 
 <details>
 <summary>Feature availability</summary>
 <div>
 
-| Status | Operating Systems | [WARP mode required](/connections/connect-devices/warp#warp-client-modes) | [Teams plans](https://www.cloudflare.com/teams-pricing/) |
-| --- | ----------------- | --------- | ---- |
-| Beta | macOS, Windows | WARP with Gateway | All plans | 
+| Operating Systems | [WARP mode required](/connections/connect-devices/warp#warp-client-modes) | [Teams plans](https://www.cloudflare.com/teams-pricing/) |
+| ----------------- | --------- | ---- |
+| Windows, Mac | WARP with Gateway | All plans | 
 
 </div>
 </details>
 
-The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given value.
+The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given **Semver** version. The version formation must be specified as a valid Semver (ex. x.x.x or 1.2.0)
 
 To enable the OS version check:
 
@@ -30,6 +30,8 @@ To enable the OS version check:
 
 ## Determine the OS Version
 Operating systems display version numbers in different ways. This section covers how to retrieve the version number in each OS, in a format matching what the OS Version posture check expects.
+
+**Note** you must ensure the version is entered is a valid x.x.x semver. If the command below only returns a value of `x.x` you must append a `.0` so the complete version looks like `x.x.0` 
 
 ### On macOS
 1. Open a terminal window

--- a/products/cloudflare-one/src/content/identity/devices/os-version.md
+++ b/products/cloudflare-one/src/content/identity/devices/os-version.md
@@ -38,16 +38,16 @@ You must ensure the version is entered is a valid `x.x.x` Semver. If the command
   </Aside>
 
 ### On macOS
-1. Open a terminal window
-1. Use the `defaults` command to check for the value of `SystemVersionStampAsString`
+1. Open a terminal window.
+1. Use the `defaults` command to check for the value of `SystemVersionStampAsString`.
 
 ```txt
 defaults read loginwindow SystemVersionStampAsString
 ```
 
 ### On Windows
-1. Open a powershell windows
-1. Use the `Get-CimInstance` command to get the version property of the `Win32_OperatingSystem` class
+1. Open a Powershell window.
+1. Use the `Get-CimInstance` command to get the version property of the `Win32_OperatingSystem` class.
 
 ```txt
 (Get-CimInstance Win32_OperatingSystem).version

--- a/products/cloudflare-one/src/content/identity/devices/os-version.md
+++ b/products/cloudflare-one/src/content/identity/devices/os-version.md
@@ -31,7 +31,11 @@ To enable the OS version check:
 ## Determine the OS Version
 Operating systems display version numbers in different ways. This section covers how to retrieve the version number in each OS, in a format matching what the OS Version posture check expects.
 
-**Note** you must ensure the version is entered is a valid x.x.x semver. If the command below only returns a value of `x.x` you must append a `.0` so the complete version looks like `x.x.0` 
+<Aside type='note'>
+
+You must ensure the version is entered is a valid `x.x.x` Semver. If the command below only returns a value of `x.x`, you must append a `.0` so the complete version follows the `x.x.0` format.
+  
+  </Aside>
 
 ### On macOS
 1. Open a terminal window

--- a/products/cloudflare-one/src/content/identity/devices/os-version.md
+++ b/products/cloudflare-one/src/content/identity/devices/os-version.md
@@ -17,7 +17,7 @@ title: OS Version
 </div>
 </details>
 
-The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given **Semver** version. The version formation must be specified as a valid Semver (ex. x.x.x or 1.2.0)
+The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given **Semver** version. The version formation must be specified as a valid Semver (for example, `x.x.x` or `1.2.0`)
 
 To enable the OS version check:
 

--- a/products/cloudflare-one/src/content/identity/devices/os-version.md
+++ b/products/cloudflare-one/src/content/identity/devices/os-version.md
@@ -17,7 +17,7 @@ title: OS Version
 </div>
 </details>
 
-The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given **Semver** version. The version formation must be specified as a valid Semver (for example, `x.x.x` or `1.2.0`)
+The OS Version device posture attribute checks whether the version of a device’s operating system matches, is greater than or lesser than a given **Semver** version. The version formation must be specified as a valid Semver (for example, `x.x.x` or `1.2.0`).
 
 To enable the OS version check:
 


### PR DESCRIPTION
We never made clear that the posture check requires a valid semver (ex. 1.2.3).