### PR TITLE
fix(assets): ensure minified function names do not share scope

### DIFF
--- a/assets/home.ts
+++ b/assets/home.ts
@@ -1,7 +1,9 @@
 import * as events from './events';
 import * as timeago from './timeago';
 
-timeago.init();
+(function () {
+  timeago.init();
 
-events.focus();
-events.mobile();
+  events.focus();
+  events.mobile();
+})();

--- a/assets/main.ts
+++ b/assets/main.ts
@@ -10,12 +10,14 @@ declare global {
   }
 }
 
-navs.init();
-timeago.init();
+(function () {
+  navs.init();
+  timeago.init();
 
-events.focus();
-events.mobile();
-events.dropdowns();
-events.copy();
+  events.focus();
+  events.mobile();
+  events.dropdowns();
+  events.copy();
 
-contents.toc();
+  contents.toc();
+})();

--- a/assets/search.ts
+++ b/assets/search.ts
@@ -1,87 +1,89 @@
-let tag = document.currentScript;
-let $ = document.querySelector.bind(document);
+(function () {
+  let tag = document.currentScript;
+  let $ = document.querySelector.bind(document);
 
-let dataset = tag && tag.dataset;
-let { index, key, filters } = dataset || {};
+  let dataset = tag && tag.dataset;
+  let { index, key, filters } = dataset || {};
 
-function loaded() {
-  let element = $('#DocsSearch--input') || $('#SiteSearch--input');
+  function loaded() {
+    let element = $('#DocsSearch--input') || $('#SiteSearch--input');
 
-  let algolia = window.docsearch({
-    indexName: index,
-    apiKey: key,
-    algoliaOptions: {
-      facetFilters: filters || '',
-    },
+    let algolia = window.docsearch({
+      indexName: index,
+      apiKey: key,
+      algoliaOptions: {
+        facetFilters: filters || '',
+      },
 
-    inputSelector: '#' + element.id,
+      inputSelector: '#' + element.id,
 
-    autocompleteOptions: {
-      // https://github.com/algolia/autocomplete.js#global-options
-      autoselect: true,
-      openOnFocus: true,
-      clearOnSelected: false,
-      tabAutocomplete: false,
+      autocompleteOptions: {
+        // https://github.com/algolia/autocomplete.js#global-options
+        autoselect: true,
+        openOnFocus: true,
+        clearOnSelected: false,
+        tabAutocomplete: false,
 
-      appendTo: '.' + element.parentNode.className,
-      hint: false,
+        appendTo: '.' + element.parentNode.className,
+        hint: false,
 
-      autoselectOnBlur: matchMedia('(pointer: course)').matches,
-    },
+        autoselectOnBlur: matchMedia('(pointer: course)').matches,
+      },
 
-    // https://docsearch.algolia.com/docs/behavior
-    handleSelected(input, event, suggestion, datasetNumber, context) {
-      let ctx = new URL(suggestion.url);
+      // https://docsearch.algolia.com/docs/behavior
+      handleSelected(input, event, suggestion, datasetNumber, context) {
+        let ctx = new URL(suggestion.url);
 
-      algolia.input.autocomplete.setVal('');
-      algolia.input[0].blur();
+        algolia.input.autocomplete.setVal('');
+        algolia.input[0].blur();
 
-      // no scroll if is H1 tag
-      if (suggestion.isLvl0) ctx.hash = '';
+        // no scroll if is H1 tag
+        if (suggestion.isLvl0) ctx.hash = '';
 
-      // redirect to new path
-      return location.assign(ctx.pathname + ctx.search + ctx.hash);
-    },
+        // redirect to new path
+        return location.assign(ctx.pathname + ctx.search + ctx.hash);
+      },
 
-    transformData(hits) {
-      // Remove empty results
-      for (let len = hits.length; len-- > 0; ) {
-        let info = hits[len].hierarchy;
-        if (!info.lvl0 && !info.lvl1) {
-          hits.splice(len, 1);
+      transformData(hits) {
+        // Remove empty results
+        for (let len = hits.length; len-- > 0; ) {
+          let info = hits[len].hierarchy;
+          if (!info.lvl0 && !info.lvl1) {
+            hits.splice(len, 1);
+          }
         }
+      },
+    });
+
+    let input = algolia.input[0];
+    let wrapper = algolia.autocomplete.autocomplete.getWrapper();
+
+    algolia.autocomplete.on('autocomplete:shown', () => {
+      wrapper.setAttribute('data-expanded', true);
+    });
+
+    algolia.autocomplete.on('autocomplete:closed', () => {
+      wrapper.setAttribute('data-expanded', false);
+    });
+
+    addEventListener('keydown', ev => {
+      if (ev.target === input) return;
+
+      let key = ev.which;
+
+      // is '/' or SHIFT+'s'
+      if (key === 191 || (ev.shiftKey && key === 83)) {
+        ev.preventDefault();
+        window.scrollTo(0, 0);
+        input.focus();
       }
-    },
-  });
+    });
+  }
 
-  let input = algolia.input[0];
-  let wrapper = algolia.autocomplete.autocomplete.getWrapper();
-
-  algolia.autocomplete.on('autocomplete:shown', () => {
-    wrapper.setAttribute('data-expanded', true);
-  });
-
-  algolia.autocomplete.on('autocomplete:closed', () => {
-    wrapper.setAttribute('data-expanded', false);
-  });
-
-  addEventListener('keydown', ev => {
-    if (ev.target === input) return;
-
-    let key = ev.which;
-
-    // is '/' or SHIFT+'s'
-    if (key === 191 || (ev.shiftKey && key === 83)) {
-      ev.preventDefault();
-      window.scrollTo(0, 0);
-      input.focus();
-    }
-  });
-}
-
-// init
-(function check() {
-  if (!index || !key) return;
-  if (window.docsearch) loaded();
-  else setTimeout(check, 25);
+  // init
+  (function check() {
+    if (!index || !key) return;
+    if (window.docsearch) loaded();
+    else setTimeout(check, 25);
+  })();
 })();


### PR DESCRIPTION
When minified in production, the `$tabbable` function happened to be renamed to `m`. This is good, but it just so happens that there is a `m` function in the Feedback SDK file (`sdk.js`).

Chrome was smart (or lucky?) enough to know/assume that the docs' assets were referencing the `m()` function within the same file, but Firefox and Safari had a name collision (accurate) and were calling the SDK's `m` function instead... causing errors; eg, unable to toggle the sidebar's submenus.

Wrapped all JS entries in an iffe, which the feedback SDK arguable should be doing anyway, too.