### PR TITLE
[ZT] Added SNI info to docs

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide.md
+++ b/content/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide.md
@@ -54,6 +54,10 @@ Follow these steps to connect an application through your tunnel. If you are loo
 
 3. Under **Additional application settings**, specify any parameters you would like to add to your tunnel configuration.
 
+{{<Aside type="note" header="SNI">}}
+  If your server uses [SNI](https://www.cloudflare.com/en-ca/learning/ssl/what-is-sni/) (for example, Caddy requires it) then you will need to provide the name that your server is expecting to see (such as `example.com`) in the `Origin Server Name` field under the `TLS` options.
+{{</Aside>}}
+
 4. Click **Save `<tunnel-name>`**.
 
 ### 3. Connect a network
@@ -207,6 +211,10 @@ url: http://localhost:8000
 tunnel: <Tunnel-UUID>
 credentials-file: /root/.cloudflared/<Tunnel-UUID>.json
 ```
+
+{{<Aside type="note" header="SNI">}}
+  If your server uses [SNI](https://www.cloudflare.com/en-ca/learning/ssl/what-is-sni/) (for example, Caddy requires it) then you will need to provide the name that your server is expecting to see (for example, `example.com`) in the `originServerName` option under the `originRequest` [options](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/local-management/ingress/#originservername).
+{{</Aside>}}
 
 **If you are connecting a network**
 


### PR DESCRIPTION
- Currently, Cloudflare Tunnel doesn't work with [SNI](https://www.cloudflare.com/en-ca/learning/ssl/what-is-sni/) without the `originServerName` flag (locally) or the Origin Server Name option (on the Zero Trust dash) specified.
- From what I can tell, this note isn't present anywhere in the docs.
- This clarifies the docs to say that the flag is required when using servers that require SNI (such as Caddy).