### PR TITLE
[ZT] Correct link in ssh tutorial

### DIFF
--- a/content/cloudflare-one/tutorials/ssh.md
+++ b/content/cloudflare-one/tutorials/ssh.md
@@ -136,7 +136,7 @@ You can now run the Tunnel to connect the target service to Cloudflare. Use the 
 cloudflared tunnel run <NAME>
 ```
 
-We recommend that you run `cloudflared` [as a service](/cloudflare-one/connections/connect-apps/run-tunnel/run-as-service/) that is configured to launch on start.
+We recommend that you run `cloudflared` [as a service](/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/) that is configured to launch on start.
 
 ## Connect from a client machine
 


### PR DESCRIPTION
Updating link to point to correct docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/