### PR TITLE
Add end slash to internal URLs

### DIFF
--- a/content/ddos-protection/managed-rulesets/http/configure-api.md
+++ b/content/ddos-protection/managed-rulesets/http/configure-api.md
@@ -8,7 +8,7 @@ meta:
 
 # Configure HTTP DDoS Attack Protection via API
 
-Configure the HTTP DDoS Attack Protection Managed Ruleset by defining overrides using the [Rulesets API](/ruleset-engine/rulesets-api).
+Configure the HTTP DDoS Attack Protection Managed Ruleset by defining overrides using the [Rulesets API](/ruleset-engine/rulesets-api/).
 
 Each zone has the HTTP DDoS Attack Protection Managed Ruleset enabled by default. This means that you do not need to deploy the Managed Ruleset to the `ddos_l7` phase ruleset explicitly. You only have to create a rule in the phase ruleset to deploy the Managed Ruleset if you need to configure overrides.
 
@@ -114,4 +114,4 @@ The response returns the created (or updated) phase entry point ruleset.
 }
 ```
 
-For more information on defining overrides for Managed Rulesets using the Rulesets API, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset) in the Ruleset Engine documentation.
+For more information on defining overrides for Managed Rulesets using the Rulesets API, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/) in the Ruleset Engine documentation.

--- a/content/firewall/cf-dashboard/create-mtls-rule.md
+++ b/content/firewall/cf-dashboard/create-mtls-rule.md
@@ -6,4 +6,4 @@ weight: 381
 
 # Create a mTLS rule
 
-Use the [Mutual TLS](/api-shield/security/mtls/configure) Rule interface in the Cloudflare dashboard to create an mTLS rule that requires requests to your API or web application to present a valid client certificate.
+Use the [Mutual TLS](/api-shield/security/mtls/configure/) Rule interface in the Cloudflare dashboard to create an mTLS rule that requires requests to your API or web application to present a valid client certificate.

--- a/content/firewall/cf-dashboard/expression-preview-editor.md
+++ b/content/firewall/cf-dashboard/expression-preview-editor.md
@@ -56,4 +56,4 @@ Cloudflare validates all expressions before saving them, so if your expression i
 
 ![Error message](/firewall/static/firewall-rules-expressions-editor-6.png)
 
-The Expression Editor supports the entire Cloudflare Rules language. For a complete listing of supported fields and operators, as well as guidance on using grouping symbols, refer to [Rules language](/ruleset-engine/rules-language).
+The Expression Editor supports the entire Cloudflare Rules language. For a complete listing of supported fields and operators, as well as guidance on using grouping symbols, refer to [Rules language](/ruleset-engine/rules-language/).

--- a/content/waf/_partials/_analytics-activity-log.md
+++ b/content/waf/_partials/_analytics-activity-log.md
@@ -21,7 +21,7 @@ For example, if you are diagnosing a bot-related issue, you may want to display 
 
 ### Event actions
 
-For a description of the actions that may appear in the **Activity Log**, refer to [Actions](/ruleset-engine/rules-language/actions).
+For a description of the actions that may appear in the **Activity Log**, refer to [Actions](/ruleset-engine/rules-language/actions/).
 
 When the *Connection Close* action appears in the **Activity Log**, it means the existing request is unaffected, but the client is instructed to establish a new connection instead of reusing the existing connection.
 

--- a/content/waf/_partials/_analytics-create-firewall-rule.md
+++ b/content/waf/_partials/_analytics-create-firewall-rule.md
@@ -5,4 +5,4 @@ _build:
   list: never
 ---
 
-To create a [firewall rule](/firewall/cf-dashboard/create-edit-delete-rules#create-a-firewall-rule) based on the filters and exclusions you selected, click **Create firewall rule** in **Firewall Events**.
+To create a [firewall rule](/firewall/cf-dashboard/create-edit-delete-rules/#create-a-firewall-rule) based on the filters and exclusions you selected, click **Create firewall rule** in **Firewall Events**.

--- a/content/waf/about.md
+++ b/content/waf/about.md
@@ -8,7 +8,7 @@ meta:
 
 # About Cloudflare Web Application Firewall (WAF)
 
-The Cloudflare Web Application Firewall (Cloudflare WAF) checks incoming web requests and filters undesired traffic based on sets of rules called rulesets. The matching engine that powers the WAF rules supports the wirefilter syntax using the [Rules language](/ruleset-engine/rules-language).
+The Cloudflare Web Application Firewall (Cloudflare WAF) checks incoming web requests and filters undesired traffic based on sets of rules called rulesets. The matching engine that powers the WAF rules supports the wirefilter syntax using the [Rules language](/ruleset-engine/rules-language/).
 
 {{<Aside type="note" header="What is a Web Application Firewall?">}}
 
@@ -36,11 +36,11 @@ Currently, you can only create and deploy custom rulesets via API.
 
 {{</Aside>}}
 
-You can [create custom rulesets](/ruleset-engine/custom-rulesets/create-custom-ruleset) with your own WAF rules that you can later [deploy to a phase entry point](/waf/managed-rulesets/deploy-api/#deploying-custom-rulesets).
+You can [create custom rulesets](/ruleset-engine/custom-rulesets/create-custom-ruleset/) with your own WAF rules that you can later [deploy to a phase entry point](/waf/managed-rulesets/deploy-api/#deploying-custom-rulesets).
 
 ## Available phases
 
-The Web Application Firewall provides the following [phases](/ruleset-engine/about#phases) where you can deploy WAF rules:
+The Web Application Firewall provides the following [phases](/ruleset-engine/about/#phases) where you can deploy WAF rules:
 
 - `http_request_firewall_custom`
 - `http_request_firewall_managed`
@@ -77,7 +77,7 @@ Currently, creating and deploying custom rulesets is only available via API.
 
 {{</Aside>}}
 
-To learn more about phases, refer to [Phases](/ruleset-engine/about#phases) in the Ruleset Engine documentation.
+To learn more about phases, refer to [Phases](/ruleset-engine/about/#phases) in the Ruleset Engine documentation.
 
 ## Rule execution order
 

--- a/content/waf/analytics/paid-plans.md
+++ b/content/waf/analytics/paid-plans.md
@@ -76,4 +76,4 @@ In **Denial-of-service attacks mitigated** you have visibility over mitigated La
 
 ![Denial-of-service attacks mitigated](/waf/static/analytics-dos-attacks-mitigated.png)
 
-You can also use the [`synAvgPps1mGroups` node in GraphQL](/analytics/graphql-api/features/data-sets) to get the total attack volume for a zone over a period of time.
+You can also use the [`synAvgPps1mGroups` node in GraphQL](/analytics/graphql-api/features/data-sets/) to get the total attack volume for a zone over a period of time.

--- a/content/waf/custom-rules/skip/api-examples.md
+++ b/content/waf/custom-rules/skip/api-examples.md
@@ -8,7 +8,7 @@ meta:
 
 # API examples of custom rules with the Skip action
 
-Use the [Rulesets API](/ruleset-engine/rulesets-api) to configure custom rules via API.
+Use the [Rulesets API](/ruleset-engine/rulesets-api/) to configure custom rules via API.
 
 The `skip` action supports different [skip options](/waf/custom-rules/skip/options/), according to the security features or products that you wish to skip.
 
@@ -18,15 +18,15 @@ Take the following into account regarding the provided examples:
 
 *   The `<ZONE_ID>` value is the ID of the zone where you want to add the rule. To retrieve a list of zones you have access to, use the [List Zones](https://api.cloudflare.com/#zone-list-zones) operation.
 
-*   The `<RULESET_ID>` value is the ID of the entry point ruleset of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view). If you do not have such a ruleset yet, you can use the [Update zone entry point ruleset](/ruleset-engine/rulesets-api/update) API operation to create the entry point ruleset with a skip rule in a single operation.
+*   The `<RULESET_ID>` value is the ID of the entry point ruleset of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). If you do not have such a ruleset yet, you can use the [Update zone entry point ruleset](/ruleset-engine/rulesets-api/update/) API operation to create the entry point ruleset with a skip rule in a single operation.
 
-*   The examples in this page add a new rule at the zone level with the `skip` action. If you wish to edit an existing rule, refer to [Update a rule in a ruleset](/ruleset-engine/rulesets-api/update-rule) for more information.
+*   The examples in this page add a new rule at the zone level with the `skip` action. If you wish to edit an existing rule, refer to [Update a rule in a ruleset](/ruleset-engine/rulesets-api/update-rule/) for more information.
 
 *   Although each example only includes one action parameter, you can use several skip options in the same rule by specifying the `ruleset`, `phases`, and `products` action parameters simultaneously.
 
 ## Skip the remaining rules in the current ruleset
 
-This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule) API operation to add a rule that skips the remaining rules in the current ruleset:
+This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule/) API operation to add a rule that skips the remaining rules in the current ruleset:
 
 ```json
 ---
