### PR TITLE
Rate Limiting Rules: Remove field references

### DIFF
--- a/products/waf/src/content/custom-rules/rate-limiting/create-api.md
+++ b/products/waf/src/content/custom-rules/rate-limiting/create-api.md
@@ -48,8 +48,7 @@ curl -X PUT \
         ],
         "period": 60,
         "requests_per_period": 100,
-        "mitigation_timeout": 600,
-        "mitigation_expression": ""
+        "mitigation_timeout": 600
       }
     }
   ]
@@ -80,8 +79,7 @@ header: Response
           ],
           "period": 60,
           "requests_per_period": 100,
-          "mitigation_timeout": 600,
-          "mitigation_expression": ""
+          "mitigation_timeout": 600
         },
         "expression": "(http.request.uri.path matches \"^/api/\")",
         "description": "My rate limiting rule",

--- a/products/waf/src/content/custom-rules/rate-limiting/parameters.md
+++ b/products/waf/src/content/custom-rules/rate-limiting/parameters.md
@@ -66,13 +66,6 @@ The available Rate Limiting rule parameters are the following:
     - Use one of the following values: `30`, `60` (one minute), `600` (ten minutes), `3600` (one hour), or `86400` (one day).
     - The value must be `0` when action is `challenge`, `js_challenge`, or `managed_challenge`.
 
-- `mitigation_expression` <Type>String</Type> <PropMeta>optional</PropMeta>
-    - Field name in the dashboard: N/A (currently only available via API).
-    - Scope of the mitigation action.
-    - Allows you to specify an action scope different from the rule scope. For example, you can count login attempts at the `/login` URI path using the `expression` field and then perform rate limiting on the entire site using the `mitigation_expression` field.
-    - The default value is `""` (empty string). When set to the default value, Cloudflare uses the value of the `expression` field as the mitigation expression.
-    - The value must be the same as the `expression` value or `""` when action is `challenge`, `js_challenge`, or `managed_challenge`.
-
 </Definitions>
 
 ## Recommendations

--- a/products/waf/src/content/custom-rules/rate-limiting/use-cases.md
+++ b/products/waf/src/content/custom-rules/rate-limiting/use-cases.md
@@ -49,7 +49,7 @@ Rule characteristics:
 
 ## Example 3
 
-The following rule performs rate limiting on requests targeting multiple URI paths in two hosts, excluding known bots. The request rate is based on IP address and `User-Agent` values. When the request rate is reached, Cloudflare performs rate limiting on all incoming requests for the two hosts.
+The following rule performs rate limiting on requests targeting multiple URI paths in two hosts, excluding known bots. The request rate is based on IP address and `User-Agent` values.
 
 <Example>
 
@@ -62,13 +62,4 @@ Rule characteristics:
 * _IP Address_
 * _HTTP Header_ > `user-agent`
 
-Mitigation expression:<br/>
-`(http.host eq "mystore1.com" or http.host eq "mystore2.com")`
-
 </Example>
-
-<Aside type='warning' header='Important'>
-
-You can only define a value for the **Mitigation expression** via API.
-
-</Aside>


### PR DESCRIPTION
Removes references to the `mitigation_expression` field.

Addresses https://jira.cfops.it/browse/PCX-3237.
