### PR TITLE
Clean up reference of Firewall Rules APIs

### DIFF
--- a/products/firewall/src/content/api/call-sequence.md
+++ b/products/firewall/src/content/api/call-sequence.md
@@ -20,19 +20,20 @@ However, for a `POST` operation, the **simplified sequence** — shown below —
 
 ![Simple flow](../images/simple-flow.png)
 
-In this sequence, a single `POST` request to the `/firewall/rules` takes the filter object in the JSON to create the filter in the Filters API (also via a `POST` request). If successful, then the Firewall Rule is created.
+In this sequence, a single `POST` request to the `/firewall/rules` endpoint takes the filter object in the JSON to create the filter in the Filters API (also via a `POST` request). If successful, the Firewall Rule is created.
 
 Below is an example call and response using this method:
 
-### Request
-
 ```json
+---
+header: Request
+---
 curl -X POST \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '[
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '[
   {
     "filter": {
       "expression": "http.request.uri.path contains \"/api/\" and ip.src eq 93.184.216.34"
@@ -42,9 +43,10 @@ curl -X POST \
 ]' 
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {
@@ -60,8 +62,8 @@ curl -X POST \
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 

--- a/products/firewall/src/content/api/call-sequence.md
+++ b/products/firewall/src/content/api/call-sequence.md
@@ -74,6 +74,6 @@ By default, if either the filter or rule is invalid, neither will be created.
 
 However, one exception applies. If you have exceeded your rule quota, the filter could be created while creating the rule may fail. This is because the rule is created after the filter in the sequence diagram and so, we learn of the quota being exceeded after the filter was created.
 
-After you resolve the issue of exceeding your quota or requesting a feature that is unavailable to your zone (namely the _JS Challenge_ action, which is not available for Free customers), return to the recommended flow to create a rule that references the filter.
+After you resolve the issue of exceeding your quota or requesting a feature that is unavailable to your zone, return to the recommended flow to create a rule that references the filter.
 
 In summary, we strongly recommend the sequence with the two API calls. Limit your rule and filter creation using the simplified sequence for emergency situations, and only via `curl` requests.

--- a/products/firewall/src/content/api/call-sequence.md
+++ b/products/firewall/src/content/api/call-sequence.md
@@ -26,14 +26,20 @@ Below is an example call and response using this method:
 
 ### Request
 
-```bash
+```json
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '[
-{"filter":{"expression":"http.request.uri.path contains \"/api/\" and ip.src eq 93.184.216.34"}, "action": "block"}
-]' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '[
+  {
+    "filter": {
+      "expression": "http.request.uri.path contains \"/api/\" and ip.src eq 93.184.216.34"
+    },
+    "action": "block"
+  }
+]' 
 ```
 
 ### Response
