### PR TITLE
Correct WARP Routing YAML spacing

### DIFF
--- a/content/cloudflare-one/tutorials/zero-trust-network-access.md
+++ b/content/cloudflare-one/tutorials/zero-trust-network-access.md
@@ -74,7 +74,7 @@ Next, you will need to configure your private network server to connect to Cloud
     tunnel: <YOUR TUNNEL ID>
     credentials-file: /root/.cloudflared/<YOUR TUNNEL ID>.json
     warp-routing:
-    enabled: true
+      enabled: true
     ```
 
     {{<Aside>}}


### PR DESCRIPTION
The WARP Routing enabled needs to be 2 spaces indented