### PR TITLE
[R2] Fix R2Objects delimitedPrefixes property

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -244,7 +244,7 @@ An object containing an R2Object array, returned by BUCKET_BINDING.list().
 
   - A token that can be passed to future {{<code>}}list{{</code>}} calls to resume listing from that point. Only present if truncated is true.
 
-- {{<code>}}cursor{{<param-type>}}delimitedPrefixes{{</param-type>}}{{</code>}}
+- {{<code>}}delimitedPrefixes{{<param-type>}}Array\<{{<type>}}string{{</type>}}\>{{</param-type>}}{{</code>}}
 
   - If a delimiter has been specified, contains all prefixes between the specified prefix and the next occurence of the delimiter.
   


### PR DESCRIPTION
Documentation currently has a duplicate `cursor` property - should be `delimitedPrefixes` which is a `string[]`

https://github.com/cloudflare/workers-types/blob/4d2664ba55a5c4cc6eaa3d4a144de3156ba6ebda/index.d.ts#L1119