### PR TITLE
Rules: Use API tokens in examples

### DIFF
--- a/products/rules/src/content/bulk-redirects/create-api.md
+++ b/products/rules/src/content/bulk-redirects/create-api.md
@@ -11,6 +11,11 @@ To create Bulk Redirects via API, you must:
 1. Add items (URL Redirects) to the list created in step 1.
 1. Create a Bulk Redirect Rule via API, which enables the list created in step 1.
 
+The API token used in API requests to manage Bulk Redirects objects (lists, list items, and rules) must have at least the following permissions:
+
+* Account Rulesets: Edit
+* Account Filter Lists: Edit
+
 ## 1. Create a Bulk Redirect List via API
 
 Use the [Create list](https://api.cloudflare.com/#rules-lists-create-list) operation to create a new Bulk Redirect List. The list `kind` must be `redirect`.

--- a/products/rules/src/content/bulk-redirects/create-api.md
+++ b/products/rules/src/content/bulk-redirects/create-api.md
@@ -16,10 +16,9 @@ To create Bulk Redirects via API, you must:
 Use the [Create list](https://api.cloudflare.com/#rules-lists-create-list) operation to create a new Bulk Redirect List. The list `kind` must be `redirect`.
 
 ```json
-curl -X POST \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists" \
--H "X-Auth-Email: <EMAIL>" \
--H "X-Auth-Key: <KEY>" \
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "name": "my_redirect_list",
   "description": "My redirect list.",
@@ -54,10 +53,9 @@ For more information on list operations, refer to the [Rules Lists API](https://
 Use the [Create list items](https://api.cloudflare.com/#rules-lists-create-list-items) operation to add URL Redirect items to the list:
 
 ```json
-curl -X POST \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists/f848b6ccb07647749411f504d6f88794/items" \
--H "X-Auth-Email: <EMAIL>" \
--H "X-Auth-Key: <KEY>" \
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists/f848b6ccb07647749411f504d6f88794/items" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '[
   {
     "redirect": {
@@ -92,8 +90,7 @@ This is an asynchronous operation. The response will contain an `operation_id` w
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists/bulk_operations/92558f8b296d4dbe9d0419e0e53f6622" \
--H "X-Auth-Email: <EMAIL>" \
--H "X-Auth-Key: <KEY>"
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 If the operation already completed successfully, the response will be similar to the following:
@@ -125,9 +122,9 @@ A Bulk Redirect Rule must have:
 The following request of the [Create account ruleset](https://api.cloudflare.com/#account-rulesets-create-account-ruleset) operation creates a phase entry point ruleset for the `http_request_redirect` phase at the account level, and defines a single redirect rule. Use this operation if you have not created a phase entry point ruleset for the `http_request_redirect` phase yet.
 
 ```json
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
--H "X-Auth-Key: <KEY>" \
--H "X-Auth-Email: <EMAIL>" \
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "name": "My redirect ruleset",
   "kind": "root",
@@ -185,9 +182,10 @@ The response will be similar to the following:
 If there is already a phase entry point ruleset for the `http_request_redirect` phase, use the [Update account ruleset](https://api.cloudflare.com/#account-rulesets-update-account-ruleset) operation instead, like in the following example:
 
 ```json
-curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
--H "X-Auth-Key: <KEY>" \
--H "X-Auth-Email: <EMAIL>" \
+curl -X PUT \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "name": "My redirect ruleset",
   "kind": "root",

--- a/products/rules/src/content/transform/request-header-modification/create-api.md
+++ b/products/rules/src/content/transform/request-header-modification/create-api.md
@@ -34,16 +34,16 @@ Follow this workflow to create an HTTP Request Header Modification Rule for a gi
 <summary>Example: Add an HTTP request header with a static value</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Request Header Modification Rule — adding an HTTP request header with a static value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Request Header Modification Rule — adding an HTTP request header with a static value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -71,14 +71,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Late Transform Ruleset",
     "description": "Zone-level ruleset that will execute Late Transform Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -92,7 +92,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Request Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",
@@ -111,16 +111,16 @@ header: Response
 <summary>Example: Add an HTTP request header with a dynamic value</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Request Header Modification Rule — adding an HTTP request header with a dynamic value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Request Header Modification Rule — adding an HTTP request header with a dynamic value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -148,14 +148,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Late Transform Ruleset",
     "description": "Zone-level ruleset that will execute Late Transform Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -169,7 +169,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Request Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",
@@ -188,16 +188,16 @@ header: Response
 <summary>Example: Remove an HTTP request header</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Request Header Modification Rule — removing an HTTP request header — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Request Header Modification Rule — removing an HTTP request header — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -224,14 +224,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Late Transform Ruleset",
     "description": "Zone-level ruleset that will execute Late Transform Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -244,7 +244,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Request Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",

--- a/products/rules/src/content/transform/request-header-modification/create-api.md
+++ b/products/rules/src/content/transform/request-header-modification/create-api.md
@@ -28,7 +28,14 @@ Follow this workflow to create an HTTP Request Header Modification Rule for a gi
 
 1. Use the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method to add an HTTP Request Header Modification Rule to the list of ruleset rules (check the examples below). Alternatively, include the rule in the [Create ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/create) request mentioned in the previous step.
 
-### Examples
+## Required API token permissions
+
+The API token used in API requests to manage HTTP Request Header Modification Rules must have at least the following permissions:
+
+* Transform Rules: Edit
+* Account Rulesets: Read
+
+## Examples
 
 <details>
 <summary>Example: Add an HTTP request header with a static value</summary>

--- a/products/rules/src/content/transform/response-header-modification/create-api.md
+++ b/products/rules/src/content/transform/response-header-modification/create-api.md
@@ -34,16 +34,16 @@ Follow this workflow to create an HTTP Response Header Modification Rule for a g
 <summary>Example: Add an HTTP response header with a static value</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Response Header Modification Rule — adding an HTTP response header with a static value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Response Header Modification Rule — adding an HTTP response header with a static value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -71,14 +71,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Response Headers Transform Ruleset",
     "description": "Zone-level ruleset that will execute Response Header Modification Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -92,7 +92,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Response Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",
@@ -111,16 +111,16 @@ header: Response
 <summary>Example: Add an HTTP response header with a dynamic value</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Response Header Modification Rule — adding an HTTP response header with a dynamic value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Response Header Modification Rule — adding an HTTP response header with a dynamic value — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -148,14 +148,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Response Headers Transform Ruleset",
     "description": "Zone-level ruleset that will execute Response Header Modification Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -169,7 +169,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Response Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",
@@ -188,16 +188,16 @@ header: Response
 <summary>Example: Remove an HTTP response header</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single HTTP Response Header Modification Rule — removing an HTTP response header — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single HTTP Response Header Modification Rule — removing an HTTP response header — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -224,14 +224,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Response Headers Transform Ruleset",
     "description": "Zone-level ruleset that will execute Response Header Modification Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -244,7 +244,7 @@ header: Response
         "expression": "(starts_with(http.request.uri.path, \"/en/\"))",
         "description": "My first HTTP Response Header Modification Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",

--- a/products/rules/src/content/transform/response-header-modification/create-api.md
+++ b/products/rules/src/content/transform/response-header-modification/create-api.md
@@ -28,7 +28,14 @@ Follow this workflow to create an HTTP Response Header Modification Rule for a g
 
 1. Use the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method to add an HTTP Response Header Modification Rule to the list of ruleset rules (check the examples below). Alternatively, include the rule in the [Create ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/create) request mentioned in the previous step.
 
-### Examples
+## Required API token permissions
+
+The API token used in API requests to manage HTTP Response Header Modification Rules must have at least the following permissions:
+
+* Transform Rules: Edit
+* Account Rulesets: Read
+
+## Examples
 
 <details>
 <summary>Example: Add an HTTP response header with a static value</summary>

--- a/products/rules/src/content/transform/url-rewrite/create-api.md
+++ b/products/rules/src/content/transform/url-rewrite/create-api.md
@@ -34,16 +34,16 @@ Follow this workflow to create a URL Rewrite Rule for a given zone via API:
 <summary>Example: Add a rule that performs a static URL rewrite</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single URL Rewrite Rule — performing a static rewrite of the URI path — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single URL Rewrite Rule — performing a static rewrite of the URI path — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -70,14 +70,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Transform Ruleset",
     "description": "Zone-level ruleset that will execute Transform Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -90,7 +90,7 @@ header: Response
         "expression": "(http.request.uri.query contains \"eu\")",
         "description": "My first static URL Rewrite Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",
@@ -109,16 +109,16 @@ header: Response
 <summary>Example: Add a rule that performs a dynamic URL rewrite</summary>
 <div>
 
-The following example sets the rules of an existing phase ruleset (`{ruleset-id}`) to a single URL Rewrite Rule — performing a dynamic rewrite of the URI path — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
+The following example sets the rules of an existing phase ruleset (`<RULESET_ID>`) to a single URL Rewrite Rule — performing a dynamic rewrite of the URI path — using the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method:
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "rules": [
     {
@@ -145,14 +145,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level Transform Ruleset",
     "description": "Zone-level ruleset that will execute Transform Rules.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "rewrite",
         "action_parameters": {
@@ -165,7 +165,7 @@ header: Response
         "expression": "starts_with(http.request.uri.path, \"/news/2012/\")",
         "description": "My first dynamic URL Rewrite Rule",
         "last_updated": "2021-04-14T14:42:04.219025Z",
-        "ref": "{rule-ref}"
+        "ref": "<RULE_REF>"
       }
     ],
     "last_updated": "2021-04-14T14:42:04.219025Z",

--- a/products/rules/src/content/transform/url-rewrite/create-api.md
+++ b/products/rules/src/content/transform/url-rewrite/create-api.md
@@ -28,7 +28,14 @@ Follow this workflow to create a URL Rewrite Rule for a given zone via API:
 
 1. Use the [Update ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/update) method to add a URL Rewrite Rule to the list of ruleset rules (check the examples below). Alternatively, include the rule in the [Create ruleset](https://developers.cloudflare.com/ruleset-engine/rulesets-api/create) request mentioned in the previous step.
 
-### Examples
+## Required API token permissions
+
+The API token used in API requests to manage URL Rewrite Rules must have at least the following permissions:
+
+* Transform Rules: Edit
+* Account Rulesets: Read
+
+## Examples
 
 <details>
 <summary>Example: Add a rule that performs a static URL rewrite</summary>


### PR DESCRIPTION
Addresses https://jira.cfops.it/browse/PCX-3289.

- Use API tokens instead of API key + email in `curl` examples
- Remove `-X POST` when there's a request body (it's the default method)
- Clean up the placeholder names according to our guidelines
- Mention required API token permissions