### PR TITLE
[Pages] Adds CF_PAGES_URL environment variable

### DIFF
--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -64,6 +64,7 @@ The following system environment variables are injected by default (but can be o
 | `CF_PAGES`            | `1`                                   | Changing build behaviour when run on Pages versus locally                               |
 | `CF_PAGES_COMMIT_SHA` | `<sha1-hash-of-current-commit>`       | Passing current commit ID to error reporting, for example, Sentry                       |
 | `CF_PAGES_BRANCH`     | `<branch-name-of-current-deployment>` | Customizing build based on branch, for example, disabling debug logging on `production` |
+| `CF_PAGES_URL`        | `<url-of-current-deployment>`         | Allowing build tools to know the URL the page will be deployed at                       |
 
 ## Language support and tools
 


### PR DESCRIPTION
An undocumented build-time Pages environment variable is `CF_PAGES_URL`, which is the deployment URL of the current build (for example, `a2b3c4d5.subdomain.pages.dev`).

This PR adds documentation about this fact. The internal ticket number for this fix is `WDC-577` if this PR should close that.