### PR TITLE
Fix base64 decoding of UTF-8 test in Basic Auth

### DIFF
--- a/products/workers/src/content/examples/basic-auth.md
+++ b/products/workers/src/content/examples/basic-auth.md
@@ -120,7 +120,9 @@ function basicAuthentication(request) {
   // Decodes the base64 value and performs unicode normalization.
   // @see https://datatracker.ietf.org/doc/html/rfc7613#section-3.3.2 (and #section-4.2.2)
   // @see https://dev.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-  const decoded = atob(encoded).normalize()
+  const decoder = new TextDecoder()
+  const buffer = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0))
+  const decoded = decoder.decode(buffer).normalize()
   
   // The username & password are split by the first colon.
   //=> example: "username:password"

--- a/products/workers/src/content/examples/basic-auth.md
+++ b/products/workers/src/content/examples/basic-auth.md
@@ -120,9 +120,8 @@ function basicAuthentication(request) {
   // Decodes the base64 value and performs unicode normalization.
   // @see https://datatracker.ietf.org/doc/html/rfc7613#section-3.3.2 (and #section-4.2.2)
   // @see https://dev.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-  const decoder = new TextDecoder()
-  const buffer = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0))
-  const decoded = decoder.decode(buffer).normalize()
+  const buffer = Uint8Array.from(atob(encoded), character => character.charCodeAt(0))
+  const decoded =  new TextDecoder().decode(buffer).normalize()
   
   // The username & password are split by the first colon.
   //=> example: "username:password"


### PR DESCRIPTION
Because JavaScript uses UTF-16 for it's strings, and base64 operates on 8-bit values, plainly decoding results in broken output.

Here's a bit more info, although I fixed it differently from how they did it.

https://www.base64decoder.io/javascript/