@@ -42,12 +48,12 @@ curl -X POST \
 {
   "result": [
     {
-      "id": "5fe867f3bc854c3ba0a29085d9aa1b34",
+      "id": "<RULE_ID>",
       "paused": false,
       "action": "block",
       "priority": null,
       "filter": {
-        "id": "e756e92ad16749a4947aa8d2f63ee120",
+        "id": "<FILTER_ID>",
         "expression": "http.request.uri.path contains \"/api/\" and ip.src eq 93.184.216.34",
         "paused": false
       }

--- a/products/firewall/src/content/api/cf-filters/delete.md
+++ b/products/firewall/src/content/api/cf-filters/delete.md
@@ -6,9 +6,6 @@ order: 475
 
 # DELETE examples
 
-- [Delete multiple filters](#delete-multiple-filters)
-- [Delete a single filter](#delete-a-single-filter)
-
 ## Delete multiple filters
 
 This example deletes filters with IDs `<FILTER_ID_1>` and `<FILTER_ID_2>`.

--- a/products/firewall/src/content/api/cf-filters/delete.md
+++ b/products/firewall/src/content/api/cf-filters/delete.md
@@ -11,22 +11,20 @@ order: 475
 
 ## Delete multiple filters
 
-```txt
-DELETE zones/<ZONE_ID>/filters
-```
-
-### Request
-
 ```bash
+---
+header: Request
+---
 curl -X DELETE \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters?id=<FILTER_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>" 
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [],
   "success": true,
@@ -37,22 +35,22 @@ curl -X DELETE \
 
 ## Delete a single filter
 
-```txt
-DELETE zones/<ZONE_ID>/filters/<FILTER_ID>
-```
-
-### Request
+This example deletes a single filter with ID `<FILTER_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X DELETE \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>"
   -H "X-Auth-Email: <EMAIL>" 
   -H "X-Auth-Key: <API_KEY>" 
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": null,
   "success": true,

--- a/products/firewall/src/content/api/cf-filters/delete.md
+++ b/products/firewall/src/content/api/cf-filters/delete.md
@@ -11,14 +11,17 @@ order: 475
 
 ## Delete multiple filters
 
-```bash
-DELETE zones/{zone_id}/filters
+```txt
+DELETE zones/<ZONE_ID>/filters
 ```
 
 ### Request
 
 ```bash
-curl -X DELETE -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters?id=60ee852f9cbb4802978d15600c7f3110"
+curl -X DELETE \
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters?id=<FILTER_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" 
 ```
 
 ### Response
@@ -34,14 +37,17 @@ curl -X DELETE -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" 
 
 ## Delete a single filter
 
-```bash
-DELETE zones/{zone_id}/filters/{id}
+```txt
+DELETE zones/<ZONE_ID>/filters/<FILTER_ID>
 ```
 
 ### Request
 
 ```bash
-curl -X DELETE -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110"
+curl -X DELETE \
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>"
+  -H "X-Auth-Email: <EMAIL>" 
+  -H "X-Auth-Key: <API_KEY>" 
 ```
 
 ### Response

--- a/products/firewall/src/content/api/cf-filters/delete.md
+++ b/products/firewall/src/content/api/cf-filters/delete.md
@@ -11,14 +11,16 @@ order: 475
 
 ## Delete multiple filters
 
+This example deletes filters with IDs `<FILTER_ID_1>` and `<FILTER_ID_2>`.
+
 ```bash
 ---
 header: Request
 ---
 curl -X DELETE \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters?id=<FILTER_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" 
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters?id=<FILTER_ID_1>&id=<FILTER_ID_2>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -26,10 +28,17 @@ curl -X DELETE \
 header: Response
 ---
 {
-  "result": [],
+  "result": [
+    {
+      "id": "<FILTER_ID_1>"
+    },
+    {
+      "id": "<FILTER_ID_2>"
+    }
+  ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 
@@ -42,9 +51,9 @@ This example deletes a single filter with ID `<FILTER_ID>`.
 header: Request
 ---
 curl -X DELETE \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>"
-  -H "X-Auth-Email: <EMAIL>" 
-  -H "X-Auth-Key: <API_KEY>" 
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>"
+-H "X-Auth-Email: <EMAIL>"
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -52,9 +61,13 @@ curl -X DELETE \
 header: Response
 ---
 {
-  "result": null,
+  "result": [
+    {
+      "id": "<FILTER_ID>"
+    }
+  ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-filters/endpoints.md
+++ b/products/firewall/src/content/api/cf-filters/endpoints.md
@@ -1,6 +1,6 @@
 ---
 pcx-content-type: reference
-type: table
+type: overview
 order: 455
 ---
 
@@ -30,13 +30,12 @@ The Cloudflare Filters API supports the operations outlined below. Visit the ass
 
 </ContentColumn>
 
-<TableWrap style='width:100%'>
 <table style='table-layout:fixed; width:100%'>
   <thead>
     <tr>
-        <th>Operation</th>
+        <th style="width: 20%">Operation</th>
         <th>Method & Endpoint</th>
-        <th>Notes</th>
+        <th style='width: 30%'>Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -46,36 +45,35 @@ The Cloudflare Filters API supports the operations outlined below. Visit the ass
           <td>Handled as a single transaction. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/get/#get-all-filters'>Fetch all filters</a></td>
+          <td><a href='/api/cf-filters/get/#get-all-filters'>Get filters</a></td>
           <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Lists all current filters. Results return paginated with 25 items per page by default. Use optional parameters to narrow results.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/get/#get-by-filter-id'>Fetch a filter by ID</a></td>
+          <td><a href='/api/cf-filters/get/#get-by-filter-id'>Get a filter</a></td>
           <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Retrieve a single filter by ID.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/put/#update-multiple-filters'>Update multiple filters</a></td>
+          <td><a href='/api/cf-filters/put/#update-multiple-filters'>Update filters</a></td>
           <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Handled as a single transaction. All filters must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/put/#update-a-single-filter'>Update a single filter by ID</a></td>
+          <td><a href='/api/cf-filters/put/#update-a-single-filter'>Update a filter</a></td>
           <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Update a single filter by ID.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/delete/#delete-multiple-filters'>Delete multiple filters</a></td>
+          <td><a href='/api/cf-filters/delete/#delete-multiple-filters'>Delete filters</a></td>
           <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters</code></td>
           <td><p>Delete existing filters. Must specify list of filter IDs.</p>
           <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified filter does not exist.</p></td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/delete/#delete-a-single-filter'>Delete a single filter by ID</a></td>
+          <td><a href='/api/cf-filters/delete/#delete-a-single-filter'>Delete a filter</a></td>
           <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Delete a filter by ID.</td>
       </tr>
   </tbody>
 </table>
-</TableWrap>

--- a/products/firewall/src/content/api/cf-filters/endpoints.md
+++ b/products/firewall/src/content/api/cf-filters/endpoints.md
@@ -26,7 +26,7 @@ To retrieve a list of zones associated with your account, use the [List Zones](h
 
 </Aside>
 
-The Cloudflare Filters API supports the operations outlined below. Visit the associated links for examples.
+The Cloudflare Filters API supports the operations outlined below. Visit the pages in this section for examples.
 
 </ContentColumn>
 
@@ -40,38 +40,38 @@ The Cloudflare Filters API supports the operations outlined below. Visit the ass
   </thead>
   <tbody>
       <tr>
-          <td><a href='/api/cf-filters/post/'>Create filters</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-create-filters'>Create filters</a></td>
           <td><code class="InlineCode">POST zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Handled as a single transaction. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/get/#get-all-filters'>Get filters</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-list-filters'>Get filters</a></td>
           <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Lists all current filters. Results return paginated with 25 items per page by default. Use optional parameters to narrow results.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/get/#get-by-filter-id'>Get a filter</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-list-individual-filter'>Get a filter</a></td>
           <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Retrieve a single filter by ID.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/put/#update-multiple-filters'>Update filters</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-update-filters'>Update filters</a></td>
           <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Handled as a single transaction. All filters must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/put/#update-a-single-filter'>Update a filter</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-update-individual-filter'>Update a filter</a></td>
           <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Update a single filter by ID.</td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/delete/#delete-multiple-filters'>Delete filters</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-delete-filters'>Delete filters</a></td>
           <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters</code></td>
           <td><p>Delete existing filters. Must specify list of filter IDs.</p>
           <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified filter does not exist.</p></td>
       </tr>
       <tr>
-          <td><a href='/api/cf-filters/delete/#delete-a-single-filter'>Delete a filter</a></td>
+          <td><a href='https://api.cloudflare.com/#filters-delete-individual-filter'>Delete a filter</a></td>
           <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Delete a filter by ID.</td>
       </tr>

--- a/products/firewall/src/content/api/cf-filters/endpoints.md
+++ b/products/firewall/src/content/api/cf-filters/endpoints.md
@@ -10,8 +10,7 @@ order: 455
 
 To invoke a Cloudflare Filters API operation, append the endpoint to the Cloudflare API base URL:
 
-```html
-
+```txt
 https://api.cloudflare.com/client/v4/
 ```
 
@@ -21,7 +20,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](ht
 
 <Aside type='warning' header='Important'>
 
-The Filters API endpoints require a value for _{zone_id}_.
+The Filters API endpoints require a value for `<ZONE_ID>`.
 
 To retrieve a list of zones associated with your account, use the [List Zones](https://api.cloudflare.com/#zone-list-zones) operation and note the Zone ID associated with the domain for which you want to manage filters.
 
@@ -43,38 +42,38 @@ The Cloudflare Filters API supports the operations outlined below. Visit the ass
   <tbody>
       <tr>
           <td><a href='/api/cf-filters/post/'>Create filters</a></td>
-          <td><code class="InlineCode">POST zones/{'{zone_id}'}/filters</code></td>
+          <td><code class="InlineCode">POST zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Handled as a single transaction. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/get/#get-all-filters'>Fetch all filters</a></td>
-          <td><code class="InlineCode">GET zones/{'{zone_id}'}/filters</code></td>
+          <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Lists all current filters. Results return paginated with 25 items per page by default. Use optional parameters to narrow results.</td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/get/#get-by-filter-id'>Fetch a filter by ID</a></td>
-          <td><code class="InlineCode">GET zones/{'{zone_id}'}/filters/{'{id}'}</code></td>
+          <td><code class="InlineCode">GET zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Retrieve a single filter by ID.</td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/put/#update-multiple-filters'>Update multiple filters</a></td>
-          <td><code class="InlineCode">PUT zones/{'{zone_id}'}/filters</code></td>
+          <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters</code></td>
           <td>Handled as a single transaction. All filters must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/put/#update-a-single-filter'>Update a single filter by ID</a></td>
-          <td><code class="InlineCode">PUT zones/{'{zone_id}'}/filters/{'{id}'}</code></td>
+          <td><code class="InlineCode">PUT zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Update a single filter by ID.</td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/delete/#delete-multiple-filters'>Delete multiple filters</a></td>
-          <td><code class="InlineCode">DELETE zones/{'{zone_id}'}/filters</code></td>
+          <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters</code></td>
           <td><p>Delete existing filters. Must specify list of filter IDs.</p>
           <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified filter does not exist.</p></td>
       </tr>
       <tr>
           <td><a href='/api/cf-filters/delete/#delete-a-single-filter'>Delete a single filter by ID</a></td>
-          <td><code class="InlineCode">DELETE zones/{'{zone_id}'}/filters/{'{id}'}</code></td>
+          <td><code class="InlineCode">DELETE zones/{'<ZONE_ID>'}/filters/{'<FILTER_ID>'}</code></td>
           <td>Delete a filter by ID.</td>
       </tr>
   </tbody>

--- a/products/firewall/src/content/api/cf-filters/get.md
+++ b/products/firewall/src/content/api/cf-filters/get.md
@@ -18,9 +18,9 @@ This example returns all filters in zone with ID `<ZONE_ID>`.
 header: Request
 ---
 curl -X GET \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -42,26 +42,26 @@ header: Response
       "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
     },
     {
-      "id": "<FILTER_ID_2>",
+      "id": "<FILTER_ID_3>",
       "paused": false,
       "description": "not /api",
       "expression": "not http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "<FILTER_ID_3>",
+      "id": "<FILTER_ID_4>",
       "paused": false,
       "description": "/api",
       "expression": "http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "<FILTER_ID_3>",
+      "id": "<FILTER_ID_5>",
       "paused": false,
       "expression": "ip.src eq 93.184.216.0"
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null,
+  "errors": [],
+  "messages": [],
   "result_info": {
     "page": 1,
     "per_page": 25,
@@ -81,9 +81,9 @@ This example returns the filter with ID `<FILTER_ID>`.
 header: Request
 ---
 curl -X GET \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -98,7 +98,7 @@ header: Response
     "expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
   },
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-filters/get.md
+++ b/products/firewall/src/content/api/cf-filters/get.md
@@ -11,22 +11,22 @@ order: 465
 
 ## Get all filters
 
-```txt
-GET zones/<ZONE_ID>/filters
-```
-
-### Request
+This example returns all filters in zone with ID `<ZONE_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X GET \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {
@@ -74,22 +74,22 @@ curl -X GET \
 
 ## Get by filter ID
 
-```txt
-GET zones/<ZONE_ID>/filters/<FILTER_ID>
-```
-
-### Request
+This example returns the filter with ID `<FILTER_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X GET \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": {
     "id": "<FILTER_ID>",

--- a/products/firewall/src/content/api/cf-filters/get.md
+++ b/products/firewall/src/content/api/cf-filters/get.md
@@ -11,17 +11,17 @@ order: 465
 
 ## Get all filters
 
-```bash
-GET zones/{zone_id}/filters
+```txt
+GET zones/<ZONE_ID>/filters
 ```
 
 ### Request
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 ### Response
@@ -30,31 +30,31 @@ curl -X GET \
 {
   "result": [
     {
-      "id": "b7ff25282d394be7b945e23c7106ce8a",
+      "id": "<FILTER_ID_1>",
       "paused": false,
       "description": "Login from office",
       "expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
     },
     {
-      "id": "c218c536b2bd406f958f278cf0fa8c0f",
+      "id": "<FILTER_ID_2>",
       "paused": false,
       "description": "Login",
       "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
     },
     {
-      "id": "f2a64520581a4209aab12187a0081364",
+      "id": "<FILTER_ID_2>",
       "paused": false,
       "description": "not /api",
       "expression": "not http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+      "id": "<FILTER_ID_3>",
       "paused": false,
       "description": "/api",
       "expression": "http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "60ee852f9cbb4802978d15600c7f3110",
+      "id": "<FILTER_ID_3>",
       "paused": false,
       "expression": "ip.src eq 93.184.216.0"
     }
@@ -74,17 +74,17 @@ curl -X GET \
 
 ## Get by filter ID
 
-```bash
-GET zones/{zone_id}/filters/{id}
+```txt
+GET zones/<ZONE_ID>/filters/<FILTER_ID>
 ```
 
 ### Request
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/b7ff25282d394be7b945e23c7106ce8a"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 ### Response
@@ -92,7 +92,7 @@ curl -X GET \
 ```json
 {
   "result": {
-    "id": "b7ff25282d394be7b945e23c7106ce8a",
+    "id": "<FILTER_ID>",
     "paused": false,
     "description": "Login from office",
     "expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"

--- a/products/firewall/src/content/api/cf-filters/get.md
+++ b/products/firewall/src/content/api/cf-filters/get.md
@@ -6,9 +6,6 @@ order: 465
 
 # GET examples
 
-- [Get all filters](#get-all-filters)
-- [Get rule by ID](#get-by-filter-id)
-
 ## Get all filters
 
 This example returns all filters in zone with ID `<ZONE_ID>`.

--- a/products/firewall/src/content/api/cf-filters/json-object.md
+++ b/products/firewall/src/content/api/cf-filters/json-object.md
@@ -11,15 +11,15 @@ A JSON response for the [Filters API](https://api.cloudflare.com/#filters-proper
 
 ```json
 {
-    "id": "6f58318e7fa2477a23112e8118c66f61",
-    "expression": "http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\""
-    "paused": true,
-    "description": "WordPress login paths",
-    "ref": ""
+  "id": "6f58318e7fa2477a23112e8118c66f61",
+  "expression": "http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
+  "paused": true,
+  "description": "WordPress login paths",
+  "ref": ""
 }
 ```
 
-This table summarizes the object properties:
+The following table summarizes the object properties:
 
 <TableWrap>
   <table style="table-layout:fixed; width: 100%;">

--- a/products/firewall/src/content/api/cf-filters/post.md
+++ b/products/firewall/src/content/api/cf-filters/post.md
@@ -13,11 +13,11 @@ This example creates several filters using a single API call.
 header: Request
 ---
 curl -X POST \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '[
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '[
   { 
     "expression": "ip.src eq 93.184.216.0"
   },
@@ -77,7 +77,7 @@ header: Response
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-filters/post.md
+++ b/products/firewall/src/content/api/cf-filters/post.md
@@ -6,15 +6,12 @@ order: 460
 
 # POST example
 
-```txt
-POST zones/<ZONE_ID>/filters
-```
-
-Creates one or more filters.
-
-## Request
+This example creates several filters using a single API call.
 
 ```json
+---
+header: Request
+---
 curl -X POST \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -43,9 +40,10 @@ curl -X POST \
 ]'
 ```
 
-## Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {

--- a/products/firewall/src/content/api/cf-filters/post.md
+++ b/products/firewall/src/content/api/cf-filters/post.md
@@ -6,26 +6,41 @@ order: 460
 
 # POST example
 
-```bash
-POST zones/{zone_id}/filters
+```txt
+POST zones/<ZONE_ID>/filters
 ```
 
 Creates one or more filters.
 
 ## Request
 
-```bash
+```json
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '[
-{"expression": "ip.src eq 93.184.216.0"},
-{"expression": "http.request.uri.path matches \"^/api/.*$\"", "description":"/api"},
-{"expression": "not http.request.uri.path matches \"^/api/.*$\"", "description":"not /api"},
-{"expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")", "description":"Login"},
-{"expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")", "description":"Login from office"}
-]' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '[
+  { 
+    "expression": "ip.src eq 93.184.216.0"
+  },
+  {
+    "expression": "http.request.uri.path matches \"^/api/.*$\"", 
+    "description": "/api"
+  },
+  {
+    "expression": "not http.request.uri.path matches \"^/api/.*$\"", 
+    "description": "not /api"
+  },
+  {
+    "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")", 
+    "description": "Login"
+  },
+  {
+    "expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")", 
+    "description": "Login from office"
+  }
+]'
 ```
 
 ## Response
@@ -34,30 +49,30 @@ curl -X POST \
 {
   "result": [
     {
-      "id": "60ee852f9cbb4802978d15600c7f3110",
+      "id": "<FILTER_ID_1>",
       "paused": false,
       "expression": "ip.src eq 93.184.216.0"
     },
     {
-      "id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+      "id": "<FILTER_ID_2>",
       "paused": false,
       "description": "/api",
       "expression": "http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "f2a64520581a4209aab12187a0081364",
+      "id": "<FILTER_ID_3>",
       "paused": false,
       "description": "not /api",
       "expression": "not http.request.uri.path matches \"^/api/.*$\""
     },
     {
-      "id": "c218c536b2bd406f958f278cf0fa8c0f",
+      "id": "<FILTER_ID_4>",
       "paused": false,
       "description": "Login",
       "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
     },
     {
-      "id": "b7ff25282d394be7b945e23c7106ce8a",
+      "id": "<FILTER_ID_5>",
       "paused": false,
       "description": "Login from office",
       "expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"

--- a/products/firewall/src/content/api/cf-filters/put.md
+++ b/products/firewall/src/content/api/cf-filters/put.md
@@ -6,9 +6,6 @@ order: 470
 
 # PUT examples
 
-- [Update multiple filters](#update-multiple-filters)
-- [Update a single filter](#update-a-single-filter)
-
 ## Update multiple filters
 
 This example updates two filters with IDs `<FILTER_ID_1>` and `<FILTER_ID_2>` using a single API call.

--- a/products/firewall/src/content/api/cf-filters/put.md
+++ b/products/firewall/src/content/api/cf-filters/put.md
@@ -11,25 +11,26 @@ order: 470
 
 ## Update multiple filters
 
-```bash
-PUT zones/{zone_id}/filters
+```txt
+PUT zones/<ZONE_ID>/filters
 ```
 
 ### Request
 
-```bash
+```json
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '[
-{
-   "id": "60ee852f9cbb4802978d15600c7f3110",
-   "paused": false,
-   "expression": "ip.src eq 93.184.216.0",
-   "description": "IP of example.org"
-}
-]' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '[
+  {
+    "id": "<FILTER_ID>",
+    "paused": false,
+    "expression": "ip.src eq 93.184.216.0",
+    "description": "IP of example.org"
+  }
+]'
 ```
 
 ### Response
@@ -38,7 +39,7 @@ curl -X PUT \
 {
   "result": [
     {
-      "id": "60ee852f9cbb4802978d15600c7f3110",
+      "id": "<FILTER_ID>",
       "paused": false,
       "description": "IP of example.org",
       "expression": "ip.src eq 93.184.216.0"
@@ -52,23 +53,24 @@ curl -X PUT \
 
 ## Update a single filter
 
-```bash
-PUT zones/{zone_id}/filters/{id}
+```txt
+PUT zones/<ZONE_ID>/filters/<FILTER_ID>
 ```
 
 ### Request
 
-```bash
+```json
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '{
-    "id": "b7ff25282d394be7b945e23c7106ce8a",
-    "paused": false,
-    "description": "Login from office",
-    "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
-}' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/filters/b7ff25282d394be7b945e23c7106ce8a"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "id": "<FILTER_ID>",
+  "paused": false,
+  "description": "Login from office",
+  "expression": "ip.src in {2400:cb00::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+}' 
 ```
 
 ### Response
@@ -76,10 +78,10 @@ curl -X PUT \
 ```json
 {
   "result": {
-    "id": "b7ff25282d394be7b945e23c7106ce8a",
+    "id": "<FILTER_ID>",
     "paused": false,
     "description": "Login from office",
-    "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+    "expression": "ip.src in {2400:cb00::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
   },
   "success": true,
   "errors": null,

--- a/products/firewall/src/content/api/cf-filters/put.md
+++ b/products/firewall/src/content/api/cf-filters/put.md
@@ -18,11 +18,11 @@ This example updates two filters with IDs `<FILTER_ID_1>` and `<FILTER_ID_2>` us
 header: Request
 ---
 curl -X PUT \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '[
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '[
   {
     "id": "<FILTER_ID_1>",
     "paused": false,
@@ -57,8 +57,8 @@ header: Response
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 
@@ -71,11 +71,11 @@ This example updates the filter with ID `<FILTER_ID>`.
 header: Request
 ---
 curl -X PUT \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '{
   "id": "<FILTER_ID>",
   "paused": false,
   "description": "Login from office",
@@ -95,7 +95,7 @@ header: Response
     "expression": "ip.src in {2400:cb00::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
   },
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-filters/put.md
+++ b/products/firewall/src/content/api/cf-filters/put.md
@@ -11,13 +11,12 @@ order: 470
 
 ## Update multiple filters
 
-```txt
-PUT zones/<ZONE_ID>/filters
-```
-
-### Request
+This example updates two filters with IDs `<FILTER_ID_1>` and `<FILTER_ID_2>` using a single API call.
 
 ```json
+---
+header: Request
+---
 curl -X PUT \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -25,17 +24,23 @@ curl -X PUT \
   -H "Content-Type: application/json" \
   -d '[
   {
-    "id": "<FILTER_ID>",
+    "id": "<FILTER_ID_1>",
     "paused": false,
     "expression": "ip.src eq 93.184.216.0",
     "description": "IP of example.org"
+  },
+  {
+    "id": "<FILTER_ID_2>",
+    "expression": "http.request.uri.path matches \"^/api/.*$\"", 
+    "description": "/api"
   }
 ]'
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {
@@ -43,6 +48,12 @@ curl -X PUT \
       "paused": false,
       "description": "IP of example.org",
       "expression": "ip.src eq 93.184.216.0"
+    },
+    {
+      "id": "<FILTER_ID_2>",
+      "paused": false,
+      "description": "/api",
+      "expression": "http.request.uri.path matches \"^/api/.*$\""
     }
   ],
   "success": true,
@@ -53,13 +64,12 @@ curl -X PUT \
 
 ## Update a single filter
 
-```txt
-PUT zones/<ZONE_ID>/filters/<FILTER_ID>
-```
-
-### Request
+This example updates the filter with ID `<FILTER_ID>`.
 
 ```json
+---
+header: Request
+---
 curl -X PUT \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/filters/<FILTER_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -73,9 +83,10 @@ curl -X PUT \
 }' 
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": {
     "id": "<FILTER_ID>",

--- a/products/firewall/src/content/api/cf-filters/validation.md
+++ b/products/firewall/src/content/api/cf-filters/validation.md
@@ -45,7 +45,10 @@ The Cloudflare Filters API supports an endpoint for validating expressions.
 #### Request
 
 ```bash
-curl -X GET -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" 'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34'
+curl -X GET \
+  'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34' \
+  -H "X-Auth-Email: <EMAIL>"
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 #### Response
@@ -65,7 +68,7 @@ curl -X GET -H "X-Auth-Email: user@cloudflare.com" -H "X-Auth-Key: REDACTED" 'ht
 
 Note the validation error in the response. In this example, the error is due to an invalid IP address format:
 
-```bash
+```txt
 Filter parsing error:
 `ip.src==34`
           ^^ couldn't parse address in network: invalid IP address syntax
@@ -75,14 +78,15 @@ Filter parsing error:
 
 #### Request
 
-```bash
+```json
 curl -X POST \
-    -H "X-Auth-Email: user@cloudflare.com" \
-    -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '{
-    "expression": "ip.src in {2400:cb00::/32 2405:8100::/2000 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29}"
-}' "https://api.cloudflare.com/client/v4/filters/validate-expr"
+  "https://api.cloudflare.com/client/v4/filters/validate-expr" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "expression": "ip.src in {2400:cb00::/32 2405:8100::/2000 2c0f:f248::/32 2a06:98c0::/29}"
+}' 
 ```
 
 #### Response
@@ -93,7 +97,7 @@ curl -X POST \
   "success": false,
   "errors": [
     {
-      "message": "Filter parsing error:\n`ip.src in {2400:cb00::/32 2405:8100::/2000 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29}`\n                                        ^^^^ number too large to fit in target type while parsing with radix 10\n"
+      "message": "Filter parsing error:\n`ip.src in {2400:cb00::/32 2405:8100::/2000 2c0f:f248::/32 2a06:98c0::/29}`\n                                        ^^^^ number too large to fit in target type while parsing with radix 10\n"
     }
   ],
   "messages": null
@@ -102,8 +106,8 @@ curl -X POST \
 
 Note the validation error in the response. In this example, the value for the subnet mask, `/2000`, is not a valid IPv6 CIDR mask:
 
-```bash
+```txt
 Filter parsing error:
-`ip.src in {2400:cb00::/32 2405:8100::/2000 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29}`
+`ip.src in {2400:cb00::/32 2405:8100::/2000 2c0f:f248::/32 2a06:98c0::/29}`
                                         ^^^^ number too large to fit in target type while parsing with radix 10
 ```

--- a/products/firewall/src/content/api/cf-filters/validation.md
+++ b/products/firewall/src/content/api/cf-filters/validation.md
@@ -47,9 +47,9 @@ The Cloudflare Filters API supports an endpoint for validating expressions.
 header: Request
 ---
 curl -X GET \
-  'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34' \
-  -H "X-Auth-Email: <EMAIL>"
-  -H "X-Auth-Key: <API_KEY>"
+'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34' \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -83,11 +83,11 @@ Filter parsing error:
 header: Request
 ---
 curl -X POST \
-  "https://api.cloudflare.com/client/v4/filters/validate-expr" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
+"https://api.cloudflare.com/client/v4/filters/validate-expr" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '{
   "expression": "ip.src in {2400:cb00::/32 2405:8100::/2000 2c0f:f248::/32 2a06:98c0::/29}"
 }' 
 ```

--- a/products/firewall/src/content/api/cf-filters/validation.md
+++ b/products/firewall/src/content/api/cf-filters/validation.md
@@ -42,18 +42,20 @@ The Cloudflare Filters API supports an endpoint for validating expressions.
 
 ### Validate expression via query string
 
-#### Request
-
 ```bash
+---
+header: Request
+---
 curl -X GET \
   'https://api.cloudflare.com/client/v4/filters/validate-expr?expression=ip.src==34' \
   -H "X-Auth-Email: <EMAIL>"
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-#### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": null,
   "success": false,
@@ -76,9 +78,10 @@ Filter parsing error:
 
 ### Validate expression via JSON object
 
-#### Request
-
 ```json
+---
+header: Request
+---
 curl -X POST \
   "https://api.cloudflare.com/client/v4/filters/validate-expr" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -89,9 +92,10 @@ curl -X POST \
 }' 
 ```
 
-#### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": null,
   "success": false,

--- a/products/firewall/src/content/api/cf-filters/what-is-a-filter.md
+++ b/products/firewall/src/content/api/cf-filters/what-is-a-filter.md
@@ -8,17 +8,19 @@ order: 445
 
 A filter is a way of saying:
 
-`if (traffic matches certain criteria) then...`
+```txt
+if (traffic matches certain criteria) then...
+```
 
-A filter contains an expression that would return _true_ or _false_ when evaluated against traffic passing through Cloudflare.
+A filter contains an expression that would return `true` or `false` when evaluated against traffic passing through Cloudflare.
 
 Filter expressions are human and machine readable, and you can compose complex logic to precisely match the traffic that you are interested in detecting and acting upon.
 
-A filter typically looks like:
+A filter typically looks like the following:
 
 ```json
 {
-  "id": "6f58318e7fa2477a23112e8118c66f61",
+  "id": "<FILTER_ID>",
   "expression": "(http.request.uri.path ~ \"^.*wp-login.php$\" or http.request.uri.path ~ \"^.*xmlrpc.php$\") and ip.src ne 93.184.216.34",
   "description": "WordPress login paths via the login page or mobile RPC endpoint"
 }
