### PR TITLE
[Workers] Fix wrangler 1 webpack migration guide link

### DIFF
--- a/content/workers/wrangler/compare-v1-v2.md
+++ b/content/workers/wrangler/compare-v1-v2.md
@@ -52,7 +52,7 @@ weight: 11
 
 | Property              | 1   | 2   | Notes                                                                          |
 | --------------------- | --- | --- | ------------------------------------------------------------------------------ |
-| `type = "webpack"`    | ✅  | ❌  | Removed, look at this guide to migrate.                                        |
+| `type = "webpack"`    | ✅  | ❌  | Removed, look at [this guide](/workers/wrangler/migration/eject-webpack/#migrate-webpack-projects-from-wrangler-version-1) to migrate.                                        |
 | `type = "rust"`       | ✅  | ❌  | Removed, use [`workers-rs`](https://github.com/cloudflare/workers-rs) instead. |
 | `type = "javascript"` | ✅  | 🚧  | No longer required, can be omitted.                                            |
 


### PR DESCRIPTION
This simply adds a link to the wrangler v1 -> v2 webpack migration guide in the expected place.