### PR TITLE
[PAGES] Update Pages asset max size in limits.md & deploy-a-blazor-site.md

### DIFF
--- a/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
+++ b/products/pages/src/content/framework-guides/deploy-a-blazor-site.md
@@ -75,9 +75,9 @@ Every time you commit new code to your Blazor site, Cloudflare Pages will automa
 
 ## Troubleshooting
 
-### A file is over the 25MB limit
+### A file is over the 25MiB limit
 
-If you receive the error message `Error: Asset "/opt/buildhome/repo/output/wwwroot/_framework/dotnet.wasm" is over the 25MB limit`, you have two options:
+If you receive the error message `Error: Asset "/opt/buildhome/repo/output/wwwroot/_framework/dotnet.wasm" is over the 25MiB limit`, you have two options:
 
 1. Reduce the size of your assets with the following [guide](https://docs.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-6.0#minimize-app-download-size).
 

--- a/products/pages/src/content/platform/limits.md
+++ b/products/pages/src/content/platform/limits.md
@@ -23,7 +23,7 @@ Pages uploads each file on your site to Cloudflare's globally distributed networ
 
 ## File size
 
-The maximum file size for a single Cloudflare Pages site asset is 25MB.
+The maximum file size for a single Cloudflare Pages site asset is 25MiB.
 
 ## Headers
 


### PR DESCRIPTION
- The per-file limit for Pages assets has been changed from 25MB to 25MiB.