### PR TITLE
Fix path regex example

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/configuration/local-management/ingress.md
+++ b/content/cloudflare-one/connections/connect-apps/configuration/local-management/ingress.md
@@ -54,7 +54,7 @@ ingress:
     service: https://localhost:8000
   # Rules can match the request's path to a regular expression:
   - hostname: static.example.com
-    path: /*.(jpg|png|css|js)
+    path: \.(jpg|png|css|js)$
     service: https://localhost:8001
   # Rules can match the request's hostname to a wildcard character:
   - hostname: '*.example.com'


### PR DESCRIPTION
The `path` regex example was misleading. It is indeed a Regex match, so to match files ending in `.jpg` etc., the regex should be `\.(jpg|png|css|js)$`