### PR TITLE
Fix broken automatic builds link

### DIFF
--- a/products/pages/src/content/platform/rollbacks.md
+++ b/products/pages/src/content/platform/rollbacks.md
@@ -16,4 +16,4 @@ In order to perform a rollback, go to **Deployments** in your Pages project. Bro
 ## Related resources
 
 - [Preview Deployments](/platform/preview-deployments)
-- [Pausing Automatic Builds](/platform/github-integration#pausing-automatic-builds)
+- [Pausing Automatic Builds](/platform/git-integration#pausing-automatic-builds)


### PR DESCRIPTION
The link to the automatic builds link is broken - this updates the link to the correct version.