@@ -48,7 +48,7 @@ curl -X POST \
 
 ## Skip a phase
 
-This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule) API operation to add a rule that skips the `http_ratelimit` phase:
+This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule/) API operation to add a rule that skips the `http_ratelimit` phase:
 
 ```json
 ---
@@ -74,7 +74,7 @@ Refer to [Available skip options](/waf/custom-rules/skip/options/) for the list 
 
 ## Skip security products
 
-This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule) API operation to add a rule that skips the Zone Lockdown and User Agent Blocking products:
+This example uses the [Add individual rule](/ruleset-engine/rulesets-api/add-rule/) API operation to add a rule that skips the Zone Lockdown and User Agent Blocking products:
 
 ```json
 ---

--- a/content/waf/custom-rules/skip/options.md
+++ b/content/waf/custom-rules/skip/options.md
@@ -31,7 +31,7 @@ The available skip options in custom rules are the following:
     - `http_request_firewall_managed`
     - `http_ratelimit`
 
-  - Refer to [Phases](/ruleset-engine/about#phases) for more information.
+  - Refer to [Phases](/ruleset-engine/about/#phases) for more information.
 
 - **Skip products**
 

--- a/content/waf/exposed-credentials-check/configure-api.md
+++ b/content/waf/exposed-credentials-check/configure-api.md
@@ -6,7 +6,7 @@ weight: 4
 
 # Configure exposed credentials checks via API
 
-Configure exposed credentials checks using the [Rulesets API](/ruleset-engine/rulesets-api). You can do the following:
+Configure exposed credentials checks using the [Rulesets API](/ruleset-engine/rulesets-api/). You can do the following:
 
 *   [Deploy the Cloudflare Exposed Credentials Check Managed Ruleset](/waf/managed-rulesets/exposed-credentials-check/#configure-via-api).
 *   Create custom rules that check for exposed credentials.
@@ -19,7 +19,7 @@ This feature is only available to customers on an Enterprise plan.
 
 {{</Aside>}}
 
-You can create rules that check for exposed credentials using the [Rulesets API](/ruleset-engine/rulesets-api). Include these rules in a custom ruleset, which you must create at the account level, and then deploy the custom ruleset to a phase.
+You can create rules that check for exposed credentials using the [Rulesets API](/ruleset-engine/rulesets-api/). Include these rules in a custom ruleset, which you must create at the account level, and then deploy the custom ruleset to a phase.
 
 A rule with exposed credentials check has a match when both the rule expression and the result from the exposed credentials check are true.
 
@@ -39,7 +39,7 @@ These options have additional requirements:
 
 You can use the `exposed_credential_check` field in rules with one of the following actions: `rewrite`, `log`, `block`, `challenge`, or `js_challenge`.
 
-To create and deploy a custom ruleset, follow the workflow described in [Work with custom rulesets](/ruleset-engine/custom-rulesets).
+To create and deploy a custom ruleset, follow the workflow described in [Work with custom rulesets](/ruleset-engine/custom-rulesets/).
 
 ### Example
 

--- a/content/waf/managed-rulesets/exposed-credentials-check.md
+++ b/content/waf/managed-rulesets/exposed-credentials-check.md
@@ -53,14 +53,14 @@ For details on configuring a Managed Ruleset in the dashboard, refer to [Configu
 
 ## Configure via API
 
-To enable the Cloudflare Exposed Credentials Check Managed Ruleset for a given zone via API, create a rule with `execute` action in the entry point ruleset for the `http_request_firewall_managed` phase. For more information on deploying a Managed Ruleset, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset).
+To enable the Cloudflare Exposed Credentials Check Managed Ruleset for a given zone via API, create a rule with `execute` action in the entry point ruleset for the `http_request_firewall_managed` phase. For more information on deploying a Managed Ruleset, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset/).
 
-To configure the Exposed Credentials Check Managed Ruleset via API, create [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset) using the Rulesets API. You can perform the following configurations:
+To configure the Exposed Credentials Check Managed Ruleset via API, create [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset/) using the Rulesets API. You can perform the following configurations:
 
 - Specify the action to perform for all the rules in the ruleset by creating a ruleset override.
 - Disable or customize the action of individual rules by creating rule overrides for those rules.
 
-For examples of creating overrides using the API, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset).
+For examples of creating overrides using the API, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
 
 {{<Aside type="note" header="Checking for exposed credentials in custom rules">}}
 

--- a/content/waf/managed-rulesets/owasp-core-ruleset.md
+++ b/content/waf/managed-rulesets/owasp-core-ruleset.md
@@ -29,15 +29,15 @@ For details on configuring a Managed Ruleset in the dashboard, refer to [Configu
 
 ## Configure via API
 
-To enable the Cloudflare OWASP Core Ruleset for a given zone via API, create a rule with `execute` action in the entry point ruleset for the `http_request_firewall_managed` phase. For more information on deploying a Managed Ruleset, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset).
+To enable the Cloudflare OWASP Core Ruleset for a given zone via API, create a rule with `execute` action in the entry point ruleset for the `http_request_firewall_managed` phase. For more information on deploying a Managed Ruleset, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset/).
 