@@ -26,7 +28,7 @@ A filter typically looks like:
 
 The expression specified in this example filter is:
 
-```bash
+```txt
 (http.request.uri.path ~ "^.*wp-login.php$" or http.request.uri.path ~ "^.*xmlrpc.php$") and ip.src ne 93.184.216.34
 ```
 

--- a/products/firewall/src/content/api/cf-firewall-rules/delete.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/delete.md
@@ -9,30 +9,32 @@ order: 435
 - [Delete multiple rules](#delete-multiple-rules)
 - [Delete a single rule](#delete-a-single-rule)
 
+<Aside type='note' header='Note'>
+
+`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, use the [Filters API](/api/cf-filters/delete).
+
+</Aside>
+
 ## Delete multiple rules
 
 ```txt
 DELETE zones/<ZONE_ID>/firewall/rules
 ```
 
-### Request
-
 ```bash
+---
+header: Request
+---
 curl -X DELETE \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules?id=<RULE_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-<Aside type='note' header='Note'>
-
-`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, you must call the `/filters` API.
-
-</Aside>
-
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [],
   "success": true,
@@ -43,22 +45,22 @@ curl -X DELETE \
 
 ## Delete a single rule
 
-```txt
-DELETE zones/<ZONE_ID>/firewall/rules/<RULE_ID>
-```
-
-### Request
+This example deletes the rule with ID `<RULE_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X DELETE \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": null,
   "success": true,

--- a/products/firewall/src/content/api/cf-firewall-rules/delete.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/delete.md
@@ -6,12 +6,9 @@ order: 435
 
 # DELETE examples
 
-- [Delete multiple rules](#delete-multiple-rules)
-- [Delete a single rule](#delete-a-single-rule)
-
 <Aside type='note' header='Note'>
 
-`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, use the [Filters API](/api/cf-filters).
+The `DELETE` operation does not delete any filter related to the Firewall Rule. To delete the filter, use the [Filters API](/api/cf-filters).
 
 </Aside>
 

