### PR TITLE
Update index.md

### DIFF
--- a/products/analytics/src/content/graphql-api/limits/index.md
+++ b/products/analytics/src/content/graphql-api/limits/index.md
@@ -79,7 +79,7 @@ The example query below demonstrates how to retrieve account limits for the `bro
   viewer {
     zones(filter: { zoneTag: $zoneTag }) {
       settings {
-        browserPerf1mGroups {
+        firewallEventsAdaptive {
           maxDuration
           maxNumberOfFields
           maxPageSize
@@ -101,12 +101,12 @@ The example query below demonstrates how to retrieve account limits for the `bro
       "zones": [
         {
           "settings": {
-            "browserPerf1mGroups": {
+            "firewallEventsAdaptive": {
               "enabled": true,
-              "maxDuration": 2592000,
+              "maxDuration": 259200,
               "maxNumberOfFields": 30,
               "maxPageSize": 10000,
-              "notOlderThan": 2595600
+              "notOlderThan": 2678400
             }
           }
         }


### PR DESCRIPTION
As it is, the example uses `browserPerf1mGroups` and returns an error:

````
{
  "data": null,
  "errors": [
    {
      "message": "unknown field \"browserPerf1mGroups\"",
      "path": null,
      "extensions": {
        "timestamp": "2022-02-14T16:22:35.585278884Z"
      }
    }
  ]
}
```

The proposed change replaces `browserPerf1mGroups` with `firewallEventsAdaptive`, which returns the expected zone limits.
Please note that if `browserPerf1mGroups` was deprecated, the table at the top of the page should also be edited to signal deprecation with `*`