### PR TITLE
[Workers] Add description for the new parameter startAfter for Durable Object list method content/workers/runtime-apis/durable-objects.md

### DIFF
--- a/content/workers/runtime-apis/durable-objects.md
+++ b/content/workers/runtime-apis/durable-objects.md
@@ -207,6 +207,10 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
       - Key at which the list results should start, inclusive.
 
+    - {{<code>}}startAfter{{<param-type>}}string{{</param-type>}}{{</code>}}
+
+      - Key after which the list results should start, exclusive. Cannot be used simultaneously with `start`.
+
     - {{<code>}}end{{<param-type>}}string{{</param-type>}}{{</code>}}
 
       - Key at which the list results should end, exclusive.


### PR DESCRIPTION
- `startAfter` is new parameter added to the list method of durable objects that allows listing to start after a key instead of on a key.
- This PR adds description for this new parameter in content/workers/runtime-apis/durable-objects.md