### PR TITLE
[Pages] Update _redirects limit information

### DIFF
--- a/content/pages/how-to/use-bulk-redirects.md
+++ b/content/pages/how-to/use-bulk-redirects.md
@@ -5,7 +5,7 @@ title: Handle redirects with Bulk Redirects
 
 # Handle redirects with Bulk Redirects
 
-In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the 100 redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 100 redirect rules.
+In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the 1,100 redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects.
 
 {{<Aside type="Note">}}
 

--- a/content/pages/how-to/use-bulk-redirects.md
+++ b/content/pages/how-to/use-bulk-redirects.md
@@ -5,7 +5,7 @@ title: Handle redirects with Bulk Redirects
 
 # Handle redirects with Bulk Redirects
 
-In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the 1,100 redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects.
+In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the 1,100 redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 1,000 static redirects and 100 dynamic redirects, for a combined total of 1,100 redirects.
 
 {{<Aside type="Note">}}
 

--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -35,7 +35,7 @@ You can have an unlimited number of [preview deployments](/pages/platform/previe
 
 ## Redirects
 
-A `_redirects` file can have a maximum of 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have a need for more than the `_redirects` file supports.
+A `_redirects` file can have a maximum of 1,000 static redirects and 100 dynamic redirects, for a combined total of 1,100 redirects. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have a need for more than the `_redirects` file supports.
 
 ## Users
 

--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -35,7 +35,7 @@ You can have an unlimited number of [preview deployments](/pages/platform/previe
 
 ## Redirects
 
-A `_redirects` file can have a maximum of 100 redirect rules. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have more than 100 redirect rules.
+A `_redirects` file can have a maximum of 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have a need for more than the `_redirects` file supports.
 
 ## Users
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -35,7 +35,7 @@ filename: _redirects
 /products/:code/:name /products?code=:code&name=:name
 ```
 
-A project is limited to 1,000 static redirects and 100 dynamic redirects, for a combined total of 1,100 redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
+A project is limited to 1,000 static redirects and 100 dynamic redirects, for a combined total of 1,100 redirects. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
 
 {{<Aside type= "note">}}
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -35,11 +35,11 @@ filename: _redirects
 /products/:code/:name /products?code=:code&name=:name
 ```
 
-A project is limited to 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
+A project is limited to 1,000 static redirects and 100 dynamic redirects, for a combined total of 1,100 redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
 
 {{<Aside type= "note">}}
 
-Make sure that static redirects are before splat redirects in your `_redirects` file.
+Make sure that static redirects are before dynamic redirects in your `_redirects` file.
 
 {{</Aside>}}
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -35,7 +35,13 @@ filename: _redirects
 /products/:code/:name /products?code=:code&name=:name
 ```
 
-A project is limited to 100 total redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
+A project is limited to 1,000 static redirects and 100 splat redirects, for a combined total of 1,100 redirects. Each redirect declaration has a 1000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
+
+{{<Aside type= "note">}}
+
+Make sure that static redirects are before splat redirects in your `_redirects` file.
+
+{{</Aside>}}
 
 Cloudflare currently offers limited support for advanced redirects. More support will be added in the future.
 


### PR DESCRIPTION
References:
- Tweet from Sid
  https://twitter.com/chatsidhartha/status/1511809202829860874

- Quote from Walshy
  > The static redirect limit is now much higher! You can have up to 1,000 static redirects (from /a to /b) and 100 dynamic redirects (from /:id to /path/:id). Note static ones need to go first in the _redirects file
  