### PR TITLE
[1.1.1.1] Updated Linux pages

### DIFF
--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
@@ -8,33 +8,27 @@ import CaptivePortals from "../_partials/_captive-portals.md"
 
 # Set up 1.1.1.1 for Families - Linux
 
-Follow these steps to configure 1.1.1.1 for Families in Ubuntu and Debian.
+Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
-## Block malware
+## Ubuntu
 
-### Ubuntu
+### Block malware
 
-#### IPv4
 
-1. Click **System** > **Preferences** > **Network Connections**.
-1. Select the **Wireless** tab, then choose the WiFi network you are currently connected to.
-1. Click **Edit** > **IPv4**.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Remove any DNS addresses that may be already listed and replace them with:
+1. Click **Show Applications** > **Settings** > **Network**.
+1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
+1. Click the **IPv4** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     1.1.1.2
     1.0.0.2
     ```
 
-1. Click **Apply**.
-
-#### IPv6
-
-1. Click **System** > **Preferences** > **Network Connections**.
-1. Select the **Wireless** tab, then choose the WiFi network you are currently connected to.
-1. Go to **IPv6**.
-1. Add the IPv6 addresses listed below:
+1. Click the **IPv6** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     2606:4700:4700::1112
@@ -43,78 +37,23 @@ Follow these steps to configure 1.1.1.1 for Families in Ubuntu and Debian.
 
 1. Click **Apply**.
 
-### Debian
+### Block malware and adult content
 
-#### IPv4
 
-1. In the command line, type:
-
-    ```bash
-    sudo vim /etc/resolv.conf
-    ```
-
-1. Press the <kbd>i</kbd> key on your keyboard to edit the document.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Replace the nameserver lines with:
-
-    ```txt
-    1.1.1.2
-    1.0.0.2
-    ```
-
-1. Press the <kbd>ESC</kbd> key on your keyboard to save and exit Vim. Then, type:
-
-    ```
-    :wq
-    ```
-
-#### IPv6
-
-1. In the command line, type:
-
-    ```bash
-    sudo vim /etc/resolv.conf
-    ```
-
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Add the IPv6 address listed below:
-
-    ```txt
-    2606:4700:4700::1112
-    2606:4700:4700::1002
-    ```
-
-1. Press the <kbd>ESC</kbd> key on your keyboard to save and exit Vim. Then, type:
-
-    ```
-    :wq
-    ```
-
-## Block Malware and Adult Content
-
-### Ubuntu
-
-#### IPv4
-
-1. Click **System** > **Preferences** > **Network Connections**.
-1. Select the **Wireless** tab, then choose the WiFi network you are currently connected to.
-1. Click **Edit** > **IPv4**.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Remove any DNS addresses that may be already listed and replace them with:
+1. Click **Show Applications** > **Settings** > **Network**.
+1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
+1. Click the **IPv4** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     1.1.1.3
     1.0.0.3
     ```
-1. Click **Apply**.
 
-#### IPv6
-
-1. Click **System** > **Preferences** > **Network Connections**.
-1. Select the **Wireless** tab, then choose the WiFi network you are currently connected to.
-1. Go to **IPv6**.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Add the IPv6 addresses listed below:
+1. Click the **IPv6** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     2606:4700:4700::1113
@@ -122,52 +61,5 @@ Follow these steps to configure 1.1.1.1 for Families in Ubuntu and Debian.
     ```
 
 1. Click **Apply**.
-
-### Debian
-
-#### IPv4
-
-1. In the command line, type:
-
-    ```bash
-    sudo vim /etc/resolv.conf
-    ```
-
-1. Press the <kbd>i</kbd> key on your keyboard to edit the document.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Replace the nameserver lines with:
-
-    ```txt
-    1.1.1.3
-    1.0.0.3
-    ```
-
-1. Press the <kbd>ESC</kbd> key on your keyboard to save and exit Vim. Then, type:
-
-    ```
-    :wq
-    ```
-
-#### IPv6
-
-1. In the command line, type:
-
-    ```bash
-    sudo vim /etc/resolv.conf
-    ```
-
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Add the IPv6 addresses listed below:
-
-    ```txt
-    2606:4700:4700::1113
-    2606:4700:4700::1003
-    ```
-
-1. Press the <kbd>ESC</kbd> key on your keyboard to save and exit Vim. Then, type:
-
-    ```
-    :wq
-    ```
 
 <CaptivePortals/>

--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
@@ -40,7 +40,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 ### Block malware and adult content
 
 
-1. Click **Show Applications** > **Settings** > **Network**.
+1. Go to **Show Applications** > **Settings** > **Network**.
 1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
 1. Click the **IPv4** tab.
 1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.

--- a/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
+++ b/products/1.1.1.1/src/content/1.1.1.1-for-families/linux.md
@@ -15,10 +15,10 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 ### Block malware
 
 
-1. Click **Show Applications** > **Settings** > **Network**.
+1. Go to **Show Applications** > **Settings** > **Network**.
 1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
 1. Click the **IPv4** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt
@@ -27,7 +27,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
     ```
 
 1. Click the **IPv6** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt
