### PR TITLE
[Magic Transit] Added SHA-1 to supported ciphers

### DIFF
--- a/content/magic-wan/tutorials/ipsec.md
+++ b/content/magic-wan/tutorials/ipsec.md
@@ -49,6 +49,7 @@ To set up your static routes, refer to [Configure static routes](/magic-wan/how-
 
 - **Integrity** (sometimes referred to as Authentication):
   - SHA2-256
+  - SHA-1
 
 - **PFS group** (sometimes referred to as "Phase 2 Diffie-Hellman Group"):
   - DH group 14 (2048-bit MODP group)


### PR DESCRIPTION
Added SHA-1 to supported ciphers to address [PCX-3811](https://jira.cfops.it/browse/PCX-3811).