### PR TITLE
[Magic WAN] Added tutorial for using Magic & WARP

### DIFF
--- a/content/magic-wan/tutorials/warp.md
+++ b/content/magic-wan/tutorials/warp.md
@@ -1,0 +1,47 @@
+---
+title: WARP
+pcx-content-type: tutorial
+meta:
+  title: Use WARP as an on-ramp
+---
+
+# WARP on-ramp to Magic WAN
+
+Use WARP as an on-ramp to Magic WAN to route traffic from user devices with WARP installed to any network connected with Magic IP-layer tunnels (Anycast [GRE](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/), [IPsec](/magic-wan/tutorials/ipsec), or [CNI](/network-interconnect)).
+
+## Prerequisites
+
+Before you can use begin using WARP as on-ramp to Magic WAN, you must: 
+
+- Set up your [Zero Trust account](/cloudflare-one/setup/#start-from-the-cloudflare-dashboard).
+- Contact your account team to enable the integration between WARP and Magic WAN.
+
+## 1. Create a service token
+
+Refer to [Create a service token](/cloudflare-one/identity/service-auth/service-tokens/#create-a-service-token) in the Cloudflare Zero Trust documentation for more information.
+
+## 2. Install the WARP client on your device
+
+Refer to [Install the WARP client on your devices](/cloudflare-one/setup/#install-the-warp-client-on-your-devices) in the Cloudflare Zero Trust documentation for more information.
+
+## 3. Configure Split Tunnels
+
+[Configure Split Tunnels](/cloudflare-one/tutorials/split-tunnel/) from your Zero Trust dashboard to only include traffic from the private IP addresses you want to acceess.
+
+Optionally, you can also just to configure Split Tunnels to include IP ranges or domains you want to use for connecting to public IP addresses. If you choose to use this option, destination ports `1023` and lower are supported.
+
+## 4. Connect to WARP from your machine
+
+Refer to [Deploy WARP to your organization](/cloudflare-one/connections/connect-devices/warp/deployment/) for more information on whether to choose a manual or managed deployment.
+
+You should be able to access Private IP addresses specified in the Split Tunnel configuration. If you requested to test TCP connectivity to public IP addresses, you should be able to access these services provided the destination port is `1023` or lower.
+
+## 5. Route packets back to WARP devices
+
+Route packets back to WARP devices from services behind an Anycast or other tunnel.
+
+WARP devices will be assigned IP addresses from the Magic WARP Virtual IP (VIP) space: 
+
+All packets with a destination IP in the VIP space need to be routed back through the tunnel. For example, with a single GRE tunnel named `gre1`, in Linux, the following command would add a routing rule that would route such packets:
+
+`sudo ip route  dev gre1`

--- a/content/magic-wan/tutorials/warp.md
+++ b/content/magic-wan/tutorials/warp.md
@@ -11,7 +11,7 @@ Use WARP as an on-ramp to Magic WAN to route traffic from user devices with WARP
 
 ## Prerequisites
 
-Before you can use begin using WARP as on-ramp to Magic WAN, you must: 
+Before you can begin using WARP as an on-ramp to Magic WAN, you must: 
 
 - Set up your [Zero Trust account](/cloudflare-one/setup/#start-from-the-cloudflare-dashboard).
 - Contact your account team to enable the integration between WARP and Magic WAN.
@@ -28,7 +28,7 @@ Refer to [Install the WARP client on your devices](/cloudflare-one/setup/#instal
 
 [Configure Split Tunnels](/cloudflare-one/tutorials/split-tunnel/) from your Zero Trust dashboard to only include traffic from the private IP addresses you want to acceess.
 
-Optionally, you can also just to configure Split Tunnels to include IP ranges or domains you want to use for connecting to public IP addresses. If you choose to use this option, destination ports `1023` and lower are supported.
+Optionally, you can configure Split Tunnels to include IP ranges or domains you want to use for connecting to public IP addresses. If you choose to use this option, destination ports `1023` and lower are supported.
 
 ## 4. Connect to WARP from your machine
 
@@ -40,7 +40,7 @@ You should be able to access Private IP addresses specified in the Split Tunnel 
 
 Route packets back to WARP devices from services behind an Anycast GRE or other type tunnel.
 
-WARP devices will be assigned IP addresses from the Magic WARP Virtual IP (VIP) space: 
+WARP devices will be assigned IP addresses from the Magic WARP Virtual IP (VIP) space.
 
 All packets with a destination IP in the VIP space need to be routed back through the tunnel. For example, with a single GRE tunnel named `gre1`, in Linux, the following command would add a routing rule that would route such packets:
 

--- a/content/magic-wan/tutorials/warp.md
+++ b/content/magic-wan/tutorials/warp.md
@@ -38,10 +38,10 @@ You should be able to access Private IP addresses specified in the Split Tunnel 
 
 ## 5. Route packets back to WARP devices
 
-Route packets back to WARP devices from services behind an Anycast or other tunnel.
+Route packets back to WARP devices from services behind an Anycast GRE or other type tunnel.
 
 WARP devices will be assigned IP addresses from the Magic WARP Virtual IP (VIP) space: 
 
 All packets with a destination IP in the VIP space need to be routed back through the tunnel. For example, with a single GRE tunnel named `gre1`, in Linux, the following command would add a routing rule that would route such packets:
 
-`sudo ip route  dev gre1`
+`ip route add 100.96.0.0/12 dev gre1`

--- a/content/magic-wan/tutorials/warp.md
+++ b/content/magic-wan/tutorials/warp.md
@@ -7,7 +7,7 @@ meta:
 
 # WARP on-ramp to Magic WAN
 
-Use WARP as an on-ramp to Magic WAN to route traffic from user devices with WARP installed to any network connected with Magic IP-layer tunnels (Anycast [GRE](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/), [IPsec](/magic-wan/tutorials/ipsec), or [CNI](/network-interconnect)).
+Use WARP as an on-ramp to Magic WAN and route traffic from user devices with WARP installed to any network connected with Magic IP-layer tunnels (Anycast [GRE](https://www.cloudflare.com/learning/network-layer/what-is-gre-tunneling/), [IPsec](/magic-wan/tutorials/ipsec/), or [CNI](/network-interconnect/)).
 
 ## Prerequisites
 


### PR DESCRIPTION
Added tutorial for using WARP as an on-ramp to Magic WAN to address [PCX-3541](https://jira.cfops.it/browse/PCX-3541).