### PR TITLE
Matching Wording Between 1.1.1.1 and Zero Trust Browser DoH Setup

### DIFF
--- a/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/encrypted-dns-browsers.md
+++ b/products/1.1.1.1/src/content/encrypted-dns/dns-over-https/encrypted-dns-browsers.md
@@ -15,7 +15,7 @@ There are several browsers compatible with DNS over HTTPS (DoH). This protocol l
 1. Click on the **Settings** button.
 1. Click **Enable DNS over HTTPS**. By default, it resolves to Cloudflare DNS.
 
-## Google Chrome
+### Google Chrome / Microsoft Edge / Brave
 
 <Aside type="note">
 
@@ -23,34 +23,9 @@ This setting may already be enabled by default.
 
 </Aside>
 
-1. Click on the three-dot menu in your browser window.
-1. Select **Settings**.
-1. Scroll down to **Privacy and security** > **Security**.
-1. Scroll down and enable the **Use secure DNS** switch.
-
-Your browser infers the DNS over HTTPS provider you want based on your system DNS. To benefit from Cloudflare DoH, make sure your system is [properly configured](/setup-1.1.1.1/windows).
-
-## Microsoft Edge
-
-<Aside type="note">
-
-This setting may already be enabled default.
-
-</Aside>
-
-1. Go to `edge://settings/privacy`.
-1. Scroll down to the **Security** section.
-1. Make sure the **Use secure DNS** option is enabled.
-1. Select **Choose a service provider** > **Cloudflare (1.1.1.1)**.
-
-## Brave
-
-1. Click the menu button in your browser window.
-1. Navigate to **Settings**.
-1. On the left side of the menu, scroll down and click **Additional settings**.
-1. Navigate to **Privacy and security** > **Security**.
-1. Enable **Use secure DNS**.
-1. Click **With Custom** and choose *Cloudflare (1.1.1.1)* as a service provider from the drop-down menu.
+1. In your address bar, type the following and hit **Enter**:
+ `chrome://settings/security`. This will take you to the Security page where you can enable DoH.
+2. Scroll down below the Advanced section and toggle **Use secure DNS** and choose **With Cloudflare (1.1.1.1)**.
 
 ## How to check if my browser is configured correctly?
 

--- a/products/cloudflare-one/src/content/connections/connect-devices/agentless/dns-over-https.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/agentless/dns-over-https.md
@@ -56,7 +56,7 @@ You should now be able to send queries through the DNS over HTTPS protocol.
 
 <Aside type="note">
 
-This setting may already be enabled by default.
+DoH may already be configured by default, but you must provide the browser with your specific DoH subdomain.
 
 </Aside>
 

--- a/products/cloudflare-one/src/content/connections/connect-devices/agentless/dns-over-https.md
+++ b/products/cloudflare-one/src/content/connections/connect-devices/agentless/dns-over-https.md
@@ -54,12 +54,16 @@ You should now be able to send queries through the DNS over HTTPS protocol.
 
 ### Google Chrome / Microsoft Edge / Brave
 
+<Aside type="note">
+
+This setting may already be enabled by default.
+
+</Aside>
+
 1. Open **Settings**.
 2. In your address bar, type the following and hit **Enter**:
- `chrome://flags/#dns-over-https`. This will take you to Secure DNS lookups.
-4. Click on the **Secure DNS lookups** radio button to enable DoH.
-
-Read more about [enabling DNS over HTTPS](https://www.chromium.org/developers/dns-over-https) on Chrome.
+ `chrome://settings/security`. This will take you to the Security page where you can enable DoH.
+3. Scroll down below the Advanced section and toggle **Use secure DNS** and choose **With Custom** and enter `https://YOUR_UNIQUE_SUBDOMAIN.cloudflare-gateway.com/dns-query` in the field.
 
 ### Safari
 


### PR DESCRIPTION
1.1.1.1 was up-to-date with how you enable DoH in the browser, but Zero Trust was still relying on the browser flag, which is no longer present as DoH has made its way into the settings menu.