### PR TITLE
[Workers] Removed wrangler secret put code snippet

### DIFF
--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -57,23 +57,7 @@ console.log(STRIPE_TOKEN);
 
 ### Adding secrets via wrangler
 
-Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by re-running the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`. Keep a list of the secrets used in your code in your `wrangler.toml` file, like the example under `[secrets]`:
-
-```toml
----
-filename: wrangler.toml
----
-name = "my-worker-dev"
-type = "javascript"
-
-account_id = "<YOUR ACCOUNTID>"
-workers_dev = true
-
-# [secrets]
-# SPARKPOST_KEY
-# GTOKEN_PRIVKEY
-# GTOKEN_KID
-```
+Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by re-running the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`.
 
 {{<Aside type="warning">}}
 

--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -57,7 +57,7 @@ console.log(STRIPE_TOKEN);
 
 ### Adding secrets via wrangler
 
-Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by re-running the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`.
+Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by rerunning the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`.
 
 {{<Aside type="warning">}}
 

--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -57,7 +57,20 @@ console.log(STRIPE_TOKEN);
 
 ### Adding secrets via wrangler
 
-Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by rerunning the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`.
+Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by rerunning the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`. Keep a list of the secrets used in your code in your `wrangler.toml` file, like the example under `[secrets]`:
+
+```toml
+[vars]
+# ...
+
+# ...
+
+# The necessary secrets are:
+# - SPARKPOST_KEY
+# - GTOKEN_PRIVKEY
+# - GTOKEN_KID
+# Run `wrangler secret put <NAME> <VALUE>` for each of these
+```
 
 {{<Aside type="warning">}}
 

--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -60,6 +60,9 @@ console.log(STRIPE_TOKEN);
 Secrets are defined by running [`wrangler secret put <NAME>`](/workers/wrangler/commands/#secret) in your terminal, where `<NAME>` is the name of your binding. You may assign environment-specific secrets by rerunning the command `wrangler secret put <NAME> -e` or `wrangler secret put <NAME> --env`. Keep a list of the secrets used in your code in your `wrangler.toml` file, like the example under `[secrets]`:
 
 ```toml
+---
+filename: wrangler.toml
+---
 [vars]
 # ...
 


### PR DESCRIPTION
- Previously there was a confusing code snippet that showed (commented out) secrets inside the `wrangler.toml`.
- This confused some users as they directly copy-pasted the code snippet (which didn't work because that's not how you define secrets).
- This PR completely removes that code snippet, as it seemed confusing (it didn't even work) and secret names can easily be viewed from the dashboard anyway.

CC @JacobMGEvans (previously discussed on Developers Discord)