### PR TITLE
Clarify `env` lifecycle

### DIFF
--- a/content/workers/runtime-apis/fetch-event.md
+++ b/content/workers/runtime-apis/fetch-event.md
@@ -77,7 +77,7 @@ export default {
 
 - `env` {{<type>}}object{{</type>}}
 
-  - The [bindings](/workers/platform/environment-variables/) assigned to the Worker. As long as the environment hasn't changed, the same object (equal by identity) is passed to all requests.
+  - The [bindings](/workers/platform/environment-variables/) assigned to the Worker. As long as the environment has not changed, the same object (equal by identity) is passed to all requests.
 
 - {{<code>}}context.waitUntil(promise{{<param-type>}}Promise{{</param-type>}}){{</code>}} {{<type>}}void{{</type>}}
 

--- a/content/workers/runtime-apis/fetch-event.md
+++ b/content/workers/runtime-apis/fetch-event.md
@@ -77,7 +77,7 @@ export default {
 
 - `env` {{<type>}}object{{</type>}}
 
-  - The [bindings](/workers/platform/environment-variables/) assigned to the Worker.
+  - The [bindings](/workers/platform/environment-variables/) assigned to the Worker. As long as the environment hasn't changed, the same object (equal by identity) is passed to all requests.
 
 - {{<code>}}context.waitUntil(promise{{<param-type>}}Promise{{</param-type>}}){{</code>}} {{<type>}}void{{</type>}}
 


### PR DESCRIPTION
Per [this tweet](https://twitter.com/KentonVarda/status/1521954706876153856?s=20&t=EcUHvzjD3H7iee562cAaEw) by @kentonv.