### PR TITLE
Switch header name prefixes to avoid word break

### DIFF
--- a/products/rules/src/content/transform/request-header-modification/index.md
+++ b/products/rules/src/content/transform/request-header-modification/index.md
@@ -18,7 +18,7 @@ To modify HTTP headers in the **response**, refer to [HTTP Response Header Modif
 
 ## Important remarks
 
-* You cannot modify or remove HTTP request headers whose name starts with `cf-` or `x-cf-` except for the `cf-connecting-ip` HTTP request header, which you can remove.
+* You cannot modify or remove HTTP request headers whose name starts with `x-cf-` or `cf-` except for the `cf-connecting-ip` HTTP request header, which you can remove.
 
 * You cannot modify the value of any header commonly used to identify the website visitor's IP address, such as `x-forwarded-for`, `true-client-ip`, or `x-real-ip`.
 


### PR DESCRIPTION
The line break was occurring in the middle of `x-cf-` (`x-` + `cf-`), which could lead to incorrect interpretations.

Addresses https://jira.cfops.it/browse/PCX-3145.