### PR TITLE
correction: API token is allowed to setup APO on subdomain

### DIFF
--- a/products/automatic-platform-optimization/src/content/reference/subdomain-subdirectories.md
+++ b/products/automatic-platform-optimization/src/content/reference/subdomain-subdirectories.md
@@ -11,7 +11,7 @@ pcx-content-type: how-to
 After you enable APO, you configure it to run on the subdomain that uses WordPress. For example, if you have a website called `www.mysite.com` which includes a subdomain running WordPress called `shop.mysite.com`, you would configure APO to run on the `shop.mysite.com` subdomain.
 
 1. Install version 4.4.0 or later of the Cloudflare WordPress plugin.
-1. Log in using **Global key**. (You can only use a Global key for the subdomain.)
+1. Log in using Cloudflare **API token** or **Global key**.
 1. Enable APO. The subdomain displays in the list of hostnames in the card.
 1. Repeat the process for each subdomain to enable APO.
 
@@ -35,25 +35,25 @@ If you choose to run APO only on a subdirectory, the rest of the domain should b
 
 The `cf-edge-cache: no-cache` instructs the APO service to bypass caching for non-WordPress parts of the site. You can implement this option with Cloudflare Workers using the example below.
 
-```js 
-  addEventListener("fetch", (event) => {
-     event.respondWith(handleRequest(event.request));
-    });
+```js
+addEventListener("fetch", (event) => {
+  event.respondWith(handleRequest(event.request));
+});
 
-    async function handleRequest(request) {
-     /**
-      * Response properties are immutable. To change them, construct a new
-      * Response object. Response headers can be modified through the headers `set` method.
-      */
-     const originalResponse = await fetch(request)
+async function handleRequest(request) {
+  /**
+   * Response properties are immutable. To change them, construct a new
+   * Response object. Response headers can be modified through the headers `set` method.
+   */
+  const originalResponse = await fetch(request);
 
-     let response = new Response(originalResponse.body, originalResponse);
+  let response = new Response(originalResponse.body, originalResponse);
 
-     // Add a header using set method
-     response.headers.set("cf-edge-cache", "no-cache")
+  // Add a header using set method
+  response.headers.set("cf-edge-cache", "no-cache");
 
-     return response
-    }
+  return response;
+}
 ```
 
 ### Use Page Rules


### PR DESCRIPTION
A follow-up for https://community.cloudflare.com/t/global-key-for-apo-on-a-subdomain/347262/5.