### PR TITLE
[Workers] Clarify subrequest limit in limits.md

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -10,7 +10,7 @@ pcx-content-type: concept
 
 | Feature                                                                         | Free      | Paid      |
 | ------------------------------------------------------------------------------- | --------- | --------- |
-| [Subrequests](#subrequests)                                                     | 50        | 50        |
+| [Subrequests](#subrequests)                                                     | 50/request| 50/request|
 | [Simultaneous outgoing<br/>connections/request](#simultaneous-open-connections) | 6         | 6         |
 | [Environment variables](#environment-variables)                                 | 64/worker | 64/worker |
 | [Environment variable<br/>size](#environment-variables)                         | 5 KB      | 5 KB      |


### PR DESCRIPTION
- ❌ I got shocked and scared when I checked Limits page! After seeing "**Subrequest: 50**", I was afraid that my API won't be able to make more than 50 requests to external services daily.
- ✔ Then, I read that the limit is only per single request!! 😅

I propose clarifying that! We could simply change it to "50/request", similarly how it's done with "64/worker".