### PR TITLE
[Pages]: Fix 404 for direct uploads demo site

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -354,7 +354,7 @@
 /pages/how-to/deploy-a-zola-site/ /pages/framework-guides/deploy-a-zola-site/ 301
 /pages/how-to/elderjs/ /pages/framework-guides/elderjs/ 301
 /pages/platform/github-integration/ /pages/platform/git-integration/ 301
-/pages/platform/direct-uploads /pages/platform/direct-upload/ 301
+/pages/platform/direct-uploads/ /pages/platform/direct-upload/ 301
 
 # page-shield
 /page-shield/script-monitor/ /page-shield/ 301

--- a/content/_redirects
+++ b/content/_redirects
@@ -355,6 +355,7 @@
 /pages/how-to/elderjs/ /pages/framework-guides/elderjs/ 301
 /pages/platform/github-integration/ /pages/platform/git-integration/ 301
 /pages/platform/direct-uploads/ /pages/platform/direct-upload/ 301
+/pages/platform/direct-uploads /pages/platform/direct-upload/ 301
 
 # page-shield
 /page-shield/script-monitor/ /page-shield/ 301

--- a/content/_redirects
+++ b/content/_redirects
@@ -354,6 +354,7 @@
 /pages/how-to/deploy-a-zola-site/ /pages/framework-guides/deploy-a-zola-site/ 301
 /pages/how-to/elderjs/ /pages/framework-guides/elderjs/ 301
 /pages/platform/github-integration/ /pages/platform/git-integration/ 301
+/pages/platform/direct-uploads /pages/platform/direct-upload/ 301
 
 # page-shield
 /page-shield/script-monitor/ /page-shield/ 301


### PR DESCRIPTION
The link to Direct uploads documentation in the demo site https://pages.cloudflare.com/direct-upload-demo/ goes to a 404. To avoid causing more 404s in a blog post or other places the link is broken. 

I have added a redirect to the actual doc. 