### PR TITLE
update cloudflared service section and add a gcp-deployment guide

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
@@ -7,24 +7,19 @@ pcx-content-type: how-to
 
 The purpose of this guide is to walk through some best practices for accessing private resources on Google Cloud Platform (GCP) by deploying Cloudflare's lightweight connector, `cloudflared`.
 
-
 # Prerequisites
 
-- Create a Cloudflare Zero Trust account.
+- Navigate to the [Zero Trust Dashboard](https://dash.teams.cloudflare.com/) and create a Cloudflare Zero Trust account.
 - [Enroll an end-user device](/connections/connect-devices/warp/warp-settings#device-enrollment-permissions) into your Cloudflare Zero Trust account.
-
 
 # Create your environment
 
 To start, you will need to navigate to the Google Cloud Console and create a project. This project will contain all of your future Google Cloud resources, including the VM instances you will create in this process.
 
 1. From the Cloud Console, navigate to **Compute Engine**.
-
 1. Under Compute Engine, select **VM Instances**.
 1. In the main window, select **Create Instance**.
-
 1. Name your VM Instance. In this example, we will name it GCP-01.
-
 1. Configure your VM Instance. The following settings are recommended to get started:
 
    <Aside type='note'>
@@ -58,9 +53,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
 Now that you have your Virtual Machine up and running in GCP, you can login into your VM instance by selecting **SSH** in the **Connect** column of our VM Instance table.
 
 1. Run `sudo su` to gain full admin rights to the Virtual Machine.
-
 1. Run `apt install wget` to install any relevant dependencies for our fresh Virtual Machine.
-
 1. Next, install `cloudflared` on your Virtual Machine. In this example, we are running a Debian-based VM Instance, so you will first download the debian build of `cloudflared`.
 
    ```sh
@@ -125,7 +118,6 @@ Now that you have your Virtual Machine up and running in GCP, you can login into
    ```
 
 1. Hit `space` and then type `:x` to save and exit.
-
 1. Run `cloudflared` as a service.
 
 ```sh
@@ -140,4 +132,4 @@ systemctl start cloudflared
 systemctl status cloudflared
 ```
 
-Next, visit the Zero Trust dashboard and ensure your new tunnel shows as `active`. Optionally, begin creating [Zero Trust policies](/policies/zero-trust) to secure your private resources.
+Next, visit the Zero Trust dashboard and ensure your new tunnel shows as **active**. Optionally, begin creating [Zero Trust policies](/policies/zero-trust) to secure your private resources.

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
@@ -30,6 +30,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
    <Aside type='note'>
    We support a number of operating systems and versions, so make a selection based on your requirements.
    </Aside>
+   
    - **Machine Family:** General Purpose
    - **Series:** E2
    - **Machine Type:** e2-micro
@@ -40,7 +41,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
 1. Add a startup script for testing access. Here is an example:
 
    ```sh
-   #! /bin/bash
+   #!/bin/bash
    apt update
    apt -y install apache2
    cat <<EOF > /var/www/html/index.html
@@ -63,7 +64,7 @@ Now that you have your Virtual Machine up and running in GCP, you can login into
 1. Next, install `cloudflared` on your Virtual Machine. In this example, we are running a Debian-based VM Instance, so you will first download the debian build of `cloudflared`.
 
    ```sh
-   wget <https://github.com/cloudflare/cloudflared/releases/download/2021.8.0/cloudflared-linux-amd64>
+   wget <https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64>
    mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared
    chmod a+x /usr/local/bin/cloudflared
    ```
@@ -74,7 +75,7 @@ Now that you have your Virtual Machine up and running in GCP, you can login into
    cloudflared update
    ```
 
-1. Run the following command to authenticate `cloudflared` to with your Cloudflare account. You may have to open the provided link in a separate window to authenticate to your Cloudflare Zero Trust account.
+1. Run the following command to authenticate `cloudflared` with your Cloudflare account. The command will launch a browser window where you will be prompted to log in with your Cloudflare account and pick any zone you have added to Cloudflare.
 
    ```sh
    $ cloudflared tunnel login
@@ -99,7 +100,7 @@ Now that you have your Virtual Machine up and running in GCP, you can login into
    ```
 
    ```sh
-   cd cloudflared
+   cd /etc/cloudflared
    ```
 
 1. Build our configuration file. Before moving forward and entering vim, copy your Tunnel ID and credentials path to a notepad.
@@ -115,12 +116,12 @@ Now that you have your Virtual Machine up and running in GCP, you can login into
    credentials-file: /root/.cloudflared/<Tunnel ID>.json
    protocol: quic
    warp-routing:
-   enabled: true
+      enabled: true
    logfile: /var/log/cloudflared.log
    #cloudflared to the origin debug
    loglevel: debug
    #cloudflared to cloudflare debug
-   transport-loglevel: debug
+   transport-loglevel: info
    ```
 
 1. Hit `space` and then type `:x` to save and exit.

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
@@ -50,7 +50,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
    EOF
    ```
 
-4. Spin up your VM Instance by clicking **Create**.
+1. Spin up your VM Instance by clicking **Create**.
 
 # Deploying `cloudflared`
 

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
@@ -1,0 +1,136 @@
+---
+order: 7
+pcx-content-type: how-to
+---
+
+# Deploy `cloudflared` in GCP
+
+The purpose of this guide is to walk through some best practices for accessing private resources on GCP by deploying our lightweight connector, `cloudflared`.
+
+
+# Prerequisites
+
+- If you haven’t created a Cloudflare Zero Trust account, navigate to the dashboard to get started.
+- If you haven’t enrolled an end-user device into your Cloudflare Zero Trust account, navigate to the Cloudflare WARP download to get started.
+
+
+# Create your environment
+
+To start, we’ll navigate to the Google Cloud Console and create a project. This project will contain all of our future Google Cloud resources, including our VM instances we’ll create in this guide.
+
+1. From the Cloud Console, navigate to**Compute Engine**
+
+   - Under Compute Engine, select**VM Instances**
+   - In the main window, select**Create Instance**
+
+2. Name your VM Instance
+
+   - In this example, I’ll name mine GCP-01
+
+3. Configure your VM Instance. We recommend the following to get started:
+
+   - **Machine Family:** General Purpose
+
+   - **Series:** E2
+
+   - **Machine Type:** e2-micro
+
+   - **Boot Disk:** Debian GNU/Linux 10
+
+     - Note: We support a number of OS/Version so make a selection based on your environmental requirements
+
+   - **Firewall:** Allow HTTP/HTTPS traffic (if necessary)
+
+   - **Networking, Disks, Security, Management, Sole-Tenancy:** Management
+
+     - Add a startup script for testing access. Here is an example:
+
+       - ```sh
+        #! /bin/bash
+        apt update
+        apt -y install apache2
+        cat <<EOF > /var/www/html/index.html
+        <html><body><h1>Hello Cloudflare!</h1>
+        <p>This page was created from a startup script for a Cloudflare demo.</p>
+        </body></html>
+        EOF
+        ```
+
+4. Spin up your VM Instance by clicking**Create**
+
+# Deploying `cloudflared`
+
+Now that we have our VM up and running in GCP we can login into our VM instance by selecting**SSH**in the Connect column of our VM Instance table
+
+1. Type sudo su to gain full admin rights to the Virtual Machine
+
+2. Install any relevant dependencies for our fresh Virtual Machine
+
+   - Run `apt install wget`
+
+3. Install `cloudflared` on our Virtual Machine
+
+   - In this example, we are running a Debian-based VM Instance
+
+     - Download the debian build of `cloudflared`
+
+       - wget <https://github.com/cloudflare/cloudflared/releases/download/2021.8.0/cloudflared-linux-amd64>
+
+         - `mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared`
+         - `chmod a+x /usr/local/bin/cloudflared`
+         - `cloudflared update`
+         - Note: This should auto-run after pasting
+         - Note: Don't forget to hit enter when you see `cloudflared` update to get the latest version
+
+4. Authenticate `cloudflared` to with your Cloudflare account
+
+   - `cloudflared tunnel login`
+
+     - You may have to open the link in a separate window to authenticate to your Cloudflare Zero Trust account
+
+5. Create your Tunnel
+
+   - `cloudflared tunnel create GCP-01`
+
+6. Route your Tunnel
+
+   - `cloudflared tunnel route ip add 10.128.0.4/32 GCP-01`
+
+     - In this example, we will expose the smallest range available and later we can add more IP routes if necessary
+
+7. Make a directory for your configuration file
+
+   - `mkdir /etc/cloudflared`
+   - `cd cloudflared`
+
+8. Build our configuration file
+
+   - Note: Before moving forward, copy your tunnel_id and credentials path to notepad before entering vim
+
+   - `vim config.yml`
+
+     - Hit `i` to begin editing in VIM
+
+       - ```text
+       tunnel: <Tunnel ID/name>
+       credentials-file: /root/.cloudflared/<Tunnel ID>.json
+       protocol: quic
+       warp-routing:
+         enabled: true
+       logfile: /var/log/cloudflared.log
+       #cloudflared to the origin debug
+       loglevel: debug
+       #cloudflared to cloudflare debug
+       transport-loglevel: debug
+       ```
+
+   - Hit `space` and then `:x` to save and exit
+
+9. Run `cloudflared` as a service
+
+   - `cloudflared service install`
+   - `systemctl start cloudflared`
+   - `systemctl status cloudflared`
+
+
+Next, visit the Zero Trust dashboard and ensure your new Tunnel shows as `active` and optionally begin creating Zero Trust policies to secure your private resources

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/google-cloud-platform.md
@@ -5,23 +5,23 @@ pcx-content-type: how-to
 
 # Deploy `cloudflared` in GCP
 
-The purpose of this guide is to walk through some best practices for accessing private resources on GCP by deploying our lightweight connector, `cloudflared`.
+The purpose of this guide is to walk through some best practices for accessing private resources on Google Cloud Platform (GCP) by deploying Cloudflare's lightweight connector, `cloudflared`.
 
 
 # Prerequisites
 
-- If you haven’t created a Cloudflare Zero Trust account, navigate to the dashboard to get started.
-- If you haven’t enrolled an end-user device into your Cloudflare Zero Trust account, navigate to the Cloudflare WARP download to get started.
+- Create a Cloudflare Zero Trust account.
+- [Enroll an end-user device](/connections/connect-devices/warp/warp-settings#device-enrollment-permissions) into your Cloudflare Zero Trust account.
 
 
 # Create your environment
 
-To start, we’ll navigate to the Google Cloud Console and create a project. This project will contain all of our future Google Cloud resources, including our VM instances we’ll create in this guide.
+To start, you will need to navigate to the Google Cloud Console and create a project. This project will contain all of your future Google Cloud resources, including the VM instances you will create in this process.
 
-1. From the Cloud Console, navigate to**Compute Engine**
+1. From the Cloud Console, navigate to **Compute Engine**.
 
-   - Under Compute Engine, select**VM Instances**
-   - In the main window, select**Create Instance**
+1. Under Compute Engine, select **VM Instances**.
+1. In the main window, select **Create Instance**.
 
 1. Name your VM Instance. In this example, we will name it GCP-01.
 

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/index.md
@@ -3,6 +3,6 @@ order: 0
 pcx-content-type: navigation
 ---
 
-# Deploying Connectors
+# Deploying `cloudflared`
 
 Cloudflare Tunnel creates a secure, outbound-only connection between your services and Cloudflare by deploying a lightweight connector in your environment. With this model, your team does not need to go through the hassle of poking holes in your firewall or validating that traffic originated from Cloudflare IPs.

--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/deployment-guides/index.md
@@ -1,0 +1,8 @@
+---
+order: 0
+pcx-content-type: navigation
+---
+
+# Deploying Connectors
+
+Cloudflare Tunnel creates a secure, outbound-only connection between your services and Cloudflare by deploying a lightweight connector in your environment. With this model, your team does not need to go through the hassle of poking holes in your firewall or validating that traffic originated from Cloudflare IPs.

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/index.md
@@ -1,0 +1,23 @@
+---
+order: 5
+pcx-content-type: navigation
+---
+
+# Run as a Service
+
+It's recommended to run `cloudflared` as a service in most cases. This helps ensure the availability `cloudflared` to your origin by allowing the program to start at boot and continue running while your origin is online.
+
+| Before you start |
+|---|
+| Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it. |
+
+Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
+
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+
+|Argument|Description|
+|---|---|
+|`tunnel`|The UUID of your Tunnel
+|`credentials-file`|The location of the credentials file for your Tunnel|
+
+You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/index.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/index.md
@@ -3,17 +3,17 @@ order: 5
 pcx-content-type: navigation
 ---
 
-# Run as a Service
+# Run as a service
 
-It's recommended to run `cloudflared` as a service in most cases. This helps ensure the availability `cloudflared` to your origin by allowing the program to start at boot and continue running while your origin is online.
+In most cases, it is recommended to run `cloudflared` as a service. This helps ensure the availability `cloudflared` to your origin by allowing the program to start at boot and continue running while your origin is online.
 
-| Before you start |
-|---|
-| Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it. |
+**Before you start**
+
+- Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it.
 
 Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
 
-By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `$HOME/.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
 
 |Argument|Description|
 |---|---|

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
@@ -1,0 +1,38 @@
+---
+order: 30
+pcx-content-type: how-to
+---
+
+# Run as a service
+
+| Before you start |
+|---|
+| Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it. |
+
+Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
+
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+
+|Argument|Description|
+|---|---|
+|`tunnel`|The UUID of your Tunnel
+|`credentials-file`|The location of the credentials file for your Tunnel|
+
+You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.
+
+If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
+
+## Linux
+
+Before getting started, ensure the `cloudflared` will be able to create an [outbound-only connection](/connections/connect-apps/install-and-setup/installation) to the Cloudflare network.
+
+### Install `cloudflared`
+
+Open a Terminal and run the following command:
+
+```sh
+$ wget https://github.com/cloudflare/cloudflared/releases/download/2021.8.0/cloudflared-linux-amd64
+mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared
+chmod a+x /usr/local/bin/cloudflared
+cloudflared update
+```

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
@@ -1,17 +1,18 @@
 ---
 order: 30
 pcx-content-type: how-to
+title: "Linux"
 ---
 
-# Run as a service
+# Run as a service on Linux
 
 | Before you start |
 |---|
 | Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it. |
 
-Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
+Cloudflare Tunnel can install itself as a system service on Linux.
 
-By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `$HOME/.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
 
 |Argument|Description|
 |---|---|
@@ -19,8 +20,6 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
 |`credentials-file`|The location of the credentials file for your Tunnel|
 
 You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.
-
-If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
 
 ## Linux
 

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/linux.md
@@ -30,7 +30,7 @@ Before getting started, ensure the `cloudflared` will be able to create an [outb
 Open a Terminal and run the following command:
 
 ```sh
-$ wget https://github.com/cloudflare/cloudflared/releases/download/2021.8.0/cloudflared-linux-amd64
+$ wget https://github.com/cloudflare/cloudflared/releases/download/latest/cloudflared-linux-amd64
 mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared
 chmod a+x /usr/local/bin/cloudflared
 cloudflared update

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/macos.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/macos.md
@@ -1,0 +1,65 @@
+---
+order: 30
+pcx-content-type: how-to
+---
+
+# Run as a service
+
+| Before you start |
+|---|
+| Follow the [Tunnel guide](/connect-apps/install-and-setup/tunnel-guide) to create a tunnel, route traffic to a tunnel, and run it. |
+
+Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
+
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+
+|Argument|Description|
+|---|---|
+|`tunnel`|The UUID of your Tunnel
+|`credentials-file`|The location of the credentials file for your Tunnel|
+
+You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.
+
+If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
+
+## MacOS
+
+### Run at login
+
+Open a Terminal and run the following command:
+
+```sh
+$ cloudflared service install
+```
+
+Cloudflare Tunnel will be installed as a launch agent, and start whenever you log in, using your local user configuration found in `~/.cloudflared/`.
+
+#### Manually start the service
+
+Run the following command:
+
+```sh
+$ launchctl start com.cloudflare.cloudflared
+```
+
+Output will be logged to `~/Library/Logs/com.cloudflare.cloudflared.err.log` and `~/Library/Logs/com.cloudflare.cloudflared.out.log`.
+
+### Run at boot
+
+Run the following command:
+
+```sh
+$ sudo cloudflared service install
+```
+
+Cloudflare Tunnel will be installed as a launch daemon, and start whenever your system boots, using your configuration found in `/etc/cloudflared`.
+
+#### Manually start the service
+
+Run the following command:
+
+```sh
+$ sudo launchctl start com.cloudflare.cloudflared
+```
+
+Output will be logged to `/Library/Logs/com.cloudflare.cloudflared.err.log` and `/Library/Logs/com.cloudflare.cloudflared.out.log`.

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/macos.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/macos.md
@@ -1,9 +1,10 @@
 ---
 order: 30
 pcx-content-type: how-to
+title: "MacOS"
 ---
 
-# Run as a service
+# Run as a service on macOS
 
 | Before you start |
 |---|
@@ -11,7 +12,7 @@ pcx-content-type: how-to
 
 Cloudflare Tunnel can install itself as a system service on Linux and Windows and as a launch agent on macOS.
 
-By default, Cloudflare Tunnel expects all of the configuration to exist in the `.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
+By default, Cloudflare Tunnel expects all of the configuration to exist in the `$HOME/.cloudflared/config.yml` configuration file. The available options are documented on the [configuration file reference](/connections/connect-apps/configuration/configuration-file/ingress), but at a minimum you must specify the following arguments to run as a service:
 
 |Argument|Description|
 |---|---|
@@ -20,13 +21,11 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
 
 You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.
 
-If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
-
 ## MacOS
 
 ### Run at login
 
-Open a Terminal and run the following command:
+Open a terminal window and run the following command:
 
 ```sh
 $ cloudflared service install

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/windows.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/windows.md
@@ -22,82 +22,12 @@ You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its c
 
 If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
 
-## Linux
-
-Run the following command:
-
-```sh
-$ sudo cloudflared service install
-```
-
-If you have already logged in and have a configuration file in `~/.cloudflared/`, these will be copied to `/etc/cloudflared/`.
-
-If you do not have a configuration file, you will need to create a config.yml file with fields listed above. You can pass a custom file by running `cloudflared --config CONFIG-FILE service install`.
-
-<Aside>
-
-The above arguments are required for pre-configured Cloudflare Tunnel deployments. If you are using legacy Tunnels, without names, you can append the `--legacy` flag when running `cloudflared` tunnel install command.
-
-</Aside>
-
-Then, start the system service with the following command:
-```sh
-$ sudo systemctl start cloudflared
-``` 
-
-Or start on boot with:
-```sh
-$ sudo systemctl enable cloudflared
-```
-
-## macOS
-
-### Run at login
-
-Open a Terminal and run the following command:
-
-```sh
-$ cloudflared service install
-```
-
-Cloudflare Tunnel will be installed as a launch agent, and start whenever you log in, using your local user configuration found in `~/.cloudflared/`.
-
-#### Manually start the service
-
-Run the following command:
-
-```sh
-$ launchctl start com.cloudflare.cloudflared
-```
-
-Output will be logged to `~/Library/Logs/com.cloudflare.cloudflared.err.log` and `~/Library/Logs/com.cloudflare.cloudflared.out.log`.
-
-### Run at boot
-
-Run the following command:
-
-```sh
-$ sudo cloudflared service install
-```
-
-Cloudflare Tunnel will be installed as a launch daemon, and start whenever your system boots, using your configuration found in `/etc/cloudflared`.
-
-#### Manually start the service
-
-Run the following command:
-
-```sh
-$ sudo launchctl start com.cloudflare.cloudflared
-```
-
-Output will be logged to `/Library/Logs/com.cloudflare.cloudflared.err.log` and `/Library/Logs/com.cloudflare.cloudflared.out.log`.
-
 ## Windows
 
 1. [Download the latest `cloudflared` version](/connections/connect-apps/install-and-setup/installation).
 
 1. Create a new directory:
-    
+
     ```bash
     C:\Cloudflared\bin
     ```
@@ -123,18 +53,18 @@ Output will be logged to `/Library/Logs/com.cloudflare.cloudflared.err.log` and 
     cloudflared.exe login
     ```
 
-1. The login command will generate a `cert.pem` file and save it to your user profile by default. Copy the file to the `.cloudflared` folder created in step 5 using this command: 
+1. The login command will generate a `cert.pem` file and save it to your user profile by default. Copy the file to the `.cloudflared` folder created in step 5 using this command:
 
     ```bash
     copy C:\Users\%USERNAME%\.cloudflared\cert.pem C:\Windows\System32\config\systemprofile\.cloudflared
     ```
 
 1. Next, create a tunnel:
-    
+
     ```bash
     cloudflared.exe tunnel create <Tunnel Name>
     ```
-    
+
     This will generate a [credentials file](/connections/connect-apps/tunnel-useful-terms#credentials-file) in `.json` format.
 
 1. [Create a configuration file](/connections/connect-apps/install-and-setup/tunnel-guide#4-create-a-configuration-file) with the following content:
@@ -152,7 +82,7 @@ Output will be logged to `/Library/Logs/com.cloudflare.cloudflared.err.log` and 
     logfile:  C:\Cloudflared\cloudflared.log
     ```
 
-1. Copy the credentials file and the configuration file to the folder created in step 6: 
+1. Copy the credentials file and the configuration file to the folder created in step 6:
 
     ```bash
     C:\Windows\System32\config\systemprofile\.cloudflared

--- a/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/windows.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/run-tunnel/as-a-service/windows.md
@@ -1,9 +1,10 @@
 ---
 order: 30
 pcx-content-type: how-to
+title: "Windows"
 ---
 
-# Run as a service
+# Run as a service on Windows
 
 | Before you start |
 |---|
@@ -19,8 +20,6 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
 |`credentials-file`|The location of the credentials file for your Tunnel|
 
 You must [create the Tunnel](/connections/connect-apps/create-tunnel), and its credentials file, prior to installing it as a service. Creating the Tunnel in advance will generate the `credentials` file.
-
-If you do not want to create the tunnel in advance, you must install `cloudflared` with the `--legacy` flag.
 
 ## Windows
 


### PR DESCRIPTION
The service install section is difficult to follow and should be broken out by OS so users see only the information pertinent to their environment. This PR also add a net-new section to Connect Resources > Get Started with cloud-specific deployment guides. The first addition is GCP with AWS and Azure to follow. 