### PR TITLE
[EMAIL ROUTING]Clarified Cloudflare as authoritative nameserver

### DIFF
--- a/products/email-routing/src/content/index.md
+++ b/products/email-routing/src/content/index.md
@@ -8,4 +8,8 @@ pcx-content-type: overview
 
 Cloudflare Email Routing (beta) is designed to simplify the way you create and manage email addresses, without needing to keep an eye on additional mailboxes. With Email Routing, you can create any number of custom email addresses that you can use in situations where you do not want to share your primary email address, such as when you subscribe to a new service or newsletter. Emails are then routed to your preferred email inbox, without you ever having to expose your primary email address.
 
-Email Routing is free for all Cloudflare users and private by design. Cloudflare will not store or access the emails routed to your inbox.
+Email Routing is free and private by design. Cloudflare will not store or access the emails routed to your inbox.
+
+## Availability
+
+Email Routing (beta) is available to all Cloudflare customers using Cloudflare as an authoritative nameserver. For more information, refer to the article [Changing your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/articles/205195708).

--- a/products/email-routing/src/content/index.md
+++ b/products/email-routing/src/content/index.md
@@ -12,4 +12,4 @@ Email Routing is free and private by design. Cloudflare will not store or access
 
 ## Availability
 
-Email Routing (beta) is available to all Cloudflare customers using Cloudflare as an authoritative nameserver. For more information, refer to the article [Changing your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/articles/205195708).
+Email Routing (beta) is available to all Cloudflare customers using Cloudflare as an authoritative nameserver. For more information, refer to [Changing your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/articles/205195708).


### PR DESCRIPTION
Clarified that Cloudflare need to be an authoritative nameserver for Email Routing to be available for customer