### PR TITLE
Fix heading levels in several documentation areas

### DIFF
--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/android.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/android.md
@@ -14,7 +14,7 @@ The app also allows you to enable encryption for DNS queries or enable [WARP mod
 
 You can select between these two options in 1.1.1.1: Faster & Safer Internet's settings. By default, 1.1.1.1: Faster & Safer Internet is configured to WARP mode. 
 
-### Set up 1.1.1.1: Faster & Safer Internet
+## Set up 1.1.1.1: Faster & Safer Internet
 
 1. Download [1.1.1.1: Faster Internet from Google Play](https://play.google.com/store/apps/details?id=com.cloudflare.onedotonedotonedotone) for free.
 1. Launch 1.1.1.1: Faster & Safer Internet and accept the Terms of Service.

--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/ios.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/ios.md
@@ -14,7 +14,7 @@ The app also allows you to enable encryption for DNS queries to the 1.1.1.1 DNS 
 
 You can select between these two options in 1.1.1.1: Faster Internet's settings. By default, 1.1.1.1:Faster Internet is configured to WARP mode. 
 
-### Set up 1.1.1.1: Faster Internet
+## Set up 1.1.1.1: Faster Internet
 
 1. Download [1.1.1.1: Faster Internet from the App Store](https://apps.apple.com/us/app/1-1-1-1-faster-internet/id1423538627) for free.
 1. Launch 1.1.1.1: Faster Internet and accept the Terms of Service.

--- a/products/1.1.1.1/src/content/setup-1.1.1.1/android.md
+++ b/products/1.1.1.1/src/content/setup-1.1.1.1/android.md
@@ -14,7 +14,7 @@ The app also allows you to enable encryption for DNS queries or enable [WARP mod
 
 You can select between these two options in 1.1.1.1: Faster Internet's settings. By default, 1.1.1.1:Faster Internet is configured to WARP mode. 
 
-### Set up 1.1.1.1: Faster Internet
+## Set up 1.1.1.1: Faster Internet
 
 1. Download [1.1.1.1: Faster Internet from Google Play](https://play.google.com/store/apps/details?id=com.cloudflare.onedotonedotonedotone) for free.
 1. Launch 1.1.1.1: Faster Internet and accept the Terms of Service.

--- a/products/1.1.1.1/src/content/setup-1.1.1.1/ios.md
+++ b/products/1.1.1.1/src/content/setup-1.1.1.1/ios.md
@@ -14,7 +14,7 @@ The app also allows you to enable encryption for DNS queries or enable [WARP mod
 
 You can select between these two options in 1.1.1.1: Faster Internet's settings. By default, 1.1.1.1:Faster Internet is configured to WARP mode. 
 
-### Set up 1.1.1.1: Faster Internet
+## Set up 1.1.1.1: Faster Internet
 
 1. Download [1.1.1.1: Faster Internet from the App Store](https://apps.apple.com/us/app/1-1-1-1-faster-internet/id1423538627) for free.
 1. Launch 1.1.1.1: Faster Internet and accept the Terms of Service.

--- a/products/analytics/src/content/graphql-api/features/filtering/index.md
+++ b/products/analytics/src/content/graphql-api/features/filtering/index.md
@@ -76,11 +76,11 @@ filters
   filter, filters
 ```
 
-## Operators
+### Operators
 
 Operator support varies, depending on the node type and node name.
 
-### Common operators
+#### Common operators
 
 The following operators are supported for all types:
 
@@ -93,7 +93,7 @@ The following operators are supported for all types:
 | `neq`    | not equal           |
 | `in`     | in                  |
 
-### String operators
+#### String operators
 
 The `like` operator is available for string comparisons and supports the `%` character as a wildcard.
 

--- a/products/analytics/src/content/graphql-api/features/filtering/index.md
+++ b/products/analytics/src/content/graphql-api/features/filtering/index.md
@@ -7,7 +7,7 @@ pcx-content-type: reference
 
 Filters constrain queries to a particular account or set of zones, requests by date, or those from a specific user agent, for example. Without filters, queries can suffer performance degradation, results can easily exceed supported bounds, and the data returned can be noisy.
 
-### Filter Structure
+## Filter Structure
 
 The GraphQL filter is represented by the [GraphQL Input Object](https://graphql.github.io/graphql-spec/June2018/#sec-Input-Objects), which exposes Boolean algebra on nodes.
 
@@ -17,7 +17,7 @@ You can use filters as an argument on the following resources:
 - accounts
 - tables (datasets)
 
-#### Zone filter
+### Zone filter
 
 Allows querying zone-related data by zone ID (`zoneTag`).
 
@@ -42,7 +42,7 @@ Use the `zoneTag: t` and `zoneTag_in: [t, ...]` forms when you know the zone IDs
 
 Omit the filter to get results for all zones (up to the supported limit).
 
-#### Account filter
+### Account filter
 
 The account filter uses the same structure and rules as the zone filter, except that it uses the Account ID (`accountTag`) instead of the Zone ID (`zoneTag`).
 
@@ -54,7 +54,7 @@ Network Analytics queries require an Account ID (`accountTag`) filter.
 
 </Aside>
 
-#### Table (dataset) filter
+### Table (dataset) filter
 
 Table filters require that you query at least one node. Use the `AND` operator to create and combine multi-node filters. Table filters also support the `OR` operator, which you must specify explicitly.
 
@@ -76,11 +76,11 @@ filters
   filter, filters
 ```
 
-#### Operators
+## Operators
 
 Operator support varies, depending on the node type and node name.
 
-##### Common operators
+### Common operators
 
 The following operators are supported for all types:
 
@@ -93,13 +93,13 @@ The following operators are supported for all types:
 | `neq`    | not equal           |
 | `in`     | in                  |
 
-##### String operators
+### String operators
 
 The `like` operator is available for string comparisons and supports the `%` character as a wildcard.
 
-### Examples
+## Examples
 
-#### General example
+### General example
 
 ```graphql
 {
@@ -113,11 +113,11 @@ The `like` operator is available for string comparisons and supports the `%` cha
 }
 ```
 
-#### Filter on a specific node
+### Filter on a specific node
 
 The following GraphQL example shows how to filter a specific node. The SQL equivalent follows.
 
-##### GraphQL {#001}
+#### GraphQL {#001}
 
 ```graphql
 httpRequestsAdaptiveGroups(filter: {datetime: "2018-01-01T10:00:00Z"}) {
@@ -125,17 +125,17 @@ httpRequestsAdaptiveGroups(filter: {datetime: "2018-01-01T10:00:00Z"}) {
 }
 ```
 
-##### SQL {#002}
+#### SQL {#002}
 
 ```sql
 WHERE datetime="2018-01-01T10:00:00Z"
 ```
 
-#### Filter on multiple fields
+### Filter on multiple fields
 
 The following GraphQL example shows how to apply a filter to multiple fields, in this case two datetime fields. The SQL equivalent follows.
 
-##### GraphQL {#003}
+#### GraphQL {#003}
 
 ```graphql
 httpRequests1hGroups(filter: {datetime_gt: "2018-01-01T10:00:00Z", datetime_lt: "2018-01-01T11:00:00Z"}) {
@@ -143,17 +143,17 @@ httpRequests1hGroups(filter: {datetime_gt: "2018-01-01T10:00:00Z", datetime_lt: 
 }
 ```
 
-##### SQL {#004}
+#### SQL {#004}
 
 ```sql
 WHERE (datetime > "2018-01-01T10:00:00Z") AND (datetime < "2018-01-01T10:00:00Z")
 ```
 
-#### Filter using the `OR` operator
+### Filter using the `OR` operator
 
 The following GraphQL example demonstrates using the `OR` operator in a filter. This `OR` operator filters for the value `US` or `GB` in the `clientCountryName` field.
 
-##### GraphQL {#005}
+#### GraphQL {#005}
 
 ```graphql
 httpRequestsAdaptiveGroups(
@@ -164,13 +164,13 @@ httpRequestsAdaptiveGroups(
 }
 ```
 
-##### SQL {#006}
+#### SQL {#006}
 
 ```sql
 WHERE datetime="2018-01-01T10:00:00Z"
   AND ((clientCountryName = "US") OR (clientCountryName = "GB"))
 ```
 
-### Subqueries (advanced filters)
+## Subqueries (advanced filters)
 
 Subqueries are not currently supported. You can use two GraphQL queries as a workaround for this limitation.

--- a/products/cloudflare-one/src/content/applications/configure-apps/saas-apps.md
+++ b/products/cloudflare-one/src/content/applications/configure-apps/saas-apps.md
@@ -9,7 +9,7 @@ Cloudflare Access allows you to integrate your SaaS products by acting as an ide
 
 ![SaaS applications diagram](../../static/documentation/applications/diagram-saas.jpg)
 
-### 1. Add your application
+## 1. Add your application
 
 1. On the [Zero Trust dashboard](https://dash.teams.cloudflare.com), navigate to **Access > Applications**.
 
@@ -47,7 +47,7 @@ SaaS applications store this information in different ways.
 
 1. Click **Next**.
 
-### 2. Add a policy
+## 2. Add a policy
 You can now configure a policy to control who can access your app.
 
 To learn more about how policies work, read our [Policies](/policies/).
@@ -57,7 +57,7 @@ To learn more about how policies work, read our [Policies](/policies/).
 1. Specify one or more rules in the **Configure a rule** box. You can add as many include, exception, or require statements as needed.
 1. Click **Next** to add your application to Access.
 
-### 3. Integrate your SaaS application with Access
+## 3. Integrate your SaaS application with Access
 
 Before you begin using your application through Access, your last step is to integrate your SaaS application to Access.
 

--- a/products/cloudflare-one/src/content/faq/teams-general-faq.md
+++ b/products/cloudflare-one/src/content/faq/teams-general-faq.md
@@ -7,19 +7,19 @@ pcx-content-type: faq
 
 # General
 
-### What is the difference between Cloudflare Gateway and 1.1.1.1?
+## What is the difference between Cloudflare Gateway and 1.1.1.1?
 
 1.1.1.1 does not block any DNS query. When a browser requests for example.com, 1.1.1.1 simply looks up the answer either in cache or by performing a full recursive DNS query.
 
 Cloudflare Gateway's DNS resolver introduces security into this flow. Instead of allowing all DNS queries, Gateway first checks the hostname being queried against the intelligence Cloudflare has about threats on the Internet. If that query matches a known threat, or is requesting a blocked domain configured by an administrator as part of a Gateway policy, Gateway stops it before the site could load for the user - and potentially execute code or phish that team member.
 
-### Is multi-factor authentication supported?
+## Is multi-factor authentication supported?
 
 Access is subjected to the MFA policies set in your identity provider. For example, users attempting to log in to an Access protected app might log in through Okta. Okta would enforce an MFA check before sending the valid authentication confirmation back to Cloudflare Access.
 
 Access does not have an independent or out-of-band MFA feature. 
 
-### Which browsers are supported?
+## Which browsers are supported?
 
 These browsers are supported:
 * Internet Explorer® 11

--- a/products/fundamentals/src/content/data-products/analytics-integrations/splunk/index.md
+++ b/products/fundamentals/src/content/data-products/analytics-integrations/splunk/index.md
@@ -7,8 +7,7 @@ pcx-content-type: how-to
 
 This tutorial explains how to analyze [Cloudflare Logs](https://www.cloudflare.com/products/cloudflare-logs/) using the [Cloudflare App for Splunk](https://splunkbase.splunk.com/app/4501/).
 
-
-### Prerequisites
+## Prerequisites
 
 Before sending your Cloudflare log data to Splunk, ensure that you:
 

--- a/products/logs/src/content/tutorials/index.md
+++ b/products/logs/src/content/tutorials/index.md
@@ -7,6 +7,6 @@ pcx-content-type: navigation
 
 Learn to manage and analyze your Cloudflare Logs with the following resources. For information about Cloudflare's analytics integrations, refer to [Analytics Integrations](https://developers.cloudflare.com/fundamentals/data-products/analytics-integrations).
 
-### Logpull and Logpush
+## Logpull and Logpush
 
 - [Parsing Cloudflare Logs JSON data](/tutorials/parsing-json-log-data/)

--- a/products/pages/src/content/tutorials/add-an-html-form-with-formspree/index.md
+++ b/products/pages/src/content/tutorials/add-an-html-form-with-formspree/index.md
@@ -11,7 +11,7 @@ Almost every website, whether it is a simple HTML portfolio page or a complex Ja
 
 In this tutorial, you will create a `<form>` using plain HTML and CSS and add it to a static HTML website hosted on Cloudflare Pages. Refer to the [Get started guide](/get-started) to familiarize yourself with the platform. You will use Formspree to collect the submitted data and send out email notifications when new submissions arrive, without requiring any JavaScript or back-end coding.
 
-### Setup
+## Setup
 
 To begin, create a [new GitHub repository](https://repo.new/). Then create a new local directory on your machine, initialize git, and attach the GitHub location as a remote destination:
 
@@ -30,7 +30,7 @@ $ git branch -M main
 
 You may now begin working in the `new-project` directory you created.
 
-### The website markup
+## The website markup
 
 You will only be using plain HTML for this example project. The home page will include a Contact Us form that accepts a name, email address, and message. 
 
@@ -105,7 +105,7 @@ The source code for this example is [available on GitHub](https://github.com/for
 
 </Aside>
 
-### The Formspree back end
+## The Formspree back end
 
 The HTML form is complete, however, when the user submits this form, the data will be sent in a `POST` request to the `/` URL. No server exists to process the data at that URL, so it will cause an error. To fix that, create a new Formspree form, and copy its unique URL into the form's `action`.  
 
@@ -140,7 +140,7 @@ For more help setting up Formspree, refer to the following resources:
 - For examples and inspiration for your own HTML forms, review the [Formspree form library](https://formspree.io/library).
 - For tips on integrating Formspree with popular platforms like Next.js, Gatsby and Eleventy, refer to the [Formspree guides](https://formspree.io/guides).
 
-### Deployment
+## Deployment
 
 You are now ready to deploy your project.
 

--- a/products/spectrum/src/content/reference/logs.md
+++ b/products/spectrum/src/content/reference/logs.md
@@ -9,11 +9,11 @@ Spectrum logs the entire lifecycle of every client that connects through it. The
 
 For each connection, Spectrum logs a connect event and either a disconnect or error event. Details on status codes can be found below.
 
-### Configuring Logpush
+## Configuring Logpush
 
 Spectrum [log events](https://developers.cloudflare.com/logs/log-fields/) can be configured through the [dashboard](https://developers.cloudflare.com/logs/logpush/logpush-dashboard/) and [API](https://developers.cloudflare.com/logs/logpush/logpush-configuration-api/).
 
-### Status Codes
+## Status Codes
 
 <TableWrap>
 


### PR DESCRIPTION
We shouldn't skip heading levels in documentation pages (for example, using an `h1` and then an `h3`).
Fixes the warnings detected by the search crawler.