### PR TITLE
Correct .deb package install command

### DIFF
--- a/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-guide.md
+++ b/products/cloudflare-one/src/content/connections/connect-apps/install-and-setup/tunnel-guide.md
@@ -57,7 +57,8 @@ Next, install `cloudflared`.
 Use the deb package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` is used in this example.
 
 ```sh
-$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb dpkg -i cloudflared-linux-amd64.deb
+$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+$ dpkg -i cloudflared-linux-amd64.deb
 ```
 
 ### ​.rpm install


### PR DESCRIPTION
Also, unrelated, but why is there a zero-width space before `.rpm` on this page?