### PR TITLE
Update CA certificate installation instructions for Debian/Ubuntu

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -195,14 +195,14 @@ The location where the root certificate should be installed is different dependi
 
 #### Debian / Ubuntu
 
-1. Download both the [.crt certificate](/cloudflare-one/static/documentation/connections/Cloudflare_CA.crt) and the [.pem certificate](/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem).
-2. Copy both certificates to the user store.
+1. Download the [.pem certificate](/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem).
+2. Copy the certificate to the system, changing the file extension to `.crt`.
 
   ```bash
-  sudo cp Cloudflare_CA.crt Cloudflare_CA.pem /usr/share/ca-certificates
+  sudo cp Cloudflare_CA.pem /usr/local/share/ca-certificates/Cloudflare_CA.crt
   ```
   
-3. Import the certificate
+3. Import the certificate.
 
 ```bash
 sudo dpkg-reconfigure ca-certificates


### PR DESCRIPTION
Putting a .pem file in `/usr/share/ca-certificates` does not seem to do anything useful.  Cite: [man update-ca-certificates](https://manpages.ubuntu.com/manpages/jammy/man8/update-ca-certificates.8.html)

> Certificates must have a  .crt extension in order to be included by update-ca-certificates.

The certificate files in `/usr/share/ca-certificates` must be PEM encoded.  Cite: https://unix.stackexchange.com/a/515195

> The script doesn't convert any certificate formats, therefore it assumes that all certificates in the source folders are in PEM format with a `.crt` file extension.

`/usr/local/share/ca-certificates` seems better than `/usr/share/ca-certificates`, because the user does not need to manually check the box in step 3 to trust the new cert.  Cite: [man update-ca-certificates](https://manpages.ubuntu.com/manpages/jammy/man8/update-ca-certificates.8.html)

> Furthermore  all  certificates  with  a  .crt  extension  found below /usr/local/share/ca-certificates are also included as implicitly trusted.

Putting the non-PEM .crt in the system certificates has caused problems ranging from `dpkg-reconfigure ca-certificates` warning that it's ignoring the `Cloudflare_CA.crt` to something I was trying to build being completely unable to use my `/etc/ssl/certs/ca-certificates.crt` file.

Tested on Debian 11, but I believe all of this holds true on all modern Ubuntu and Debian versions.