### PR TITLE
Use (IPs from) documentation prefixes where appropriate.

### DIFF
--- a/products/firewall/src/content/cf-dashboard/rules-lists/manage-items.md
+++ b/products/firewall/src/content/cf-dashboard/rules-lists/manage-items.md
@@ -1,4 +1,4 @@
----
+--
 pcx-content-type: how-to
 order: 360
 ---
@@ -35,10 +35,10 @@ You can combine individual addresses and CIDR ranges in the same list.
 
 To specify an IPv6 address, enter it as a CIDR range with a `/64` prefix, the largest supported prefix for IPv6 CIDR ranges.
 
-For example, instead of `2001:8a0:6a0b:1a01:d423:43b9:13c5:2e8f`, enter one of the following:
+For example, instead of `2001:db8:6a0b:1a01:d423:43b9:13c5:2e8f`, enter one of the following:
 
-* `2001:8a0:6a0b:1a01:0000:0000:0000:0000/64`
-* `2001:8a0:6a0b:1a01::/64` (using the [double colon notation](https://tools.ietf.org/html/rfc5952#section-4.2))
+* `2001:db8:6a0b:1a01:0000:0000:0000:0000/64`
+* `2001:db8:6a0b:1a01::/64` (using the [double colon notation](https://tools.ietf.org/html/rfc5952#section-4.2))
 
 </Aside>
 

--- a/products/firewall/src/content/known-issues-and-faq/index.md
+++ b/products/firewall/src/content/known-issues-and-faq/index.md
@@ -273,7 +273,7 @@ Exclude multiple IP addresses from a blocking/challenging rule that assesses Thr
       <td>
         <em
           >(http.host eq "example.com" and cf.threat_score &gt; 5) and not
-          (ip.src in {'{1.2.3.4 4.3.2.110.20.30.0/24}'})</em
+          (ip.src in {'{192.0.2.1 198.51.100.42 203.0.113.0/24}'})</em
         >
       </td>
     </tr>
@@ -286,7 +286,7 @@ Exclude multiple IP addresses from a blocking/challenging rule that assesses Thr
       <td>Rule 1</td>
       <td>
         Action: <em>allow</em><br />
-        Expression: <em>ip.src in {'{1.2.3.4 4.3.2.110.20.30.0/24}'}</em>
+        Expression: <em>ip.src in {'{192.0.2.1 198.51.100.42 203.0.113.0/24}'}</em>
       </td>
     </tr>
     <tr>

--- a/products/fundamentals/src/content/glossary/index.md
+++ b/products/fundamentals/src/content/glossary/index.md
@@ -128,7 +128,7 @@ DNS records are instructions that live in authoritative DNS servers and provide 
 **Relevant links:** [Learning Center guide on DNS records](https://www.cloudflare.com/learning/dns/dns-records/)
 
 ## DNS server
-Each device connected to the Internet has a unique IP address which other machines use to find the device. DNS servers eliminate the need for humans to memorize IP addresses such as 192.168.1.1 (in IPv4), or more complex newer alphanumeric IP addresses such as 2400:cb00:2048:1::c629:d7a2 (in IPv6).
+Each device connected to the Internet has a unique IP address which other machines use to find the device. DNS servers eliminate the need for humans to memorize IP addresses such as 192.168.1.1 (in IPv4), or more complex newer alphanumeric IP addresses such as 2001:db8::1:1:1:1 (in IPv6).
 
 **Related terms:** DNS
 

--- a/products/network-interconnect/src/content/set-up-cni/configure-bgp.md
+++ b/products/network-interconnect/src/content/set-up-cni/configure-bgp.md
@@ -13,10 +13,10 @@ After establishing your connection, the next steps include provisioning the Gene
 Cloudflare sends a set of IPs that you assign to your connection before Cloudflare establishes the BGP connection. The set of IPs will look similar to the example below.
 
 ```
-Cloudflare v4: 123.234.234.10/31
-Acme v4: 123.234.234.11/31
-Cloudflare v6: 1234:ab00:12:3::7ac2:d64a/127
-Acme: 1234:ab00:12:3::7ac2:d64b/127
+Cloudflare v4: 192.0.2.10/31
+Acme v4: 192.0.2.11/31
+Cloudflare v6: 2001:db8:12:3::7ac2:d64a/127
+Acme: 2001:db8:12:3::7ac2:d64b/127
 ```
 
 Assign the set of IPs to your connection. Next, perform a series of ping tests to ensure the connection is established. Although you may see the green connection from [configuring the cross-connect](/set-up-cni/configure-cross-connect), the ping tests confirm packets are flowing over the link.


### PR DESCRIPTION
As defined in RFC3849 as well as RFC5737 there are some prefixes designated
for documentation which will never be used on the Internet and therefore will
never clash with existing infrastructure. We are already using them in some
examples and screenshots, let's use them throughout the documentation :)