### PR TITLE
[R2] Add extensions and unicode interop documentation

### DIFF
--- a/content/r2/api.md
+++ b/content/r2/api.md
@@ -2,8 +2,6 @@
 title: API
 pcx-content-type: configuration
 weight: 1
-meta:
-  title: API
 ---
 
 # R2 Workers API

--- a/content/r2/api.md
+++ b/content/r2/api.md
@@ -1,0 +1,11 @@
+---
+title: API
+pcx-content-type: configuration
+weight: 1
+meta:
+  title: API
+---
+
+# R2 Workers API
+
+Placeholder

--- a/content/r2/api.md
+++ b/content/r2/api.md
@@ -1,7 +1,6 @@
 ---
 title: API
 pcx-content-type: configuration
-weight: 1
 ---
 
 # R2 Workers API

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -1,19 +1,15 @@
 ---
 title: Extensions
 pcx-content-type: reference
-meta:
-  title: Extensions
 ---
 
 # Extensions
 
-R2 implements some extensions on top of the stock S3 API. This page outlines those additional features that are available:
+R2 implements some extensions on top of the basic S3 API. This page outlines these additional features that are available.
 
 ## Extended Metadata Using Unicode
 
-The [Workers R2 API](/r2/api) supports Unicode in supports Unicode in keys and values natively without requiring any additional
-encoding or decoding for the `customMetadata` field. These fields map to the `x-amz-meta-`-prefixed headers used within the
-R2 S3-compatible API endpoint.
+The [Workers R2 API](/r2/api/) supports Unicode in keys and values natively without requiring any additional encoding or decoding for the `customMetadata` field. These fields map to the `x-amz-meta-`-prefixed headers used within the R2 S3-compatible API endpoint.
 
 HTTP header names and values may only contain ASCII characters, which is a small subset of the Unicode character library. To easily
 accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html/rfc2047) and automatically decodes all
