### PR TITLE
Document the `global_navigator` compat flag

### DIFF
--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -73,7 +73,7 @@ Newest changes are listed first.
   </tbody>
 </table>
 
-With the `global_navigator` flag set, a new global `navigator` property is available from within Workers. Currently, it exposes only a single `navigator.userAgent` property whose value is set to `Cloudflare-Workers`. This property can be used to reliably determine whether code is running within the Workers environment.
+With the `global_navigator` flag set, a new global `navigator` property is available from within Workers. Currently, it exposes only a single `navigator.userAgent` property whose value is set to `'Cloudflare-Workers'`. This property can be used to reliably determine whether code is running within the Workers environment.
 
 ### Setters/getters on API object prototypes
 

--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -44,6 +44,37 @@ Most developers will not need to use `compatibility_flags`; instead, Cloudflare 
 
 Newest changes are listed first.
 
+### Global `navigator`
+
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <strong>Default as of</strong>
+      </td>
+      <td>2022-03-21</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Flag to enable</strong>
+      </td>
+      <td>
+        <code>global_navigator</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Flag to disable</strong>
+      </td>
+      <td>
+        <code>no_global_navigator</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+With the `global_navigator` flag set, a new global `navigator` property is available from within Workers. Currently, it exposes only a single `navigator.userAgent` property whose value is set to `Cloudflare-Workers`. This property can be used to reliably determine whether code is running within the Workers environment.
+
 ### Setters/getters on API object prototypes
 
 <table>

--- a/content/workers/runtime-apis/web-standards.md
+++ b/content/workers/runtime-apis/web-standards.md
@@ -114,3 +114,7 @@ The URL API supports URLs conforming to HTTP and HTTPs schemes.
 The Workers’ Runtime’s URL class behavior differs from the URL Spec documented above. If you would like to use another URL implementation, you can [shim the URL class using webpack](/workers/cli-wrangler/webpack/#shimming-globals).
 
 {{</Aside>}}
+
+## `navigator.userAgent`
+
+When the [`global_navigator`](/workers/platform/compatibility-dates/#global_navigator) compatibility flag is set, the [`navigator.userAgent`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) property is available with the value `'Cloudflare-Workers'`. This can be used, for instance, to reliably determine that code is running within the Workers environments.

--- a/content/workers/runtime-apis/web-standards.md
+++ b/content/workers/runtime-apis/web-standards.md
@@ -117,4 +117,4 @@ The Workers’ Runtime’s URL class behavior differs from the URL Spec document
 
 ## `navigator.userAgent`
 
-When the [`global_navigator`](/workers/platform/compatibility-dates/#global_navigator) compatibility flag is set, the [`navigator.userAgent`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) property is available with the value `'Cloudflare-Workers'`. This can be used, for instance, to reliably determine that code is running within the Workers environments.
+When the [`global_navigator`](/workers/platform/compatibility-dates/#global_navigator) compatibility flag is set, the [`navigator.userAgent`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) property is available with the value `'Cloudflare-Workers'`. This can be used, for instance, to reliably determine that code is running within the Workers environment.

--- a/content/workers/runtime-apis/web-standards.md
+++ b/content/workers/runtime-apis/web-standards.md
@@ -117,4 +117,4 @@ The Workers’ Runtime’s URL class behavior differs from the URL Spec document
 
 ## `navigator.userAgent`
 
-When the [`global_navigator`](/workers/platform/compatibility-dates/#global_navigator) compatibility flag is set, the [`navigator.userAgent`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) property is available with the value `'Cloudflare-Workers'`. This can be used, for instance, to reliably determine that code is running within the Workers environment.
+When the [`global_navigator`](/workers/platform/compatibility-dates/#global_navigator) compatibility flag is set, the [`navigator.userAgent`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) property is available with the value `'Cloudflare-Workers'`. This can be used, for example, to reliably determine that code is running within the Workers environment.


### PR DESCRIPTION
The underlying flag landed in last week's release.