### PR TITLE
[R2] Fix incorrect operations per bucket limits

### DIFF
--- a/content/r2/platform/limits.md
+++ b/content/r2/platform/limits.md
@@ -15,8 +15,8 @@ pcx-content-type: concept
 | Data storage per bucket       | Unlimited                             |
 | Object size                   | 5 TB per object<sup>1</sup>           |
 | Max upload size<sup>3</sup>   | 5 GB<sup>2</sup>                      |
-| Class A Operations per bucket | 1000 per second<sup>4</sup>           |
-| Class B Operations per bucket | 250 per second<sup>4</sup>            |
+| Class A Operations per bucket | 250 per second<sup>4</sup>            |
+| Class B Operations per bucket | 1000 per second<sup>4</sup>           |
 
 {{</table-wrap>}}
 


### PR DESCRIPTION
Limits are the wrong way around - Class A is limited at 250 operations per sec and Class B is limited at 1000 operations per sec