@@ -21,12 +17,11 @@ accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html
 the response. The length limit for metadata values is applied to the decoded Unicode value.
 
 {{<Aside type="warning" header="Metadata variance">
-Be mindful when using both Workers and S3 API endpoints to access the same data. If the R2 metadata keys contain Unicode, they
-are stripped when accessed through the through S3 API and the `x-amz-missing-meta` header is set to the number of keys that were
-omitted.
+Be mindful when using both Workers and S3 API endpoints to access the same data. If the R2 metadata keys contain Unicode, they are stripped when accessed through the through S3 API and the `x-amz-missing-meta` header is set to the number of keys that were omitted.
 {{</Aside>}}
 
 These headers map to the `httpMetadata` field in the R2 bindings:
+
 {{<table-wrap>}}
 | HTTP Header           | Property Name                     |
 |---------------------- | --------------------------------- |
@@ -38,14 +33,10 @@ These headers map to the `httpMetadata` field in the R2 bindings:
 | `Expires`             | `httpMetadata.expires`            |
 {{</table-wrap>}}
 
-If using Unicode in object key names, it may be helpful to review the [technical notes](/r2/platform/unicode-interoperability) regarding
-that.
+If using Unicode in object key names, refer to the [Unicode Interoperability technical notes](/r2/platform/unicode-interoperability/).
 
 ## CopyObject
 
 ### MERGE metadata directive
 
-The `x-amz-metadata-directive` allows a `MERGE` value, in addition to the standard `COPY` and `REPLACE` options. When used,
-`MERGE` is a combination of `COPY` and `REPLACE`, which will `COPY` any metadata keys from the source object and `REPLACE` those
-that are specified in the request with the new value. You cannot use `MERGE` to remove existing metadata keys from the
-source — use `REPLACE` instead.
+The `x-amz-metadata-directive` allows a `MERGE` value, in addition to the standard `COPY` and `REPLACE` options. When used, `MERGE` is a combination of `COPY` and `REPLACE`, which will `COPY` any metadata keys from the source object and `REPLACE` those that are specified in the request with the new value. You cannot use `MERGE` to remove existing metadata keys from the source — use `REPLACE` instead.

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -1,0 +1,51 @@
+---
+title: Extensions
+pcx-content-type: reference
+meta:
+  title: Extensions
+---
+
+# Extensions
+
+R2 implements some extensions on top of the stock S3 API. This page outlines those additional features that are available:
+
+## Extended Metadata Using Unicode
+
+The [Workers R2 API](/r2/api) supports Unicode in supports Unicode in keys and values natively without requiring any additional
+encoding or decoding for the `customMetadata` field. These fields map to the `x-amz-meta-`-prefixed headers used within the
+R2 S3-compatible API endpoint.
+
+HTTP header names and values may only contain ASCII characters, which is a small subset of the Unicode character library. To easily
+accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html/rfc2047) and automatically decodes all
+`x-amz-meta-*` header values before storage. On retrieval, any metadata values with unicode are RFC2047-encoded before rendering
+the response. The length limit for metadata values is applied to the decoded Unicode value.
+
+{{<Aside type="warning" header="Metadata variance">
+Be mindful when using both Workers and S3 API endpoints to access the same data. If the R2 metadata keys contain Unicode, they
+are stripped when accessed through the through S3 API and the `x-amz-missing-meta` header is set to the number of keys that were
+omitted.
+{{</Aside>}}
+
+These headers map to the `httpMetadata` field in the R2 bindings:
+{{<table-wrap>}}
+| HTTP Header           | Property Name                     |
+|---------------------- | --------------------------------- |
+| `Content-Encoding`    | `httpMetadata.contentEncoding`    |
+| `Content-Type`        | `httpMetadata.contentType`        |
+| `Content-Language`    | `httpMetadata.contentLanguage`    |
+| `Content-Disposition` | `httpMetadata.contentDisposition` |
+| `Cache-Control`       | `httpMetadata.cacheControl`       |
+| `Expires`             | `httpMetadata.expires`            |
+{{</table-wrap>}}
+
+If using Unicode in object key names, it may be helpful to review the [technical notes](/r2/platform/unicode-interoperability) regarding
+that.
+
+## CopyObject
+
+### MERGE metadata directive
+
+The `x-amz-metadata-directive` allows a `MERGE` value, in addition to the standard `COPY` and `REPLACE` options. When used,
+`MERGE` is a combination of `COPY` and `REPLACE`, which will `COPY` any metadata keys from the source object and `REPLACE` those
+that are specified in the request with the new value. You cannot use `MERGE` to remove existing metadata keys from the
+source — use `REPLACE` instead.

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -5,7 +5,7 @@ pcx-content-type: concept
 
 # Extensions
 
-R2 implements some extensions on top of the basic S3 API. This page outlines these additional features that are available.
+R2 implements some extensions on top of the basic S3 API. This page outlines these additional, available features.
 
 ## Extended metadata using Unicode
 

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -13,7 +13,7 @@ The [Workers R2 API](/r2/api/) supports Unicode in keys and values natively with
 
 HTTP header names and values may only contain ASCII characters, which is a small subset of the Unicode character library. To easily accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html/rfc2047) and automatically decodes all `x-amz-meta-*` header values before storage. On retrieval, any metadata values with unicode are RFC2047-encoded before rendering the response. The length limit for metadata values is applied to the decoded Unicode value.
 
-{{<Aside type="warning" header="Metadata variance">
+{{<Aside type="warning" header="Metadata variance">}}
 Be mindful when using both Workers and S3 API endpoints to access the same data. If the R2 metadata keys contain Unicode, they are stripped when accessed through the through S3 API and the `x-amz-missing-meta` header is set to the number of keys that were omitted.
 {{</Aside>}}
 

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -11,10 +11,7 @@ R2 implements some extensions on top of the basic S3 API. This page outlines the
 
 The [Workers R2 API](/r2/api/) supports Unicode in keys and values natively without requiring any additional encoding or decoding for the `customMetadata` field. These fields map to the `x-amz-meta-`-prefixed headers used within the R2 S3-compatible API endpoint.
 
-HTTP header names and values may only contain ASCII characters, which is a small subset of the Unicode character library. To easily
-accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html/rfc2047) and automatically decodes all
-`x-amz-meta-*` header values before storage. On retrieval, any metadata values with unicode are RFC2047-encoded before rendering
-the response. The length limit for metadata values is applied to the decoded Unicode value.
+HTTP header names and values may only contain ASCII characters, which is a small subset of the Unicode character library. To easily accommodate users, R2 adheres to [RFC2047](https://datatracker.ietf.org/doc/html/rfc2047) and automatically decodes all `x-amz-meta-*` header values before storage. On retrieval, any metadata values with unicode are RFC2047-encoded before rendering the response. The length limit for metadata values is applied to the decoded Unicode value.
 
 {{<Aside type="warning" header="Metadata variance">
 Be mindful when using both Workers and S3 API endpoints to access the same data. If the R2 metadata keys contain Unicode, they are stripped when accessed through the through S3 API and the `x-amz-missing-meta` header is set to the number of keys that were omitted.

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -7,7 +7,7 @@ pcx-content-type: concept
 
 R2 implements some extensions on top of the basic S3 API. This page outlines these additional features that are available.
 
-## Extended Metadata Using Unicode
+## Extended metadata using Unicode
 
 The [Workers R2 API](/r2/api/) supports Unicode in keys and values natively without requiring any additional encoding or decoding for the `customMetadata` field. These fields map to the `x-amz-meta-`-prefixed headers used within the R2 S3-compatible API endpoint.
 

--- a/content/r2/platform/s3-compatibility/extensions.md
+++ b/content/r2/platform/s3-compatibility/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-pcx-content-type: reference
+pcx-content-type: concept
 ---
 
 # Extensions

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -1,0 +1,28 @@
+---
+title: Filename encoding and interoperability problems
+pcx-content-type: reference
+meta:
+  title: Filename encoding and interoperability problems
+---
+
+## Filename encoding and interoperability problems
+
+Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked
+is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode
+equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence).
+
+Based on feedback from our users, we've chosen to NFC-normalize key names before storing by default. This means
+`Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
+
+R2 is encoding-preserving for display though. When you list the objects, you'll get back the last encoding you uploaded with.
+
+There are still some platform-specific differences to consider
+
+* Windows filenames are case-insensitive while R2, Linux, and macOS are not.
+* Windows console support for Unicode can be error-prone. Make sure to run `chcp 65001` before using command-line tools or use Cygwin
+if your object names are coming out garbled.
+* Linux allows distinct files that are unicode equivalent because filenames are byte streams. Unicode equivalent files on Linux
+will map to the same R2 object.
+
+If it's important for you to be able to bypass the unicode equivalence and use byte-oriented key names, contact your Cloudflare account
+team.

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -17,4 +17,4 @@ There are still some platform-specific differences to consider:
 * Windows console support for Unicode can be error-prone. Make sure to run `chcp 65001` before using command-line tools or use Cygwin if your object names appear to be incorrect.
 * Linux allows distinct files that are unicode-equivalent because filenames are byte streams. Unicode-equivalent filenames on Linux will point to the same R2 object.
 
-If it's important for you to be able to bypass the unicode equivalence and use byte-oriented key names, contact your Cloudflare account team.
+If it is important for you to be able to bypass the unicode equivalence and use byte-oriented key names, contact your Cloudflare account team.

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -7,7 +7,7 @@ pcx-content-type: reference
 
 Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence).
 
-Based on feedback from our users, we've chosen to NFC-normalize key names before storing by default. This means `Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
+Based on feedback from our users, we have chosen to NFC-normalize key names before storing by default. This means `Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
 
 R2 is encoding-preserving for display though. When you list the objects, you'll get back the last encoding you uploaded with.
 

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -9,7 +9,7 @@ Since R2 is built on top of Workers, it supports Unicode natively. One nuance of
 
 Based on feedback from our users, we have chosen to NFC-normalize key names before storing by default. This means `Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
 
-R2 is encoding-preserving for display though. When you list the objects, you'll get back the last encoding you uploaded with.
+R2 preserves the encoding for display though. When you list the objects, you will get back the last encoding you uploaded with.
 
 There are still some platform-specific differences to consider:
 

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -1,14 +1,11 @@
 ---
 title: Filename encoding and interoperability problems
 pcx-content-type: reference
-meta:
-  title: Filename encoding and interoperability problems
 ---
 
 ## Filename encoding and interoperability problems
 
-Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked
-is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode
+Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode
 equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence).
 
 Based on feedback from our users, we've chosen to NFC-normalize key names before storing by default. This means
@@ -16,13 +13,10 @@ Based on feedback from our users, we've chosen to NFC-normalize key names before
 
 R2 is encoding-preserving for display though. When you list the objects, you'll get back the last encoding you uploaded with.
 
-There are still some platform-specific differences to consider
+There are still some platform-specific differences to consider:
 
 * Windows filenames are case-insensitive while R2, Linux, and macOS are not.
-* Windows console support for Unicode can be error-prone. Make sure to run `chcp 65001` before using command-line tools or use Cygwin
-if your object names are coming out garbled.
-* Linux allows distinct files that are unicode equivalent because filenames are byte streams. Unicode equivalent files on Linux
-will map to the same R2 object.
+* Windows console support for Unicode can be error-prone. Make sure to run `chcp 65001` before using command-line tools or use Cygwin if your object names appear to be incorrect.
+* Linux allows distinct files that are unicode-equivalent because filenames are byte streams. Unicode-equivalent filenames on Linux will point to the same R2 object.
 
-If it's important for you to be able to bypass the unicode equivalence and use byte-oriented key names, contact your Cloudflare account
-team.
+If it's important for you to be able to bypass the unicode equivalence and use byte-oriented key names, contact your Cloudflare account team.

--- a/content/r2/platform/unicode-interoperability.md
+++ b/content/r2/platform/unicode-interoperability.md
@@ -5,11 +5,9 @@ pcx-content-type: reference
 
 ## Filename encoding and interoperability problems
 
-Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode
-equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence).
+Since R2 is built on top of Workers, it supports Unicode natively. One nuance of Unicode that is often overlooked is the issue of [filename interoperability](https://en.wikipedia.org/wiki/Filename#Encoding_indication_interoperability) due to [Unicode equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence).
 
-Based on feedback from our users, we've chosen to NFC-normalize key names before storing by default. This means
-`Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
+Based on feedback from our users, we've chosen to NFC-normalize key names before storing by default. This means `Héllo` and `Héllo` are the same object in R2 but different objects in other storage providers.
 
 R2 is encoding-preserving for display though. When you list the objects, you'll get back the last encoding you uploaded with.
 


### PR DESCRIPTION
Document Unicode metadata behavior. Document object Unicode name issues.
The unicode interop doc page is similar in style to the GCS page:
https://cloud.google.com/storage/docs/gsutil/addlhelp/Filenameencodingandinteroperabilityproblems