### PR TITLE
Fix build command: it had permissions failures

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -57,7 +57,7 @@ Deploy your site to Pages by logging into the [Cloudflare dashboard](https://das
 | Configuration option | Value            |
 | -------------------- | ---------------- |
 | Production branch    | `main`           |
-| Build command        | `./build.sh`     |
+| Build command        | `chmod +x build.sh && ./build.sh`     |
 | Build directory      | `output/wwwroot` |
 
 </TableLayout>

--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -52,12 +52,17 @@ $ git push -u origin main
 
 Deploy your site to Pages by logging into the [Cloudflare dashboard](https://dash.cloudflare.com/) > **Account Home** > **Pages** dashboard and selecting **Create a project**. Select the new GitHub repository that you created and, in the **Set up builds and deployments** section, provide the following information:
 
+<Aside type="note">
+
+Your `build.sh` file needs to be executable for the build command to work. You can do this by running `chmod +x build.sh`, or commit the file as an executable by running `git add --chmod=+x build.sh`.
+</Aside>
+
 <TableLayout>
 
 | Configuration option | Value            |
 | -------------------- | ---------------- |
 | Production branch    | `main`           |
-| Build command        | `chmod +x build.sh && ./build.sh`     |
+| Build command        | `./build.sh`     |
 | Build directory      | `output/wwwroot` |
 
 </TableLayout>


### PR DESCRIPTION
The simple build command of `./build.sh` failed on the "Building Application" stage due to insufficient permissions. Applying the fix suggested by [andyraddatz](https://community.cloudflare.com/t/permission-denied-on-build-script/295840/5) in the community forum fixed the issue by allowing `build.sh` to execute as a program (more details in this [SO post](https://askubuntu.com/a/443799).)

Fixes #3242