### PR TITLE
[Images] Links to api and clarified bearer token

### DIFF
--- a/content/images/cloudflare-images/delete-images.md
+++ b/content/images/cloudflare-images/delete-images.md
@@ -22,7 +22,7 @@ Here is an example of how to delete an image through an API call:
 
 ```bash
 curl -X DELETE https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
---header 'Authorization: Bearer :token'
+--header 'Authorization: Bearer :<API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/delete-images.md
+++ b/content/images/cloudflare-images/delete-images.md
@@ -22,7 +22,7 @@ Here is an example of how to delete an image through an API call:
 
 ```bash
 curl -X DELETE https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
---header 'Authorization: Bearer :<API_TOKEN>'
+--header 'Authorization: Bearer <API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/delete-variants.md
+++ b/content/images/cloudflare-images/delete-variants.md
@@ -34,7 +34,7 @@ The following example deletes a variant through an API call:
 
 ```bash
 curl -X DELETE https://api.cloudflare.com/client/v4/account/<ACCOUNT_ID>/images/v1/variants/<VARIANT_NAME> \
---header 'Authorization: Bearer :<API_TOKEN>'
+--header 'Authorization: Bearer <API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/delete-variants.md
+++ b/content/images/cloudflare-images/delete-variants.md
@@ -34,7 +34,7 @@ The following example deletes a variant through an API call:
 
 ```bash
 curl -X DELETE https://api.cloudflare.com/client/v4/account/<ACCOUNT_ID>/images/v1/variants/<VARIANT_NAME> \
---header 'Authorization: Bearer :token'
+--header 'Authorization: Bearer :<API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/make-an-image-private.md
+++ b/content/images/cloudflare-images/make-an-image-private.md
@@ -12,7 +12,7 @@ You can require an image to only be accessible with a signed URL token. To make 
 curl --request POST \
   --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/direct_upload \
   --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer :token' \
+  --header 'Authorization: Bearer :<API_TOKEN>' \
   --data '{
 	  "requireSignedURLs":"true"
    }'

--- a/content/images/cloudflare-images/make-an-image-private.md
+++ b/content/images/cloudflare-images/make-an-image-private.md
@@ -12,7 +12,7 @@ You can require an image to only be accessible with a signed URL token. To make 
 curl --request POST \
   --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/direct_upload \
   --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer :<API_TOKEN>' \
+  --header 'Authorization: Bearer <API_TOKEN>' \
   --data '{
 	  "requireSignedURLs":"true"
    }'

--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -50,3 +50,5 @@ You will then receive a response similar to this:
 ```
 
 You can use the custom ID feature with the ability to [serve images from custom domains](/images/cloudflare-images/serve-images/#serving-images-from-custom-domains) for added flexibility.
+
+Refer to [Make your first API request](/images/cloudflare-images/api-request/) to learn more about API tokens.

--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -16,7 +16,7 @@ Below is an example of the custom ID feature using upload via URL:
 
 ```bash
 curl --request POST https://api.cloudflare.com/client/v4/accounts/<​​ACCOUNT_ID>/images/v1 \
-  --header 'Authorization: Bearer :<API_TOKEN>' \
+  --header 'Authorization: Bearer <API_TOKEN>' \
   --form 'url=https://<REMOTE_PATH_TO_IMAGE>' \
   --form 'id=<PATH_TO_YOUR_IMAGE>'
 ```
@@ -26,7 +26,7 @@ You can also use the custom ID feature with direct file upload:
 ```bash
 curl --request POST \
   https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1 \
-  --header 'Authorization: Bearer :<API_TOKEN>' \
+  --header 'Authorization: Bearer <API_TOKEN>' \
   --form 'file=@./<PATH_TO_YOUR_IMAGE>' \
   --form 'id=<PATH_TO_YOUR_IMAGE>'
 ```

--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -16,7 +16,7 @@ Below is an example of the custom ID feature using upload via URL:
 
 ```bash
 curl --request POST https://api.cloudflare.com/client/v4/accounts/<​​ACCOUNT_ID>/images/v1 \
-  --header 'Authorization: Bearer :token' \
+  --header 'Authorization: Bearer :<API_TOKEN>' \
   --form 'url=https://<REMOTE_PATH_TO_IMAGE>' \
   --form 'id=<PATH_TO_YOUR_IMAGE>'
 ```
@@ -26,7 +26,7 @@ You can also use the custom ID feature with direct file upload:
 ```bash
 curl --request POST \
   https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1 \
