### PR TITLE
[Magic Transit] Added section for Clear DF bit

### DIFF
--- a/content/magic-transit/prerequisites.md
+++ b/content/magic-transit/prerequisites.md
@@ -60,7 +60,9 @@ Unless you apply these MSS settings at the origin, client machines do not know t
 
 ### Clear Don't Fragment (DF)
 
-If you are unable to set the MSS on your physical interfaces to a value lower than 1500 bytes, you can choose to clear the `don't-fragment` bit in the IP header. When this option is enabled, Cloudflare fragments packets greater than 1500 bytes, and the packets are reassembled on your infrastructure after decapsulation. 
+If you are unable to set the MSS on your physical interfaces to a value lower than 1500 bytes, you can choose to clear the `don't-fragment` bit in the IP header. When this option is enabled, Cloudflare fragments packets greater than 1500 bytes, and the packets are reassembled on your infrastructure after decapsulation. In most environments, enabling this option does not have significant impact on traffic throughput.
+
+To enable this option for your network, contact your account team.
 
 ## Apply MSS clamps
 

--- a/content/magic-transit/prerequisites.md
+++ b/content/magic-transit/prerequisites.md
@@ -58,6 +58,10 @@ If you are using IPsec inside GRE, set the MSS clamp at the IPsec tunnel interfa
 
 Unless you apply these MSS settings at the origin, client machines do not know that they must use an MSS of 1436 bytes when sending packets to your origin.
 
+### Clear Don't Fragment (DF)
+
+If you are unable to set the MSS on your physical interfaces to a value lower than 1500 bytes, you can choose to clear the `don't-fragment` bit in the IP header. When this option is enabled, Cloudflare fragments packets greater than 1500 bytes, and the packets are reassembled on your infrastructure after decapsulation. 
+
 ## Apply MSS clamps
 
 Instructions to adjust MSS by applying MSS clamps vary depending on the vendor of your router.

--- a/content/magic-transit/prerequisites.md
+++ b/content/magic-transit/prerequisites.md
@@ -58,7 +58,7 @@ If you are using IPsec inside GRE, set the MSS clamp at the IPsec tunnel interfa
 
 Unless you apply these MSS settings at the origin, client machines do not know that they must use an MSS of 1436 bytes when sending packets to your origin.
 
-## Apply MSS clmaps
+## Apply MSS clamps
 
 Instructions to adjust MSS by applying MSS clamps vary depending on the vendor of your router.
 


### PR DESCRIPTION
Added section to prerequisites that lets users know about the clear DF bit. Addresses [PCX-2094](https://jira.cfops.it/browse/PCX-2094).