### PR TITLE
Fix 'wich'->'with' typo in API Gateway page

### DIFF
--- a/content/api-shield/api-gateway.md
+++ b/content/api-shield/api-gateway.md
@@ -10,7 +10,7 @@ weight: 2
 API Gateway is a package of features that will do everything for your APIs, including:
 
 - **Security**: Protect your API from malicious traffic with [API Discovery](/api-shield/security/api-discovery/), [Schema Validation](/api-shield/security/schema-validation/), [mTLS validation](/api-shield/security/mtls/), and more.
-- **Management and monitoring**: Streamline API management wich [tools](https://blog.cloudflare.com/api-gateway/) like analytics, routing, and authentication.
+- **Management and monitoring**: Streamline API management with [tools](https://blog.cloudflare.com/api-gateway/) like analytics, routing, and authentication.
 - **Logging, quota management, and more**: All of Cloudflare's [established features](https://blog.cloudflare.com/api-gateway/), like caching, load balancing, and log integrations work natively with API Gateway.
 
 For more details about API Gateway, refer to the [introductory blog post](https://blog.cloudflare.com/api-gateway/).


### PR DESCRIPTION
Just a quick PR to edit a typo in the "API Gateway" of the "API Shield" documentation.