### PR TITLE
[Spectrum & Stream] Updating image alt text

### DIFF
--- a/content/spectrum/about/ftp.md
+++ b/content/spectrum/about/ftp.md
@@ -38,7 +38,7 @@ Configuring Spectrum to protect your FTP server requires creating a set of Spect
 
 The control plane runs on port 21 by default, and there is nothing special that needs to be to protect this part of the FTP server. In the example below, replace 198.51.100.1 with the IP of the origin server.
 
-![Control plane port](/spectrum/img/ftp/ftp-control-plane-app.png)
+![Add an application dialog with IP address and port set to 21](/spectrum/img/ftp/ftp-control-plane-app.png)
 
 This configuration proxies incoming connections to the origin. However, if clients issue a PASV command, they will still receive the IP of the actual origin for the data connection. This is not preferred, as this exposes the origin's IP to the client instead of being masked behind Spectrum. Steps to prevent this are documented in sections below.
 

--- a/content/spectrum/about/load-balancer.md
+++ b/content/spectrum/about/load-balancer.md
@@ -28,7 +28,7 @@ The example below shows a TCP health check configuration for an application runn
 </summary>
 <div class="special-class" markdown="1">
 
-![Health Check UI](/spectrum/img/load-balancing/spectrum-tcp-check.png)
+![Manage monitors dialog with TCP health check running on port 2408 and a 30 second refresh rate](/spectrum/img/load-balancing/spectrum-tcp-check.png)
 
 </div>
 </details>

--- a/content/stream/stream-live/simulcasting.md
+++ b/content/stream/stream-live/simulcasting.md
@@ -8,8 +8,6 @@ weight: 9
 
 Simulcasting lets you forward your live stream to third-party platforms such as YouTube Live and Facebook Live. To begin simulcasting, select an input and add one or more Outputs:
 
-![Begin simulcasting](../simulcasting.png)
-
 ## Add an Output using the API
 
 Add an Output to start retransmitting live video. You can add or remove Outputs at any time during a broadcast to start and stop retransmitting.

--- a/content/stream/uploading-videos/applying-watermarks.md
+++ b/content/stream/uploading-videos/applying-watermarks.md
@@ -33,7 +33,7 @@ tus-upload --chunk-size 5242880 \
 
 ### Step 3: Done
 
-![Watermarked Video](../cat.png)
+![Screenshot of a video with Cloudflare watermark at top right](../cat.png)
 
 ## Profiles
 

--- a/content/stream/viewing-videos/displaying-thumbnails.md
+++ b/content/stream/viewing-videos/displaying-thumbnails.md
@@ -14,7 +14,7 @@ A thumbnail from your video can be generated using a special link where you spec
 https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.jpg?time=68s&height=270
 `
 
-<img src="https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.jpg?time=68s&height=270" />
+<img src="https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.jpg?time=68s&height=270" alt="Example of thumbnail image generated from video of car driving down highway" />
 
 Using the `poster` query parameter in the embed URL, you can set a thumbnail to any time in your video. If [signed URLs](/stream/viewing-videos/securing-your-stream/) are required, you must use a signed URL instead of video IDs.
 
@@ -74,7 +74,7 @@ Stream supports animated GIFs as thumbnails. Views using animated thumbnails do 
  https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.gif?time=38s&height=200&duration=4s
  `
 
-<img src="https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.gif?time=38s&height=200&duration=4s" />
+<img src="https://videodelivery.net/5d5bc37ffcf54c9b82e996823bffbb81/thumbnails/thumbnail.gif?time=38s&height=200&duration=4s" alt="Animated gif example of car driving down highway" />
 
 Supported URL attributes for animated thumbnails are:
 


### PR DESCRIPTION
Updated image alt text for Spectrum and Stream. Addresses [PCX-3399](https://jira.cfops.it/browse/PCX-3399).