### PR TITLE
Remove a duplicate question and its answer

### DIFF
--- a/products/dns/src/content/dns-firewall/faq.md
+++ b/products/dns/src/content/dns-firewall/faq.md
@@ -69,15 +69,6 @@ Not by default, but you can set `negative_cache_ttl` via the [API](https://api.c
 </details>
 
 <details>
-<summary>Does DNS Firewall cache responses with status SERVFAIL?</summary>
-<div>
-
-No. If the upstream nameserver responds with a `SERVFAIL`, DNS Firewall will try again on the next query and not cache that response.
-  
-</div>
-</details>
-
-<details>
 <summary>How can I set PTR records for nameserver hostnames?</summary>
 <div>
 


### PR DESCRIPTION
The 7th question `Does DNS Firewall cache responses with status SERVFAIL?` is actually same as the 3rd one `Does the DNS Firewall cache SERVFAIL?`. 

I think we can remove one of them.