### PR TITLE
fix(r2): typo & remove repeat titles

### DIFF
--- a/content/r2/examples/aws-sdk-js.md
+++ b/content/r2/examples/aws-sdk-js.md
@@ -1,12 +1,10 @@
 ---
-title: Configure aws-sdk-jd for R2
-summary: Example of how to configure aws-sdk-js to use R2.
+title: Configure `aws-sdk-js` for R2
+summary: Example of how to configure `aws-sdk-js` to use R2.
 pcx-content-type: configuration
 weight: 1001
 layout: example
 ---
-
-# Configure `aws-sdk-jd` for R2
 
 You must [generate an Access Key](/r2/platform/s3-compatibility/tokens/) before getting started. All examples will utilitize `access_key_id` and `access_key_secret` variables which represent the **Access Key ID** and **Secret Access Key** values you generated.
 

--- a/content/r2/examples/boto3.md
+++ b/content/r2/examples/boto3.md
@@ -1,12 +1,10 @@
 ---
-title: Configure boto3 for R2
-summary: Example of how to configure boto3 to use R2.
+title: Configure `boto3` for R2
+summary: Example of how to configure `boto3` to use R2.
 pcx-content-type: configuration
 weight: 1001
 layout: example
 ---
-
-# Configure `boto3` for R2
 
 You must [generate an Access Key](/r2/platform/s3-compatibility/tokens/) before getting started. All examples will utilitize `access_key_id` and `access_key_secret` variables which represent the **Access Key ID** and **Secret Access Key** values you generated.
 

--- a/content/r2/examples/demo-worker.md
+++ b/content/r2/examples/demo-worker.md
@@ -6,8 +6,6 @@ weight: 1001
 layout: example
 ---
 
-# Using R2 in a Worker
-
 We've provided an example Worker that exposes an R2 bucket to the Internet and demonstrates its functionality for storing and retrieving objects.
 
 ```js
@@ -121,4 +119,3 @@ export default {
   }
 }
 ```
-

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -1,12 +1,10 @@
 ---
-title: Configure rclone for R2
-summary: Example of how to configure rclone to use R2.
+title: Configure `rclone` for R2
+summary: Example of how to configure `rclone` to use R2.
 pcx-content-type: configuration
 weight: 1001
 layout: example
 ---
-
-# Configure `rclone` for R2
 
 You must [generate an Access Key](/r2/platform/s3-compatibility/tokens/) before getting started. All examples will utilitize `access_key_id` and `access_key_secret` variables which represent the **Access Key ID** and **Secret Access Key** values you generated.
 


### PR DESCRIPTION
code ticks show in the title & summary content, but it's better than having:

```
<Title Text>

<summary text>

<Title text again (via content)>

<content>
```