### PR TITLE
[R2] Remove sha1 from R2PutOptions

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -189,10 +189,6 @@ R2GetOptions accepts a range parameter, which restricts data returned in {{<code
 
   - A md5 hash to use to check the recieved object's integrity.
 
-- {{<code>}}sha1{{<param-type>}}ArrayBuffer{{</param-type>}}{{<param-type>}}string{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}{{</code>}}
-
-  - A sha1 hash to use to check the recieved object's integrity.
-
 {{</definitions>}}
 
 ### R2ListOptions


### PR DESCRIPTION
> R2 bindings: sha1 is removed as an option because it wasn’t actually hooked up to anything. TBD on additional checksum options beyond md5.

https://community.cloudflare.com/t/2022-5-12-workers-runtime-release-notes/383116