### PR TITLE
[Workers] fix typo and highlight locations in tutorials/build-a-slackbot/index.md

### DIFF
--- a/content/workers/tutorials/build-a-slackbot/index.md
+++ b/content/workers/tutorials/build-a-slackbot/index.md
@@ -596,7 +596,7 @@ Add a simple utility function, `compact`, which takes an array, and filters out 
 ```js
 ---
 filename: src/utils/slack.js
-highlight: [1, 24]
+highlight: [1, 20]
 ---
 const compact = array => array.filter(el => el);
 
@@ -682,7 +682,7 @@ To do this, wrap the majority of the `webhook` function handler in a try/catch b
 ```js
 ---
 filename: src/handlers/webhook.js
-highlight: [4, 22, 23, 24, 25]
+highlight: [4, 18, 19, 20, 21]
 ---
 import { constructGhIssueSlackMessage } from '../utils/slack';
 

--- a/content/workers/tutorials/build-a-slackbot/index.md
+++ b/content/workers/tutorials/build-a-slackbot/index.md
@@ -135,7 +135,7 @@ To build your Slack bot on Cloudflare Workers, you will build up your applicatio
 
 The router template includes a class, `Router`, that is included to help developers with the common task of associating “routes” in your application (for instance, `/users`, or `/about`) with “functions”. In this tutorial, there are two routes/function handlers that you need to define:
 
-1.  The `lookup` function will take requests from Slack (sent when a user uses the `/issue` command), and look up the corresponding issue using the GitHub API. This function will be a `PUT` request to `/lookup`.
+1.  The `lookup` function will take requests from Slack (sent when a user uses the `/issue` command), and look up the corresponding issue using the GitHub API. This function will be a `POST` request to `/lookup`.
 
 2.  The `webhook` function will be called when an issue changes on GitHub, via a configured webhook. This function will be a `POST` request to `/webhook`.
 


### PR DESCRIPTION
* Fix typo describing use of `PUT` request, when the code uses `POST`
* Update highlight locations to show the correct code segments that have changed

I went through and completed this tutorial for my first time today. This PR corrects some typos and incorrect highlighting I came across.