--- a/products/firewall/src/content/api/cf-firewall-rules/delete.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/delete.md
@@ -11,24 +11,22 @@ order: 435
 
 <Aside type='note' header='Note'>
 
-`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, use the [Filters API](/api/cf-filters/delete).
+`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, use the [Filters API](/api/cf-filters).
 
 </Aside>
 
 ## Delete multiple rules
 
-```txt
-DELETE zones/<ZONE_ID>/firewall/rules
-```
+This example deletes Firewall Rules with IDs `<RULE_ID_1>` and `<RULE_ID_2>`.
 
 ```bash
 ---
 header: Request
 ---
 curl -X DELETE \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules?id=<RULE_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules?id=<RULE_ID_1>&id=<RULE_ID_2>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -36,10 +34,17 @@ curl -X DELETE \
 header: Response
 ---
 {
-  "result": [],
+  "result": [
+    {
+      "id": "<RULE_ID_1>"
+    },
+    {
+      "id": "<RULE_ID_2>"
+    }
+  ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 
@@ -52,9 +57,9 @@ This example deletes the rule with ID `<RULE_ID>`.
 header: Request
 ---
 curl -X DELETE \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -62,9 +67,13 @@ curl -X DELETE \
 header: Response
 ---
 {
-  "result": null,
+  "result": [
+    {
+      "id": "<RULE_ID>"
+    }
+  ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-firewall-rules/delete.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/delete.md
@@ -11,22 +11,22 @@ order: 435
 
 ## Delete multiple rules
 
-```bash
-DELETE zones/{zone_id}/firewall/rules
+```txt
+DELETE zones/<ZONE_ID>/firewall/rules
 ```
 
 ### Request
 
 ```bash
 curl -X DELETE \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules?id=cbf4b7a5a2a24e59a03044d6d44ceb09"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules?id=<RULE_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 <Aside type='note' header='Note'>
 
-`DELETE` does not delete any filter related to the firewall rule. To delete the filter, it's necessary to call the `/filters` API.
+`DELETE` does not delete any filter related to the Firewall Rule. To delete the filter, you must call the `/filters` API.
 
 </Aside>
 
@@ -43,22 +43,22 @@ curl -X DELETE \
 
 ## Delete a single rule
 
-```bash
-DELETE zones/{zone_id}/firewall/rules/{id}
+```txt
+DELETE zones/<ZONE_ID>/firewall/rules/<RULE_ID>
 ```
 
 ### Request
 
 ```bash
 curl -X DELETE \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/cbf4b7a5a2a24e59a03044d6d44ceb09"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 ### Response
 
-```bash
+```json
 {
   "result": null,
   "success": true,

--- a/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
@@ -1,6 +1,6 @@
 ---
 pcx-content-type: reference
-type: table
+type: overview
 order: 415
 ---
 
@@ -30,13 +30,12 @@ The Cloudflare Firewall Rules API supports the operations outlined below. Visit 
 
 </ContentColumn>
 
-<TableWrap style='width:100%'>
 <table style='table-layout:fixed; width:100%'>
   <thead>
       <tr>
-          <th>Operation</th>
+          <th style='width: 20%'>Operation</th>
           <th>Method & Endpoint</th>
-          <th>Notes</th>
+          <th style='width: 30%'>Notes</th>
       </tr>
   </thead>
   <tbody>
@@ -51,7 +50,7 @@ The Cloudflare Firewall Rules API supports the operations outlined below. Visit 
         <td>Lists all current Firewall Rules. Results return paginated with 25 items per page by default. Use optional parameters to narrow results. </td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/get/#get-rule-by-id'>Get Firewall Rule by ID</a></td>
+        <td><a href='/api/cf-firewall-rules/get/#get-rule-by-id'>Get a Firewall Rule</a></td>
         <td><code class="InlineCode">GET&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Retrieve a single Firewall Rule by ID.</td>
       </tr>
@@ -61,22 +60,21 @@ The Cloudflare Firewall Rules API supports the operations outlined below. Visit 
         <td>Handled as a single transaction. All rules must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/put/#update-a-single-rule'>Update a Firewall Rule by ID</a></td>
+        <td><a href='/api/cf-firewall-rules/put/#update-a-single-rule'>Update a Firewall Rule</a></td>
         <td><code class="InlineCode">PUT&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Update a single Firewall Rule by ID.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/delete/#delete-all-rules'>Delete Firewall Rules</a></td>
+        <td><a href='/api/cf-firewall-rules/delete/#delete-multiple-rules'>Delete Firewall Rules</a></td>
         <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td><p>Delete existing Firewall Rules. Must specify list of Firewall Rule IDs.</p>
         <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified rule does not exist.</p>
         </td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/delete/#delete-a-single-rule'>Delete Firewall Rule by ID</a></td>
+        <td><a href='/api/cf-firewall-rules/delete/#delete-a-single-rule'>Delete a Firewall Rule</a></td>
         <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td><p>Delete a Firewall Rule by ID.</p></td>
       </tr>
   </tbody>
 </table>
-</TableWrap>

--- a/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
@@ -10,7 +10,7 @@ order: 415
 
 To invoke a Cloudflare Firewall Rules API operation, append the endpoint to the Cloudflare API base URL:
 
-```html
+```txt
 https://api.cloudflare.com/client/v4/
 ```
 
