### PR TITLE
[Pages] Enable dropdown on sidebar for Migrations

### DIFF
--- a/content/pages/migrations/_index.md
+++ b/content/pages/migrations/_index.md
@@ -1,6 +1,5 @@
 ---
 type: overview
-hideChildren: true
 pcx-content-type: navigation
 title: Migration guides
 weight: 5


### PR DESCRIPTION
Currently, the `Migration guides` in the sidebar doesn't have dropdown functionality - whereas Frameworks, which is formatted very similarly, does.

![image](https://user-images.githubusercontent.com/94662631/163698553-ddd3de69-c0b9-41c5-a774-e7edd8df174c.png)

![image](https://user-images.githubusercontent.com/94662631/163698561-a457fca7-1e8e-4472-af75-d44c5d5144f6.png)

If this is intentional, feel free to close - I just think it looks a bit out of place.