### PR TITLE
[Teams] Add indent to Private Networking tutorial

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-networks/private-net/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-networks/private-net/index.md
@@ -51,7 +51,7 @@ To connect a private network to Cloudflare's edge, follow the guide below. You c
     tunnel: <Tunnel-UUID>
     credentials-file: /root/.cloudflared/credentials-file.json
     warp-routing:
-    enabled: true
+        enabled: true
     ```
 
 1. Run the tunnel. Traffic inside of your organization coming from enrolled WARP clients will be sent to this instance when the destination is your private IP range.


### PR DESCRIPTION
If the YAML is copied as-is, the configuration will be accepted
as valid but won't work with WARP routing.

This corrects that.