### PR TITLE
[Workers] Add Hono template

### DIFF
--- a/products/workers/src/content/get-started/quickstarts.md
+++ b/products/workers/src/content/get-started/quickstarts.md
@@ -70,7 +70,7 @@ $ wrangler generate <new-project-name> <github-repo-url>
 
 <WorkerStarter
   title="Hono Starter"
-  description="Hono is an ultrafast web framework built for Cloudflare Workers. This is a minimal project using Hono, TypeScript, esbuild, and miniflare."
+  description="Hono is an ultrafast web framework built for Cloudflare Workers. This is a minimal project using Hono, TypeScript, esbuild, and Miniflare."
   repo="yusukebe/hono-minimal"
 />
 

--- a/products/workers/src/content/get-started/quickstarts.md
+++ b/products/workers/src/content/get-started/quickstarts.md
@@ -68,6 +68,12 @@ $ wrangler generate <new-project-name> <github-repo-url>
   repo="sunderjs/sunder-worker-template"
 />
 
+<WorkerStarter
+  title="Hono Starter"
+  description="Hono is an ultrafast web framework built for Cloudflare Workers. This is a minimal project using Hono, TypeScript, esbuild, and miniflare."
+  repo="yusukebe/hono-minimal"
+/>
+
 --------------------------------
 
 ## Frameworks


### PR DESCRIPTION
Hi!

This PR is adding a **[Hono](https://github.com/yusukebe/hono)** starter template to QuickStart page. Hono is an *ultrafast* web framework what I'm building with effort. This template includes only few files - `package.json`, `wrangler.toml`, and `src/index.ts`. I think others can start creating Workers little by little.