### PR TITLE
Fix Spectrum Plans table

### DIFF
--- a/content/spectrum/protocols-per-plan.md
+++ b/content/spectrum/protocols-per-plan.md
@@ -9,11 +9,11 @@ weight: 2
 On this table, you have information about which protocols are available per plan.
 
 |                               | Free | Pro | Business | Enterprise |
-| :---------------------------- | :--: | :-: | :------: | :--------: | --- |
+| :---------------------------- | :--: | :-: | :------: | :--------: |
 | TCP                           |      |     |          |     ✔      |
 | UDP                           |      |     |          |     ✔      |
 | Minecraft\*                   |      |  ✔  |    ✔     |     ✔      |
 | SSH                           |      |  ✔  |    ✔     |     ✔      |
-| RDP                           |      |     |    ✔     |     ✔      | ✔   |
+| RDP                           |      |     |    ✔     |     ✔      |
 
 \*Minecraft Java Edition is supported but Minecraft Bedrock Edition is not supported.


### PR DESCRIPTION
Somehow, an extra column was introduced which renders as a checkbox
outside of the table. This can be removed, RDP is only available on biz
and enterprise