### PR TITLE
Durable Objects link runtime API and learning page

### DIFF
--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -445,7 +445,7 @@ export class Counter {
 }
 ```
 
-## See also
+## Related resources
 
 - [Durable Objects runtime API](/runtime-apis/durable-objects)
 

--- a/products/workers/src/content/learning/using-durable-objects.md
+++ b/products/workers/src/content/learning/using-durable-objects.md
@@ -445,6 +445,10 @@ export class Counter {
 }
 ```
 
+## See also
+
+- [Durable Objects runtime API](/runtime-apis/durable-objects)
+
 ## Troubleshooting
 
 ### Debugging

--- a/products/workers/src/content/runtime-apis/durable-objects.md
+++ b/products/workers/src/content/runtime-apis/durable-objects.md
@@ -422,3 +422,7 @@ Any uncaught exceptions thrown by the Durable Object's `fetch()` handler will be
 ## Listing Durable Objects
 
 The Cloudflare REST API supports retrieving a [list of Durable Objects](https://api.cloudflare.com/#durable-objects-namespace-list-objects) within a namespace and a [list of namespaces](https://api.cloudflare.com/#durable-objects-namespace-list-namespaces) associated with an account.
+
+## See also
+
+- [Learn how to use Durable Objects](/learning/using-durable-objects)

--- a/products/workers/src/content/runtime-apis/durable-objects.md
+++ b/products/workers/src/content/runtime-apis/durable-objects.md
@@ -423,6 +423,6 @@ Any uncaught exceptions thrown by the Durable Object's `fetch()` handler will be
 
 The Cloudflare REST API supports retrieving a [list of Durable Objects](https://api.cloudflare.com/#durable-objects-namespace-list-objects) within a namespace and a [list of namespaces](https://api.cloudflare.com/#durable-objects-namespace-list-namespaces) associated with an account.
 
-## See also
+## Related resources
 
 - [Learn how to use Durable Objects](/learning/using-durable-objects)


### PR DESCRIPTION
Linking our Learning page for Durable Objects to the Runtime API page and vice versa. 