### PR TITLE
Add end slashes to internal URLs (part 2)

### DIFF
--- a/content/analytics/_index.md
+++ b/content/analytics/_index.md
@@ -6,7 +6,7 @@ weight: 1
 
 # Overview
 
-Cloudflare visualizes the metadata collected by our products in the Cloudflare dashboard. Refer to [Accessing the data Cloudflare collects](/fundamentals/data-products/accessing-cf-data) for more information about the various types of analytics and where they exist in the dashboard.
+Cloudflare visualizes the metadata collected by our products in the Cloudflare dashboard. Refer to [Accessing the data Cloudflare collects](/fundamentals/data-products/accessing-cf-data/) for more information about the various types of analytics and where they exist in the dashboard.
 
 ## Cloudflare Web Analytics
 

--- a/content/analytics/graphql-api/getting-started/authentication/api-token-auth.md
+++ b/content/analytics/graphql-api/getting-started/authentication/api-token-auth.md
@@ -8,7 +8,7 @@ weight: 21
 
 Cloudflare recommends API tokens as the preferred authentication method with Cloudflare APIs. This article walks through creating API tokens for authentication to the GraphQL Analytics API.
 
-For more details on API tokens and the full range of supported options, refer to [Creating API tokens](/api/tokens/create).
+For more details on API tokens and the full range of supported options, refer to [Creating API tokens](/api/tokens/create/).
 
 To create an API token for authentication to the GraphQL Analytics API, use this workflow:
 

--- a/content/analytics/graphql-api/migration-guides/network-analytics-v2/node-reference.md
+++ b/content/analytics/graphql-api/migration-guides/network-analytics-v2/node-reference.md
@@ -40,7 +40,7 @@ The sample rate is 1/10,000 packets.
 
 {{<Aside type="note" header="Adjusting attack mitigation">}}
 
-To adjust mitigation sensitivities and actions, or to define expression filters that exclude or include traffic from mitigation actions, customize the [Network-layer DDoS Attack Protection Managed Ruleset](/ddos-protection/managed-rulesets/network).
+To adjust mitigation sensitivities and actions, or to define expression filters that exclude or include traffic from mitigation actions, customize the [Network-layer DDoS Attack Protection Managed Ruleset](/ddos-protection/managed-rulesets/network/).
 
 {{</Aside>}}
 

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
@@ -5,11 +5,11 @@ title: Querying Magic Transit Tunnel Health Check Results with GraphQL
 
 # Querying Magic Transit Tunnel Health Check Results with GraphQL
 
-In this example, you are going to use the GraphQL Analytics API to query Magic Transit Health check results which are aggregated from individual health checks carried out by Cloudflare servers to GRE tunnels you have set up to work with Magic Transit during the [onboarding process](/magic-transit/get-started). You can query up to one week of data for dates up to three months ago.
+In this example, you are going to use the GraphQL Analytics API to query Magic Transit Health check results which are aggregated from individual health checks carried out by Cloudflare servers to GRE tunnels you have set up to work with Magic Transit during the [onboarding process](/magic-transit/get-started/). You can query up to one week of data for dates up to three months ago.
 
 The following API call will request a particular account's tunnel health checks over a one day period for a particular Cloudflare colo, and outputs the requested fields. Be sure to replace `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetimeStart`, `datetimeEnd` and `accountTag` variables as needed.
 
