### PR TITLE
[Magic Firewall] Added supported TCP & UDP ports

### DIFF
--- a/content/magic-firewall/plans.md
+++ b/content/magic-firewall/plans.md
@@ -27,4 +27,4 @@ All standard features are included with the purchase of the advanced features be
 - Geoblocking based on user location by country
 - Packet captures on demand for network troubleshooting
 - Protocol validation rules to inspect traffic validity and enforce a positive security model
-- Optional upgrade to full stateful Secure Web Gateway using [Cloudflare Zero Trust](/cloudflare-one/) for outbound Internet traffic
+- Optional upgrade to full stateful Secure Web Gateway using [Cloudflare Zero Trust](/cloudflare-one/) for outbound Internet traffic. The Secure Web Gateway upgrade now supports TCP and UDP ports 0-1023.

--- a/content/magic-wan/tutorials/secure-web-gateway.md
+++ b/content/magic-wan/tutorials/secure-web-gateway.md
@@ -64,6 +64,8 @@ In keeping with the example scenario, the list of static routes should match the
 
 ## Secure Web Gateway
 
-After setting up the Anycast GRE and static routes, configure the policies for Secure Web Gateway in the Teams dashboard. To set up the policies, refer to [Secure Web Gateway policies](/cloudflare-one/policies/filtering/).
+After setting up the Anycast GRE and static routes, configure the policies for Secure Web Gateway in the Teams dashboard. To set up the policies, refer to [Secure Web Gateway policies](/cloudflare-one/policies/filtering/). 
+
+The Secure Web Gateway upgrade now supports TCP and UDP ports 0-1023.
 
 After you configured Secure Web Gateway, enterprise users and devices from each of the sites mentioned in the example scenario would be able to safely browse or access Internet resources under the protection of the Cloudflare edge network.


### PR DESCRIPTION
Added sentence about supported TCP & UDP ports with the Secure Web Gateway upgrade. Addresses [PCX-3571](https://jira.cfops.it/browse/PCX-3571).