### PR TITLE
Fix interim content types

### DIFF
--- a/products/distributed-web/src/content/index.md
+++ b/products/distributed-web/src/content/index.md
@@ -2,7 +2,7 @@
 title: Overview
 order: 0
 type: overview
-pcx-content: landing-page
+pcx-content-type: overview
 ---
 
 # Cloudflare Distributed Web docs

--- a/products/randomness-beacon/src/content/cryptographic-background/randomness-generation.md
+++ b/products/randomness-beacon/src/content/cryptographic-background/randomness-generation.md
@@ -1,6 +1,6 @@
 ---
 order: 1
-pcx-content-type: interim
+pcx-content-type: concept
 ---
 
 # Randomness Generation

--- a/products/randomness-beacon/src/content/cryptographic-background/setup-phase.md
+++ b/products/randomness-beacon/src/content/cryptographic-background/setup-phase.md
@@ -1,6 +1,6 @@
 ---
 order: 0
-pcx-content-type: interim
+pcx-content-type: concept
 ---
 
 # Setup Phase

--- a/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/custom-metadata.md
+++ b/products/ssl/src/content/ssl-for-saas/hostname-specific-behavior/custom-metadata.md
@@ -1,6 +1,6 @@
 ---
 order: 1
-pcx-content-type:  interim
+pcx-content-type: concept
 ---
 
 import PlanLimitation from "../../_partials/_ssl-for-saas-plan-limitation.md"

--- a/products/waf/src/content/exposed-credentials-check/configure-api.md
+++ b/products/waf/src/content/exposed-credentials-check/configure-api.md
@@ -1,5 +1,5 @@
 ---
-pcx-content-type: interim
+pcx-content-type: how-to
 order: 3
 ---
 

--- a/products/warp-client/src/content/legal/3rdparty.md
+++ b/products/warp-client/src/content/legal/3rdparty.md
@@ -1,6 +1,7 @@
 ---
 title: Third party licenses
 hidden: true
+pcx-content-type: reference
 ---
 # Third party licenses
 Following is the third party license information for our desktop applications. License information for our iOS and Android clients can be found in-app.

--- a/products/warp-client/src/content/legal/index.md
+++ b/products/warp-client/src/content/legal/index.md
@@ -1,5 +1,6 @@
 ---
 order: 10
+pcx-content-type: navigation
 ---
 
 # Legal

--- a/products/workers/src/content/platform/changelog.md
+++ b/products/workers/src/content/platform/changelog.md
@@ -1,3 +1,7 @@
+---
+pcx-content-type: changelog
+---
+
 # Changelog
 
 ## 2022-01-20


### PR DESCRIPTION
These changes are not customer-facing. They only affect non-visible metadata on our docs that we use for internal reporting purposes.