### PR TITLE
[Redirects] Updated partials with redirects to prevent old search indexing + 404s

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -994,3 +994,6 @@
 /fundamentals/_partials/* /fundamentals/ 301
 /load-balancing/_partials/* /load-balancing/ 301
 /api-shield/_partials/* /api-shield/ 301
+/registrar/_partials/* /registrar/ 301
+/waf/_partials/* /waf/ 301
+/1.1.1.1/_partials/* /1.1.1.1/ 301

--- a/content/_redirects
+++ b/content/_redirects
@@ -982,3 +982,15 @@
 /browser-isolation/* /cloudflare-one/policies/browser-isolation/ 301
 
 /ssl/custom-certificates/* /ssl/edge-certificates/custom-certificates/:splat 301
+
+# partial redirects (will expand later)
+
+/ssl/_partials/* /ssl/ 301
+/waiting-room/_partials/* /waiting-room/ 301
+/warp-client/_partials/* /warp-client/ 301
+/bots/_partials/* /bots/ 301
+/api-security/_partials/* /api-shield/ 301
+/logs/_partials/* /logs/ 301
+/fundamentals/_partials/* /fundamentals/ 301
+/load-balancing/_partials/* /load-balancing/ 301
+/api-shield/_partials/* /api-shield/ 301

--- a/content/warp-client/_partials/_modes-options.md
+++ b/content/warp-client/_partials/_modes-options.md
@@ -1,3 +1,10 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
 ## WARP modes
 
 The WARP app has two main modes of operation: WARP and 1.1.1.1.


### PR DESCRIPTION
Pulled the top doc areas getting partial requests and set up redirects. List will probably be updated in the future, but for now it's probably fine to just update as we see more requests going to specific areas.

Think this should also naturally calm down over time due to our updated sitemaps that don't list partials in the index.