### PR TITLE
[Pages] Add GitLab role requirement into Get Started

### DIFF
--- a/content/pages/get-started/index.md
+++ b/content/pages/get-started/index.md
@@ -30,6 +30,8 @@ You will be prompted to sign in with your preferred git provider which allows [C
 
 Signing in with GitLab will grant Pages access to all repositories on your account. Additionally, if you are a part of a multi-user Cloudflare account, and you sign in with GitLab, other members will also have the ability to deploy your repositories to Pages.
 
+If you are using GitLab, make sure you have the **Maintainer** role or higher on the repository.   
+
 {{</Aside>}}
 
 ## Configuration and deployment

--- a/content/pages/get-started/index.md
+++ b/content/pages/get-started/index.md
@@ -30,7 +30,7 @@ You will be prompted to sign in with your preferred git provider which allows [C
 
 Signing in with GitLab will grant Pages access to all repositories on your account. Additionally, if you are a part of a multi-user Cloudflare account, and you sign in with GitLab, other members will also have the ability to deploy your repositories to Pages.
 
-If you are using GitLab, make sure you have the **Maintainer** role or higher on the repository.   
+If you are using GitLab, you must have the **Maintainer** role or higher on the repository to successfully deploy with Cloudflare Pages.
 
 {{</Aside>}}
 


### PR DESCRIPTION
It's mentioned in https://developers.cloudflare.com/pages/platform/debugging-pages/ that **Maintainer** is required but you're not going to see that if just following the Get Started - added it into here as well.