### PR TITLE
Update CloudflareWARP.mobileconfig

### DIFF
--- a/content/cloudflare-one/static/documentation/connections/CloudflareWARP.mobileconfig
+++ b/content/cloudflare-one/static/documentation/connections/CloudflareWARP.mobileconfig
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadContent</key>
-	<array/>
 	<key>PayloadDisplayName</key>
 	<string>Cloudflare WARP</string>
 	<key>PayloadIdentifier</key>
@@ -14,52 +12,38 @@
 	<false/>
 	<key>PayloadType</key>
 	<string>Configuration</string>
+	<key>PayloadScope</key>
+	<string>System</string>
 	<key>PayloadUUID</key>
 	<string>F5046847-2B1C-4DA0-A872-F6E040B1B20E</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-    <key>PayloadContent</key>
-    <array>
-        <dict>
-            <key>PayloadDisplayName</key>
-            <string>Custom</string>
-            <key>PayloadIdentifier</key>
-            <string>com.cloudflare.warp</string>
-            <key>PayloadOrganization</key>
-            <string>Cloudflare Ltd.</string>
-            <key>PayloadType</key>
-            <string>com.apple.ManagedClient.preferences</string>
-            <key>PayloadUUID</key>
-            <string>C2575334-358E-4925-8B29-30B4348D31E3</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-            <key>PayloadEnabled</key>
-            <true/>
-            <key>PayloadContent</key>
-            <dict>
-                <key>com.cloudflare.warp</key>
-                <dict>
-                    <key>Forced</key>
-                    <array>
-                        <dict>
-                            <key>mcx_preference_settings</key>
-                            <dict>
-                                <key>organization</key>
-                                <string>yourorganization</string>
-                                <key>auto_connect</key> 
-                                <integer>1</integer>
-                                <key>switch_locked</key> 
-                                <false />
-                                <key>service_mode</key>
-                                <string>warp</string>
-                                <key>support_url</key>
-                                <string>https://support.example.com</string>
-                            </dict>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-    </array>
+  <key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>auto_connect</key>
+			<integer>1</integer>
+			<key>organization</key>
+			<string>yourorganization</string>
+			<key>service_mode</key>
+			<string>warp</string>
+			<key>support_url</key>
+			<string>https://support.example.com</string>
+			<key>switch_locked</key>
+			<false/>
+			<key>PayloadDisplayName</key>
+			<string>Warp Configuration</string>
+			<key>PayloadIdentifier</key>
+			<string>com.cloudflare.warp.5A31FA24-FF8C-41EA-989E-F070820F2A80</string>
+			<key>PayloadOrganization</key>
+			<string>Cloudflare Ltd.</string>
+			<key>PayloadType</key>
+			<string>com.cloudflare.warp</string>
+			<key>PayloadUUID</key>
+			<string>5A31FA24-FF8C-41EA-989E-F070820F2A80</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The example `CloudflareWARP.mobileconfig` was not working at all for me when installing it locally.

After some debugging, I found it was missing the `PayloadScope=System`. Without setting this, it was installed into `/Library/Managed Preferences/$USER` and Warp was unable to discover the file. Probably this is set correctly when installed via MDM but I wanted to try it out locally before doing so.

Also I simplified the configuration by removing `com.apple.ManagedClient.preferences` and `mcx_preference_settings`. This makes the configuration human readable in the Profiles overview of macOS.

The documentation should also state it's a good idea to embed the root ca which I did in my local testing but did not add this here.

Anyway, thanks for Cloudflare tunnels! 👍 