### PR TITLE
Remove unused variable in cache api example

### DIFF
--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -19,7 +19,6 @@ pcx-content-type: configuration
 
 async function handleRequest(event) {
   const request = event.request
-  const cacheUrl = new URL(request.url)
 
   // Construct the cache key from the cache URL
   const cacheKey = new Request(cacheUrl.toString(), request)


### PR DESCRIPTION
`const cacheUrl = new URL(request.url)` appears to be unused as the cache is generated from `cacheUrl.toString()`