### PR TITLE
Update test login for exposed credentials checks

### DIFF
--- a/products/waf/src/content/exposed-credentials-check/test-configuration.md
+++ b/products/waf/src/content/exposed-credentials-check/test-configuration.md
@@ -9,7 +9,7 @@ After enabling and configuring exposed credentials checks, you may want to test 
 
 Cloudflare provides a special set of credentials for this purpose:
 
-* Username: `CF_EXPOSED_USERNAME` or `CF_EXPOSED_USERNAME@example.com`
+* Login: `CF_EXPOSED_USERNAME` or `CF_EXPOSED_USERNAME@example.com`
 * Password: `CF_EXPOSED_PASSWORD`
 
 The WAF always considers these specific credentials as having been previously exposed. Use them to force an "exposed credentials" event, which allows you to check the behavior of your current configuration.


### PR DESCRIPTION
Addresses https://jira.cfops.it/browse/PCX-3225.

The trigger for testing exposed credentials checks expects a "login" instead of a "username".