### PR TITLE
notes about service environments

### DIFF
--- a/content/workers/learning/using-services/index.md
+++ b/content/workers/learning/using-services/index.md
@@ -8,7 +8,7 @@ weight: 0
 
 {{<Aside type="note">}}
 
-We've temporarily disabled the creation of Service Environments while we are improving this feature.
+We have temporarily disabled the creation of Service Environments while we are improving this feature.
 
 {{</Aside>}}
 

--- a/content/workers/learning/using-services/index.md
+++ b/content/workers/learning/using-services/index.md
@@ -6,6 +6,12 @@ weight: 0
 
 # Workers Services
 
+{{<Aside type="note">}}
+
+We've temporarily disabled the creation of Service Environments while we are improving this feature.
+
+{{</Aside>}}
+
 Workers Services are the new building blocks for deploying applications on Cloudflare Workers. Workers Services are made of environments, which are scripts that can contain bindings to KV stores, Durable Objects, or even other services, as well as environment variables and secrets. Workers Services can have multiple environments and can set up pipelines for promoting a deployment from one environment to another.
 
 {{<Aside type="note" header="Workers versus Workers Services?">}}

--- a/content/workers/wrangler/environments.md
+++ b/content/workers/wrangler/environments.md
@@ -6,4 +6,10 @@ weight: 6
 
 ## Environments
 
-`wrangler` 2 supports environments from wrangler 1 (herafter referred to as legacy environments). It also supports the newer, preferred, first-class service environments on the Cloudflare Workers platform. This document describes the features and differences between the two.
+{{<Aside type="note">}}
+
+We've temporarily disabled the creation of Service Environments while we are improving this feature.
+
+{{</Aside>}}
+
+Wrangler 2 supports [environments](/workers/platform/environments/) from wrangler 1. We are currently working on support for [Service Environments](/workers/learning/using-services/). You can find the documentation on Wrangler 1 legacy environments [here](/workers/platform/environments/).


### PR DESCRIPTION
Adds a note about Service Environments being temporarily disabled and updates Wrangler2 docs with the same info.