### PR TITLE
[Magic WAN] Updated DH group support

### DIFF
--- a/content/magic-wan/tutorials/ipsec.md
+++ b/content/magic-wan/tutorials/ipsec.md
@@ -34,6 +34,7 @@ To set up your static routes, refer to [Configure static routes](/magic-wan/how-
 
 - **Diffie-Hellman group**:
   - DH group 14 (2048-bit MODP group)
+  - DH group 15 (3072-bit MODP group)
 
 - **Pseudorandom function (PRF)** (not to be confused with PFS. PRF is often not a configurable setting):
   - SHA2-256


### PR DESCRIPTION
Added DH group 15 to list of supported configuration parameters. Addresses [PCX-3730](https://jira.cfops.it/browse/PCX-3730).