### PR TITLE
[ZT] Remove plans aside from Service Tokens

### DIFF
--- a/content/cloudflare-one/identity/service-auth/service-tokens.md
+++ b/content/cloudflare-one/identity/service-auth/service-tokens.md
@@ -6,12 +6,6 @@ weight: 4
 
 # Service tokens
 
-{{<Aside>}}
-
-This feature is only available if you're using the Zero Trust Standard plan or the Zero Trust Enterprise plan. For more information, see our [plans page](https://www.cloudflare.com/teams-pricing/).
-
-{{</Aside>}}
-
 You can provide automated systems with service tokens to authenticate against Cloudflare's Zero Trust policies. Cloudflare for teams will generate service tokens that consist of an ID and Secret. Automated systems or applications can then use these values to reach an application protected by Access.
 
 This section covers how to create, renew, and revoke a service token.


### PR DESCRIPTION
Service Tokens are now available to the free Zero Trust plan - as per https://community.cloudflare.com/t/retiring-the-legacy-access-configuration-tab/376771/22?u=kiannh

Unable to test myself as I have a paid plan but checked with a few others and they are now seeing Service Tokens in the dashboard on a free plan.