### PR TITLE
Document comments format in _headers

### DIFF
--- a/products/pages/src/content/platform/headers.md
+++ b/products/pages/src/content/platform/headers.md
@@ -82,6 +82,22 @@ filename: _headers
   x-movie-name: You are watching ":title"
 ```
 
+### Comments
+
+If you want to document the rules or headers, you can put comments on a separate lines, starting with an octothorpe (`#`). 
+
+```txt
+---
+filename: _headers
+---
+# source: https://example.org/some-security-headers
+/secure/page
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+```
+
+
 ## Examples
 
 ### Cross-Origin Resource Sharing (CORS)

--- a/products/pages/src/content/platform/headers.md
+++ b/products/pages/src/content/platform/headers.md
@@ -84,7 +84,7 @@ filename: _headers
 
 ### Comments
 
-If you want to document the rules or headers, you can put comments on a separate lines, starting with an octothorpe (`#`). 
+If you want to document the rules or headers, you can put comments on separate lines, starting with an octothorpe (`#`). 
 
 ```txt
 ---

--- a/products/pages/src/content/platform/headers.md
+++ b/products/pages/src/content/platform/headers.md
@@ -28,6 +28,7 @@ You can define as many `[name]: [value]` pairs as you require on subsequent line
 ---
 filename: _headers
 ---
+# This is a comment
 /secure/page
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
@@ -81,22 +82,6 @@ filename: _headers
 /movies/:title
   x-movie-name: You are watching ":title"
 ```
-
-### Comments
-
-If you want to document the rules or headers, you can put comments on separate lines, starting with an octothorpe (`#`). 
-
-```txt
----
-filename: _headers
----
-# source: https://example.org/some-security-headers
-/secure/page
-  X-Frame-Options: DENY
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: no-referrer
-```
-
 
 ## Examples
 


### PR DESCRIPTION
In the `_headers` documentation, I could not find how to do comments.

I've asked on Discord, and verified the answer.

I also noticed that `_redirects` lacks the same documentation, and though I suspect the syntax is the same, I did not verify that.