### PR TITLE
[R2] Clarify region when using S3 API

### DIFF
--- a/content/r2/platform/s3-compatibility/api.md
+++ b/content/r2/platform/s3-compatibility/api.md
@@ -20,7 +20,7 @@ Refer the feature column of each table to review which features of an API have b
 
 ## Bucket region
 
-When using the S3 API, the region for a R2 bucket is `auto`. For compatibility with tools that do not allow you to specify a region, an empty value and `us-east-1` will alias to the `auto` region.
+When using the S3 API, the region for an R2 bucket is `auto`. For compatibility with tools that do not allow you to specify a region, an empty value and `us-east-1` will alias to the `auto` region.
 
 This also applies to the `LocationConstraint` for the `CreateBucket` API.
 

--- a/content/r2/platform/s3-compatibility/api.md
+++ b/content/r2/platform/s3-compatibility/api.md
@@ -18,6 +18,12 @@ Refer the feature column of each table to review which features of an API have b
 ✅ Feature Implemented  
 ❌ Feature Not Implemented
 
+## Bucket region
+
+When using the S3 API, the region for a R2 bucket is `auto`. For compatibility with tools that do not allow you to specify a region, an empty value and `us-east-1` will alias to the `auto` region.
+
+This also applies to the `LocationConstraint` for the `CreateBucket` API.
+
 ## Bucket-level operations
 
 The following tables are related to bucket-level operations.


### PR DESCRIPTION
Document the R2 bucket 'region' and which values are accepted.

> The empty string and `us-east-1` are now accepted as region parameters. They automatically alias to the `auto` region. This also applies to the location constraint for CreateBucket.