### PR TITLE
[Documentation] Fix "wget" URL on "Run as a service on Linux" page

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/linux.md
+++ b/content/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/linux.md
@@ -24,8 +24,8 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
 Open a terminal window and run the following command to install the latest version of `cloudflared`:
 
 ```sh
-$ wget https://github.com/cloudflare/cloudflared/releases/download/latest/cloudflared-linux-amd64
-mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared
+$ wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+sudo mv ./cloudflared-linux-amd64 /usr/local/bin/cloudflared
 chmod a+x /usr/local/bin/cloudflared
 cloudflared update
 ```


### PR DESCRIPTION
- Fix URL in `wget` command
- Also specified using `sudo` on the `mv` command as typical users do not have access to move items into `/usr/local/bin`