### PR TITLE
WAF: Add missing content type information

### DIFF
--- a/products/waf/src/content/change-log/2019-09-16.md
+++ b/products/waf/src/content/change-log/2019-09-16.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 1000
+pcx-content-type: changelog
 ---
 
 # 2019-09-16

--- a/products/waf/src/content/change-log/2019-09-26---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-09-26---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-09-26 – Emergency"
 type: table
 order: 999
+pcx-content-type: changelog
 ---
 
 # 2019-09-26 – Emergency release

--- a/products/waf/src/content/change-log/2019-09-30.md
+++ b/products/waf/src/content/change-log/2019-09-30.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 998
+pcx-content-type: changelog
 ---
 
 # 2019-09-30

--- a/products/waf/src/content/change-log/2019-10-07.md
+++ b/products/waf/src/content/change-log/2019-10-07.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 997
+pcx-content-type: changelog
 ---
 
 # 2019-10-07

--- a/products/waf/src/content/change-log/2019-10-14.md
+++ b/products/waf/src/content/change-log/2019-10-14.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 996
+pcx-content-type: changelog
 ---
 
 # 2019-10-14

--- a/products/waf/src/content/change-log/2019-10-17---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-10-17---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-10-17 – Emergency"
 type: table
 order: 995
+pcx-content-type: changelog
 ---
 
 # 2019-10-17 – Emergency release

--- a/products/waf/src/content/change-log/2019-10-21.md
+++ b/products/waf/src/content/change-log/2019-10-21.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 994
+pcx-content-type: changelog
 ---
 
 # 2019-10-21

--- a/products/waf/src/content/change-log/2019-10-23---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-10-23---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-10-23 – Emergency"
 type: table
 order: 993
+pcx-content-type: changelog
 ---
 
 # 2019-10-23 – Emergency release

--- a/products/waf/src/content/change-log/2019-10-27---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-10-27---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-10-27 – Emergency"
 type: table
 order: 992
+pcx-content-type: changelog
 ---
 
 # 2019-10-27 – Emergency release

--- a/products/waf/src/content/change-log/2019-11-04.md
+++ b/products/waf/src/content/change-log/2019-11-04.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 991
+pcx-content-type: changelog
 ---
 
 # 2019-11-04

--- a/products/waf/src/content/change-log/2019-11-07---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-11-07---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-11-07 – Emergency"
 type: table
 order: 990
+pcx-content-type: changelog
 ---
 
 # 2019-11-07 – Emergency release

--- a/products/waf/src/content/change-log/2019-11-12.md
+++ b/products/waf/src/content/change-log/2019-11-12.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 989
+pcx-content-type: changelog
 ---
 
 # 2019-11-12

--- a/products/waf/src/content/change-log/2019-11-25---emergency-release.md
+++ b/products/waf/src/content/change-log/2019-11-25---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2019-11-25 – Emergency"
 type: table
 order: 988
+pcx-content-type: changelog
 ---
 
 # 2019-11-25 – Emergency release

--- a/products/waf/src/content/change-log/2019-12-16.md
+++ b/products/waf/src/content/change-log/2019-12-16.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 987
+pcx-content-type: changelog
 ---
 
 # 2019-12-16

--- a/products/waf/src/content/change-log/2020-01-16---emergency-release.md
+++ b/products/waf/src/content/change-log/2020-01-16---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2020-01-16 – Emergency"
 type: table
 order: 986
+pcx-content-type: changelog
 ---
 
 # 2020-01-16 – Emergency release

--- a/products/waf/src/content/change-log/2020-01-20.md
+++ b/products/waf/src/content/change-log/2020-01-20.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 985
+pcx-content-type: changelog
 ---
 
 # 2020-01-20

--- a/products/waf/src/content/change-log/2020-01-27.md
+++ b/products/waf/src/content/change-log/2020-01-27.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 984
+pcx-content-type: changelog
 ---
 
 # 2020-01-27

--- a/products/waf/src/content/change-log/2020-02-10.md
+++ b/products/waf/src/content/change-log/2020-02-10.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 983
+pcx-content-type: changelog
 ---
 
 # 2020-02-10

--- a/products/waf/src/content/change-log/2020-02-17.md
+++ b/products/waf/src/content/change-log/2020-02-17.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 982
+pcx-content-type: changelog
 ---
 
 # 2020-02-17

--- a/products/waf/src/content/change-log/2020-03-02---emergency-release.md
+++ b/products/waf/src/content/change-log/2020-03-02---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2020-03-02 – Emergency"
 type: table
 order: 981
+pcx-content-type: changelog
 ---
 
 # 2020-03-02 – Emergency release

--- a/products/waf/src/content/change-log/2020-03-09.md
+++ b/products/waf/src/content/change-log/2020-03-09.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 980
+pcx-content-type: changelog
 ---
 
 # 2020-03-09

