### PR TITLE
Update API token permissions and templates

### DIFF
--- a/products/api/src/content/tokens/create/permissions.md
+++ b/products/api/src/content/tokens/create/permissions.md
@@ -115,8 +115,8 @@ The applicable scope of zone permissions is `com.cloudflare.api.account.zone`.
 
 <TableWrap>
 
-|Name | Description |
-|-----|-------------|
+| Name | Description |
+|------|-------------|
 | Access: Apps and Policies Read | Grants read access to Cloudflare Access zone resources. |
 | Access: Apps and Policies Revoke | Grants ability to revoke all tokens to Cloudflare Access zone resources. |
 | Access: Apps and Policies Write | Grants write access to Cloudflare Access zone resources. |

--- a/products/api/src/content/tokens/create/permissions.md
+++ b/products/api/src/content/tokens/create/permissions.md
@@ -1,114 +1,161 @@
 ---
 order: 10
-type: table
+type: overview
 ---
 
-# API tokens permissions
+# API token permissions
 
 <ContentColumn>
 
-Below is a list of all the Token Permissions that are available to use. The current list can be [fetched via the API](https://api.cloudflare.com/#permission-groups-list-permission-groups) at any time.
+Below is a list of the available token permissions.
+
+To obtain an updated list of token permissions, including the permission ID and the scope of each permission, use the [List permission groups](https://api.cloudflare.com/#permission-groups-list-permission-groups) API method. 
 
 </ContentColumn>
 
 ## User permissions
 
+The applicable scope of user permissions is `com.cloudflare.api.user`.
+
 <TableWrap>
 
-|Name|ID|Description|Applicable Scope|
-|---|---|---|---|
-|API Tokens Read|0cc3a61731504c89b99ec1be78b77aa0|Grants read access to user's API Tokens|com.cloudflare.api.user|
-|API Tokens Write|686d18d5ac6c441c867cbf6771e58a0a|Grants write access to user's API Tokens|com.cloudflare.api.user|
-|Memberships Read|3518d0f75557482e952c6762d3e64903|Grants read access to a user's account memberships,|com.cloudflare.api.user|
-|Memberships Write|9201bc6f42d440968aaab0c6f17ebb1d|Grants write access to a user's account memberships|com.cloudflare.api.user|
-|User Details Read|8acbe5bb0d54464ab867149d7f7cf8ac|Grants read access to user details|com.cloudflare.api.user|
-|User Details Write|55a5e17cc99e4a3fa1f3432d262f2e55|Grants write access to user details|com.cloudflare.api.user|
+| Name | Description |
+|------|-------------|
+| API Tokens Read | Grants read access to user's API Tokens. |
+| API Tokens Write | Grants write access to user's API Tokens. |
+| Memberships Read | Grants read access to a user's account memberships. |
+| Memberships Write | Grants write access to a user's account memberships. |
+| User Details Read | Grants read access to user details. |
+| User Details Write | Grants write access to user details. |
 
 </TableWrap>
 
 ## Account permissions
 
+The applicable scope of account permissions is `com.cloudflare.api.account`.
+
 <TableWrap>
 
-|Name|ID|Description|Applicable Scope|
-|---|---|---|---|
-|Access: Apps and Policies Read|7ea222f6d5064cfa89ea366d7c1fee89|Grants read access to Cloudflare Access zone resources|com.cloudflare.api.account.zone|
-|Access: Apps and Policies Write|1e13c5124ca64b72b1969a67e8829049|Grants write access to Cloudflare Access zone resources|com.cloudflare.api.account.zone|
-|Access: Organizations, Identity Providers, and Groups Read|26bc23f853634eb4bff59983b9064fde|Grants read access to Cloudflare Access account resources|com.cloudflare.api.account|
-|Access: Organizations, Identity Providers, and Groups Write|bfe0d8686a584fa680f4c53b5eb0de6d|Grants write access to Cloudflare Access account resources|com.cloudflare.api.account|
-|Account Firewall Access Rules Read|de7a688cc47d43bd9ea700b467a09c96|Grants read access to account firewall access rules|com.cloudflare.api.account|
-|Account Firewall Access Rules Write|a416acf9ef5a4af19fb11ed3b96b1fe6|Grants write access to account firewall access rules|com.cloudflare.api.account|
-|Account Settings Read|c1fde68c7bcc44588cbb6ddbc16d6480|Grants read access to Account resources, account membership, and account level features|com.cloudflare.api.account|
-|Account Settings Write|1af1fa2adc104452b74a9a3364202f20|Grants write access to Account resources, account membership, and account level features|com.cloudflare.api.account|
-|Analytics Read|9c88f9c5bce24ce7af9a958ba9c504db|Grants read access to analytics|com.cloudflare.api.account.zone|
-|Apps Write|094547ab6e77498c8c4dfa87fadd5c51|Grants full access to Cloudflare Apps|com.cloudflare.api.account.zone|
-|Billing Read|7cf72faf220841aabcfdfab81c43c4f6|Grants read access to billing profile, subscriptions, and access to fetch invoices and entitlements|com.cloudflare.api.account|
-|Billing Write|6c80e02421494afc9ae14414ed442632|Grants write access to billing profile, subscriptions, and access to fetch invoices and entitlements|com.cloudflare.api.account|
-|Cache Purge|e17beae8b8cb423a99b1730f21238bed|Grants access to purge cache|com.cloudflare.api.account.zone|
-|DNS Firewall Read|5f48a472240a4b489a21d43bd19a06e1|Grants read access to DNS Firewall|com.cloudflare.api.account|
-|DNS Firewall Write|da6d2d6f2ec8442eaadda60d13f42bca|Grants write access to DNS Firewall|com.cloudflare.api.account|
-|DNS Read|82e64a83756745bbbb1c9c2701bf816b|Grants read access to DNS|com.cloudflare.api.account.zone|
-|DNS Write|4755a26eedb94da69e1066d98aa820be|Grants write access to DNS|com.cloudflare.api.account.zone|
-|Firewall Services Read|4ec32dfcb35641c5bb32d5ef1ab963b4|Grants read access to Firewall resources|com.cloudflare.api.account.zone|
-|Firewall Services Write|43137f8d07884d3198dc0ee77ca6e79b|Grants write access to Firewall resources|com.cloudflare.api.account.zone|
-|IP Prefixes: BGP On Demand Read|e763fae6ee95443b8f56f19213c5f2a5|Grants access to read ip prefix bgp configuration|com.cloudflare.api.account|
-|IP Prefixes: BGP On Demand Write|2ae23e4939d54074b7d252d27ce75a77|Grants access to read and change ip prefix bgp configuration|com.cloudflare.api.account|
-|Load Balancers Read|e9a975f628014f1d85b723993116f7d5|Grants read access to load balancers and associated resources|com.cloudflare.api.account.zone|
-|Load Balancers Write|6d7f2f5f5b1d4a0e9081fdc98d432fd1|Grants write access to load balancers and associated resources|com.cloudflare.api.account.zone|
-|Load Balancing: Monitors and Pools Read|9d24387c6e8544e2bc4024a03991339f|Grants read access to account level load balancer resources|com.cloudflare.api.account|
-|Load Balancing: Monitors and Pools Write|d2a1802cc9a34e30852f8b33869b2f3c|Grants write access to account level load balancer resources|com.cloudflare.api.account|
-|Logs Read|6a315a56f18441e59ed03352369ae956|Grants read access to logs and logpush jobs|com.cloudflare.api.account|
-|Logs Write|96163bd1b0784f62b3e44ed8c2ab1eb6|Grants write access to logpush jobs|com.cloudflare.api.account|
-|Page Rules Read|b415b70a4fd1412886f164451f20405c|Grants read access to Page Rules|com.cloudflare.api.account.zone|
-|Page Rules Write|ed07f6c337da4195b4e72a1fb2c6bcae|Grants write access to Page Rules|com.cloudflare.api.account.zone|
-|SSL and Certificates Read|7b7216b327b04b8fbc8f524e1f9b7531|Grants read access to SSL configuration and cert management|com.cloudflare.api.account.zone|
-|SSL and Certificates Write|c03055bc037c4ea9afb9a9f104b7b721|Grants write access to SSL configuration and cert management|com.cloudflare.api.account.zone|
-|Stream Read|de21485a24744b76a004aa153898f7fe|Grants read access to Cloudflare Stream|com.cloudflare.api.account|
-|Stream Write|714f9c13a5684c2885a793f5edb36f59|Grants write access to Cloudflare Stream|com.cloudflare.api.account|
-|Teams Read|3f376c8e6f764a938b848bd01c8995c4|Grants read access to teams|com.cloudflare.api.account|
-|Teams Report|efb81b5cd37d49f3be1da9363a6d7a19|Grants reporting access to teams|com.cloudflare.api.account|
-|Teams Write|b33f02c6f7284e05a6f20741c0bb0567|Grants write access to teams|com.cloudflare.api.account|
-|Workers KV Storage Read|8b47d2786a534c08a1f94ee8f9f599ef|Grants read access to Cloudflare Workers KV Storage|com.cloudflare.api.account|
-|Workers KV Storage Write|f7f0eda5697f475c90846e879bab8666|Grants write access to Cloudflare Workers KV Storage|com.cloudflare.api.account|
-|Workers Routes Read|2072033d694d415a936eaeb94e6405b8|Grants read access to Cloudflare Workers and Workers KV Storage|com.cloudflare.api.account.zone|
-|Workers Routes Write|28f4b596e7d643029c524985477ae49a|Grants write access to Cloudflare Workers and Workers KV Storage|com.cloudflare.api.account.zone|
-|Workers Scripts Read|1a71c399035b4950a1bd1466bbe4f420|Grants read access to Cloudflare Workers scripts|com.cloudflare.api.account|
-|Workers Scripts Write|e086da7e2179491d91ee5f35b3ca210a|Grants write access to Cloudflare Workers scripts|com.cloudflare.api.account|
-|Zone Read|c8fed203ed3043cba015a93ad1616f1f|Grants read access to zone management|com.cloudflare.api.account.zone|
-|Zone Settings Read|517b21aee92c4d89936c976ba6e4be55|Grants read access to zone settings|com.cloudflare.api.account.zone|
-|Zone Settings Write|3030687196b94b638145a3953da2b699|Grants write access to zone settings|com.cloudflare.api.account.zone|
-|Zone Write|e6d2666161e84845a636613608cee8d5|Grants write access to zone management|com.cloudflare.api.account.zone|
+| Name | Description |
+|------|-------------|
+| Access: Apps and Policies Read | Grants read access to Cloudflare Access account resources.|
+| Access: Apps and Policies Revoke | Grants ability to revoke all tokens to Cloudflare Access account resources.|
+| Access: Apps and Policies Write | Grants write access to Cloudflare Access account resources.|
+| Access: Audit Logs Read | Grants read access to Cloudflare Access audit logs.|
+| Access: Certificates Read | Grants read access to Cloudflare Access mTLS certificates.|
+| Access: Certificates Write | Grants write access to Cloudflare Access mTLS certificates.|
+| Access: Device Posture Read | Grants read access to Cloudflare Access Device Posture.|
+| Access: Device Posture Write | Grants write access to Cloudflare Access Device Posture.|
+| Access: Organizations, Identity Providers, and Groups Read | Grants read access to Cloudflare Access account resources.|
+| Access: Organizations, Identity Providers, and Groups Revoke | Grants ability to revoke user sessions to Cloudflare Access account resources. |
+| Access: Organizations, Identity Providers, and Groups Write | Grants write access to Cloudflare Access account resources. |
+| Access: Service Tokens Read | Grants read access to Cloudflare Access Service Tokens. |
+| Access: Service Tokens Write | Grants write access to Cloudflare Access Service Tokens. |
+| Account Analytics Read | Grants read access to analytics. |
+| Account Firewall Access Rules Read | Grants read access to account firewall access rules. |
+| Account Firewall Access Rules Write | Grants write access to account firewall access rules. |
+| Account Rule Lists Read | Grants read access to Rule Lists. |
+| Account Rule Lists Write | Grants write access to Rule Lists. |
+| Account Rulesets Read | Grants read access to Account Rulesets. |
+| Account Rulesets Write | Grants write access to Account Rulesets. |
+| Account Settings Read | Grants read access to Account resources, account membership, and account level features. |
+| Account Settings Write | Grants write access to Account resources, account membership, and account level features. |
+| Account WAF Read | Grants read access to Account WAF. |
+| Account WAF Write | Grants write access to Account WAF. |
+| Argo Tunnel Read | Grants access to view Argo Tunnels. |
+| Argo Tunnel Write | Grants access to create and delete Argo Tunnels. |
+| Billing Read | Grants read access to billing profile, subscriptions, and access to fetch invoices and entitlements. |
+| Billing Write | Grants write access to billing profile, subscriptions, and access to fetch invoices and entitlements. |
+| DDoS Protection Read | Grants read access to DDoS protection. |
+| DDoS Protection Write | Grants write access to DDoS protection. |
+| DNS Firewall Read | Grants read access to DNS Firewall. |
+| DNS Firewall Write | Grants write access to DNS Firewall. |
+| IP Prefixes: BGP On Demand Read | Grants access to read IP prefix BGP configuration. |
+| IP Prefixes: BGP On Demand Write | Grants access to read and change IP prefix BGP configuration. |
+| IP Prefixes: Read | Grants access to read IP prefix settings. |
+| IP Prefixes: Write | Grants access to read/write IP prefix settings. |
+| Images Read | Grants read access to Images. |
+| Images Write | Grants write access to upload Images. |
+| L4 DDoS Managed Ruleset Read | Grants read access to L4 DDoS Managed Ruleset. |
+| L4 DDoS Managed Ruleset Write | Grants write access to L4 DDoS Managed Ruleset. |
+| Load Balancing: Monitors and Pools Read | Grants read access to account level load balancer resources. |
+| Load Balancing: Monitors and Pools Write | Grants write access to account level load balancer resources. |
+| Logs Read | Grants read access to logs and Logpush jobs. |
+| Logs Write | Grants write access to Logpush jobs. |
+| Magic Firewall Packet Captures - Read PCAPs API | Grants read access to Packet Captures. |
+| Magic Firewall Packet Captures - Write PCAPs API | Grants write access to Packet Captures. |
+| Magic Firewall Read | Grants read access to Magic Firewall. |
+| Magic Firewall Write | Grants write access to Magic Firewall. |
+| Magic Transit Prefix Read | Grants read access to manage a user's Magic Transit prefixes. |
+| Magic Transit Prefix Write | Grants write access to manage a user's Magic Transit prefixes. |
+| Bulk URL Redirects Read | Grants read access to Bulk URL Redirects. |
+| Bulk URL Redirects Write | Grants write access to Bulk URL Redirects. |
+| Rule Policies Read | Grants read access to Rule Policies. |
+| Rule Policies Write | Grants write access to Rule Policies. |
+| Stream Read | Grants read access to Cloudflare Stream. |
+| Stream Write | Grants write access to Cloudflare Stream. |
+| Teams Read | Grants read access to teams. |
+| Teams Report | Grants reporting access to teams. |
+| Teams Write | Grants write access to teams. |
+| Transform Rules Read | Grants read access to Transform Rules. |
+| Transform Rules Write | Grants write access to Transform Rules. |
+| Workers KV Storage Read | Grants read access to Cloudflare Workers KV Storage. |
+| Workers KV Storage Write | Grants write access to Cloudflare Workers KV Storage. |
+| Workers R2 Storage Read | Grants read access to Cloudflare R2 Storage. |
+| Workers R2 Storage Write | Grants write access to Cloudflare R2 Storage. |
+| Workers Scripts Read | Grants read access to Cloudflare Workers scripts. |
+| Workers Scripts Write | Grants write access to Cloudflare Workers scripts. |
+| Workers Tail Read | Grants `wrangler tail` read permissions. |
 
 </TableWrap>
 
 ## Zone permissions
 
+The applicable scope of zone permissions is `com.cloudflare.api.account.zone`.
+
 <TableWrap>
 
-|Name|ID|Description|Applicable Scope|
-|---|---|---|---|
-|Access: Apps and Policies Read|7ea222f6d5064cfa89ea366d7c1fee89|Grants read access to Cloudflare Access zone resources|com.cloudflare.api.account.zone|
-|Access: Apps and Policies Write|1e13c5124ca64b72b1969a67e8829049|Grants write access to Cloudflare Access zone resources|com.cloudflare.api.account.zone|
-|Analytics Read|9c88f9c5bce24ce7af9a958ba9c504db|Grants read access to analytics|com.cloudflare.api.account.zone|
-|Apps Write|094547ab6e77498c8c4dfa87fadd5c51|Grants full access to Cloudflare Apps|com.cloudflare.api.account.zone|
-|Cache Purge|e17beae8b8cb423a99b1730f21238bed|Grants access to purge cache|com.cloudflare.api.account.zone|
-|DNS Read|82e64a83756745bbbb1c9c2701bf816b|Grants read access to DNS|com.cloudflare.api.account.zone|
-|DNS Write|4755a26eedb94da69e1066d98aa820be|Grants write access to DNS|com.cloudflare.api.account.zone|
-|Firewall Services Read|4ec32dfcb35641c5bb32d5ef1ab963b4|Grants read access to Firewall resources|com.cloudflare.api.account.zone|
-|Firewall Services Write|43137f8d07884d3198dc0ee77ca6e79b|Grants write access to Firewall resources|com.cloudflare.api.account.zone|
-|Load Balancers Read|e9a975f628014f1d85b723993116f7d5|Grants read access to load balancers and associated resources|com.cloudflare.api.account.zone|
-|Load Balancers Write|6d7f2f5f5b1d4a0e9081fdc98d432fd1|Grants write access to load balancers and associated resources|com.cloudflare.api.account.zone|
-|Logs Read|c4a30cd58c5d42619c86a3c36c441e2d|Grants read access to logs and logpush jobs|com.cloudflare.api.account.zone|
-|Logs Write|3e0b5820118e47f3922f7c989e673882|Grants write access to logpush jobs|com.cloudflare.api.account.zone|
-|Page Rules Read|b415b70a4fd1412886f164451f20405c|Grants read access to Page Rules|com.cloudflare.api.account.zone|
-|Page Rules Write|ed07f6c337da4195b4e72a1fb2c6bcae|Grants write access to Page Rules|com.cloudflare.api.account.zone|
-|SSL and Certificates Read|7b7216b327b04b8fbc8f524e1f9b7531|Grants read access to SSL configuration and cert management|com.cloudflare.api.account.zone|
-|SSL and Certificates Write|c03055bc037c4ea9afb9a9f104b7b721|Grants write access to SSL configuration and cert management|com.cloudflare.api.account.zone|
-|Workers Routes Read|2072033d694d415a936eaeb94e6405b8|Grants read access to Cloudflare Workers and Workers KV Storage|com.cloudflare.api.account.zone|
-|Workers Routes Write|28f4b596e7d643029c524985477ae49a|Grants write access to Cloudflare Workers and Workers KV Storage|com.cloudflare.api.account.zone|
-|Zone Read|c8fed203ed3043cba015a93ad1616f1f|Grants read access to zone management|com.cloudflare.api.account.zone|
-|Zone Settings Read|517b21aee92c4d89936c976ba6e4be55|Grants read access to zone settings|com.cloudflare.api.account.zone|
-|Zone Settings Write|3030687196b94b638145a3953da2b699|Grants write access to zone settings|com.cloudflare.api.account.zone|
-|Zone Write|e6d2666161e84845a636613608cee8d5|Grants write access to zone management|com.cloudflare.api.account.zone|
+|Name | Description |
+|-----|-------------|
+| Access: Apps and Policies Read | Grants read access to Cloudflare Access zone resources. |
+| Access: Apps and Policies Revoke | Grants ability to revoke all tokens to Cloudflare Access zone resources. |
+| Access: Apps and Policies Write | Grants write access to Cloudflare Access zone resources. |
+| Analytics Read | Grants read access to analytics. |
+| Apps Write | Grants full access to Cloudflare Apps. |
+| Bot Management Read | Grants read access to Bot Management. |
+| Bot Management Write | Grants write access to Bot Management. |
+| Cache Purge | Grants access to purge cache. |
+| DNS Read | Grants read access to DNS. |
+| DNS Write | Grants write access to DNS. |
+| Firewall Services Read | Grants read access to Firewall resources. |
+| Firewall Services Write | Grants write access to Firewall resources. |
+| HTTP DDoS Managed Ruleset Read | Grants read access to HTTP DDoS Managed Ruleset. |
+| HTTP DDoS Managed Ruleset Write | Grants write access to HTTP DDoS Managed Ruleset. |
+| Health Checks Read | Grants read access to Health Checks. |
+| Health Checks Write | Grants write access to Health Checks. |
+| Load Balancers Read | Grants read access to load balancers and associated resources. |
+| Load Balancers Write | Grants write access to load balancers and associated resources. |
+| Logs Read | Grants read access to logs and Logpush jobs. |
+| Logs Write | Grants write access to Logpush jobs. |
+| Page Rules Read | Grants read access to Page Rules. |
+| Page Rules Write | Grants write access to Page Rules. |
+| SSL and Certificates Read | Grants read access to SSL configuration and certificate management. |
+| SSL and Certificates Write | Grants write access to SSL configuration and certificate management. |
+| Sanitize Read | Grants read access to sanitization. |
+| Sanitize Write | Grants write access to sanitization. |
+| Waiting Rooms Read | Grants read access to Waiting Rooms. |
+| Waiting Rooms Write | Grants write access to Waiting Rooms. |
+| Web3 Hostnames Read | Grants read access to Web3 Hostnames. |
+| Web3 Hostnames Write | Grants write access to Web3 Hostnames. |
+| Workers Routes Read | Grants read access to Cloudflare Workers and Workers KV Storage. |
+| Workers Routes Write | Grants write access to Cloudflare Workers and Workers KV Storage. |
+| Zone Read | Grants read access to zone management. |
+| Zone Settings Read | Grants read access to zone settings. |
+| Zone Settings Write | Grants write access to zone settings. |
+| Zone Transform Rules Read | Grants read access to Transform Rules at zone level. |
+| Zone Transform Rules Write | Grants write access to Transform Rules at zone level. |
+| Zone WAF Read | Grants read access to Zone WAF. |
+| Zone WAF Write | Grants write access to Zone WAF. |
+| Zone Write | Grants write access to zone management. |
 
 </TableWrap>

--- a/products/api/src/content/tokens/create/template.md
+++ b/products/api/src/content/tokens/create/template.md
@@ -1,13 +1,13 @@
 ---
 order: 5
-type: table
+type: overview
 ---
 
 # API token templates
 
 <ContentColumn>
 
-Below is a table of the currently available API Token Templates and access they grant. You can start creating a token with one of these templates and modify the permissions and resources from there.
+Below is a table of the currently available API token templates and the default [token permissions](/tokens/create/permissions) they grant. You can start creating a token with one of these templates and modify the permissions and resources from there.
 
 </ContentColumn>
 
@@ -22,20 +22,20 @@ Below is a table of the currently available API Token Templates and access they 
     </tr>
     <tr>
       <td>Edit Zone DNS</td>
-      <td>DNS Edit</td>
+      <td>DNS Write</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td rowspan="2">Read Billing Info</td>
-      <td>Read Billing</td>
+      <td rowspan="2">Read billing info</td>
+      <td>Billing Read</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Read Accounts</td>
-      <td>Account</td>
+      <td>Account resources: Include all accounts</td>
+      <td></td>
     </tr>
     <tr>
-      <td rowspan="2">Read Analytics and Logs</td>
+      <td rowspan="2">Read analytics and logs</td>
       <td>Analytics Read</td>
       <td>Zone</td>
     </tr>
@@ -44,69 +44,93 @@ Below is a table of the currently available API Token Templates and access they 
       <td>Zone</td>
     </tr>
     <tr>
-      <td rowspan="5">Edit Cloudflare Workers</td>
-      <td>Edit Workers Routes</td>
+      <td rowspan="7">Edit Cloudflare Workers</td>
+      <td>Workers Routes Write</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td>Edit Workers Scripts</td>
+      <td>Workers Scripts Write</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Edit Workers KV</td>
+      <td>Workers KV Storage Write</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Read Account Settings</td>
+      <td>Workers Tail Read</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Read User Profile</td>
+      <td>Workers R2 Storage Write</td>
+      <td>Account</td>
+    </tr>
+    <tr>
+      <td>Account Settings Read</td>
+      <td>Account</td>
+    </tr>
+    <tr>
+      <td>User Details Read</td>
       <td>User</td>
     </tr>
     <tr>
       <td rowspan="2">Edit load balancing configuration</td>
-      <td>Edit Load Balancing: Monitors and Pools</td>
+      <td>Load Balancing: Monitors and Pools Write</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Edit Load Balancers</td>
+      <td>Load Balancers Write</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td rowspan="6">WordPress</td>
-      <td>Read Analytics</td>
+      <td rowspan="8">WordPress</td>
+      <td>Analytics Read</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td>Read Zones</td>
+      <td>Zone Read</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td>Edit Zone Settings</td>
+      <td>Zone Settings Write</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td>Read Account Settings</td>
+      <td>Account Settings Read</td>
       <td>Account</td>
     </tr>
     <tr>
-      <td>Read DNS</td>
+      <td>DNS Read</td>
       <td>Zone</td>
     </tr>
     <tr>
-      <td>Purge Cache</td>
+      <td>Cache Purge</td>
       <td>Zone</td>
+    </tr>
+    <tr>
+      <td>Account resources: Include all accounts</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Zone resources: Include all zones</td>
+      <td></td>
     </tr>
     <tr>
       <td>Create Additional Tokens</td>
-      <td>Edit API Tokens</td>
+      <td>API Tokens Write</td>
       <td>User</td>
     </tr>
     <tr>
-      <td>Read all resources</td>
-      <td><em>All Read Permissions</em></td>
-      <td><em>Account & Zone</em></td>
+      <td rowspan="3">Read All Resources</td>
+      <td><em>(All read permissions)</em></td>
+      <td>Account, Zone, User</td>
+    </tr>
+    <tr>
+      <td>Account resources: Include all accounts</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Zone resources: Include all zones</td>
+      <td></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Addresses https://jira.cfops.it/browse/PCX-3227.

- Removes permission IDs from Dev Docs, since some of them were incorrect and users can obtain the latest information using an API call.
- API permission descriptions, except for the occasional fix, come straight from the API call response.
- API token templates were missing some permissions already in production.