-To configure the Cloudflare OWASP Core Ruleset via API, create [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset) using the Rulesets API. You can perform the following configurations:
+To configure the Cloudflare OWASP Core Ruleset via API, create [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset/) using the Rulesets API. You can perform the following configurations:
 
 *   Enable all the rules up to a specific paranoia level.
 *   Configure the score threshold.
 *   Specify the action to perform when the threat score is greater than the threshold.
 
-You can also disable specific rules in the Managed Ruleset using [rule overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset).
+You can also disable specific rules in the Managed Ruleset using [rule overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
 
 ### Setting the paranoia level
 
@@ -151,7 +151,7 @@ highlight: [12,14,15,16]
       </div>
     </details>
 
-3.  Update the rule you just identified using the [Patch individual rule](/ruleset-engine/rulesets-api/update-rule) method, adding tag overrides that disable the rules with tags `paranoia-level-3` and `paranoia-level-4`.
+3.  Update the rule you just identified using the [Patch individual rule](/ruleset-engine/rulesets-api/update-rule/) method, adding tag overrides that disable the rules with tags `paranoia-level-3` and `paranoia-level-4`.
 
      <details>
       <summary>Request</summary>
@@ -190,7 +190,7 @@ curl -X PATCH \
       </div>
     </details>
 
-For more information on creating overrides, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset).
+For more information on creating overrides, refer to [Override a Managed Ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
 
 ### Configuring the score threshold and the action
 
@@ -362,7 +362,7 @@ highlight: [12,14,15,16]
       </div>
     </details>
 
-4.  Update the rule you just identified in the entry point ruleset using the [Patch individual rule](/ruleset-engine/rulesets-api/update-rule) method, adding a rule override for the last rule in the OWASP ruleset (identified in step 2) with the following properties and values:
+4.  Update the rule you just identified in the entry point ruleset using the [Patch individual rule](/ruleset-engine/rulesets-api/update-rule/) method, adding a rule override for the last rule in the OWASP ruleset (identified in step 2) with the following properties and values:
 
     *   `"score_threshold": 60`
     *   `"action": "managed_challenge"`
@@ -403,4 +403,4 @@ curl -X PATCH \
 
 ### Additional resources
 
-For more API examples, refer to [Workflow examples](/ruleset-engine/common-use-cases) in the Ruleset Engine documentation.
+For more API examples, refer to [Workflow examples](/ruleset-engine/common-use-cases/) in the Ruleset Engine documentation.

--- a/content/waf/managed-rulesets/payload-logging/configure-api.md
+++ b/content/waf/managed-rulesets/payload-logging/configure-api.md
@@ -38,7 +38,7 @@ You can generate a public key [in the command line](/waf/managed-rulesets/payloa
 
 ### Example
 
-The following example updates rule `{rule-id-1}` that executes the Cloudflare Managed Ruleset for zone `{zone-id}`, configuring payload logging with the provided public key.
+The following example updates rule `<RULE_ID_1>` that executes the Cloudflare Managed Ruleset for zone `<ZONE_ID>`, configuring payload logging with the provided public key.
 
 ```json
 ---
@@ -46,14 +46,14 @@ header: Request
 highlight: [9,10,11]
 ---
 curl -X PATCH \
-"https://api.cloudflare.com/client/v4/zone/{zone-id}/rulesets/{ruleset-id}/rules/{rule-id-1}" \
+"https://api.cloudflare.com/client/v4/zone/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
 -H "Authorization: Bearer <API_TOKEN>" \
 -d '{
   "action": "execute",
   "action_parameters": {
-    "id": "{cloudflare-managed-ruleset-id}",
+    "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
     "matched_data": {
-      "public_key": "{your-public-key}"
+      "public_key": "<YOUR_PUBLIC_KEY>"
     }
   },
   "expression": "true",
@@ -69,27 +69,27 @@ header: Response
 ---
 {
   "result": {
-    "id": "{zone-level-phase-ruleset-id}",
+    "id": "<ZONE_LEVEL_RULESET_ID>",
     "name": "Zone-level Ruleset 1",
     "description": "",
     "kind": "zone",
     "version": "3",
     "rules": [
       {
-        "id": "{rule-id-1}",
+        "id": "<RULE_ID_1>",
         "version": "1",
         "action": "execute",
         "action_parameters": {
-          "id": "{cloudflare-managed-ruleset-id}",
+          "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
           "version": "latest",
           "matched_data": {
-            "public_key": "{your-public-key}"
+            "public_key": "<YOUR_PUBLIC_KEY>"
           }
         },
         "expression": "true",
         "description": "Executes the Cloudflare Managed Ruleset",
         "last_updated": "2021-06-28T18:08:14.003361Z",
-        "ref": "{ruleset-ref-1}",
+        "ref": "<RULE_REF_1>",
         "enabled": true
       },
       // ...
@@ -121,7 +121,7 @@ The following example rule executes a Managed Ruleset with payload logging disab
 {
   "action": "execute",
   "action_parameters": {
-    "id": "{managed-ruleset-id}"
+    "id": "<MANAGED_RULESET_ID>"
   },
   "expression": "true",
   "description": ""

--- a/content/waf/managed-rulesets/payload-logging/configure-api.md
+++ b/content/waf/managed-rulesets/payload-logging/configure-api.md
@@ -14,7 +14,7 @@ You can use the [Rulesets API](https://api.cloudflare.com/) to configure payload
 
 To configure:
 
-1.  Use the [Update rule in ruleset](/ruleset-engine/rulesets-api/update-rule) API method to update the rule that executes the Managed Ruleset.
+1.  Use the [Update rule in ruleset](/ruleset-engine/rulesets-api/update-rule/) API method to update the rule that executes the Managed Ruleset.
 
 2.  In the configuration of the rule that executes the Managed Ruleset, include a `matched_data` object in `action_parameters` to configure payload logging.
 
@@ -103,7 +103,7 @@ header: Response
 }
 ```
 
-For more information on deploying Managed Rulesets via API, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset) in the Ruleset Engine documentation.
+For more information on deploying Managed Rulesets via API, refer to [Deploy a Managed Ruleset](/ruleset-engine/managed-rulesets/deploy-managed-ruleset/) in the Ruleset Engine documentation.
 
 ***
 
@@ -111,7 +111,7 @@ For more information on deploying Managed Rulesets via API, refer to [Deploy a M
 
 To disable payload logging for a Managed Ruleset:
 
-1.  Use the [Update rule in ruleset](/ruleset-engine/rulesets-api/update-rule) API method to update the rule that executes the Managed Ruleset.
+1.  Use the [Update rule in ruleset](/ruleset-engine/rulesets-api/update-rule/) API method to update the rule that executes the Managed Ruleset.
 
 2.  Modify the rule definition so that there is no `matched_data` object in `action_parameters`.
 

--- a/content/waf/managed-rulesets/waf-exceptions/_index.md
+++ b/content/waf/managed-rulesets/waf-exceptions/_index.md
@@ -22,13 +22,13 @@ WAF exceptions can have one of the following behaviors (from highest to lowest p
 
 You define WAF exceptions in a given context — zone level or account level — and they apply only to that context. For example, if you define a WAF exception that skips all remaining rules at the account level, the WAF rules at the zone level will still be evaluated.
 
-Define the exception expression using the [Rules language](/ruleset-engine/rules-language). If there is a match for the expressions of several WAF exceptions, the WAF will consider the exception with the highest priority.
+Define the exception expression using the [Rules language](/ruleset-engine/rules-language/). If there is a match for the expressions of several WAF exceptions, the WAF will consider the exception with the highest priority.
 
 ## Additional notes
 
 WAF exceptions only apply to rules executing a Managed Ruleset listed after them. If you add a WAF exception at the end of the WAF rules list, nothing will be skipped.
 
-WAF exceptions have priority over [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset).
+WAF exceptions have priority over [overrides](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
 
 If you define a WAF exception that skips all remaining rules, the expressions of those rules are not evaluated.
 

--- a/content/waf/managed-rulesets/waf-exceptions/define-api.md
+++ b/content/waf/managed-rulesets/waf-exceptions/define-api.md
@@ -6,11 +6,11 @@ weight: 3
 
 # Define WAF exceptions via API
 
-To define a WAF exception via API, create a rule with `skip` action in a [phase entry point ruleset](/ruleset-engine/about#phases) of the `http_request_firewall_managed` phase. You can define WAF exceptions at the account level and at the zone level.
+To define a WAF exception via API, create a rule with `skip` action in a [phase entry point ruleset](/ruleset-engine/about/#phases) of the `http_request_firewall_managed` phase. You can define WAF exceptions at the account level and at the zone level.
 
 To configure the WAF exception, define the `action_parameters` object according to the [exception type](/waf/managed-rulesets/waf-exceptions/#types-of-waf-exceptions).
 
-Refer to [Add rules to phase entry point rulesets](/ruleset-engine/basic-operations/add-rule-phase-rulesets) for more information on adding rules using the [Rulesets API](/ruleset-engine/rulesets-api).
+Refer to [Add rules to phase entry point rulesets](/ruleset-engine/basic-operations/add-rule-phase-rulesets/) for more information on adding rules using the [Rulesets API](/ruleset-engine/rulesets-api/).
 
 {{<Aside type="note" header="Rule execution order">}}
 

--- a/content/waf/managed-rulesets/waf-exceptions/define-dashboard.md
+++ b/content/waf/managed-rulesets/waf-exceptions/define-dashboard.md
@@ -16,7 +16,7 @@ weight: 2
 
     ![Create exception page](/waf/static/waf-exception-create.png)
 
-5. In **When incoming requests match**, specify a filter expression that defines the conditions for applying the WAF exception. The filter expression uses the [Rules language](/ruleset-engine/rules-language).
+5. In **When incoming requests match**, specify a filter expression that defines the conditions for applying the WAF exception. The filter expression uses the [Rules language](/ruleset-engine/rules-language/).
 
 6. In **Then**, select the [exception type](/waf/managed-rulesets/waf-exceptions/#types-of-waf-exceptions) that determines which rules to skip:
 

--- a/content/waf/rate-limiting-rules/_index.md
+++ b/content/waf/rate-limiting-rules/_index.md
@@ -18,7 +18,7 @@ For guidance on the previous version of rate limiting rules, refer to [Configuri
 
 Like other rules evaluated by Cloudflare's Ruleset Engine, rate limiting rules have an associated **expression** and an **action**.
 
-The **expression** specifies the criteria you are matching traffic on using the [Rules language](/ruleset-engine/rules-language). The **action** specifies what to perform when there is a match for the rule and any additional conditions are met. In the case of rate limiting rules, the action occurs when the request rate reaches the specified limit.
+The **expression** specifies the criteria you are matching traffic on using the [Rules language](/ruleset-engine/rules-language/). The **action** specifies what to perform when there is a match for the rule and any additional conditions are met. In the case of rate limiting rules, the action occurs when the request rate reaches the specified limit.
 
 Besides these two parameters, rate limiting rules require the following additional parameters:
 

--- a/content/waf/rate-limiting-rules/parameters.md
+++ b/content/waf/rate-limiting-rules/parameters.md
@@ -65,7 +65,7 @@ The available rate limiting rule parameters are the following:
 
 {{<Aside type="note">}}
 
-Use _IP with NAT support_ to handle situations such as requests under NAT sharing the same IP address. Cloudflare uses a variety of privacy-preserving techniques to identify unique visitors, which may include use of session cookies — refer to [Cloudflare Cookies](/fundamentals/get-started/cloudflare-cookies) for details.
+Use _IP with NAT support_ to handle situations such as requests under NAT sharing the same IP address. Cloudflare uses a variety of privacy-preserving techniques to identify unique visitors, which may include use of session cookies — refer to [Cloudflare Cookies](/fundamentals/get-started/cloudflare-cookies/) for details.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Addresses missing end slashes in `firewall`, `ddos-protection`, `waf`.
Fixes placeholders in API examples.