### PR TITLE
[R2] Fix `DeleteMultipartUpload` typo

### DIFF
--- a/content/r2/platform/pricing.md
+++ b/content/r2/platform/pricing.md
@@ -40,7 +40,7 @@ Class B Operations include `HeadBucket`, `HeadObject`, and `GetObject`.
 
 ### Free Operations
 
-Free operations include `DeleteObject`, `DeleteBucket` and `DeleteMulitpartUpload`.
+Free operations include `DeleteObject`, `DeleteBucket` and `DeleteMultipartUpload`.
 
 ## R2 billing examples
 


### PR DESCRIPTION
I noticed a very minor typo on the new R2 pricing docs.