--- a/products/waf/src/content/change-log/2020-03-12.md
+++ b/products/waf/src/content/change-log/2020-03-12.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 979
+pcx-content-type: changelog
 ---
 
 # 2020-03-12

--- a/products/waf/src/content/change-log/2020-03-23.md
+++ b/products/waf/src/content/change-log/2020-03-23.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 977
+pcx-content-type: changelog
 ---
 
 # 2020-03-23

--- a/products/waf/src/content/change-log/2020-03-30.md
+++ b/products/waf/src/content/change-log/2020-03-30.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 976
+pcx-content-type: changelog
 ---
 
 # 2020-03-30

--- a/products/waf/src/content/change-log/2020-04-06.md
+++ b/products/waf/src/content/change-log/2020-04-06.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 975
+pcx-content-type: changelog
 ---
 
 # 2020-04-06

--- a/products/waf/src/content/change-log/2020-04-20.md
+++ b/products/waf/src/content/change-log/2020-04-20.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 974
+pcx-content-type: changelog
 ---
 
 # 2020-04-20

--- a/products/waf/src/content/change-log/2020-04-27.md
+++ b/products/waf/src/content/change-log/2020-04-27.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 973
+pcx-content-type: changelog
 ---
 
 # 2020-04-27

--- a/products/waf/src/content/change-log/2020-05-04.md
+++ b/products/waf/src/content/change-log/2020-05-04.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 972
+pcx-content-type: changelog
 ---
 
 # 2020-05-04

--- a/products/waf/src/content/change-log/2020-05-11.md
+++ b/products/waf/src/content/change-log/2020-05-11.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 971
+pcx-content-type: changelog
 ---
 
 # 2020-05-11

--- a/products/waf/src/content/change-log/2020-05-25.md
+++ b/products/waf/src/content/change-log/2020-05-25.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 970
+pcx-content-type: changelog
 ---
 
 # 2020-05-25

--- a/products/waf/src/content/change-log/2020-06-08.md
+++ b/products/waf/src/content/change-log/2020-06-08.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 969
+pcx-content-type: changelog
 ---
 
 # 2020-06-08

--- a/products/waf/src/content/change-log/2020-06-15.md
+++ b/products/waf/src/content/change-log/2020-06-15.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 968
+pcx-content-type: changelog
 ---
 
 # 2020-06-15

--- a/products/waf/src/content/change-log/2020-06-22.md
+++ b/products/waf/src/content/change-log/2020-06-22.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 967
+pcx-content-type: changelog
 ---
 
 # 2020-06-22

--- a/products/waf/src/content/change-log/2020-07-07---emergency-release.md
+++ b/products/waf/src/content/change-log/2020-07-07---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2020-07-07 – Emergency"
 type: table
 order: 966
+pcx-content-type: changelog
 ---
 
 # 2020-07-07 – Emergency release

--- a/products/waf/src/content/change-log/2020-07-13.md
+++ b/products/waf/src/content/change-log/2020-07-13.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 966
+pcx-content-type: changelog
 ---
 
 # 2020-07-13

--- a/products/waf/src/content/change-log/2020-07-20.md
+++ b/products/waf/src/content/change-log/2020-07-20.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 965
+pcx-content-type: changelog
 ---
 
 # 2020-07-20

--- a/products/waf/src/content/change-log/2020-07-27.md
+++ b/products/waf/src/content/change-log/2020-07-27.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 964
+pcx-content-type: changelog
 ---
 
 # 2020-07-27

--- a/products/waf/src/content/change-log/2020-08-03.md
+++ b/products/waf/src/content/change-log/2020-08-03.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 964
+pcx-content-type: changelog
 ---
 
 # 2020-08-03

--- a/products/waf/src/content/change-log/2020-08-24.md
+++ b/products/waf/src/content/change-log/2020-08-24.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 963
+pcx-content-type: changelog
 ---
 
 # 2020-08-24

--- a/products/waf/src/content/change-log/2020-09-01.md
+++ b/products/waf/src/content/change-log/2020-09-01.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 963
+pcx-content-type: changelog
 ---
 
 # 2020-09-01

--- a/products/waf/src/content/change-log/2020-09-07.md
+++ b/products/waf/src/content/change-log/2020-09-07.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 959
+pcx-content-type: changelog
 ---
 
 # 2020-09-07

--- a/products/waf/src/content/change-log/2020-09-15.md
+++ b/products/waf/src/content/change-log/2020-09-15.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 958
+pcx-content-type: changelog
 ---
 
 # 2020-09-15

--- a/products/waf/src/content/change-log/2020-09-21.md
+++ b/products/waf/src/content/change-log/2020-09-21.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 957
+pcx-content-type: changelog
 ---
 
 # 2020-09-21

