### PR TITLE
doc(quickstarts): add GraphQL Yoga 2.0 support

### DIFF
--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -69,6 +69,8 @@ $ wrangler generate <new-project-name> <github-repo-url>
 ## Frameworks
 
 {{<worker-starter title="Apollo GraphQL Server" repo="signalnerve/workers-graphql-server" description="Lightning-fast, globally distributed Apollo GraphQL server, deployed at the edge using Cloudflare Workers.">}}
+  
+{{<worker-starter title="GraphQL Yoga" repo="the-guild-org/yoga-cloudflare-workers-template" description="The most flexible, fastest, and lightest GraphQL server for all environments, Cloudflare Workers included.">}}
 
 {{<worker-starter title="Flareact" repo="flareact/flareact" description="Flareact is an edge-rendered React framework built for Cloudflare Workers. It features file-based page routing with dynamic page paths and edge-side data fetching APIs.">}}
 


### PR DESCRIPTION
Add documentation for GraphQL Yoga 2.0 support for CF Workers with a Wrangler template.