### PR TITLE
Add Hummingbird to APO plugin compatibility list

### DIFF
--- a/products/automatic-platform-optimization/src/content/about/plugin-compatibility.md
+++ b/products/automatic-platform-optimization/src/content/about/plugin-compatibility.md
@@ -33,6 +33,7 @@ For questions about a specific plugin not shown in the list, create a thread in 
 - [Jetpack (Mobile Theme)](https://wordpress.org/plugins/jetpack/)
 - [wiziApp](https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app)
 - [WPML](https://wpml.org/)
+- [Hummingbird] (https://wordpress.org/plugins/hummingbird-performance/)
 
 ## Plugins and services that may cause issues
 


### PR DESCRIPTION
Add 'Hummingbird' to the list of APO compatible WordPress plugins