### PR TITLE
Recommend users install wrangler locally, not globally

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -21,7 +21,7 @@ To purchase R2:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login).
 2. In **Account Home**, select **R2**.
 3. Select **Purchase R2 Plan**.
-4. Select **Proceed to Payment Details** to review your payment. 
+4. Select **Proceed to Payment Details** to review your payment.
 5. Select **Return to R2** to go to the R2 dashboard.
 
 ## 1. Install Wrangler
@@ -31,19 +31,13 @@ To create your R2 bucket, install [Wrangler](/workers/get-started/guide/#2-insta
 To install [`wrangler`](https://github.com/cloudflare/wrangler), ensure you have [`npm` installed](https://www.npmjs.com/get-npm). Use a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -g wrangler
+$ npm install -D wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn global add wrangler
-```
-
-or install with cargo:
-
-```sh
-$ cargo install wrangler
+$ yarn add wrangler
 ```
 
 Refer to the Wrangler [Install/Update](/workers/wrangler/get-started/) page for more information.

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -26,13 +26,13 @@ Cloudflare Workers provides a [serverless](https://www.cloudflare.com/learning/s
 To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://www.npmjs.com/get-npm), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -g wrangler
+$ npm install -D wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn global add wrangler
+$ yarn add wrangler
 ```
 
 Read more about [installing `wrangler`](/workers/wrangler/get-started/).

--- a/content/workers/get-started/guide.md
+++ b/content/workers/get-started/guide.md
@@ -39,13 +39,13 @@ Installing `wrangler`, the Workers CLI, gives you the freedom to [`init`](/worke
 To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://www.npmjs.com/get-npm), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -g wrangler
+$ npm install -D wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn global add wrangler
+$ yarn add wrangler
 ```
 
 ---


### PR DESCRIPTION
We are in the process of making the CLI a better experience when installed globally. For now, the official recommendation is to always install it locally to your project:

https://github.com/cloudflare/wrangler2/issues/955