### PR TITLE
Error Correction [ruleset-engine/rules-language/functions.md]

### DIFF
--- a/content/ruleset-engine/rules-language/functions.md
+++ b/content/ruleset-engine/rules-language/functions.md
@@ -49,7 +49,7 @@ The Rules language supports these transformation functions:
   - <em>Example:</em>
     <br />
 
-    `all(http.request.headers['content-type'][*] == "application/json")`
+    `all(http.request.headers["content-type"][*] == "application/json")`
 
 - <code>concat({{<type>}}String | Integer | bytes | Array elements{{</type>}})</code> {{<type>}}String{{</type>}}
 


### PR DESCRIPTION
Filter parsing error (1:26): all(http.request.headers['content-type'][*] == "application/json") 
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
expected literal "expected quoted utf8 string or positive integer"