### PR TITLE
[Magic Transit & WAN] Added scoped routes to correct section

### DIFF
--- a/content/magic-transit/how-to/configure-static-routes.md
+++ b/content/magic-transit/how-to/configure-static-routes.md
@@ -51,3 +51,5 @@ For example, you can send `x.x.x.0/29` to Datacenter 1 and `x.x.x.8/29` to Datac
 2.  Next to **Static routes configuration**, click **Configure**.
 
 {{<render file="_static-routes.md">}}
+
+{{<render file="_scoped-routes.md">}}

--- a/content/magic-transit/how-to/configure-tunnels.md
+++ b/content/magic-transit/how-to/configure-tunnels.md
@@ -83,5 +83,3 @@ Router(config)# ip nat inside
 ```txt
 Router(config)# end
 ```
-
-{{<render file="_scoped-routes.md">}}

--- a/content/magic-wan/how-to/configure-static-routes.md
+++ b/content/magic-wan/how-to/configure-static-routes.md
@@ -39,3 +39,5 @@ For an example edge routing configuration, refer to the example below.
 2. Next to **Manage Magic WAN configuration**, click **Configure**.
 
 {{<render file="../../magic-transit/_partials/_static-routes.md">}}
+
+{{<render file="../../magic-transit/_partials/_scoped-routes.md">}}

--- a/content/magic-wan/how-to/configure-tunnels.md
+++ b/content/magic-wan/how-to/configure-tunnels.md
@@ -25,5 +25,3 @@ For an example Anycast GRE or IPsec tunnel configuration, see [Anycast GRE confi
 2.  Next to **Manage Magic WAN configuration**, click **Configure**.
 
 {{<render file="../../magic-transit/_partials/_tunnel-configuration.md">}}
-
-{{<render file="../../magic-transit/_partials/_scoped-routes.md">}}


### PR DESCRIPTION
Added the scoped routes partial to the correct section. Accidentally added to tunnel endpoints instead of static routes.