### PR TITLE
Update ssl-modes.md to add port notice

### DIFF
--- a/content/ssl/origin-configuration/ssl-modes.md
+++ b/content/ssl/origin-configuration/ssl-modes.md
@@ -74,7 +74,7 @@ Choose this option when you cannot set up an SSL certificate on your origin or y
 
 ### Limitations
 
-Flexible mode is only supported for HTTPS connections on port 443 (default port). Other ports using HTTPS will fall back to Full mode.
+Flexible mode is only supported for HTTPS connections on port 443 (default port). Other ports using HTTPS will fall back to [**Full** mode](#full).
 
 If your application contains sensitive information (personalized data, user login), use [**Full**](#full) or [**Full (Strict)**](#full-strict) modes instead.
 

--- a/content/ssl/origin-configuration/ssl-modes.md
+++ b/content/ssl/origin-configuration/ssl-modes.md
@@ -74,6 +74,8 @@ Choose this option when you cannot set up an SSL certificate on your origin or y
 
 ### Limitations
 
+Flexible mode is only supported for HTTPS connections on port 443 (default port). Other ports using HTTPS will fall back to Full mode.
+
 If your application contains sensitive information (personalized data, user login), use [**Full**](#full) or [**Full (Strict)**](#full-strict) modes instead.
 
 ![With an encryption mode of Flexible, your application encrypts traffic between the visitor and Cloudflare, but not between Cloudflare and your server.](/ssl/static/ssl-encryption-mode-flexible.png)


### PR DESCRIPTION
Ports other than 443 do not support Flexible SSL mode as documented CF-internally.