### PR TITLE
Apps folder locations to try the Quiche HTTP/3 client

### DIFF
--- a/products/http3/src/content/tutorials/quiche-http3-client.md
+++ b/products/http3/src/content/tutorials/quiche-http3-client.md
@@ -10,9 +10,9 @@ Quiche is Cloudflare's own implementation of the QUIC transport protocol and HTT
 
 ```sh
 $ git clone --recursive https://github.com/cloudflare/quiche.git
-$ cd quiche/tools/apps
+$ cd quiche/apps
 $ cargo build
-$ cd target/debug/
+$ cd ../target/debug/
 ```
 
 ## Use quiche-client


### PR DESCRIPTION
Dearest.
The apps folder is now outside of tools.
Cheers.

FYI the "larger file" URL is broken.
