### PR TITLE
Add logs for quick editor users to cache API example

### DIFF
--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -31,7 +31,7 @@ async function handleRequest(event) {
   let response = await cache.match(cacheKey)
 
   if (!response) {
-    console.log(`Response for request url: ${request.url} not present in chace. We fetch and cache it.`); 
+    console.log(`Response for request url: ${request.url} not present in cache. Fetching and caching request.`); 
     // If not in cache, get it from origin
     response = await fetch(request)
 

--- a/products/workers/src/content/examples/cache-api.md
+++ b/products/workers/src/content/examples/cache-api.md
@@ -31,6 +31,7 @@ async function handleRequest(event) {
   let response = await cache.match(cacheKey)
 
   if (!response) {
+    console.log(`Response for request url: ${request.url} not present in chace. We fetch and cache it.`); 
     // If not in cache, get it from origin
     response = await fetch(request)
 
@@ -47,6 +48,8 @@ async function handleRequest(event) {
     // Use waitUntil so you can return the response without blocking on
     // writing to cache
     event.waitUntil(cache.put(cacheKey, response.clone()))
+  } else {
+    console.log(`Cache hit for: ${request.url}.`); 
   }
   return response
 }


### PR DESCRIPTION
Added a console.log statement to to inform about ache hits in the console. This is useful for quick editor users.