### PR TITLE
[Workers] avoid abstract equality for TLS checks

### DIFF
--- a/products/workers/src/content/examples/block-on-tls.md
+++ b/products/workers/src/content/examples/block-on-tls.md
@@ -20,7 +20,7 @@ async function handleRequest(request) {
     const tlsVersion = request.cf.tlsVersion
 
     // Allow only TLS versions 1.2 and 1.3
-    if (tlsVersion != "TLSv1.2" && tlsVersion != "TLSv1.3") {
+    if (tlsVersion !== "TLSv1.2" && tlsVersion !== "TLSv1.3") {
       return new Response("Please use TLS version 1.2 or higher.", {
         status: 403,
       })

--- a/products/workers/src/content/examples/security-headers.md
+++ b/products/workers/src/content/examples/security-headers.md
@@ -82,7 +82,7 @@ async function addHeaders(req) {
         newHeaders.delete(name)
     })
 
-    if (tlsVersion != "TLSv1.2" && tlsVersion != "TLSv1.3") {
+    if (tlsVersion !== "TLSv1.2" && tlsVersion !== "TLSv1.3") {
         return new Response("You need to use TLS version 1.2 or higher.", { status: 400 })
     } else {
         return new Response(response.body, {


### PR DESCRIPTION
- Abstract equality should be avoided in general (with some exceptions around `undefined`/`null`), but especially in examples related to security.