--- a/products/waf/src/content/change-log/2020-09-28.md
+++ b/products/waf/src/content/change-log/2020-09-28.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 956
+pcx-content-type: changelog
 ---
 
 # 2020-09-28

--- a/products/waf/src/content/change-log/2020-10-05.md
+++ b/products/waf/src/content/change-log/2020-10-05.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 955
+pcx-content-type: changelog
 ---
 
 # 2020-10-05

--- a/products/waf/src/content/change-log/2020-10-12.md
+++ b/products/waf/src/content/change-log/2020-10-12.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 954
+pcx-content-type: changelog
 ---
 
 # 2020-10-12

--- a/products/waf/src/content/change-log/2020-10-19.md
+++ b/products/waf/src/content/change-log/2020-10-19.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 953
+pcx-content-type: changelog
 ---
 
 # 2020-10-19

--- a/products/waf/src/content/change-log/2020-11-04---emergency-release.md
+++ b/products/waf/src/content/change-log/2020-11-04---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2020-11-04 – Emergency"
 type: table
 order: 952
+pcx-content-type: changelog
 ---
 
 # 2020-11-04 – Emergency release

--- a/products/waf/src/content/change-log/2020-11-05---emergency-release.md
+++ b/products/waf/src/content/change-log/2020-11-05---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2020-11-05 – Emergency"
 type: table
 order: 951
+pcx-content-type: changelog
 ---
 
 # 2020-11-05 – Emergency release

--- a/products/waf/src/content/change-log/2020-11-16.md
+++ b/products/waf/src/content/change-log/2020-11-16.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 950
+pcx-content-type: changelog
 ---
 
 # 2020-11-16

--- a/products/waf/src/content/change-log/2020-12-02.md
+++ b/products/waf/src/content/change-log/2020-12-02.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 949
+pcx-content-type: changelog
 ---
 
 # 2020-12-02

--- a/products/waf/src/content/change-log/2020-12-14.md
+++ b/products/waf/src/content/change-log/2020-12-14.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 948
+pcx-content-type: changelog
 ---
 
 # 2020-12-14

--- a/products/waf/src/content/change-log/2021-03-01.md
+++ b/products/waf/src/content/change-log/2021-03-01.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 947
+pcx-content-type: changelog
 ---
 
 # 2021-03-01

--- a/products/waf/src/content/change-log/2021-03-05---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-03-05---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-03-05 – Emergency"
 type: table
 order: 946
+pcx-content-type: changelog
 ---
 
 # 2021-03-05 – Emergency release

--- a/products/waf/src/content/change-log/2021-03-06---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-03-06---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-03-06 – Emergency"
 type: table
 order: 945
+pcx-content-type: changelog
 ---
 
 # 2021-03-06 – Emergency release

--- a/products/waf/src/content/change-log/2021-03-08.md
+++ b/products/waf/src/content/change-log/2021-03-08.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 944
+pcx-content-type: changelog
 ---
 
 # 2021-03-08 

--- a/products/waf/src/content/change-log/2021-03-22.md
+++ b/products/waf/src/content/change-log/2021-03-22.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 943
+pcx-content-type: changelog
 ---
 
 # 2021-03-22 

--- a/products/waf/src/content/change-log/2021-04-19.md
+++ b/products/waf/src/content/change-log/2021-04-19.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 942
+pcx-content-type: changelog
 ---
 
 # 2021-04-19

--- a/products/waf/src/content/change-log/2021-04-21---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-04-21---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-04-21 – Emergency"
 type: table
 order: 941
+pcx-content-type: changelog
 ---
 
 # 2021-04-21 – Emergency Release

--- a/products/waf/src/content/change-log/2021-06-01.md
+++ b/products/waf/src/content/change-log/2021-06-01.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 940
+pcx-content-type: changelog
 ---
 
 # 2021-06-01

--- a/products/waf/src/content/change-log/2021-06-07.md
+++ b/products/waf/src/content/change-log/2021-06-07.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 939
+pcx-content-type: changelog
 ---
 
 # 2021-06-07

--- a/products/waf/src/content/change-log/2021-06-14.md
+++ b/products/waf/src/content/change-log/2021-06-14.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 938
+pcx-content-type: changelog
 ---
 
 # 2021-06-14

--- a/products/waf/src/content/change-log/2021-06-21.md
+++ b/products/waf/src/content/change-log/2021-06-21.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 937
+pcx-content-type: changelog
 ---
 
 # 2021-06-21

--- a/products/waf/src/content/change-log/2021-07-01---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-07-01---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-07-01 – Emergency"
 type: table
 order: 936
+pcx-content-type: changelog
 ---
 
 # 2021-07-01 – Emergency Release

--- a/products/waf/src/content/change-log/2021-07-19.md
+++ b/products/waf/src/content/change-log/2021-07-19.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 935
+pcx-content-type: changelog
 ---
 
 # 2021-07-19

