### PR TITLE
[Magic WAN] Added traffic steering and tunnel & encapsulation info

### DIFF
--- a/content/magic-wan/about/_index.md
+++ b/content/magic-wan/about/_index.md
@@ -1,0 +1,11 @@
+---
+title: About
+pcx-content-type: navigation
+weight: 2
+---
+
+# About
+
+For more information on concepts related to Magic WAN, review the information below.
+
+{{<directory-listing>}}

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -5,7 +5,7 @@ title: Traffic steering
 
 # Traffic steering
 
-Magic WAN uses a static configuration to route traffic through [Anycast tunnels](/magic-wan/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your network and from your network to CLoudflare's edge.
+Magic WAN uses a static configuration to route traffic through [Anycast tunnels](/magic-wan/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your network and from your network to Cloudflare's edge.
 
 Magic WAN steers traffic along GRE tunnel routes based on priorities you define during the onboarding process.
 
@@ -76,11 +76,11 @@ When Magic WAN determines that Tunnels 1 and 2 are healthy again, it re-prioriti
 
 Because ECMP is probabilistic, the algorithm routes roughly the same number of flows through each tunnel. However it does _not_ consider the amount of traffic already sent through a tunnel when deciding where to route the next packet.
 
-For example, consider a scenario with many very low-bandwidth TCP connections and one very high-bandwidth TCP connection. Packets for the high-bandwidth connection have the same hash and thus use the same tunnel. As a result, that tunnel utilizes greater bandwidth than the others.
+For example, consider a scenario with many very low-bandwidth TCP connections and one very high-bandwidth TCP connection. Packets for the high-bandwidth connection have the same hash and thus use the same tunnel. As a result, the high-bandwidth connection tunnel utilizes greater bandwidth than the others.
 
 {{<Aside type="note" header="Note">}}
 
-Magic WAN supports a "weight" field that you can apply to a tunnel so that a specified percentage of traffic uses that tunnel rather than other equal-cost tunnels.
+Magic WAN supports a weight field that you can apply to a tunnel so that a specified percentage of traffic uses that tunnel rather than other equal-cost tunnels.
 
 For example, in a scenario where you want to route 70% of your traffic through ISP A and 30% through ISP B, you can use the weight field to help achieve that.
 

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -7,7 +7,7 @@ title: Traffic steering
 
 Magic WAN uses a static configuration to route traffic through [Anycast tunnels](/magic-wan/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your network and from your network to Cloudflare's edge.
 
-Magic WAN steers traffic along GRE tunnel routes based on priorities you define during the onboarding process.
+Magic WAN steers traffic along static routes based on priorities you define during the onboarding process.
 
 The example in this diagram has three tunnel routes. Tunnels 1 and 2 have top priority and Tunnel 3 is secondary.
 
@@ -44,7 +44,7 @@ This diagram illustrates how ECMP distributes traffic equally across 2 paths wit
 </div>
 </details>
 
-When Magic WAN health checks determine that GRE Tunnel 2 is unhealthy, that route is dynamically de-prioritized, leaving Tunnel 1 the sole top-priority route. As a result, traffic is steered away from Tunnel 2, and all traffic flows to Tunnel 1:
+When Magic WAN health checks determine that Tunnel 2 is unhealthy, that route is dynamically de-prioritized, leaving Tunnel 1 the sole top-priority route. As a result, traffic is steered away from Tunnel 2, and all traffic flows to Tunnel 1:
 
 <details>
 <summary>
@@ -57,7 +57,7 @@ When Magic WAN health checks determine that GRE Tunnel 2 is unhealthy, that rout
 </div>
 </details>
 
-When Magic WAN determines that GRE Tunnel 1 is unhealthy as well, that route is also de-prioritized, leaving GRE Tunnel 3 as the top priority route. In that case, all traffic flows to GRE Tunnel 3.
+When Magic WAN determines that Tunnel 1 is unhealthy as well, that route is also de-prioritized, leaving Tunnel 3 as the top priority route. In that case, all traffic flows to Tunnel 3.
 
 <details>
 <summary>

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -1,0 +1,92 @@
+---
+pcx-content-type: concept
+title: Traffic steering
+weight: 
+---
+
+# Traffic steering
+
+Magic WAN uses a static configuration to route traffic through [Anycast tunnels](/magic-wan/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your network and from your network to CLoudflare's edge.
+
+Magic WAN steers traffic along GRE tunnel routes based on priorities you define during the onboarding process.
+
+The example in this diagram has three tunnel routes. Tunnels 1 and 2 have top priority and Tunnel 3 is secondary.
+
+![Example route priorities](/magic-transit/static/mt-traffic-steering-ecmp-baseline.png)
+
+When there are multiple routes with equal priority and different next-hops, Cloudflare uses equal-cost multi-path (ECMP) routing. An example of multiple routes with equal priority would be Tunnel 1 and Tunnel 2.
+
+The use of ECMP routing provides load balancing across tunnels with the same priority.
+
+## Equal-cost multi-path routing
+
+Equal-cost multi-path routing uses hashes calculated from packet data to determine routes. The hash always uses the source and destination IP addresses. For TCP and UDP packets, the hash includes the source and destination ports as well. The ECMP algorithm divides the hash for each packet by the number of equal-cost next hops. The modulus (remainder) determines the route the packet takes.
+
+Using ECMP has a number of consequences:
+
+- Routing to equal-cost paths is probabilistic.
+
+- Packets in the same session (or flow) with the same source and destination have the same hash. The packets also use the same next hop.
+
+- Routing changes in the number of equal-cost next hops can cause traffic to use different tunnels. For example, dynamic prioritization triggered by health check events can cause traffic to use different tunnels.
+
+### Examples
+
+This diagram illustrates how ECMP distributes traffic equally across 2 paths with the same priority.
+
+<details>
+<summary>
+  Normal traffic flow
+</summary>
+  <div class="special-class" markdown="1">
+
+![ECMP diagram of health network](/magic-transit/static/mt-traffic-steering-ecmp-normal.png)
+
+</div>
+</details>
+
+When Magic WAN health checks determine that GRE Tunnel 2 is unhealthy, that route is dynamically de-prioritized, leaving Tunnel 1 the sole top-priority route. As a result, traffic is steered away from Tunnel 2, and all traffic flows to Tunnel 1:
+
+<details>
+<summary>
+  Failover traffic flow: Scenario 1
+</summary>
+  <div class="special-class" markdown="1">
+
+![ECMP diagram of unhealthy Tunnel 2](/magic-transit/static/mt-traffic-steering-ecmp-failure-1.png)
+
+</div>
+</details>
+
+When Magic WAN determines that GRE Tunnel 1 is unhealthy as well, that route is also de-prioritized, leaving GRE Tunnel 3 as the top priority route. In that case, all traffic flows to GRE Tunnel 3.
+
+<details>
+<summary>
+  Failover traffic flow: Scenario 2
+</summary>
+  <div class="special-class" markdown="1">
+
+![ECMP diagram of unhealthy Tunnels 1 and 2](/magic-transit/static/mt-traffic-steering-ecmp-failure-2.png)
+
+</div>
+</details>
+
+When Magic WAN determines that Tunnels 1 and 2 are healthy again, it re-prioritizes those routes, and traffic flow returns to normal.
+
+## ECMP and bandwidth utilization
+
+Because ECMP is probabilistic, the algorithm routes roughly the same number of flows through each tunnel. However it does _not_ consider the amount of traffic already sent through a tunnel when deciding where to route the next packet.
+
+For example, consider a scenario with many very low-bandwidth TCP connections and one very high-bandwidth TCP connection. Packets for the high-bandwidth connection have the same hash and thus use the same tunnel. As a result, that tunnel utilizes greater bandwidth than the others.
+
+{{<Aside type="note" header="Note">}}
+
+Magic WAN supports a "weight" field that you can apply to a tunnel so that a specified percentage of traffic uses that tunnel rather than other equal-cost tunnels.
+
+For example, in a scenario where you want to route 70% of your traffic through ISP A and 30% through ISP B, you can use the weight field to help achieve that.
+
+Keep in mind that because ECMP balances flows probabilistically, the use of weights is only approximate.
+
+For more on Magic WAN tunnel weights, contact your Cloudflare customer service manager.
+
+{{</Aside>}}

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -84,8 +84,8 @@ Magic WAN supports a weight field that you can apply to a tunnel so that a speci
 
 For example, in a scenario where you want to route 70% of your traffic through ISP A and 30% through ISP B, you can use the weight field to help achieve that.
 
-Keep in mind that because ECMP balances flows probabilistically, the use of weights is only approximate.
+Note that because ECMP balances flows probabilistically, the use of weights is only approximate.
 
-For more on Magic WAN tunnel weights, contact your Cloudflare customer service manager.
+For more on Magic WAN tunnel weights, contact your Cloudflare account manager.
 
 {{</Aside>}}

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -1,7 +1,6 @@
 ---
 pcx-content-type: concept
 title: Traffic steering
-weight: 
 ---
 
 # Traffic steering

--- a/content/magic-wan/about/tunnels-and-encapsulation.md
+++ b/content/magic-wan/about/tunnels-and-encapsulation.md
@@ -6,11 +6,11 @@ weight:
 
 # Tunnels & encapsulation
 
-Magic WAN uses [Generic Routing Encapsulation (GRE)](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/) tunnels to transmit packets from Cloudflare’s edge to your origin network. Cloudflare sets up GRE tunnel endpoints on edge servers inside your network namespace, and you [set up tunnel endpoints](/magic-wan/how-to/configure-tunnels/) on routers at your data center.
+Magic WAN uses [Generic Routing Encapsulation (GRE)](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/) and [IPsec](https://www.cloudflare.com/learning/network-layer/what-is-ipsec/) tunnels to transmit packets from Cloudflare’s edge to your origin network. Cloudflare sets up tunnel endpoints on edge servers inside your network namespace, and you [set up tunnel endpoints](/magic-wan/how-to/configure-tunnels/) on routers at your data center.
 
 ## Encapsulation
 
-Magic WAN [encapsulates IP packets](https://www.cloudflare.com/learning/network-layer/what-is-tunneling/) destined for your network and transmits them across the GRE tunnels to your tunnel endpoint router, which decapsulates the packets and sends them to your internal network.
+Magic WAN [encapsulates IP packets](https://www.cloudflare.com/learning/network-layer/what-is-tunneling/) destined for your network and transmits them across the tunnels to your tunnel endpoint router, which decapsulates the packets and sends them to your internal network.
 
 {{<Aside type="note" header="Note">}}
 
@@ -24,6 +24,6 @@ For instructions, refer to [Set Maximum Segment Size](/magic-wan/prerequisites/#
 
 Magic WAN uses [Anycast](https://www.cloudflare.com/learning/cdn/glossary/anycast-network/) IP addresses for Cloudflare’s tunnel endpoints, meaning that any server in any data center is capable of encapsulating and decapsulating packets for the same tunnel.
 
-This works because the Anycast protocol is stateless — each packet is processed independently and does not require any negotiation or coordination between tunnel endpoints. Tunnel endpoints are technically bound to IP addresses but do not need to be bound to specific devices. Any device that can strip off the outer headers and then route the inner packet can handle any GRE packet sent over the tunnel.
+This works because the Anycast protocol is stateless — each packet is processed independently and does not require any negotiation or coordination between tunnel endpoints. Tunnel endpoints are technically bound to IP addresses but do not need to be bound to specific devices. Any device that can strip off the outer headers and then route the inner packet can handle any packet sent over the tunnel.
 
 Cloudflare’s Anycast architecture provides a conduit to your Anycast tunnel for every server in every data center on Cloudflare’s global edge network.

--- a/content/magic-wan/about/tunnels-and-encapsulation.md
+++ b/content/magic-wan/about/tunnels-and-encapsulation.md
@@ -1,0 +1,29 @@
+---
+pcx-content-type: concept
+title: Tunnels & encapsulation
+weight: 
+---
+
+# Tunnels & encapsulation
+
+Magic WAN uses [Generic Routing Encapsulation (GRE)](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/) tunnels to transmit packets from Cloudflare’s edge to your origin network. Cloudflare sets up GRE tunnel endpoints on edge servers inside your network namespace, and you [set up tunnel endpoints](/magic-wan/how-to/configure-tunnels/) on routers at your data center.
+
+## Encapsulation
+
+Magic WAN [encapsulates IP packets](https://www.cloudflare.com/learning/network-layer/what-is-tunneling/) destined for your network and transmits them across the GRE tunnels to your tunnel endpoint router, which decapsulates the packets and sends them to your internal network.
+
+{{<Aside type="note" header="Note">}}
+
+To accommodate additional header data introduced by encapsulation, the maximum segment size (MSS) must be adjusted so that packets comply with the standard Internet routable maximum transmission unit (MTU), which is 1500 bytes.
+
+For instructions, refer to [Set Maximum Segment Size](/magic-wan/prerequisites/#set-maximum-segment-size).
+
+{{</Aside>}}
+
+## Anycast GRE
+
+Magic WAN uses [Anycast](https://www.cloudflare.com/learning/cdn/glossary/anycast-network/) IP addresses for Cloudflare’s tunnel endpoints, meaning that any server in any data center is capable of encapsulating and decapsulating packets for the same tunnel.
+
+This works because the Anycast protocol is stateless — each packet is processed independently and does not require any negotiation or coordination between tunnel endpoints. Tunnel endpoints are technically bound to IP addresses but do not need to be bound to specific devices. Any device that can strip off the outer headers and then route the inner packet can handle any GRE packet sent over the tunnel.
+
+Cloudflare’s Anycast architecture provides a conduit to your Anycast tunnel for every server in every data center on Cloudflare’s global edge network.

--- a/content/magic-wan/get-started.md
+++ b/content/magic-wan/get-started.md
@@ -1,7 +1,7 @@
 ---
 title: Get started
 pcx-content-type: get-started
-weight: 3
+weight: 4
 ---
 
 # Get started

--- a/content/magic-wan/how-to/_index.md
+++ b/content/magic-wan/how-to/_index.md
@@ -1,7 +1,7 @@
 ---
 title: How to
 pcx-content-type: how-to
-weight: 4
+weight: 5
 ---
 
 # How to

--- a/content/magic-wan/how-to/configure-static-routes.md
+++ b/content/magic-wan/how-to/configure-static-routes.md
@@ -6,14 +6,14 @@ weight: 2
 
 # Configure static routes
 
-Magic WAN uses a static configuration to route your traffic through [Generic Routing Encapsulation (GRE) tunnels](/magic-transit/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your locations.
+Magic WAN uses a static configuration to route your traffic through [Generic Routing Encapsulation (GRE) tunnels](/magic-wan/about/tunnels-and-encapsulation/) from Cloudflare’s edge to your locations.
 
 You must assign a route priority to each Anycast GRE or IPsec tunnel–subnet pair in your GRE configuration, as follows:
 
 - Lower values have greater priority.
-- When the priority values for prefix entries match — as illustrated by the 103.21.244.0/24 subnet in the example routing configuration (in bold) — Cloudflare uses equal-cost multi-path (ECMP) packet forwarding to route traffic.
+- When the priority values for prefix entries match — as illustrated by the 10.10.10.102/31 subnet in the example routing configuration (in bold) — Cloudflare uses equal-cost multi-path (ECMP) packet forwarding to route traffic.
 
-For more on how Cloudflare uses ECMP packet forwarding, see [Traffic steering](/magic-transit/about/traffic-steering/).
+For more on how Cloudflare uses ECMP packet forwarding, see [Traffic steering](/magic-wan/about/traffic-steering/).
 
 For an example edge routing configuration, refer to the example below.
 

--- a/content/magic-wan/how-to/configure-static-routes.md
+++ b/content/magic-wan/how-to/configure-static-routes.md
@@ -13,7 +13,7 @@ You must assign a route priority to each Anycast GRE or IPsec tunnel–subnet pa
 - Lower values have greater priority.
 - When the priority values for prefix entries match — as illustrated by the 10.10.10.102/31 subnet in the example routing configuration (in bold) — Cloudflare uses equal-cost multi-path (ECMP) packet forwarding to route traffic.
 
-For more on how Cloudflare uses ECMP packet forwarding, see [Traffic steering](/magic-wan/about/traffic-steering/).
+For more on how Cloudflare uses ECMP packet forwarding, refer to [Traffic steering](/magic-wan/about/traffic-steering/).
 
 For an example edge routing configuration, refer to the example below.
 

--- a/content/magic-wan/partners/_index.md
+++ b/content/magic-wan/partners/_index.md
@@ -1,7 +1,7 @@
 ---
 pcx-content-type: navigation
 title: Partners
-weight: 6
+weight: 7
 ---
 
 # Partners

--- a/content/magic-wan/prerequisites.md
+++ b/content/magic-wan/prerequisites.md
@@ -1,7 +1,7 @@
 ---
 title: Prerequisites
 pcx-content-type: how-to
-weight: 2
+weight: 3
 ---
 
 # Prerequisites

--- a/content/magic-wan/reference/_index.md
+++ b/content/magic-wan/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 pcx-content-type: navigation
 title: Reference
-weight: 7
+weight: 8
 ---
 
 # Reference

--- a/content/magic-wan/tutorials/_index.md
+++ b/content/magic-wan/tutorials/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 pcx-content-type: navigation
-weight: 5
+weight: 6
 ---
 
 # Tutorials


### PR DESCRIPTION
Added topics on traffic steering and tunnels & encapsulation from Magic Transit. Updated content to be specific to Magic WAN.

(Other edits included updates to page order and fixing an IP address on the Static Routes page.)

Addresses [PCX-3283](https://jira.cfops.it/browse/PCX-3283).