### PR TITLE
Fix Pages functions routing example

### DIFF
--- a/products/pages/src/content/platform/functions.md
+++ b/products/pages/src/content/platform/functions.md
@@ -26,15 +26,15 @@ For example, assume this directory structure:
 ```
 ├── ...
 ├── functions
-|   └── api
-│       ├── [[path]].ts
-│       ├── [username]
-│       │   └── profile.ts
-│       ├── time.ts
-│       └── todos
-│           ├── [[path]].ts
-│           ├── [id].ts
-│           └── index.ts
+|   ├── api
+│   │   ├── time.ts
+│   │   └── todos
+│   │       ├── [[path]].ts
+│   │       ├── [id].ts
+│   │       └── index.ts
+│   ├── [[path]].ts
+│   └── [username]
+│       └── profile.ts
 └── ...
 ```
 
@@ -45,8 +45,8 @@ The following routes will be generated based on the file structure, mapping the 
 /api/todos => ./functions/api/todos/index.ts
 /api/todos/* => ./functions/api/todos/[id].ts
 /api/todos/*/** => ./functions/api/todos/[[path]].ts
-/*/profile => ./functions/api/[username]/profile.ts
-/** => ./functions/api/[[path]].ts
+/*/profile => ./functions/[username]/profile.ts
+/** => ./functions/[[path]].ts
 ```
 
 ### Path segments


### PR DESCRIPTION
I think the current example of [functions routing on Cloudflare Pages](https://developers.cloudflare.com/pages/platform/functions#functions-routing) is wrong 😬 
Example leads to believe that `/functions/api/[[path]].ts` would render index (for example), but at least with `wrangler dev pages` it doesn't, `/functions/api/[[path]].ts` actually does the trick...