--- a/products/waf/src/content/change-log/2021-07-26.md
+++ b/products/waf/src/content/change-log/2021-07-26.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 934
+pcx-content-type: changelog
 ---
 
 # 2021-07-26

--- a/products/waf/src/content/change-log/2021-08-16.md
+++ b/products/waf/src/content/change-log/2021-08-16.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 933
+pcx-content-type: changelog
 ---
 
 # 2021-08-16

--- a/products/waf/src/content/change-log/2021-08-23.md
+++ b/products/waf/src/content/change-log/2021-08-23.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 932
+pcx-content-type: changelog
 ---
 
 # 2021-08-23

--- a/products/waf/src/content/change-log/2021-08-31.md
+++ b/products/waf/src/content/change-log/2021-08-31.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 931
+pcx-content-type: changelog
 ---
 
 # 2021-08-31

--- a/products/waf/src/content/change-log/2021-09-01---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-09-01---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-09-01 – Emergency"
 type: table
 order: 930
+pcx-content-type: changelog
 ---
 
 # 2021-09-01 – Emergency Release

--- a/products/waf/src/content/change-log/2021-09-06.md
+++ b/products/waf/src/content/change-log/2021-09-06.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 929
+pcx-content-type: changelog
 ---
 
 # 2021-09-06

--- a/products/waf/src/content/change-log/2021-10-04.md
+++ b/products/waf/src/content/change-log/2021-10-04.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 928
+pcx-content-type: changelog
 ---
 
 # 2021-10-04

--- a/products/waf/src/content/change-log/2021-10-19.md
+++ b/products/waf/src/content/change-log/2021-10-19.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 927
+pcx-content-type: changelog
 ---
 
 # 2021-10-19

--- a/products/waf/src/content/change-log/2021-10-25.md
+++ b/products/waf/src/content/change-log/2021-10-25.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 926
+pcx-content-type: changelog
 ---
 
 # 2021-10-25

--- a/products/waf/src/content/change-log/2021-11-01.md
+++ b/products/waf/src/content/change-log/2021-11-01.md
@@ -1,6 +1,7 @@
 ---
 type: table
 order: 925
+pcx-content-type: changelog
 ---
 
 # 2021-11-01

--- a/products/waf/src/content/change-log/2021-12-10---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-12-10---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-12-10 – Emergency"
 type: table
 order: 924
+pcx-content-type: changelog
 ---
 
 # 2021-12-10 – Emergency Release

--- a/products/waf/src/content/change-log/2021-12-14---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-12-14---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-12-14 – Emergency"
 type: table
 order: 923
+pcx-content-type: changelog
 ---
 
 # 2021-12-14 – Emergency Release

--- a/products/waf/src/content/change-log/2021-12-16---emergency-release.md
+++ b/products/waf/src/content/change-log/2021-12-16---emergency-release.md
@@ -2,6 +2,7 @@
 title: "2021-12-16 – Emergency"
 type: table
 order: 922
+pcx-content-type: changelog
 ---
 
 # 2021-12-16 – Emergency Release

--- a/products/waf/src/content/change-log/2022-01-24.md
+++ b/products/waf/src/content/change-log/2022-01-24.md
@@ -2,6 +2,7 @@
 title: "2022-01-24"
 type: table
 order: 921
+pcx-content-type: changelog
 ---
 
 # 2022-01-24

--- a/products/waf/src/content/change-log/historical.md
+++ b/products/waf/src/content/change-log/historical.md
@@ -3,6 +3,7 @@ date: 2019-09-15
 type: table
 order: 1001
 summary: Changes that were completed before the change log was made publicly available.
+pcx-content-type: changelog
 ---
 
 # Historical

--- a/products/waf/src/content/change-log/scheduled-changes.md
+++ b/products/waf/src/content/change-log/scheduled-changes.md
@@ -1,8 +1,11 @@
 ---
 type: table
 order: 1
+pcx-content-type: changelog
 ---
+
 # Scheduled changes
+
 <TableWrap><table style="width: 100%">
     <thead>
         <tr>
@@ -32,7 +35,7 @@ order: 1
             </th>
         </tr>
     </thead>
-<tbody>   
+    <tbody>
         <tr>
             <td>
                 2022-02-07
@@ -85,5 +88,5 @@ order: 1
                 Block
             </td>
         </tr>
-</tbody>
+    </tbody>
 </table></TableWrap>


### PR DESCRIPTION
Addresses https://jira.cfops.it/browse/PCX-3327.

This change has no visual impact in the documentation pages, it is only adding some metadata used internally.

Also did some minor formatting adjustments in `scheduled-changes.md`.

Cc @unknownhad @ggaborCF - Please include the `pcx-content-type: changelog` line in the frontmatter of any new changelog pages you create from now on.
