### PR TITLE
[Workers] update getRandomValues for new release

### DIFF
--- a/products/workers/src/content/runtime-apis/web-crypto.md
+++ b/products/workers/src/content/runtime-apis/web-crypto.md
@@ -48,7 +48,7 @@ The Web Crypto API differs significantly from Node’s Crypto API. If you want t
 
     - <Code>buffer<ParamType>ArrayBufferView</ParamType></Code>
 
-      - Must be an <Code><Type>Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array</Type></Code>.
+      - Must be an <Code><Type>Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array</Type></Code>.
 
 - <Code>crypto.randomUUID()</Code>
   <Type>string</Type>


### PR DESCRIPTION
`getRandomValues` supports 64-bit integer types as of release 2022-02-08.

Refs: https://github.com/cloudflare/workers-types/pull/194