### PR TITLE
docs: request.cf.asn is type Number, not string

### DIFF
--- a/content/workers/runtime-apis/request.md
+++ b/content/workers/runtime-apis/request.md
@@ -196,7 +196,7 @@ All plans have access to:
 
 {{<definitions>}}
 
-*   `asn` {{<type>}}string{{</type>}}
+*   `asn` {{<type>}}Number{{</type>}}
 
     *   ASN of the incoming request, for example, `395747`.
 


### PR DESCRIPTION
Reported by a customer and confirmed.

```
➜  curl https://echo.silverlock.workers.dev/ -s | jq '.event.request.cf.asn | type'
"number"
```

