### PR TITLE
Ruleset Engine: Update API examples and placeholders

### DIFF
--- a/products/ruleset-engine/src/content/basic-operations/add-rule-phase-rulesets.md
+++ b/products/ruleset-engine/src/content/basic-operations/add-rule-phase-rulesets.md
@@ -33,22 +33,21 @@ The following example sets the rules of a phase entry point ruleset at the zone 
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{managed-ruleset-id-1}"
+        "id": "<MANAGED_RULESET_ID_1>"
       },
       "expression": "true"
     },
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{managed-ruleset-id-2}"
+        "id": "<MANAGED_RULESET_ID_2>"
       },
       "expression": "true"
     }
@@ -62,29 +61,29 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Default",
     "description": "",
     "kind": "zone",
     "version": "1",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id-1}"
+          "id": "<MANAGED_RULESET_ID_1>"
         },
         "last_updated": "2021-06-17T15:42:37.917815Z"
       },
       {
-        "id": "{rule-id-2}",
+        "id": "<RULE_ID_2>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id-2}"
+          "id": "<MANAGED_RULESET_ID_2>"
         },
         "last_updated": "2021-06-17T15:42:37.917815Z"
       }
@@ -105,20 +104,18 @@ header: Response
 <summary>Example: Add a single rule to a phase entry point ruleset at the zone level</summary>
 <div>
 
-The following example adds a single rule to a phase entry point ruleset (with ID `{ruleset-id}`) at the zone level using the [Add rule to ruleset](/rulesets-api/add-rule) API method.
+The following example adds a single rule to a phase entry point ruleset (with ID `<RULESET_ID>`) at the zone level using the [Add rule to ruleset](/rulesets-api/add-rule) API method.
 
 ```json
 ---
 header: Request
 ---
-curl -X POST \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zone/{zone-id}/rulesets/{ruleset-id}/rules" \
+curl "https://api.cloudflare.com/client/v4/zone/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "action": "execute",
   "action_parameters": {
-    "id": "{managed-ruleset-id}"
+    "id": "<MANAGED_RULESET_ID>"
   },
   "expression": "true"
 }'
@@ -130,29 +127,29 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point ruleset",
     "description": "",
     "kind": "root",
     "version": "2",
     "rules": [
       {
-        "id": "{existing-rule-id}",
+        "id": "<EXISTING_RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{another-managed-ruleset-id}"
+          "id": "<ANOTHER_MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       },
       {
-        "id": "{new-rule-id}",
+        "id": "<NEW_RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-06-30T15:42:37.917815Z"
       }

--- a/products/ruleset-engine/src/content/basic-operations/deploy-rulesets.md
+++ b/products/ruleset-engine/src/content/basic-operations/deploy-rulesets.md
@@ -22,22 +22,21 @@ To apply a rule to every request in a phase at the **zone** level, set the rule 
 
 ## Example
 
-The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of a given zone (`{zone-id}`) by adding a rule that executes the Managed Ruleset.
+The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of a given zone (`<ZONE_ID>`) by adding a rule that executes the Managed Ruleset.
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{cloudflare-managed-ruleset-id}"
+        "id": "<CLOUDFLARE_MANAGED_RULESET_ID>"
       },
       "expression": "true",
       "description": "Execute Cloudflare Managed Ruleset on my zone ruleset"
@@ -52,24 +51,24 @@ header: Response
 ---
 {
   "result": {
-    "id": "{zone-level-phase-ruleset-id}",
+    "id": "<ZONE_PHASE_RULESET_ID>",
     "name": "Zone-level Ruleset 1",
     "description": "",
     "kind": "zone",
     "version": "latest",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{cloudflare-managed-ruleset-id}",
+          "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
           "version": "3"
         },
         "expression": "true",
         "description": "Execute Cloudflare Managed Ruleset on my zone ruleset",
         "last_updated": "2021-03-18T18:08:14.003361Z",
-        "ref": "{ruleset-ref}",
+        "ref": "<RULE_REF>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/basic-operations/view-rulesets.md
+++ b/products/ruleset-engine/src/content/basic-operations/view-rulesets.md
@@ -18,10 +18,8 @@ You can list the available rulesets for a zone, account, or phase.
 ---
 header: Request
 ---
-curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 The response displays the following rulesets:
@@ -37,7 +35,7 @@ header: Response
 {
   "result": [
     {
-      "id": "{zone-level-phase-ruleset-id}",
+      "id": "<ZONE_PHASE_RULESET_ID>",
       "name": "Zone-level Ruleset 1",
       "description": "Ruleset for http_request_firewall_managed phase at the zone level",
       "kind": "zone",
@@ -46,7 +44,7 @@ header: Response
       "phase": "http_request_firewall_managed"
     },
     {
-      "id": "{cloudflare-managed-ruleset-id}",
+      "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
       "name": "Cloudflare Managed Ruleset",
       "description": "Created by the Cloudflare security team, this ruleset is designed to provide fast and effective protection for all your applications. It is frequently updated to cover new vulnerabilities and reduce false positives",
       "kind": "managed",
@@ -55,7 +53,7 @@ header: Response
       "phase": "http_request_firewall_managed"
     },
     {
-      "id": "{cloudflare-owasp-core-ruleset-id}",
+      "id": "<CLOUDFLARE_OWASP_CORE_RULESET_ID>",
       "name": "Cloudflare OWASP Core Ruleset",
       "description": "Cloudflare's implementation of the Open Web Application Security Project (OWASP) ModSecurity Core Rule Set. We routinely monitor for updates from OWASP based on the latest version available from the official code repository",
       "kind": "managed",
@@ -81,10 +79,8 @@ header: Response
 ---
 header: Request
 ---
-curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets"
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 The response displays the following rulesets:
@@ -100,7 +96,7 @@ header: Response
 {
   "result": [
     {
-      "id": "{custom-ruleset-id}",
+      "id": "<CUSTOM_RULESET_ID>",
       "name": "Custom Ruleset 1",
       "description": "My custom ruleset",
       "kind": "custom",
@@ -109,7 +105,7 @@ header: Response
       "phase": "http_request_firewall_custom"
     },
     {
-      "id": "{account-level-phase-ruleset-id}",
+      "id": "<ACCOUNT_PHASE_RULESET_ID>",
       "name": "Account-level ruleset for http_request_firewall_managed phase",
       "description": "Account-level ruleset for executing one or more Managed Rulesets",
       "kind": "root",
@@ -118,7 +114,7 @@ header: Response
       "phase": "http_request_firewall_managed"
     },
     {
-      "id": "{cloudflare-managed-ruleset-id}",
+      "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
       "name": "Cloudflare Managed Ruleset",
       "description": "Created by the Cloudflare security team, this ruleset is designed to provide fast and effective protection for all your applications. It is frequently updated to cover new vulnerabilities and reduce false positives",
       "kind": "managed",
@@ -127,7 +123,7 @@ header: Response
       "phase": "http_request_firewall_managed"
     },
     {
-      "id": "{cloudflare-owasp-core-ruleset-id}",
+      "id": "<CLOUDFLARE_OWASP_CORE_RULESET_ID>",
       "name": "Cloudflare OWASP Core Ruleset",
       "description": "Cloudflare's implementation of the Open Web Application Security Project (OWASP) ModSecurity Core Rule Set. We routinely monitor for updates from OWASP based on the latest version available from the official code repository",
       "kind": "managed",
@@ -159,10 +155,8 @@ The following example lists the rules in version `2` of the `http_request_firewa
 ---
 header: Request
 ---
-curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint/versions/2"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint/versions/2" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -171,19 +165,19 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point ruleset",
     "description": "This ruleset executes a Managed Ruleset.",
     "kind": "zone",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       }
@@ -210,10 +204,8 @@ The following example lists the rules in version `2` of a Managed Ruleset (the m
 ---
 header: Request
 ---
-curl -X GET \
-  -H "X-Auth-Email: user@cloudflare.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{managed-ruleset-id}/versions/2"
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<MANAGED_RULESET_ID>/versions/2" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -222,14 +214,14 @@ header: Response
 ---
 {
   "result": {
-    "id": "{managed-ruleset-id}",
+    "id": "<MANAGED_RULESET_ID>",
     "name": "Cloudflare Managed Ruleset",
     "description": "Created by the Cloudflare security team, this ruleset is designed to provide fast and effective protection for all your applications. It is frequently updated to cover new vulnerabilities and reduce false positives",
     "kind": "managed",
     "version": "2",
     "rules": [
       {
-        "id": "{rule-1-id}",
+        "id": "<RULE_1_ID>",
         "version": "1",
         "action": "log",
         "categories": [
@@ -242,11 +234,11 @@ header: Response
         ],
         "description": "Drupal, Wordpress - DoS - XMLRPC - CVE:CVE-2014-5265, CVE:CVE-2014-5266, CVE:CVE-2014-5267",
         "last_updated": "2021-03-18T14:42:40.972022Z",
-        "ref": "{rule-1-ref}",
+        "ref": "<RULE_1_REF>",
         "enabled": true
       },
       {
-        "id": "{rule-2-id}",
+        "id": "<RULE_2_ID>",
         "version": "1",
         "action": "block",
         "categories": [
@@ -256,7 +248,7 @@ header: Response
         ],
         "description": "Wordpress - Broken Access Control - CVE:CVE-2018-12895",
         "last_updated": "2021-03-18T14:42:40.972022Z",
-        "ref": "{rule-2-ref}",
+        "ref": "<RULE_2_REF>",
         "enabled": true
       },
       // (...)
@@ -277,4 +269,4 @@ Each rule in a Managed Ruleset can have associated tags or categories, listed in
 
 ---
 
-For more information on the available API methods for viewing rulesets, check [List and view rulesets](/rulesets-api/view).
+For more information on the available API methods for viewing rulesets, refer to [List and view rulesets](/rulesets-api/view).

--- a/products/ruleset-engine/src/content/common-use-cases/deploy-cmr-joomla-only.md
+++ b/products/ruleset-engine/src/content/common-use-cases/deploy-cmr-joomla-only.md
@@ -25,16 +25,15 @@ The example below uses the [Update ruleset](/rulesets-api/update) endpoint to de
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "categories": [
@@ -51,7 +50,7 @@ curl -X PUT \
 }'
 ```
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for the specified zone (`{zone-id}`).
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for the specified zone (`<ZONE_ID>`).
 * `"enabled": false` defines an override at the ruleset level that disables all rules in the Managed Ruleset.
 * `"categories": [{"category": "joomla", "action": "block", "enabled": true}]` defines an override at the tag level that enables the Joomla rules and sets their action to `block`.
 
@@ -64,16 +63,15 @@ curl -X PUT \
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "categories": [
@@ -90,7 +88,7 @@ curl -X PUT \
 }'
 ```
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for `example.com`.
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for `example.com`.
 * `"enabled": false` defines an override at the ruleset level that disables all rules in the Managed Ruleset.
 * `"categories": [{"category": "joomla", "action": "block", "enabled": true}]` defines an override at the tag level that enables the Joomla rules and sets their action to `block`.
 
@@ -99,7 +97,7 @@ curl -X PUT \
 
 You can add more than one category override to a rule.
 
-The example below uses a `PUT` request to add two overrides to the rule that executes a Managed Ruleset (`{managed-ruleset-id}`) in the `http_request_firewall_managed` phase. Note that the `name`, `kind`, and `phase` fields are omitted from the request because they are immutable.
+The example below uses a `PUT` request to add two overrides to the rule that executes a Managed Ruleset (`<MANAGED_RULESET_ID>`) in the `http_request_firewall_managed` phase. Note that the `name`, `kind`, and `phase` fields are omitted from the request because they are immutable.
 
 <details>
 <summary>Example: Add more than one category override at the zone level</summary>
@@ -107,16 +105,15 @@ The example below uses a `PUT` request to add two overrides to the rule that exe
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "categories": [
@@ -146,16 +143,15 @@ curl -X PUT \
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/account/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/account/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,          
           "categories": [

--- a/products/ruleset-engine/src/content/common-use-cases/deploy-cmr-wordpress-block.md
+++ b/products/ruleset-engine/src/content/common-use-cases/deploy-cmr-wordpress-block.md
@@ -23,16 +23,15 @@ The example below uses the [Update ruleset](/rulesets-api/update) operation to p
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "categories": [
             {
@@ -56,16 +55,15 @@ curl -X PUT \
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "categories": [
             {

--- a/products/ruleset-engine/src/content/common-use-cases/enable-selected-rules.md
+++ b/products/ruleset-engine/src/content/common-use-cases/enable-selected-rules.md
@@ -21,32 +21,31 @@ The following `PUT` request uses the [Update ruleset](/rulesets-api/update) oper
 
 In this example:
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the phase entry point ruleset to execute a Managed Ruleset for requests in the specified zone (`{zone-id}`).
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the phase entry point ruleset to execute a Managed Ruleset for requests in the specified zone (`<ZONE_ID>`).
 * `"enabled": false` defines an override at the ruleset level to disable all rules in the Managed Ruleset.
-* `"rules": [{"id": "{rule-id-1}", "action": "block", "enabled": true}, {"id": "{rule-id-2}", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
+* `"rules": [{"id": "<RULE_ID_1>", "action": "block", "enabled": true}, {"id": "<RULE_ID_2>", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true", 
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,          
           "rules": [
             {
-              "id": "{rule-id-1}",
+              "id": "<RULE_ID_1>",
               "action": "block",
               "enabled": true
             },
             {
-              "id": "{rule-id-2}",
+              "id": "<RULE_ID_2>",
               "action": "log",
               "enabled": true              
             }
@@ -69,32 +68,31 @@ The following `PUT` request uses the [Update ruleset](/rulesets-api/update) oper
 
 In this example:
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the phase entry point ruleset to execute a Managed Ruleset for requests addressed to `example.com`.
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the phase entry point ruleset to execute a Managed Ruleset for requests addressed to `example.com`.
 * `"enabled": false` defines an override at the ruleset level to disable all rules in the Managed Ruleset.
-* `"rules": [{"id": "{rule-id-1}", "action": "block", "enabled": true}, {"id": "{rule-id-2}", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
+* `"rules": [{"id": "<RULE_ID_1>", "action": "block", "enabled": true}, {"id": "<RULE_ID_2>", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"", 
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "rules": [
             {
-              "id": "{rule-id-1}",
+              "id": "<RULE_ID_1>",
               "action": "block",
               "enabled": true
             },
             {
-              "id": "{rule-id-2}",
+              "id": "<RULE_ID_2>",
               "action": "log",
               "enabled": true
             }

--- a/products/ruleset-engine/src/content/common-use-cases/override-ddos-rule-sensitivity.md
+++ b/products/ruleset-engine/src/content/common-use-cases/override-ddos-rule-sensitivity.md
@@ -13,8 +13,8 @@ Follow the steps below to override the sensitivity of a specific rule of the Clo
 
 The example below uses the [Update ruleset](/rulesets-api/update) operation to execute the steps in a single `PUT` request.
 
-* Add a rule to the ruleset of the `ddos_l7` phase that applies the Cloudflare HTTP DDoS Managed Ruleset (with ID `{http-ddos-ruleset-id}`).
-* Create an override for the rule with ID `{rule-id}` and set the rule sensitivity to `low`. All other rules use the default sensitivity defined by Cloudflare.
+* Add a rule to the ruleset of the `ddos_l7` phase that applies the Cloudflare HTTP DDoS Managed Ruleset (with ID `<HTTP_DDOS_RULESET_ID>`).
+* Create an override for the rule with ID `<RULE_ID>` and set the rule sensitivity to `low`. All other rules use the default sensitivity defined by Cloudflare.
 
 <details>
 <summary>Example: Use an override to set the sensitivity of an HTTP DDoS rule at the zone level</summary>
@@ -22,20 +22,19 @@ The example below uses the [Update ruleset](/rulesets-api/update) operation to e
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/ddos_l7/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/ddos_l7/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{http-ddos-ruleset-id}",
+        "id": "<HTTP_DDOS_RULESET_ID>",
         "overrides": {
           "rules": [
             {
-              "id": "{rule-id}",
+              "id": "<RULE_ID>",
               "sensitivity_level": "low"
             }
           ]

--- a/products/ruleset-engine/src/content/common-use-cases/override-ruleset-tag-rule.md
+++ b/products/ruleset-engine/src/content/common-use-cases/override-ruleset-tag-rule.md
@@ -25,21 +25,21 @@ The request below uses the [Update ruleset](/rulesets-api/update) operation to e
 
 In this example:
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset to execute a Managed Ruleset for requests addressed to a zone (`{zone-id}`).
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset to execute a Managed Ruleset for requests addressed to a zone (`<ZONE_ID>`).
 * `"enabled": false` defines an override at the ruleset level to disable all rules in the Managed Ruleset.
 * `"categories": [{"category": "wordpress", "action": "log", "enabled": true}, {"category": "drupal", "action": "log", "enabled": true}]` defines an override at the tag level to enable rules tagged with `wordpress` or `drupal` and sets their action to `log`.
-* `"rules": [{"id": "{rule-id}", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
+* `"rules": [{"id": "<RULE_ID>", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
 
 ```json
 curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "true", 
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "categories": [
@@ -56,7 +56,7 @@ curl -X PUT \
           ],
           "rules": [
             {
-              "id": "{rule-id}",
+              "id": "<RULE_ID>",
               "action": "block",
               "enabled": true
             }
@@ -77,21 +77,21 @@ curl -X PUT \
 
 In this example:
 
-* `"id": "{managed-ruleset-id}"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset that executes a Managed Ruleset for requests addressed to `example.com`.
+* `"id": "<MANAGED_RULESET_ID>"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset that executes a Managed Ruleset for requests addressed to `example.com`.
 * `"enabled": false` defines an override at the ruleset level to disable all rules in the Managed Ruleset.
 * `"categories": [{"category": "wordpress", "action": "log", "enabled": true}, {"category": "drupal", "action": "log", "enabled": true}]` defines an override at the tag level to enable rules tagged with `wordpress` or `drupal` and sets their action to `log`.
-* `"rules": [{"id": "{rule-id}", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
+* `"rules": [{"id": "<RULE_ID>", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
 
 ```json
 curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"", 
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "enabled": false,
           "categories": [
@@ -108,7 +108,7 @@ curl -X PUT \
           ],
           "rules": [
             {
-              "id": "{rule-id}",
+              "id": "<RULE_ID>",
               "action": "block",
               "enabled": true
             }

--- a/products/ruleset-engine/src/content/custom-rulesets/add-rules-ruleset.md
+++ b/products/ruleset-engine/src/content/custom-rulesets/add-rules-ruleset.md
@@ -27,9 +27,8 @@ The following request adds two rules to a custom ruleset. These will be the only
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{custom-ruleset-id}" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<CUSTOM_RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
@@ -54,29 +53,29 @@ header: Response
 ---
 {
   "result": {
-    "id": "{custom-ruleset-id}",
+    "id": "<CUSTOM_RULESET_ID>",
     "name": "Custom Ruleset 1",
     "kind": "custom",
     "version": "2",
     "rules": [
       {
-        "id": "{custom-rule-id-1}",
+        "id": "<CUSTOM_RULE_ID_1>",
         "version": "1",
         "action": "challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score \u003e 0",
         "description": "challenge GB and FR or based on IP Reputation",
         "last_updated": "2021-03-18T18:25:08.122758Z",
-        "ref": "{custom-rule-ref-1}",
+        "ref": "<CUSTOM_RULE_REF_1>",
         "enabled": true
       },
       {
-        "id": "{custom-rule-id-2}",
+        "id": "<CUSTOM_RULE_ID_2>",
         "version": "1",
         "action": "challenge",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "description": "challenge not /api",
         "last_updated": "2021-03-18T18:25:08.122758Z",
-        "ref": "{custom-rule-ref-2}",
+        "ref": "<CUSTOM_RULE_REF_2>",
         "enabled": true
       }
     ],
@@ -100,19 +99,18 @@ The following request edits one rule in a custom ruleset and updates the executi
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
-      "id": "{custom-rule-id-2}",
+      "id": "<CUSTOM_RULE_ID_2>",
       "expression": "not http.request.uri.path matches \"^/api/.*$\"",
       "action": "js_challenge",
       "description": "js_challenge when not /api"
     },
     {
-      "id": "{custom-rule-id-1}"
+      "id": "<CUSTOM_RULE_ID_1>"
     }
   ]
 }'
@@ -126,29 +124,29 @@ header: Response
 ---
 {
   "result": {
-    "id": "{custom-ruleset-id}",
+    "id": "<CUSTOM_RULESET_ID>",
     "name": "Custom Ruleset 1",
     "kind": "custom",
     "version": "3",
     "rules": [
       {
-        "id": "{custom-rule-id-2}",
+        "id": "<CUSTOM_RULE_ID_2>",
         "version": "2",
         "action": "js_challenge",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "description": "js_challenge when not /api",
         "last_updated": "2021-03-18T18:30:08.122758Z",
-        "ref": "{custom-rule-id-2}",
+        "ref": "<CUSTOM_RULE_ID_2>",
         "enabled": true
       },
       {
-        "id": "{custom-rule-id-1}",
+        "id": "<CUSTOM_RULE_ID_1>",
         "version": "1",
         "action": "challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score \u003e 0",
         "description": "challenge GB and FR or based on IP Reputation",
         "last_updated": "2021-03-18T18:25:08.122758Z",
-        "ref": "{custom-rule-id-1}",
+        "ref": "<CUSTOM_RULE_ID_1>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/custom-rulesets/create-custom-ruleset.md
+++ b/products/ruleset-engine/src/content/custom-rulesets/create-custom-ruleset.md
@@ -13,10 +13,8 @@ The following `POST` request creates a new custom ruleset. Set the `kind` field 
 ---
 header: Request
 ---
-curl -X POST \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets" \
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "name": "Custom Ruleset 1",
   "description": "My First Custom Ruleset",

--- a/products/ruleset-engine/src/content/custom-rulesets/deploy-custom-ruleset.md
+++ b/products/ruleset-engine/src/content/custom-rulesets/deploy-custom-ruleset.md
@@ -19,9 +19,8 @@ Issue a `PUT` request that adds a rule to execute the custom ruleset when the zo
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_custom/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_custom/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
@@ -29,14 +28,14 @@ curl -X PUT \
       "description":"Execute custom ruleset",
       "expression": "cf.zone.name == \"example.com\"",
       "action_parameters": {
-        "id":"{custom-ruleset-id}"
+        "id":"<CUSTOM_RULESET_ID>"
       }
     },
     {
-      "id": "{existing-phase-rule-id-1}"
+      "id": "<EXISTING_PHASE_RULE_ID_1>"
     },
     {
-      "id": "{existing-phase-rule-id-2}"
+      "id": "<EXISTING_PHASE_RULE_ID_2>"
     }
   ]
 }'
@@ -50,50 +49,50 @@ header: Response
 ---
 {
   "result": {
-    "id": "{account-phase-ruleset-id}",
+    "id": "<ACCOUNT_PHASE_RULESET_ID>",
     "name": "http_request_firewall_custom phase entry point ruleset for my account",
     "description": "Execute several rulesets",
     "kind": "root",
     "version": "3",
     "rules": [
       {
-        "id": "{phase-rule-id}",
+        "id": "<PHASE_RULE_ID>",
         "version": "1",
         "action": "execute",
         "description":"Execute custom ruleset",
         "action_parameters": {
-          "id": "{custom-ruleset-id}",
+          "id": "<CUSTOM_RULESET_ID>",
           "version": "latest"
         },
         "expression": "cf.zone.name == \"example.com\"",
         "last_updated": "2021-03-18T18:35:14.135697Z",
-        "ref": "{root-rule-id}",
+        "ref": "<PHASE_RULE_ID>",
         "enabled": true
       },
       {
-        "id": "{existing-phase-rule-id-1}",
+        "id": "<EXISTING_PHASE_RULE_ID_1>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{id-of-ruleset-executed-by-existing-rule-id}",
+          "id": "<EXECUTED_RULESET_ID_1>",
           "version": "latest"
         },
         "expression": "cf.zone.name eq  \"example.com\"",
         "last_updated": "2021-03-16T15:51:49.180378Z",
-        "ref": "{existing-phase-rule-ref-1}",
+        "ref": "<EXISTING_PHASE_RULE_REF_1>",
         "enabled": true
       },
       {
-        "id": "{existing-phase-rule-id-2}",
+        "id": "<EXISTING_PHASE_RULE_ID_2>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{id-of-ruleset-executed-by-existing-rule-id-2}",
+          "id": "<EXECUTED_RULESET_ID_2>",
           "version": "latest"
         },
         "expression": "cf.zone.name eq  \"example.com\"",
         "last_updated": "2021-03-16T15:50:29.861157Z",
-        "ref": "{existing-phase-rule-ref}",
+        "ref": "<EXISTING_PHASE_RULE_REF_2>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/custom-rulesets/deploy-custom-ruleset.md
+++ b/products/ruleset-engine/src/content/custom-rulesets/deploy-custom-ruleset.md
@@ -66,7 +66,7 @@ header: Response
         },
         "expression": "cf.zone.name == \"example.com\"",
         "last_updated": "2021-03-18T18:35:14.135697Z",
-        "ref": "<PHASE_RULE_ID>",
+        "ref": "<PHASE_RULE_REF>",
         "enabled": true
       },
       {

--- a/products/ruleset-engine/src/content/managed-rulesets/deploy-managed-ruleset.md
+++ b/products/ruleset-engine/src/content/managed-rulesets/deploy-managed-ruleset.md
@@ -19,22 +19,21 @@ Use the following workflow to deploy a Managed Ruleset to a phase at the account
 
 ### Example
 
-The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of your account (`{account-id}`) by creating a rule that executes the Managed Ruleset. The rules in the Managed Ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
+The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of your account (`<ACCOUNT_ID>`) by creating a rule that executes the Managed Ruleset. The rules in the Managed Ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{cloudflare-managed-ruleset-id}"
+        "id": "<CLOUDFLARE_MANAGED_RULESET_ID>"
       },
       "expression": "cf.zone.name in {\"example.com\" \"anotherexample.com\"}",
       "description": "Execute Cloudflare Managed Ruleset on my account-level phase entry point"
@@ -49,24 +48,24 @@ header: Response
 ---
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Account-level phase entry point",
     "description": "",
     "kind": "root",
     "version": "5",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{cloudflare-managed-ruleset-id}",
+          "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
           "version": "latest"
         },
         "expression": "cf.zone.name in {\"example.com\" \"anotherexample.com\"}",
         "description": "Execute Cloudflare Managed Ruleset on my account-level phase entry point",
         "last_updated": "2021-03-18T18:30:08.122758Z",
-        "ref": "{rule-ref}",
+        "ref": "<RULE_REF>",
         "enabled": true
       }
     ],
@@ -90,22 +89,21 @@ Use the following workflow to deploy a Managed Ruleset to a phase at the zone le
 
 ### Example
 
-The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of a given zone (`{zone-id}`) by creating a rule that executes the Managed Ruleset.
+The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of a given zone (`<ZONE_ID>`) by creating a rule that executes the Managed Ruleset.
 
 ```json
 ---
 header: Request
 ---
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{cloudflare-managed-ruleset-id}"
+        "id": "<CLOUDFLARE_MANAGED_RULESET_ID>"
       },
       "expression": "true",
       "description": "Execute Cloudflare Managed Ruleset on my zone-level phase entry point"
@@ -120,24 +118,24 @@ header: Response
 ---
 {
   "result": {
-    "id": "{zone-level-phase-ruleset-id}",
+    "id": "<ZONE_PHASE_RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "",
     "kind": "zone",
     "version": "3",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{cloudflare-managed-ruleset-id}",
+          "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
           "version": "latest"
         },
         "expression": "true",
         "description": "Execute Cloudflare Managed Ruleset on my zone-level phase entry point",
         "last_updated": "2021-03-18T18:08:14.003361Z",
-        "ref": "{ruleset-ref-1}",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/managed-rulesets/override-managed-ruleset.md
+++ b/products/ruleset-engine/src/content/managed-rulesets/override-managed-ruleset.md
@@ -26,7 +26,7 @@ To apply an override for a Managed Ruleset:
 
 ```json
 "action_parameters": {
-  "id": "{ruleset-id}",
+  "id": "<RULESET_ID>",
   "overrides": {
     // ruleset overrides
     "property-to-modify": "value",
@@ -34,7 +34,7 @@ To apply an override for a Managed Ruleset:
     // tag overrides
     "categories": [
       {
-        "category": "{tag-name}",
+        "category": "<TAG_NAME>",
         "property-to-modify": "value",
         "property-to-modify": "value"
       }
@@ -42,7 +42,7 @@ To apply an override for a Managed Ruleset:
     // rule overrides
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "property-to-modify": "value",
         "property-to-modify": "value"
       }
@@ -74,9 +74,8 @@ The following request adds a rule that executes a Managed Ruleset in the `http_r
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "description": "Managed rule behavior set to log action",
   "rules": [
@@ -84,7 +83,7 @@ curl -X PUT \
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "action": "log",
           "enabled": true
@@ -104,9 +103,8 @@ curl -X PUT \
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@cloudflare.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "description": "Managed rule behavior set to log action",
   "rules": [
@@ -114,7 +112,7 @@ curl -X PUT \
       "action": "execute",
       "expression": "cf.zone.name eq \"example.com\"",
       "action_parameters": {
-        "id": "{managed-ruleset-id}",
+        "id": "<MANAGED_RULESET_ID>",
         "overrides": {
           "action": "log",
           "enabled": true

--- a/products/ruleset-engine/src/content/rulesets-api/add-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/add-rule.md
@@ -12,8 +12,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Add an individual rule][ar-account] (account) | `POST /accounts/{account-id}/rulesets/{ruleset-id}/rules` |
-| Add an individual rule (zone) | `POST /zones/{zone-id}/rulesets/{ruleset-id}/rules` |
+| [Add an individual rule][ar-account] (account) | `POST /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules` |
+| Add an individual rule (zone) | `POST /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules` |
 
 [ar-account]: https://api.cloudflare.com/#account-rulesets-add-an-individual-rule
 
@@ -23,17 +23,15 @@ Include the rule definition in the request body. The rule will be added to the e
 
 ## Example
 
-The following example adds a rule to ruleset `{ruleset-id}` of zone `{zone-id}`. The ruleset ID was previously obtained using the [List rulesets](/rulesets-api/view#list-existing-rulesets) method, and corresponds to the entry point ruleset for the `http_request_firewall_custom` phase.
+The following example adds a rule to ruleset `<RULESET_ID>` of zone `<ZONE_ID>`. The ruleset ID was previously obtained using the [List rulesets](/rulesets-api/view#list-existing-rulesets) method, and corresponds to the entry point ruleset for the `http_request_firewall_custom` phase.
 
 <details open>
 <summary>Request</summary>
 <div>
 
 ```json
-curl -X POST \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules" \
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "action": "js_challenge",
   "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
@@ -53,29 +51,29 @@ The response includes the complete ruleset after adding the rule.
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone Ruleset 1",
     "description": "My phase entry point ruleset at the zone level",
     "kind": "zone",
     "version": "11",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "1",
         "action": "challenge",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "last_updated": "2020-11-23T11:36:24.192361Z",
-        "ref": "{rule-ref-1}",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       },
       {
-        "id": "{new-rule-id}",
+        "id": "<NEW_RULE_ID>",
         "version": "1",
         "action": "js_challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
         "description": "challenge GB and FR or based on IP Reputation",
         "last_updated": "2021-06-22T12:35:58.144683Z",
-        "ref": "{new-rule-ref}",
+        "ref": "<NEW_RULE_REF>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/rulesets-api/create.md
+++ b/products/ruleset-engine/src/content/rulesets-api/create.md
@@ -13,8 +13,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Create account ruleset][cr-account] | `POST /accounts/{account-id}/rulesets` |
-| [Create zone ruleset][cr-zone] | `POST /zones/{zone-id}/rulesets` |
+| [Create account ruleset][cr-account] | `POST /accounts/<ACCOUNT_ID>/rulesets` |
+| [Create zone ruleset][cr-zone] | `POST /zones/<ZONE_ID>/rulesets` |
 
 [cr-account]: https://api.cloudflare.com/#account-rulesets-create-account-ruleset
 [cr-zone]: https://api.cloudflare.com/#zone-rulesets-create-zone-ruleset
@@ -75,10 +75,8 @@ The following example request creates a custom ruleset in the `http_request_fire
 <div>
 
 ```json
-curl -X POST \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets" \
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "name": "Example custom ruleset",
   "kind": "custom",
@@ -103,14 +101,14 @@ curl -X POST \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Example custom ruleset",
     "description": "Example ruleset description",
     "kind": "custom",
     "version": "1",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "log",
         "expression": "cf.zone.name eq \"example.com\"",
@@ -144,10 +142,8 @@ You do not have to use this method to create a phase entry point ruleset — Clo
 <div>
 
 ```json
-curl -X POST \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets" \
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "name": "Zone-level phase entry point",
   "kind": "zone",
@@ -157,7 +153,7 @@ curl -X POST \
       "action": "execute",
       "expression": "true",
       "action_parameters": {
-        "id": "{managed-ruleset-id}"
+        "id": "<MANAGED_RULESET_ID>"
       }
     }
   ],
@@ -175,19 +171,19 @@ curl -X POST \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "This ruleset executes a Managed Ruleset.",
     "kind": "zone",
     "version": "1",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       }

--- a/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
@@ -27,7 +27,7 @@ The following example deletes rule `<RULE_ID_1>` belonging to ruleset `<RULESET_
 <summary>Request</summary>
 <div>
 
-```json
+```bash
 curl -X DELETE \
 "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
 -H "Authorization: Bearer <API_TOKEN>"

--- a/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete-rule.md
@@ -12,8 +12,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Delete an individual rule][dr-account] (account) | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
-| Delete an individual rule (zone) | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
+| [Delete an individual rule][dr-account] (account) | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
+| Delete an individual rule (zone) | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
 
 [dr-account]: https://api.cloudflare.com/#account-rulesets-delete-an-individual-rule
 
@@ -21,7 +21,7 @@ If the delete operation succeeds, the API method call returns a `200 OK` HTTP st
 
 ## Example
 
-The following example deletes rule `{rule-id-1}` belonging to ruleset `{ruleset-id}`.
+The following example deletes rule `<RULE_ID_1>` belonging to ruleset `<RULESET_ID>`.
 
 <details open>
 <summary>Request</summary>
@@ -29,9 +29,8 @@ The following example deletes rule `{rule-id-1}` belonging to ruleset `{ruleset-
 
 ```json
 curl -X DELETE \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id-1}"
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -44,20 +43,20 @@ curl -X DELETE \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Custom Ruleset 1",
     "description": "My first custom ruleset",
     "kind": "custom",
     "version": "12",
     "rules": [
       {
-        "id": "{rule-id-2}",
+        "id": "<RULE_ID_2>",
         "version": "2",
         "action": "js_challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
         "description": "challenge GB and FR or based on IP Reputation",
         "last_updated": "2021-07-22T12:54:58.144683Z",
-        "ref": "{rule-ref-2}",
+        "ref": "<RULE_REF_2>",
         "enabled": true
       }
     ],

--- a/products/ruleset-engine/src/content/rulesets-api/delete.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete.md
@@ -39,7 +39,7 @@ To delete the ruleset, update or delete any rules that reference the ruleset and
 
 The following example request deletes an existing ruleset.
 
-```json
+```bash
 ---
 header: Request
 ---
@@ -78,7 +78,7 @@ To delete the ruleset version, update or delete any rules that reference the rul
 
 The following example request deletes a version of an existing ruleset.
 
-```json
+```bash
 ---
 header: Request
 ---

--- a/products/ruleset-engine/src/content/rulesets-api/delete.md
+++ b/products/ruleset-engine/src/content/rulesets-api/delete.md
@@ -19,8 +19,8 @@ Use one of the following API endpoints:
 
 | Operation                            | Method + Endpoint                                     |
 |--------------------------------------|-------------------------------------------------------|
-| [Delete account ruleset][dr-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}` |
-| [Delete zone ruleset][dr-zone]       | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}`       |
+| [Delete account ruleset][dr-account] | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>` |
+| [Delete zone ruleset][dr-zone]       | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>`       |
 
 [dr-account]: https://api.cloudflare.com/#account-rulesets-delete-account-ruleset
 [dr-zone]: https://api.cloudflare.com/#zone-rulesets-delete-zone-ruleset
@@ -44,9 +44,8 @@ The following example request deletes an existing ruleset.
 header: Request
 ---
 curl -X DELETE \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}"
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 ## Delete ruleset version
@@ -57,8 +56,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Delete a version of an account ruleset][drv-account] | `DELETE /accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
-| [Delete a version of a zone ruleset][drv-zone] | `DELETE /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}` |
+| [Delete a version of an account ruleset][drv-account] | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>` |
+| [Delete a version of a zone ruleset][drv-zone] | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>` |
 
 [drv-account]: https://api.cloudflare.com/#account-rulesets-delete-a-version-of-an-account-ruleset
 [drv-zone]: https://api.cloudflare.com/#zone-rulesets-delete-a-version-of-a-zone-ruleset
@@ -84,7 +83,6 @@ The following example request deletes a version of an existing ruleset.
 header: Request
 ---
 curl -X DELETE \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/versions/{version-number}"
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```

--- a/products/ruleset-engine/src/content/rulesets-api/endpoints.md
+++ b/products/ruleset-engine/src/content/rulesets-api/endpoints.md
@@ -10,19 +10,19 @@ For some operations, you can use specific endpoints provided by the Rulesets API
 
 For example, instead of using the following endpoint:
 
-```bash
-PUT /zones/{zone-id}/rulesets/{ruleset-id}
+```txt
+PUT /zones/<ZONE_ID>/rulesets/<RULESET_ID>
 ```
 
 You can use the following endpoint:
 
-```bash
-PUT /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint
+```txt
+PUT /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint
 ```
 
 To invoke a Cloudflare Rulesets API operation, append the endpoint to the Cloudflare API base URL:
 
-```bash
+```txt
 https://api.cloudflare.com/client/v4
 ```
 
@@ -32,7 +32,7 @@ For help with endpoints and pagination, see [Getting Started: Endpoints](https:/
 
 <Aside>
 
-The Rulesets API endpoints require a value for `{account_id}` or `{zone-id}`.
+The Rulesets API endpoints require a value for `<ACCOUNT_ID>` or `<ZONE_ID>`.
 
 To retrieve a list of accounts you have access to, use the [List Accounts](https://api.cloudflare.com/#accounts-list-accounts) operation. Note the IDs of the accounts you want to manage.
 

--- a/products/ruleset-engine/src/content/rulesets-api/update-rule.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update-rule.md
@@ -13,8 +13,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Patch an individual rule][ur-account] (account) | `PATCH /accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
-| Patch an individual rule (zone) | `PATCH /zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id}` |
+| [Patch an individual rule][ur-account] (account) | `PATCH /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
+| Patch an individual rule (zone) | `PATCH /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
 
 [ur-account]: https://api.cloudflare.com/#account-rulesets-patch-an-individual-rule
 
@@ -30,9 +30,8 @@ To update the definition of a rule, include the new rule definition in the reque
 
 ```json
 curl -X PATCH \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/rules/{rule-id-1}" \
+"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "action": "js_challenge",
   "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
@@ -52,29 +51,29 @@ The response includes the complete ruleset after updating the rule.
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Custom Ruleset 1",
     "description": "My first custom ruleset",
     "kind": "custom",
     "version": "11",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "2",
         "action": "js_challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
         "description": "challenge GB and FR or based on IP Reputation",
         "last_updated": "2021-03-22T12:54:58.144683Z",
-        "ref": "rule-ref-1",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       },
       {
-        "id": "{rule-id-2}",
+        "id": "<RULE_ID_2>",
         "version": "1",
         "action": "challenge",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
         "last_updated": "2020-11-23T11:36:24.192361Z",
-        "ref": "{rule-ref-2}",
+        "ref": "<RULE_REF_2>",
         "enabled": true
       }
     ],
@@ -94,11 +93,11 @@ The response includes the complete ruleset after updating the rule.
 
 To reorder a rule in a list of ruleset rules, include a `position` field in the request, containing one of the following arguments:
 
-* `"before": "{rule-id}"` — Places the rule before rule `{rule-id}`. Use this argument with an empty rule ID value (`""`) to set the rule as the first rule in the ruleset.
+* `"before": "<RULE_ID>"` — Places the rule before rule `<RULE_ID>`. Use this argument with an empty rule ID value (`""`) to set the rule as the first rule in the ruleset.
 
-* `"after": "{rule-id}"` — Places the rule after rule `{rule-id}`. Use this argument with an empty rule ID value (`""`) to set the rule as the last rule in the ruleset.
+* `"after": "<RULE_ID>"` — Places the rule after rule `<RULE_ID>`. Use this argument with an empty rule ID value (`""`) to set the rule as the last rule in the ruleset.
 
-* `"index": {position-number}` — Places the rule in the exact position specified by the integer number `{position-number}`. Position numbers start with `1`. Existing rules in the ruleset from the specified position number onward are shifted one position (no rule is overwritten). For example, when you place a rule in position <var>n</var> using `index`, existing rules with index <var>n</var>, <var>n</var>+1, <var>n</var>+2, and so on, are shifted one position — their new position will be <var>n</var>+1, <var>n</var>+2, <var>n</var>+3, and so forth. If the index is out of range, the method returns 400 HTTP Status Code.
+* `"index": <POSITION_NUMBER>` — Places the rule in the exact position specified by the integer number `<POSITION_NUMBER>`. Position numbers start with `1`. Existing rules in the ruleset from the specified position number onward are shifted one position (no rule is overwritten). For example, when you place a rule in position <var>n</var> using `index`, existing rules with index <var>n</var>, <var>n</var>+1, <var>n</var>+2, and so on, are shifted one position — their new position will be <var>n</var>+1, <var>n</var>+2, <var>n</var>+3, and so forth. If the index is out of range, the method returns 400 HTTP Status Code.
 
 <Aside type='warning' header='Important'>
 
@@ -113,26 +112,25 @@ The following examples build upon the following (abbreviated) ruleset:
 ```json
 {
   "rules": [
-    { "id": "{rule-id-1}" },
-    { "id": "{rule-id-2}" },
-    { "id": "{rule-id-3}" },
-    { "id": "{rule-id-4}" }
+    { "id": "<RULE_ID_1>" },
+    { "id": "<RULE_ID_2>" },
+    { "id": "<RULE_ID_3>" },
+    { "id": "<RULE_ID_4>" }
   ]
 }
 ```
 
 ### Example #1
 
-The following request with the `position` field places rule `{rule-id-2}` as the first rule:
+The following request with the `position` field places rule `<RULE_ID_2>` as the first rule:
 
 ```json
 ---
 header: Request
 ---
 curl -X PATCH \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-2}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_2>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "position": {
     "before": ""
@@ -141,43 +139,41 @@ curl -X PATCH \
 ```
 In this case, the new rule order would be:
 
-`{rule-id-2}`, `{rule-id-1}`, `{rule-id-3}`, `{rule-id-4}`
+`<RULE_ID_2>`, `<RULE_ID_1>`, `<RULE_ID_3>`, `<RULE_ID_4>`
 
 ### Example #2
 
-The following request with the `position` field places rule `{rule-id-2}` after rule 3:
+The following request with the `position` field places rule `<RULE_ID_2>` after rule 3:
 
 ```json
 ---
 header: Request
 ---
 curl -X PATCH \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-2}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_2>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "position": {
-    "after": "{rule-id-3}"
+    "after": "<RULE_ID_3>"
   }
 }
 ```
 
 In this case, the new rule order would be:
 
-`{rule-id-1}`, `{rule-id-3}`, `{rule-id-2}`, `{rule-id-4}`
+`<RULE_ID_1>`, `<RULE_ID_3>`, `<RULE_ID_2>`, `<RULE_ID_4>`
 
 ### Example #3
 
-The following request with the `position` field places rule `{rule-id-1}` in position 3, becoming the third rule in the ruleset:
+The following request with the `position` field places rule `<RULE_ID_1>` in position 3, becoming the third rule in the ruleset:
 
 ```json
 ---
 header: Request
 ---
 curl -X PATCH \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-1}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "position": {
     "index": 3
@@ -187,4 +183,4 @@ curl -X PATCH \
 
 In this case, the new rule order would be:
 
-`{rule-id-2}`, `{rule-id-3}`, `{rule-id-1}`, `{rule-id-4}`
+`<RULE_ID_2>`, `<RULE_ID_3>`, `<RULE_ID_1>`, `<RULE_ID_4>`

--- a/products/ruleset-engine/src/content/rulesets-api/update.md
+++ b/products/ruleset-engine/src/content/rulesets-api/update.md
@@ -12,10 +12,10 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Update account ruleset][ur-account] | `PUT /accounts/{account-id}/rulesets/{ruleset-id}` |
-| [Update zone ruleset][ur-zone] | `PUT /zones/{zone-id}/rulesets/{ruleset-id}` |
-| [Update account entry point ruleset][uep-account] | `PUT /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint` |
-| [Update zone entry point ruleset][uep-zone] | `PUT /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint` |
+| [Update account ruleset][ur-account] | `PUT /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>` |
+| [Update zone ruleset][ur-zone] | `PUT /zones/<ZONE_ID>/rulesets/<RULESET_ID>` |
+| [Update account entry point ruleset][uep-account] | `PUT /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
+| [Update zone entry point ruleset][uep-zone] | `PUT /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
 
 [ur-account]: https://api.cloudflare.com/#account-rulesets-update-account-ruleset
 [ur-zone]: https://api.cloudflare.com/#zone-rulesets-update-a-zone-ruleset
@@ -38,15 +38,14 @@ Use this API method to set the rules of a ruleset. You must include all the rule
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{managed-ruleset-id}"
+        "id": "<MANAGED_RULESET_ID>"
       },
       "expression": "true"
     }
@@ -64,19 +63,19 @@ curl -X PUT \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "This ruleset executes a Managed Ruleset.",
     "kind": "zone",
     "version": "4",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "2",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       }
@@ -97,7 +96,7 @@ curl -X PUT \
 
 To deploy a ruleset, create a rule with `"action": "execute"` that executes the ruleset, and add the ruleset ID to the `action_parameters` field in the `id` parameter.
 
-The following example deploys a Managed Ruleset to the zone-level `http_request_firewall_managed` phase of a zone (`{zone-id}`).
+The following example deploys a Managed Ruleset to the zone-level `http_request_firewall_managed` phase of a zone (`<ZONE_ID>`).
 
 <details open>
 <summary>Request</summary>
@@ -105,15 +104,14 @@ The following example deploys a Managed Ruleset to the zone-level `http_request_
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
+-H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "rules": [
     {
       "action": "execute",
       "action_parameters": {
-        "id": "{managed-ruleset-id}"
+        "id": "<MANAGED_RULESET_ID>"
       },
       "expression": "true",
       "description": "Execute Cloudflare Managed Ruleset on my phase entry point"
@@ -132,24 +130,24 @@ curl -X PUT \
 ```json
 {
   "result": {
-    "id": "{phase-ruleset-id}",
+    "id": "<ZONE_PHASE_RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "",
     "kind": "zone",
     "version": "4",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{managed-ruleset-id}",
+          "id": "<MANAGED_RULESET_ID>",
           "version": "latest"
         },
         "expression": "true",
         "description": "Execute Cloudflare Managed Ruleset on my phase entry point",
         "last_updated": "2021-03-21T11:02:08.769537Z",
-        "ref": "{rule-ref-1}",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       }
     ],
@@ -183,10 +181,9 @@ You cannot update the description or the rules in a Managed Ruleset. You can onl
 
 ```json
 curl -X PUT \
--H "X-Auth-Email: user@example.com" \
--H "X-Auth-Key: REDACTED" \
-"https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}" \
--d '{ 
+"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>" \
+-d '{
   "description": "My updated phase entry point"
 }'
 ```
@@ -203,7 +200,7 @@ The response includes the complete ruleset definition, including all the rules.
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone entry point",
     "description": "My updated phase entry point",
     "kind": "zone",

--- a/products/ruleset-engine/src/content/rulesets-api/view.md
+++ b/products/ruleset-engine/src/content/rulesets-api/view.md
@@ -21,8 +21,8 @@ Use one of the following API endpoints:
 
 | Operation                           | Method + Endpoint                     |
 |-------------------------------------|---------------------------------------|
-| [List account rulesets][lr-account] | `GET /accounts/{account-id}/rulesets` |
-| [List zone rulesets][lr-zone]       | `GET /zones/{zone-id}/rulesets`       |
+| [List account rulesets][lr-account] | `GET /accounts/<ACCOUNT_ID>/rulesets` |
+| [List zone rulesets][lr-zone]       | `GET /zones/<ZONE_ID>/rulesets`       |
 
 [lr-account]: https://api.cloudflare.com/#account-rulesets-list-account-rulesets
 [lr-zone]: https://api.cloudflare.com/#zone-rulesets-list-zone-rulesets
@@ -46,10 +46,8 @@ The result does not include the list of rules in the ruleset. Check [View a spec
 <div>
 
 ```bash
-curl -X GET \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -63,7 +61,7 @@ curl -X GET \
 {
   "result": [
     {
-      "id": "{phase-ruleset-id}",
+      "id": "<PHASE_RULESET_ID>",
       "name": "Zone-level phase entry point",
       "description": "",
       "kind": "zone",
@@ -89,10 +87,10 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Get an account ruleset][gr-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}` |
-| [Get a zone ruleset][gr-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}` |
-| [Get account entry point ruleset][gep-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint` |
-| [Get zone entry point ruleset][gep-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint` |
+| [Get an account ruleset][gr-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>` |
+| [Get a zone ruleset][gr-zone] | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>` |
+| [Get account entry point ruleset][gep-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
+| [Get zone entry point ruleset][gep-zone] | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
 
 [gr-account]: https://api.cloudflare.com/#account-rulesets-get-an-account-ruleset
 [gr-zone]: https://api.cloudflare.com/#zone-rulesets-get-a-zone-ruleset
@@ -117,10 +115,8 @@ The API returns a `404 Not Found` HTTP status code under these conditions:
 <div>
 
 ```bash
-curl -X GET \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -133,19 +129,19 @@ curl -X GET \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "Executes a Managed Ruleset.",
     "kind": "zone",
     "version": "3",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       }
@@ -170,10 +166,10 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [List versions of an account ruleset][lv-account] | `GET /accounts/{account-id}/rulesets/{ruleset-id}/versions` |
-| List versions of a zone ruleset | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions` |
-| [List versions of an account entry point ruleset][lvep-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions`|
-| [List versions of a zone entry point ruleset][lvep-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions` |
+| [List versions of an account ruleset][lv-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions` |
+| List versions of a zone ruleset | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions` |
+| [List versions of an account entry point ruleset][lvep-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions`|
+| [List versions of a zone entry point ruleset][lvep-zone] | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions` |
 
 [lv-account]: https://api.cloudflare.com/#account-rulesets-list-versions-of-an-account-ruleset
 [lvep-account]: https://api.cloudflare.com/#account-rulesets-list-versions-of-an-entrypoint-ruleset
@@ -192,10 +188,8 @@ When the specified phase entry point ruleset does not exist, this API method ret
 <div>
 
 ```bash
-curl -X GET \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/versions"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -209,7 +203,7 @@ curl -X GET \
 {
   "result": [
     {
-      "id": "{ruleset-id}",
+      "id": "<RULESET_ID>",
       "name": "Zone Ruleset 1",
       "description": "",
       "kind": "zone",
@@ -218,7 +212,7 @@ curl -X GET \
       "phase": "http_request_firewall_managed"
     },
     {
-      "id": "{ruleset-id}",
+      "id": "<RULESET_ID>",
       "name": "Zone Ruleset 1",
       "description": "",
       "kind": "zone",
@@ -244,10 +238,10 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Get an account ruleset version][grv-account] | `GET /account/{account-id}/rulesets/{ruleset-id}/versions/{version-number}` |
-| [Get a zone ruleset version][grv-zone] | `GET /zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}`
-| [Get account entry point ruleset version][gepv-account] | `GET /accounts/{account-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}` |
-| [Get zone entry point ruleset version][gepv-zone] | `GET /zones/{zone-id}/rulesets/phases/{phase-name}/entrypoint/versions/{version-number}` |
+| [Get an account ruleset version][grv-account] | `GET /account/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>` |
+| [Get a zone ruleset version][grv-zone] | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>`
+| [Get account entry point ruleset version][gepv-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions/<VERSION_NUMBER>` |
+| [Get zone entry point ruleset version][gepv-zone] | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions/<VERSION_NUMBER>` |
 
 [grv-account]: https://api.cloudflare.com/#account-rulesets-get-an-account-ruleset-version
 [grv-zone]: https://api.cloudflare.com/#zone-rulesets-get-a-zone-ruleset-version
@@ -265,10 +259,8 @@ When the specified phase entry point ruleset does not exist, this API method ret
 <div>
 
 ```bash
-curl -X GET \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/zones/{zone-id}/rulesets/{ruleset-id}/versions/{version-number}"
+curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -281,19 +273,19 @@ curl -X GET \
 ```json
 {
   "result": {
-    "id": "{ruleset-id}",
+    "id": "<RULESET_ID>",
     "name": "Zone-level phase entry point",
     "description": "Executes a Managed Ruleset.",
     "kind": "zone",
     "version": "3",
     "rules": [
       {
-        "id": "{rule-id}",
+        "id": "<RULE_ID>",
         "version": "1",
         "action": "execute",
         "expression": "true",
         "action_parameters": {
-          "id": "{managed-ruleset-id}"
+          "id": "<MANAGED_RULESET_ID>"
         },
         "last_updated": "2021-03-17T15:42:37.917815Z"
       }
@@ -322,7 +314,7 @@ Returns a list of all the rules in a Managed Ruleset with a specific tag.
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| List rules in ruleset by tag | `GET /accounts/{account-id}/rulesets/{managed-ruleset-id}/{version-number}/by_tag/{tag-name}` |
+| List rules in ruleset by tag | `GET /accounts/<ACCOUNT_ID>/rulesets/<MANAGED_RULESET_ID>/versions/<VERSION_NUMBER>/by_tag/<TAG_NAME>` |
 
 ### Example
 
@@ -331,10 +323,8 @@ Returns a list of all the rules in a Managed Ruleset with a specific tag.
 <div>
 
 ```bash
-curl -X GET \
-  -H "X-Auth-Email: user@example.com" \
-  -H "X-Auth-Key: REDACTED" \
-  "https://api.cloudflare.com/client/v4/accounts/{account-id}/rulesets/{ruleset-id}/versions/2/by_tag/wordpress"
+curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/2/by_tag/wordpress" \
+-H "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -347,14 +337,14 @@ curl -X GET \
 ```json
 {
   "result": {
-    "id": "{managed-ruleset-id}",
+    "id": "<MANAGED_RULESET_ID>",
     "name": "Cloudflare Managed Ruleset",
     "description": "Managed Ruleset created by Cloudflare",
     "kind": "managed",
     "version": "4",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "3",
         "action": "log",
         "categories": [
@@ -367,11 +357,11 @@ curl -X GET \
         ],
         "description": "Drupal, Wordpress - DoS - XMLRPC - CVE:CVE-2014-5265, CVE:CVE-2014-5266, CVE:CVE-2014-5267",
         "last_updated": "2021-03-19T16:54:32.942986Z",
-        "ref": "{rule-ref-1}",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       },
       {
-        "id": "{rule-id-2}",
+        "id": "<RULE_ID_2>",
         "version": "3",
         "action": "block",
         "categories": [
@@ -381,7 +371,7 @@ curl -X GET \
         ],
         "description": "Wordpress - Broken Access Control - CVE:CVE-2018-12895",
         "last_updated": "2021-03-19T16:54:32.942986Z",
-        "ref": "{rule-ref-2}",
+        "ref": "<RULE_REF_2>",
         "enabled": true
       },
       // (...)


### PR DESCRIPTION
* Replace Email + API key auth with API token auth.
* Remove unnecessary `-X GET` and `-X POST` command-line parameters (for `curl`).
* Update placeholder formatting.
* Fix some minor errors in the API examples.