@@ -43,7 +43,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 1. Go to **Show Applications** > **Settings** > **Network**.
 1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
 1. Click the **IPv4** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt
@@ -52,7 +52,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
     ```
 
 1. Click the **IPv6** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt

--- a/products/1.1.1.1/src/content/setup-1.1.1.1/linux.md
+++ b/products/1.1.1.1/src/content/setup-1.1.1.1/linux.md
@@ -12,10 +12,10 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 
 ## Ubuntu
 
-1. Click **Show Applications** > **Settings** > **Network**.
+1. Go to **Show Applications** > **Settings** > **Network**.
 1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
 1. Click the **IPv4** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt
@@ -24,7 +24,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
     ```
 
 1. Click the **IPv6** tab.
-1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. In the **DNS** section, disable the **Automatic** toggle.
 1. Change the DNS servers to:
 
     ```txt

--- a/products/1.1.1.1/src/content/setup-1.1.1.1/linux.md
+++ b/products/1.1.1.1/src/content/setup-1.1.1.1/linux.md
@@ -8,23 +8,24 @@ import CaptivePortals from "../_partials/_captive-portals.md"
 
 # Set up 1.1.1.1 - Linux
 
-Follow these steps to configure 1.1.1.1 in Ubuntu and Debian:
+Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
 ## Ubuntu
 
-1. Click **System** > **Preferences** > **Network Connections**.
-1. Select the **Wireless tab**, then choose the WiFi network you are currently connected to.
-1. Click **Edit** > **IPv4**.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Change the DNS servers listed to:
+1. Click **Show Applications** > **Settings** > **Network**.
+1. Select the adapter you want to configure - like your Ethernet adapter or Wi-Fi card - and click the **settings** button.
+1. Click the **IPv4** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     1.1.1.1
     1.0.0.1
     ```
 
-1. Click **Apply**.
-1. Then, go to **IPv6** and add the DNS servers:
+1. Click the **IPv6** tab.
+1. In the **DNS** section, make sure the **Automatic** toggle is **disabled**.
+1. Change the DNS servers to:
 
     ```txt
     2606:4700:4700::1111
@@ -32,40 +33,6 @@ Follow these steps to configure 1.1.1.1 in Ubuntu and Debian:
     ```
 
 1. Click **Apply**.
-
-1. Visit [1.1.1.1/help](https://1.1.1.1/help) to make sure your system is connected to 1.1.1.1.
-
-## Debian
-
-1. In the command line, type:
-
-  ```sh
-  $ sudo vim /etc/resolv.conf
-  ```
-
-1. Press the <kbd>i</kbd> key on your keyboard to edit the document.
-1. Take note of any DNS addresses you might have and save them in a safe place in case you need to use them later.
-1. Replace the `nameserver` lines with:
-
-  For IPv4:
-
-    ```txt
-    nameserver 1.0.0.1
-    nameserver 1.1.1.1
-    ```
-
-  For IPv6:
-
-    ```txt
-    nameserver 2606:4700:4700::1111
-    nameserver 2606:4700:4700::1001
-    ```
-
-1. Press the <kbd>ESC</kbd> key on your keyboard to save and exit Vim. Then, type:
-
-  ```
-  :wq
-  ```
 
 1. Visit [1.1.1.1/help](https://1.1.1.1/help) to make sure your system is connected to 1.1.1.1.
 


### PR DESCRIPTION
- Updated how-to steps for Ubuntu
- Deleted Debian as it was out of date and the steps are the same as for Ubuntu