### PR TITLE
[R2] Fix incorrect parameter name in R2Range

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -159,7 +159,7 @@ async function handleRequest(request) {
 
 ### Ranged reads
 
-R2GetOptions accepts a range parameter, which restricts data returned in {{<code>}}body{{</code>}} to be {{<code>}}range{{</code>}} bytes, starting from {{<code>}}offset{{</code>}}, inclusive.
+R2GetOptions accepts a `length` parameter, which restricts data returned in {{<code>}}body{{</code>}} to be {{<code>}}length{{</code>}} bytes, starting from {{<code>}}offset{{</code>}}, inclusive.
 
 {{<definitions>}}
 
@@ -167,7 +167,7 @@ R2GetOptions accepts a range parameter, which restricts data returned in {{<code
 
   - The byte to begin returning data from, inclusive.
 
-- {{<code>}}range{{<param-type>}}number{{</param-type>}}{{</code>}}
+- {{<code>}}length{{<param-type>}}number{{</param-type>}}{{</code>}}
 
   - The number of bytes to return. If more bytes are requested than exist in the object, fewer bytes than this number may be returned.
 


### PR DESCRIPTION
As per #4436, the parameter is `length` and not `range`

This can be seen in the `workers-types` definition for `R2Range`:

https://github.com/cloudflare/workers-types/blob/4d2664ba55a5c4cc6eaa3d4a144de3156ba6ebda/index.d.ts#L1129