### PR TITLE
Add pages-plugin-trpc into Community Pages Plugins

### DIFF
--- a/content/pages/platform/functions/plugins/community-plugins.md
+++ b/content/pages/platform/functions/plugins/community-plugins.md
@@ -16,7 +16,7 @@ The following are some of the community-maintained Pages Plugins. If you have cr
 
 - [pages-plugin-trpc](https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc)
 
-    It allows developers to create tRPC server on Cloudflare Page Function rapidly.
+    Allows developers to quickly create a tRPC server with a Cloudflare Pages Function.
 
 - [pages-plugin-twind](https://github.com/helloimalastair/twind-plugin)
 

--- a/content/pages/platform/functions/plugins/community-plugins.md
+++ b/content/pages/platform/functions/plugins/community-plugins.md
@@ -14,7 +14,7 @@ The following are some of the community-maintained Pages Plugins. If you have cr
   Given a folder of assets in multiple formats, this Plugin will automatically negotiate with a client to serve an optimized version of a requested asset.
 
 
-- [pages-plugin-trpc](https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc)
+- [cloudflare-pages-plugin-trpc](https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc)
 
     Allows developers to quickly create a tRPC server with a Cloudflare Pages Function.
 

--- a/content/pages/platform/functions/plugins/community-plugins.md
+++ b/content/pages/platform/functions/plugins/community-plugins.md
@@ -13,6 +13,11 @@ The following are some of the community-maintained Pages Plugins. If you have cr
 
   Given a folder of assets in multiple formats, this Plugin will automatically negotiate with a client to serve an optimized version of a requested asset.
 
+
+- [pages-plugin-trpc](https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc)
+
+    It allows developers to create tRPC server on Cloudflare Page Function rapidly.
+
 - [pages-plugin-twind](https://github.com/helloimalastair/twind-plugin)
 
   Automatically injects Tailwind CSS styles into HTML pages after analyzing which classes are used.


### PR DESCRIPTION
Hi 👋 

I really exited for many new service that announced on Cloudflare Platform week.

Especially, I think that SQLite on Edge called D1 and Cloudflare Pages Plugin quite change web development.

By the way, do you know tRPC? tRPC is library that allows End-to-end typesafe APIs made easy. 

So, I’am considering that D1 and tRPC allows  End-to-end typesafe application made quite easy and cost-effective.

Therefore I decided to try it out as soon as D1 was released, and first created a page plugin for tRPC.