### PR TITLE
Added worktop.build fix

### DIFF
--- a/products/workers/src/content/tutorials/store-data-with-fauna/index.md
+++ b/products/workers/src/content/tutorials/store-data-with-fauna/index.md
@@ -137,10 +137,13 @@ Worktop solves common needs such as routing, path parameters, and  HTTP methods.
 Edit `package.json` and add the `build` script:
 
 ```json
-"scripts": {
-  "build": "worktop build index.js",
-  ...
-},
+{
+  // ...
+  "scripts": {
+    "build": "worktop build index.js",
+    // ...
+  }
+}
 ```
 
 Edit your `wrangler.toml` file found in your Worker's project directory. Set the type to `"javascript"` (not `"webpack"`) and add the `[build]` and `[build.upload]` sections as shown in the following snippet:

--- a/products/workers/src/content/tutorials/store-data-with-fauna/index.md
+++ b/products/workers/src/content/tutorials/store-data-with-fauna/index.md
@@ -128,7 +128,8 @@ Next, install the [Worktop][worktop] framework for Cloudflare Workers.
 ---
 header: Installing Worktop
 ---
-$ npm install worktop worktop.build
+$ npm install worktop
+$ npm install worktop.build --save-dev
 ```
 
 Worktop solves common needs such as routing, path parameters, and  HTTP methods.

--- a/products/workers/src/content/tutorials/store-data-with-fauna/index.md
+++ b/products/workers/src/content/tutorials/store-data-with-fauna/index.md
@@ -128,11 +128,20 @@ Next, install the [Worktop][worktop] framework for Cloudflare Workers.
 ---
 header: Installing Worktop
 ---
-$ npm install worktop
+$ npm install worktop@0.7
 $ npm install worktop.build --save-dev
 ```
 
 Worktop solves common needs such as routing, path parameters, and  HTTP methods.
+
+Edit `package.json` and add the `build` script:
+
+```json
+"scripts": {
+  "build": "worktop build index.js",
+  ...
+},
+```
 
 Edit your `wrangler.toml` file found in your Worker's project directory. Set the type to `"javascript"` (not `"webpack"`) and add the `[build]` and `[build.upload]` sections as shown in the following snippet:
 

--- a/products/workers/src/content/tutorials/store-data-with-fauna/index.md
+++ b/products/workers/src/content/tutorials/store-data-with-fauna/index.md
@@ -128,7 +128,7 @@ Next, install the [Worktop][worktop] framework for Cloudflare Workers.
 ---
 header: Installing Worktop
 ---
-$ npm install worktop@0.7
+$ npm install worktop worktop.build
 ```
 
 Worktop solves common needs such as routing, path parameters, and  HTTP methods.


### PR DESCRIPTION
This submissions fixes a missing dependency when using the worktop build tools in the tutorial "Create a serverless, globally distributed REST API with Fauna."