@@ -20,7 +20,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](ht
 
 <Aside type='warning' header='Important'>
 
-The Firewall Rules API endpoints require a value for _{zone_id}_.
+The Firewall Rules API endpoints require a value for `<ZONE_ID>`.
 
 To retrieve a list of zones associated with your account, use the [List Zones](https://api.cloudflare.com/#zone-list-zones) operation and note the zone ID associated with the domain whose Firewall Rules you want to manage.
 
@@ -42,39 +42,39 @@ The Cloudflare Firewall Rules API supports the operations outlined below. Visit 
   <tbody>
       <tr>
         <td><a href='/api/cf-firewall-rules/post/'>Create Firewall Rules</a></td>
-        <td><code class="InlineCode">POST&nbsp;zones/{'{zone_id}'}/firewall/rules</code></td>
+        <td><code class="InlineCode">POST&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Handled as a single transaction. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/get/#get-all-rules'>List Firewall Rules</a></td>
-        <td><code class="InlineCode">GET&nbsp;zones/{'{zone_id}'}/firewall/rules</code></td>
+        <td><code class="InlineCode">GET&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Lists all current Firewall Rules. Results return paginated with 25 items per page by default. Use optional parameters to narrow results. </td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/get/#get-rule-by-id'>Get Firewall Rule by ID</a></td>
-        <td><code class="InlineCode">GET&nbsp;zones/{'{zone_id}'}/firewall/rules/{'{id}'}</code></td>
+        <td><code class="InlineCode">GET&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Retrieve a single Firewall Rule by ID.</td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/put/#update-multiple-rules'>Update Firewall Rules</a></td>
-        <td><code class="InlineCode">PUT&nbsp;zones/{'{zone_id}'}/firewall/rules</code></td>
+        <td><code class="InlineCode">PUT&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Handled as a single transaction. All rules must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/put/#update-a-single-rule'>Update a Firewall Rule by ID</a></td>
-        <td><code class="InlineCode">PUT&nbsp;zones/{'{zone_id}'}/firewall/rules/{'{id}'}</code></td>
+        <td><code class="InlineCode">PUT&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Update a single Firewall Rule by ID.</td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/delete/#delete-all-rules'>Delete Firewall Rules</a></td>
-        <td><code class="InlineCode">DELETE&nbsp;zones/{'{zone_id}'}/firewall/rules</code></td>
+        <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td><p>Delete existing Firewall Rules. Must specify list of Firewall Rule IDs.</p>
         <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified rule does not exist.</p>
         </td>
       </tr>
       <tr>
         <td><a href='/api/cf-firewall-rules/delete/#delete-a-single-rule'>Delete Firewall Rule by ID</a></td>
-        <td><code class="InlineCode">DELETE&nbsp;zones/{'{zone_id}'}/firewall/rules/{'{id}'}</code></td>
+        <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td><p>Delete a Firewall Rule by ID.</p></td>
       </tr>
   </tbody>

--- a/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/endpoints.md
@@ -26,7 +26,7 @@ To retrieve a list of zones associated with your account, use the [List Zones](h
 
 </Aside>
 
-The Cloudflare Firewall Rules API supports the operations outlined below. Visit the associated links for examples.
+The Cloudflare Firewall Rules API supports the operations outlined below. Visit the pages in this section for examples.
 
 </ContentColumn>
 
@@ -40,39 +40,39 @@ The Cloudflare Firewall Rules API supports the operations outlined below. Visit 
   </thead>
   <tbody>
       <tr>
-        <td><a href='/api/cf-firewall-rules/post/'>Create Firewall Rules</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-create-firewall-rules'>Create Firewall Rules</a></td>
         <td><code class="InlineCode">POST&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Handled as a single transaction. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/get/#get-all-rules'>List Firewall Rules</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-list-of-firewall-rules'>List Firewall Rules</a></td>
         <td><code class="InlineCode">GET&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Lists all current Firewall Rules. Results return paginated with 25 items per page by default. Use optional parameters to narrow results. </td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/get/#get-rule-by-id'>Get a Firewall Rule</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-get-individual-firewall-rule'>Get a Firewall Rule</a></td>
         <td><code class="InlineCode">GET&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Retrieve a single Firewall Rule by ID.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/put/#update-multiple-rules'>Update Firewall Rules</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-update-firewall-rules'>Update Firewall Rules</a></td>
         <td><code class="InlineCode">PUT&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td>Handled as a single transaction. All rules must exist for operation to succeed. If there is an error, the entire operation fails.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/put/#update-a-single-rule'>Update a Firewall Rule</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-update-individual-firewall-rule'>Update a Firewall Rule</a></td>
         <td><code class="InlineCode">PUT&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td>Update a single Firewall Rule by ID.</td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/delete/#delete-multiple-rules'>Delete Firewall Rules</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-delete-firewall-rules'>Delete Firewall Rules</a></td>
         <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules</code></td>
         <td><p>Delete existing Firewall Rules. Must specify list of Firewall Rule IDs.</p>
         <p>Empty requests result in no deletion. Returns HTTP status code 200 if a specified rule does not exist.</p>
         </td>
       </tr>
       <tr>
-        <td><a href='/api/cf-firewall-rules/delete/#delete-a-single-rule'>Delete a Firewall Rule</a></td>
+        <td><a href='https://api.cloudflare.com/#firewall-rules-delete-individual-firewall-rules'>Delete a Firewall Rule</a></td>
         <td><code class="InlineCode">DELETE&nbsp;zones/{'<ZONE_ID>'}/firewall/rules/{'<RULE_ID>'}</code></td>
         <td><p>Delete a Firewall Rule by ID.</p></td>
       </tr>

--- a/products/firewall/src/content/api/cf-firewall-rules/get.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/get.md
@@ -6,9 +6,6 @@ order: 425
 
 # GET examples
 
-- [Get all rules](#get-all-rules)
-- [Get rule by ID](#get-rule-by-id)
-
 ## Get all rules
 
 This example returns all the Firewall Rules in the zone with ID `<ZONE_ID>`.

--- a/products/firewall/src/content/api/cf-firewall-rules/get.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/get.md
@@ -18,9 +18,9 @@ This example returns all the Firewall Rules in the zone with ID `<ZONE_ID>`.
 header: Request
 ---
 curl -X GET \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -83,8 +83,8 @@ header: Response
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null,
+  "errors": [],
+  "messages": [],
   "result_info": {
     "page": 1,
     "per_page": 25,
@@ -104,9 +104,9 @@ This example returns the Firewall Rule with ID `<RULE_ID>`.
 header: Request
 ---
 curl -X GET \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>"
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>"
 ```
 
 ```json
@@ -128,7 +128,7 @@ header: Response
     }
   },
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-firewall-rules/get.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/get.md
@@ -11,17 +11,17 @@ order: 425
 
 ## Get all rules
 
-```bash
-GET zones/{zone_id}/firewall/rules
+```txt
+GET zones/<ZONE_ID>/firewall/rules
 ```
 
 ### Request
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 ### Response
@@ -30,52 +30,52 @@ curl -X GET \
 {
   "result": [
     {
-      "id": "4ae338944d6143378c3cf05a7c77d983",
+      "id": "<RULE_ID_1>",
       "paused": false,
       "description": "allow API traffic without challenge",
       "action": "allow",
       "priority": null,
       "filter": {
-        "id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+        "id": "<FILTER_ID_1>",
         "expression": "http.request.uri.path matches \"^/api/.*$\"",
         "paused": false,
         "description": "/api"
       }
     },
     {
-      "id": "f2d427378e7542acb295380d352e2ebd",
+      "id": "<RULE_ID_2>",
       "paused": false,
       "description": "do not challenge login from office",
       "action": "allow",
       "priority": null,
       "filter": {
-        "id": "b7ff25282d394be7b945e23c7106ce8a",
-        "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+        "id": "<FILTER_ID_2>",
+        "expression": "ip.src in {2400:cb00::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
         "paused": false,
         "description": "Login from office"
       }
     },
     {
-      "id": "cbf4b7a5a2a24e59a03044d6d44ceb09",
+      "id": "<RULE_ID_3>",
       "paused": false,
       "description": "challenge login",
       "action": "challenge",
       "priority": null,
       "filter": {
-        "id": "c218c536b2bd406f958f278cf0fa8c0f",
+        "id": "<FILTER_ID_3>",
         "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
         "paused": false,
         "description": "Login"
       }
     },
     {
-      "id": "52161eb6af4241bb9d4b32394be72fdf",
+      "id": "<RULE_ID_4>",
       "paused": false,
       "description": "JS challenge site",
       "action": "js_challenge",
       "priority": null,
       "filter": {
-        "id": "f2a64520581a4209aab12187a0081364",
+        "id": "<FILTER_ID_4>",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "paused": false,
         "description": "not /api"
@@ -97,17 +97,17 @@ curl -X GET \
 
 ## Get by rule ID
 
-```bash
-GET zones/{zone_id}/firewall/rules/{id}
+```txt
+GET zones/<ZONE_ID>/firewall/rules/<RULE_ID>
 ```
 
 ### Request
 
 ```bash
 curl -X GET \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd"
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>"
 ```
 
 ### Response
@@ -115,14 +115,14 @@ curl -X GET \
 ```json
 {
   "result": {
-    "id": "f2d427378e7542acb295380d352e2ebd",
+    "id": "<RULE_ID>",
     "paused": false,
     "description": "do not challenge login from office",
     "action": "allow",
     "priority": null,
     "filter": {
-      "id": "b7ff25282d394be7b945e23c7106ce8a",
-      "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+      "id": "<FILTER_ID>",
+      "expression": "ip.src in {2400:cb00::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
       "paused": false,
       "description": "Login from office"
     }

--- a/products/firewall/src/content/api/cf-firewall-rules/get.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/get.md
@@ -7,26 +7,26 @@ order: 425
 # GET examples
 
 - [Get all rules](#get-all-rules)
-- [Get rule by ID](#get-by-rule-id)
+- [Get rule by ID](#get-rule-by-id)
 
 ## Get all rules
 
-```txt
-GET zones/<ZONE_ID>/firewall/rules
-```
-
-### Request
+This example returns all the Firewall Rules in the zone with ID `<ZONE_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X GET \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {
@@ -95,24 +95,24 @@ curl -X GET \
 }
 ```
 
-## Get by rule ID
+## Get rule by ID
 
-```txt
-GET zones/<ZONE_ID>/firewall/rules/<RULE_ID>
-```
-
-### Request
+This example returns the Firewall Rule with ID `<RULE_ID>`.
 
 ```bash
+---
+header: Request
+---
 curl -X GET \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
   -H "X-Auth-Key: <API_KEY>"
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": {
     "id": "<RULE_ID>",

--- a/products/firewall/src/content/api/cf-firewall-rules/json-object.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/json-object.md
@@ -15,7 +15,7 @@ A JSON response for the [Firewall Rules API](https://api.cloudflare.com/#firewal
   "id": "772bf1026a72c400ea576db1ffa16407",
   "filter": {
     "id": "6f58318e7fa2477a23112e8118c66f61",
-    "expression": "http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\""
+    "expression": "http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
     "paused": false,
     "description": "WordPress login paths",
     "ref": ""

--- a/products/firewall/src/content/api/cf-firewall-rules/json-object.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/json-object.md
@@ -103,6 +103,6 @@ Priority plays a key role in configuring Firewall Rules. With Cloudflare Filters
 
 Requests from the office IP range using the user agent to block would trigger both rules, but we cannot both allow and block the request. To solve this problem, Firewall Rules follows a strict ordering depending on action and priority.
 
-Cloudflare prioritizes rules in descending order, such that priority 1 is first and rules with no priority are last. For rules of equal priority, Cloudflare orders them by action according to their [order of precedence](/cf-firewall-rules/actions#supported-actions). In the example above, if no priority is set, the `allow request from the office IP range` would apply because the _allow_ action has a higher precedence than _block_.
+Cloudflare prioritizes rules in descending order, such that priority 1 is first and rules with no priority are last. For rules of equal priority, Cloudflare orders them by action according to their [order of precedence](/cf-firewall-rules/actions#supported-actions). In the example above, if no priority is set, the rule `allow request from the office IP range` would apply because the _allow_ action has a higher precedence than _block_.
 
 To reduce the risk of unintended behavior, it is best to explicitly specify the desired priority for potentially conflicting rules.

--- a/products/firewall/src/content/api/cf-firewall-rules/post.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/post.md
@@ -6,8 +6,8 @@ order: 420
 
 # POST example
 
-```bash
-POST zones/{zone_id}/firewall/rules
+```txt
+POST zones/<ZONE_ID>/firewall/rules
 ```
 
 Creates one or more Firewall Rules.
@@ -20,41 +20,42 @@ To create a Firewall Rule you need a [filter](/api/cf-filters/what-is-a-filter) 
 
 ## Request
 
-```bash
+```json
 curl -X POST \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '[
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '[
   {
     "filter": {
-      "id": "b7ff25282d394be7b945e23c7106ce8a"
+      "id": "<FILTER_ID_1>"
     },
     "action": "allow",
-    "description": "do not challenge login from office"
+    "description": "Do not challenge login from office"
   },
   {
     "filter": {
-      "id": "c218c536b2bd406f958f278cf0fa8c0f"
+      "id": "<FILTER_ID_2>"
     },
     "action": "challenge",
-    "description": "challenge login"
+    "description": "Challenge login"
   },
   {
     "filter": {
-      "id": "f2a64520581a4209aab12187a0081364"
+      "id": "<FILTER_ID_3>"
     },
     "action": "js_challenge",
     "description": "JS challenge site"
   },
   {
     "filter": {
-      "id": "14217d7bd5ab435e84b1bd468bf4fb9f"
+      "id": "<FILTER_ID_4>"
     },
     "action": "allow",
-    "description": "allow API traffic without challenge"
+    "description": "Allow API traffic without challenge"
   }
-]' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules"
+]'
 ```
 
 ## Response
@@ -63,52 +64,52 @@ curl -X POST \
 {
   "result": [
     {
-      "id": "f2d427378e7542acb295380d352e2ebd",
+      "id": "<RULE_ID_1>",
       "paused": false,
-      "description": "do not challenge login from office",
+      "description": "Do not challenge login from office",
       "action": "allow",
       "priority": null,
       "filter": {
-        "id": "b7ff25282d394be7b945e23c7106ce8a",
-        "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+        "id": "<FILTER_ID_1>",
+        "expression": "ip.src in {2400:cb00::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
         "paused": false,
         "description": "Login from office"
       }
     },
     {
-      "id": "cbf4b7a5a2a24e59a03044d6d44ceb09",
+      "id": "<RULE_ID_2>",
       "paused": false,
-      "description": "challenge login",
+      "description": "Challenge login",
       "action": "challenge",
       "priority": null,
       "filter": {
-        "id": "c218c536b2bd406f958f278cf0fa8c0f",
+        "id": "<FILTER_ID_2>",
         "expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
         "paused": false,
         "description": "Login"
       }
     },
     {
-      "id": "52161eb6af4241bb9d4b32394be72fdf",
+      "id": "<RULE_ID_3>",
       "paused": false,
       "description": "JS challenge site",
       "action": "js_challenge",
       "priority": null,
       "filter": {
-        "id": "f2a64520581a4209aab12187a0081364",
+        "id": "<FILTER_ID_3>",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "paused": false,
         "description": "not /api"
       }
     },
     {
-      "id": "4ae338944d6143378c3cf05a7c77d983",
+      "id": "<RULE_ID_4>",
       "paused": false,
-      "description": "allow API traffic without challenge",
+      "description": "Allow API traffic without challenge",
       "action": "allow",
       "priority": null,
       "filter": {
-        "id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+        "id": "<FILTER_ID_4>",
         "expression": "http.request.uri.path matches \"^/api/.*$\"",
         "paused": false,
         "description": "/api"

--- a/products/firewall/src/content/api/cf-firewall-rules/post.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/post.md
@@ -6,11 +6,7 @@ order: 420
 
 # POST example
 
-```txt
-POST zones/<ZONE_ID>/firewall/rules
-```
-
-Creates one or more Firewall Rules.
+This example creates several Firewall Rules using a single API call.
 
 <Aside type="note">
 
@@ -18,9 +14,10 @@ To create a Firewall Rule you need a [filter](/api/cf-filters/what-is-a-filter) 
 
 </Aside>
 
-## Request
-
 ```json
+---
+header: Request
+---
 curl -X POST \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -58,9 +55,10 @@ curl -X POST \
 ]'
 ```
 
-## Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {

--- a/products/firewall/src/content/api/cf-firewall-rules/post.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/post.md
@@ -10,7 +10,7 @@ This example creates several Firewall Rules using a single API call.
 
 <Aside type="note">
 
-To create a Firewall Rule you need a [filter](/api/cf-filters/what-is-a-filter) identifier (`id`). If you have not created a filter yet, refer to the [Cloudflare Filters API documentation](/api/cf-filters/post).
+To create a Firewall Rule you need a [filter](/api/cf-filters/what-is-a-filter) identifier (`id`). If you have not created a filter yet, refer to the [Cloudflare Filters API documentation](/api/cf-filters).
 
 </Aside>
 
@@ -19,11 +19,11 @@ To create a Firewall Rule you need a [filter](/api/cf-filters/what-is-a-filter) 
 header: Request
 ---
 curl -X POST \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '[
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '[
   {
     "filter": {
       "id": "<FILTER_ID_1>"
@@ -115,7 +115,7 @@ header: Response
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```

--- a/products/firewall/src/content/api/cf-firewall-rules/put.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/put.md
@@ -5,9 +5,6 @@ order: 430
 
 # PUT examples
 
-- [Update multiple rules](#update-multiple-rules)
-- [Update a single rule](#update-a-single-rule)
-
 ## Update multiple rules
 
 This example updates several Firewall Rules using a single API call.

--- a/products/firewall/src/content/api/cf-firewall-rules/put.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/put.md
@@ -10,41 +10,42 @@ order: 430
 
 ## Update multiple rules
 
-```bash
-PUT zones/{zone_id}/firewall/rules
+```txt
+PUT zones/<ZONE_ID>/firewall/rules
 ```
 
-You can include up to 25 rules in the JSON object array (_-d_ flag) to update as a batch. The batch is handled as a transaction.
+You can include up to 25 rules in the JSON object array (`-d` flag) to update as a batch. The batch is handled as a transaction.
 
 ### Request
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '[
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '[
   {
-    "id": "52161eb6af4241bb9d4b32394be72fdf",
+    "id": "<RULE_ID>",
     "paused": false,
-    "description": "challenge site",
+    "description": "Challenge site",
     "action": "challenge",
     "priority": null,
     "filter": {
-      "id": "f2a64520581a4209aab12187a0081364",
+      "id": "<FILTER_ID>",
       "expression": "not http.request.uri.path matches \"^/api/.*$\"",
       "paused": false,
       "description": "not /api"
     }
   }
-]' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules"
+]'
 ```
 
 <Aside type='note' header='Note'>
 
-`PUT` does not update the filter specified. It only looks at the _filter id_ to update the rule with a new filter.
+`PUT` does not update the filter specified. It only looks at the filter ID (`<FILTER_ID>`) to update the rule with a new filter.
 
-To update the filter, use the [Filters API](/api/cf-filters/).
+To update the filter, use the [Filters API](/api/cf-filters).
 
 </Aside>
 
@@ -54,13 +55,13 @@ To update the filter, use the [Filters API](/api/cf-filters/).
 {
   "result": [
     {
-      "id": "52161eb6af4241bb9d4b32394be72fdf",
+      "id": "<RULE_ID>",
       "paused": false,
-      "description": "challenge site",
+      "description": "Challenge site",
       "action": "challenge",
       "priority": null,
       "filter": {
-        "id": "f2a64520581a4209aab12187a0081364",
+        "id": "<FILTER_ID>",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "paused": false,
         "description": "not /api"
@@ -75,25 +76,25 @@ To update the filter, use the [Filters API](/api/cf-filters/).
 
 ## Update a single rule
 
-```bash
-PUT zones/{zone_id}/firewall/rules/{id}
+```txt
+PUT zones/<ZONE_ID>/firewall/rules/<RULE_ID>
 ```
 
 These fields are required:
 
-- _id_
-- _action_
-- _filter.id_
+- `id`
+- `action`
+- `filter.id`
 
 All other fields are optional.
 
 <Aside type='note' header='Note'>
 
-`PUT` overwrites fields that aren't explicitly passed in the request.
+`PUT` overwrites fields that are not explicitly passed in the request.
 
 For example, if the request omits `description`, any previously existing `description` value will be erased.
 
-To preserve existing values, issue a `GET` request and based on the response, determine which fields (and respective values) to include in your `PUT` request and avoid undesired overwrites.
+To preserve existing values, issue a `GET` request and based on the response, determine which fields (and respective values) to include in your `PUT` request.
 
 </Aside>
 
@@ -101,22 +102,23 @@ To preserve existing values, issue a `GET` request and based on the response, de
 
 ```bash
 curl -X PUT \
-     -H "X-Auth-Email: user@cloudflare.com" \
-     -H "X-Auth-Key: REDACTED" \
-     -H "Content-Type: application/json" \
-     -d '{
-  "id": "f2d427378e7542acb295380d352e2ebd",
+  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+  -H "X-Auth-Email: <EMAIL>" \
+  -H "X-Auth-Key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "id": "<RULE_ID>",
   "paused": false,
-  "description": "do not challenge login from office IPv6",
+  "description": "Do not challenge login from office IPv6",
   "action": "allow",
   "priority": null,
   "filter": {
-    "id": "b7ff25282d394be7b945e23c7106ce8a",
-    "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+    "id": "<FILTER_ID>",
+    "expression": "ip.src in {2400:cb00::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
     "paused": false,
     "description": "Login from office"
   }
-}' "https://api.cloudflare.com/client/v4/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd"
+}' 
 ```
 
 ### Response
@@ -124,14 +126,14 @@ curl -X PUT \
 ```json
 {
   "result": {
-    "id": "f2d427378e7542acb295380d352e2ebd",
+    "id": "<RULE_ID>",
     "paused": false,
-    "description": "do not challenge login from office IPv6",
+    "description": "Do not challenge login from office IPv6",
     "action": "allow",
     "priority": null,
     "filter": {
-      "id": "b7ff25282d394be7b945e23c7106ce8a",
-      "expression": "ip.src in {2400:cb00::/32 2405:8100::/32 2405:b500::/32 2606:4700::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+      "id": "<FILTER_ID>",
+      "expression": "ip.src in {2400:cb00::/32 2803:f800::/32 2c0f:f248::/32 2a06:98c0::/29} and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
       "paused": false,
       "description": "Login from office"
     }

--- a/products/firewall/src/content/api/cf-firewall-rules/put.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/put.md
@@ -10,15 +10,14 @@ order: 430
 
 ## Update multiple rules
 
-```txt
-PUT zones/<ZONE_ID>/firewall/rules
-```
+This example updates several Firewall Rules using a single API call.
 
 You can include up to 25 rules in the JSON object array (`-d` flag) to update as a batch. The batch is handled as a transaction.
 
-### Request
-
 ```bash
+---
+header: Request
+---
 curl -X PUT \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -49,9 +48,10 @@ To update the filter, use the [Filters API](/api/cf-filters).
 
 </Aside>
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": [
     {
@@ -76,11 +76,9 @@ To update the filter, use the [Filters API](/api/cf-filters).
 
 ## Update a single rule
 
-```txt
-PUT zones/<ZONE_ID>/firewall/rules/<RULE_ID>
-```
+This example updates the Firewall Rule with ID `<RULE_ID>`.
 
-These fields are required:
+You must include the following fields in the request body:
 
 - `id`
 - `action`
@@ -88,19 +86,10 @@ These fields are required:
 
 All other fields are optional.
 
-<Aside type='note' header='Note'>
-
-`PUT` overwrites fields that are not explicitly passed in the request.
-
-For example, if the request omits `description`, any previously existing `description` value will be erased.
-
-To preserve existing values, issue a `GET` request and based on the response, determine which fields (and respective values) to include in your `PUT` request.
-
-</Aside>
-
-### Request
-
-```bash
+```json
+---
+header: Request
+---
 curl -X PUT \
   "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
   -H "X-Auth-Email: <EMAIL>" \
@@ -121,9 +110,10 @@ curl -X PUT \
 }' 
 ```
 
-### Response
-
 ```json
+---
+header: Response
+---
 {
   "result": {
     "id": "<RULE_ID>",
@@ -143,3 +133,13 @@ curl -X PUT \
   "messages": null
 }
 ```
+
+<Aside type='note' header='Note'>
+
+`PUT` overwrites fields that are not explicitly passed in the request.
+
+For example, if the request omits `description`, any previously existing `description` value will be erased.
+
+To preserve existing values, issue a `GET` request and based on the response, determine which fields (and respective values) to include in your `PUT` request.
+
+</Aside>

--- a/products/firewall/src/content/api/cf-firewall-rules/put.md
+++ b/products/firewall/src/content/api/cf-firewall-rules/put.md
@@ -14,16 +14,16 @@ This example updates several Firewall Rules using a single API call.
 
 You can include up to 25 rules in the JSON object array (`-d` flag) to update as a batch. The batch is handled as a transaction.
 
-```bash
+```json
 ---
 header: Request
 ---
 curl -X PUT \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '[
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '[
   {
     "id": "<RULE_ID>",
     "paused": false,
@@ -69,8 +69,8 @@ header: Response
     }
   ],
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 
@@ -91,11 +91,11 @@ All other fields are optional.
 header: Request
 ---
 curl -X PUT \
-  "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
-  -H "X-Auth-Email: <EMAIL>" \
-  -H "X-Auth-Key: <API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/firewall/rules/<RULE_ID>" \
+-H "X-Auth-Email: <EMAIL>" \
+-H "X-Auth-Key: <API_KEY>" \
+-H "Content-Type: application/json" \
+-d '{
   "id": "<RULE_ID>",
   "paused": false,
   "description": "Do not challenge login from office IPv6",
@@ -129,8 +129,8 @@ header: Response
     }
   },
   "success": true,
-  "errors": null,
-  "messages": null
+  "errors": [],
+  "messages": []
 }
 ```
 

--- a/products/firewall/src/content/api/cf-lists/endpoints.md
+++ b/products/firewall/src/content/api/cf-lists/endpoints.md
@@ -16,7 +16,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](ht
 
 <Aside type='warning' header='Important'>
 
-The Rules Lists API endpoints require a value for `{account_id}`.
+The Rules Lists API endpoints require a value for `<ACCOUNT_ID>`.
 
 To retrieve a list of accounts to which you have access, use the [List Accounts](https://api.cloudflare.com/#accounts-list-accounts) operation and note the IDs of the accounts you want to manage.
 
@@ -38,22 +38,22 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
     <tbody>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-create-list'>Create List</a></td>
-          <td><code class="InlineCode">POST accounts/{'{account_id}'}/rules/lists</code></td>
+          <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
           <td style='width:25%; word-wrap:break-word; white-space:normal'>Creates an empty list.</td>
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-list-lists'>List Lists</a></td>
-          <td><code class="InlineCode">GET accounts/{'{account_id}'}/rules/lists</code></td>
+          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
           <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetch all lists for the account. (This request does not fetch the items in the lists.)</td>
         </tr>
         <tr>
           <td><a href='https://api.cloudflare.com/#rules-lists-get-list'>Get List</a></td>
-          <td><code class="InlineCode">GET accounts/{'{account_id}'}/rules/lists/{'{list_id}'}</code></td>
+          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
           <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetches a list by its <code class="InlineCode">id</code>. (This request does not display the items in the list.)</td>
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-update-list'>Update List</a></td>
-          <td><code class="InlineCode">PUT accounts/{'{account_id}'}/rules/lists/{'{list_id}'}</code></td>
+          <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
           <td style='width:25%; word-wrap:break-word; white-space:normal'>
               <p>Updates the <code class="InlineCode">description</code> of a list. You cannot edit the <code class="InlineCode">name</code> or <code class="InlineCode">kind</code>, and you cannot update items in a list.</p>
               <p>To update an item in a list, use the <a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a> operation.</p>
@@ -61,7 +61,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list'>Delete List</a></td>
-          <td><code class="InlineCode">DELETE accounts/{'{account_id}'}/rules/lists/{'{list_id}'}</code></td>
+          <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
           <td style='width:25%; word-wrap:break-word; white-space:normal'>Deletes the list, but only when no filters reference it. </td>
         </tr>
     </tbody>
@@ -88,7 +88,7 @@ When you make requests to a list while a bulk operation on that list is in progr
     <tbody>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-list-list-items'>List Items</a></td>
-            <td><code class="InlineCode">GET accounts/{'{account_id}'}/rules/lists/{'{list_id}'}/items</code></td>
+            <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
             <td><p>Fetches all items in a list.</p>
                 <p>Items are sorted in ascending order by IP address.</p>
                 <p>CIDRs are sorted by IP address, then by the subnet mask.</p>
@@ -96,13 +96,13 @@ When you make requests to a list while a bulk operation on that list is in progr
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-get-list-item'>Get List Item</a></td>
-            <td><code class="InlineCode">GET accounts/{'{account_id}'}/rules/lists/{'{list_id}'}/items/{'{item_id}'}</code></td>
+            <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items/{'<ITEM_ID>'}</code></td>
             <td><p>Fetches an item from a list by ID.</p>
             </td>
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-create-list-items'>Create List Items</a></td>
-            <td><code class="InlineCode">POST accounts/{'{account_id}'}/rules/lists/{'{list_id}'}/items</code></td>
+            <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
             <td>
               <p>Appends a new item or items to a list.</p>
               <p>Replaces entries that already exist in the list, does not delete any items.</p>
@@ -112,7 +112,7 @@ When you make requests to a list while a bulk operation on that list is in progr
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a></td>
-            <td><code class="InlineCode">PUT accounts/{'{account_id}'}/rules/lists/{'{list_id}'}/items</code></td>
+            <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
             <td>
                 <p>Deletes all current items in the list and replaces them with <code class="InlineCode">items</code>.</p>
                 <p>When <code class="InlineCode">items</code> is empty, deletes <strong>all</strong> items in the list.</p>
@@ -121,7 +121,7 @@ When you make requests to a list while a bulk operation on that list is in progr
         </tr>
         <tr>
 	        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list-items'>Delete List Items</a></td>
-            <td><code class="InlineCode">DELETE accounts/{'{account_id}'}/rules/lists/{'{list_id}'}/items</code></td>
+            <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
             <td>
                 <p>Deletes specified list items.</p>
                 <p>The response includes an <code class="InlineCode">operation_id</code>.</p>

--- a/products/firewall/src/content/api/cf-lists/endpoints.md
+++ b/products/firewall/src/content/api/cf-lists/endpoints.md
@@ -1,10 +1,13 @@
 ---
 title: Endpoints
 pcx-content-type: reference
+type: overview
 order: 495
 ---
 
 # Endpoints
+
+<ContentColumn>
 
 To invoke a [Cloudflare Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) operation, append the endpoint to the Cloudflare API base URL:
 
@@ -24,51 +27,53 @@ To retrieve a list of accounts to which you have access, use the [List Accounts]
 
 The Cloudflare Rules Lists API supports the operations outlined below. Visit the associated links for examples.
 
+</ContentColumn>
+
 ## Manage lists
 
-<TableWrap>
-  <table style="table-layout:fixed; width:100%;">
-    <thead>
-        <tr>
-            <th style='width:25%'>Operation</th>
-            <th style='width:50%'>Method & Endpoint</th>
-            <th style='width:25%'>Notes</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-create-list'>Create List</a></td>
-          <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
-          <td style='width:25%; word-wrap:break-word; white-space:normal'>Creates an empty list.</td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-list-lists'>List Lists</a></td>
-          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
-          <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetch all lists for the account. (This request does not fetch the items in the lists.)</td>
-        </tr>
-        <tr>
-          <td><a href='https://api.cloudflare.com/#rules-lists-get-list'>Get List</a></td>
-          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
-          <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetches a list by its <code class="InlineCode">id</code>. (This request does not display the items in the list.)</td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-update-list'>Update List</a></td>
-          <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
-          <td style='width:25%; word-wrap:break-word; white-space:normal'>
-              <p>Updates the <code class="InlineCode">description</code> of a list. You cannot edit the <code class="InlineCode">name</code> or <code class="InlineCode">kind</code>, and you cannot update items in a list.</p>
-              <p>To update an item in a list, use the <a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a> operation.</p>
-          </td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list'>Delete List</a></td>
-          <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
-          <td style='width:25%; word-wrap:break-word; white-space:normal'>Deletes the list, but only when no filters reference it. </td>
-        </tr>
-    </tbody>
-  </table>
-</TableWrap>
+<table style="table-layout:fixed; width:100%;">
+  <thead>
+      <tr>
+          <th style='width: 20%'>Operation</th>
+          <th>Method & Endpoint</th>
+          <th style='width: 30%'>Notes</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-create-list'>Create a List</a></td>
+        <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
+        <td style='width:25%; word-wrap:break-word; white-space:normal'>Creates an empty list.</td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-list-lists'>List Lists</a></td>
+        <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists</code></td>
+        <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetch all lists for the account. (This request does not fetch the items in the lists.)</td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-get-list'>Get a List</a></td>
+        <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
+        <td style='width:25%; word-wrap:break-word; white-space:normal'>Fetches a list by its <code class="InlineCode">id</code>. (This request does not display the items in the list.)</td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-update-list'>Update a List</a></td>
+        <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
+        <td style='width:25%; word-wrap:break-word; white-space:normal'>
+            <p>Updates the <code class="InlineCode">description</code> of a list. You cannot edit the <code class="InlineCode">name</code> or <code class="InlineCode">kind</code>, and you cannot update items in a list.</p>
+            <p>To update an item in a list, use the <a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a> operation.</p>
+        </td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list'>Delete a List</a></td>
+        <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}</code></td>
+        <td style='width:25%; word-wrap:break-word; white-space:normal'>Deletes the list, but only when no filters reference it. </td>
+      </tr>
+  </tbody>
+</table>
 
 ## Manage items in a list
+
+<ContentColumn>
 
 Nearly all the operations for managing items in a list are asynchronous. When you add or delete a large amount of items to or from a list, there may be a delay before the bulk operation is complete.
 
@@ -76,57 +81,57 @@ Asynchronous list operations return an `operation_id`, which you can use to moni
 
 When you make requests to a list while a bulk operation on that list is in progress, the requests are queued and processed in sequence (first in, first out). Requests for successful asynchronous operations return an `HTTP 201` status code.
 
-<TableWrap>
-  <table style="table-layout:fixed; width:100%;">
-    <thead>
-        <tr>
-            <th>Operation</th>
-            <th>Method & Endpoint</th>
-            <th>Notes</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-list-list-items'>List Items</a></td>
-            <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
-            <td><p>Fetches all items in a list.</p>
-                <p>Items are sorted in ascending order by IP address.</p>
-                <p>CIDRs are sorted by IP address, then by the subnet mask.</p>
-            </td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-get-list-item'>Get List Item</a></td>
-            <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items/{'<ITEM_ID>'}</code></td>
-            <td><p>Fetches an item from a list by ID.</p>
-            </td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-create-list-items'>Create List Items</a></td>
-            <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
-            <td>
-              <p>Appends a new item or items to a list.</p>
-              <p>Replaces entries that already exist in the list, does not delete any items.</p>
-              <p>Overwrites the <code class="InlineCode">comment</code> of the original item.</p>
+</ContentColumn>
+
+<table style="table-layout:fixed; width:100%;">
+  <thead>
+      <tr>
+          <th style="width: 20%">Operation</th>
+          <th>Method & Endpoint</th>
+          <th style='width: 30%'>Notes</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-list-list-items'>List Items</a></td>
+          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
+          <td><p>Fetches all items in a list.</p>
+              <p>Items are sorted in ascending order by IP address.</p>
+              <p>CIDRs are sorted by IP address, then by the subnet mask.</p>
+          </td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-get-list-item'>Get a List Item</a></td>
+          <td><code class="InlineCode">GET accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items/{'<ITEM_ID>'}</code></td>
+          <td><p>Fetches an item from a list by ID.</p>
+          </td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-create-list-items'>Create List Items</a></td>
+          <td><code class="InlineCode">POST accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
+          <td>
+            <p>Appends a new item or items to a list.</p>
+            <p>Replaces entries that already exist in the list, does not delete any items.</p>
+            <p>Overwrites the <code class="InlineCode">comment</code> of the original item.</p>
+            <p>The response includes an <code class="InlineCode">operation_id</code>.</p>
+          </td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a></td>
+          <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
+          <td>
+              <p>Deletes all current items in the list and replaces them with <code class="InlineCode">items</code>.</p>
+              <p>When <code class="InlineCode">items</code> is empty, deletes <strong>all</strong> items in the list.</p>
               <p>The response includes an <code class="InlineCode">operation_id</code>.</p>
-            </td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-replace-list-items'>Replace List Items</a></td>
-            <td><code class="InlineCode">PUT accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
-            <td>
-                <p>Deletes all current items in the list and replaces them with <code class="InlineCode">items</code>.</p>
-                <p>When <code class="InlineCode">items</code> is empty, deletes <strong>all</strong> items in the list.</p>
-                <p>The response includes an <code class="InlineCode">operation_id</code>.</p>
-            </td>
-        </tr>
-        <tr>
-	        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list-items'>Delete List Items</a></td>
-            <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
-            <td>
-                <p>Deletes specified list items.</p>
-                <p>The response includes an <code class="InlineCode">operation_id</code>.</p>
-            </td>
-        </tr>
-    </tbody>
-  </table>
-</TableWrap>
+          </td>
+      </tr>
+      <tr>
+        <td><a href='https://api.cloudflare.com/#rules-lists-delete-list-items'>Delete List Items</a></td>
+          <td><code class="InlineCode">DELETE accounts/{'<ACCOUNT_ID>'}/rules/lists/{'<LIST_ID>'}/items</code></td>
+          <td>
+              <p>Deletes specified list items.</p>
+              <p>The response includes an <code class="InlineCode">operation_id</code>.</p>
+          </td>
+      </tr>
+  </tbody>
+</table>

--- a/products/firewall/src/content/api/cf-lists/json-object.md
+++ b/products/firewall/src/content/api/cf-lists/json-object.md
@@ -8,7 +8,7 @@ order: 490
 
 ## List object structure and properties
 
-A JSON response for the [Rules Lists API](https://api.cloudflare.com/#filters-properties) has this structure:
+A JSON response for the [Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) has this structure:
 
 ```json
 {


### PR DESCRIPTION
Uses placeholders according to internal guidelines (for example, `<EMAIL>`).
Adjust some examples that were outdated.
Endpoints pages now link to API reference docs.
