### PR TITLE
r2: clarify rclone min version

### DIFF
--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -16,6 +16,10 @@ It is recommended that you choose a unique provider name and then rely on all de
 This will create a `rclone` configuration file, which you can then modify with the preset configuration given below.
 {{</Aside>}}
 
+{{<Aside type="note">}}
+Ensure you are running `rclone` v1.59 or greater ([rclone downloads](https://beta.rclone.org/)). Versions prior to v1.59 may return `HTTP 401: Unauthorized` errors, as earlier versions of `rclone` do not strictly align to the S3 specification in all cases.
+{{</Aside}}
+
 If you have already configured `rclone` in the past, you may run `rclone config file` to print the location of your `rclone` configuration file:
 
 ```sh

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -18,7 +18,7 @@ This will create a `rclone` configuration file, which you can then modify with t
 
 {{<Aside type="note">}}
 Ensure you are running `rclone` v1.59 or greater ([rclone downloads](https://beta.rclone.org/)). Versions prior to v1.59 may return `HTTP 401: Unauthorized` errors, as earlier versions of `rclone` do not strictly align to the S3 specification in all cases.
-{{</Aside}}
+{{</Aside>}}
 
 If you have already configured `rclone` in the past, you may run `rclone config file` to print the location of your `rclone` configuration file:
 


### PR DESCRIPTION
Most package managers do not install v1.59 yet, and so many users will end up seeing errors when using their existing rclone installations.

> The S3 specification requires an `X-Amz-Content-Sha256` header on all requests. R2, sticking closely to the spec, requires this header but most other S3-compatible providers don't. Rclone version < 1.59 only sends this header when the body is empty (such as when getting an object or creating a bucket) - not when the body has content. So that's why uploads fail in older rclone versions.