### PR TITLE
Document increased durable object storage limit

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -115,15 +115,15 @@ Refer to [KV pricing](/workers/platform/pricing/#workers-kv) to review the speci
 
 {{<table-wrap>}}
 
-| Feature                                 | Limit                                          |
-| --------------------------------------- | ---------------------------------------------- |
-| [Number of objects](#durable-objects)   | unlimited                                      |
-| [Storage per account](#durable-objects) | 10 GB (can be raised by contacting Cloudflare) |
-| [Storage per class](#durable-objects)   | unlimited                                      |
-| [Storage per object](#durable-objects)  | unlimited                                      |
-| [Key size](#durable-objects)            | 2048 bytes                                     |
-| [Value size](#durable-objects)          | 128 KiB                                        |
-| [CPU per request](#durable-objects)     | 30s                                            |
+| Feature                                 | Limit
+| --------------------------------------- | ------
+| [Number of objects](#durable-objects)   | unlimited
+| [Storage per account](#durable-objects) | 50 GB (can be raised by contacting Cloudflare)
+| [Storage per class](#durable-objects)   | unlimited
+| [Storage per object](#durable-objects)  | unlimited
+| [Key size](#durable-objects)            | 2048 bytes
+| [Value size](#durable-objects)          | 128 KiB
+| [CPU per request](#durable-objects)     | 30s
 
 {{</table-wrap>}}
 
@@ -278,7 +278,7 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 
 - Unlimited Durable Objects within an account or of a given class
 
-- 10 GB total storage per account (can be raised by contacting Cloudflare)
+- 50 GB total storage per account (can be raised by contacting Cloudflare)
 
 - No storage limit per Durable Object separate from the account limit
 


### PR DESCRIPTION
Each account may now store up to 50 GB before needing to contact us for
an increase.

@greg-mckeon the "can be raised by contacting Cloudflare" wording kind of bugs me as being not very actionable for anyone who doesn't some sort of support or sales contact. Do you have a particular recommendation for how self-service users should contact us if they want more?