### PR TITLE
Clarify that durable objects storage pricing applies only to uses of …

### DIFF
--- a/products/workers/src/content/platform/pricing.md
+++ b/products/workers/src/content/platform/pricing.md
@@ -133,7 +133,7 @@ Total = ~$38.73 USD + $409.72 USD + Minimum $5/mo usage = $453.45
 
 ## Durable Objects storage API
 
-The Durable Objects storage API is only accessible from within Durable Objects.
+The [Durable Objects storage API](/runtime-apis/durable-objects#transactional-storage-api) is only accessible from within Durable Objects. Durable Objects do not have to use the storage API, but if your code does call methods on `state.storage`, it will incur the following additional charges:
 
 <TableWrap>
 


### PR DESCRIPTION
…the storage api

Someone on Discord was confused about whether storage pricing is always incurred on every request