### PR TITLE
[Durable Objects] Remote exceptions can be differentiated by property

### DIFF
--- a/content/workers/runtime-apis/durable-objects.md
+++ b/content/workers/runtime-apis/durable-objects.md
@@ -396,7 +396,7 @@ let response = await stub.fetch(url, options);
 
 The `fetch()` method of a stub has the exact same signature as the [global `fetch`](/workers/runtime-apis/fetch/). However, instead of sending an HTTP request to the Internet, the request is always sent to the Durable Object to which the stub points.
 
-Any uncaught exceptions thrown by the Durable Object's `fetch()` handler will be propagated to the caller's `fetch()` promise.
+Any uncaught exceptions thrown by the Durable Object's `fetch()` handler will be propagated to the caller's `fetch()` promise. Furthermore, if an uncaught exception is thrown by the Durable Object's `fetch()` handler, then the exception propagated to the caller's `fetch()` promise will include a property `.remote`, which will be set to `True`. If the caller's `fetch()` failed as a result of being unable to reach the Durable Object, the exception thrown to the caller's `fetch()` will not have the `.remote` property, indicating the exception was not generated remotely.
 
 ## Listing Durable Objects
 


### PR DESCRIPTION
Previously, we couldn't determine if an exception thrown to a Worker from a remote Durable Object/Worker was created by the remote or due to a failure in reaching the remote. We can now differentiate these by using the `.remote` property on the exception.