-  --header 'Authorization: Bearer :token' \
+  --header 'Authorization: Bearer :<API_TOKEN>' \
   --form 'file=@./<PATH_TO_YOUR_IMAGE>' \
   --form 'id=<PATH_TO_YOUR_IMAGE>'
 ```

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -13,7 +13,7 @@ To request a one-time upload URL, call the [`direct_upload` endpoint](https://ap
 ```bash
 curl --request POST \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v2/direct_upload \
- --header 'Authorization: Bearer :<API_TOKEN>' \
+ --header 'Authorization: Bearer <API_TOKEN>' \
  --form 'requireSignedURLs=true' \
  --form 'metadata={"key":"value"}'
 ```
@@ -46,7 +46,7 @@ With version 2 of `direct_upload`, a new draft image record is created when you 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
  --header 'Content-Type: application/json' \
- --header 'Authorization: Bearer :<API_TOKEN>'
+ --header 'Authorization: Bearer <API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -6,7 +6,7 @@ weight: 2
 
 # Direct Creator Upload
 
-The Direct Creator Upload feature in Cloudflare Images lets your users upload pictures with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing your API key or token to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
+The Direct Creator Upload feature in Cloudflare Images lets your users upload pictures with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing [your API key or token](/images/cloudflare-images/api-request/) to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
 
 To request a one-time upload URL, call the [`direct_upload` endpoint](https://api.cloudflare.com/#cloudflare-images-create-authenticated-direct-upload-url-v2) in your back-end (or Worker script):
 

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -13,7 +13,7 @@ To request a one-time upload URL, call the [`direct_upload` endpoint](https://ap
 ```bash
 curl --request POST \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v2/direct_upload \
- --header 'Authorization: Bearer :token' \
+ --header 'Authorization: Bearer :<API_TOKEN>' \
  --form 'requireSignedURLs=true' \
  --form 'metadata={"key":"value"}'
 ```
@@ -46,7 +46,7 @@ With version 2 of `direct_upload`, a new draft image record is created when you 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
  --header 'Content-Type: application/json' \
- --header 'Authorization: Bearer :token'
+ --header 'Authorization: Bearer :<API_TOKEN>'
 ```
 
 You will receive a response similar to this:

--- a/content/images/cloudflare-images/upload-images/upload-via-url.md
+++ b/content/images/cloudflare-images/upload-images/upload-via-url.md
@@ -10,7 +10,7 @@ meta:
 
 Sometimes it can be useful to use a URL of an image instead of uploading its data. To accommodate this need, Cloudflare Images provides an option to use a URL to migrate images to Cloudflare without fetching them first.
 
-To learn more about the supported image formats you can upload, refer to [Supported image formats](/images/cloudflare-images/upload-images/supported-formats).
+To learn more about the supported image formats you can upload, refer to [Supported image formats](/images/cloudflare-images/upload-images/supported-formats). Refer to [Make your first API request](/images/cloudflare-images/api-request/) to learn more about API tokens.
 
 Below is an example of how to use the upload via URL feature:
 

--- a/content/images/cloudflare-images/upload-images/upload-via-url.md
+++ b/content/images/cloudflare-images/upload-images/upload-via-url.md
@@ -17,7 +17,7 @@ Below is an example of how to use the upload via URL feature:
 ```bash
 curl --request POST \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1 \
- --header 'Authorization: Bearer :<API_TOKEN>' \
+ --header 'Authorization: Bearer <API_TOKEN>' \
  --form 'url=https://[user:password@]example.com/<PATH_TO_IMAGE>' \
  --form 'metadata={"key":"value"}' \
  --form 'requireSignedURLs=false' 

--- a/content/images/cloudflare-images/upload-images/upload-via-url.md
+++ b/content/images/cloudflare-images/upload-images/upload-via-url.md
@@ -17,7 +17,7 @@ Below is an example of how to use the upload via URL feature:
 ```bash
 curl --request POST \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1 \
- --header 'Authorization: Bearer :token' \
+ --header 'Authorization: Bearer :<API_TOKEN>' \
  --form 'url=https://[user:password@]example.com/<PATH_TO_IMAGE>' \
  --form 'metadata={"key":"value"}' \
  --form 'requireSignedURLs=false' 


### PR DESCRIPTION
- Added extra links to API page
- Changed `Bearer :token` to `Bearer :<API_TOKEN>` to make it clearer it's the user's token
- [PCX-3795](https://jira.cfops.it/browse/PCX-3795)