### PR TITLE
[KV] Document maximum key length

### DIFF
--- a/content/workers/runtime-apis/kv.md
+++ b/content/workers/runtime-apis/kv.md
@@ -30,7 +30,7 @@ await NAMESPACE.put(key, value)
 {{<definitions>}}
 
 *   `key` {{<type>}}string{{</type>}}
-    *   The key to associate with the value. A key cannot be empty, `.` or `..`. All other keys are valid.
+    *   The key to associate with the value. A key cannot be empty, `.` or `..`. All other keys are valid. Keys have a maximum length of 512 bytes.
 
 *   `value` {{<type>}}string{{</type>}} | {{<type>}}ReadableStream{{</type>}} | {{<type>}}ArrayBuffer{{</type>}}
     *   The value to store. The type is inferred.


### PR DESCRIPTION
Attempting to access KV with a key size over 512 bytes results in an error such as:
```
Error: KV GET failed: 414 UTF-8 encoded length of 513 exceeds key length limit of 512.
```