### PR TITLE
[Workers] fix typo in cli-wranger/commands.md

### DIFF
--- a/products/workers/src/content/cli-wrangler/commands.md
+++ b/products/workers/src/content/cli-wrangler/commands.md
@@ -466,7 +466,7 @@ $ wrangler secret list --env ENVIRONMENT_NAME
 <Definitions>
 
 - `--env $ENVIRONMENT_NAME` <PropMeta>optional</PropMeta>
-  - If defined, only the specified environemnt's secrets will be listed. Refer to [Environments](/platform/environments) for more information.
+  - If defined, only the specified environment's secrets will be listed. Refer to [Environments](/platform/environments) for more information.
 
 </Definitions>
 


### PR DESCRIPTION
- Change `environemnt` to `environment`.