### PR TITLE
[Magic WAN] Fixing supported config parameters

### DIFF
--- a/content/magic-wan/tutorials/ipsec.md
+++ b/content/magic-wan/tutorials/ipsec.md
@@ -52,6 +52,8 @@ To set up your static routes, refer to [Configure static routes](/magic-wan/how-
 - **PFS group** (sometimes referred to as "Phase 2 Diffie-Hellman Group"):
   - DH group 14 (2048-bit MODP group)
 
+### Additional configuration parameters
+
 - Auth is PSK
 - Remote Port of 500
 - 0s reauth time or no reauth

--- a/content/magic-wan/tutorials/ipsec.md
+++ b/content/magic-wan/tutorials/ipsec.md
@@ -51,3 +51,9 @@ To set up your static routes, refer to [Configure static routes](/magic-wan/how-
 
 - **PFS group** (sometimes referred to as "Phase 2 Diffie-Hellman Group"):
   - DH group 14 (2048-bit MODP group)
+
+- Auth is PSK
+- Remote Port of 500
+- 0s reauth time or no reauth
+- 4h rekey time
+- Disable anti-replay protection

--- a/content/magic-wan/tutorials/secure-web-gateway.md
+++ b/content/magic-wan/tutorials/secure-web-gateway.md
@@ -16,6 +16,7 @@ In this tutorial, you will learn how to configure the Anycast GRE or IPsec tunne
 Before you can configure the Anycast GRE or IPsec tunnel on-ramp to Magic WAN, the following items should already be completed:
 
 - Purchased Magic WAN and Secure Web Gateway
+- Added a root certificate
 - Cloudflare created and provisioned Magic WAN and Secure Web Gateway
 - Received the Cloudflare GRE endpoint (Anycast IP address) assigned to Magic WAN
 - Established connectivity between site edge routers and the Cloudflare GRE endpoint via the Internet or Cloudflare Network Interconnect (CNI)

--- a/content/magic-wan/tutorials/secure-web-gateway.md
+++ b/content/magic-wan/tutorials/secure-web-gateway.md
@@ -21,6 +21,8 @@ Before you can configure the Anycast GRE or IPsec tunnel on-ramp to Magic WAN, t
 - Established connectivity between site edge routers and the Cloudflare GRE endpoint via the Internet or Cloudflare Network Interconnect (CNI)
 - Use site routers that support Anycast GRE or IPsec tunnels and Policy-based Routing (PBR) so that specific Internet-bound traffic from the sites' private networks can be routed over the Anycast GRE or IPsec tunnel to Magic WAN, and subsequently Secure Web Gateway, to enforce a user's specific web access policies.
 
+Proper routing techniques, such as policy-based routing, should also be utilized on the site routers to match relevant Internet-bound traffic from the site’s appropriate local private subnets, and route them over the GRE tunnel to Cloudflare Magic WAN and Secure Web Gateway for processing. Otherwise, such Internet-bound traffic would likely be routed straight out of the physical uplink of the site router without the protection enforced by the Cloudflare Secure Web Gateway
+
 ## Example scenario
 
 For the purpose of this tutorial, setup will reference a scenario where an enterprise has three sites: headquarters, a branch office, and a data center. Each site has a local private network with RFC1918 address assignments:

--- a/content/magic-wan/tutorials/secure-web-gateway.md
+++ b/content/magic-wan/tutorials/secure-web-gateway.md
@@ -22,7 +22,7 @@ Before you can configure the Anycast GRE or IPsec tunnel on-ramp to Magic WAN, t
 - Established connectivity between site edge routers and the Cloudflare GRE endpoint via the Internet or Cloudflare Network Interconnect (CNI)
 - Use site routers that support Anycast GRE or IPsec tunnels and Policy-based Routing (PBR) so that specific Internet-bound traffic from the sites' private networks can be routed over the Anycast GRE or IPsec tunnel to Magic WAN, and subsequently Secure Web Gateway, to enforce a user's specific web access policies.
 
-Proper routing techniques, such as policy-based routing, should also be utilized on the site routers to match relevant Internet-bound traffic from the site’s appropriate local private subnets, and route them over the GRE tunnel to Cloudflare Magic WAN and Secure Web Gateway for processing. Otherwise, such Internet-bound traffic would likely be routed straight out of the physical uplink of the site router without the protection enforced by the Cloudflare Secure Web Gateway
+Proper routing techniques, such as policy-based routing, should also be utilized on the site routers to match relevant Internet-bound traffic from the site’s appropriate local private subnets and route them over the GRE tunnel to Cloudflare Magic WAN and Secure Web Gateway for processing. Otherwise, such Internet-bound traffic would likely be routed straight out of the physical uplink of the site router without the protection enforced by the Cloudflare Secure Web Gateway.
 
 ## Example scenario
 


### PR DESCRIPTION
Putting back config parameters that were removed in https://github.com/cloudflare/cloudflare-docs/pull/3984. 

Also using this PR as an opportunity to address [PCX-3607](https://jira.cfops.it/browse/PCX-3607) and add a missing prereq to the Secure Web Gateway tutorial.