### PR TITLE
fix(docs): terraform tutorials

### DIFF
--- a/content/terraform/tutorial/add-page-rules.md
+++ b/content/terraform/tutorial/add-page-rules.md
@@ -26,7 +26,7 @@ resource "cloudflare_page_rule" "increase-security-on-expensive-page" {
   target   = "www.${var.domain}/expensive-db-call"
   priority = 1
 
-  actions = {
+  actions {
     security_level = "under_attack",
   }
 }
@@ -36,7 +36,7 @@ resource "cloudflare_page_rule" "redirect-to-new-db-page" {
   target   = "www.${var.domain}/old-location.php"
   priority = 2
 
-  actions = {
+  actions {
     forwarding_url {
       url = "https://www.${var.domain}/expensive-db-call"
       status_code = 301

--- a/content/terraform/tutorial/revert-configuration.md
+++ b/content/terraform/tutorial/revert-configuration.md
@@ -95,7 +95,7 @@ index 0b39450..ef11d8a 100644
 +  target = "www.${var.domain}/expensive-db-call"
 +  priority = 1
 +
-+  actions = {
++  actions {
 +    security_level = "under_attack",
 +  }
 +}
@@ -105,7 +105,7 @@ index 0b39450..ef11d8a 100644
 +  target = "www.${var.domain}/old-location.php"
 +  priority = 2
 +
-+  actions = {
++  actions {
 +    forwarding_url {
 +      url = "https://${var.domain}/expensive-db-call"
 +      status_code = 301


### PR DESCRIPTION
## What/why?
Fixing little mistake in your Terraform tutorials

## How?
By removing `=` where it isn't supposed to be.
As documented [here](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/page_rule) for example.