### PR TITLE
[Cache] Removed info about enabled in batches.

### DIFF
--- a/products/cache/src/content/about/early-hints.md
+++ b/products/cache/src/content/about/early-hints.md
@@ -23,7 +23,7 @@ For more information about Early Hints, refer to the [Early Hints blog](https://
 1. From the dashboard, click **Speed** > **Optimization**.
 1. Under **Optimized Delivery**, click **Join the beta**.
 
-After you sign up, you will be added to a list of beta users, and the feature will be enabled in batches from the list. After admission into the Beta, you can toggle Early Hints on or off from **Optimized Delivery**.
+After joining the Beta, you can toggle Early Hints on or off from **Optimized Delivery**.
 
 ## Generating Early Hints
 


### PR DESCRIPTION
Removed note from Early Hints beta about being admitted into beta in batches; admission into beta now happens instantaneously.