### PR TITLE
Clarify KV binding usage in Pages Functions with Wranglerv2

### DIFF
--- a/content/pages/platform/functions.md
+++ b/content/pages/platform/functions.md
@@ -315,7 +315,7 @@ Workers KV is Cloudflare's globally replicated key-value storage solution. Withi
 
 ### KV namespace locally
 
-While developing locally you can interact with your KV namespace by add `-k, --kv [Namespace name]` to your run command. For example, if your namespace is called `TodoList`, you can access the KV namespace in your local dev by running `npx wrangler pages dev dist --kv TodoList`. The data from this namespace can be accessed using `context.env`.
+While developing locally you can interact with your KV namespace by add `-k, --kv [Namespace Binding]` to your run command. For example, if your namespace is bound to `TodoList`, you can access the KV namespace in your local dev by running `npx wrangler pages dev dist --kv TodoList`. The data from this namespace can be accessed using `context.env`.
 
 ```js
 export async function onRequest({ env }) {

--- a/content/pages/platform/functions.md
+++ b/content/pages/platform/functions.md
@@ -315,7 +315,7 @@ Workers KV is Cloudflare's globally replicated key-value storage solution. Withi
 
 ### KV namespace locally
 
-While developing locally you can interact with your KV namespace by add `-k, --kv [Namespace Binding]` to your run command. For example, if your namespace is bound to `TodoList`, you can access the KV namespace in your local dev by running `npx wrangler pages dev dist --kv TodoList`. The data from this namespace can be accessed using `context.env`.
+While developing locally, you can interact with your KV namespace by add `-k, --kv [Namespace Binding]` to your run command. For example, if your namespace is bound to `TodoList`, you can access the KV namespace in your local dev by running `npx wrangler pages dev dist --kv TodoList`. The data from this namespace can be accessed using `context.env`.
 
 ```js
 export async function onRequest({ env }) {


### PR DESCRIPTION
Original wording is unclear whether `Name` of KV Namespace that is referenced is the actual `Name`, or `Binding`. PR clarifies that for local dev, only `Binding` is necessary.