### PR TITLE
Build an API Tutorial: Highlighting to include added `async`

### DIFF
--- a/content/pages/tutorials/build-an-api-with-workers/index.md
+++ b/content/pages/tutorials/build-an-api-with-workers/index.md
@@ -151,7 +151,7 @@ With `PostsStore` set up, you can import it and use it in our handlers:
 ```ts
 ---
 filename: "src/handlers/posts.ts"
-highlight: [1, 4, 5]
+highlight: [1, 3, 4, 5]
 ---
 import Store from '../posts_store';
 
@@ -168,7 +168,7 @@ export default Posts;
 ```ts
 ---
 filename: "src/handlers/post.ts"
-highlight: [1, 4, 7]
+highlight: [1, 3, 4, 7]
 ---
 import Store from '../posts_store';
 


### PR DESCRIPTION
Hey Cloudflare Team 👋,

Super tiny detail while going through one of the Pages tutorials. 🙂 

Following the [Build an API for your front end using Cloudflare Workers](https://developers.cloudflare.com/pages/tutorials/build-an-api-with-workers) docs, I saw that the highlighting for the "Defining a static data class" was missing a line where the handler functions (for both `posts` and `post`) were being changed to `async` functions. 

Created a quick fork and a PR.
 