### PR TITLE
Adds rule to not wrap the `copy` button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1600,6 +1600,7 @@ span.Tooltip---root {
   border-bottom-right-radius: 0;
   font-weight: 600;
   background: var(--code-block-background-color);
+  white-space: nowrap;
 }
 [theme="light"] .WorkerStarter--command-copy-button-wrapper button {
   background: var(--code-block-background-color-light-theme);


### PR DESCRIPTION
Currently, the copy button on the quickstart section is wrapping and looks bad in Firefox. Adds a simple rule to stop the wrapping behavior

Goes from looking janky:

<img width="202" alt="image" src="https://user-images.githubusercontent.com/187095/167901157-f924e75f-0640-4887-b88b-76285b8d6e78.png">

To looking right ✨ :

<img width="330" alt="image" src="https://user-images.githubusercontent.com/187095/167901208-02f3e4cb-5dff-48f1-af16-08763e86140e.png">

Happy Platform week, you guys are on 🔥 !
