### PR TITLE
[Bots] Fix broken link in free.md

### DIFF
--- a/content/bots/get-started/free.md
+++ b/content/bots/get-started/free.md
@@ -12,7 +12,7 @@ Bot Fight Mode is a simple, free product that helps detect and mitigate bot traf
 
 - Identifies traffic matching patterns of known bots
 - Issues computationally expensive challenges in response to these bots
-- Notifies [Bandwidth Alliance](https://support.cloudflare.com/hc/articles/360016143912) partners (if applicable) to disable bots
+- Notifies [Bandwidth Alliance](https://www.cloudflare.com/bandwidth-alliance/) partners (if applicable) to disable bots
 
 ## Enable Bot Fight Mode
 

--- a/content/bots/get-started/free.md
+++ b/content/bots/get-started/free.md
@@ -12,7 +12,7 @@ Bot Fight Mode is a simple, free product that helps detect and mitigate bot traf
 
 - Identifies traffic matching patterns of known bots
 - Issues computationally expensive challenges in response to these bots
-- Notifies [Bandwidth Alliance](https://www.cloudflare.com/bandwidth-alliance/) partners (if applicable) to disable bots
+- Notifies [Bandwidth Alliance](https://cloudflare.com/bandwidth-alliance/) partners (if applicable) to disable bots
 
 ## Enable Bot Fight Mode
 


### PR DESCRIPTION
Bandwidth Alliance link on the [bots/get-started/free.md](https://developers.cloudflare.com/bots/get-started/free/) site was broken