### PR TITLE
Remove target: '#svelte' from svelte.config,js

### DIFF
--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -94,7 +94,6 @@ const config = {
   kit: {
 ++  adapter: adapter(),
     // ... truncated ...
-    target: '#svelte'
   }
 };
 


### PR DESCRIPTION
Remove target: '#svelte' from svelte.config.js. Because it is no longer required.