### PR TITLE
[Chore]: Css fixes for table hover and link color on dark mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3334,7 +3334,7 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 .DocsMarkdown--table-wrap table {
   word-break: normal;
 }
-@media (hover: hover) {
+/* @media (hover: hover) {
   .DocsMarkdown--table-wrap:hover {
     width: calc(100% + var(--docs-body-sidebar-width));
   }
@@ -3342,7 +3342,7 @@ blockquote .DocsMarkdown--header-anchor-positioner {
     background-color: var(--background-color);
     z-index: 1;
   }
-}
+} */
 .DocsMarkdown--table-wrap tr > :first-child {
   position: -webkit-sticky;
   position: sticky;

--- a/static/style.css
+++ b/static/style.css
@@ -4232,3 +4232,11 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 [theme="light"] .DocsMarkdown td > a {
   color: var(--orange);
 }
+
+[theme="dark"] .DocsMarkdown td > strong > a {
+  color: var(--orange);
+}
+
+[theme="light"] .DocsMarkdown td > strong > a {
+  color: var(--orange);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -4237,6 +4237,10 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   color: var(--orange);
 }
 
-[theme="light"] .DocsMarkdown td > strong > a {
+[theme="light"] .DocsMarkdown--aside > p > a {
+  color: var(--orange);
+}
+
+[theme="dark"] .DocsMarkdown--aside > p > a {
   color: var(--orange);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,1 +1,4234 @@
-:root{--reach-skip-nav:1}[data-reach-skip-nav-link]{border:0;clip:rect(0 0 0 0);height:1px;width:1px;margin:-1px;padding:0;overflow:hidden;position:absolute}[data-reach-skip-nav-link]:focus{padding:1rem;position:fixed;top:10px;left:10px;background:#fff;z-index:1;width:auto;height:auto;clip:auto}.DocsTutorials--column[data-column=type]{width:8em;padding-left:calc(var(--gap)/2);padding-right:calc(var(--gap)/2)}*{box-sizing:inherit;margin:0}img,svg{display:block}img{max-width:100%}svg{height:100%;width:100%}button,input,select,textarea{font:inherit}h1,h2,h3,h4,h5,h6{font-weight:400}a,button,input,select,textarea{-webkit-tap-highlight-color:transparent}html{--html-font-size:17px;--line-height:1.5;--form-field-line-height:1.3;--focus-size:.1875em;--button-top-padding:.55em;--button-bottom-padding:.65em;--button-horizontal-padding:.9em;--button-line-height:var(--form-field-line-height);--button-border-radius:.375em;--section-vertical-padding:6em;--header-height:4.5rem;--code-font-size:.9em;--inline-code-font-size:.85em}@media (max-width:1280px){html{--html-font-size:16px}}@media (max-width:1024px){html{--section-vertical-padding:4em}}@media (max-width:414px){html{--header-height:4rem;--code-font-size:.8em;--inline-code-font-size:var(--code-font-size)}}html{--sans-serif-font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;--monospace-font-family:Menlo,"SF Mono","Andale Mono","Roboto Mono",Monaco,monospace;--font-family:var(--sans-serif-font-family);--cloudflare-logo-gray-rgb:64,64,65;--cloudflare-logo-orange-rgb:243,128,32;--cloudflare-logo-light-orange-rgb:248,173,76;--orange-rgb:var(--cloudflare-logo-orange-rgb);--orange:rgb(var(--orange-rgb));--orange-for-use-as-selection-color:#ef9530;--light-blue-rgb:79,140,200;--light-blue:rgb(var(--light-blue-rgb));--blue-rgb:0,81,127;--blue:rgb(var(--blue-rgb));--red-0:#430c15;--red-0-rgb:67,12,21;--red-1:#711423;--red-1-rgb:113,20,35;--red-2:#a01c32;--red-2-rgb:160,28,50;--red-3:#bf223c;--red-3-rgb:191,34,60;--red-4:#da304c;--red-4-rgb:218,48,76;--red-5:#e35f75;--red-5-rgb:227,95,117;--red-6:#ec93a2;--red-6-rgb:236,147,162;--red-7:#f3bac3;--red-7-rgb:243,186,195;--red-8:#f9dce1;--red-8-rgb:249,220,225;--red-9:#fcf0f2;--red-9-rgb:252,240,242;--orange-0:#341a04;--orange-0-rgb:52,26,4;--orange-1:#5b2c06;--orange-1-rgb:91,44,6;--orange-2:#813f09;--orange-2-rgb:129,63,9;--orange-3:#a24f0b;--orange-3-rgb:162,79,11;--orange-4:#b6590d;--orange-4-rgb:182,89,13;--orange-5:#e06d10;--orange-5-rgb:224,109,16;--orange-6:#f4a15d;--orange-6-rgb:244,161,93;--orange-7:#f8c296;--orange-7-rgb:248,194,150;--orange-8:#fbdbc1;--orange-8-rgb:251,219,193;--orange-9:#fdf1e7;--orange-9-rgb:253,241,231;--gold-0:#2c1c02;--gold-0-rgb:44,28,2;--gold-1:#573905;--gold-1-rgb:87,57,5;--gold-2:#744c06;--gold-2-rgb:116,76,6;--gold-3:#8e5c07;--gold-3-rgb:142,92,7;--gold-4:#a26a09;--gold-4-rgb:162,106,9;--gold-5:#c7820a;--gold-5-rgb:199,130,10;--gold-6:#f4a929;--gold-6-rgb:244,169,41;--gold-7:#f8cd81;--gold-7-rgb:248,205,129;--gold-8:#fbe2b6;--gold-8-rgb:251,226,182;--gold-9:#fdf3e2;--gold-9-rgb:253,243,226;--green-0:#0f2417;--green-0-rgb:15,36,23;--green-1:#1c422b;--green-1-rgb:28,66,43;--green-2:#285d3d;--green-2-rgb:40,93,61;--green-3:#31724b;--green-3-rgb:49,114,75;--green-4:#398557;--green-4-rgb:57,133,87;--green-5:#46a46c;--green-5-rgb:70,164,108;--green-6:#79c698;--green-6-rgb:121,198,152;--green-7:#b0ddc2;--green-7-rgb:176,221,194;--green-8:#d8eee1;--green-8-rgb:216,238,225;--green-9:#eff8f3;--green-9-rgb:239,248,243;--cyan-0:#0c2427;--cyan-0-rgb:12,36,39;--cyan-1:#164249;--cyan-1-rgb:22,66,73;--cyan-2:#1d5962;--cyan-2-rgb:29,89,98;--cyan-3:#26727e;--cyan-3-rgb:38,114,126;--cyan-4:#2b818e;--cyan-4-rgb:43,129,142;--cyan-5:#35a0b1;--cyan-5-rgb:53,160,177;--cyan-6:#66c3d1;--cyan-6-rgb:102,195,209;--cyan-7:#a5dce4;--cyan-7-rgb:165,220,228;--cyan-8:#d0edf1;--cyan-8-rgb:208,237,241;--cyan-9:#e9f7f9;--cyan-9-rgb:233,247,249;--blue-0:#0c2231;--blue-0-rgb:12,34,49;--blue-1:#163d57;--blue-1-rgb:22,61,87;--blue-2:#1f567a;--blue-2-rgb:31,86,122;--blue-3:#276d9b;--blue-3-rgb:39,109,155;--blue-4:#2c7cb0;--blue-4-rgb:44,124,176;--blue-5:#479ad1;--blue-5-rgb:71,154,209;--blue-6:#7cb7de;--blue-6-rgb:124,183,222;--blue-7:#add2eb;--blue-7-rgb:173,210,235;--blue-8:#d6e9f5;--blue-8-rgb:214,233,245;--blue-9:#ebf4fa;--blue-9-rgb:235,244,250;--indigo-0:#181e34;--indigo-0-rgb:24,30,52;--indigo-1:#2c365e;--indigo-1-rgb:44,54,94;--indigo-2:#404e88;--indigo-2-rgb:64,78,136;--indigo-3:#5062aa;--indigo-3-rgb:80,98,170;--indigo-4:#6373b6;--indigo-4-rgb:99,115,182;--indigo-5:#8794c7;--indigo-5-rgb:135,148,199;--indigo-6:#a5aed5;--indigo-6-rgb:165,174,213;--indigo-7:#c8cde5;--indigo-7-rgb:200,205,229;--indigo-8:#e0e3f0;--indigo-8-rgb:224,227,240;--indigo-9:#f1f3f8;--indigo-9-rgb:241,243,248;--violet-0:#2d1832;--violet-0-rgb:45,24,50;--violet-1:#502b5a;--violet-1-rgb:80,43,90;--violet-2:#753f83;--violet-2-rgb:117,63,131;--violet-3:#8e4c9e;--violet-3-rgb:142,76,158;--violet-4:#9f5bb0;--violet-4-rgb:159,91,176;--violet-5:#b683c3;--violet-5-rgb:182,131,195;--violet-6:#c9a2d2;--violet-6-rgb:201,162,210;--violet-7:#dbc1e1;--violet-7-rgb:219,193,225;--violet-8:#ebddee;--violet-8-rgb:235,221,238;--violet-9:#f7f1f8;--violet-9-rgb:247,241,248;--gray-00-rgb:23,23,24;--gray-00:rgb(var(--gray-00-rgb));--gray-0F-rgb:25,27,29;--gray-0F:rgb(var(--gray-0F-rgb));--gray-0-rgb:29,31,32;--gray-0:rgb(var(--gray-0-rgb));--gray-05-rgb:36,38,40;--gray-05:rgb(var(--gray-05-rgb));--gray-1-rgb:54,57,58;--gray-1:rgb(var(--gray-1-rgb));--gray-2-rgb:78,82,85;--gray-2:rgb(var(--gray-2-rgb));--gray-3-rgb:98,103,106;--gray-3:rgb(var(--gray-3-rgb));--gray-4-rgb:114,119,123;--gray-4:rgb(var(--gray-4-rgb));--gray-5-rgb:146,151,155;--gray-5:rgb(var(--gray-5-rgb));--gray-6-rgb:183,187,189;--gray-6:rgb(var(--gray-6-rgb));--gray-7-rgb:213,215,216;--gray-7:rgb(var(--gray-7-rgb));--gray-8-rgb:234,235,235;--gray-8:rgb(var(--gray-8-rgb));--gray-9-rgb:243,243,244;--gray-9:rgb(var(--gray-9-rgb));--gray-A-rgb:247,247,248;--gray-A:rgb(var(--gray-A-rgb));--code-gray:#a7a7a3;--code-red:#ed8978;--code-orange:#fba056;--code-gold:#fdda68;--code-green:#57c78f;--code-blue:#78c0ed;--code-cyan:#71e4f4;--code-indigo:#7b99ea;--code-lilac:#d188dd;--code-violet:#a68adb;--code-gray-light-theme:var(--gray-3);--code-red-light-theme:#8f1500;--code-orange-light-theme:#b35000;--code-gold-light-theme:#b35300;--code-green-light-theme:#007a3d;--code-blue-light-theme:#00588f;--code-cyan-light-theme:#006c7a;--code-indigo-light-theme:#00268f;--code-lilac-light-theme:#7c008f;--code-violet-light-theme:#32008f;--diff-indicator-red:var(--code-red);--diff-indicator-green:var(--code-green);--diff-indicator-red-light-theme:#eb0052;--diff-indicator-green-light-theme:#0c6}html[theme=light]{--color-rgb:var(--gray-0-rgb);--color:rgb(var(--color-rgb));--background-color-rgb:255,255,255;--background-color:rgb(var(--background-color-rgb));--selection-background-color:var(--orange-for-use-as-selection-color);--selection-color:#fff;--code-block-color:#fff;--code-block-background-color:var(--color);--code-block-background-color-light-theme:var(--gray-9);--code-block-scrollbar-color:hsla(0,0%,100%,0.25);--tab-background-color:var(--gray-9);--shadow-color-rgb:var(--color-rgb);--section-tiger-stripe-background-color:var(--gray-9);--deemphasized-color:var(--gray-1)}html[theme=dark],html[theme=light]{--cloudflare-logo-wordmark-color:rgb(var(--cloudflare-logo-gray-rgb));--focus-color:rgba(var(--orange-rgb),.5)}html[theme=dark]{--color-rgb:255,255,255;--color:rgb(var(--color-rgb));--background-color-rgb:var(--gray-0-rgb);--background-color:rgb(var(--background-color-rgb));--selection-background-color:#ff9e40;--selection-color:rgb(var(--color-rgb));--code-block-color:rgb(var(--color-rgb));--code-block-background-color:var(--gray-05);--code-block-scrollbar-color:hsla(0,0%,100%,0.25);--tab-background-color:var(--gray-1);--shadow-color-rgb:0,0,0;--section-tiger-stripe-background-color:var(--gray-05);--deemphasized-color:var(--gray-7)}[theme=dark] [light-theme-only],[theme=light] [dark-theme-only]{display:none}::selection{background:var(--selection-background-color);color:var(--selection-color)}html{box-sizing:border-box;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;text-size-adjust:100%;font-size:var(--html-font-size);font-family:var(--font-family);line-height:var(--line-height);color:var(--color);background:var(--background-color)}@media (max-width:414px){[desktop-only]{display:none!important}}@media (min-width:415px){[mobile-only]{display:none!important}}@media (prefers-reduced-motion:no-preference){[is-smooth-scrolling]{scroll-behavior:smooth}}[is-visually-hidden]{position:absolute;height:1px;width:1px;padding:0;border:0;clip:rect(1px 1px 1px 1px);clip:rect(1px,1px,1px,1px);-webkit-clip-path:inset(0 0 99.9% 99.9%);clip-path:inset(0 0 99.9% 99.9%);overflow:hidden;-webkit-user-select:none;-ms-user-select:none;user-select:none}[with-styled-webkit-scrollbars]{--scrollbar-thumb-background-color:var(--gray-6);--scrollbar-thumb-background-color-active:var(--gray-4)}[theme=dark][with-styled-webkit-scrollbars],[theme=dark] [with-styled-webkit-scrollbars]{--scrollbar-thumb-background-color:var(--gray-2);--scrollbar-thumb-background-color-active:var(--gray-5)}[with-styled-webkit-scrollbars]::-webkit-scrollbar,[with-styled-webkit-scrollbars] ::-webkit-scrollbar{width:1em}[with-styled-webkit-scrollbars]::-webkit-scrollbar-track,[with-styled-webkit-scrollbars] ::-webkit-scrollbar-track{background:none;border:none}[with-styled-webkit-scrollbars]::-webkit-scrollbar-thumb,[with-styled-webkit-scrollbars] ::-webkit-scrollbar-thumb{min-height:3.5em;background-color:var(--scrollbar-thumb-background-color);background-clip:padding-box;border:.25em solid transparent;border-radius:.5em;box-shadow:none}[with-styled-webkit-scrollbars]::-webkit-scrollbar-thumb:active,[with-styled-webkit-scrollbars] ::-webkit-scrollbar-thumb:active{background-color:var(--scrollbar-thumb-background-color-active)}.AspectRatio{--aspect-ratio:1;position:relative;display:block;width:100%;height:0;padding-bottom:calc(100%/var(--aspect-ratio))}.AspectRatio--content{position:absolute;display:block;left:0;top:0;width:100%;height:100%}.Breadcrumbs{display:inline-flex;font-size:.9em;color:var(--gray-4);font-weight:500}.Breadcrumbs,.Breadcrumbs--item{margin:0;padding:0;list-style:none}.Breadcrumbs--item+.Breadcrumbs--item:before{content:"\276F";margin:0 .25em;padding:0 .3em;opacity:.4;font-weight:900}.Button{cursor:pointer;display:inline-block;-webkit-user-select:none;-ms-user-select:none;user-select:none;touch-action:manipulation;position:relative;border:0;background:transparent;color:inherit;line-height:var(--button-line-height);padding:var(--button-top-padding) var(--button-horizontal-padding) var(--button-bottom-padding);border-radius:var(--button-border-radius);text-decoration:none;-webkit-tap-highlight-color:transparent;--active-box-shadow-color:transparent;--active-box-shadow:inset 0 .0625em .1875em var(--active-box-shadow-color);--active-overlay-box-shadow-color:transparent;--active-overlay-box-shadow:inset 0 0 0 9999em var(--active-overlay-box-shadow-color);--hover-box-shadow-color:transparent;--hover-box-shadow:inset 0 0 0 9999em var(--hover-box-shadow-color);--focus-box-shadow:0 0 0 var(--focus-size) var(--focus-color);--border-color:transparent;--border-box-shadow:inset 0 0 0 1px var(--border-color);--shadow-box-shadow:0 1px 1px rgba(var(--shadow-color-rgb),.075),0 .1333em .26667em rgba(var(--shadow-color-rgb),.075),0 .2222em .66667em 0 rgba(var(--shadow-color-rgb),.075),0 .4444em 1.3333em 0 rgba(var(--shadow-color-rgb),.075);--box-shadow:0 0 0 0 transparent;box-shadow:var(--active-box-shadow),var(--active-overlay-box-shadow),var(--hover-box-shadow),var(--focus-box-shadow),var(--border-box-shadow),var(--box-shadow);--box-shadow-transition-duration:.3s;transition:box-shadow var(--box-shadow-transition-duration) ease}.Button[disabled]{cursor:not-allowed;opacity:.5}@media (hover:hover){.Button:hover{--hover-box-shadow-color:hsla(0,0%,100%,0.2)}[theme=dark] .Button:hover{--hover-box-shadow-color:hsla(0,0%,100%,0.05)}}.Button:not([disabled]):active{--box-shadow-transition-duration:0s;--hover-box-shadow-color:transparent;--box-shadow:0 0 0 0 transparent;--active-overlay-box-shadow-color:rgba(0,0,0,0.08);--active-box-shadow-color:rgba(0,0,0,0.2)}@media (hover:none){.Button:not([disabled]):active{--active-overlay-box-shadow-color:rgba(0,0,0,0.3)}}[js-focus-visible-polyfill-available] .Button:focus{outline:none}.Button[is-focus-visible]{--box-shadow-transition-duration:0s}.Button:not([is-focus-visible]){--focus-size:0}@-moz-document url-prefix(){.Button:not([is-focus-visible]){--focus-color:transparent}}.Button-is-primary{--box-shadow:var(--shadow-box-shadow);background:linear-gradient(25deg,rgb(var(--cloudflare-logo-orange-rgb)),rgb(var(--cloudflare-logo-light-orange-rgb)));color:#fff}.Button-is-secondary{background:var(--gray-9)}[theme=dark] .Button-is-secondary{background:var(--gray-05)}.Button-is-secondary-orange{--color-rgb:var(--orange-3-rgb);background:rgba(var(--cloudflare-logo-light-orange-rgb),.12);color:rgb(var(--color-rgb))}[theme=dark] .Button-is-secondary-orange{--color-rgb:var(--orange-7-rgb)}[theme=light] .Button-is-secondary-orange:not([disabled]):active{--active-box-shadow-color:rgba(var(--color-rgb),.4)}.Button-is-docs-primary{background:var(--orange-5);color:#fff}[theme=dark] .Button-is-docs-primary{--border-color:rgba(var(--orange-rgb),.7);color:inherit;background:transparent}.Button-is-docs-secondary{background:var(--gray-9)}[theme=dark] .Button-is-docs-secondary{--border-color:rgba(var(--color-rgb),.3);color:inherit;background:transparent}[theme=dark] .Button-is-docs-secondary[is-focus-visible]{--border-color:rgba(var(--orange-rgb),.7)}.Button-is-white{background:#fff}.Button-is-inverted{background:var(--color);color:var(--background-color)}.CloudflareLogo{display:block;width:6.5em;height:2.25em;color:var(--cloudflare-logo-wordmark-color)}.CloudflareWorkersLogo{display:block}.CloudflareWorkersLogo-horizontal-combination-mark{width:10em;height:2.75em}.CloudflareWorkersLogoCombinationMark--cloudflare-wordmark,.CloudflareWorkersLogoCombinationMark--workers-wordmark{fill:currentColor}.CloudflareWorkersLogoCombinationMark--cloudflare-wordmark{opacity:.6}.CodeBlock{-webkit-font-smoothing:antialiased;position:relative;display:block;white-space:pre-wrap;word-break:break-word;font-family:var(--monospace-font-family);font-size:var(--code-font-size);margin:0;--padding-vertical:.9em;--padding-horizontal:1.25em;--border-radius:.5em;border-radius:var(--border-radius);background:var(--code-block-background-color);color:var(--code-block-color);--outdent:0rem;margin-left:calc(var(--outdent)*-1);width:calc(100% + var(--outdent)*2);max-width:calc(100% + var(--outdent)*2);cursor:text}[theme=light] .CodeBlock-is-light-in-light-theme{--code-block-background-color:var(--code-block-background-color-light-theme);--code-block-color:currentColor;--code-block-scrollbar-color:var(--gray-6);--code-gray:var(--code-gray-light-theme);--code-red:var(--code-red-light-theme);--code-orange:var(--code-orange-light-theme);--code-gold:var(--code-gold-light-theme);--code-green:var(--code-green-light-theme);--code-blue:var(--code-blue-light-theme);--code-cyan:var(--code-cyan-light-theme);--code-indigo:var(--code-indigo-light-theme);--code-lilac:var(--code-lilac-light-theme);--code-violet:var(--code-violet-light-theme);--diff-indicator-red:var(--diff-indicator-red-light-theme);--diff-indicator-green:var(--diff-indicator-green-light-theme)}.CodeBlock>code{display:block;padding:var(--padding-vertical) var(--padding-horizontal);font-family:inherit;cursor:default}.CodeBlock>code>*{cursor:text}.CodeBlock>code::-webkit-scrollbar{height:14px}.CodeBlock>code::-webkit-scrollbar-track-piece{background:transparent;border-radius:var(--border-radius)}.CodeBlock>code::-webkit-scrollbar-thumb{border-radius:var(--border-radius);box-shadow:inset 0 1px 1px rgba(var(--background-color-rgb),.1);background-color:var(--code-block-scrollbar-color);background-clip:padding-box;border:4px solid transparent;border-radius:calc(var(--border-radius)*20)}[theme=dark] .CodeBlock>code::-webkit-scrollbar-thumb{box-shadow:inset 0 1px 1px rgba(var(--color-rgb),.1)}.CodeBlock-is-one-liner>code{border-radius:calc(var(--border-radius)*0.625);white-space:nowrap}.CodeBlock-is-one-liner>code,.CodeBlock-scrolls-horizontally>code{word-break:normal;overflow-x:auto;-webkit-overflow-scrolling:touch}.CodeBlock-scrolls-horizontally>code{white-space:pre}.CodeBlock-is-hero{--padding-vertical:1.25em;--padding-horizontal:1.5em;box-shadow:0 1px 1px rgba(var(--shadow-color-rgb),.075),0 .1333em .26667em rgba(var(--shadow-color-rgb),.075),0 .2222em .66667em 0 rgba(var(--shadow-color-rgb),.075),0 .4444em 1.3333em 0 rgba(var(--shadow-color-rgb),.075)}.CodeBlock--filename,.CodeBlock--header{display:block;background:rgba(var(--color-rgb),.05);box-shadow:0 1px rgba(var(--shadow-color-rgb),.12);padding:.4em var(--padding-horizontal);border-radius:var(--border-radius) var(--border-radius) 0 0;opacity:.9;font-weight:700}[theme=light] .CodeBlock-is-light-in-light-theme .CodeBlock--filename,[theme=light] .CodeBlock-is-light-in-light-theme .CodeBlock--header{background:transparent}.CodeBlock--header{font-family:var(--font-family)}.CodeBlock--filename{padding-top:.45em;font-size:.9em;padding-left:calc(var(--padding-horizontal)/.9);padding-right:calc(var(--padding-horizontal)/.9)}.CodeBlock b{font-weight:400}.CodeBlock u{-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none;text-decoration:none;transition:opacity .25s ease}.CodeBlock:hover u,.CodeBlock[has-selection-contained-within] u{opacity:.25}.CodeBlock.CodeBlock-with-rows.CodeBlock-scrolls-horizontally>code{display:block}.CodeBlock.CodeBlock-with-rows,.CodeBlock.CodeBlock-with-rows>code{white-space:normal}.CodeBlock-with-rows>code{padding-left:0;padding-right:0}.CodeBlock-with-rows .CodeBlock--rows{display:block}.CodeBlock-with-rows .CodeBlock--rows-content{display:inline-block;min-width:100%}.CodeBlock-with-rows .CodeBlock--row{position:relative;display:block;width:100%}.CodeBlock-with-rows .CodeBlock--row-content{display:block;white-space:pre-wrap;padding:0 var(--padding-horizontal)}.CodeBlock-with-rows.CodeBlock-scrolls-horizontally .CodeBlock--row-content{white-space:pre}.CodeBlock--row-is-highlighted{background:rgba(var(--color-rgb),.05);box-shadow:inset 2px 0 rgba(var(--color-rgb),.3)}.CodeBlock--row-diff-add{--row-diff-background-color:rgba(var(--color-rgb),.05);background:var(--row-diff-background-color)}[theme=light] .CodeBlock-is-light-in-light-theme.CodeBlock-with-rows .CodeBlock--row-diff-add{--row-diff-background-color:rgba(var(--background-color-rgb),.8)}.CodeBlock--row-diff-remove{-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none;text-decoration:none}.CodeBlock-with-rows .CodeBlock--row-diff-add .CodeBlock--row-indicator,.CodeBlock-with-rows .CodeBlock--row-diff-remove .CodeBlock--row-indicator{position:-webkit-sticky;position:sticky;left:0;display:flex;border-left:.125em solid;--width:.75em;width:var(--width);margin-right:calc(var(--width)*-1);background:linear-gradient(90deg,var(--row-diff-background-color),transparent),linear-gradient(90deg,var(--code-block-background-color),transparent)}.CodeBlock-with-rows .CodeBlock--row-diff-add .CodeBlock--row-indicator{border-left-color:var(--diff-indicator-green)}.CodeBlock-with-rows .CodeBlock--row-diff-remove .CodeBlock--row-indicator{border-left-color:var(--diff-indicator-red)}[theme=light] .CodeBlock-with-rows.CodeBlock-is-light-in-light-theme .CodeBlock--row-diff-add .CodeBlock--row-indicator{background:transparent}.CodeBlock-with-rows .CodeBlock--word-remove{opacity:.5;position:relative}.CodeBlock-with-rows .CodeBlock--word-remove:after{content:"";display:block;position:absolute;top:.125em;right:-.5em;bottom:0;left:-.5em;height:1px;margin-top:auto;margin-bottom:auto;background:linear-gradient(90deg,rgba(var(--color-rgb),0),rgba(var(--color-rgb),0) 1em,rgba(var(--color-rgb),.5) 2em,rgba(var(--color-rgb),.5) calc(100% - 2em),rgba(var(--color-rgb),0) calc(100% - .5em),rgba(var(--color-rgb),0))}.CodeBlock--token-punctuation,.CodeBlock--token-template-string.CodeBlock--token-interpolation{color:inherit}.CodeBlock--token-block-comment,.CodeBlock--token-cdata,.CodeBlock--token-comment,.CodeBlock--token-doctype,.CodeBlock--token-prolog{font-style:italic;color:var(--code-gray)}.CodeBlock--token-keyword,.CodeBlock--token-operator,.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-interpolation-punctuation{color:var(--code-red)}.CodeBlock--token-class,.CodeBlock--token-class-name,.CodeBlock--token-function,.CodeBlock--token-function-name,.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-function{color:var(--code-green)}.CodeBlock--token-constant,.CodeBlock--token-symbol,.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-interpolation-constant{color:var(--code-indigo)}.CodeBlock--token-arrow,.CodeBlock--token-declaration-keyword{color:var(--code-cyan)}.CodeBlock--token-function-parameter,.CodeBlock--token-parameter{font-style:italic;color:var(--code-lilac)}.CodeBlock--token-boolean,.CodeBlock--token-builtin,.CodeBlock--token-method,.CodeBlock--token-null-undefined,.CodeBlock--token-number{color:var(--code-violet)}.CodeBlock--token-api{color:var(--code-orange)}.CodeBlock--token-char,.CodeBlock--token-object-property,.CodeBlock--token-regex,.CodeBlock--token-string,.CodeBlock--token-template-string{color:var(--code-gold)}.CodeBlock--token-bold,.CodeBlock--token-important{font-weight:700}.CodeBlock--token-italic{font-style:italic}.CodeBlock--token-deleted,.CodeBlock--token-namespace{color:var(--code-red)}.CodeBlock--token-entity{color:var(--code-blue);cursor:help}.CodeBlock--token-inserted{color:var(--code-green)}.CodeBlock--token-link,.CodeBlock--token-url{color:var(--code-violet)}.CodeBlock--token-link.CodeBlock--token-content,.CodeBlock--token-url.CodeBlock--token-content{color:inherit}.CodeBlock--token-tag{color:var(--code-red)}.CodeBlock--token-tag.CodeBlock--token-punctuation{color:inherit}.CodeBlock--token-tag.CodeBlock--token-attr-name{color:var(--code-green)}.CodeBlock--token-tag.CodeBlock--token-attr-name+.CodeBlock--token-punctuation{color:inherit}.CodeBlock--token-tag.CodeBlock--token-attr-value{color:var(--code-gold)}.CodeBlock--language-css.CodeBlock--token-plain,.CodeBlock--language-css.CodeBlock--token-property,.CodeBlock--language-css.CodeBlock--token-style,[language=css] .CodeBlock--token-plain,[language=css] .CodeBlock--token-property{color:var(--code-blue)}.CodeBlock--language-css.CodeBlock--token-style.CodeBlock--token-punctuation{color:inherit}.CodeBlock--language-css.CodeBlock--token-selector,[language=css] .CodeBlock--token-selector{color:var(--code-red)}.CodeBlock--language-css.CodeBlock--token-attribute,.CodeBlock--language-css.CodeBlock--token-class,[language=css] .CodeBlock--token-attribute,[language=css] .CodeBlock--token-class{color:var(--code-green)}.CodeBlock--language-css.CodeBlock--token-function,[language=css] .CodeBlock--token-function{color:var(--code-lilac)}.CodeBlock--language-css.CodeBlock--token-variable,[language=css] .CodeBlock--token-variable{color:var(--code-violet)}.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-value,[language=css] .CodeBlock--token-attribute.CodeBlock--token-value{color:var(--code-gold)}.CodeBlock--language-css.CodeBlock--token-color,[language=css] .CodeBlock--token-color{color:var(--code-violet)}.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-punctuation,[language=css] .CodeBlock--token-attribute.CodeBlock--token-punctuation{color:inherit}.CodeBlock--language-css.CodeBlock--token-atrule.CodeBlock--token-rule,.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-operator,.CodeBlock--language-css.CodeBlock--token-important,.CodeBlock--language-css.CodeBlock--token-unit,[language=css] .CodeBlock--token-atrule.CodeBlock--token-rule,[language=css] .CodeBlock--token-attribute.CodeBlock--token-operator,[language=css] .CodeBlock--token-important,[language=css] .CodeBlock--token-unit{color:var(--code-red)}.CodeBlock--language-css.CodeBlock--token-pseudo-class,.CodeBlock--language-css.CodeBlock--token-pseudo-element,[language=css] .CodeBlock--token-pseudo-class,[language=css] .CodeBlock--token-pseudo-element{color:var(--code-violet)}[language=markdown] .CodeBlock--token-header,[language=markdown] .CodeBlock--token-title{color:var(--code-orange)}[language=markdown] .CodeBlock--token-list{color:var(--code-red)}[language=markdown] .CodeBlock--token-blockquote{color:var(--code-blue)}[language=markdown] .CodeBlock--token-code{color:var(--code-green)}[language=markdown] .CodeBlock--token-hr{color:var(--code-gold)}[language=sh] .CodeBlock--token-directory{color:var(--code-orange)}[language=sh] .CodeBlock--token-prompt{color:var(--code-orange);opacity:.7}[language=sh] .CodeBlock--token-value{color:var(--code-cyan)}[language=sh] .CodeBlock--token-success{color:var(--code-green)}[language=sh] .CodeBlock--token-plain{color:var(--code-gray)}[language=sh] .CodeBlock--token-plain,[language=sh] .CodeBlock--token-unselectable{-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none;text-decoration:none;transition:opacity .25s ease}[language=sh]:hover .CodeBlock--token-plain,[language=sh]:hover .CodeBlock--token-unselectable,[language=sh][has-selection-contained-within] .CodeBlock--token-plain,[language=sh][has-selection-contained-within] .CodeBlock--token-unselectable{opacity:.25}.CodeBlock--row>.CodeBlock--row-indicator:empty+.CodeBlock--row-content>.CodeBlock--token-plain:empty+.CodeBlock--token-doc-comment.CodeBlock--token-comment:empty:after,.CodeBlock--row>.CodeBlock--row-indicator:empty+.CodeBlock--row-content>.CodeBlock--token-table.CodeBlock--token-table-data-rows:empty+.CodeBlock--token-plain:empty:after{content:" "}.ThemeToggle{width:50px;height:28px;border-radius:99em}.ThemeToggle--input{position:absolute;opacity:0;top:-9999em}.ThemeToggle--toggle{position:relative;display:block;width:100%;height:100%;border-radius:99em;background:rgba(var(--gray-6-rgb),.7);cursor:pointer;box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.ThemeToggle--input:not([is-focus-visible])~.ThemeToggle--toggle{--focus-size:0}.ThemeToggle--input:checked~.ThemeToggle--toggle,[theme=dark] .ThemeToggle[data-is-loading=true] .ThemeToggle--toggle{background:rgba(var(--gray-2-rgb),.7)}.ThemeToggle--toggle-handle{position:absolute;top:3px;left:3px;--size:22px;width:var(--size);height:var(--size);border-radius:99em;background:#fff;box-shadow:0 .15em .3em rgba(0,0,0,.15),0 .2em .5em rgba(0,0,0,.3)}.ThemeToggle--input:checked~.ThemeToggle--toggle .ThemeToggle--toggle-handle,[theme=dark] .ThemeToggle[data-is-loading=true] .ThemeToggle--toggle-handle{left:auto;right:3px;background:var(--gray-00);border:1px solid #000;box-shadow:0 .5px hsla(0,0%,100%,.16)}.ThemeToggle--toggle-handle-icon{position:absolute;top:6px;width:16px;height:16px}.ThemeToggle--moon,.ThemeToggle--sun{pointer-events:none}.ThemeToggle--sun{left:6px}@media (max-width:320px){.ThemeToggle--sun{-webkit-transform:translateX(-.1px);transform:translateX(-.1px)}}.ThemeToggle--moon{right:6px;color:var(--gray-3)}.ThemeToggle--input:checked~.ThemeToggle--toggle .ThemeToggle--moon,.ThemeToggle--sun,[theme=dark] .ThemeToggle[data-is-loading=true] .ThemeToggle--moon{color:var(--orange)}.ThemeToggle--input:checked~.ThemeToggle--toggle .ThemeToggle--sun,[theme=dark] .ThemeToggle[data-is-loading=true] .ThemeToggle--sun{color:rgba(var(--gray-6-rgb),.8)}[theme-is-changing] *{transition:none!important}.Dropdown{position:relative}.Dropdown--dropdown{position:absolute;top:100%;left:0;padding:.5em 0;background:var(--background-color);border-radius:.3125em;pointer-events:none;opacity:0;--dropdown-focus-size:var(--focus-size);--focus-shadow:0 0 0 var(--dropdown-focus-size) var(--focus-color);--box-shadow:0 0 0 1px rgba(var(--shadow-color-rgb),.075),0 .3em 2em rgb(var(--shadow-color-rgb),.1);box-shadow:var(--box-shadow),var(--focus-shadow);-webkit-transform:scaleX(.5) scaleY(.5) perspective(1px);transform:scaleX(.5) scaleY(.5) perspective(1px);-webkit-transform-origin:top left;transform-origin:top left;transition:opacity .1s,box-shadow .3s,-webkit-transform .3s;transition:opacity .1s,box-shadow .3s,transform .3s;transition:opacity .1s,box-shadow .3s,transform .3s,-webkit-transform .3s}[theme=dark] .Dropdown--dropdown{background:var(--gray-1)}@supports ((-webkit-backdrop-filter:blur(1em)) or (backdrop-filter:blur(1em))){.Dropdown--dropdown{background:rgba(var(--background-color-rgb),.8);-webkit-backdrop-filter:saturate(200%) blur(1.25em);backdrop-filter:saturate(200%) blur(1.25em)}[theme=dark] .Dropdown--dropdown{background:rgba(var(--gray-1-rgb),.7)}}.Dropdown[data-expanded=true] .Dropdown--dropdown{opacity:1;pointer-events:all;-webkit-transform:scaleX(1) scaleY(1) perspective(1px);transform:scaleX(1) scaleY(1) perspective(1px);--spring-easing:cubic-bezier(.175,.885,.4,1.1);transition:opacity .2s ease-out,box-shadow .3s,-webkit-transform .2s var(--spring-easing);transition:opacity .2s ease-out,box-shadow .3s,transform .2s var(--spring-easing);transition:opacity .2s ease-out,box-shadow .3s,transform .2s var(--spring-easing),-webkit-transform .2s var(--spring-easing)}[js-focus-visible-polyfill-available] .Dropdown--dropdown:focus{outline:none}.Dropdown--dropdown:not([is-focus-visible]){--dropdown-focus-size:0}.Dropdown--item,.Dropdown--list{padding:0;list-style:none}.Dropdown--link{display:block;text-decoration:none;color:inherit;padding:.25em 1.5em;white-space:nowrap;max-width:calc(100vw - 2em);overflow:hidden;text-overflow:ellipsis;--focus-size:3px;box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.Dropdown--link:hover{color:var(--orange);background:rgba(var(--orange-rgb),.05)}[theme=dark] .Dropdown--link:hover{background:rgba(var(--color-rgb),.05)}[js-focus-visible-polyfill-available] .Dropdown--link:focus{outline:none}.Dropdown--link:not([is-focus-visible]){--focus-size:0}p>code,span>code,div>code,li>code,td>code,.DocsMarkdown--aside>code,.InlineCode{font-family:var(--monospace-font-family);font-size:var(--inline-code-font-size);--default-padding:.2em .3em;padding:var(--padding,var(--default-padding));--default-background:rgba(var(--color-rgb),.05);background:var(--background,var(--default-background));border-radius:.25em;max-width:100%}code.InlineCode-is-nowrap,.InlineCode.InlineCode-is-nowrap{white-space:nowrap}.InlineCode--type,.InlineCode.InlineCode-is-type{font-weight:700;font-size:.7rem;border-radius:.2em;opacity:.75;--border-opacity:.4;box-shadow:0 0 0 1px rgba(var(--color-rgb),var(--border-opacity));-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none}[theme=dark] .InlineCode.InlineCode-is-type{--border-opacity:.3}.InlineCode.InlineCode-is-type{padding:1px 4px;--background:transparent}.InlineCode--type{padding:0 3px;margin-left:.5em;--border-opacity:.25}@media (max-width:768px){.InlineCode--type,.InlineCode.InlineCode-is-type{padding:0 2px}}.Link{text-decoration:none;color:inherit;--accent-color:var(--orange);--underline-size:-.16em;--underline-color:var(--accent-color);--underline-shadow:inset 0 var(--underline-size) var(--underline-color);--focus-size:3px;--focus-shadow:0 0 0 var(--focus-size) var(--focus-color);box-shadow:var(--focus-shadow),var(--underline-shadow)}.Link-is-blue{--accent-color:var(--blue-6)}.Link-is-cyan{--accent-color:var(--cyan-6)}.Link-is-gray{--accent-color:var(--gray-6)}.Link-is-green{--accent-color:var(--green-6)}.Link-is-gold{--accent-color:var(--gold-6)}.Link-is-orange{--accent-color:var(--orange)}.Link-is-indigo{--accent-color:var(--indigo-6)}.Link-is-violet{--accent-color:var(--violet-6)}@media (hover:hover){.Link:hover{color:var(--accent-color)}}.Link-is-juicy{padding:.5em;margin:-.5em}.Link-with-left-arrow,.Link-with-right-arrow,.Link-without-underline{--underline-size:0}.Link-with-left-arrow:before{content:"\2190\A0"}.Link-with-right-arrow:after{content:"\A0\2192"}[js-focus-visible-polyfill-available] .Link:focus{outline:none}.Link[is-focus-visible]{--underline-size:0}.Link:not([is-focus-visible]){--focus-size:0}.NetworkMap--land{fill:rgba(var(--gray-7-rgb),.8)}[theme=dark] .NetworkMap--land{fill:rgba(var(--gray-2-rgb),.7)}.NetworkMap--datacenters{fill:var(--orange);stroke:var(--orange-1);stroke-width:2px;paint-order:stroke;opacity:.85}[theme=dark] .NetworkMap--datacenters{stroke:var(--background-color);stroke-width:3px}.Scrollbars--track-vertical{top:.25em;right:.25em;bottom:.25em;width:.5em!important}.Scrollbars--thumb{cursor:pointer;background-color:var(--gray-6);border-radius:.5em}.Scrollbars--thumb:active{background-color:var(--gray-4)}[theme=dark] .Scrollbars--thumb{background-color:var(--gray-2)}[theme=dark] .Scrollbars--thumb:active{background-color:var(--gray-5)}.StreamVideo .video-js{font-family:inherit}.StreamVideo .video-js .vjs-control-bar{font-size:1.75em}.StreamVideo .video-js .cf-quality-selector,.StreamVideo .video-js .vjs-playback-rate{display:none}.StreamVideo .video-js .vjs-slider{background:rgba(var(--gray-5-rgb),.5)}.Superscript{vertical-align:initial;font-size:.8em;top:-.5em}.Superscript,.Tooltip---root{position:relative}span.Tooltip---root{display:inline-block}.Tooltip{--gap:.75em;position:absolute;font-size:.925em;font-weight:400;font-style:normal;line-height:var(--line-height);text-transform:none;letter-spacing:normal;padding:.3em .85em;white-space:nowrap;max-width:calc(100vw - 1em);color:var(--background-color);background:var(--color);opacity:0;transition:opacity .25s ease;border-radius:.25em;z-index:10;-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none}@media (hover:hover){.Tooltip---root:hover .Tooltip{opacity:1}}.Tooltip:not([position]),.Tooltip[position=top]{bottom:100%;margin-bottom:var(--gap)}.Tooltip:not([position]),.Tooltip[position=bottom],.Tooltip[position=top]{left:50%;-webkit-transform:translate3d(-50%,0,0);transform:translate3d(-50%,0,0)}.Tooltip[position=bottom]{top:100%;margin-top:var(--gap)}.Tooltip[position=left]{right:100%;margin-right:var(--gap)}.Tooltip[position=left],.Tooltip[position=right]{top:50%;-webkit-transform:translate3d(0,-50%,0);transform:translate3d(0,-50%,0)}.Tooltip[position=right]{left:100%;margin-left:var(--gap)}.Tooltip[position=top-start]{bottom:100%;margin-bottom:var(--gap);left:0}.Tooltip[position=bottom-start]{top:100%;margin-top:var(--gap);left:0}.Tooltip[position=top-end]{bottom:100%;margin-bottom:var(--gap);right:0}.Tooltip[position=bottom-end]{top:100%;margin-top:var(--gap);right:0}.SkipNavLink{position:absolute;overflow:hidden;color:inherit;text-decoration:none;clip:rect(0 0 0 0);height:1px;width:1px;margin:-1px;padding:0}.SkipNavLink:focus{padding:.5em 1em;position:fixed;top:0;left:50%;-webkit-transform:translate3d(-50%,0,0);transform:translate3d(-50%,0,0);background:var(--background-color);width:auto;height:auto;clip:auto;z-index:100;outline:none;box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.TagsFilter{display:flex;flex-wrap:wrap;margin:0 -.25em}.TagsFilter--button{--border-color:rgba(var(--color-rgb),.2);padding:.25em .3125em;margin:.3125em .25em;border-radius:.125em}.TagsFilter--button[is-focus-visible]{--border-color:rgba(var(--orange-rgb),.7)}.TagsFilter--button-active{pointer-events:none}[theme=light] .TagsFilter--button-active{--border-color:transparent}[theme=dark] .TagsFilter--button-active{color:var(--code-orange)}.WorkerStarter{display:block;margin-top:2.5rem}.WorkerStarter+.WorkerStarter{margin-top:3rem}.WorkerStarter--title{font-size:1.35em;line-height:1.2;font-weight:500;margin-bottom:.3125em}.WorkerStarter--title .Link{color:inherit;--underline-opacity:.75;text-decoration:underline;-webkit-text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));box-shadow:0 0 0 var(--focus-size) var(--focus-color)}@media (max-width:768px){.WorkerStarter--title{font-size:1.375em;margin-bottom:.5rem}}.WorkerStarter--description{display:block;margin-bottom:.4375rem;width:calc(100% - var(--docs-body-sidebar-width))}.WorkerStarter--command{position:relative;font-size:.9em;--copy-button-width:4rem;--height:2.5rem}.WorkerStarter--command-copy-button-wrapper{position:absolute;width:calc(var(--copy-button-width) - 2px);height:var(--height)}.WorkerStarter--command-copy-button-wrapper button{width:100%;height:100%;border-top-right-radius:0;border-bottom-right-radius:0;font-weight:600;background:var(--code-block-background-color)}[theme=light] .WorkerStarter--command-copy-button-wrapper button{background:var(--code-block-background-color-light-theme)}.WorkerStarter--command-codeblock-wrapper{padding-left:var(--copy-button-width)}.WorkerStarter--command .WorkerStarter--command-codeblock-wrapper pre{height:var(--height);line-height:1.4;margin-bottom:0;border-top-left-radius:0;border-bottom-left-radius:0;overflow:hidden}.ArchitectureDiagram{--user-code-size:25px;--accent-color-rgb:var(--orange-rgb);position:relative;display:flex;flex-wrap:wrap;justify-content:space-between;width:100%;max-width:100%}@media (max-width:1350px){.ArchitectureDiagram{--user-code-size:22px}}@media (max-width:1280px){.ArchitectureDiagram{--user-code-size:24px}}@media (max-width:1250px){.ArchitectureDiagram{--user-code-size:22px}}@media (max-width:1195px){.ArchitectureDiagram{--user-code-size:20px}}@media (max-width:1152px){.ArchitectureDiagram{--user-code-size:25px}}@media (max-width:1080px){.ArchitectureDiagram{--user-code-size:22px}}@media (max-width:986px){.ArchitectureDiagram{--user-code-size:20px}}@media (max-width:920px){.ArchitectureDiagram{--user-code-size:15px}}@media (max-width:820px){.ArchitectureDiagram{--user-code-size:12px}}@media (max-width:768px){.ArchitectureDiagram{--user-code-size:20px}}@media (max-width:576px){.ArchitectureDiagram{--user-code-size:18px}}@media (max-width:520px){.ArchitectureDiagram{--user-code-size:16px}}.ArchitectureDiagram--diagram{--size:calc(var(--user-code-size)*9);width:var(--size)}@media (max-width:480px){.ArchitectureDiagram{--user-code-size:25px;justify-content:flex-start}.ArchitectureDiagram--diagram{width:100%}.ArchitectureDiagram--diagram+.ArchitectureDiagram--diagram{margin-top:2em}.ArchitectureDiagram--key{position:absolute;top:0;right:0;bottom:0}.ArchitectureDiagram--key-content{position:-webkit-sticky;position:sticky;top:calc(var(--docs-header-height) + var(--user-code-size))}.ArchitectureDiagram--caption{width:var(--size)}}@media (max-width:374px){.ArchitectureDiagram--key{width:5em}}@media (max-width:414px){.ArchitectureDiagram{--user-code-size:22px}}@media (max-width:375px){.ArchitectureDiagram{--user-code-size:20px}}@media (max-width:360px){.ArchitectureDiagram{--user-code-size:19px}}@media (max-width:340px){.ArchitectureDiagram{--user-code-size:18px}}@media (max-width:330px){.ArchitectureDiagram{--user-code-size:17px}}@media (max-width:319px){.ArchitectureDiagram{display:none}}.ArchitectureDiagram--content{position:relative;display:flex;flex-wrap:wrap;flex-shrink:0;width:var(--size);height:var(--size)}.ArchitectureDiagram--caption{margin-top:.666em;max-width:100%;line-height:1.3}.ArchitectureDiagram--process-overhead{--size:calc(var(--user-code-size)*3);position:relative;display:flex;flex-wrap:wrap;flex-shrink:0;width:var(--size);height:var(--size)}.ArchitectureDiagram--process-overhead:after{content:"\21BB";display:block;position:absolute;top:0;right:0;bottom:0;left:0;height:1em;width:1em;margin:auto;font-size:2em;line-height:1;text-align:center;color:rgb(var(--accent-color-rgb))}.ArchitectureDiagram--process-overhead-background{position:absolute;top:0;right:0;bottom:0;left:0;background:rgba(var(--accent-color-rgb),.25)}.ArchitectureDiagram--user-code{position:relative;z-index:1;width:var(--user-code-size);height:var(--user-code-size);background:rgba(var(--accent-color-rgb),.9)}.ArchitectureDiagram--process-overhead-background,.ArchitectureDiagram--user-code{--box-shadow:inset 0 0 0 1px rgb(var(--background-color-rgb));box-shadow:var(--box-shadow)}.ArchitectureDiagram--user-code:after{content:"{ }";display:block;font-size:calc(var(--user-code-size)*0.5);line-height:calc(var(--user-code-size)*0.93);font-weight:700;height:100%;width:100%;text-align:center;color:rgba(var(--background-color-rgb),.7)}.ArchitectureDiagram--key-user-code{margin-bottom:1em}.ArchitectureDiagram--key-label{opacity:.8;padding-top:.25em}.DocsNoscript{position:fixed;top:0;left:50%;-webkit-transform:translate3d(-50%,0,0);transform:translate3d(-50%,0,0);font-size:.8em;padding:.5em 1em;background:rgba(var(--orange-rgb),.15);border-radius:0 0 .25em .25em;z-index:100}.DocsNavLogoLockup{display:flex;align-items:center;flex-shrink:0;--gap:var(--docs-logo-lockup-gap)}.DocsNavLogoLockup.DocsNavLogoLockup-with-small-gap{--gap:var(--docs-logo-lockup-gap-small)}.DocsNavLogoLockup--logo{--size:var(--logo-size,2.5em);height:var(--size);width:var(--size);color:var(--orange);margin-right:var(--gap);flex-shrink:0;fill:var(--orange)}.DocsNavLogoLockup--logo path{fill:var(--orange)}.DocsNavLogoLockup--text{font-size:var(--font-size,1em);font-weight:700;line-height:1;padding-top:.05em;letter-spacing:-.03em}@-moz-document url-prefix(){.DocsNavLogoLockup--text{letter-spacing:0}}.DocsNavLogoLockup--text [data-text=Cloudflare]~[data-text=Docs]{font-weight:500;margin-left:-.05em}@media (max-width:768px){.DocsNavLogoLockup--text{font-weight:600}.DocsNavLogoLockup--text [data-text=Cloudflare]~[data-text=Docs]{font-weight:400}}html[is-docs-page],html[is-docs-page] body{scroll-behavior:smooth;height:100%;overscroll-behavior-y:none}.DocsPage{--sixty-four-px-rem:3.7647058824rem;--docs-content-gap:var(--sixty-four-px-rem);--docs-header-height:var(--sixty-four-px-rem);--docs-sidebar-width:18.25rem;--docs-body-sidebar-width:var(--docs-sidebar-width);--docs-page-side-padding:1rem;--docs-max-page-width:1440px;--docs-page-width:var(--docs-max-page-width);--docs-sidebars-combined-width:calc(var(--docs-sidebar-width) + var(--docs-body-sidebar-width));--docs-body-width:calc(var(--docs-page-width) - var(--docs-sidebars-combined-width));--docs-logo-lockup-gap:.4rem;--docs-logo-lockup-gap-small:.2rem;position:relative;width:100%;max-width:var(--docs-max-page-width);min-height:100%;margin:0 auto}@media (max-width:1439px){.DocsPage{--docs-page-width:100vw;--docs-page-sidebar-preserverd-width:calc(100vw - var(--docs-sidebar-width) - var(--docs-max-page-width) + var(--docs-sidebar-width)*2);--docs-body-sidebar-width:calc(15vw + var(--docs-page-sidebar-preserverd-width)/4)}}@media (max-width:1350px){.DocsPage{--docs-sidebar-width:18rem}}@media (max-width:1280px){.DocsPage{--docs-sidebar-width:17rem;--docs-body-sidebar-width:18vw}}@media (max-width:1152px){.DocsPage{--docs-sidebar-width:calc(10rem + 12vw);--docs-body-sidebar-width:0px}}@media (max-width:768px){.DocsPage{--docs-header-height:3rem;padding-top:var(--docs-header-height)}html[is-docs-page][is-mobile-sidebar-open]{overflow:hidden}}.DocsSidebar{position:fixed;top:0;bottom:0;--sidebar-background-color:var(--background-color);--content-indent:var(--docs-page-side-padding);--logo-size:2.8235294118rem;--text-indent:calc(var(--content-indent) + var(--logo-size) + var(--docs-logo-lockup-gap) + 0.1em);width:var(--docs-sidebar-width);z-index:2}.DocsSidebar [is-visually-hidden]{-webkit-clip-path:none;clip-path:none;left:-10000px;top:auto}[theme=dark] .DocsSidebar{--sidebar-background-color:var(--gray-0F)}[theme=dark] .DocsSidebar:before{content:"";position:absolute;top:0;right:0;bottom:0;width:999em;background:var(--sidebar-background-color);pointer-events:none}.DocsSidebar--link{color:inherit;text-decoration:none}[js-focus-visible-polyfill-available] .DocsSidebar--link:focus{outline:none}.DocsSidebar--link[is-focus-visible]:focus{box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.DocsSidebar--link:not([is-focus-visible]){--focus-size:0}.DocsSidebar--sections{height:100%;display:flex;flex-direction:column}.DocsSidebar--shadow{pointer-events:none;position:absolute;top:0;right:0;bottom:0;z-index:6}.DocsSidebar--shadow:after,.DocsSidebar--shadow:before{content:"";position:absolute;top:0;right:0;bottom:0;background:linear-gradient(90deg,rgba(var(--shadow-color-rgb),0),rgba(var(--shadow-color-rgb),.07))}.DocsSidebar--shadow:before{width:5px;opacity:.8}.DocsSidebar--shadow:after{width:2px;opacity:.5}@media (min-width:769px){[theme=dark] .DocsSidebar--shadow{left:calc(100% + 2px);right:auto}[theme=dark] .DocsSidebar--shadow:before{background:rgb(var(--shadow-color-rgb));border-right:1px solid rgba(var(--color-rgb),.15);width:1px;opacity:1}[theme=dark] .DocsSidebar--shadow:after{opacity:1;width:14px;right:1px}}.DocsSidebar--section{position:relative}.DocsSidebar--section-separator{position:relative;flex-shrink:0;--fade-indent:1.25em;--shadow-opacity:.07;margin-top:-1px}[theme=dark] .DocsSidebar--section-separator{--shadow-opacity:1}.DocsSidebar--section-separator:after,.DocsSidebar--section-separator:before{content:"";position:absolute;left:0;right:0;height:1px}.DocsSidebar--section-separator:before{background:linear-gradient(90deg,rgba(var(--shadow-color-rgb),0) 0,rgba(var(--shadow-color-rgb),var(--shadow-opacity)) var(--fade-indent),rgba(var(--shadow-color-rgb),var(--shadow-opacity)))}[theme=light] .DocsSidebar--section-separator:after{display:none}[theme=dark] .DocsSidebar--section-separator:after{top:1px;background:linear-gradient(90deg,rgba(var(--color-rgb),0) 0,rgba(var(--color-rgb),.07) var(--fade-indent),rgba(var(--color-rgb),.07))}@media (max-width:1440px){.DocsSidebar--section-separator:before{background:rgba(var(--shadow-color-rgb),var(--shadow-opacity))}[theme=dark] .DocsSidebar--section-separator:after{background:rgba(var(--color-rgb),.07)}}.DocsSidebar--header-section{display:flex;flex-shrink:0;height:var(--docs-header-height);z-index:1}.DocsSidebar--cloudflare-logo-link{--font-size:1.17647em;display:flex;align-items:center;padding-left:var(--content-indent);padding-right:var(--content-indent)}.DocsSidebar--docs-title-section{position:relative;display:flex;z-index:7}.DocsSidebar--docs-title-logo-link{--font-size:1.58824em;padding:.7em var(--content-indent);max-width:calc(100% - 3em)}.DocsSidebar--cloudflare-logo-link,.DocsSidebar--docs-title-logo-link{transition:opacity .2s ease,color .2s ease}.DocsSidebar--cloudflare-logo-link:hover,.DocsSidebar--docs-title-logo-link:hover{opacity:.75;color:rgba(var(--color-rgb),.75)}.DocsSidebar--docs-title-text-scaler{--font-size:1em * (1 - ((var(--length) - 10)/20));font-size:clamp(.7em,var(--font-size),1em);display:inherit}.DocsSidebar--section-more{position:absolute;right:.75em;top:0;bottom:0;margin-top:auto;margin-bottom:auto;height:2.5em;width:1.75em}.DocsSidebar--section-more-button{position:relative;height:100%;width:100%;transition:opacity .2s ease}.DocsSidebar:not(:hover) .DocsSidebar--section-more:not([data-expanded=true]) .DocsSidebar--section-more-button:not(:focus){opacity:0}.DocsSidebar--section-more-button-icon{position:absolute;top:0;right:0;bottom:0;left:0;padding:.625em .4em;transition:opacity .2s ease;opacity:.5}@media (hover:hover){.DocsSidebar--section-more-button:hover .DocsSidebar--section-more-button-icon{opacity:1}}.DocsSidebar--nav-section{display:flex;flex-direction:column;flex:1 1;overflow-y:auto;-webkit-overflow-scrolling:touch;scrollbar-width:thin;scrollbar-color:rgba(var(--color-rgb),.1) transparent}@media (hover:hover){.DocsSidebar--nav-section:hover{scrollbar-color:rgba(var(--color-rgb),.35) transparent}}.DocsSidebar--nav-section-shadow{position:-webkit-sticky;position:sticky;flex-shrink:0;top:0;width:100%;height:.25em;box-shadow:inset 0 1px rgba(var(--shadow-color-rgb),.04);background:linear-gradient(rgba(var(--shadow-color-rgb),.09),rgba(var(--shadow-color-rgb),0));opacity:0;z-index:4}@media (min-width:1441px){.DocsSidebar--nav-section-shadow{-webkit-mask-image:linear-gradient(90deg,transparent,#000 1.5em,#000);mask-image:linear-gradient(90deg,transparent,#000 1.5em,#000)}}[theme=dark] .DocsSidebar--nav-section-shadow{box-shadow:inset 0 1px rgba(var(--shadow-color-rgb),.5);background:linear-gradient(rgba(var(--shadow-color-rgb),.2),transparent);height:.5em;border-top:1px solid #222}.DocsSidebar--nav{list-style:none;font-size:1.11em;padding-top:0;padding-bottom:2em;padding-left:0;word-break:break-word}@media (max-width:1280px){.DocsSidebar--nav{font-size:1.05em;--text-indent:3rem}}.DocsSidebar--nav-item{position:relative}.DocsSidebar--nav-item+.DocsSidebar--nav-item{margin-top:.333em}.DocsSidebar--nav-expand-collapse-button{position:absolute;z-index:3;--size:2em;--margin-right:.75em;left:calc(var(--text-indent) - var(--size) - var(--margin-right) + var(--depth, 0)*1rem);top:0;height:var(--size);width:var(--size);line-height:.5em;padding:0;text-align:center}@media (max-width:1280px){.DocsSidebar--nav-expand-collapse-button{--margin-right:.25em}}@media (hover:hover){.DocsSidebar--nav-expand-collapse-button:hover,[theme=dark] .DocsSidebar--nav-expand-collapse-button:hover{--hover-box-shadow-color:transparent}.DocsSidebar--nav-expand-collapse-button:hover{background:rgba(var(--gray-5-rgb),.2)}[theme=dark] .DocsSidebar--nav-expand-collapse-button:hover{color:var(--code-orange);background:rgba(var(--orange-rgb),.08)}}.DocsSidebar--nav-expand-collapse-button:before{content:"";position:absolute;right:0;top:0;bottom:0;width:5em;z-index:-1}.DocsSidebar--nav-expand-collapse-button-content{display:inline-block;vertical-align:middle;transition:-webkit-transform .4s ease;transition:transform .4s ease;transition:transform .4s ease,-webkit-transform .4s ease;border:solid transparent;border-left:solid;border-width:.3333em .6em;margin-left:37%;will-change:transform;-webkit-transform:translateZ(0);transform:translateZ(0);-webkit-transform-origin:.2em .4em;transform-origin:.2em .4em}.DocsSidebar--nav-item[is-active-root]:not([is-expanded])>.DocsSidebar--nav-expand-collapse-button>.DocsSidebar--nav-expand-collapse-button-content,[theme=dark] .DocsSidebar--nav-item[is-active]>.DocsSidebar--nav-expand-collapse-button>.DocsSidebar--nav-expand-collapse-button-content{color:var(--orange)}@media (hover:hover){.DocsSidebar--nav-expand-collapse-button:not(:hover)>.DocsSidebar--nav-expand-collapse-button-content{opacity:.4}[theme=dark] .DocsSidebar--nav-item[is-active]>.DocsSidebar--nav-expand-collapse-button>.DocsSidebar--nav-expand-collapse-button-content{opacity:.8}.DocsSidebar--nav-item[is-active-root]:not([is-expanded])>.DocsSidebar--nav-expand-collapse-button>.DocsSidebar--nav-expand-collapse-button-content{opacity:1}}.DocsSidebar--nav-item[is-expanded]>.DocsSidebar--nav-expand-collapse-button>.DocsSidebar--nav-expand-collapse-button-content{-webkit-transform:rotate(90deg) translate3d(-.1em,0,0);transform:rotate(90deg) translate3d(-.1em,0,0)}.DocsSidebar--nav-item-collapse-container{overflow:hidden}.DocsSidebar--nav-item-collapse-container.DocsSidebar--nav-item-collapse-hidden{height:0}.DocsSidebar--nav-item-collapse-content{opacity:0;-webkit-transform:translate3d(-.5em,0,0);transform:translate3d(-.5em,0,0);will-change:transform,opacity;transition:opacity .4s ease,-webkit-transform .4s ease;transition:transform .4s ease,opacity .4s ease;transition:transform .4s ease,opacity .4s ease,-webkit-transform .4s ease}.DocsSidebar--nav-item[is-expanded]>.DocsSidebar--nav-item-collapse-container>.DocsSidebar--nav-item-collapse-content,.DocsSidebar--nav-item[is-expanded]>.DocsSidebar--nav-item-collapse-container>.DocsSidebar--nav-item-collapse-wrapper>.DocsSidebar--nav-item-collapse-wrapperInner>.DocsSidebar--nav-item-collapse-content{opacity:1;-webkit-transform:translateZ(0);transform:translateZ(0)}@media (prefers-reduced-motion:reduce){.DocsSidebar--nav-expand-collapse-button-content,.DocsSidebar--nav-item-collapse-content{transition:none}}.DocsSidebar--nav-subnav{list-style:none;font-size:.94rem;padding:.25em 0 .75em}@media (max-width:1280px){.DocsSidebar--nav-subnav{font-size:.9em}}.DocsSidebar--nav-subnav .DocsSidebar--nav-item+.DocsSidebar--nav-item{margin-top:.0625em}.DocsSidebar--nav-link{color:inherit;text-decoration:none;position:relative;display:block;padding-left:var(--text-indent)}.DocsSidebar--nav-subnav .DocsSidebar--nav-link{padding-left:calc(var(--text-indent) + var(--depth)*1rem)}.DocsSidebar--nav-link:focus{z-index:1}.DocsSidebar--nav-link[is-active]{z-index:2}.DocsSidebar--nav-link[is-active]:before{content:"";position:absolute;top:0;bottom:0;left:0;width:.4125em;background:var(--orange);z-index:4}.DocsSidebar--nav-link-text{position:relative;display:inline-block;padding:.25em .6em;margin-left:-.6em;z-index:1}@media (hover:hover){.DocsSidebar--nav-link:hover .DocsSidebar--nav-link-text:before{content:"";position:absolute;top:0;right:0;bottom:0;left:0;pointer-events:none;height:100%;background:rgba(var(--gray-5-rgb),.2);z-index:-1;border-radius:.25em}}.DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text:before{content:"";position:absolute;top:0;right:0;bottom:0;left:0;pointer-events:none;height:100%;background:rgba(var(--gray-5-rgb),.2);z-index:-1;border-radius:.25em}@media (max-width:1440px){.DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text:before{left:calc(var(--docs-sidebar-width)*-1);border-top-left-radius:0;border-bottom-left-radius:0}}@media (min-width:1441px){.DocsSidebar--nav-link[is-active]:before{display:none}}@media (hover:hover){[theme=dark] .DocsSidebar--nav-link:hover .DocsSidebar--nav-link-text{color:var(--code-orange)}[theme=dark] .DocsSidebar--nav-link:hover .DocsSidebar--nav-link-text:before{background:rgba(var(--orange-rgb),.08)}}[theme=dark] .DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text{color:var(--code-orange)}[theme=dark] .DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text:before{background:rgba(var(--orange-rgb),.08)}.DocsSidebar--nav-link .DocsSidebar--nav-link-text:after{content:"";position:absolute;top:0;right:0;bottom:0;left:0;pointer-events:none;border-radius:.25em}[js-focus-visible-polyfill-available] .DocsSidebar--nav-link:focus{outline:none}.DocsSidebar--nav-link[is-focus-visible]:focus .DocsSidebar--nav-link-text:after{box-shadow:0 0 0 var(--focus-size) var(--focus-color)}@media (max-width:768px){.DocsSidebar{z-index:20;background:var(--sidebar-background-color);width:calc(100% - 3.5rem);-webkit-transform:translate3d(-100%,0,0);transform:translate3d(-100%,0,0);will-change:transform;transition:-webkit-transform .3s ease;transition:transform .3s ease;transition:transform .3s ease,-webkit-transform .3s ease}[theme=dark] .DocsSidebar{--sidebar-background-color:var(--background-color)}.DocsSidebar--shadow{opacity:0;transition:opacity .3s ease}.DocsSidebar--shadow,.DocsSidebar--shadow:after,.DocsSidebar--shadow:before{right:auto;left:100%}.DocsSidebar--shadow:after,.DocsSidebar--shadow:before{background:linear-gradient(270deg,rgba(var(--shadow-color-rgb),0),rgba(var(--shadow-color-rgb),.2))}.DocsSidebar--shadow:before{width:.3125em}[is-resizing] .DocsSidebar{transition:none}[is-mobile-sidebar-open] .DocsSidebar{-webkit-transform:translateZ(0);transform:translateZ(0)}[is-mobile-sidebar-open] .DocsSidebar--shadow{opacity:1}.DocsSidebar--docs-title-section,.DocsSidebar--header-section,.DocsSidebar--header-section+.DocsSidebar--section-separator,.DocsSidebar--nav-section-shadow{display:none}.DocsSidebar--nav{padding:1rem 0}}.DocsBody{position:relative;padding-top:var(--docs-header-height);padding-left:var(--docs-sidebar-width)}@media (max-width:768px){.DocsBody{padding-top:0;padding-left:0;will-change:opacity;transition:opacity .3s ease}[is-mobile-sidebar-open] .DocsBody{opacity:.3}}.DocsBody--sidebar{position:absolute;right:0;top:calc(var(--docs-header-height) + 1.7em);bottom:1em;width:var(--docs-body-sidebar-width)}@media (max-width:1152px){.DocsBody--sidebar{display:none}}.DocsBody--sidebar-content-scroll-fade{position:-webkit-sticky;position:sticky;top:0;display:block;background:linear-gradient(var(--background-color),rgba(var(--background-color-rgb),0));height:1em;margin-left:-1em;width:100%;z-index:1}.DocsBody--sidebar-content{position:-webkit-sticky;position:sticky;top:0;width:calc(100% + 1em);max-height:100vh;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:1em 0 0 1em;margin:-1em;transition:opacity .3s ease;scrollbar-width:thin;scrollbar-color:rgba(var(--color-rgb),.1) transparent}@media (min-width:1281px){.DocsBody--sidebar{padding-left:2em}}.DocsBody--sidebar-content:hover{scrollbar-color:rgba(var(--color-rgb),.35) transparent}[theme=dark] .DocsBody--sidebar-content:not(:hover):not(:focus-within){opacity:.55}.DocsTableOfContents{list-style:none;font-size:.94117647059em;padding-left:0;width:100%}.DocsTableOfContents ul{padding-left:1.5em;list-style:none}.DocsTableOfContents ul ul{font-size:.9em;padding-left:1.5em;margin-bottom:.25em}@media (max-height:768px){.DocsTableOfContents ul ul{display:none}}.DocsTableOfContents ul ul ul{display:none}.DocsTableOfContents-link{display:inline-block;line-height:1.3;max-width:100%;white-space:nowrap;text-overflow:ellipsis;overflow:hidden;color:inherit;text-decoration:none;padding:.2em 0;margin:-.2em 0}.DocsTableOfContents-link:hover{color:var(--orange)}[js-focus-visible-polyfill-available] .DocsTableOfContents-link:focus{outline:none}.DocsTableOfContents-link[is-focus-visible]:focus{box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.DocsTableOfContents-link:not([is-focus-visible]){--focus-size:0}.DocsContent{padding:2.6rem var(--docs-content-gap) 3.5rem;min-height:calc(100vh - 12.5em)}.DocsContent[page-type=document]{width:calc(100% - var(--docs-body-sidebar-width))}@media (min-width:769px){[search-disabled] .DocsContent{padding-top:0}}@media (max-width:768px){.DocsContent{--docs-content-horizontal-padding:1rem;padding:2rem var(--docs-content-horizontal-padding);min-height:1em}}.DocsContent--breadcrumbs{margin:-.5em 0 .3125em}@media (min-width:769px){.DocsContent--breadcrumbs{display:none}}.DocsMarkdown{word-wrap:break-word}.DocsMarkdown img{border-style:none;box-sizing:content-box;max-width:100%}.DocsMarkdown hr{box-sizing:content-box;height:0;overflow:visible}.DocsMarkdown .small-img{max-width:242px;margin-bottom:1em}.DocsMarkdown .medium-img{max-width:311px;margin-bottom:1em}.DocsMarkdown .large-img{max-width:450px;margin-bottom:1em}.DocsMarkdown .full-img{max-width:692px;margin-bottom:1em}.DocsMarkdown--link{text-decoration:none;color:inherit;--background-color-rgb:var(--orange-rgb);--background-color-alpha:.08;--border-bottom-color-rgb:var(--orange-3-rgb);--border-bottom-color-alpha:.3;--background-color:rgba(var(--background-color-rgb),var(--background-color-alpha));--focus-shadow:0 0 0 var(--focus-size) var(--focus-color);box-shadow:var(--focus-shadow)}.DocsMarkdown--link .DocsMarkdown--link-content{background-color:var(--background-color);border-bottom:1px solid rgba(var(--border-bottom-color-rgb),var(--border-bottom-color-alpha))}.DocsMarkdown--link-external-icon{display:inline-block;height:16px;width:16px;vertical-align:middle;position:relative;top:-1px;margin-left:4px;opacity:.7}.DocsMarkdown--link:focus .DocsMarkdown--link-external-icon{opacity:1}@media (hover:hover){.DocsMarkdown--link:hover .DocsMarkdown--link-external-icon{opacity:1}}[js-focus-visible-polyfill-available] .DocsMarkdown--link:focus{outline:none}.DocsMarkdown--link[is-focus-visible]{border-color:transparent}.DocsMarkdown--link:not([is-focus-visible]){--focus-size:0}.DocsMarkdown--link:hover{--background-color-alpha:.15}.DocsMarkdown--link-content>code{--padding:0;--background:transparent}.DocsMarkdown--link[data-is-type-link=true] .DocsMarkdown--link-content{background:transparent;border:none}@media (min-width:1025px){.DocsMarkdown--link[data-is-type-link=true] .DocsMarkdown--link-external-icon{top:1px}}.DocsMarkdown--link[data-is-type-link=true] .DocsMarkdown--link-content>code{--color-rgb:var(--orange-3-rgb);--background:var(--background-color)}.DocsMarkdown code .DocsMarkdown--link[data-is-type-link=true]{margin-left:.5em}[theme=dark] .DocsMarkdown--link{--background-color-alpha:.03;--border-bottom-color-rgb:var(--orange-rgb);--border-bottom-color-alpha:.35;color:var(--code-orange)}[theme=dark] .DocsMarkdown--link:hover{--background-color-alpha:.08}.DocsMarkdown strong{font-weight:600}.DocsMarkdown ol ol,.DocsMarkdown ul ol{list-style-type:lower-roman}.DocsMarkdown ol ol ol,.DocsMarkdown ol ul ol,.DocsMarkdown ul ol ol,.DocsMarkdown ul ul ol{list-style-type:lower-alpha}.DocsMarkdown dd{margin-left:0}.DocsMarkdown blockquote,.DocsMarkdown dl,.DocsMarkdown ol,.DocsMarkdown p,.DocsMarkdown ul{margin-bottom:1em}.DocsMarkdown figure,.DocsMarkdown pre,.DocsMarkdown table{margin-bottom:2em}.DocsMarkdown figure{margin-top:2em}.DocsMarkdown li figure,.DocsMarkdown li pre,.DocsMarkdown li table{margin-bottom:1em}.DocsMarkdown h1,.DocsMarkdown h2,.DocsMarkdown h3,.DocsMarkdown h4,.DocsMarkdown h5,.DocsMarkdown h6,p.DocsMarkdown--small-header{font-weight:600}.DocsMarkdown h2,.DocsMarkdown h3,.DocsMarkdown h4,.DocsMarkdown h5,.DocsMarkdown h6,p.DocsMarkdown--small-header{line-height:1.25;margin-bottom:.5em}.DocsMarkdown h2{margin-top:1.55em}.DocsMarkdown h3,.DocsMarkdown h4,.DocsMarkdown h5,.DocsMarkdown h6{margin-top:1.8em}p.DocsMarkdown--small-header{margin-top:1.5em;margin-bottom:.75em}.DocsMarkdown h2+h3,.DocsMarkdown h3+h4,.DocsMarkdown h4+h5,.DocsMarkdown h5+h6{margin-top:1em}@media (min-width:1440px){.DocsMarkdown h3,.DocsMarkdown h4,.DocsMarkdown h5,.DocsMarkdown h6{margin-top:2em}}.DocsMarkdown h1{font-size:2.4em;line-height:1.1;letter-spacing:-.03em;margin-bottom:.375em}@-moz-document url-prefix(){.DocsMarkdown h1{letter-spacing:0}}@media (max-width:768px){.DocsMarkdown h1{font-size:2.25em}}@media (max-width:374px){.DocsMarkdown h1{font-size:2em}}.DocsMarkdown h2{font-size:1.6666em}@media (max-width:768px){.DocsMarkdown h2{font-size:1.5em}}.DocsMarkdown h3{font-size:1.25em}.DocsMarkdown h4{font-size:1em}.DocsMarkdown h2 code,.DocsMarkdown h3 code,.DocsMarkdown h4 code,.DocsMarkdown h5 code{--background:transparent;--padding:0}.DocsMarkdown h2 code,.DocsMarkdown h3 code{--inline-code-font-size:.9375em}.DocsMarkdown h4 code,.DocsMarkdown h5 code{--inline-code-font-size:1em}.DocsMarkdown h5,.DocsMarkdown h6,p.DocsMarkdown--small-header{font-size:.875em}.DocsMarkdown ul{list-style:disc}.DocsMarkdown ol,.DocsMarkdown ul{padding-left:1.25em}.DocsMarkdown li{margin-bottom:.5em}.DocsMarkdown ol ol,.DocsMarkdown ol ul,.DocsMarkdown ul ol,.DocsMarkdown ul ul{margin-bottom:.75em}.DocsMarkdown li>p+ul{margin-top:-.5em}.DocsMarkdown dl{padding:0}.DocsMarkdown dl dt{font-size:1em;font-style:normal;font-weight:400;padding:0}.DocsMarkdown dl dd{margin-bottom:1.25em;padding:.25em 0 0 2em}.DocsMarkdown--definitions{margin:1.25em 0}.DocsMarkdown h3+.DocsMarkdown--definitions,.DocsMarkdown h4+.DocsMarkdown--definitions{margin-top:1em}.DocsMarkdown--definitions>ul{list-style:none;margin:0;padding:0}.DocsMarkdown--definitions ul li:not(:last-child){margin-bottom:1.5em}.DocsMarkdown--definitions ul li>p:first-child{margin:0}.DocsMarkdown--definitions ul li>code:first-child,.DocsMarkdown--definitions ul li>p:first-child>code:first-child{display:inline-block;vertical-align:middle;font-weight:600;--padding:0 .3em}.DocsMarkdown--definitions ul li>ul{list-style:none;padding-left:2em;margin-top:.25em}.DocsMarkdown hr{height:1px;border:0;border-bottom:1px solid rgba(var(--color-rgb),.1);margin-top:3em;margin-bottom:3em}.DocsMarkdown--prop-meta{color:rgba(var(--color-rgb),.85);font-size:.75em;font-weight:500;padding:0 2px}code .DocsMarkdown--prop-meta{font-family:var(--sans-serif-font-family);font-size:.8125em;margin-left:.4375em;-webkit-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none}[theme=dark] .DocsMarkdown blockquote,[theme=dark] .DocsMarkdown dl,[theme=dark] .DocsMarkdown ol,[theme=dark] .DocsMarkdown p,[theme=dark] .DocsMarkdown pre,[theme=dark] .DocsMarkdown table,[theme=dark] .DocsMarkdown ul{color:var(--gray-7)}.DocsMarkdown>pre{--outdent:1rem}[page-type=example] .DocsMarkdown>pre{--outdent:0px}@media (max-width:768px){.DocsMarkdown>pre{--border-radius:0em}}.DocsMarkdown blockquote,.DocsMarkdown dl,.DocsMarkdown p,.DocsMarkdown table{max-width:100%}.DocsMarkdown blockquote{position:relative;margin:1.5em 0}.DocsMarkdown blockquote>p{font-style:italic}.DocsMarkdown blockquote>p>em{font-style:normal}.DocsMarkdown blockquote cite{font-weight:700;font-style:normal;font-size:.9em}.DocsMarkdown blockquote cite:before{content:"\2014   "}.DocsMarkdown blockquote:after{position:absolute;content:"";top:1.5em;bottom:0;left:-1rem;width:2px;background:rgba(var(--color-rgb),.2)}@media (max-width:768px){.DocsMarkdown blockquote{margin-left:1rem}}.DocsMarkdown blockquote:before{quotes:"\201C" "\201D";content:open-quote;position:absolute;top:.05em;left:-.8em;display:inline-block;font-family:Arial;font-weight:700;font-size:2em;line-height:1;height:.5em;width:.7em}.DocsMarkdown--aside{font-size:.9em;margin:1.5em 0;padding:1em 1.3333em;border-left:.28125em solid rgba(var(--color-rgb),.5);background-color:rgba(var(--color-rgb),.125);border-radius:0 .5em .5em 0}.DocsMarkdown--aside-header{font-weight:600;margin-bottom:.25em}.DocsMarkdown--aside[data-type=warning]{border-left-color:rgba(var(--orange-5-rgb),.5);background-color:rgba(var(--orange-5-rgb),.125)}[theme=dark] .DocsMarkdown--aside[data-type=warning]{border-left-color:rgba(var(--orange-5-rgb),.7);background-color:rgba(var(--orange-6-rgb),.04)}.DocsMarkdown--aside[data-type=note]{border-left-color:rgba(var(--blue-4-rgb),.4);background-color:rgba(var(--blue-4-rgb),.1)}.DocsMarkdown--aside[data-type=note] .DocsMarkdown--link{--background-color-rgb:var(--blue-4-rgb);--border-bottom-color-rgb:var(--blue-2-rgb)}[theme=dark] .DocsMarkdown--aside[data-type=note]{border-left-color:rgba(var(--blue-4-rgb),.8);background-color:rgba(var(--blue-6-rgb),.05)}[theme=dark] .DocsMarkdown--aside[data-type=note] .DocsMarkdown--link{color:inherit;--background-color-rgb:var(--blue-6-rgb);--background-color-alpha:.1;--border-bottom-color-rgb:var(--blue-7-rgb)}[theme=dark] .DocsMarkdown--aside[data-type=note] .DocsMarkdown--link:hover{--background-color-alpha:.2}.DocsMarkdown a[name]:not([href]):before,.DocsMarkdown h2[id]:before,.DocsMarkdown h3[id]:before,.DocsMarkdown h4[id]:before,.DocsMarkdown h5[id]:before,.DocsMarkdown h6[id]:before{content:"";display:block;--offset:2rem;height:var(--offset);margin-top:calc(var(--offset)*-1);visibility:hidden;pointer-events:none}@media (max-width:768px){.DocsMarkdown a[name]:not([href]):before,.DocsMarkdown h2[id]:before,.DocsMarkdown h3[id]:before,.DocsMarkdown h4[id]:before,.DocsMarkdown h5[id]:before,.DocsMarkdown h6[id]:before{--offset:calc(var(--docs-header-height) + 2rem)}}.DocsMarkdown--header-anchor-positioner{position:absolute}blockquote .DocsMarkdown--header-anchor-positioner{display:none}.DocsMarkdown--header-anchor{position:absolute;right:100%;top:0;height:1.25em;opacity:0;padding-right:.125em;transition:opacity .15s,color .15s}.DocsMarkdown--header-anchor:before{content:"#"}@media (max-width:768px){.DocsMarkdown--header-anchor{margin-top:-.125em;padding-right:.0625em}.DocsMarkdown--header-anchor:before{font-size:1.1rem}}.DocsMarkdown--header-anchor:focus,.DocsMarkdown h2:hover .DocsMarkdown--header-anchor,.DocsMarkdown h3:hover .DocsMarkdown--header-anchor,.DocsMarkdown h4:hover .DocsMarkdown--header-anchor{opacity:1}.DocsMarkdown table{word-break:break-word;border-collapse:collapse;border-spacing:0;border:0;--border-color:rgba(var(--color-rgb),.1)}.DocsMarkdown th{word-break:normal;vertical-align:bottom;font-weight:700;border-bottom:2px solid var(--border-color)}.DocsMarkdown td,.DocsMarkdown th{padding:.66em 1em;text-align:left}.DocsMarkdown td[align=right],.DocsMarkdown th[align=right]{text-align:right}.DocsMarkdown td:not([valign]){vertical-align:top}.DocsMarkdown td:first-child,.DocsMarkdown th:first-child{padding-left:0}.DocsMarkdown td:last-child,.DocsMarkdown th:last-child{padding-right:0}.DocsMarkdown th{padding-bottom:.1875em}.DocsMarkdown tbody tr:not(:last-child) td{border-bottom:1px solid var(--border-color)}.DocsMarkdown details summary{padding:0 .8em;line-height:2;background:rgba(var(--color-rgb),.05);border-radius:.25em;font-weight:600;cursor:pointer;box-shadow:0 0 0 var(--focus-size) var(--focus-color)}[js-focus-visible-polyfill-available] .DocsMarkdown details summary:focus{outline:none}.DocsMarkdown details summary:not([is-focus-visible]){--focus-size:0em}.DocsMarkdown details{margin-top:1em;margin-bottom:1em}.DocsMarkdown details summary+div{padding:1em 1.9em;border:1px solid rgba(var(--color-rgb),.1);border-top:0;border-bottom-left-radius:.25em;border-bottom-right-radius:.25em}.DocsMarkdown details[open]{margin-bottom:1.5em}.DocsMarkdown details[open] summary{background:rgba(var(--color-rgb),.1);border-bottom-left-radius:0;border-bottom-right-radius:0}.DocsMarkdown sub{top:.35em}.DocsMarkdown sub,.DocsMarkdown sup{font-size:.8em;vertical-align:baseline;position:relative}.DocsMarkdown sup{top:-.35em}.DocsMarkdown var{font-style:italic}.DocsMarkdown kbd{font-family:inherit;font-size:.9em;padding:.3em .4em;background:rgba(var(--color-rgb),.025);box-shadow:inset 0 0 0 1px rgba(var(--color-rgb),.2),inset 0 -1px rgba(var(--color-rgb),.25),0 1px rgba(var(--color-rgb),.4);border-radius:.25em}[theme=dark] .DocsMarkdown kbd{background:rgba(var(--orange-rgb),.1);box-shadow:inset 0 0 0 1px rgba(var(--orange-rgb),.5);border-radius:.4em}.DocsMarkdown--demo{position:relative}.DocsMarkdown--demo:not(:last-child){margin-bottom:1.5em}.DocsMarkdown--demo:after{content:"";position:absolute;top:0;right:0;bottom:0;left:0;box-shadow:inset 0 0 0 1px rgba(var(--color-rgb),.15);pointer-events:none}.DocsMarkdown--demo iframe{background:#fff;height:100%;width:100%}.DocsMarkdown figure[data-type=youtube]{background:#000}.DocsMarkdown--table-wrap{--table-border-width:1px;border:var(--table-border-width) solid rgba(var(--color-rgb),.15);padding:.25em 0;border-radius:.3125em;overflow-x:auto;-webkit-overflow-scrolling:touch}.DocsMarkdown--table-wrap:not(:last-child){margin-bottom:1.5em}.DocsMarkdown--table-wrap-inner{display:flex}.DocsMarkdown--table-wrap table{min-width:calc(var(--docs-body-width) - var(--docs-content-gap)*2 - var(--table-border-width)*2);margin:0}@media (max-width:768px){.DocsMarkdown--table-wrap table{min-width:calc(100vw - var(--docs-content-horizontal-padding)*2 - var(--table-border-width)*2)}}.DocsMarkdown--table-wrap table{word-break:normal}@media (hover:hover){.DocsMarkdown--table-wrap:hover{width:calc(100% + var(--docs-body-sidebar-width))}.DocsMarkdown--table-wrap:hover table{background-color:var(--background-color);z-index:1}}.DocsMarkdown--table-wrap tr>:first-child{position:-webkit-sticky;position:sticky;left:0;white-space:nowrap;padding-left:1em;background:var(--background-color);box-shadow:5px 0 5px -3px var(--background-color)}.DocsMarkdown--table-wrap tr>:last-child{padding-right:1em}.DocsMarkdown--content-column{width:calc(100% - var(--docs-body-sidebar-width))}.DocsMarkdown--content-column:not(:last-child){margin-bottom:1em}.DocsMarkdown--button-group-content{display:flex;flex-wrap:wrap;margin:-.375em}.DocsMarkdown--button-group-content>a,.DocsMarkdown--button-group-content>button{margin:.375em}.DocsMarkdown--example{padding:1em 1.25em;margin:-.5em auto 1.25em;border:1px solid rgba(var(--color-rgb),.1);border-radius:.125em}.DocsMarkdown--example hr{margin-top:1em;margin-bottom:1em}.DocsMarkdown--aside>:first-child,.DocsMarkdown--content-column>:first-child,.DocsMarkdown--example>:first-child,.DocsMarkdown>:first-child,.DocsMarkdown blockquote>:first-child,.DocsMarkdown details>:first-child,.DocsMarkdown details summary+div>:first-child,.DocsMarkdown li>:first-child,.DocsMarkdown ol>:first-child,.DocsMarkdown ul>:first-child{margin-top:0}.DocsMarkdown--aside>:last-child,.DocsMarkdown--content-column>:last-child,.DocsMarkdown--example>:last-child,.DocsMarkdown>:last-child,.DocsMarkdown blockquote>:last-child,.DocsMarkdown details>:last-child,.DocsMarkdown details summary+div>:last-child,.DocsMarkdown li>:not(ul):not(ol):not(pre):not(figure):not(table):last-child,.DocsMarkdown ol>:last-child,.DocsMarkdown ul>:last-child{margin-bottom:0}.DocsToolbar{position:absolute;left:var(--docs-sidebar-width);top:0;right:0;display:flex;height:var(--docs-header-height);z-index:2}.DocsToolbar--search{flex:1 1;max-width:var(--docs-body-width);margin-right:auto}[search-disabled] .DocsToolbar--search{visibility:hidden}.DocsToolbar--feedback{display:flex;align-items:center;padding:.5rem 1rem}.DocsToolbar--feedback svg{width:1em;margin-right:.5em;height:1em}.DocsToolbar--tools{display:flex;align-items:center;justify-content:flex-end;padding:0 var(--docs-page-side-padding)}.DocsToolbar--tools-spacer{display:inline-flex;height:1em;width:1em}.DocsToolbar--tools-icon-item{display:inline-flex;height:1.647058823rem;width:1.647058823rem;color:rgba(var(--color-rgb),.7)}[theme=light] .DocsToolbar--tools-icon-item{color:var(--gray-3)}.DocsToolbar--tools-icon-item-content>a{display:block;height:100%;width:100%;padding:.1em}@media (max-width:768px){.DocsToolbar{left:0;z-index:12;pointer-events:none}.DocsToolbar--tools{pointer-events:all;padding-left:0;padding-right:.9rem}.DocsToolbar--search{flex-basis:3em;flex-grow:0;margin-left:auto;margin-right:0;max-width:100vw}.DocsToolbar--feedback,.DocsToolbar--tools-icon-item,.DocsToolbar--tools-spacer{display:none}}.DocsSearch{--text-indent:calc(var(--docs-content-gap) + 1px);height:var(--docs-header-height)}.DocsSearch--input,.DocsSearch--input-wrapper{position:relative;height:100%}.DocsSearch--input{color:inherit;width:100%;border:0;padding:0 var(--text-indent) .05em;background:transparent;outline:none;z-index:2}@-moz-document url-prefix(){.DocsSearch--input{letter-spacing:0}}.DocsSearch--input::-webkit-input-placeholder{color:rgba(var(--color-rgb),.45);opacity:1}.DocsSearch--input:-ms-input-placeholder{color:rgba(var(--color-rgb),.45);opacity:1}.DocsSearch--input::placeholder{color:rgba(var(--color-rgb),.45);opacity:1}[theme=dark] .DocsSearch--input::-webkit-input-placeholder{color:rgba(var(--color-rgb),.55)}[theme=dark] .DocsSearch--input:-ms-input-placeholder{color:rgba(var(--color-rgb),.55)}[theme=dark] .DocsSearch--input::placeholder{color:rgba(var(--color-rgb),.55)}.DocsSearch--input-icon{position:absolute;top:0;bottom:.05em;margin-top:auto;margin-bottom:auto;left:2.2em;height:.8823529411em;width:.8823529411em;pointer-events:none;opacity:.5;transition:color .3s ease,opacity .3s ease;z-index:3}.DocsSearch--input-wrapper:focus-within .DocsSearch--input-icon{color:var(--orange);opacity:1}.DocsSearch--input-bottom-border{position:absolute;left:0;width:50%;bottom:0;height:1px;background:linear-gradient(90deg,rgba(var(--color-rgb),.07) 0,rgba(var(--color-rgb),.07) calc(100% - 6em),rgba(var(--color-rgb),0))}[theme=dark] .DocsSearch--input{background:linear-gradient(90deg,rgba(var(--shadow-color-rgb),.1) 0,rgba(var(--shadow-color-rgb),.1) calc(30% - 6em),rgba(var(--shadow-color-rgb),0) 30%)}[theme=dark] .DocsSearch--input-bottom-border{bottom:-1px}[theme=dark] .DocsSearch--input-bottom-border:before{content:"";display:block;position:absolute;top:-1px;width:100%;bottom:0;height:1px;background:linear-gradient(90deg,rgba(var(--shadow-color-rgb),.5) 0,rgba(var(--shadow-color-rgb),.5) calc(100% - 6em),rgba(var(--shadow-color-rgb),0))}.DocsSearch .algolia-autocomplete{--dropdown-text-indent:var(--text-indent);--suggestion-item-vertical-padding:.5em;display:block!important;top:0!important;left:0!important;right:auto!important;width:var(--docs-body-width)!important;z-index:1!important;background:var(--background-color);--box-shadow:0 3rem 6rem -1.2rem rgba(var(--shadow-color-rgb),.25),0 3rem 6rem -3rem rgba(var(--shadow-color-rgb),.3);--backdrop-box-shadow-alpha:.07;--backdrop-box-shadow:0 0 0 999em rgba(var(--shadow-color-rgb),var(--backdrop-box-shadow-alpha));box-shadow:var(--box-shadow),var(--backdrop-box-shadow);border-radius:0 0 .5em .5em;will-change:opacity;transition:opacity .15s ease}[theme=dark] .DocsSearch .algolia-autocomplete{--dark-theme-shadow-offset:1px;--dropdown-text-indent:calc(var(--text-indent) - var(--dark-theme-shadow-offset));--box-shadow:0 0 0 1px rgb(var(--shadow-color-rgb),.3),0 .3em 2em rgb(var(--shadow-color-rgb),.3);--backdrop-box-shadow-alpha:.3;background:var(--gray-0);margin-left:var(--dark-theme-shadow-offset)}.DocsSearch .algolia-autocomplete:not([data-expanded=true]),.DocsSearch .algolia-autocomplete[style*="display: none"]{opacity:0;--backdrop-box-shadow:none;pointer-events:none}@supports ((-webkit-backdrop-filter:blur(1em)) or (backdrop-filter:blur(1em))){.DocsSearch .algolia-autocomplete{background:rgba(var(--background-color-rgb),.8);-webkit-backdrop-filter:saturate(200%) blur(1.25em);backdrop-filter:saturate(200%) blur(1.25em)}[theme=dark] .DocsSearch .algolia-autocomplete{background:rgba(var(--gray-0-rgb),.8)}@media not all and (min-resolution:.001dpcm){@media{.DocsSearch .algolia-autocomplete{background:rgba(var(--background-color-rgb),1)}}}}.DocsSearch .algolia-autocomplete [class|=ds-dataset]>:first-child{position:relative;--padding-top:calc(var(--docs-header-height) + 0.66rem);padding:var(--padding-top) var(--dropdown-text-indent) 0}.DocsSearch .algolia-autocomplete [class|=ds-dataset]>:first-child:before{content:"";position:absolute;left:0;right:0;top:var(--docs-header-height);margin-top:-1px;height:1px;background:rgba(var(--color-rgb),.07)}[theme=dark] .DocsSearch .algolia-autocomplete [class|=ds-dataset]>:first-child:before{margin-top:0;background:rgba(var(--color-rgb),.07);box-shadow:0 -1px rgba(var(--shadow-color-rgb),.2),0 calc(var(--docs-header-height)*-1) rgba(var(--shadow-color-rgb),.1)}.DocsSearch .ds-suggestion{display:block;--horizontal-padding:1em;padding:var(--suggestion-item-vertical-padding) var(--horizontal-padding);margin:0 calc(var(--horizontal-padding)*-1);border-radius:.25em}.DocsSearch .ds-suggestion.ds-cursor{background:rgba(var(--gray-5-rgb),.2)}[theme=dark] .DocsSearch .ds-suggestion.ds-cursor{background:rgba(var(--gray-6-rgb),.15)}.DocsSearch a.algolia-docsearch-suggestion{display:block;color:inherit;text-decoration:none}.DocsSearch .algolia-docsearch-suggestion--text{font-size:.9em;color:rgba(var(--color-rgb),.8)}.DocsSearch .algolia-docsearch-suggestion--highlight{--highlight-opacity:.2;background-color:rgba(var(--orange-rgb),var(--highlight-opacity));color:var(--color)}[theme=dark] .DocsSearch .algolia-docsearch-suggestion--highlight{--highlight-opacity:.4}.DocsSearch .algolia-docsearch-suggestion--no-results{padding-top:var(--suggestion-item-vertical-padding);margin-bottom:1em}.DocsSearch .algolia-docsearch-suggestion--no-results .algolia-docsearch-suggestion--text{padding-top:var(--suggestion-item-vertical-padding);font-size:1em}.DocsSearch .algolia-docsearch-suggestion--no-results b{font-weight:inherit}.DocsSearch .algolia-docsearch-footer{margin-top:.5rem;padding:0 var(--dropdown-text-indent) 2rem;font-size:.7em;opacity:.5}.DocsSearch .algolia-docsearch-footer--logo{color:inherit}.DocsSearch .algolia-docsearch-suggestion--category-header-lvl0:empty:before{content:"Document"}.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--subcategory-column,.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--subcategory-inline,.DocsSearch .algolia-docsearch-suggestion__main .algolia-docsearch-suggestion--subcategory-column,.DocsSearch .algolia-docsearch-suggestion__main .algolia-docsearch-suggestion--subcategory-inline,.DocsSearch .algolia-docsearch-suggestion__main .algolia-docsearch-suggestion--title{display:none}.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--category-header,.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--content,.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--title,.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--wrapper{display:inline}.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--content:not(.algolia-docsearch-suggestion--no-results):before{content:"\203A";opacity:.15;padding:0 .333em;display:inline-block;-webkit-transform:scale3d(1.5,1.2,1);transform:scale3d(1.5,1.2,1)}.DocsSearch .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main) .algolia-docsearch-suggestion--content:not(.algolia-docsearch-suggestion--no-results) .algolia-docsearch-suggestion--title:before{content:"#";padding-right:.25em;opacity:.5}@media (max-width:768px){.DocsSearch{pointer-events:all}.DocsSearch--input:not(:focus){padding:0;opacity:0}.DocsSearch[is-focused]{position:fixed;top:0;left:0;right:0;--text-indent:3rem;z-index:2}.DocsSearch--input-icon{left:15px;height:15px;width:15px}.DocsSearch--input-wrapper:focus-within .DocsSearch--input-icon{left:19px}.DocsSearch[is-focused] .DocsSearch--input-wrapper{background:var(--background-color);height:var(--docs-header-height)}.DocsSearch--input-bottom-border{display:none}.DocsSearch .algolia-autocomplete{position:fixed;top:var(--docs-header-height);width:100%!important}@supports ((-webkit-backdrop-filter:blur(1em)) or (backdrop-filter:blur(1em))){.DocsSearch .algolia-autocomplete{-webkit-backdrop-filter:none;backdrop-filter:none}.DocsSearch .algolia-autocomplete,[theme=dark] .DocsSearch .algolia-autocomplete{background:var(--background-color)}}}.DocsMobileHeader{position:absolute;display:flex;align-items:center;top:0;left:0;width:100%;height:var(--docs-header-height);background:var(--background-color);box-shadow:0 1px rgba(var(--color-rgb),.05);z-index:11;--content-indent:.666em}[theme=dark] .DocsMobileHeader{background:var(--gray-05)}@media (min-width:769px){.DocsMobileHeader{display:none}}.DocsMobileHeader--cloudflare-logo-link{--font-size:1.1em;display:flex;align-items:center;padding-left:var(--content-indent);padding-right:var(--content-indent);transition:opacity .2s ease,color .2s ease}@media (hover:hover){.DocsMobileHeader--cloudflare-logo-link:hover{opacity:.75;color:rgba(var(--color-rgb),.75)}}@media (hover:none){.DocsMobileHeader--cloudflare-logo-link:active{opacity:.75;color:rgba(var(--color-rgb),.75)}}.DocsMobileTitleHeader{position:-webkit-sticky;position:sticky;display:flex;align-items:center;top:0;left:0;width:100%;padding-right:.5rem;height:var(--docs-header-height);background:var(--background-color);box-shadow:0 1px rgba(var(--shadow-color-rgb),.075),0 .2em .3em -.1em rgba(var(--shadow-color-rgb),.075);z-index:10;--content-indent:.666em}[theme=dark] .DocsMobileTitleHeader{background:var(--gray-05)}@media (min-width:769px){.DocsMobileTitleHeader{display:none}}.DocsMobileTitleHeader--logo-link{--font-size:1.333em;display:flex;align-items:center;padding-left:var(--content-indent);padding-right:var(--content-indent);transition:opacity .2s ease,color .2s ease}@media (hover:hover){.DocsMobileTitleHeader--logo-link:hover{opacity:.75;color:rgba(var(--color-rgb),.75)}}@media (hover:none){.DocsMobileTitleHeader--logo-link:active{opacity:.75;color:rgba(var(--color-rgb),.75)}}.DocsMobileTitleHeader--text-scaler{--font-size:1em * (1 - ((var(--length) - 10)/50));font-size:clamp(.7em,var(--font-size),1em);display:inherit}.DocsMobileTitleHeader--sidebar-toggle-button{width:40px;height:40px;margin-left:auto;padding:0}.DocsMobileTitleHeader--sidebar-toggle-button path{transition:opacity .3s ease,-webkit-transform .3s ease;transition:transform .3s ease,opacity .3s ease;transition:transform .3s ease,opacity .3s ease,-webkit-transform .3s ease}[is-mobile-sidebar-open] .DocsMobileTitleHeader--sidebar-toggle-button path[data-index="1"]{-webkit-transform:translateY(15%) rotate(45deg);transform:translateY(15%) rotate(45deg)}[is-mobile-sidebar-open] .DocsMobileTitleHeader--sidebar-toggle-button path[data-index="2"]{opacity:0}[is-mobile-sidebar-open] .DocsMobileTitleHeader--sidebar-toggle-button path[data-index="3"]{-webkit-transform:translateY(-15%) rotate(-45deg);transform:translateY(-15%) rotate(-45deg)}.DocsMobileNavBackdrop{position:fixed;top:0;right:0;bottom:0;left:0;opacity:0;pointer-events:none;background:rgba(var(--shadow-color-rgb),.5);will-change:opacity;transition:opacity .3s ease;z-index:8}@media (min-width:769px){.DocsMobileNavBackdrop{display:none}}[is-mobile-sidebar-open] .DocsMobileNavBackdrop{opacity:1;pointer-events:all}.DocsFooter{margin-left:var(--docs-sidebar-width);padding:3.5rem 0;padding-left:var(--docs-content-gap);padding-right:calc(var(--docs-body-sidebar-width) + var(--docs-content-gap));--border-color:rgba(var(--color-rgb),.08);border-top:1px solid var(--border-color)}@media (max-width:768px){.DocsFooter{margin-left:0;padding:2rem 1rem 4rem}}.DocsFooter--content{display:flex}@media (max-width:414px){.DocsFooter--edit-on-gh-link-wrapper{display:block;margin-bottom:.5em}.DocsFooter--content-dot-spacer{display:none}}.DocsCodeExamplesOverview{margin:2.5rem 0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));grid-gap:var(--docs-content-gap)}.DocsCodeExamplesOverview--example{border-radius:.5em}.DocsCodeExamplesOverview--example-title{font-size:1.5em;line-height:1.2;font-weight:500;margin-bottom:.5em;white-space:nowrap;text-overflow:ellipsis;overflow:hidden}.DocsCodeExamplesOverview--example-title .Link{color:inherit;--underline-opacity:.75;text-decoration:underline;-webkit-text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));box-shadow:0 0 0 var(--focus-size) var(--focus-color)}.DocsCodeExamplesOverview--example-description{margin-bottom:1em}@media (min-width:1153px){.DocsCodeExamplesOverview--example-description{--lines:2;display:-webkit-box;-webkit-line-clamp:var(--lines);-webkit-box-orient:vertical;height:calc(1em*var(--lines)*var(--line-height));overflow:hidden}}.DocsCodeExamplesOverview--example-description>:last-child{margin-bottom:0}.DocsCodeExamplesOverview--example-codeblock-link{display:block;position:relative;color:inherit}.DocsCodeExamplesOverview--example-codeblock-link:after{content:"";position:absolute;top:0;right:0;bottom:0;left:0;--active-box-shadow-color:transparent;box-shadow:inset 0 .0625em .1875em var(--active-box-shadow-color);border-radius:.5em}@media (hover:hover){.DocsCodeExamplesOverview--example-codeblock-link:hover:not(:active):after{background:hsla(0,0%,100%,.2)}[theme=dark] .DocsCodeExamplesOverview--example-codeblock-link:hover:not(:active):after{background:rgba(var(--color-rgb),.05)}}.DocsCodeExamplesOverview--example-codeblock-link:active:after{background:rgba(var(--shadow-color-rgb),.05);--active-box-shadow-color:rgba(var(--shadow-color-rgb),.2)}.DocsCodeExamplesOverview--example-codeblock-link pre{height:19em;margin-bottom:0;pointer-events:none}.DocsCodeExamplesOverview--example-codeblock-link pre,.DocsCodeExamplesOverview--example-codeblock-link pre code{overflow:hidden}@media (max-width:1152px){.DocsCodeExamplesOverview{margin-left:0;margin-right:0;grid-template-columns:100%}}@media (max-width:768px){.DocsCodeExamplesOverview--example-title{font-size:1.375em;margin-bottom:.5rem}.DocsCodeExamplesOverview--example-codeblock-link{margin-left:-1rem;width:calc(100% + 2rem)}.DocsCodeExamplesOverview--example-codeblock-link:after{border-radius:0}.DocsCodeExamplesOverview--example-codeblock-link pre{height:12.2em;--border-radius:0em}}.DocsTutorials{margin:2em 0;width:53em;max-width:100%}[theme=dark] .DocsTutorials{color:var(--gray-7)}.DocsTutorials--row{display:flex;align-items:baseline;--gap:1.5em;padding-bottom:.5em;border-bottom:1px solid rgba(var(--color-rgb),.1);margin-bottom:.5em}.DocsTutorials--body .DocsTutorials--row:last-child{margin-bottom:0;border-bottom:0}.DocsTutorials--header .DocsTutorials--column-text{font-size:.9em;font-weight:700}.DocsTutorials--header .DocsTutorials--row{border-bottom-width:.125em;padding-bottom:.1875em}.DocsTutorials--body .DocsTutorials--column:not([data-column=name]){position:relative;top:-.1em}.DocsTutorials--body .DocsTutorials--column[data-column=length]{top:-.2em}.DocsTutorials--column[data-column=name]{flex:1 1;padding-right:calc(var(--gap)/2)}.DocsTutorials--link{position:relative;font-size:1.2em;color:inherit;--underline-opacity:.75;-webkit-text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));text-decoration-color:rgba(var(--orange-rgb),var(--underline-opacity));box-shadow:0 0 0 var(--focus-size) var(--focus-color)}[theme=dark] .DocsTutorials--link{--underline-opacity:.5}.DocsTutorials--row-is-new .DocsTutorials--link:after{content:"";position:absolute;top:.45em;right:100%;margin-right:.625em;height:8px;width:8px;border-radius:999em;background:var(--orange)}@media (max-width:1280px){.DocsTutorials--link{text-decoration:none;box-shadow:inset 0 -2px rgba(var(--orange-rgb),var(--underline-opacity))}.DocsTutorials--row-is-new .DocsTutorials--link:after{top:.375em}}@media (max-width:768px){.DocsTutorials--link{font-size:1.1em}.DocsTutorials--row-is-new .DocsTutorials--link:after{display:none}}@media (max-width:414px){.DocsTutorials--link{font-size:1em}.DocsTutorials--ago-text{display:none}}[js-focus-visible-polyfill-available] .DocsTutorials--link:focus{outline:none}.DocsTutorials--link[is-focus-visible]{--underline-size:0}.DocsTutorials--link:not([is-focus-visible]){--focus-size:0}.DocsTutorials--column[data-column=difficulty],.DocsTutorials--column[data-column=updated]{padding-left:calc(var(--gap)/2);padding-right:calc(var(--gap)/2)}.DocsTutorials--column[data-column=difficulty]{width:7.5em;flex-shrink:0}.DocsTutorials--column[data-column=length]{width:4.5em;padding-left:calc(var(--gap)/2);flex-shrink:0}.DocsTutorials--length-bar{width:100%;height:.5em;border-radius:1em;background:rgba(var(--color-rgb),.1);overflow:hidden}.DocsTutorials--length-bar-inner{background:rgba(var(--color-rgb),.5);border-radius:1em;min-width:.6em;height:100%}@media (max-width:1024px){.DocsTutorials--column[data-column=updated]{padding-right:0}.DocsTutorials--column[data-column=difficulty],.DocsTutorials--column[data-column=length]{display:none}}
+:root {
+  --reach-skip-nav: 1;
+}
+[data-reach-skip-nav-link] {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+[data-reach-skip-nav-link]:focus {
+  padding: 1rem;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  background: #fff;
+  z-index: 1;
+  width: auto;
+  height: auto;
+  clip: auto;
+}
+.DocsTutorials--column[data-column="type"] {
+  width: 8em;
+  padding-left: calc(var(--gap) / 2);
+  padding-right: calc(var(--gap) / 2);
+}
+* {
+  box-sizing: inherit;
+  margin: 0;
+}
+img,
+svg {
+  display: block;
+}
+img {
+  max-width: 100%;
+}
+svg {
+  height: 100%;
+  width: 100%;
+}
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 400;
+}
+a,
+button,
+input,
+select,
+textarea {
+  -webkit-tap-highlight-color: transparent;
+}
+html {
+  --html-font-size: 17px;
+  --line-height: 1.5;
+  --form-field-line-height: 1.3;
+  --focus-size: 0.1875em;
+  --button-top-padding: 0.55em;
+  --button-bottom-padding: 0.65em;
+  --button-horizontal-padding: 0.9em;
+  --button-line-height: var(--form-field-line-height);
+  --button-border-radius: 0.375em;
+  --section-vertical-padding: 6em;
+  --header-height: 4.5rem;
+  --code-font-size: 0.9em;
+  --inline-code-font-size: 0.85em;
+}
+@media (max-width: 1280px) {
+  html {
+    --html-font-size: 16px;
+  }
+}
+@media (max-width: 1024px) {
+  html {
+    --section-vertical-padding: 4em;
+  }
+}
+@media (max-width: 414px) {
+  html {
+    --header-height: 4rem;
+    --code-font-size: 0.8em;
+    --inline-code-font-size: var(--code-font-size);
+  }
+}
+html {
+  --sans-serif-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
+  --monospace-font-family: Menlo, "SF Mono", "Andale Mono", "Roboto Mono",
+    Monaco, monospace;
+  --font-family: var(--sans-serif-font-family);
+  --cloudflare-logo-gray-rgb: 64, 64, 65;
+  --cloudflare-logo-orange-rgb: 243, 128, 32;
+  --cloudflare-logo-light-orange-rgb: 248, 173, 76;
+  --orange-rgb: var(--cloudflare-logo-orange-rgb);
+  --orange: rgb(var(--orange-rgb));
+  --orange-for-use-as-selection-color: #ef9530;
+  --light-blue-rgb: 79, 140, 200;
+  --light-blue: rgb(var(--light-blue-rgb));
+  --blue-rgb: 0, 81, 127;
+  --blue: rgb(var(--blue-rgb));
+  --red-0: #430c15;
+  --red-0-rgb: 67, 12, 21;
+  --red-1: #711423;
+  --red-1-rgb: 113, 20, 35;
+  --red-2: #a01c32;
+  --red-2-rgb: 160, 28, 50;
+  --red-3: #bf223c;
+  --red-3-rgb: 191, 34, 60;
+  --red-4: #da304c;
+  --red-4-rgb: 218, 48, 76;
+  --red-5: #e35f75;
+  --red-5-rgb: 227, 95, 117;
+  --red-6: #ec93a2;
+  --red-6-rgb: 236, 147, 162;
+  --red-7: #f3bac3;
+  --red-7-rgb: 243, 186, 195;
+  --red-8: #f9dce1;
+  --red-8-rgb: 249, 220, 225;
+  --red-9: #fcf0f2;
+  --red-9-rgb: 252, 240, 242;
+  --orange-0: #341a04;
+  --orange-0-rgb: 52, 26, 4;
+  --orange-1: #5b2c06;
+  --orange-1-rgb: 91, 44, 6;
+  --orange-2: #813f09;
+  --orange-2-rgb: 129, 63, 9;
+  --orange-3: #a24f0b;
+  --orange-3-rgb: 162, 79, 11;
+  --orange-4: #b6590d;
+  --orange-4-rgb: 182, 89, 13;
+  --orange-5: #e06d10;
+  --orange-5-rgb: 224, 109, 16;
+  --orange-6: #f4a15d;
+  --orange-6-rgb: 244, 161, 93;
+  --orange-7: #f8c296;
+  --orange-7-rgb: 248, 194, 150;
+  --orange-8: #fbdbc1;
+  --orange-8-rgb: 251, 219, 193;
+  --orange-9: #fdf1e7;
+  --orange-9-rgb: 253, 241, 231;
+  --gold-0: #2c1c02;
+  --gold-0-rgb: 44, 28, 2;
+  --gold-1: #573905;
+  --gold-1-rgb: 87, 57, 5;
+  --gold-2: #744c06;
+  --gold-2-rgb: 116, 76, 6;
+  --gold-3: #8e5c07;
+  --gold-3-rgb: 142, 92, 7;
+  --gold-4: #a26a09;
+  --gold-4-rgb: 162, 106, 9;
+  --gold-5: #c7820a;
+  --gold-5-rgb: 199, 130, 10;
+  --gold-6: #f4a929;
+  --gold-6-rgb: 244, 169, 41;
+  --gold-7: #f8cd81;
+  --gold-7-rgb: 248, 205, 129;
+  --gold-8: #fbe2b6;
+  --gold-8-rgb: 251, 226, 182;
+  --gold-9: #fdf3e2;
+  --gold-9-rgb: 253, 243, 226;
+  --green-0: #0f2417;
+  --green-0-rgb: 15, 36, 23;
+  --green-1: #1c422b;
+  --green-1-rgb: 28, 66, 43;
+  --green-2: #285d3d;
+  --green-2-rgb: 40, 93, 61;
+  --green-3: #31724b;
+  --green-3-rgb: 49, 114, 75;
+  --green-4: #398557;
+  --green-4-rgb: 57, 133, 87;
+  --green-5: #46a46c;
+  --green-5-rgb: 70, 164, 108;
+  --green-6: #79c698;
+  --green-6-rgb: 121, 198, 152;
+  --green-7: #b0ddc2;
+  --green-7-rgb: 176, 221, 194;
+  --green-8: #d8eee1;
+  --green-8-rgb: 216, 238, 225;
+  --green-9: #eff8f3;
+  --green-9-rgb: 239, 248, 243;
+  --cyan-0: #0c2427;
+  --cyan-0-rgb: 12, 36, 39;
+  --cyan-1: #164249;
+  --cyan-1-rgb: 22, 66, 73;
+  --cyan-2: #1d5962;
+  --cyan-2-rgb: 29, 89, 98;
+  --cyan-3: #26727e;
+  --cyan-3-rgb: 38, 114, 126;
+  --cyan-4: #2b818e;
+  --cyan-4-rgb: 43, 129, 142;
+  --cyan-5: #35a0b1;
+  --cyan-5-rgb: 53, 160, 177;
+  --cyan-6: #66c3d1;
+  --cyan-6-rgb: 102, 195, 209;
+  --cyan-7: #a5dce4;
+  --cyan-7-rgb: 165, 220, 228;
+  --cyan-8: #d0edf1;
+  --cyan-8-rgb: 208, 237, 241;
+  --cyan-9: #e9f7f9;
+  --cyan-9-rgb: 233, 247, 249;
+  --blue-0: #0c2231;
+  --blue-0-rgb: 12, 34, 49;
+  --blue-1: #163d57;
+  --blue-1-rgb: 22, 61, 87;
+  --blue-2: #1f567a;
+  --blue-2-rgb: 31, 86, 122;
+  --blue-3: #276d9b;
+  --blue-3-rgb: 39, 109, 155;
+  --blue-4: #2c7cb0;
+  --blue-4-rgb: 44, 124, 176;
+  --blue-5: #479ad1;
+  --blue-5-rgb: 71, 154, 209;
+  --blue-6: #7cb7de;
+  --blue-6-rgb: 124, 183, 222;
+  --blue-7: #add2eb;
+  --blue-7-rgb: 173, 210, 235;
+  --blue-8: #d6e9f5;
+  --blue-8-rgb: 214, 233, 245;
+  --blue-9: #ebf4fa;
+  --blue-9-rgb: 235, 244, 250;
+  --indigo-0: #181e34;
+  --indigo-0-rgb: 24, 30, 52;
+  --indigo-1: #2c365e;
+  --indigo-1-rgb: 44, 54, 94;
+  --indigo-2: #404e88;
+  --indigo-2-rgb: 64, 78, 136;
+  --indigo-3: #5062aa;
+  --indigo-3-rgb: 80, 98, 170;
+  --indigo-4: #6373b6;
+  --indigo-4-rgb: 99, 115, 182;
+  --indigo-5: #8794c7;
+  --indigo-5-rgb: 135, 148, 199;
+  --indigo-6: #a5aed5;
+  --indigo-6-rgb: 165, 174, 213;
+  --indigo-7: #c8cde5;
+  --indigo-7-rgb: 200, 205, 229;
+  --indigo-8: #e0e3f0;
+  --indigo-8-rgb: 224, 227, 240;
+  --indigo-9: #f1f3f8;
+  --indigo-9-rgb: 241, 243, 248;
+  --violet-0: #2d1832;
+  --violet-0-rgb: 45, 24, 50;
+  --violet-1: #502b5a;
+  --violet-1-rgb: 80, 43, 90;
+  --violet-2: #753f83;
+  --violet-2-rgb: 117, 63, 131;
+  --violet-3: #8e4c9e;
+  --violet-3-rgb: 142, 76, 158;
+  --violet-4: #9f5bb0;
+  --violet-4-rgb: 159, 91, 176;
+  --violet-5: #b683c3;
+  --violet-5-rgb: 182, 131, 195;
+  --violet-6: #c9a2d2;
+  --violet-6-rgb: 201, 162, 210;
+  --violet-7: #dbc1e1;
+  --violet-7-rgb: 219, 193, 225;
+  --violet-8: #ebddee;
+  --violet-8-rgb: 235, 221, 238;
+  --violet-9: #f7f1f8;
+  --violet-9-rgb: 247, 241, 248;
+  --gray-00-rgb: 23, 23, 24;
+  --gray-00: rgb(var(--gray-00-rgb));
+  --gray-0F-rgb: 25, 27, 29;
+  --gray-0F: rgb(var(--gray-0F-rgb));
+  --gray-0-rgb: 29, 31, 32;
+  --gray-0: rgb(var(--gray-0-rgb));
+  --gray-05-rgb: 36, 38, 40;
+  --gray-05: rgb(var(--gray-05-rgb));
+  --gray-1-rgb: 54, 57, 58;
+  --gray-1: rgb(var(--gray-1-rgb));
+  --gray-2-rgb: 78, 82, 85;
+  --gray-2: rgb(var(--gray-2-rgb));
+  --gray-3-rgb: 98, 103, 106;
+  --gray-3: rgb(var(--gray-3-rgb));
+  --gray-4-rgb: 114, 119, 123;
+  --gray-4: rgb(var(--gray-4-rgb));
+  --gray-5-rgb: 146, 151, 155;
+  --gray-5: rgb(var(--gray-5-rgb));
+  --gray-6-rgb: 183, 187, 189;
+  --gray-6: rgb(var(--gray-6-rgb));
+  --gray-7-rgb: 213, 215, 216;
+  --gray-7: rgb(var(--gray-7-rgb));
+  --gray-8-rgb: 234, 235, 235;
+  --gray-8: rgb(var(--gray-8-rgb));
+  --gray-9-rgb: 243, 243, 244;
+  --gray-9: rgb(var(--gray-9-rgb));
+  --gray-A-rgb: 247, 247, 248;
+  --gray-A: rgb(var(--gray-A-rgb));
+  --code-gray: #a7a7a3;
+  --code-red: #ed8978;
+  --code-orange: #fba056;
+  --code-gold: #fdda68;
+  --code-green: #57c78f;
+  --code-blue: #78c0ed;
+  --code-cyan: #71e4f4;
+  --code-indigo: #7b99ea;
+  --code-lilac: #d188dd;
+  --code-violet: #a68adb;
+  --code-gray-light-theme: var(--gray-3);
+  --code-red-light-theme: #8f1500;
+  --code-orange-light-theme: #b35000;
+  --code-gold-light-theme: #b35300;
+  --code-green-light-theme: #007a3d;
+  --code-blue-light-theme: #00588f;
+  --code-cyan-light-theme: #006c7a;
+  --code-indigo-light-theme: #00268f;
+  --code-lilac-light-theme: #7c008f;
+  --code-violet-light-theme: #32008f;
+  --diff-indicator-red: var(--code-red);
+  --diff-indicator-green: var(--code-green);
+  --diff-indicator-red-light-theme: #eb0052;
+  --diff-indicator-green-light-theme: #0c6;
+}
+html[theme="light"] {
+  --color-rgb: var(--gray-0-rgb);
+  --color: rgb(var(--color-rgb));
+  --background-color-rgb: 255, 255, 255;
+  --background-color: rgb(var(--background-color-rgb));
+  --selection-background-color: var(--orange-for-use-as-selection-color);
+  --selection-color: #fff;
+  --code-block-color: #fff;
+  --code-block-background-color: var(--color);
+  --code-block-background-color-light-theme: var(--gray-9);
+  --code-block-scrollbar-color: hsla(0, 0%, 100%, 0.25);
+  --tab-background-color: var(--gray-9);
+  --shadow-color-rgb: var(--color-rgb);
+  --section-tiger-stripe-background-color: var(--gray-9);
+  --deemphasized-color: var(--gray-1);
+}
+html[theme="dark"],
+html[theme="light"] {
+  --cloudflare-logo-wordmark-color: rgb(var(--cloudflare-logo-gray-rgb));
+  --focus-color: rgba(var(--orange-rgb), 0.5);
+}
+html[theme="dark"] {
+  --color-rgb: 255, 255, 255;
+  --color: rgb(var(--color-rgb));
+  --background-color-rgb: var(--gray-0-rgb);
+  --background-color: rgb(var(--background-color-rgb));
+  --selection-background-color: #ff9e40;
+  --selection-color: rgb(var(--color-rgb));
+  --code-block-color: rgb(var(--color-rgb));
+  --code-block-background-color: var(--gray-05);
+  --code-block-scrollbar-color: hsla(0, 0%, 100%, 0.25);
+  --tab-background-color: var(--gray-1);
+  --shadow-color-rgb: 0, 0, 0;
+  --section-tiger-stripe-background-color: var(--gray-05);
+  --deemphasized-color: var(--gray-7);
+}
+[theme="dark"] [light-theme-only],
+[theme="light"] [dark-theme-only] {
+  display: none;
+}
+::selection {
+  background: var(--selection-background-color);
+  color: var(--selection-color);
+}
+html {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  font-size: var(--html-font-size);
+  font-family: var(--font-family);
+  line-height: var(--line-height);
+  color: var(--color);
+  background: var(--background-color);
+}
+@media (max-width: 414px) {
+  [desktop-only] {
+    display: none !important;
+  }
+}
+@media (min-width: 415px) {
+  [mobile-only] {
+    display: none !important;
+  }
+}
+@media (prefers-reduced-motion: no-preference) {
+  [is-smooth-scrolling] {
+    scroll-behavior: smooth;
+  }
+}
+[is-visually-hidden] {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  border: 0;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(0 0 99.9% 99.9%);
+  clip-path: inset(0 0 99.9% 99.9%);
+  overflow: hidden;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+[with-styled-webkit-scrollbars] {
+  --scrollbar-thumb-background-color: var(--gray-6);
+  --scrollbar-thumb-background-color-active: var(--gray-4);
+}
+[theme="dark"][with-styled-webkit-scrollbars],
+[theme="dark"] [with-styled-webkit-scrollbars] {
+  --scrollbar-thumb-background-color: var(--gray-2);
+  --scrollbar-thumb-background-color-active: var(--gray-5);
+}
+[with-styled-webkit-scrollbars]::-webkit-scrollbar,
+[with-styled-webkit-scrollbars] ::-webkit-scrollbar {
+  width: 1em;
+}
+[with-styled-webkit-scrollbars]::-webkit-scrollbar-track,
+[with-styled-webkit-scrollbars] ::-webkit-scrollbar-track {
+  background: none;
+  border: none;
+}
+[with-styled-webkit-scrollbars]::-webkit-scrollbar-thumb,
+[with-styled-webkit-scrollbars] ::-webkit-scrollbar-thumb {
+  min-height: 3.5em;
+  background-color: var(--scrollbar-thumb-background-color);
+  background-clip: padding-box;
+  border: 0.25em solid transparent;
+  border-radius: 0.5em;
+  box-shadow: none;
+}
+[with-styled-webkit-scrollbars]::-webkit-scrollbar-thumb:active,
+[with-styled-webkit-scrollbars] ::-webkit-scrollbar-thumb:active {
+  background-color: var(--scrollbar-thumb-background-color-active);
+}
+.AspectRatio {
+  --aspect-ratio: 1;
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 0;
+  padding-bottom: calc(100% / var(--aspect-ratio));
+}
+.AspectRatio--content {
+  position: absolute;
+  display: block;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+.Breadcrumbs {
+  display: inline-flex;
+  font-size: 0.9em;
+  color: var(--gray-4);
+  font-weight: 500;
+}
+.Breadcrumbs,
+.Breadcrumbs--item {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.Breadcrumbs--item + .Breadcrumbs--item:before {
+  content: "\276F";
+  margin: 0 0.25em;
+  padding: 0 0.3em;
+  opacity: 0.4;
+  font-weight: 900;
+}
+.Button {
+  cursor: pointer;
+  display: inline-block;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
+  position: relative;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  line-height: var(--button-line-height);
+  padding: var(--button-top-padding) var(--button-horizontal-padding)
+    var(--button-bottom-padding);
+  border-radius: var(--button-border-radius);
+  text-decoration: none;
+  -webkit-tap-highlight-color: transparent;
+  --active-box-shadow-color: transparent;
+  --active-box-shadow: inset 0 0.0625em 0.1875em var(--active-box-shadow-color);
+  --active-overlay-box-shadow-color: transparent;
+  --active-overlay-box-shadow: inset 0 0 0 9999em
+    var(--active-overlay-box-shadow-color);
+  --hover-box-shadow-color: transparent;
+  --hover-box-shadow: inset 0 0 0 9999em var(--hover-box-shadow-color);
+  --focus-box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+  --border-color: transparent;
+  --border-box-shadow: inset 0 0 0 1px var(--border-color);
+  --shadow-box-shadow: 0 1px 1px rgba(var(--shadow-color-rgb), 0.075),
+    0 0.1333em 0.26667em rgba(var(--shadow-color-rgb), 0.075),
+    0 0.2222em 0.66667em 0 rgba(var(--shadow-color-rgb), 0.075),
+    0 0.4444em 1.3333em 0 rgba(var(--shadow-color-rgb), 0.075);
+  --box-shadow: 0 0 0 0 transparent;
+  box-shadow: var(--active-box-shadow), var(--active-overlay-box-shadow),
+    var(--hover-box-shadow), var(--focus-box-shadow), var(--border-box-shadow),
+    var(--box-shadow);
+  --box-shadow-transition-duration: 0.3s;
+  transition: box-shadow var(--box-shadow-transition-duration) ease;
+}
+.Button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+@media (hover: hover) {
+  .Button:hover {
+    --hover-box-shadow-color: hsla(0, 0%, 100%, 0.2);
+  }
+  [theme="dark"] .Button:hover {
+    --hover-box-shadow-color: hsla(0, 0%, 100%, 0.05);
+  }
+}
+.Button:not([disabled]):active {
+  --box-shadow-transition-duration: 0s;
+  --hover-box-shadow-color: transparent;
+  --box-shadow: 0 0 0 0 transparent;
+  --active-overlay-box-shadow-color: rgba(0, 0, 0, 0.08);
+  --active-box-shadow-color: rgba(0, 0, 0, 0.2);
+}
+@media (hover: none) {
+  .Button:not([disabled]):active {
+    --active-overlay-box-shadow-color: rgba(0, 0, 0, 0.3);
+  }
+}
+[js-focus-visible-polyfill-available] .Button:focus {
+  outline: none;
+}
+.Button[is-focus-visible] {
+  --box-shadow-transition-duration: 0s;
+}
+.Button:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+@-moz-document url-prefix() {
+  .Button:not([is-focus-visible]) {
+    --focus-color: transparent;
+  }
+}
+.Button-is-primary {
+  --box-shadow: var(--shadow-box-shadow);
+  background: linear-gradient(
+    25deg,
+    rgb(var(--cloudflare-logo-orange-rgb)),
+    rgb(var(--cloudflare-logo-light-orange-rgb))
+  );
+  color: #fff;
+}
+.Button-is-secondary {
+  background: var(--gray-9);
+}
+[theme="dark"] .Button-is-secondary {
+  background: var(--gray-05);
+}
+.Button-is-secondary-orange {
+  --color-rgb: var(--orange-3-rgb);
+  background: rgba(var(--cloudflare-logo-light-orange-rgb), 0.12);
+  color: rgb(var(--color-rgb));
+}
+[theme="dark"] .Button-is-secondary-orange {
+  --color-rgb: var(--orange-7-rgb);
+}
+[theme="light"] .Button-is-secondary-orange:not([disabled]):active {
+  --active-box-shadow-color: rgba(var(--color-rgb), 0.4);
+}
+.Button-is-docs-primary {
+  background: var(--orange-5);
+  color: #fff;
+}
+[theme="dark"] .Button-is-docs-primary {
+  --border-color: rgba(var(--orange-rgb), 0.7);
+  color: inherit;
+  background: transparent;
+}
+.Button-is-docs-secondary {
+  background: var(--gray-9);
+}
+[theme="dark"] .Button-is-docs-secondary {
+  --border-color: rgba(var(--color-rgb), 0.3);
+  color: inherit;
+  background: transparent;
+}
+[theme="dark"] .Button-is-docs-secondary[is-focus-visible] {
+  --border-color: rgba(var(--orange-rgb), 0.7);
+}
+.Button-is-white {
+  background: #fff;
+}
+.Button-is-inverted {
+  background: var(--color);
+  color: var(--background-color);
+}
+.CloudflareLogo {
+  display: block;
+  width: 6.5em;
+  height: 2.25em;
+  color: var(--cloudflare-logo-wordmark-color);
+}
+.CloudflareWorkersLogo {
+  display: block;
+}
+.CloudflareWorkersLogo-horizontal-combination-mark {
+  width: 10em;
+  height: 2.75em;
+}
+.CloudflareWorkersLogoCombinationMark--cloudflare-wordmark,
+.CloudflareWorkersLogoCombinationMark--workers-wordmark {
+  fill: currentColor;
+}
+.CloudflareWorkersLogoCombinationMark--cloudflare-wordmark {
+  opacity: 0.6;
+}
+.CodeBlock {
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--monospace-font-family);
+  font-size: var(--code-font-size);
+  margin: 0;
+  --padding-vertical: 0.9em;
+  --padding-horizontal: 1.25em;
+  --border-radius: 0.5em;
+  border-radius: var(--border-radius);
+  background: var(--code-block-background-color);
+  color: var(--code-block-color);
+  --outdent: 0rem;
+  margin-left: calc(var(--outdent) * -1);
+  width: calc(100% + var(--outdent) * 2);
+  max-width: calc(100% + var(--outdent) * 2);
+  cursor: text;
+}
+[theme="light"] .CodeBlock-is-light-in-light-theme {
+  --code-block-background-color: var(--code-block-background-color-light-theme);
+  --code-block-color: currentColor;
+  --code-block-scrollbar-color: var(--gray-6);
+  --code-gray: var(--code-gray-light-theme);
+  --code-red: var(--code-red-light-theme);
+  --code-orange: var(--code-orange-light-theme);
+  --code-gold: var(--code-gold-light-theme);
+  --code-green: var(--code-green-light-theme);
+  --code-blue: var(--code-blue-light-theme);
+  --code-cyan: var(--code-cyan-light-theme);
+  --code-indigo: var(--code-indigo-light-theme);
+  --code-lilac: var(--code-lilac-light-theme);
+  --code-violet: var(--code-violet-light-theme);
+  --diff-indicator-red: var(--diff-indicator-red-light-theme);
+  --diff-indicator-green: var(--diff-indicator-green-light-theme);
+}
+.CodeBlock > code {
+  display: block;
+  padding: var(--padding-vertical) var(--padding-horizontal);
+  font-family: inherit;
+  cursor: default;
+}
+.CodeBlock > code > * {
+  cursor: text;
+}
+.CodeBlock > code::-webkit-scrollbar {
+  height: 14px;
+}
+.CodeBlock > code::-webkit-scrollbar-track-piece {
+  background: transparent;
+  border-radius: var(--border-radius);
+}
+.CodeBlock > code::-webkit-scrollbar-thumb {
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 1px 1px rgba(var(--background-color-rgb), 0.1);
+  background-color: var(--code-block-scrollbar-color);
+  background-clip: padding-box;
+  border: 4px solid transparent;
+  border-radius: calc(var(--border-radius) * 20);
+}
+[theme="dark"] .CodeBlock > code::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 1px 1px rgba(var(--color-rgb), 0.1);
+}
+.CodeBlock-is-one-liner > code {
+  border-radius: calc(var(--border-radius) * 0.625);
+  white-space: nowrap;
+}
+.CodeBlock-is-one-liner > code,
+.CodeBlock-scrolls-horizontally > code {
+  word-break: normal;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.CodeBlock-scrolls-horizontally > code {
+  white-space: pre;
+}
+.CodeBlock-is-hero {
+  --padding-vertical: 1.25em;
+  --padding-horizontal: 1.5em;
+  box-shadow: 0 1px 1px rgba(var(--shadow-color-rgb), 0.075),
+    0 0.1333em 0.26667em rgba(var(--shadow-color-rgb), 0.075),
+    0 0.2222em 0.66667em 0 rgba(var(--shadow-color-rgb), 0.075),
+    0 0.4444em 1.3333em 0 rgba(var(--shadow-color-rgb), 0.075);
+}
+.CodeBlock--filename,
+.CodeBlock--header {
+  display: block;
+  background: rgba(var(--color-rgb), 0.05);
+  box-shadow: 0 1px rgba(var(--shadow-color-rgb), 0.12);
+  padding: 0.4em var(--padding-horizontal);
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+  opacity: 0.9;
+  font-weight: 700;
+}
+[theme="light"] .CodeBlock-is-light-in-light-theme .CodeBlock--filename,
+[theme="light"] .CodeBlock-is-light-in-light-theme .CodeBlock--header {
+  background: transparent;
+}
+.CodeBlock--header {
+  font-family: var(--font-family);
+}
+.CodeBlock--filename {
+  padding-top: 0.45em;
+  font-size: 0.9em;
+  padding-left: calc(var(--padding-horizontal) / 0.9);
+  padding-right: calc(var(--padding-horizontal) / 0.9);
+}
+.CodeBlock b {
+  font-weight: 400;
+}
+.CodeBlock u {
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  text-decoration: none;
+  transition: opacity 0.25s ease;
+}
+.CodeBlock:hover u,
+.CodeBlock[has-selection-contained-within] u {
+  opacity: 0.25;
+}
+.CodeBlock.CodeBlock-with-rows.CodeBlock-scrolls-horizontally > code {
+  display: block;
+}
+.CodeBlock.CodeBlock-with-rows,
+.CodeBlock.CodeBlock-with-rows > code {
+  white-space: normal;
+}
+.CodeBlock-with-rows > code {
+  padding-left: 0;
+  padding-right: 0;
+}
+.CodeBlock-with-rows .CodeBlock--rows {
+  display: block;
+}
+.CodeBlock-with-rows .CodeBlock--rows-content {
+  display: inline-block;
+  min-width: 100%;
+}
+.CodeBlock-with-rows .CodeBlock--row {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+.CodeBlock-with-rows .CodeBlock--row-content {
+  display: block;
+  white-space: pre-wrap;
+  padding: 0 var(--padding-horizontal);
+}
+.CodeBlock-with-rows.CodeBlock-scrolls-horizontally .CodeBlock--row-content {
+  white-space: pre;
+}
+.CodeBlock--row-is-highlighted {
+  background: rgba(var(--color-rgb), 0.05);
+  box-shadow: inset 2px 0 rgba(var(--color-rgb), 0.3);
+}
+.CodeBlock--row-diff-add {
+  --row-diff-background-color: rgba(var(--color-rgb), 0.05);
+  background: var(--row-diff-background-color);
+}
+[theme="light"]
+  .CodeBlock-is-light-in-light-theme.CodeBlock-with-rows
+  .CodeBlock--row-diff-add {
+  --row-diff-background-color: rgba(var(--background-color-rgb), 0.8);
+}
+.CodeBlock--row-diff-remove {
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  text-decoration: none;
+}
+.CodeBlock-with-rows .CodeBlock--row-diff-add .CodeBlock--row-indicator,
+.CodeBlock-with-rows .CodeBlock--row-diff-remove .CodeBlock--row-indicator {
+  position: -webkit-sticky;
+  position: sticky;
+  left: 0;
+  display: flex;
+  border-left: 0.125em solid;
+  --width: 0.75em;
+  width: var(--width);
+  margin-right: calc(var(--width) * -1);
+  background: linear-gradient(
+      90deg,
+      var(--row-diff-background-color),
+      transparent
+    ),
+    linear-gradient(90deg, var(--code-block-background-color), transparent);
+}
+.CodeBlock-with-rows .CodeBlock--row-diff-add .CodeBlock--row-indicator {
+  border-left-color: var(--diff-indicator-green);
+}
+.CodeBlock-with-rows .CodeBlock--row-diff-remove .CodeBlock--row-indicator {
+  border-left-color: var(--diff-indicator-red);
+}
+[theme="light"]
+  .CodeBlock-with-rows.CodeBlock-is-light-in-light-theme
+  .CodeBlock--row-diff-add
+  .CodeBlock--row-indicator {
+  background: transparent;
+}
+.CodeBlock-with-rows .CodeBlock--word-remove {
+  opacity: 0.5;
+  position: relative;
+}
+.CodeBlock-with-rows .CodeBlock--word-remove:after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0.125em;
+  right: -0.5em;
+  bottom: 0;
+  left: -0.5em;
+  height: 1px;
+  margin-top: auto;
+  margin-bottom: auto;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--color-rgb), 0),
+    rgba(var(--color-rgb), 0) 1em,
+    rgba(var(--color-rgb), 0.5) 2em,
+    rgba(var(--color-rgb), 0.5) calc(100% - 2em),
+    rgba(var(--color-rgb), 0) calc(100% - 0.5em),
+    rgba(var(--color-rgb), 0)
+  );
+}
+.CodeBlock--token-punctuation,
+.CodeBlock--token-template-string.CodeBlock--token-interpolation {
+  color: inherit;
+}
+.CodeBlock--token-block-comment,
+.CodeBlock--token-cdata,
+.CodeBlock--token-comment,
+.CodeBlock--token-doctype,
+.CodeBlock--token-prolog {
+  font-style: italic;
+  color: var(--code-gray);
+}
+.CodeBlock--token-keyword,
+.CodeBlock--token-operator,
+.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-interpolation-punctuation {
+  color: var(--code-red);
+}
+.CodeBlock--token-class,
+.CodeBlock--token-class-name,
+.CodeBlock--token-function,
+.CodeBlock--token-function-name,
+.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-function {
+  color: var(--code-green);
+}
+.CodeBlock--token-constant,
+.CodeBlock--token-symbol,
+.CodeBlock--token-template-string.CodeBlock--token-interpolation.CodeBlock--token-interpolation-constant {
+  color: var(--code-indigo);
+}
+.CodeBlock--token-arrow,
+.CodeBlock--token-declaration-keyword {
+  color: var(--code-cyan);
+}
+.CodeBlock--token-function-parameter,
+.CodeBlock--token-parameter {
+  font-style: italic;
+  color: var(--code-lilac);
+}
+.CodeBlock--token-boolean,
+.CodeBlock--token-builtin,
+.CodeBlock--token-method,
+.CodeBlock--token-null-undefined,
+.CodeBlock--token-number {
+  color: var(--code-violet);
+}
+.CodeBlock--token-api {
+  color: var(--code-orange);
+}
+.CodeBlock--token-char,
+.CodeBlock--token-object-property,
+.CodeBlock--token-regex,
+.CodeBlock--token-string,
+.CodeBlock--token-template-string {
+  color: var(--code-gold);
+}
+.CodeBlock--token-bold,
+.CodeBlock--token-important {
+  font-weight: 700;
+}
+.CodeBlock--token-italic {
+  font-style: italic;
+}
+.CodeBlock--token-deleted,
+.CodeBlock--token-namespace {
+  color: var(--code-red);
+}
+.CodeBlock--token-entity {
+  color: var(--code-blue);
+  cursor: help;
+}
+.CodeBlock--token-inserted {
+  color: var(--code-green);
+}
+.CodeBlock--token-link,
+.CodeBlock--token-url {
+  color: var(--code-violet);
+}
+.CodeBlock--token-link.CodeBlock--token-content,
+.CodeBlock--token-url.CodeBlock--token-content {
+  color: inherit;
+}
+.CodeBlock--token-tag {
+  color: var(--code-red);
+}
+.CodeBlock--token-tag.CodeBlock--token-punctuation {
+  color: inherit;
+}
+.CodeBlock--token-tag.CodeBlock--token-attr-name {
+  color: var(--code-green);
+}
+.CodeBlock--token-tag.CodeBlock--token-attr-name
+  + .CodeBlock--token-punctuation {
+  color: inherit;
+}
+.CodeBlock--token-tag.CodeBlock--token-attr-value {
+  color: var(--code-gold);
+}
+.CodeBlock--language-css.CodeBlock--token-plain,
+.CodeBlock--language-css.CodeBlock--token-property,
+.CodeBlock--language-css.CodeBlock--token-style,
+[language="css"] .CodeBlock--token-plain,
+[language="css"] .CodeBlock--token-property {
+  color: var(--code-blue);
+}
+.CodeBlock--language-css.CodeBlock--token-style.CodeBlock--token-punctuation {
+  color: inherit;
+}
+.CodeBlock--language-css.CodeBlock--token-selector,
+[language="css"] .CodeBlock--token-selector {
+  color: var(--code-red);
+}
+.CodeBlock--language-css.CodeBlock--token-attribute,
+.CodeBlock--language-css.CodeBlock--token-class,
+[language="css"] .CodeBlock--token-attribute,
+[language="css"] .CodeBlock--token-class {
+  color: var(--code-green);
+}
+.CodeBlock--language-css.CodeBlock--token-function,
+[language="css"] .CodeBlock--token-function {
+  color: var(--code-lilac);
+}
+.CodeBlock--language-css.CodeBlock--token-variable,
+[language="css"] .CodeBlock--token-variable {
+  color: var(--code-violet);
+}
+.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-value,
+[language="css"] .CodeBlock--token-attribute.CodeBlock--token-value {
+  color: var(--code-gold);
+}
+.CodeBlock--language-css.CodeBlock--token-color,
+[language="css"] .CodeBlock--token-color {
+  color: var(--code-violet);
+}
+.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-punctuation,
+[language="css"] .CodeBlock--token-attribute.CodeBlock--token-punctuation {
+  color: inherit;
+}
+.CodeBlock--language-css.CodeBlock--token-atrule.CodeBlock--token-rule,
+.CodeBlock--language-css.CodeBlock--token-attribute.CodeBlock--token-operator,
+.CodeBlock--language-css.CodeBlock--token-important,
+.CodeBlock--language-css.CodeBlock--token-unit,
+[language="css"] .CodeBlock--token-atrule.CodeBlock--token-rule,
+[language="css"] .CodeBlock--token-attribute.CodeBlock--token-operator,
+[language="css"] .CodeBlock--token-important,
+[language="css"] .CodeBlock--token-unit {
+  color: var(--code-red);
+}
+.CodeBlock--language-css.CodeBlock--token-pseudo-class,
+.CodeBlock--language-css.CodeBlock--token-pseudo-element,
+[language="css"] .CodeBlock--token-pseudo-class,
+[language="css"] .CodeBlock--token-pseudo-element {
+  color: var(--code-violet);
+}
+[language="markdown"] .CodeBlock--token-header,
+[language="markdown"] .CodeBlock--token-title {
+  color: var(--code-orange);
+}
+[language="markdown"] .CodeBlock--token-list {
+  color: var(--code-red);
+}
+[language="markdown"] .CodeBlock--token-blockquote {
+  color: var(--code-blue);
+}
+[language="markdown"] .CodeBlock--token-code {
+  color: var(--code-green);
+}
+[language="markdown"] .CodeBlock--token-hr {
+  color: var(--code-gold);
+}
+[language="sh"] .CodeBlock--token-directory {
+  color: var(--code-orange);
+}
+[language="sh"] .CodeBlock--token-prompt {
+  color: var(--code-orange);
+  opacity: 0.7;
+}
+[language="sh"] .CodeBlock--token-value {
+  color: var(--code-cyan);
+}
+[language="sh"] .CodeBlock--token-success {
+  color: var(--code-green);
+}
+[language="sh"] .CodeBlock--token-plain {
+  color: var(--code-gray);
+}
+[language="sh"] .CodeBlock--token-plain,
+[language="sh"] .CodeBlock--token-unselectable {
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  text-decoration: none;
+  transition: opacity 0.25s ease;
+}
+[language="sh"]:hover .CodeBlock--token-plain,
+[language="sh"]:hover .CodeBlock--token-unselectable,
+[language="sh"][has-selection-contained-within] .CodeBlock--token-plain,
+[language="sh"][has-selection-contained-within] .CodeBlock--token-unselectable {
+  opacity: 0.25;
+}
+.CodeBlock--row
+  > .CodeBlock--row-indicator:empty
+  + .CodeBlock--row-content
+  > .CodeBlock--token-plain:empty
+  + .CodeBlock--token-doc-comment.CodeBlock--token-comment:empty:after,
+.CodeBlock--row
+  > .CodeBlock--row-indicator:empty
+  + .CodeBlock--row-content
+  > .CodeBlock--token-table.CodeBlock--token-table-data-rows:empty
+  + .CodeBlock--token-plain:empty:after {
+  content: " ";
+}
+.ThemeToggle {
+  width: 50px;
+  height: 28px;
+  border-radius: 99em;
+}
+.ThemeToggle--input {
+  position: absolute;
+  opacity: 0;
+  top: -9999em;
+}
+.ThemeToggle--toggle {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 99em;
+  background: rgba(var(--gray-6-rgb), 0.7);
+  cursor: pointer;
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.ThemeToggle--input:not([is-focus-visible]) ~ .ThemeToggle--toggle {
+  --focus-size: 0;
+}
+.ThemeToggle--input:checked ~ .ThemeToggle--toggle,
+[theme="dark"] .ThemeToggle[data-is-loading="true"] .ThemeToggle--toggle {
+  background: rgba(var(--gray-2-rgb), 0.7);
+}
+.ThemeToggle--toggle-handle {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  --size: 22px;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 99em;
+  background: #fff;
+  box-shadow: 0 0.15em 0.3em rgba(0, 0, 0, 0.15),
+    0 0.2em 0.5em rgba(0, 0, 0, 0.3);
+}
+.ThemeToggle--input:checked ~ .ThemeToggle--toggle .ThemeToggle--toggle-handle,
+[theme="dark"]
+  .ThemeToggle[data-is-loading="true"]
+  .ThemeToggle--toggle-handle {
+  left: auto;
+  right: 3px;
+  background: var(--gray-00);
+  border: 1px solid #000;
+  box-shadow: 0 0.5px hsla(0, 0%, 100%, 0.16);
+}
+.ThemeToggle--toggle-handle-icon {
+  position: absolute;
+  top: 6px;
+  width: 16px;
+  height: 16px;
+}
+.ThemeToggle--moon,
+.ThemeToggle--sun {
+  pointer-events: none;
+}
+.ThemeToggle--sun {
+  left: 6px;
+}
+@media (max-width: 320px) {
+  .ThemeToggle--sun {
+    -webkit-transform: translateX(-0.1px);
+    transform: translateX(-0.1px);
+  }
+}
+.ThemeToggle--moon {
+  right: 6px;
+  color: var(--gray-3);
+}
+.ThemeToggle--input:checked ~ .ThemeToggle--toggle .ThemeToggle--moon,
+.ThemeToggle--sun,
+[theme="dark"] .ThemeToggle[data-is-loading="true"] .ThemeToggle--moon {
+  color: var(--orange);
+}
+.ThemeToggle--input:checked ~ .ThemeToggle--toggle .ThemeToggle--sun,
+[theme="dark"] .ThemeToggle[data-is-loading="true"] .ThemeToggle--sun {
+  color: rgba(var(--gray-6-rgb), 0.8);
+}
+[theme-is-changing] * {
+  transition: none !important;
+}
+.Dropdown {
+  position: relative;
+}
+.Dropdown--dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  padding: 0.5em 0;
+  background: var(--background-color);
+  border-radius: 0.3125em;
+  pointer-events: none;
+  opacity: 0;
+  --dropdown-focus-size: var(--focus-size);
+  --focus-shadow: 0 0 0 var(--dropdown-focus-size) var(--focus-color);
+  --box-shadow: 0 0 0 1px rgba(var(--shadow-color-rgb), 0.075),
+    0 0.3em 2em rgb(var(--shadow-color-rgb), 0.1);
+  box-shadow: var(--box-shadow), var(--focus-shadow);
+  -webkit-transform: scaleX(0.5) scaleY(0.5) perspective(1px);
+  transform: scaleX(0.5) scaleY(0.5) perspective(1px);
+  -webkit-transform-origin: top left;
+  transform-origin: top left;
+  transition: opacity 0.1s, box-shadow 0.3s, -webkit-transform 0.3s;
+  transition: opacity 0.1s, box-shadow 0.3s, transform 0.3s;
+  transition: opacity 0.1s, box-shadow 0.3s, transform 0.3s,
+    -webkit-transform 0.3s;
+}
+[theme="dark"] .Dropdown--dropdown {
+  background: var(--gray-1);
+}
+@supports (
+  (-webkit-backdrop-filter: blur(1em)) or (backdrop-filter: blur(1em))
+) {
+  .Dropdown--dropdown {
+    background: rgba(var(--background-color-rgb), 0.8);
+    -webkit-backdrop-filter: saturate(200%) blur(1.25em);
+    backdrop-filter: saturate(200%) blur(1.25em);
+  }
+  [theme="dark"] .Dropdown--dropdown {
+    background: rgba(var(--gray-1-rgb), 0.7);
+  }
+}
+.Dropdown[data-expanded="true"] .Dropdown--dropdown {
+  opacity: 1;
+  pointer-events: all;
+  -webkit-transform: scaleX(1) scaleY(1) perspective(1px);
+  transform: scaleX(1) scaleY(1) perspective(1px);
+  --spring-easing: cubic-bezier(0.175, 0.885, 0.4, 1.1);
+  transition: opacity 0.2s ease-out, box-shadow 0.3s,
+    -webkit-transform 0.2s var(--spring-easing);
+  transition: opacity 0.2s ease-out, box-shadow 0.3s,
+    transform 0.2s var(--spring-easing);
+  transition: opacity 0.2s ease-out, box-shadow 0.3s,
+    transform 0.2s var(--spring-easing),
+    -webkit-transform 0.2s var(--spring-easing);
+}
+[js-focus-visible-polyfill-available] .Dropdown--dropdown:focus {
+  outline: none;
+}
+.Dropdown--dropdown:not([is-focus-visible]) {
+  --dropdown-focus-size: 0;
+}
+.Dropdown--item,
+.Dropdown--list {
+  padding: 0;
+  list-style: none;
+}
+.Dropdown--link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.25em 1.5em;
+  white-space: nowrap;
+  max-width: calc(100vw - 2em);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  --focus-size: 3px;
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.Dropdown--link:hover {
+  color: var(--orange);
+  background: rgba(var(--orange-rgb), 0.05);
+}
+[theme="dark"] .Dropdown--link:hover {
+  background: rgba(var(--color-rgb), 0.05);
+}
+[js-focus-visible-polyfill-available] .Dropdown--link:focus {
+  outline: none;
+}
+.Dropdown--link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+p > code,
+span > code,
+div > code,
+li > code,
+td > code,
+.DocsMarkdown--aside > code,
+.InlineCode {
+  font-family: var(--monospace-font-family);
+  font-size: var(--inline-code-font-size);
+  --default-padding: 0.2em 0.3em;
+  padding: var(--padding, var(--default-padding));
+  --default-background: rgba(var(--color-rgb), 0.05);
+  background: var(--background, var(--default-background));
+  border-radius: 0.25em;
+  max-width: 100%;
+}
+code.InlineCode-is-nowrap,
+.InlineCode.InlineCode-is-nowrap {
+  white-space: nowrap;
+}
+.InlineCode--type,
+.InlineCode.InlineCode-is-type {
+  font-weight: 700;
+  font-size: 0.7rem;
+  border-radius: 0.2em;
+  opacity: 0.75;
+  --border-opacity: 0.4;
+  box-shadow: 0 0 0 1px rgba(var(--color-rgb), var(--border-opacity));
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+}
+[theme="dark"] .InlineCode.InlineCode-is-type {
+  --border-opacity: 0.3;
+}
+.InlineCode.InlineCode-is-type {
+  padding: 1px 4px;
+  --background: transparent;
+}
+.InlineCode--type {
+  padding: 0 3px;
+  margin-left: 0.5em;
+  --border-opacity: 0.25;
+}
+@media (max-width: 768px) {
+  .InlineCode--type,
+  .InlineCode.InlineCode-is-type {
+    padding: 0 2px;
+  }
+}
+.Link {
+  text-decoration: none;
+  color: inherit;
+  --accent-color: var(--orange);
+  --underline-size: -0.16em;
+  --underline-color: var(--accent-color);
+  --underline-shadow: inset 0 var(--underline-size) var(--underline-color);
+  --focus-size: 3px;
+  --focus-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+  box-shadow: var(--focus-shadow), var(--underline-shadow);
+}
+.Link-is-blue {
+  --accent-color: var(--blue-6);
+}
+.Link-is-cyan {
+  --accent-color: var(--cyan-6);
+}
+.Link-is-gray {
+  --accent-color: var(--gray-6);
+}
+.Link-is-green {
+  --accent-color: var(--green-6);
+}
+.Link-is-gold {
+  --accent-color: var(--gold-6);
+}
+.Link-is-orange {
+  --accent-color: var(--orange);
+}
+.Link-is-indigo {
+  --accent-color: var(--indigo-6);
+}
+.Link-is-violet {
+  --accent-color: var(--violet-6);
+}
+@media (hover: hover) {
+  .Link:hover {
+    color: var(--accent-color);
+  }
+}
+.Link-is-juicy {
+  padding: 0.5em;
+  margin: -0.5em;
+}
+.Link-with-left-arrow,
+.Link-with-right-arrow,
+.Link-without-underline {
+  --underline-size: 0;
+}
+.Link-with-left-arrow:before {
+  content: "\2190\A0";
+}
+.Link-with-right-arrow:after {
+  content: "\A0\2192";
+}
+[js-focus-visible-polyfill-available] .Link:focus {
+  outline: none;
+}
+.Link[is-focus-visible] {
+  --underline-size: 0;
+}
+.Link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+.NetworkMap--land {
+  fill: rgba(var(--gray-7-rgb), 0.8);
+}
+[theme="dark"] .NetworkMap--land {
+  fill: rgba(var(--gray-2-rgb), 0.7);
+}
+.NetworkMap--datacenters {
+  fill: var(--orange);
+  stroke: var(--orange-1);
+  stroke-width: 2px;
+  paint-order: stroke;
+  opacity: 0.85;
+}
+[theme="dark"] .NetworkMap--datacenters {
+  stroke: var(--background-color);
+  stroke-width: 3px;
+}
+.Scrollbars--track-vertical {
+  top: 0.25em;
+  right: 0.25em;
+  bottom: 0.25em;
+  width: 0.5em !important;
+}
+.Scrollbars--thumb {
+  cursor: pointer;
+  background-color: var(--gray-6);
+  border-radius: 0.5em;
+}
+.Scrollbars--thumb:active {
+  background-color: var(--gray-4);
+}
+[theme="dark"] .Scrollbars--thumb {
+  background-color: var(--gray-2);
+}
+[theme="dark"] .Scrollbars--thumb:active {
+  background-color: var(--gray-5);
+}
+.StreamVideo .video-js {
+  font-family: inherit;
+}
+.StreamVideo .video-js .vjs-control-bar {
+  font-size: 1.75em;
+}
+.StreamVideo .video-js .cf-quality-selector,
+.StreamVideo .video-js .vjs-playback-rate {
+  display: none;
+}
+.StreamVideo .video-js .vjs-slider {
+  background: rgba(var(--gray-5-rgb), 0.5);
+}
+.Superscript {
+  vertical-align: initial;
+  font-size: 0.8em;
+  top: -0.5em;
+}
+.Superscript,
+.Tooltip---root {
+  position: relative;
+}
+span.Tooltip---root {
+  display: inline-block;
+}
+.Tooltip {
+  --gap: 0.75em;
+  position: absolute;
+  font-size: 0.925em;
+  font-weight: 400;
+  font-style: normal;
+  line-height: var(--line-height);
+  text-transform: none;
+  letter-spacing: normal;
+  padding: 0.3em 0.85em;
+  white-space: nowrap;
+  max-width: calc(100vw - 1em);
+  color: var(--background-color);
+  background: var(--color);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  border-radius: 0.25em;
+  z-index: 10;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+}
+@media (hover: hover) {
+  .Tooltip---root:hover .Tooltip {
+    opacity: 1;
+  }
+}
+.Tooltip:not([position]),
+.Tooltip[position="top"] {
+  bottom: 100%;
+  margin-bottom: var(--gap);
+}
+.Tooltip:not([position]),
+.Tooltip[position="bottom"],
+.Tooltip[position="top"] {
+  left: 50%;
+  -webkit-transform: translate3d(-50%, 0, 0);
+  transform: translate3d(-50%, 0, 0);
+}
+.Tooltip[position="bottom"] {
+  top: 100%;
+  margin-top: var(--gap);
+}
+.Tooltip[position="left"] {
+  right: 100%;
+  margin-right: var(--gap);
+}
+.Tooltip[position="left"],
+.Tooltip[position="right"] {
+  top: 50%;
+  -webkit-transform: translate3d(0, -50%, 0);
+  transform: translate3d(0, -50%, 0);
+}
+.Tooltip[position="right"] {
+  left: 100%;
+  margin-left: var(--gap);
+}
+.Tooltip[position="top-start"] {
+  bottom: 100%;
+  margin-bottom: var(--gap);
+  left: 0;
+}
+.Tooltip[position="bottom-start"] {
+  top: 100%;
+  margin-top: var(--gap);
+  left: 0;
+}
+.Tooltip[position="top-end"] {
+  bottom: 100%;
+  margin-bottom: var(--gap);
+  right: 0;
+}
+.Tooltip[position="bottom-end"] {
+  top: 100%;
+  margin-top: var(--gap);
+  right: 0;
+}
+.SkipNavLink {
+  position: absolute;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+}
+.SkipNavLink:focus {
+  padding: 0.5em 1em;
+  position: fixed;
+  top: 0;
+  left: 50%;
+  -webkit-transform: translate3d(-50%, 0, 0);
+  transform: translate3d(-50%, 0, 0);
+  background: var(--background-color);
+  width: auto;
+  height: auto;
+  clip: auto;
+  z-index: 100;
+  outline: none;
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.TagsFilter {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -0.25em;
+}
+.TagsFilter--button {
+  --border-color: rgba(var(--color-rgb), 0.2);
+  padding: 0.25em 0.3125em;
+  margin: 0.3125em 0.25em;
+  border-radius: 0.125em;
+}
+.TagsFilter--button[is-focus-visible] {
+  --border-color: rgba(var(--orange-rgb), 0.7);
+}
+.TagsFilter--button-active {
+  pointer-events: none;
+}
+[theme="light"] .TagsFilter--button-active {
+  --border-color: transparent;
+}
+[theme="dark"] .TagsFilter--button-active {
+  color: var(--code-orange);
+}
+.WorkerStarter {
+  display: block;
+  margin-top: 2.5rem;
+}
+.WorkerStarter + .WorkerStarter {
+  margin-top: 3rem;
+}
+.WorkerStarter--title {
+  font-size: 1.35em;
+  line-height: 1.2;
+  font-weight: 500;
+  margin-bottom: 0.3125em;
+}
+.WorkerStarter--title .Link {
+  color: inherit;
+  --underline-opacity: 0.75;
+  text-decoration: underline;
+  -webkit-text-decoration-color: rgba(
+    var(--orange-rgb),
+    var(--underline-opacity)
+  );
+  text-decoration-color: rgba(var(--orange-rgb), var(--underline-opacity));
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+@media (max-width: 768px) {
+  .WorkerStarter--title {
+    font-size: 1.375em;
+    margin-bottom: 0.5rem;
+  }
+}
+.WorkerStarter--description {
+  display: block;
+  margin-bottom: 0.4375rem;
+  width: calc(100% - var(--docs-body-sidebar-width));
+}
+.WorkerStarter--command {
+  position: relative;
+  font-size: 0.9em;
+  --copy-button-width: 4rem;
+  --height: 2.5rem;
+}
+.WorkerStarter--command-copy-button-wrapper {
+  position: absolute;
+  width: calc(var(--copy-button-width) - 2px);
+  height: var(--height);
+}
+.WorkerStarter--command-copy-button-wrapper button {
+  width: 100%;
+  height: 100%;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  font-weight: 600;
+  background: var(--code-block-background-color);
+}
+[theme="light"] .WorkerStarter--command-copy-button-wrapper button {
+  background: var(--code-block-background-color-light-theme);
+}
+.WorkerStarter--command-codeblock-wrapper {
+  padding-left: var(--copy-button-width);
+}
+.WorkerStarter--command .WorkerStarter--command-codeblock-wrapper pre {
+  height: var(--height);
+  line-height: 1.4;
+  margin-bottom: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  overflow: hidden;
+}
+.ArchitectureDiagram {
+  --user-code-size: 25px;
+  --accent-color-rgb: var(--orange-rgb);
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 100%;
+}
+@media (max-width: 1350px) {
+  .ArchitectureDiagram {
+    --user-code-size: 22px;
+  }
+}
+@media (max-width: 1280px) {
+  .ArchitectureDiagram {
+    --user-code-size: 24px;
+  }
+}
+@media (max-width: 1250px) {
+  .ArchitectureDiagram {
+    --user-code-size: 22px;
+  }
+}
+@media (max-width: 1195px) {
+  .ArchitectureDiagram {
+    --user-code-size: 20px;
+  }
+}
+@media (max-width: 1152px) {
+  .ArchitectureDiagram {
+    --user-code-size: 25px;
+  }
+}
+@media (max-width: 1080px) {
+  .ArchitectureDiagram {
+    --user-code-size: 22px;
+  }
+}
+@media (max-width: 986px) {
+  .ArchitectureDiagram {
+    --user-code-size: 20px;
+  }
+}
+@media (max-width: 920px) {
+  .ArchitectureDiagram {
+    --user-code-size: 15px;
+  }
+}
+@media (max-width: 820px) {
+  .ArchitectureDiagram {
+    --user-code-size: 12px;
+  }
+}
+@media (max-width: 768px) {
+  .ArchitectureDiagram {
+    --user-code-size: 20px;
+  }
+}
+@media (max-width: 576px) {
+  .ArchitectureDiagram {
+    --user-code-size: 18px;
+  }
+}
+@media (max-width: 520px) {
+  .ArchitectureDiagram {
+    --user-code-size: 16px;
+  }
+}
+.ArchitectureDiagram--diagram {
+  --size: calc(var(--user-code-size) * 9);
+  width: var(--size);
+}
+@media (max-width: 480px) {
+  .ArchitectureDiagram {
+    --user-code-size: 25px;
+    justify-content: flex-start;
+  }
+  .ArchitectureDiagram--diagram {
+    width: 100%;
+  }
+  .ArchitectureDiagram--diagram + .ArchitectureDiagram--diagram {
+    margin-top: 2em;
+  }
+  .ArchitectureDiagram--key {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+  }
+  .ArchitectureDiagram--key-content {
+    position: -webkit-sticky;
+    position: sticky;
+    top: calc(var(--docs-header-height) + var(--user-code-size));
+  }
+  .ArchitectureDiagram--caption {
+    width: var(--size);
+  }
+}
+@media (max-width: 374px) {
+  .ArchitectureDiagram--key {
+    width: 5em;
+  }
+}
+@media (max-width: 414px) {
+  .ArchitectureDiagram {
+    --user-code-size: 22px;
+  }
+}
+@media (max-width: 375px) {
+  .ArchitectureDiagram {
+    --user-code-size: 20px;
+  }
+}
+@media (max-width: 360px) {
+  .ArchitectureDiagram {
+    --user-code-size: 19px;
+  }
+}
+@media (max-width: 340px) {
+  .ArchitectureDiagram {
+    --user-code-size: 18px;
+  }
+}
+@media (max-width: 330px) {
+  .ArchitectureDiagram {
+    --user-code-size: 17px;
+  }
+}
+@media (max-width: 319px) {
+  .ArchitectureDiagram {
+    display: none;
+  }
+}
+.ArchitectureDiagram--content {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  width: var(--size);
+  height: var(--size);
+}
+.ArchitectureDiagram--caption {
+  margin-top: 0.666em;
+  max-width: 100%;
+  line-height: 1.3;
+}
+.ArchitectureDiagram--process-overhead {
+  --size: calc(var(--user-code-size) * 3);
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  width: var(--size);
+  height: var(--size);
+}
+.ArchitectureDiagram--process-overhead:after {
+  content: "\21BB";
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1em;
+  width: 1em;
+  margin: auto;
+  font-size: 2em;
+  line-height: 1;
+  text-align: center;
+  color: rgb(var(--accent-color-rgb));
+}
+.ArchitectureDiagram--process-overhead-background {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(var(--accent-color-rgb), 0.25);
+}
+.ArchitectureDiagram--user-code {
+  position: relative;
+  z-index: 1;
+  width: var(--user-code-size);
+  height: var(--user-code-size);
+  background: rgba(var(--accent-color-rgb), 0.9);
+}
+.ArchitectureDiagram--process-overhead-background,
+.ArchitectureDiagram--user-code {
+  --box-shadow: inset 0 0 0 1px rgb(var(--background-color-rgb));
+  box-shadow: var(--box-shadow);
+}
+.ArchitectureDiagram--user-code:after {
+  content: "{ }";
+  display: block;
+  font-size: calc(var(--user-code-size) * 0.5);
+  line-height: calc(var(--user-code-size) * 0.93);
+  font-weight: 700;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  color: rgba(var(--background-color-rgb), 0.7);
+}
+.ArchitectureDiagram--key-user-code {
+  margin-bottom: 1em;
+}
+.ArchitectureDiagram--key-label {
+  opacity: 0.8;
+  padding-top: 0.25em;
+}
+.DocsNoscript {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  -webkit-transform: translate3d(-50%, 0, 0);
+  transform: translate3d(-50%, 0, 0);
+  font-size: 0.8em;
+  padding: 0.5em 1em;
+  background: rgba(var(--orange-rgb), 0.15);
+  border-radius: 0 0 0.25em 0.25em;
+  z-index: 100;
+}
+.DocsNavLogoLockup {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  --gap: var(--docs-logo-lockup-gap);
+}
+.DocsNavLogoLockup.DocsNavLogoLockup-with-small-gap {
+  --gap: var(--docs-logo-lockup-gap-small);
+}
+.DocsNavLogoLockup--logo {
+  --size: var(--logo-size, 2.5em);
+  height: var(--size);
+  width: var(--size);
+  color: var(--orange);
+  margin-right: var(--gap);
+  flex-shrink: 0;
+  fill: var(--orange);
+}
+.DocsNavLogoLockup--logo path {
+  fill: var(--orange);
+}
+.DocsNavLogoLockup--text {
+  font-size: var(--font-size, 1em);
+  font-weight: 700;
+  line-height: 1;
+  padding-top: 0.05em;
+  letter-spacing: -0.03em;
+}
+@-moz-document url-prefix() {
+  .DocsNavLogoLockup--text {
+    letter-spacing: 0;
+  }
+}
+.DocsNavLogoLockup--text [data-text="Cloudflare"] ~ [data-text="Docs"] {
+  font-weight: 500;
+  margin-left: -0.05em;
+}
+@media (max-width: 768px) {
+  .DocsNavLogoLockup--text {
+    font-weight: 600;
+  }
+  .DocsNavLogoLockup--text [data-text="Cloudflare"] ~ [data-text="Docs"] {
+    font-weight: 400;
+  }
+}
+html[is-docs-page],
+html[is-docs-page] body {
+  scroll-behavior: smooth;
+  height: 100%;
+  overscroll-behavior-y: none;
+}
+.DocsPage {
+  --sixty-four-px-rem: 3.7647058824rem;
+  --docs-content-gap: var(--sixty-four-px-rem);
+  --docs-header-height: var(--sixty-four-px-rem);
+  --docs-sidebar-width: 18.25rem;
+  --docs-body-sidebar-width: var(--docs-sidebar-width);
+  --docs-page-side-padding: 1rem;
+  --docs-max-page-width: 1440px;
+  --docs-page-width: var(--docs-max-page-width);
+  --docs-sidebars-combined-width: calc(
+    var(--docs-sidebar-width) + var(--docs-body-sidebar-width)
+  );
+  --docs-body-width: calc(
+    var(--docs-page-width) - var(--docs-sidebars-combined-width)
+  );
+  --docs-logo-lockup-gap: 0.4rem;
+  --docs-logo-lockup-gap-small: 0.2rem;
+  position: relative;
+  width: 100%;
+  max-width: var(--docs-max-page-width);
+  min-height: 100%;
+  margin: 0 auto;
+}
+@media (max-width: 1439px) {
+  .DocsPage {
+    --docs-page-width: 100vw;
+    --docs-page-sidebar-preserverd-width: calc(
+      100vw - var(--docs-sidebar-width) - var(--docs-max-page-width) +
+        var(--docs-sidebar-width) * 2
+    );
+    --docs-body-sidebar-width: calc(
+      15vw + var(--docs-page-sidebar-preserverd-width) / 4
+    );
+  }
+}
+@media (max-width: 1350px) {
+  .DocsPage {
+    --docs-sidebar-width: 18rem;
+  }
+}
+@media (max-width: 1280px) {
+  .DocsPage {
+    --docs-sidebar-width: 17rem;
+    --docs-body-sidebar-width: 18vw;
+  }
+}
+@media (max-width: 1152px) {
+  .DocsPage {
+    --docs-sidebar-width: calc(10rem + 12vw);
+    --docs-body-sidebar-width: 0px;
+  }
+}
+@media (max-width: 768px) {
+  .DocsPage {
+    --docs-header-height: 3rem;
+    padding-top: var(--docs-header-height);
+  }
+  html[is-docs-page][is-mobile-sidebar-open] {
+    overflow: hidden;
+  }
+}
+.DocsSidebar {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  --sidebar-background-color: var(--background-color);
+  --content-indent: var(--docs-page-side-padding);
+  --logo-size: 2.8235294118rem;
+  --text-indent: calc(
+    var(--content-indent) + var(--logo-size) + var(--docs-logo-lockup-gap) +
+      0.1em
+  );
+  width: var(--docs-sidebar-width);
+  z-index: 2;
+}
+.DocsSidebar [is-visually-hidden] {
+  -webkit-clip-path: none;
+  clip-path: none;
+  left: -10000px;
+  top: auto;
+}
+[theme="dark"] .DocsSidebar {
+  --sidebar-background-color: var(--gray-0F);
+}
+[theme="dark"] .DocsSidebar:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 999em;
+  background: var(--sidebar-background-color);
+  pointer-events: none;
+}
+.DocsSidebar--link {
+  color: inherit;
+  text-decoration: none;
+}
+[js-focus-visible-polyfill-available] .DocsSidebar--link:focus {
+  outline: none;
+}
+.DocsSidebar--link[is-focus-visible]:focus {
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.DocsSidebar--link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+.DocsSidebar--sections {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.DocsSidebar--shadow {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 6;
+}
+.DocsSidebar--shadow:after,
+.DocsSidebar--shadow:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--shadow-color-rgb), 0),
+    rgba(var(--shadow-color-rgb), 0.07)
+  );
+}
+.DocsSidebar--shadow:before {
+  width: 5px;
+  opacity: 0.8;
+}
+.DocsSidebar--shadow:after {
+  width: 2px;
+  opacity: 0.5;
+}
+@media (min-width: 769px) {
+  [theme="dark"] .DocsSidebar--shadow {
+    left: calc(100% + 2px);
+    right: auto;
+  }
+  [theme="dark"] .DocsSidebar--shadow:before {
+    background: rgb(var(--shadow-color-rgb));
+    border-right: 1px solid rgba(var(--color-rgb), 0.15);
+    width: 1px;
+    opacity: 1;
+  }
+  [theme="dark"] .DocsSidebar--shadow:after {
+    opacity: 1;
+    width: 14px;
+    right: 1px;
+  }
+}
+.DocsSidebar--section {
+  position: relative;
+}
+.DocsSidebar--section-separator {
+  position: relative;
+  flex-shrink: 0;
+  --fade-indent: 1.25em;
+  --shadow-opacity: 0.07;
+  margin-top: -1px;
+}
+[theme="dark"] .DocsSidebar--section-separator {
+  --shadow-opacity: 1;
+}
+.DocsSidebar--section-separator:after,
+.DocsSidebar--section-separator:before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+}
+.DocsSidebar--section-separator:before {
+  background: linear-gradient(
+    90deg,
+    rgba(var(--shadow-color-rgb), 0) 0,
+    rgba(var(--shadow-color-rgb), var(--shadow-opacity)) var(--fade-indent),
+    rgba(var(--shadow-color-rgb), var(--shadow-opacity))
+  );
+}
+[theme="light"] .DocsSidebar--section-separator:after {
+  display: none;
+}
+[theme="dark"] .DocsSidebar--section-separator:after {
+  top: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--color-rgb), 0) 0,
+    rgba(var(--color-rgb), 0.07) var(--fade-indent),
+    rgba(var(--color-rgb), 0.07)
+  );
+}
+@media (max-width: 1440px) {
+  .DocsSidebar--section-separator:before {
+    background: rgba(var(--shadow-color-rgb), var(--shadow-opacity));
+  }
+  [theme="dark"] .DocsSidebar--section-separator:after {
+    background: rgba(var(--color-rgb), 0.07);
+  }
+}
+.DocsSidebar--header-section {
+  display: flex;
+  flex-shrink: 0;
+  height: var(--docs-header-height);
+  z-index: 1;
+}
+.DocsSidebar--cloudflare-logo-link {
+  --font-size: 1.17647em;
+  display: flex;
+  align-items: center;
+  padding-left: var(--content-indent);
+  padding-right: var(--content-indent);
+}
+.DocsSidebar--docs-title-section {
+  position: relative;
+  display: flex;
+  z-index: 7;
+}
+.DocsSidebar--docs-title-logo-link {
+  --font-size: 1.58824em;
+  padding: 0.7em var(--content-indent);
+  max-width: calc(100% - 3em);
+}
+.DocsSidebar--cloudflare-logo-link,
+.DocsSidebar--docs-title-logo-link {
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+.DocsSidebar--cloudflare-logo-link:hover,
+.DocsSidebar--docs-title-logo-link:hover {
+  opacity: 0.75;
+  color: rgba(var(--color-rgb), 0.75);
+}
+.DocsSidebar--docs-title-text-scaler {
+  --font-size: 1em * (1 - ((var(--length) - 10)/20));
+  font-size: clamp(0.7em, var(--font-size), 1em);
+  display: inherit;
+}
+.DocsSidebar--section-more {
+  position: absolute;
+  right: 0.75em;
+  top: 0;
+  bottom: 0;
+  margin-top: auto;
+  margin-bottom: auto;
+  height: 2.5em;
+  width: 1.75em;
+}
+.DocsSidebar--section-more-button {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  transition: opacity 0.2s ease;
+}
+.DocsSidebar:not(:hover)
+  .DocsSidebar--section-more:not([data-expanded="true"])
+  .DocsSidebar--section-more-button:not(:focus) {
+  opacity: 0;
+}
+.DocsSidebar--section-more-button-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 0.625em 0.4em;
+  transition: opacity 0.2s ease;
+  opacity: 0.5;
+}
+@media (hover: hover) {
+  .DocsSidebar--section-more-button:hover
+    .DocsSidebar--section-more-button-icon {
+    opacity: 1;
+  }
+}
+.DocsSidebar--nav-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--color-rgb), 0.1) transparent;
+}
+@media (hover: hover) {
+  .DocsSidebar--nav-section:hover {
+    scrollbar-color: rgba(var(--color-rgb), 0.35) transparent;
+  }
+}
+.DocsSidebar--nav-section-shadow {
+  position: -webkit-sticky;
+  position: sticky;
+  flex-shrink: 0;
+  top: 0;
+  width: 100%;
+  height: 0.25em;
+  box-shadow: inset 0 1px rgba(var(--shadow-color-rgb), 0.04);
+  background: linear-gradient(
+    rgba(var(--shadow-color-rgb), 0.09),
+    rgba(var(--shadow-color-rgb), 0)
+  );
+  opacity: 0;
+  z-index: 4;
+}
+@media (min-width: 1441px) {
+  .DocsSidebar--nav-section-shadow {
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 1.5em, #000);
+    mask-image: linear-gradient(90deg, transparent, #000 1.5em, #000);
+  }
+}
+[theme="dark"] .DocsSidebar--nav-section-shadow {
+  box-shadow: inset 0 1px rgba(var(--shadow-color-rgb), 0.5);
+  background: linear-gradient(rgba(var(--shadow-color-rgb), 0.2), transparent);
+  height: 0.5em;
+  border-top: 1px solid #222;
+}
+.DocsSidebar--nav {
+  list-style: none;
+  font-size: 1.11em;
+  padding-top: 0;
+  padding-bottom: 2em;
+  padding-left: 0;
+  word-break: break-word;
+}
+@media (max-width: 1280px) {
+  .DocsSidebar--nav {
+    font-size: 1.05em;
+    --text-indent: 3rem;
+  }
+}
+.DocsSidebar--nav-item {
+  position: relative;
+}
+.DocsSidebar--nav-item + .DocsSidebar--nav-item {
+  margin-top: 0.333em;
+}
+.DocsSidebar--nav-expand-collapse-button {
+  position: absolute;
+  z-index: 3;
+  --size: 2em;
+  --margin-right: 0.75em;
+  left: calc(
+    var(--text-indent) - var(--size) - var(--margin-right) + var(--depth, 0) *
+      1rem
+  );
+  top: 0;
+  height: var(--size);
+  width: var(--size);
+  line-height: 0.5em;
+  padding: 0;
+  text-align: center;
+}
+@media (max-width: 1280px) {
+  .DocsSidebar--nav-expand-collapse-button {
+    --margin-right: 0.25em;
+  }
+}
+@media (hover: hover) {
+  .DocsSidebar--nav-expand-collapse-button:hover,
+  [theme="dark"] .DocsSidebar--nav-expand-collapse-button:hover {
+    --hover-box-shadow-color: transparent;
+  }
+  .DocsSidebar--nav-expand-collapse-button:hover {
+    background: rgba(var(--gray-5-rgb), 0.2);
+  }
+  [theme="dark"] .DocsSidebar--nav-expand-collapse-button:hover {
+    color: var(--code-orange);
+    background: rgba(var(--orange-rgb), 0.08);
+  }
+}
+.DocsSidebar--nav-expand-collapse-button:before {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 5em;
+  z-index: -1;
+}
+.DocsSidebar--nav-expand-collapse-button-content {
+  display: inline-block;
+  vertical-align: middle;
+  transition: -webkit-transform 0.4s ease;
+  transition: transform 0.4s ease;
+  transition: transform 0.4s ease, -webkit-transform 0.4s ease;
+  border: solid transparent;
+  border-left: solid;
+  border-width: 0.3333em 0.6em;
+  margin-left: 37%;
+  will-change: transform;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-transform-origin: 0.2em 0.4em;
+  transform-origin: 0.2em 0.4em;
+}
+.DocsSidebar--nav-item[is-active-root]:not([is-expanded])
+  > .DocsSidebar--nav-expand-collapse-button
+  > .DocsSidebar--nav-expand-collapse-button-content,
+[theme="dark"]
+  .DocsSidebar--nav-item[is-active]
+  > .DocsSidebar--nav-expand-collapse-button
+  > .DocsSidebar--nav-expand-collapse-button-content {
+  color: var(--orange);
+}
+@media (hover: hover) {
+  .DocsSidebar--nav-expand-collapse-button:not(:hover)
+    > .DocsSidebar--nav-expand-collapse-button-content {
+    opacity: 0.4;
+  }
+  [theme="dark"]
+    .DocsSidebar--nav-item[is-active]
+    > .DocsSidebar--nav-expand-collapse-button
+    > .DocsSidebar--nav-expand-collapse-button-content {
+    opacity: 0.8;
+  }
+  .DocsSidebar--nav-item[is-active-root]:not([is-expanded])
+    > .DocsSidebar--nav-expand-collapse-button
+    > .DocsSidebar--nav-expand-collapse-button-content {
+    opacity: 1;
+  }
+}
+.DocsSidebar--nav-item[is-expanded]
+  > .DocsSidebar--nav-expand-collapse-button
+  > .DocsSidebar--nav-expand-collapse-button-content {
+  -webkit-transform: rotate(90deg) translate3d(-0.1em, 0, 0);
+  transform: rotate(90deg) translate3d(-0.1em, 0, 0);
+}
+.DocsSidebar--nav-item-collapse-container {
+  overflow: hidden;
+}
+.DocsSidebar--nav-item-collapse-container.DocsSidebar--nav-item-collapse-hidden {
+  height: 0;
+}
+.DocsSidebar--nav-item-collapse-content {
+  opacity: 0;
+  -webkit-transform: translate3d(-0.5em, 0, 0);
+  transform: translate3d(-0.5em, 0, 0);
+  will-change: transform, opacity;
+  transition: opacity 0.4s ease, -webkit-transform 0.4s ease;
+  transition: transform 0.4s ease, opacity 0.4s ease;
+  transition: transform 0.4s ease, opacity 0.4s ease,
+    -webkit-transform 0.4s ease;
+}
+.DocsSidebar--nav-item[is-expanded]
+  > .DocsSidebar--nav-item-collapse-container
+  > .DocsSidebar--nav-item-collapse-content,
+.DocsSidebar--nav-item[is-expanded]
+  > .DocsSidebar--nav-item-collapse-container
+  > .DocsSidebar--nav-item-collapse-wrapper
+  > .DocsSidebar--nav-item-collapse-wrapperInner
+  > .DocsSidebar--nav-item-collapse-content {
+  opacity: 1;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .DocsSidebar--nav-expand-collapse-button-content,
+  .DocsSidebar--nav-item-collapse-content {
+    transition: none;
+  }
+}
+.DocsSidebar--nav-subnav {
+  list-style: none;
+  font-size: 0.94rem;
+  padding: 0.25em 0 0.75em;
+}
+@media (max-width: 1280px) {
+  .DocsSidebar--nav-subnav {
+    font-size: 0.9em;
+  }
+}
+.DocsSidebar--nav-subnav .DocsSidebar--nav-item + .DocsSidebar--nav-item {
+  margin-top: 0.0625em;
+}
+.DocsSidebar--nav-link {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  display: block;
+  padding-left: var(--text-indent);
+}
+.DocsSidebar--nav-subnav .DocsSidebar--nav-link {
+  padding-left: calc(var(--text-indent) + var(--depth) * 1rem);
+}
+.DocsSidebar--nav-link:focus {
+  z-index: 1;
+}
+.DocsSidebar--nav-link[is-active] {
+  z-index: 2;
+}
+.DocsSidebar--nav-link[is-active]:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 0.4125em;
+  background: var(--orange);
+  z-index: 4;
+}
+.DocsSidebar--nav-link-text {
+  position: relative;
+  display: inline-block;
+  padding: 0.25em 0.6em;
+  margin-left: -0.6em;
+  z-index: 1;
+}
+@media (hover: hover) {
+  .DocsSidebar--nav-link:hover .DocsSidebar--nav-link-text:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    height: 100%;
+    background: rgba(var(--gray-5-rgb), 0.2);
+    z-index: -1;
+    border-radius: 0.25em;
+  }
+}
+.DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  height: 100%;
+  background: rgba(var(--gray-5-rgb), 0.2);
+  z-index: -1;
+  border-radius: 0.25em;
+}
+@media (max-width: 1440px) {
+  .DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text:before {
+    left: calc(var(--docs-sidebar-width) * -1);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+@media (min-width: 1441px) {
+  .DocsSidebar--nav-link[is-active]:before {
+    display: none;
+  }
+}
+@media (hover: hover) {
+  [theme="dark"] .DocsSidebar--nav-link:hover .DocsSidebar--nav-link-text {
+    color: var(--code-orange);
+  }
+  [theme="dark"]
+    .DocsSidebar--nav-link:hover
+    .DocsSidebar--nav-link-text:before {
+    background: rgba(var(--orange-rgb), 0.08);
+  }
+}
+[theme="dark"] .DocsSidebar--nav-link[is-active] .DocsSidebar--nav-link-text {
+  color: var(--code-orange);
+}
+[theme="dark"]
+  .DocsSidebar--nav-link[is-active]
+  .DocsSidebar--nav-link-text:before {
+  background: rgba(var(--orange-rgb), 0.08);
+}
+.DocsSidebar--nav-link .DocsSidebar--nav-link-text:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  border-radius: 0.25em;
+}
+[js-focus-visible-polyfill-available] .DocsSidebar--nav-link:focus {
+  outline: none;
+}
+.DocsSidebar--nav-link[is-focus-visible]:focus
+  .DocsSidebar--nav-link-text:after {
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+@media (max-width: 768px) {
+  .DocsSidebar {
+    z-index: 20;
+    background: var(--sidebar-background-color);
+    width: calc(100% - 3.5rem);
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
+    will-change: transform;
+    transition: -webkit-transform 0.3s ease;
+    transition: transform 0.3s ease;
+    transition: transform 0.3s ease, -webkit-transform 0.3s ease;
+  }
+  [theme="dark"] .DocsSidebar {
+    --sidebar-background-color: var(--background-color);
+  }
+  .DocsSidebar--shadow {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+  .DocsSidebar--shadow,
+  .DocsSidebar--shadow:after,
+  .DocsSidebar--shadow:before {
+    right: auto;
+    left: 100%;
+  }
+  .DocsSidebar--shadow:after,
+  .DocsSidebar--shadow:before {
+    background: linear-gradient(
+      270deg,
+      rgba(var(--shadow-color-rgb), 0),
+      rgba(var(--shadow-color-rgb), 0.2)
+    );
+  }
+  .DocsSidebar--shadow:before {
+    width: 0.3125em;
+  }
+  [is-resizing] .DocsSidebar {
+    transition: none;
+  }
+  [is-mobile-sidebar-open] .DocsSidebar {
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+  }
+  [is-mobile-sidebar-open] .DocsSidebar--shadow {
+    opacity: 1;
+  }
+  .DocsSidebar--docs-title-section,
+  .DocsSidebar--header-section,
+  .DocsSidebar--header-section + .DocsSidebar--section-separator,
+  .DocsSidebar--nav-section-shadow {
+    display: none;
+  }
+  .DocsSidebar--nav {
+    padding: 1rem 0;
+  }
+}
+.DocsBody {
+  position: relative;
+  padding-top: var(--docs-header-height);
+  padding-left: var(--docs-sidebar-width);
+}
+@media (max-width: 768px) {
+  .DocsBody {
+    padding-top: 0;
+    padding-left: 0;
+    will-change: opacity;
+    transition: opacity 0.3s ease;
+  }
+  [is-mobile-sidebar-open] .DocsBody {
+    opacity: 0.3;
+  }
+}
+.DocsBody--sidebar {
+  position: absolute;
+  right: 0;
+  top: calc(var(--docs-header-height) + 1.7em);
+  bottom: 1em;
+  width: var(--docs-body-sidebar-width);
+}
+@media (max-width: 1152px) {
+  .DocsBody--sidebar {
+    display: none;
+  }
+}
+.DocsBody--sidebar-content-scroll-fade {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  display: block;
+  background: linear-gradient(
+    var(--background-color),
+    rgba(var(--background-color-rgb), 0)
+  );
+  height: 1em;
+  margin-left: -1em;
+  width: 100%;
+  z-index: 1;
+}
+.DocsBody--sidebar-content {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  width: calc(100% + 1em);
+  max-height: 100vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 1em 0 0 1em;
+  margin: -1em;
+  transition: opacity 0.3s ease;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--color-rgb), 0.1) transparent;
+}
+@media (min-width: 1281px) {
+  .DocsBody--sidebar {
+    padding-left: 2em;
+  }
+}
+.DocsBody--sidebar-content:hover {
+  scrollbar-color: rgba(var(--color-rgb), 0.35) transparent;
+}
+[theme="dark"] .DocsBody--sidebar-content:not(:hover):not(:focus-within) {
+  opacity: 0.55;
+}
+.DocsTableOfContents {
+  list-style: none;
+  font-size: 0.94117647059em;
+  padding-left: 0;
+  width: 100%;
+}
+.DocsTableOfContents ul {
+  padding-left: 1.5em;
+  list-style: none;
+}
+.DocsTableOfContents ul ul {
+  font-size: 0.9em;
+  padding-left: 1.5em;
+  margin-bottom: 0.25em;
+}
+@media (max-height: 768px) {
+  .DocsTableOfContents ul ul {
+    display: none;
+  }
+}
+.DocsTableOfContents ul ul ul {
+  display: none;
+}
+.DocsTableOfContents-link {
+  display: inline-block;
+  line-height: 1.3;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  padding: 0.2em 0;
+  margin: -0.2em 0;
+}
+.DocsTableOfContents-link:hover {
+  color: var(--orange);
+}
+[js-focus-visible-polyfill-available] .DocsTableOfContents-link:focus {
+  outline: none;
+}
+.DocsTableOfContents-link[is-focus-visible]:focus {
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.DocsTableOfContents-link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+.DocsContent {
+  padding: 2.6rem var(--docs-content-gap) 3.5rem;
+  min-height: calc(100vh - 12.5em);
+}
+.DocsContent[page-type="document"] {
+  width: calc(100% - var(--docs-body-sidebar-width));
+}
+@media (min-width: 769px) {
+  [search-disabled] .DocsContent {
+    padding-top: 0;
+  }
+}
+@media (max-width: 768px) {
+  .DocsContent {
+    --docs-content-horizontal-padding: 1rem;
+    padding: 2rem var(--docs-content-horizontal-padding);
+    min-height: 1em;
+  }
+}
+.DocsContent--breadcrumbs {
+  margin: -0.5em 0 0.3125em;
+}
+@media (min-width: 769px) {
+  .DocsContent--breadcrumbs {
+    display: none;
+  }
+}
+.DocsMarkdown {
+  word-wrap: break-word;
+}
+.DocsMarkdown img {
+  border-style: none;
+  box-sizing: content-box;
+  max-width: 100%;
+}
+.DocsMarkdown hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+.DocsMarkdown .small-img {
+  max-width: 242px;
+  margin-bottom: 1em;
+}
+.DocsMarkdown .medium-img {
+  max-width: 311px;
+  margin-bottom: 1em;
+}
+.DocsMarkdown .large-img {
+  max-width: 450px;
+  margin-bottom: 1em;
+}
+.DocsMarkdown .full-img {
+  max-width: 692px;
+  margin-bottom: 1em;
+}
+.DocsMarkdown--link {
+  text-decoration: none;
+  color: inherit;
+  --background-color-rgb: var(--orange-rgb);
+  --background-color-alpha: 0.08;
+  --border-bottom-color-rgb: var(--orange-3-rgb);
+  --border-bottom-color-alpha: 0.3;
+  --background-color: rgba(
+    var(--background-color-rgb),
+    var(--background-color-alpha)
+  );
+  --focus-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+  box-shadow: var(--focus-shadow);
+}
+.DocsMarkdown--link .DocsMarkdown--link-content {
+  background-color: var(--background-color);
+  border-bottom: 1px solid
+    rgba(var(--border-bottom-color-rgb), var(--border-bottom-color-alpha));
+}
+.DocsMarkdown--link-external-icon {
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+  margin-left: 4px;
+  opacity: 0.7;
+}
+.DocsMarkdown--link:focus .DocsMarkdown--link-external-icon {
+  opacity: 1;
+}
+@media (hover: hover) {
+  .DocsMarkdown--link:hover .DocsMarkdown--link-external-icon {
+    opacity: 1;
+  }
+}
+[js-focus-visible-polyfill-available] .DocsMarkdown--link:focus {
+  outline: none;
+}
+.DocsMarkdown--link[is-focus-visible] {
+  border-color: transparent;
+}
+.DocsMarkdown--link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+.DocsMarkdown--link:hover {
+  --background-color-alpha: 0.15;
+}
+.DocsMarkdown--link-content > code {
+  --padding: 0;
+  --background: transparent;
+}
+.DocsMarkdown--link[data-is-type-link="true"] .DocsMarkdown--link-content {
+  background: transparent;
+  border: none;
+}
+@media (min-width: 1025px) {
+  .DocsMarkdown--link[data-is-type-link="true"]
+    .DocsMarkdown--link-external-icon {
+    top: 1px;
+  }
+}
+.DocsMarkdown--link[data-is-type-link="true"]
+  .DocsMarkdown--link-content
+  > code {
+  --color-rgb: var(--orange-3-rgb);
+  --background: var(--background-color);
+}
+.DocsMarkdown code .DocsMarkdown--link[data-is-type-link="true"] {
+  margin-left: 0.5em;
+}
+[theme="dark"] .DocsMarkdown--link {
+  --background-color-alpha: 0.03;
+  --border-bottom-color-rgb: var(--orange-rgb);
+  --border-bottom-color-alpha: 0.35;
+  color: var(--code-orange);
+}
+[theme="dark"] .DocsMarkdown--link:hover {
+  --background-color-alpha: 0.08;
+}
+.DocsMarkdown strong {
+  font-weight: 600;
+}
+.DocsMarkdown ol ol,
+.DocsMarkdown ul ol {
+  list-style-type: lower-roman;
+}
+.DocsMarkdown ol ol ol,
+.DocsMarkdown ol ul ol,
+.DocsMarkdown ul ol ol,
+.DocsMarkdown ul ul ol {
+  list-style-type: lower-alpha;
+}
+.DocsMarkdown dd {
+  margin-left: 0;
+}
+.DocsMarkdown blockquote,
+.DocsMarkdown dl,
+.DocsMarkdown ol,
+.DocsMarkdown p,
+.DocsMarkdown ul {
+  margin-bottom: 1em;
+}
+.DocsMarkdown figure,
+.DocsMarkdown pre,
+.DocsMarkdown table {
+  margin-bottom: 2em;
+}
+.DocsMarkdown figure {
+  margin-top: 2em;
+}
+.DocsMarkdown li figure,
+.DocsMarkdown li pre,
+.DocsMarkdown li table {
+  margin-bottom: 1em;
+}
+.DocsMarkdown h1,
+.DocsMarkdown h2,
+.DocsMarkdown h3,
+.DocsMarkdown h4,
+.DocsMarkdown h5,
+.DocsMarkdown h6,
+p.DocsMarkdown--small-header {
+  font-weight: 600;
+}
+.DocsMarkdown h2,
+.DocsMarkdown h3,
+.DocsMarkdown h4,
+.DocsMarkdown h5,
+.DocsMarkdown h6,
+p.DocsMarkdown--small-header {
+  line-height: 1.25;
+  margin-bottom: 0.5em;
+}
+.DocsMarkdown h2 {
+  margin-top: 1.55em;
+}
+.DocsMarkdown h3,
+.DocsMarkdown h4,
+.DocsMarkdown h5,
+.DocsMarkdown h6 {
+  margin-top: 1.8em;
+}
+p.DocsMarkdown--small-header {
+  margin-top: 1.5em;
+  margin-bottom: 0.75em;
+}
+.DocsMarkdown h2 + h3,
+.DocsMarkdown h3 + h4,
+.DocsMarkdown h4 + h5,
+.DocsMarkdown h5 + h6 {
+  margin-top: 1em;
+}
+@media (min-width: 1440px) {
+  .DocsMarkdown h3,
+  .DocsMarkdown h4,
+  .DocsMarkdown h5,
+  .DocsMarkdown h6 {
+    margin-top: 2em;
+  }
+}
+.DocsMarkdown h1 {
+  font-size: 2.4em;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.375em;
+}
+@-moz-document url-prefix() {
+  .DocsMarkdown h1 {
+    letter-spacing: 0;
+  }
+}
+@media (max-width: 768px) {
+  .DocsMarkdown h1 {
+    font-size: 2.25em;
+  }
+}
+@media (max-width: 374px) {
+  .DocsMarkdown h1 {
+    font-size: 2em;
+  }
+}
+.DocsMarkdown h2 {
+  font-size: 1.6666em;
+}
+@media (max-width: 768px) {
+  .DocsMarkdown h2 {
+    font-size: 1.5em;
+  }
+}
+.DocsMarkdown h3 {
+  font-size: 1.25em;
+}
+.DocsMarkdown h4 {
+  font-size: 1em;
+}
+.DocsMarkdown h2 code,
+.DocsMarkdown h3 code,
+.DocsMarkdown h4 code,
+.DocsMarkdown h5 code {
+  --background: transparent;
+  --padding: 0;
+}
+.DocsMarkdown h2 code,
+.DocsMarkdown h3 code {
+  --inline-code-font-size: 0.9375em;
+}
+.DocsMarkdown h4 code,
+.DocsMarkdown h5 code {
+  --inline-code-font-size: 1em;
+}
+.DocsMarkdown h5,
+.DocsMarkdown h6,
+p.DocsMarkdown--small-header {
+  font-size: 0.875em;
+}
+.DocsMarkdown ul {
+  list-style: disc;
+}
+.DocsMarkdown ol,
+.DocsMarkdown ul {
+  padding-left: 1.25em;
+}
+.DocsMarkdown li {
+  margin-bottom: 0.5em;
+}
+.DocsMarkdown ol ol,
+.DocsMarkdown ol ul,
+.DocsMarkdown ul ol,
+.DocsMarkdown ul ul {
+  margin-bottom: 0.75em;
+}
+.DocsMarkdown li > p + ul {
+  margin-top: -0.5em;
+}
+.DocsMarkdown dl {
+  padding: 0;
+}
+.DocsMarkdown dl dt {
+  font-size: 1em;
+  font-style: normal;
+  font-weight: 400;
+  padding: 0;
+}
+.DocsMarkdown dl dd {
+  margin-bottom: 1.25em;
+  padding: 0.25em 0 0 2em;
+}
+.DocsMarkdown--definitions {
+  margin: 1.25em 0;
+}
+.DocsMarkdown h3 + .DocsMarkdown--definitions,
+.DocsMarkdown h4 + .DocsMarkdown--definitions {
+  margin-top: 1em;
+}
+.DocsMarkdown--definitions > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.DocsMarkdown--definitions ul li:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+.DocsMarkdown--definitions ul li > p:first-child {
+  margin: 0;
+}
+.DocsMarkdown--definitions ul li > code:first-child,
+.DocsMarkdown--definitions ul li > p:first-child > code:first-child {
+  display: inline-block;
+  vertical-align: middle;
+  font-weight: 600;
+  --padding: 0 0.3em;
+}
+.DocsMarkdown--definitions ul li > ul {
+  list-style: none;
+  padding-left: 2em;
+  margin-top: 0.25em;
+}
+.DocsMarkdown hr {
+  height: 1px;
+  border: 0;
+  border-bottom: 1px solid rgba(var(--color-rgb), 0.1);
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+.DocsMarkdown--prop-meta {
+  color: rgba(var(--color-rgb), 0.85);
+  font-size: 0.75em;
+  font-weight: 500;
+  padding: 0 2px;
+}
+code .DocsMarkdown--prop-meta {
+  font-family: var(--sans-serif-font-family);
+  font-size: 0.8125em;
+  margin-left: 0.4375em;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+}
+[theme="dark"] .DocsMarkdown blockquote,
+[theme="dark"] .DocsMarkdown dl,
+[theme="dark"] .DocsMarkdown ol,
+[theme="dark"] .DocsMarkdown p,
+[theme="dark"] .DocsMarkdown pre,
+[theme="dark"] .DocsMarkdown table,
+[theme="dark"] .DocsMarkdown ul {
+  color: var(--gray-7);
+}
+.DocsMarkdown > pre {
+  --outdent: 1rem;
+}
+[page-type="example"] .DocsMarkdown > pre {
+  --outdent: 0px;
+}
+@media (max-width: 768px) {
+  .DocsMarkdown > pre {
+    --border-radius: 0em;
+  }
+}
+.DocsMarkdown blockquote,
+.DocsMarkdown dl,
+.DocsMarkdown p,
+.DocsMarkdown table {
+  max-width: 100%;
+}
+.DocsMarkdown blockquote {
+  position: relative;
+  margin: 1.5em 0;
+}
+.DocsMarkdown blockquote > p {
+  font-style: italic;
+}
+.DocsMarkdown blockquote > p > em {
+  font-style: normal;
+}
+.DocsMarkdown blockquote cite {
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9em;
+}
+.DocsMarkdown blockquote cite:before {
+  content: "\2014   ";
+}
+.DocsMarkdown blockquote:after {
+  position: absolute;
+  content: "";
+  top: 1.5em;
+  bottom: 0;
+  left: -1rem;
+  width: 2px;
+  background: rgba(var(--color-rgb), 0.2);
+}
+@media (max-width: 768px) {
+  .DocsMarkdown blockquote {
+    margin-left: 1rem;
+  }
+}
+.DocsMarkdown blockquote:before {
+  quotes: "\201C""\201D";
+  content: open-quote;
+  position: absolute;
+  top: 0.05em;
+  left: -0.8em;
+  display: inline-block;
+  font-family: Arial;
+  font-weight: 700;
+  font-size: 2em;
+  line-height: 1;
+  height: 0.5em;
+  width: 0.7em;
+}
+.DocsMarkdown--aside {
+  font-size: 0.9em;
+  margin: 1.5em 0;
+  padding: 1em 1.3333em;
+  border-left: 0.28125em solid rgba(var(--color-rgb), 0.5);
+  background-color: rgba(var(--color-rgb), 0.125);
+  border-radius: 0 0.5em 0.5em 0;
+}
+.DocsMarkdown--aside-header {
+  font-weight: 600;
+  margin-bottom: 0.25em;
+}
+.DocsMarkdown--aside[data-type="warning"] {
+  border-left-color: rgba(var(--orange-5-rgb), 0.5);
+  background-color: rgba(var(--orange-5-rgb), 0.125);
+}
+[theme="dark"] .DocsMarkdown--aside[data-type="warning"] {
+  border-left-color: rgba(var(--orange-5-rgb), 0.7);
+  background-color: rgba(var(--orange-6-rgb), 0.04);
+}
+.DocsMarkdown--aside[data-type="note"] {
+  border-left-color: rgba(var(--blue-4-rgb), 0.4);
+  background-color: rgba(var(--blue-4-rgb), 0.1);
+}
+.DocsMarkdown--aside[data-type="note"] .DocsMarkdown--link {
+  --background-color-rgb: var(--blue-4-rgb);
+  --border-bottom-color-rgb: var(--blue-2-rgb);
+}
+[theme="dark"] .DocsMarkdown--aside[data-type="note"] {
+  border-left-color: rgba(var(--blue-4-rgb), 0.8);
+  background-color: rgba(var(--blue-6-rgb), 0.05);
+}
+[theme="dark"] .DocsMarkdown--aside[data-type="note"] .DocsMarkdown--link {
+  color: inherit;
+  --background-color-rgb: var(--blue-6-rgb);
+  --background-color-alpha: 0.1;
+  --border-bottom-color-rgb: var(--blue-7-rgb);
+}
+[theme="dark"]
+  .DocsMarkdown--aside[data-type="note"]
+  .DocsMarkdown--link:hover {
+  --background-color-alpha: 0.2;
+}
+.DocsMarkdown a[name]:not([href]):before,
+.DocsMarkdown h2[id]:before,
+.DocsMarkdown h3[id]:before,
+.DocsMarkdown h4[id]:before,
+.DocsMarkdown h5[id]:before,
+.DocsMarkdown h6[id]:before {
+  content: "";
+  display: block;
+  --offset: 2rem;
+  height: var(--offset);
+  margin-top: calc(var(--offset) * -1);
+  visibility: hidden;
+  pointer-events: none;
+}
+@media (max-width: 768px) {
+  .DocsMarkdown a[name]:not([href]):before,
+  .DocsMarkdown h2[id]:before,
+  .DocsMarkdown h3[id]:before,
+  .DocsMarkdown h4[id]:before,
+  .DocsMarkdown h5[id]:before,
+  .DocsMarkdown h6[id]:before {
+    --offset: calc(var(--docs-header-height) + 2rem);
+  }
+}
+.DocsMarkdown--header-anchor-positioner {
+  position: absolute;
+}
+blockquote .DocsMarkdown--header-anchor-positioner {
+  display: none;
+}
+.DocsMarkdown--header-anchor {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  height: 1.25em;
+  opacity: 0;
+  padding-right: 0.125em;
+  transition: opacity 0.15s, color 0.15s;
+}
+.DocsMarkdown--header-anchor:before {
+  content: "#";
+}
+@media (max-width: 768px) {
+  .DocsMarkdown--header-anchor {
+    margin-top: -0.125em;
+    padding-right: 0.0625em;
+  }
+  .DocsMarkdown--header-anchor:before {
+    font-size: 1.1rem;
+  }
+}
+.DocsMarkdown--header-anchor:focus,
+.DocsMarkdown h2:hover .DocsMarkdown--header-anchor,
+.DocsMarkdown h3:hover .DocsMarkdown--header-anchor,
+.DocsMarkdown h4:hover .DocsMarkdown--header-anchor {
+  opacity: 1;
+}
+.DocsMarkdown table {
+  word-break: break-word;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 0;
+  --border-color: rgba(var(--color-rgb), 0.1);
+}
+.DocsMarkdown th {
+  word-break: normal;
+  vertical-align: bottom;
+  font-weight: 700;
+  border-bottom: 2px solid var(--border-color);
+}
+.DocsMarkdown td,
+.DocsMarkdown th {
+  padding: 0.66em 1em;
+  text-align: left;
+}
+.DocsMarkdown td[align="right"],
+.DocsMarkdown th[align="right"] {
+  text-align: right;
+}
+.DocsMarkdown td:not([valign]) {
+  vertical-align: top;
+}
+.DocsMarkdown td:first-child,
+.DocsMarkdown th:first-child {
+  padding-left: 0;
+}
+.DocsMarkdown td:last-child,
+.DocsMarkdown th:last-child {
+  padding-right: 0;
+}
+.DocsMarkdown th {
+  padding-bottom: 0.1875em;
+}
+.DocsMarkdown tbody tr:not(:last-child) td {
+  border-bottom: 1px solid var(--border-color);
+}
+.DocsMarkdown details summary {
+  padding: 0 0.8em;
+  line-height: 2;
+  background: rgba(var(--color-rgb), 0.05);
+  border-radius: 0.25em;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+[js-focus-visible-polyfill-available] .DocsMarkdown details summary:focus {
+  outline: none;
+}
+.DocsMarkdown details summary:not([is-focus-visible]) {
+  --focus-size: 0em;
+}
+.DocsMarkdown details {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+.DocsMarkdown details summary + div {
+  padding: 1em 1.9em;
+  border: 1px solid rgba(var(--color-rgb), 0.1);
+  border-top: 0;
+  border-bottom-left-radius: 0.25em;
+  border-bottom-right-radius: 0.25em;
+}
+.DocsMarkdown details[open] {
+  margin-bottom: 1.5em;
+}
+.DocsMarkdown details[open] summary {
+  background: rgba(var(--color-rgb), 0.1);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.DocsMarkdown sub {
+  top: 0.35em;
+}
+.DocsMarkdown sub,
+.DocsMarkdown sup {
+  font-size: 0.8em;
+  vertical-align: baseline;
+  position: relative;
+}
+.DocsMarkdown sup {
+  top: -0.35em;
+}
+.DocsMarkdown var {
+  font-style: italic;
+}
+.DocsMarkdown kbd {
+  font-family: inherit;
+  font-size: 0.9em;
+  padding: 0.3em 0.4em;
+  background: rgba(var(--color-rgb), 0.025);
+  box-shadow: inset 0 0 0 1px rgba(var(--color-rgb), 0.2),
+    inset 0 -1px rgba(var(--color-rgb), 0.25), 0 1px rgba(var(--color-rgb), 0.4);
+  border-radius: 0.25em;
+}
+[theme="dark"] .DocsMarkdown kbd {
+  background: rgba(var(--orange-rgb), 0.1);
+  box-shadow: inset 0 0 0 1px rgba(var(--orange-rgb), 0.5);
+  border-radius: 0.4em;
+}
+.DocsMarkdown--demo {
+  position: relative;
+}
+.DocsMarkdown--demo:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+.DocsMarkdown--demo:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  box-shadow: inset 0 0 0 1px rgba(var(--color-rgb), 0.15);
+  pointer-events: none;
+}
+.DocsMarkdown--demo iframe {
+  background: #fff;
+  height: 100%;
+  width: 100%;
+}
+.DocsMarkdown figure[data-type="youtube"] {
+  background: #000;
+}
+.DocsMarkdown--table-wrap {
+  --table-border-width: 1px;
+  border: var(--table-border-width) solid rgba(var(--color-rgb), 0.15);
+  padding: 0.25em 0;
+  border-radius: 0.3125em;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.DocsMarkdown--table-wrap:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+.DocsMarkdown--table-wrap-inner {
+  display: flex;
+}
+.DocsMarkdown--table-wrap table {
+  min-width: calc(
+    var(--docs-body-width) - var(--docs-content-gap) * 2 -
+      var(--table-border-width) * 2
+  );
+  margin: 0;
+}
+@media (max-width: 768px) {
+  .DocsMarkdown--table-wrap table {
+    min-width: calc(
+      100vw - var(--docs-content-horizontal-padding) * 2 -
+        var(--table-border-width) * 2
+    );
+  }
+}
+.DocsMarkdown--table-wrap table {
+  word-break: normal;
+}
+@media (hover: hover) {
+  .DocsMarkdown--table-wrap:hover {
+    width: calc(100% + var(--docs-body-sidebar-width));
+  }
+  .DocsMarkdown--table-wrap:hover table {
+    background-color: var(--background-color);
+    z-index: 1;
+  }
+}
+.DocsMarkdown--table-wrap tr > :first-child {
+  position: -webkit-sticky;
+  position: sticky;
+  left: 0;
+  white-space: nowrap;
+  padding-left: 1em;
+  background: var(--background-color);
+  box-shadow: 5px 0 5px -3px var(--background-color);
+}
+.DocsMarkdown--table-wrap tr > :last-child {
+  padding-right: 1em;
+}
+.DocsMarkdown--content-column {
+  width: calc(100% - var(--docs-body-sidebar-width));
+}
+.DocsMarkdown--content-column:not(:last-child) {
+  margin-bottom: 1em;
+}
+.DocsMarkdown--button-group-content {
+  display: flex;
+  flex-wrap: wrap;
+  margin: -0.375em;
+}
+.DocsMarkdown--button-group-content > a,
+.DocsMarkdown--button-group-content > button {
+  margin: 0.375em;
+}
+.DocsMarkdown--example {
+  padding: 1em 1.25em;
+  margin: -0.5em auto 1.25em;
+  border: 1px solid rgba(var(--color-rgb), 0.1);
+  border-radius: 0.125em;
+}
+.DocsMarkdown--example hr {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+.DocsMarkdown--aside > :first-child,
+.DocsMarkdown--content-column > :first-child,
+.DocsMarkdown--example > :first-child,
+.DocsMarkdown > :first-child,
+.DocsMarkdown blockquote > :first-child,
+.DocsMarkdown details > :first-child,
+.DocsMarkdown details summary + div > :first-child,
+.DocsMarkdown li > :first-child,
+.DocsMarkdown ol > :first-child,
+.DocsMarkdown ul > :first-child {
+  margin-top: 0;
+}
+.DocsMarkdown--aside > :last-child,
+.DocsMarkdown--content-column > :last-child,
+.DocsMarkdown--example > :last-child,
+.DocsMarkdown > :last-child,
+.DocsMarkdown blockquote > :last-child,
+.DocsMarkdown details > :last-child,
+.DocsMarkdown details summary + div > :last-child,
+.DocsMarkdown li > :not(ul):not(ol):not(pre):not(figure):not(table):last-child,
+.DocsMarkdown ol > :last-child,
+.DocsMarkdown ul > :last-child {
+  margin-bottom: 0;
+}
+.DocsToolbar {
+  position: absolute;
+  left: var(--docs-sidebar-width);
+  top: 0;
+  right: 0;
+  display: flex;
+  height: var(--docs-header-height);
+  z-index: 2;
+}
+.DocsToolbar--search {
+  flex: 1 1;
+  max-width: var(--docs-body-width);
+  margin-right: auto;
+}
+[search-disabled] .DocsToolbar--search {
+  visibility: hidden;
+}
+.DocsToolbar--feedback {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+.DocsToolbar--feedback svg {
+  width: 1em;
+  margin-right: 0.5em;
+  height: 1em;
+}
+.DocsToolbar--tools {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 var(--docs-page-side-padding);
+}
+.DocsToolbar--tools-spacer {
+  display: inline-flex;
+  height: 1em;
+  width: 1em;
+}
+.DocsToolbar--tools-icon-item {
+  display: inline-flex;
+  height: 1.647058823rem;
+  width: 1.647058823rem;
+  color: rgba(var(--color-rgb), 0.7);
+}
+[theme="light"] .DocsToolbar--tools-icon-item {
+  color: var(--gray-3);
+}
+.DocsToolbar--tools-icon-item-content > a {
+  display: block;
+  height: 100%;
+  width: 100%;
+  padding: 0.1em;
+}
+@media (max-width: 768px) {
+  .DocsToolbar {
+    left: 0;
+    z-index: 12;
+    pointer-events: none;
+  }
+  .DocsToolbar--tools {
+    pointer-events: all;
+    padding-left: 0;
+    padding-right: 0.9rem;
+  }
+  .DocsToolbar--search {
+    flex-basis: 3em;
+    flex-grow: 0;
+    margin-left: auto;
+    margin-right: 0;
+    max-width: 100vw;
+  }
+  .DocsToolbar--feedback,
+  .DocsToolbar--tools-icon-item,
+  .DocsToolbar--tools-spacer {
+    display: none;
+  }
+}
+.DocsSearch {
+  --text-indent: calc(var(--docs-content-gap) + 1px);
+  height: var(--docs-header-height);
+}
+.DocsSearch--input,
+.DocsSearch--input-wrapper {
+  position: relative;
+  height: 100%;
+}
+.DocsSearch--input {
+  color: inherit;
+  width: 100%;
+  border: 0;
+  padding: 0 var(--text-indent) 0.05em;
+  background: transparent;
+  outline: none;
+  z-index: 2;
+}
+@-moz-document url-prefix() {
+  .DocsSearch--input {
+    letter-spacing: 0;
+  }
+}
+.DocsSearch--input::-webkit-input-placeholder {
+  color: rgba(var(--color-rgb), 0.45);
+  opacity: 1;
+}
+.DocsSearch--input:-ms-input-placeholder {
+  color: rgba(var(--color-rgb), 0.45);
+  opacity: 1;
+}
+.DocsSearch--input::placeholder {
+  color: rgba(var(--color-rgb), 0.45);
+  opacity: 1;
+}
+[theme="dark"] .DocsSearch--input::-webkit-input-placeholder {
+  color: rgba(var(--color-rgb), 0.55);
+}
+[theme="dark"] .DocsSearch--input:-ms-input-placeholder {
+  color: rgba(var(--color-rgb), 0.55);
+}
+[theme="dark"] .DocsSearch--input::placeholder {
+  color: rgba(var(--color-rgb), 0.55);
+}
+.DocsSearch--input-icon {
+  position: absolute;
+  top: 0;
+  bottom: 0.05em;
+  margin-top: auto;
+  margin-bottom: auto;
+  left: 2.2em;
+  height: 0.8823529411em;
+  width: 0.8823529411em;
+  pointer-events: none;
+  opacity: 0.5;
+  transition: color 0.3s ease, opacity 0.3s ease;
+  z-index: 3;
+}
+.DocsSearch--input-wrapper:focus-within .DocsSearch--input-icon {
+  color: var(--orange);
+  opacity: 1;
+}
+.DocsSearch--input-bottom-border {
+  position: absolute;
+  left: 0;
+  width: 50%;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--color-rgb), 0.07) 0,
+    rgba(var(--color-rgb), 0.07) calc(100% - 6em),
+    rgba(var(--color-rgb), 0)
+  );
+}
+[theme="dark"] .DocsSearch--input {
+  background: linear-gradient(
+    90deg,
+    rgba(var(--shadow-color-rgb), 0.1) 0,
+    rgba(var(--shadow-color-rgb), 0.1) calc(30% - 6em),
+    rgba(var(--shadow-color-rgb), 0) 30%
+  );
+}
+[theme="dark"] .DocsSearch--input-bottom-border {
+  bottom: -1px;
+}
+[theme="dark"] .DocsSearch--input-bottom-border:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -1px;
+  width: 100%;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--shadow-color-rgb), 0.5) 0,
+    rgba(var(--shadow-color-rgb), 0.5) calc(100% - 6em),
+    rgba(var(--shadow-color-rgb), 0)
+  );
+}
+.DocsSearch .algolia-autocomplete {
+  --dropdown-text-indent: var(--text-indent);
+  --suggestion-item-vertical-padding: 0.5em;
+  display: block !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: auto !important;
+  width: var(--docs-body-width) !important;
+  z-index: 1 !important;
+  background: var(--background-color);
+  --box-shadow: 0 3rem 6rem -1.2rem rgba(var(--shadow-color-rgb), 0.25),
+    0 3rem 6rem -3rem rgba(var(--shadow-color-rgb), 0.3);
+  --backdrop-box-shadow-alpha: 0.07;
+  --backdrop-box-shadow: 0 0 0 999em
+    rgba(var(--shadow-color-rgb), var(--backdrop-box-shadow-alpha));
+  box-shadow: var(--box-shadow), var(--backdrop-box-shadow);
+  border-radius: 0 0 0.5em 0.5em;
+  will-change: opacity;
+  transition: opacity 0.15s ease;
+}
+[theme="dark"] .DocsSearch .algolia-autocomplete {
+  --dark-theme-shadow-offset: 1px;
+  --dropdown-text-indent: calc(
+    var(--text-indent) - var(--dark-theme-shadow-offset)
+  );
+  --box-shadow: 0 0 0 1px rgb(var(--shadow-color-rgb), 0.3),
+    0 0.3em 2em rgb(var(--shadow-color-rgb), 0.3);
+  --backdrop-box-shadow-alpha: 0.3;
+  background: var(--gray-0);
+  margin-left: var(--dark-theme-shadow-offset);
+}
+.DocsSearch .algolia-autocomplete:not([data-expanded="true"]),
+.DocsSearch .algolia-autocomplete[style*="display: none"] {
+  opacity: 0;
+  --backdrop-box-shadow: none;
+  pointer-events: none;
+}
+@supports (
+  (-webkit-backdrop-filter: blur(1em)) or (backdrop-filter: blur(1em))
+) {
+  .DocsSearch .algolia-autocomplete {
+    background: rgba(var(--background-color-rgb), 0.8);
+    -webkit-backdrop-filter: saturate(200%) blur(1.25em);
+    backdrop-filter: saturate(200%) blur(1.25em);
+  }
+  [theme="dark"] .DocsSearch .algolia-autocomplete {
+    background: rgba(var(--gray-0-rgb), 0.8);
+  }
+  @media not all and (min-resolution: 0.001dpcm) {
+    @media {
+      .DocsSearch .algolia-autocomplete {
+        background: rgba(var(--background-color-rgb), 1);
+      }
+    }
+  }
+}
+.DocsSearch .algolia-autocomplete [class|="ds-dataset"] > :first-child {
+  position: relative;
+  --padding-top: calc(var(--docs-header-height) + 0.66rem);
+  padding: var(--padding-top) var(--dropdown-text-indent) 0;
+}
+.DocsSearch .algolia-autocomplete [class|="ds-dataset"] > :first-child:before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: var(--docs-header-height);
+  margin-top: -1px;
+  height: 1px;
+  background: rgba(var(--color-rgb), 0.07);
+}
+[theme="dark"]
+  .DocsSearch
+  .algolia-autocomplete
+  [class|="ds-dataset"]
+  > :first-child:before {
+  margin-top: 0;
+  background: rgba(var(--color-rgb), 0.07);
+  box-shadow: 0 -1px rgba(var(--shadow-color-rgb), 0.2),
+    0 calc(var(--docs-header-height) * -1) rgba(var(--shadow-color-rgb), 0.1);
+}
+.DocsSearch .ds-suggestion {
+  display: block;
+  --horizontal-padding: 1em;
+  padding: var(--suggestion-item-vertical-padding) var(--horizontal-padding);
+  margin: 0 calc(var(--horizontal-padding) * -1);
+  border-radius: 0.25em;
+}
+.DocsSearch .ds-suggestion.ds-cursor {
+  background: rgba(var(--gray-5-rgb), 0.2);
+}
+[theme="dark"] .DocsSearch .ds-suggestion.ds-cursor {
+  background: rgba(var(--gray-6-rgb), 0.15);
+}
+.DocsSearch a.algolia-docsearch-suggestion {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+.DocsSearch .algolia-docsearch-suggestion--text {
+  font-size: 0.9em;
+  color: rgba(var(--color-rgb), 0.8);
+}
+.DocsSearch .algolia-docsearch-suggestion--highlight {
+  --highlight-opacity: 0.2;
+  background-color: rgba(var(--orange-rgb), var(--highlight-opacity));
+  color: var(--color);
+}
+[theme="dark"] .DocsSearch .algolia-docsearch-suggestion--highlight {
+  --highlight-opacity: 0.4;
+}
+.DocsSearch .algolia-docsearch-suggestion--no-results {
+  padding-top: var(--suggestion-item-vertical-padding);
+  margin-bottom: 1em;
+}
+.DocsSearch
+  .algolia-docsearch-suggestion--no-results
+  .algolia-docsearch-suggestion--text {
+  padding-top: var(--suggestion-item-vertical-padding);
+  font-size: 1em;
+}
+.DocsSearch .algolia-docsearch-suggestion--no-results b {
+  font-weight: inherit;
+}
+.DocsSearch .algolia-docsearch-footer {
+  margin-top: 0.5rem;
+  padding: 0 var(--dropdown-text-indent) 2rem;
+  font-size: 0.7em;
+  opacity: 0.5;
+}
+.DocsSearch .algolia-docsearch-footer--logo {
+  color: inherit;
+}
+.DocsSearch .algolia-docsearch-suggestion--category-header-lvl0:empty:before {
+  content: "Document";
+}
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--subcategory-column,
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--subcategory-inline,
+.DocsSearch
+  .algolia-docsearch-suggestion__main
+  .algolia-docsearch-suggestion--subcategory-column,
+.DocsSearch
+  .algolia-docsearch-suggestion__main
+  .algolia-docsearch-suggestion--subcategory-inline,
+.DocsSearch
+  .algolia-docsearch-suggestion__main
+  .algolia-docsearch-suggestion--title {
+  display: none;
+}
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--category-header,
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--content,
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--title,
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--wrapper {
+  display: inline;
+}
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--content:not(.algolia-docsearch-suggestion--no-results):before {
+  content: "\203A";
+  opacity: 0.15;
+  padding: 0 0.333em;
+  display: inline-block;
+  -webkit-transform: scale3d(1.5, 1.2, 1);
+  transform: scale3d(1.5, 1.2, 1);
+}
+.DocsSearch
+  .algolia-docsearch-suggestion:not(.algolia-docsearch-suggestion__main)
+  .algolia-docsearch-suggestion--content:not(.algolia-docsearch-suggestion--no-results)
+  .algolia-docsearch-suggestion--title:before {
+  content: "#";
+  padding-right: 0.25em;
+  opacity: 0.5;
+}
+@media (max-width: 768px) {
+  .DocsSearch {
+    pointer-events: all;
+  }
+  .DocsSearch--input:not(:focus) {
+    padding: 0;
+    opacity: 0;
+  }
+  .DocsSearch[is-focused] {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    --text-indent: 3rem;
+    z-index: 2;
+  }
+  .DocsSearch--input-icon {
+    left: 15px;
+    height: 15px;
+    width: 15px;
+  }
+  .DocsSearch--input-wrapper:focus-within .DocsSearch--input-icon {
+    left: 19px;
+  }
+  .DocsSearch[is-focused] .DocsSearch--input-wrapper {
+    background: var(--background-color);
+    height: var(--docs-header-height);
+  }
+  .DocsSearch--input-bottom-border {
+    display: none;
+  }
+  .DocsSearch .algolia-autocomplete {
+    position: fixed;
+    top: var(--docs-header-height);
+    width: 100% !important;
+  }
+  @supports (
+    (-webkit-backdrop-filter: blur(1em)) or (backdrop-filter: blur(1em))
+  ) {
+    .DocsSearch .algolia-autocomplete {
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+    .DocsSearch .algolia-autocomplete,
+    [theme="dark"] .DocsSearch .algolia-autocomplete {
+      background: var(--background-color);
+    }
+  }
+}
+.DocsMobileHeader {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--docs-header-height);
+  background: var(--background-color);
+  box-shadow: 0 1px rgba(var(--color-rgb), 0.05);
+  z-index: 11;
+  --content-indent: 0.666em;
+}
+[theme="dark"] .DocsMobileHeader {
+  background: var(--gray-05);
+}
+@media (min-width: 769px) {
+  .DocsMobileHeader {
+    display: none;
+  }
+}
+.DocsMobileHeader--cloudflare-logo-link {
+  --font-size: 1.1em;
+  display: flex;
+  align-items: center;
+  padding-left: var(--content-indent);
+  padding-right: var(--content-indent);
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+@media (hover: hover) {
+  .DocsMobileHeader--cloudflare-logo-link:hover {
+    opacity: 0.75;
+    color: rgba(var(--color-rgb), 0.75);
+  }
+}
+@media (hover: none) {
+  .DocsMobileHeader--cloudflare-logo-link:active {
+    opacity: 0.75;
+    color: rgba(var(--color-rgb), 0.75);
+  }
+}
+.DocsMobileTitleHeader {
+  position: -webkit-sticky;
+  position: sticky;
+  display: flex;
+  align-items: center;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding-right: 0.5rem;
+  height: var(--docs-header-height);
+  background: var(--background-color);
+  box-shadow: 0 1px rgba(var(--shadow-color-rgb), 0.075),
+    0 0.2em 0.3em -0.1em rgba(var(--shadow-color-rgb), 0.075);
+  z-index: 10;
+  --content-indent: 0.666em;
+}
+[theme="dark"] .DocsMobileTitleHeader {
+  background: var(--gray-05);
+}
+@media (min-width: 769px) {
+  .DocsMobileTitleHeader {
+    display: none;
+  }
+}
+.DocsMobileTitleHeader--logo-link {
+  --font-size: 1.333em;
+  display: flex;
+  align-items: center;
+  padding-left: var(--content-indent);
+  padding-right: var(--content-indent);
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+@media (hover: hover) {
+  .DocsMobileTitleHeader--logo-link:hover {
+    opacity: 0.75;
+    color: rgba(var(--color-rgb), 0.75);
+  }
+}
+@media (hover: none) {
+  .DocsMobileTitleHeader--logo-link:active {
+    opacity: 0.75;
+    color: rgba(var(--color-rgb), 0.75);
+  }
+}
+.DocsMobileTitleHeader--text-scaler {
+  --font-size: 1em * (1 - ((var(--length) - 10)/50));
+  font-size: clamp(0.7em, var(--font-size), 1em);
+  display: inherit;
+}
+.DocsMobileTitleHeader--sidebar-toggle-button {
+  width: 40px;
+  height: 40px;
+  margin-left: auto;
+  padding: 0;
+}
+.DocsMobileTitleHeader--sidebar-toggle-button path {
+  transition: opacity 0.3s ease, -webkit-transform 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease,
+    -webkit-transform 0.3s ease;
+}
+[is-mobile-sidebar-open]
+  .DocsMobileTitleHeader--sidebar-toggle-button
+  path[data-index="1"] {
+  -webkit-transform: translateY(15%) rotate(45deg);
+  transform: translateY(15%) rotate(45deg);
+}
+[is-mobile-sidebar-open]
+  .DocsMobileTitleHeader--sidebar-toggle-button
+  path[data-index="2"] {
+  opacity: 0;
+}
+[is-mobile-sidebar-open]
+  .DocsMobileTitleHeader--sidebar-toggle-button
+  path[data-index="3"] {
+  -webkit-transform: translateY(-15%) rotate(-45deg);
+  transform: translateY(-15%) rotate(-45deg);
+}
+.DocsMobileNavBackdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  background: rgba(var(--shadow-color-rgb), 0.5);
+  will-change: opacity;
+  transition: opacity 0.3s ease;
+  z-index: 8;
+}
+@media (min-width: 769px) {
+  .DocsMobileNavBackdrop {
+    display: none;
+  }
+}
+[is-mobile-sidebar-open] .DocsMobileNavBackdrop {
+  opacity: 1;
+  pointer-events: all;
+}
+.DocsFooter {
+  margin-left: var(--docs-sidebar-width);
+  padding: 3.5rem 0;
+  padding-left: var(--docs-content-gap);
+  padding-right: calc(var(--docs-body-sidebar-width) + var(--docs-content-gap));
+  --border-color: rgba(var(--color-rgb), 0.08);
+  border-top: 1px solid var(--border-color);
+}
+@media (max-width: 768px) {
+  .DocsFooter {
+    margin-left: 0;
+    padding: 2rem 1rem 4rem;
+  }
+}
+.DocsFooter--content {
+  display: flex;
+}
+@media (max-width: 414px) {
+  .DocsFooter--edit-on-gh-link-wrapper {
+    display: block;
+    margin-bottom: 0.5em;
+  }
+  .DocsFooter--content-dot-spacer {
+    display: none;
+  }
+}
+.DocsCodeExamplesOverview {
+  margin: 2.5rem 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-gap: var(--docs-content-gap);
+}
+.DocsCodeExamplesOverview--example {
+  border-radius: 0.5em;
+}
+.DocsCodeExamplesOverview--example-title {
+  font-size: 1.5em;
+  line-height: 1.2;
+  font-weight: 500;
+  margin-bottom: 0.5em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.DocsCodeExamplesOverview--example-title .Link {
+  color: inherit;
+  --underline-opacity: 0.75;
+  text-decoration: underline;
+  -webkit-text-decoration-color: rgba(
+    var(--orange-rgb),
+    var(--underline-opacity)
+  );
+  text-decoration-color: rgba(var(--orange-rgb), var(--underline-opacity));
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+.DocsCodeExamplesOverview--example-description {
+  margin-bottom: 1em;
+}
+@media (min-width: 1153px) {
+  .DocsCodeExamplesOverview--example-description {
+    --lines: 2;
+    display: -webkit-box;
+    -webkit-line-clamp: var(--lines);
+    -webkit-box-orient: vertical;
+    height: calc(1em * var(--lines) * var(--line-height));
+    overflow: hidden;
+  }
+}
+.DocsCodeExamplesOverview--example-description > :last-child {
+  margin-bottom: 0;
+}
+.DocsCodeExamplesOverview--example-codeblock-link {
+  display: block;
+  position: relative;
+  color: inherit;
+}
+.DocsCodeExamplesOverview--example-codeblock-link:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  --active-box-shadow-color: transparent;
+  box-shadow: inset 0 0.0625em 0.1875em var(--active-box-shadow-color);
+  border-radius: 0.5em;
+}
+@media (hover: hover) {
+  .DocsCodeExamplesOverview--example-codeblock-link:hover:not(:active):after {
+    background: hsla(0, 0%, 100%, 0.2);
+  }
+  [theme="dark"]
+    .DocsCodeExamplesOverview--example-codeblock-link:hover:not(:active):after {
+    background: rgba(var(--color-rgb), 0.05);
+  }
+}
+.DocsCodeExamplesOverview--example-codeblock-link:active:after {
+  background: rgba(var(--shadow-color-rgb), 0.05);
+  --active-box-shadow-color: rgba(var(--shadow-color-rgb), 0.2);
+}
+.DocsCodeExamplesOverview--example-codeblock-link pre {
+  height: 19em;
+  margin-bottom: 0;
+  pointer-events: none;
+}
+.DocsCodeExamplesOverview--example-codeblock-link pre,
+.DocsCodeExamplesOverview--example-codeblock-link pre code {
+  overflow: hidden;
+}
+@media (max-width: 1152px) {
+  .DocsCodeExamplesOverview {
+    margin-left: 0;
+    margin-right: 0;
+    grid-template-columns: 100%;
+  }
+}
+@media (max-width: 768px) {
+  .DocsCodeExamplesOverview--example-title {
+    font-size: 1.375em;
+    margin-bottom: 0.5rem;
+  }
+  .DocsCodeExamplesOverview--example-codeblock-link {
+    margin-left: -1rem;
+    width: calc(100% + 2rem);
+  }
+  .DocsCodeExamplesOverview--example-codeblock-link:after {
+    border-radius: 0;
+  }
+  .DocsCodeExamplesOverview--example-codeblock-link pre {
+    height: 12.2em;
+    --border-radius: 0em;
+  }
+}
+.DocsTutorials {
+  margin: 2em 0;
+  width: 53em;
+  max-width: 100%;
+}
+[theme="dark"] .DocsTutorials {
+  color: var(--gray-7);
+}
+.DocsTutorials--row {
+  display: flex;
+  align-items: baseline;
+  --gap: 1.5em;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid rgba(var(--color-rgb), 0.1);
+  margin-bottom: 0.5em;
+}
+.DocsTutorials--body .DocsTutorials--row:last-child {
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+.DocsTutorials--header .DocsTutorials--column-text {
+  font-size: 0.9em;
+  font-weight: 700;
+}
+.DocsTutorials--header .DocsTutorials--row {
+  border-bottom-width: 0.125em;
+  padding-bottom: 0.1875em;
+}
+.DocsTutorials--body .DocsTutorials--column:not([data-column="name"]) {
+  position: relative;
+  top: -0.1em;
+}
+.DocsTutorials--body .DocsTutorials--column[data-column="length"] {
+  top: -0.2em;
+}
+.DocsTutorials--column[data-column="name"] {
+  flex: 1 1;
+  padding-right: calc(var(--gap) / 2);
+}
+.DocsTutorials--link {
+  position: relative;
+  font-size: 1.2em;
+  color: inherit;
+  --underline-opacity: 0.75;
+  -webkit-text-decoration-color: rgba(
+    var(--orange-rgb),
+    var(--underline-opacity)
+  );
+  text-decoration-color: rgba(var(--orange-rgb), var(--underline-opacity));
+  box-shadow: 0 0 0 var(--focus-size) var(--focus-color);
+}
+[theme="dark"] .DocsTutorials--link {
+  --underline-opacity: 0.5;
+}
+.DocsTutorials--row-is-new .DocsTutorials--link:after {
+  content: "";
+  position: absolute;
+  top: 0.45em;
+  right: 100%;
+  margin-right: 0.625em;
+  height: 8px;
+  width: 8px;
+  border-radius: 999em;
+  background: var(--orange);
+}
+@media (max-width: 1280px) {
+  .DocsTutorials--link {
+    text-decoration: none;
+    box-shadow: inset 0 -2px rgba(var(--orange-rgb), var(--underline-opacity));
+  }
+  .DocsTutorials--row-is-new .DocsTutorials--link:after {
+    top: 0.375em;
+  }
+}
+@media (max-width: 768px) {
+  .DocsTutorials--link {
+    font-size: 1.1em;
+  }
+  .DocsTutorials--row-is-new .DocsTutorials--link:after {
+    display: none;
+  }
+}
+@media (max-width: 414px) {
+  .DocsTutorials--link {
+    font-size: 1em;
+  }
+  .DocsTutorials--ago-text {
+    display: none;
+  }
+}
+[js-focus-visible-polyfill-available] .DocsTutorials--link:focus {
+  outline: none;
+}
+.DocsTutorials--link[is-focus-visible] {
+  --underline-size: 0;
+}
+.DocsTutorials--link:not([is-focus-visible]) {
+  --focus-size: 0;
+}
+.DocsTutorials--column[data-column="difficulty"],
+.DocsTutorials--column[data-column="updated"] {
+  padding-left: calc(var(--gap) / 2);
+  padding-right: calc(var(--gap) / 2);
+}
+.DocsTutorials--column[data-column="difficulty"] {
+  width: 7.5em;
+  flex-shrink: 0;
+}
+.DocsTutorials--column[data-column="length"] {
+  width: 4.5em;
+  padding-left: calc(var(--gap) / 2);
+  flex-shrink: 0;
+}
+.DocsTutorials--length-bar {
+  width: 100%;
+  height: 0.5em;
+  border-radius: 1em;
+  background: rgba(var(--color-rgb), 0.1);
+  overflow: hidden;
+}
+.DocsTutorials--length-bar-inner {
+  background: rgba(var(--color-rgb), 0.5);
+  border-radius: 1em;
+  min-width: 0.6em;
+  height: 100%;
+}
+@media (max-width: 1024px) {
+  .DocsTutorials--column[data-column="updated"] {
+    padding-right: 0;
+  }
+  .DocsTutorials--column[data-column="difficulty"],
+  .DocsTutorials--column[data-column="length"] {
+    display: none;
+  }
+}
+[theme="dark"] .DocsMarkdown td > a {
+  color: var(--orange);
+}
+
+[theme="light"] .DocsMarkdown td > a {
+  color: var(--orange);
+}


### PR DESCRIPTION
This Pr 

1. Removes the hover effect we have on tables in the doc. 
2. Fixes link color in dark mode

Links have very low contrast in a dark mood. This PR fixes that.
![Screenshot 2022-03-03 at 12 35 42](https://user-images.githubusercontent.com/35943047/156565999-190eacc8-095f-44bf-b9f7-864431413b00.png)
![Screenshot 2022-03-03 at 12 35 32](https://user-images.githubusercontent.com/35943047/156566023-c6711cca-a4be-4721-9f97-c8b057b1576d.png)

