### PR TITLE
Document IdentityTransformStream and FixedLengthStream

### DIFF
--- a/content/workers/runtime-apis/streams/transformstream.md
+++ b/content/workers/runtime-apis/streams/transformstream.md
@@ -36,6 +36,67 @@ let { readable, writable } = new TransformStream();
 
 {{</definitions>}}
 
+## `IdentityTransformStream`
+
+The current implementation of `TransformStream` in the Workers platform is not current compliant with the [Streams Standard](https://streams.spec.whatwg.org/#transform-stream) and we will soon be making changes to the implementation to make it conform with the specification. In preparation for doing so, we have introduced the `IdentityTransformStream` class that implements behavior identical to the current `TransformStream` class. This type of stream forwards all chunks of byte data (in the form of `TypedArray`s) written to its writable side to its readable side, without any changes.
+
+The `IdentityTransformStream` readable side supports ["bring your own buffer" (BYOB) reads](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader).
+
+### Constructor
+
+```js
+let { readable, writable } = new IdentityTransformStream();
+```
+
+{{<definitions>}}
+
+- `IdentityTransformStream()` {{<type>}}IdentityTransformStream{{</type>}}
+
+  - Returns a new identity transform stream.
+
+{{</definitions>}}
+
+### Properties
+
+{{<definitions>}}
+
+- `readable` {{<type-link href="#readablestream">}}ReadableStream{{</type-link>}}
+  - An instance of a `ReadableStream`.
+- `writable` {{<type-link href="#writablestream">}}WritableStream{{</type-link>}}
+  - An instance of a `WritableStream`.
+
+{{</definitions>}}
+
+## `FixedLengthStream`
+
+The `FixedLengthStream` is a specialization of `IdentityTransformStream` that limits the total number of bytes that the stream will passthrough. It is useful primarily because, when using `FixedLengthStream` to produce either a `Response` or `Request`, the fixed length of the stream will be used as the `Content-Length` header value as opposed to use chunked encoding when using any other type of stream. An error will occur if too many, or too few bytes are written through the stream.
+
+### Constructor
+
+```js
+let { readable, writable } = new FixedLengthStream(1000);
+```
+
+{{<definitions>}}
+
+- `FixedLengthStream(length)` {{<type>}}FixedLengthStream{{</type>}}
+
+  - Returns a new identity transform stream.
+  - `length` maybe a `number` or `bigint` with a maximum value of `2^53 - 1`.
+
+{{</definitions>}}
+
+### Properties
+
+{{<definitions>}}
+
+- `readable` {{<type-link href="#readablestream">}}ReadableStream{{</type-link>}}
+  - An instance of a `ReadableStream`.
+- `writable` {{<type-link href="#writablestream">}}WritableStream{{</type-link>}}
+  - An instance of a `WritableStream`.
+
+{{</definitions>}}
+
 ## See also
 
 - [Using Streams.](/workers/learning/using-streams/)

--- a/content/workers/runtime-apis/streams/transformstream.md
+++ b/content/workers/runtime-apis/streams/transformstream.md
@@ -40,7 +40,7 @@ let { readable, writable } = new TransformStream();
 
 The current implementation of `TransformStream` in the Workers platform is not current compliant with the [Streams Standard](https://streams.spec.whatwg.org/#transform-stream) and we will soon be making changes to the implementation to make it conform with the specification. In preparation for doing so, we have introduced the `IdentityTransformStream` class that implements behavior identical to the current `TransformStream` class. This type of stream forwards all chunks of byte data (in the form of `TypedArray`s) written to its writable side to its readable side, without any changes.
 
-The `IdentityTransformStream` readable side supports ["bring your own buffer" (BYOB) reads](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader).
+The `IdentityTransformStream` readable side supports [bring your own buffer (BYOB) reads](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader).
 
 ### Constructor
 
@@ -97,7 +97,7 @@ let { readable, writable } = new FixedLengthStream(1000);
 
 {{</definitions>}}
 
-## See also
+## Related resources
 
 - [Using Streams.](/workers/learning/using-streams/)
 - [Transform Streams in the WHATWG Streams API specification.](https://streams.spec.whatwg.org/#transform-stream)


### PR DESCRIPTION
`IdentityTransformStream` is expected to land in next week's release. This should not land until next weeks release is complete.