### PR TITLE
Python example needs the package cryptography

### DIFF
--- a/content/cloudflare-one/identity/users/validating-json.md
+++ b/content/cloudflare-one/identity/users/validating-json.md
@@ -132,6 +132,7 @@ func main() {
 - flask
 - requests
 - PyJWT
+- cryptography
 
 ```python
 from flask import Flask, request


### PR DESCRIPTION
Without installing the package `cryptography`, it the app while throw the following error:

```File "/app/main.py", line 51, in wrapper keys = _get_public_keys() File "/app/main.py", line 37, in _get_public_keys public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict)) AttributeError: module 'jwt.algorithms' has no attribute 'RSAAlgorithm'```