### PR TITLE
Move Wrangler instructions back to global

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -31,13 +31,13 @@ To create your R2 bucket, install [Wrangler](/workers/get-started/guide/#2-insta
 To install [`wrangler`](https://github.com/cloudflare/wrangler), ensure you have [`npm` installed](https://www.npmjs.com/get-npm). Use a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -D wrangler
+$ npm install -g wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn add wrangler
+$ yarn global add wrangler
 ```
 
 Refer to the Wrangler [Install/Update](/workers/wrangler/get-started/) page for more information.

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -26,13 +26,13 @@ Cloudflare Workers provides a [serverless](https://www.cloudflare.com/learning/s
 To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://www.npmjs.com/get-npm), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -D wrangler
+$ npm install -g wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn add wrangler
+$ yarn global add wrangler
 ```
 
 Read more about [installing `wrangler`](/workers/wrangler/get-started/).

--- a/content/workers/get-started/guide.md
+++ b/content/workers/get-started/guide.md
@@ -39,13 +39,13 @@ Installing `wrangler`, the Workers CLI, gives you the freedom to [`init`](/worke
 To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://www.npmjs.com/get-npm), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues or to easily change Node.js versions, then run:
 
 ```sh
-$ npm install -D wrangler
+$ npm install -g wrangler
 ```
 
 or install with yarn:
 
 ```sh
-$ yarn add -D wrangler
+$ yarn global add wrangler
 ```
 
 ---

--- a/content/workers/wrangler/get-started.md
+++ b/content/workers/wrangler/get-started.md
@@ -28,5 +28,5 @@ npx wrangler publish
 ## Installation
 
 ```bash
-$ npm install wrangler --save-dev
+$ npm install -g wrangler
 ```

--- a/content/workers/wrangler/get-started.md
+++ b/content/workers/wrangler/get-started.md
@@ -27,6 +27,18 @@ npx wrangler publish
 
 ## Installation
 
+{{<Aside>}}
+
+If you previously had [Wrangler 1](/workers/wrangler/cli-wrangler/) installed globally, uninstall it first by running:
+
+```bash
+$ npm uninstall -g @cloudflare/wrangler
+```
+
+{{</Aside>}}
+
+Install Wrangler globally:
+
 ```bash
 $ npm install -g wrangler
 ```

--- a/content/workers/wrangler/migration/eject-webpack.md
+++ b/content/workers/wrangler/migration/eject-webpack.md
@@ -120,4 +120,4 @@ command = "npm run build" # or "yarn build"
 
 5. Test
 
-Try running `npx wrangler publish` to test that your configuration works as expected.
+Try running `wrangler publish` to test that your configuration works as expected.

--- a/content/workers/wrangler/migration/migrating-from-wrangler-1.md
+++ b/content/workers/wrangler/migration/migrating-from-wrangler-1.md
@@ -28,13 +28,13 @@ $ npm uninstall -g @cloudflare/wrangler
 Now, install the latest version of Wrangler into your project, adding it to your `devDependencies`:
 
 ```sh
-$ npm install -D wrangler@latest
+$ npm install -g wrangler
 ```
 
 To check that you have installed the correct Wrangler version, run:
 
 ```sh
-npx wrangler --version
+$ wrangler --version
 ```
 
 ### Build your Worker
@@ -47,7 +47,7 @@ Note that in most cases, the messages will include actionable instructions on ho
   These do not stop Wrangler from building your Worker, but consider updating the configuration to remove them.
 
 ```sh
-$ npx wrangler dev
+$ wrangler dev
 ```
 
 Here is an example of some warnings and errors:

--- a/content/workers/wrangler/module-system.md
+++ b/content/workers/wrangler/module-system.md
@@ -29,7 +29,7 @@ First, create the project and install the dependencies.
 ```sh
 $ mkdir new-project
 $ cd new-project
-$ npx wrangler init -y
+$ wrangler init -y
 $ npm i meaning-of-life
 ```
 
@@ -45,7 +45,7 @@ export default {
 };
 ```
 
-Now, run `npx wrangler dev` and hit `b` to open the app in your browser.
+Now, run `wrangler dev` and hit `b` to open the app in your browser.
 
 You should get a blank page with the number `42` on it.
 The page is served by your Worker which is consuming the `meaning-of-life` package.


### PR DESCRIPTION
After talking with @threepointone and @deadlypants1973 we decided that telling people to install Wrangler globally is the best path forward.

This updates the respective docs as well as mentioning you should uninstall @cloudflare/wrangler globally before installing Wrangler2.