### PR TITLE
[R2] Update getting started guide for new public bindings

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -152,13 +152,13 @@ async function handleRequest(request) {
       await MY_BUCKET.put(key, request.body);
       return new Response(`Put ${key} successfully!`);
    case 'GET':
-     const { value } = await MY_BUCKET.get(key);
+     const value = await MY_BUCKET.get(key);
 
      if (value === null) {
        return new Response('Object Not Found', { status: 404 });
      }
 
-     return new Response(value);
+     return new Response(value.body);
    case 'DELETE':
      await MY_BUCKET.delete(key);
      return new Response('Deleted!', { status: 200 });


### PR DESCRIPTION
The docs are currently using the older `const { value } = await MY_BUCKET.get(key);` syntax, which was used in the early stages of R2 with internal bindings.

Nowadays, the R2 bindings return a `R2ObjectBody`, where we can directly get the `ReadableStream` and return this.