### PR TITLE
[Cache] Purging cache by tag might need to specify Tag, not URL

### DIFF
--- a/content/cache/how-to/purge-cache.md
+++ b/content/cache/how-to/purge-cache.md
@@ -102,7 +102,7 @@ When your content reaches our edge network, Cloudflare:
 1.  Log in to your Cloudflare dashboard.
 2.  Click **Caching** > **Configuration**.
 3.  Under **Purge Cache**, click **Custom Purge**. The **Custom Purge** window appears.
-4.  Under **Purge by**, select **URL**.
+4.  Under **Purge by**, select **Tag**.
 5.  In the text box, enter your tags to use to purge the cached resources. To purge multiple cache-tagged resources, separate each tag with a comma or have one tag per line.
 6.  Click **Purge**.
 


### PR DESCRIPTION
Hi, not sure if the steps documented here are correct, so I've proposed a change.

If they are correct, then this behaviour is confusing and the docs could potentially use a line clarifying why.

In the dashboard, following the docs and clicking the URL button, looks like this:

<img width="846" alt="Screen Shot 2022-05-03 at 10 26 21 am" src="https://user-images.githubusercontent.com/6218499/166346399-70762ff1-9f30-4c91-86f2-849e80682344.png">

But I think it should be Tag instead, which produces this form:

<img width="843" alt="Screen Shot 2022-05-03 at 10 27 44 am" src="https://user-images.githubusercontent.com/6218499/166346448-96577968-1d51-4bbf-9d2f-30448d6cb1ee.png">

Tag seems like the intended behaviour in this section.