-It will return the tunnel health check results by Cloudflare colo. The result for each colo is aggregated from the healthchecks conducted on individual servers. The tunnel state field in the value represents the [state of the tunnel](/magic-transit/about/health-checks#tunnel-health-checks). These states are used by Magic Transit for [routing](/magic-transit/about/health-checks#tunnel-health-checks). The value `0` for the tunnel state represents it being down, the value `0.5` being degraded and the value `1` as healthy.
+It will return the tunnel health check results by Cloudflare colo. The result for each colo is aggregated from the healthchecks conducted on individual servers. The tunnel state field in the value represents the [state of the tunnel](/magic-transit/about/health-checks/#tunnel-health-checks). These states are used by Magic Transit for [routing](/magic-transit/about/health-checks/#tunnel-health-checks). The value `0` for the tunnel state represents it being down, the value `0.5` being degraded and the value `1` as healthy.
 
 ## API Call
 

--- a/content/api-shield/security/api-discovery.md
+++ b/content/api-shield/security/api-discovery.md
@@ -39,4 +39,4 @@ This process currently requires a session identifier, like an authorization toke
 
 To better understand your API traffic, you can also see [API requests](https://dash.cloudflare.com/?to=/:account/:zone/analytics/traffic/api-requests) in your application dashboard.
 
-This view adds a lightweight filter to application requests so you can better identify API traffic. If you want a more sophisticated understanding of API traffic, check out [Bot Tags](/bots/concepts/cloudflare-bot-tags).
+This view adds a lightweight filter to application requests so you can better identify API traffic. If you want a more sophisticated understanding of API traffic, check out [Bot Tags](/bots/concepts/cloudflare-bot-tags/).

--- a/content/api-shield/security/mtls/_index.md
+++ b/content/api-shield/security/mtls/_index.md
@@ -18,7 +18,7 @@ For help setting up mTLS for one or more hosts using the dashboard, refer to [Co
 
 ## Availability
 
-All Cloudflare plans can set up mTLS with a Cloudflare-managed certificate authority (CA). For certificates from another CA, use [Cloudflare Access](/cloudflare-one/identity/devices/mutual-tls-authentication).
+All Cloudflare plans can set up mTLS with a Cloudflare-managed certificate authority (CA). For certificates from another CA, use [Cloudflare Access](/cloudflare-one/identity/devices/mutual-tls-authentication/).
 
 ## Limitations
 

--- a/content/api-shield/security/mtls/configure.md
+++ b/content/api-shield/security/mtls/configure.md
@@ -11,17 +11,17 @@ When you specify API hosts in [mTLS authentication](/api-shield/security/mtls/),
 
 ## Prerequisites
 
-Before you can protect your your API or web application with mTLS rules, you need to:
+Before you can protect your API or web application with mTLS rules, you need to:
 
-- [Create a client certificate](/ssl/client-certificates/create-a-client-certificate).
-- [Configure your mobile app or IoT device](/ssl/client-certificates/configure-your-mobile-app-or-iot-device) to use your Cloudflare-issued client certificate.
-- [Enable mutual Transport Layer Security (mTLS) for a host](/ssl/client-certificates/enable-mtls) in your zone.
+- [Create a client certificate](/ssl/client-certificates/create-a-client-certificate/).
+- [Configure your mobile app or IoT device](/ssl/client-certificates/configure-your-mobile-app-or-iot-device/) to use your Cloudflare-issued client certificate.
+- [Enable mutual Transport Layer Security (mTLS) for a host](/ssl/client-certificates/enable-mtls/) in your zone.
 
 {{<Aside type="warning" header="Important">}}
 
 You can only use mTLS with a certificate authority (CA) that is fully managed by Cloudflare. Cloudflare generates a unique CA for each zone.
 
-If you need to use certificates issued by another CA, use [Cloudflare Access](/cloudflare-one/identity/devices/mutual-tls-authentication) to upload your own CA.
+If you need to use certificates issued by another CA, use [Cloudflare Access](/cloudflare-one/identity/devices/mutual-tls-authentication/) to upload your own CA.
 
 {{</Aside>}}
 
@@ -38,7 +38,7 @@ To create an mTLS rule in the Cloudflare dashboard, follow these steps:
 4.  Enter the following information:
 
     - **Rule name**: A descriptive identifier for your mTLS rule.
-    - **Hostname**: The mTLS-enabled hostnames to protect, only showing hosts in your application with [mTLS enabled](/ssl/client-certificates/enable-mtls).
+    - **Hostname**: The mTLS-enabled hostnames to protect, only showing hosts in your application with [mTLS enabled](/ssl/client-certificates/enable-mtls/).
 
 5.  By default, your rule will have a [configuration](#expression-builder) similar to the following:
 
@@ -48,7 +48,7 @@ To create an mTLS rule in the Cloudflare dashboard, follow these steps:
 
     To make this rule active, click **Deploy**. To add additional firewall logic — such as checking for [revoked certificates](#check-for-revoked-certificates) — click **Use firewall rule builder**.
 
-6.  Once you have deployed your mTLS rule, any requests without a [Cloudflare-issued client certificate](/ssl/client-certificates/configure-your-mobile-app-or-iot-device) will be blocked.
+6.  Once you have deployed your mTLS rule, any requests without a [Cloudflare-issued client certificate](/ssl/client-certificates/configure-your-mobile-app-or-iot-device/) will be blocked.
 
 ### Expression Builder
 
@@ -60,11 +60,11 @@ The first expression uses the `http.host` field, combined with the `in` operator
 
 The second expression — `not cf.tls_client_auth.cert_verified` — returns `true` when a request to access your API or web application does not present a valid client certificate.
 
-Because the [action](/firewall/cf-firewall-rules/actions) for your rule is _Block_, only requests that present a valid client certificate can access the specified hosts.
+Because the [action](/firewall/cf-firewall-rules/actions/) for your rule is _Block_, only requests that present a valid client certificate can access the specified hosts.
 
 ### Check for revoked certificates
 
-To check for [revoked client certificates](/ssl/client-certificates/revoke-client-certificate), you can either add a new mTLS rule or add a new expression to the [default rule](#expression-builder).
+To check for [revoked client certificates](/ssl/client-certificates/revoke-client-certificate/), you can either add a new mTLS rule or add a new expression to the [default rule](#expression-builder).
 
 When a request includes a revoked certificate, the `cf.tls_client_auth.cert_revoked` field is set to `true`. If you combined this with the [default mTLS rule](#expression-builder), it would look similar to the following:
 

--- a/content/bots/_index.md
+++ b/content/bots/_index.md
@@ -23,6 +23,6 @@ To see the differences in features and functionality, visit [Plans](/bots/plans/
 ## Next steps
 
 {{<button-group>}}
-  {{<button type="primary" href="/bots/get-started">}}Get started{{</button>}}
-  {{<button type="secondary" href="/bots/concepts">}}Learn more{{</button>}}
+  {{<button type="primary" href="/bots/get-started/">}}Get started{{</button>}}
+  {{<button type="secondary" href="/bots/concepts/">}}Learn more{{</button>}}
 {{</button-group>}}

--- a/content/bots/_partials/_about-plan-bm-subscription.md
+++ b/content/bots/_partials/_about-plan-bm-subscription.md
@@ -39,7 +39,7 @@ _build:
     </tr>
     <tr>
       <td><b>Additional control</b></td>
-      <td>Ability to restrict by path, IP address, and more. Access to <a href="/bots/concepts/bot-score">bot score</a>, <a href="/bots/concepts/ja3-fingerprint">JA3 fingerprint</a>, and <a href="/bots/concepts/cloudflare-bot-tags">bot tags</a> fields.</td>
+      <td>Ability to restrict by path, IP address, and more. Access to <a href="/bots/concepts/bot-score/">bot score</a>, <a href="/bots/concepts/ja3-fingerprint/">JA3 fingerprint</a>, and <a href="/bots/concepts/cloudflare-bot-tags/">bot tags</a> fields.</td>
     </tr>
   </tbody>
 </table>

--- a/content/bots/_partials/_bfm-ruleset-engine.md
+++ b/content/bots/_partials/_bfm-ruleset-engine.md
@@ -5,4 +5,4 @@ _build:
   list: never
 ---
 
-Super Bot Fight Mode runs during the `http_request_sbfm` phase of the [Ruleset Engine](/ruleset-engine/about#phases).
+Super Bot Fight Mode runs during the `http_request_sbfm` phase of the [Ruleset Engine](/ruleset-engine/about/#phases).

--- a/content/bots/_partials/_bots-ad.md
+++ b/content/bots/_partials/_bots-ad.md
@@ -7,4 +7,4 @@ _build:
 
 The **Anomaly Detection (AD)** engine is an optional detection engine that uses a form of unsupervised learning. Cloudflare records a baseline of your domain's traffic and uses the baseline to intelligently detect outlier requests. This approach is user agent-agnostic and can be turned on or off by your account team.
 
-Cloudflare does not recommend AD for domains that use [SSL for SaaS](/ssl/ssl-for-saas) or expect large amounts of API traffic. The AD engine immediately gives automated requests a score of one.
+Cloudflare does not recommend AD for domains that use [SSL for SaaS](/ssl/ssl-for-saas/) or expect large amounts of API traffic. The AD engine immediately gives automated requests a score of one.

--- a/content/bots/_partials/_bots-cookie.md
+++ b/content/bots/_partials/_bots-cookie.md
@@ -5,4 +5,4 @@ _build:
   list: never
 ---
 
-Cloudflare uses the `__cf_bm cookie` to identify bots. For more details, refer to [Cloudflare Cookies](/fundamentals/get-started/cloudflare-cookies).
+Cloudflare uses the `__cf_bm cookie` to identify bots. For more details, refer to [Cloudflare Cookies](/fundamentals/get-started/cloudflare-cookies/).

--- a/content/bots/_partials/_buttons-plan-pages.md
+++ b/content/bots/_partials/_buttons-plan-pages.md
@@ -6,8 +6,8 @@ _build:
 ---
 
 {{<button-group>}}
-  {{<button type="primary" href="../free">}}Free{{</button>}}
-  {{<button type="primary" href="../pro">}}Pro{{</button>}}
-  {{<button type="primary" href="../biz-and-ent">}}Business{{</button>}}
-  {{<button type="primary" href="../bm-subscription">}}Bot Management for Enterprise{{</button>}}
+  {{<button type="primary" href="../free/">}}Free{{</button>}}
+  {{<button type="primary" href="../pro/">}}Pro{{</button>}}
+  {{<button type="primary" href="../biz-and-ent/">}}Business{{</button>}}
+  {{<button type="primary" href="../bm-subscription/">}}Bot Management for Enterprise{{</button>}}
 {{</button-group>}}

--- a/content/bots/bot-analytics/bm-subscription.md
+++ b/content/bots/bot-analytics/bm-subscription.md
@@ -42,4 +42,4 @@ Bot Management customers can use Bot Analytics to:
 
 Data from Bot Analytics is also available via the GraphQL API. You can access bot scores, bot sources, [Bot Tags](/bots/concepts/cloudflare-bot-tags/), and bot _decisions_ (_automated_, _likely automated_, etc.).
 
-Read the [GraphQL Analytics API documentation](/analytics/graphql-api) for more information about GraphQL and basic querying.
+Read the [GraphQL Analytics API documentation](/analytics/graphql-api/) for more information about GraphQL and basic querying.

--- a/content/bots/concepts/cloudflare-bot-tags.md
+++ b/content/bots/concepts/cloudflare-bot-tags.md
@@ -38,7 +38,7 @@ The following values are **examples** of what may be present in the `BotTags` lo
 
 ## Enable bot tags
 
-To enable bot tags, include the `BotTags` log field when using our [Logpush service](/logs/about).
+To enable bot tags, include the `BotTags` log field when using our [Logpush service](/logs/about/).
 
 ## Limitations
 

--- a/content/bots/concepts/ja3-fingerprint.md
+++ b/content/bots/concepts/ja3-fingerprint.md
@@ -18,8 +18,8 @@ JA3 Fingerprints are only available to Enterprise customers who have purchased B
 To get more information about potential bot requests, use these JA3 Fingerprints in:
 
 - [Bot Analytics](/bots/bot-analytics/bm-subscription/)
-- [Firewall Analytics](/waf/analytics)
-- [Analytics GraphQL API](/analytics/graphql-api), specifically the **HTTP Requests** data set
+- [Firewall Analytics](/waf/analytics/)
+- [Analytics GraphQL API](/analytics/graphql-api/), specifically the **HTTP Requests** data set
 - [Logs](/logs/reference/log-fields/zone/http_requests/)
 
 ## Actions

--- a/content/bots/plans/_index.md
+++ b/content/bots/plans/_index.md
@@ -14,10 +14,10 @@ meta:
 {{<render file="_plan-intro.md">}}
 
 {{<button-group>}}
-  {{<button type="primary" href="/bots/plans/free">}}Free{{</button>}}
-  {{<button type="primary" href="/bots/plans/pro">}}Pro{{</button>}}
-  {{<button type="primary" href="/bots/plans/biz-and-ent">}}Business{{</button>}}
-  {{<button type="primary" href="/bots/plans/bm-subscription">}}Bot Management for Enterprise{{</button>}}
+  {{<button type="primary" href="/bots/plans/free/">}}Free{{</button>}}
+  {{<button type="primary" href="/bots/plans/pro/">}}Pro{{</button>}}
+  {{<button type="primary" href="/bots/plans/biz-and-ent/">}}Business{{</button>}}
+  {{<button type="primary" href="/bots/plans/bm-subscription/">}}Bot Management for Enterprise{{</button>}}
 {{</button-group>}}
 
 ## How do I get started?

--- a/content/bots/reference/bot-management-variables.md
+++ b/content/bots/reference/bot-management-variables.md
@@ -6,14 +6,14 @@ weight: 0
 
 # Bot Management variables
 
-Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields#dynamic-fields) within the Firewall expression builder.
+Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields/#dynamic-fields) within the Firewall expression builder.
 
 - **Bot Score**: An integer between 1-99 that indicates [Cloudflare's level of certainty](/bots/concepts/bot-score/) that a request comes from a bot.
-- **Verified Bot**: A boolean value that is true if the request comes from a good bot, like Google or Bing. Most customers choose to allow this traffic. For more details, see [Traffic from known bots](/firewall/known-issues-and-faq#how-does-firewall-rules-handle-traffic-from-known-bots).
+- **Verified Bot**: A boolean value that is true if the request comes from a good bot, like Google or Bing. Most customers choose to allow this traffic. For more details, see [Traffic from known bots](/firewall/known-issues-and-faq/#how-does-firewall-rules-handle-traffic-from-known-bots).
 - **Serves Static Resource**: An identifier that matches [file extensions](/bots/reference/static-resources/) for many types of static resources. Use this variable if you send emails that retrieve static images.
 - **ja3Hash**: A [**JA3 Fingerprint**](/bots/concepts/ja3-fingerprint/) helps you profile specific SSL/TLS clients across different destination IPs, Ports, and X509 certificates.
 
-These variables are also available as part of the [request.cf](/workers/runtime-apis/request#incomingrequestcfproperties) object via Cloudflare Workers:
+These variables are also available as part of the [request.cf](/workers/runtime-apis/request/#incomingrequestcfproperties) object via Cloudflare Workers:
 
 - `request.cf.botManagement.score`
 - `request.cf.botManagement.verifiedBot`

--- a/content/byoip/_index.md
+++ b/content/byoip/_index.md
@@ -13,5 +13,5 @@ With **Bringing Your Own IPs** (BYOIP), Cloudflare announces your IPs in all our
 BYOIP is compatible with Magic Transit, Spectrum, and CDN services.
 
 {{<button-group>}}
-  {{<button type="primary" href="/byoip/get-started">}}Get started{{</button>}}
+  {{<button type="primary" href="/byoip/get-started/">}}Get started{{</button>}}
 {{</button-group>}}

--- a/content/byoip/about/irr.md
+++ b/content/byoip/about/irr.md
@@ -11,6 +11,6 @@ The IRR consists of many individual [routing registries](http://www.irr.net/docs
 
 To announce your subnet prefixes, Cloudflare requires accurate IRR entries for your prefixes and autonomous system numbers (ASNs).
 
-When you configure network infrastructure for services such as [Magic Transit](/magic-transit/about), [verify your IRR entries](/byoip/how-to/verify-irr-entries/).
+When you configure network infrastructure for services such as [Magic Transit](/magic-transit/about/), [verify your IRR entries](/byoip/how-to/verify-irr-entries/).
 
 For help with adding missing IRR entries or updating inaccurate entries, refer to the [best practices for IRR entries](/byoip/best-practices/irr-entries/).

--- a/content/byoip/about/prefix-delegations.md
+++ b/content/byoip/about/prefix-delegations.md
@@ -11,7 +11,7 @@ The effect of a delegation depends on the service used with the prefix. Currentl
 
 ## CDN
 
-CDN delegations only have an effect if you are using [SSL for SaaS](/ssl/ssl-for-saas) in addition to BYOIP + CDN. In this example, Account A is using BYOIP + CDN and SSL for SaaS. Account A can validate and serve traffic for a custom hostname on any of the IPs in its prefix. If Account A delegates some or all of the prefix to Account B, Account B may also validate and serve traffic for custom hostnames on those IPs as well. This is very useful if you use SSL for SaaS but manage different configurations in different accounts. All the accounts can use the IPs through a delegation.
+CDN delegations only have an effect if you are using [SSL for SaaS](/ssl/ssl-for-saas/) in addition to BYOIP + CDN. In this example, Account A is using BYOIP + CDN and SSL for SaaS. Account A can validate and serve traffic for a custom hostname on any of the IPs in its prefix. If Account A delegates some or all of the prefix to Account B, Account B may also validate and serve traffic for custom hostnames on those IPs as well. This is very useful if you use SSL for SaaS but manage different configurations in different accounts. All the accounts can use the IPs through a delegation.
 
 ## API calls for prefix delegations
 
@@ -32,6 +32,6 @@ The dashboard only supports delegation of an entire prefix. If you want to deleg
 
 ## Spectrum
 
-If Account A delegates use of part or all of a prefix to Account B via a prefix delegation, Account B can also use the [Spectrum API](/spectrum/about/byoip) with the IPs it was delegated access to.
+If Account A delegates use of part or all of a prefix to Account B via a prefix delegation, Account B can also use the [Spectrum API](/spectrum/about/byoip/) with the IPs it was delegated access to.
 
 **Example:** Account A is the primary owner of prefix 1.2.3.4/24. Account A delegates the use of 1.2.3.4/32 to Account B. Account B can now use the Spectrum API to create a Spectrum app with 1.2.3.4/32.

--- a/content/byoip/how-to/configure-dynamic-advertisement.md
+++ b/content/byoip/how-to/configure-dynamic-advertisement.md
@@ -13,7 +13,7 @@ To prevent issues and simplify the advertisement process during an attack scenar
 
 ## Before you start (Magic Transit customers only)
 
-If you are advertising a new prefix or enabling the advertisement of an existing IP prefix (changing it from _Withdrawn_ to _Advertised_), make sure you disable the [Advanced TCP Protection Managed Ruleset](/ddos-protection/managed-rulesets/tcp-protection) first.
+If you are advertising a new prefix or enabling the advertisement of an existing IP prefix (changing it from _Withdrawn_ to _Advertised_), make sure you disable the [Advanced TCP Protection Managed Ruleset](/ddos-protection/managed-rulesets/tcp-protection/) first.
 
 After enabling the prefix advertisement or advertising a new prefix, do the following:
 

--- a/content/cache/_index.md
+++ b/content/cache/_index.md
@@ -19,4 +19,4 @@ Cloudflare caches static content based on the following factors:
 *   Origin headers that indicate dynamic content
 *   Page rules that bypass cache on cookie
 
-Cloudflare only caches resources within the Cloudflare data center that serve the request. Cloudflare does not cache off-site or third-party resources, such as Facebook or Flickr, or content hosted on [unproxied (grey-clouded)](/dns/manage-dns-records/reference/proxied-dns-records) DNS records.
+Cloudflare only caches resources within the Cloudflare data center that serve the request. Cloudflare does not cache off-site or third-party resources, such as Facebook or Flickr, or content hosted on [unproxied (grey-clouded)](/dns/manage-dns-records/reference/proxied-dns-records/) DNS records.

--- a/content/cache/about/cache-control.md
+++ b/content/cache/about/cache-control.md
@@ -61,8 +61,8 @@ Revalidation determines how the cache should behave when a resource expires, and
 
 - `must-revalidate` — Indicates that once the resource is stale, a cache (client or proxy) must not use the response to satisfy subsequent requests without successful validation on the origin server.
 - `proxy-revalidate` — Has the same meaning as the `must-revalidate` response directive except that it does not apply to private client caches.
-- `stale-while-revalidate=seconds` — When present in an HTTP response, indicates caches may serve the response in which it appears after it becomes stale, up to the indicated number of seconds since the resource expired. If [Always Online](/cache/about/always-online/) is enabled, then the `stale-while-revalidate` and `stale-if-error` directives are ignored. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Worker's documentation for Cache API](/workers/platform/limits#cache-api).
-- `stale-if-error=seconds` — Indicates that when an error is encountered, a cached stale response may be used to satisfy the request, regardless of other freshness information. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Worker's documentation for Cache API](/workers/platform/limits#cache-api).
+- `stale-while-revalidate=seconds` — When present in an HTTP response, indicates caches may serve the response in which it appears after it becomes stale, up to the indicated number of seconds since the resource expired. If [Always Online](/cache/about/always-online/) is enabled, then the `stale-while-revalidate` and `stale-if-error` directives are ignored. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Worker's documentation for Cache API](/workers/platform/limits/#cache-api).
+- `stale-if-error=seconds` — Indicates that when an error is encountered, a cached stale response may be used to satisfy the request, regardless of other freshness information. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Worker's documentation for Cache API](/workers/platform/limits/#cache-api).
 
 The `stale-if-error` directive is ignored if [Always Online](/cache/about/always-online/) is enabled or if an explicit in-protocol directive is passed. Examples of explicit in-protocol directives include a `no-store` or `no-cache cache` directive, a `must-revalidate` cache-response-directive, or an applicable `s-maxage` or `proxy-revalidate` cache-response-directive.
 
@@ -359,17 +359,17 @@ This configuration indicates the asset is fresh for 600 seconds. The asset can b
 
 ## Interaction with other Cloudflare features
 
-### [Edge Cache TTL](/cache/about/edge-browser-cache-ttl/#edge-cache-ttl)
+### Edge Cache TTL
 
-Edge Cache TTL Page Rules override `s-maxage` and disable revalidation directives if present. When Origin Cache-Control is enabled at Cloudflare, the original Cache-Control header passes downstream from our edge even if Edge Cache TTL overrides are present. Otherwise, when Origin Cache-Control is disabled at Cloudflare (the default), Cloudflare overrides the origin cache control.
+[Edge Cache TTL](/cache/about/edge-browser-cache-ttl/#edge-cache-ttl) Page Rules override `s-maxage` and disable revalidation directives if present. When Origin Cache-Control is enabled at Cloudflare, the original Cache-Control header passes downstream from our edge even if Edge Cache TTL overrides are present. Otherwise, when Origin Cache-Control is disabled at Cloudflare (the default), Cloudflare overrides the origin cache control.
 
-### [Browser Cache TTL](/cache/about/edge-browser-cache-ttl/#browser-cache-ttl)
+### Browser Cache TTL
 
-Browser Cache TTL Page Rules override `max-age` settings passed downstream from our edge, typically to your visitor's browsers.
+[Browser Cache TTL](/cache/about/edge-browser-cache-ttl/#browser-cache-ttl) Page Rules override `max-age` settings passed downstream from our edge, typically to your visitor's browsers.
 
-### [Polish](/images/polish)
+### Polish
 
-Polish is disabled when the `no-transform` directive is present.
+[Polish](/images/polish/) is disabled when the `no-transform` directive is present.
 
 ### Gzip and Other Compression
 

--- a/content/cache/about/cache-keys.md
+++ b/content/cache/about/cache-keys.md
@@ -35,7 +35,7 @@ There are a couple of common reasons to change the Cache Key Template. You might
 
 {{<Aside type="note" header="Note">}}
 
-`$scheme` is the protocol (HTTP or HTTPS) sent to your origin web server and not the protocol received from the visitor. Therefore, setting the Cloudflare [SSL option](https://support.cloudflare.com/hc/articles/200170416) influences caching decisions. For instance, Cloudflare only attempts to connect to your origin web server via HTTP when [Flexible SSL](/ssl/origin-configuration/ssl-modes#flexible) is utilized. Thus, Cloudflare serves the same cached resource for visitor requests via either HTTP or HTTPS since Flexible SSL instructs Cloudflare to connect to an origin solely over HTTP.
+`$scheme` is the protocol (HTTP or HTTPS) sent to your origin web server and not the protocol received from the visitor. Therefore, setting the Cloudflare [SSL option](https://support.cloudflare.com/hc/articles/200170416) influences caching decisions. For instance, Cloudflare only attempts to connect to your origin web server via HTTP when [Flexible SSL](/ssl/origin-configuration/ssl-modes/#flexible) is utilized. Thus, Cloudflare serves the same cached resource for visitor requests via either HTTP or HTTPS since Flexible SSL instructs Cloudflare to connect to an origin solely over HTTP.
 
 {{</Aside>}}
 

--- a/content/cache/about/default-cache-behavior.md
+++ b/content/cache/about/default-cache-behavior.md
@@ -40,7 +40,7 @@ To cache additional content, see [Page Rules](/cache/how-to/create-page-rules/) 
 Cloudflare’s CDN provides several cache customization options:
 
 - Caching behavior for individual URLs via [Cloudflare Page Rules](/cache/how-to/create-page-rules/)
-- Customize caching with [Cloudflare Workers](/workers/learning/how-the-cache-works)
+- Customize caching with [Cloudflare Workers](/workers/learning/how-the-cache-works/)
 - Adjust caching level, cache TTL, and more via the Cloudflare Caching app
 
 Cloudflare limits the upload size (HTTP POST request size) per plan type:
@@ -49,7 +49,7 @@ Cloudflare limits the upload size (HTTP POST request size) per plan type:
 - 200MB Business
 - 500MB Enterprise by default. Contact [Customer Support](https://support.cloudflare.com/hc/articles/200172476) to request a limit increase.
 
-If you require a larger upload, group requests smaller than the upload thresholds or upload the full resource through an [unproxied (grey-clouded) DNS record](/dns/manage-dns-records/reference/proxied-dns-records).
+If you require a larger upload, group requests smaller than the upload thresholds or upload the full resource through an [unproxied (grey-clouded) DNS record](/dns/manage-dns-records/reference/proxied-dns-records/).
 
 ## Cloudflare cache responses
 

--- a/content/cache/best-practices/always-online.md
+++ b/content/cache/best-practices/always-online.md
@@ -7,13 +7,13 @@ pcx-content-type: concept
 
 Observe the following best practices when enabling Always Online with Internet Archive integration.
 
-- **Allow requests from Cloudflare IP addresses.** Origin servers for domains [proxied through Cloudflare](/dns/manage-dns-records/reference/proxied-dns-records) receive requests from Cloudflare IP addresses. To avoid blocking these requests, follow the guidelines for [allowing Cloudflare IP addresses](https://support.cloudflare.com/hc/articles/201897700). When you observe the Always Online banner while your origin web server is online, your origin web server or hosting provider is likely blocking or rate limiting Cloudflare requests.
+- **Allow requests from Cloudflare IP addresses.** Origin servers for domains [proxied through Cloudflare](/dns/manage-dns-records/reference/proxied-dns-records/) receive requests from Cloudflare IP addresses. To avoid blocking these requests, follow the guidelines for [allowing Cloudflare IP addresses](https://support.cloudflare.com/hc/articles/201897700). When you observe the Always Online banner while your origin web server is online, your origin web server or hosting provider is likely blocking or rate limiting Cloudflare requests.
 - **Configure your origin server’s Cache Control header.** To ensure Always Online caches resources for your site, do not set your origin server’s Cache Control header to `no-cache`, `must-revalidate`, or `max-age=0`.
 - **Consider potential conflicts with Cloudflare features that transform URIs.** Always Online Beta with Internet Archive integration may cause issues with Page Rules and other Cloudflare features that transform URIs due to the way the Internet Archive crawls pages to archive. Specifically, some redirects that take place at the edge may cause the Internet Archive's crawler not to archive the target URL. Before enabling Origin Cache Control, review [how Cloudflare caches resources by default](/cache/about/default-cache-behavior/) as well as any Page Rules you have configured so that you can avoid these issues. If you experience problems, disable Always Online Beta.
 
 Do not use Always Online with:
 
-- [Custom Hostnames (SSL for SaaS)](/ssl/ssl-for-saas)
+- [Custom Hostnames (SSL for SaaS)](/ssl/ssl-for-saas/)
 - API traffic
 - An [IP Access Rule](https://support.cloudflare.com/hc/articles/217074967) or [Firewall Rule](https://support.cloudflare.com/hc/articles/360016473712) that blocks the United States or
 - A [Cache Everything Page Rule](/cache/how-to/create-page-rules/#cache-everything) that configures an Edge Cache TTL lower than the Always Online crawl frequency pertaining to your domain plan type.

--- a/content/cache/get-started.md
+++ b/content/cache/get-started.md
@@ -12,8 +12,8 @@ meta:
 
 Discover the benefits of caching with Cloudflare’s CDN and understand the default cache behavior.
 
-- [What is a CDN?](/fundamentals/get-started/cdn)
-- [Understand the default file types Cloudflare caches](/cache/about/default-cache-behavior#default-cached-file-extensions)
+- [What is a CDN?](/fundamentals/get-started/cdn/)
+- [Understand the default file types Cloudflare caches](/cache/about/default-cache-behavior/#default-cached-file-extensions)
 
 ## Make more resources cacheable
 
@@ -50,11 +50,11 @@ Review the list of Cloudflare features that function in this manner.
 
 - [Auto Minify](https://support.cloudflare.com/hc/articles/200168196)
 - [Rocket Loader](https://support.cloudflare.com/hc/articles/200168056)
-- [Polish](/images/polish)
+- [Polish](/images/polish/)
 - [Mirage](https://support.cloudflare.com/hc/articles/219178057)
 - [Hotlink Protection](https://support.cloudflare.com/hc/articles/200170026)
 - [Email address obfuscation](https://support.cloudflare.com/hc/articles/200170016)
-- [Bot Management Javascript Detections](/bots/reference/javascript-detections)
+- [Bot Management Javascript Detections](/bots/reference/javascript-detections/)
 
 ## Troubleshoot
 

--- a/content/cache/how-to/interact-with-workers.md
+++ b/content/cache/how-to/interact-with-workers.md
@@ -7,6 +7,6 @@ pcx-content-type: concept
 
 You can use [Workers](/workers/) to customize cache behavior on Cloudflare's CDN. Because Cloudflare’s Workers can run before and after the cache, you can utilize Workers to modify assets after they are returned from the cache, to sign or personalize responses while reducing load on an origin, or reduce latency to the end user by serving assets from a nearby location.
 
-To determine how to cache a resource by setting TTLs, custom cache keys, and cache headers in a fetch request, refer to [Cache using fetch](/workers/examples/cache-using-fetch).
+To determine how to cache a resource by setting TTLs, custom cache keys, and cache headers in a fetch request, refer to [Cache using fetch](/workers/examples/cache-using-fetch/).
 
-To use the Cache API to store responses in Cloudflare's cache, refer to [Using the Cache API](/workers/examples/cache-api).
+To use the Cache API to store responses in Cloudflare's cache, refer to [Using the Cache API](/workers/examples/cache-api/).

--- a/content/cache/how-to/purge-cache.md
+++ b/content/cache/how-to/purge-cache.md
@@ -66,7 +66,7 @@ Cache-tag purging makes multi-file purging easier because you can bulk purge by 
 ### General workflow for cache-tags
 
 1.  Add tags to the `Cache-Tag HTTP` response header from your origin web server for your web content, such as pages, static assets, etc.
-2.  [Ensure your web traffic is proxied](/dns/manage-dns-records/reference/proxied-dns-records) through Cloudflare.
+2.  [Ensure your web traffic is proxied](/dns/manage-dns-records/reference/proxied-dns-records/) through Cloudflare.
 3.  Cloudflare associates the tags in the `Cache-Tag HTTP` header with the content being cached.
 4.  Use specific cache-tags to purge your Cloudflare CDN cache of all content containing that cache-tag from your dashboard or [using our API](https://api.cloudflare.com/#zone-purge-files-by-cache-tags-or-host).
 5.  Cloudflare forces a [cache miss](/cache/about/default-cache-behavior/#cloudflare-cache-responses) on content with the purged cache-tag.

--- a/content/cache/reference/development-mode.md
+++ b/content/cache/reference/development-mode.md
@@ -5,7 +5,7 @@ pcx-content-type: how-to
 
 # Development Mode
 
-Development Mode temporarily suspends Cloudflare's edge caching, [minification](https://support.cloudflare.com/hc/en-us/articles/200168196), [Polish](/images/polish), and [Railgun](/railgun/) features for three hours unless disabled beforehand. Development Mode allows customers to immediately observe changes to their cacheable content like images, CSS, or JavaScript.
+Development Mode temporarily suspends Cloudflare's edge caching, [minification](https://support.cloudflare.com/hc/en-us/articles/200168196), [Polish](/images/polish/), and [Railgun](/railgun/) features for three hours unless disabled beforehand. Development Mode allows customers to immediately observe changes to their cacheable content like images, CSS, or JavaScript.
 
 ## Enable Development Mode
 


### PR DESCRIPTION
Addresses: `analytics`, `api-shield`, `bots`, `byoip`, `cache`.