### PR TITLE
[Stream] Moved placement of live viewer content

### DIFF
--- a/content/stream/getting-analytics/live-viewer-count.md
+++ b/content/stream/getting-analytics/live-viewer-count.md
@@ -1,0 +1,18 @@
+---
+pcx-content-type: how to
+title: Get live viewer counts
+---
+
+# Live viewer counts for third party players
+
+The Stream player has full support for live viewer counts by default. To get the viewer count for live videos for use with third party players, make a `GET` request to the `/views` endpoint.
+
+```bash
+https://videodelivery.net/55b9b5ce48c3968c6b514c458959d6a/views
+```
+
+Below is a response for a live video with several active viewers:
+
+```json
+{"liveViewers": 113}
+```

--- a/content/stream/stream-live/watch-live-stream.md
+++ b/content/stream/stream-live/watch-live-stream.md
@@ -136,20 +136,6 @@ Or if the input ID does not have an active live stream:
 
 When viewing a livestream via the live input id, the `requireSignedURLs` and `allowedOrigins` options in the live input recording settings are used. These settings are independent of the video-level settings.
 
-## Get live viewer counts for third party players
-
-The Stream player has full support for live viewer counts by default. To get the viewer count for a live video for use with third party players, you can make a `GET` request to the `/views` endpoint.
-
-```bash
-https://videodelivery.net/55b9b5ce48c3968c6b514c458959d6a/views
-```
-
-This is a response for an live video with several active viewers:
-
-```json
-{"liveViewers": 113}
-```
-
 ## Replaying recordings
 
 Live streams are automatically recorded. To get a list of recorded streams for a given input id, make the same `GET` request as you would to get the live video and filter for videos where the state property is set to `ready`:


### PR DESCRIPTION
Separated live viewer content into its own topic and moved under Getting Analytics section.

Addresses [PCX-3371](https://jira.cfops.it/browse/PCX-3371).