### PR TITLE
Fix misleading example on images custom ID

### DIFF
--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -40,7 +40,7 @@ You will then receive a response similar to this:
     "filename": "<YOUR_IMAGE>",
     "uploaded": "2022-04-20T09:51:09.559Z",
     "requireSignedURLs": false,
-    "variants": ["https://imagedelivery.net/Vi7wi5KSItxGFsWRG2Us6Q/content/images/<YOUR_IMAGE>/public"]
+    "variants": ["https://imagedelivery.net/Vi7wi5KSItxGFsWRG2Us6Q/<PATH_TO_YOUR_IMAGE>/public"]
   },
   "result_info": null,
   "success": true,


### PR DESCRIPTION
Fixes a misleading example in custom ID documentation.

Rationale: the placeholder changed by the PR should be as the ID.