### PR TITLE
Grammatical improvements to known-issues.md

### DIFF
--- a/products/pages/src/content/platform/known-issues.md
+++ b/products/pages/src/content/platform/known-issues.md
@@ -6,7 +6,7 @@ pcx-content-type: concept
 # Known issues
 
 Here are some known bugs and issues with Cloudflare Pages:
-- Source code hosting tools besides GitHub or GitLab—for instance, BitBucket—are not currently supported.
+- GitHub and GitLab are currently the only supported Source code hosting tools.
 - Pages currently only supports a single project per repository. Monorepos or repositories with multiple codebases/applications currently cannot deploy more than one project to Pages at a time.
 - Once you have selected a GitHub repository for your Pages application, it cannot be changed. Remove/delete your Pages project and create a new one pointing at a different repository if you need to update it.
 - `*.pages.dev` subdomains currently cannot be changed. If you need to change your `*.pages.dev` subdomain, delete your project and create a new one.


### PR DESCRIPTION
Saying "GitHub and GitLab are currently the only supported Source code hosting tools." is WAYYYY more straight forward than "Source code hosting tools besides GitHub or GitLab—for instance, BitBucket—are not currently supported." and also has 28 less characters so you don't fall asleep trying to read this