### PR TITLE
[R2] Updated limits.md

### DIFF
--- a/content/r2/platform/limits.md
+++ b/content/r2/platform/limits.md
@@ -20,8 +20,8 @@ pcx-content-type: concept
 
 {{</table-wrap>}}
 
-1. The object size limit is 5 GB under 5 TB. 
-2. The max upload size is 5 MB under 5 GB.
+1. The object size limit is 5 GB less than 5 TB. 
+2. The max upload size is 5 MB less than 5 GB.
 3. Max upload size applies to uploading a file via one request, uploading a part of a multipart upload, or
 copying into a part of a multipart upload. If you have a Worker, its inbound request size is
 constrained by [Workers limits](/workers/platform/limits). The max upload size limit does not apply to subrequests.

--- a/content/r2/platform/limits.md
+++ b/content/r2/platform/limits.md
@@ -20,8 +20,8 @@ pcx-content-type: concept
 
 {{</table-wrap>}}
 
-1. The object size limit is 5 GB less than 5 TB. 
-2. The max upload size is 5 MB less than 5 GB.
+1. The object size limit is 5 GB less than 5 TB, so 4.995 TB.
+2. The max upload size is 5 MB less than 5 GB, so 4.995 GB.
 3. Max upload size applies to uploading a file via one request, uploading a part of a multipart upload, or
 copying into a part of a multipart upload. If you have a Worker, its inbound request size is
 constrained by [Workers limits](/workers/platform/limits). The max upload size limit does not apply to subrequests.


### PR DESCRIPTION
- Some users have been confused about the wording here.
- "5mb under 5gb" and "5gb under 5tb" are confusing because users don't understand what the "under" part means.
- This clarifies the wording to "less than" which is more clear.