### PR TITLE
remove warning about websockets not being supported in `wrangler dev`

### DIFF
--- a/products/workers/src/content/learning/using-websockets.md
+++ b/products/workers/src/content/learning/using-websockets.md
@@ -23,12 +23,6 @@ WebSockets utilize a simple event-based system for receiving and sending message
 
 ## Writing a WebSocket Server
 
-<Aside type="note">
-
-The `wrangler dev` tool currently does not support connecting to Workers via the WebSocket protocol. Support for WebSockets in `wrangler dev` is tracked in [this GitHub issue](https://github.com/cloudflare/wrangler/issues/1910).
-
-</Aside>
-
 WebSocket servers in Cloudflare Workers allow you to receive messages from a client in real time. This guide will show you how to set up a WebSocket server in Workers.
 
 A client can make a WebSocket request in the browser by instantiating a new instance of `WebSocket`, passing in the URL for your Workers function:


### PR DESCRIPTION
WebSockets ARE supported in `wrangler dev` as of `@cloudflare/wrangler@1.19.6`, yay. This PR simply removes the message in the docs saying that they aren't.