### PR TITLE
[1.1.1.1] fix instuctions to contain ipv6 for windows 11

### DIFF
--- a/content/1.1.1.1/setup/windows.md
+++ b/content/1.1.1.1/setup/windows.md
@@ -36,7 +36,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 6. Click the **IPv4** toggle to turn it on.
 7. {{<render file="_all-ipv4.md">}}
 8. Click the **IPv6** toggle.
-9. {{<render file="_all-ipv4.md">}}
+9. {{<render file="_all-ipv6.md">}}
 10. Click **Save**.
 
 {{<render file="_captive-portals.md">}}


### PR DESCRIPTION
ipv4 is used twice for widows 11 instuctions, this is incorrect 