### PR TITLE
Clarify a bit of awkwardness in the KV limits documentation

### DIFF
--- a/products/workers/src/content/platform/limits.md
+++ b/products/workers/src/content/platform/limits.md
@@ -84,7 +84,8 @@ The Workers Unbound Usage Model has a significantly higher limit than the Bundle
 | [Writes/second (same key)](#kv)       | 1                     | 1          |
 | [Operations/worker invocation](#kv)   | 1000                  | 1000       |
 | [Namespaces](#kv)                     | 100                   | 100        |
-| [Keys/namespace](#kv)                 | 1 GB                  | unlimited  |
+| [Storage/namespace](#kv)              | 1 GB                  | unlimited  |
+| [Keys/namespace](#kv)                 | unlimited             | unlimited  |
 | [Key size](#kv)                       | 512 bytes             | 512 bytes  |
 | [Key metadata](#kv)                   | 1024 bytes            | 1024 bytes |
 | [Value size](#kv)                     | 25 MiB                | 25 MiB     |
@@ -244,6 +245,7 @@ Workers KV supports:
 
 - Up to 100 Namespaces per account
 - Unlimited keys per namespace
+- Unlimited storage per namespace (except on the free tier, which is limited to 1 GB)
 - Keys of up to 512 bytes
 - Values of up to 25 MiB
 - Metadata of up to 1024 bytes per key


### PR DESCRIPTION
We were saying that the free tier is limited to 1 GB of
"keys/namespace", which is kind of an odd framing. The limit is 1 GB of
data (whether stored in keys, or values, or metadata), and there's no
specific limit on the number of keys, just the 1 GB total storage
restriction.

Noticed while doing #3597 and figured we ought to clean this up