### PR TITLE
fix(seo): include canonical links

### DIFF
--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -33,6 +33,7 @@
 <meta name="twitter:card" content="summary_large_image"/>
 
 <link rel="icon" href="/favicon-32x32.png"/>
+<link rel="canonical" href="{{ .Context.Permalink }}"/>
 <link rel="sitemap" href="/sitemap.xml" type="application/xml"/>
 <link rel="manifest" href="/manifest.webmanifest"/>
 


### PR DESCRIPTION
Re-include canonical links – every page incudes the trailing slash in the `href`, which is the value that Hugo knows/identifies each page.

Examples:

```html
<link rel=canonical href=https://developers.cloudflare.com/workers/tutorials/>
<link rel=canonical href=https://developers.cloudflare.com/workers/>
<link rel=canonical href=https://developers.cloudflare.com/>
<link rel=canonical href=https://developers.cloudflare.com/cloudflare-one/identity/devices/mutual-tls-authentication/>
```