### PR TITLE
fix: header level in FAQ

### DIFF
--- a/products/stream/src/content/faq/index.md
+++ b/products/stream/src/content/faq/index.md
@@ -15,7 +15,7 @@ pcx-content-type: faq
 
 Cloudflare decides on which bitrate, resolution, and codec is best for you. We deliver all videos to industry standard H264 codec. We use a few different adaptive streaming levels from 360p to 1080p to ensure smooth streaming for your audience watching on different devices and bandwidth constraints.
 
-## Does Stream support multi-audio tracks?
+### Does Stream support multi-audio tracks?
 
 Stream does not currently support multi-audio tracks. For files with multiple audio tracks, Stream uses the first available audio track.
 


### PR DESCRIPTION
Fixes the header level to be consistent with the rest of the FAQ.