### PR TITLE
Add note about why we cannot list specific page rules disabled on Wor…

### DIFF
--- a/content/workers/platform/workers-with-page-rules.md
+++ b/content/workers/platform/workers-with-page-rules.md
@@ -20,6 +20,12 @@ When using Page Rules with Workers, the following workflow is applied.
 4.  Page Rules run as part of normal request processing with some features now disabled.
 5.  Worker executes.
 
+{{<Aside type="note" header="Listing specific page rules">}}
+
+A complete list of features which can be configured "before" versus "after" Workers would be difficult to generate, because they are defined implicitly by the features which we disallow. In general, security-related features run "before" Workers, while most others run "after"
+
+{{</Aside>}}
+
 If you are experiencing Page Rule errors when running Workers, contact your Cloudflare account team or [Cloudflare Support](https://support.cloudflare.com/hc/en-us/articles/200172476-Contacting-Cloudflare-Support).
 
 ## Email Obfuscation

--- a/content/workers/platform/workers-with-page-rules.md
+++ b/content/workers/platform/workers-with-page-rules.md
@@ -22,7 +22,7 @@ When using Page Rules with Workers, the following workflow is applied.
 
 {{<Aside type="note" header="Listing specific Page Rules">}}
 
-A complete list of features which can be configured "before" versus "after" Workers would be difficult to generate, because they are defined implicitly by the features which we disallow. In general, security-related features run "before" Workers, while most others run "after"
+A complete list of features which can be configured before and after Workers would be difficult to generate, because they are defined implicitly by the features which we disallow. In general, security-related features run before Workers, while most others run after.
 
 {{</Aside>}}
 

--- a/content/workers/platform/workers-with-page-rules.md
+++ b/content/workers/platform/workers-with-page-rules.md
@@ -20,7 +20,7 @@ When using Page Rules with Workers, the following workflow is applied.
 4.  Page Rules run as part of normal request processing with some features now disabled.
 5.  Worker executes.
 
-{{<Aside type="note" header="Listing specific page rules">}}
+{{<Aside type="note" header="Listing specific Page Rules">}}
 
 A complete list of features which can be configured "before" versus "after" Workers would be difficult to generate, because they are defined implicitly by the features which we disallow. In general, security-related features run "before" Workers, while most others run "after"
 

--- a/content/workers/platform/workers-with-page-rules.md
+++ b/content/workers/platform/workers-with-page-rules.md
@@ -22,7 +22,7 @@ When using Page Rules with Workers, the following workflow is applied.
 
 {{<Aside type="note" header="Listing specific Page Rules">}}
 
-A complete list of features which can be configured before and after Workers would be difficult to generate, because they are defined implicitly by the features which we disallow. In general, security-related features run before Workers, while most others run after.
+A complete list of features that run before and after Workers is challenging to generate. In general, security-related features run before Workers, while most others run after.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Customer service is still getting a lot of questions on which page rules run before or after Workers. I spoke with them and we thought maybe adding this note with a few snippets of internal documentation would clear things up.