### PR TITLE
[ZT] Fix dashes in VNET guide

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/private-net/tunnel-virtual-networks.md
+++ b/content/cloudflare-one/connections/connect-networks/private-net/tunnel-virtual-networks.md
@@ -68,8 +68,8 @@ All accounts come pre-configured with a Virtual Network named `default`. You can
 4. Configure your tunnels with the IP/CIDR range of your private networks, and assign the tunnels to their respective Virtual Networks.
 
     ```bash
-    $ cloudflared tunnel route ip add -–vnet staging-vnet 10.128.0.3/32 staging-tunnel
-    $ cloudflared tunnel route ip add -–vnet production-vnet 10.128.0.3/32 production-tunnel
+    $ cloudflared tunnel route ip add --vnet staging-vnet 10.128.0.3/32 staging-tunnel
+    $ cloudflared tunnel route ip add --vnet production-vnet 10.128.0.3/32 production-tunnel
     ```
 
 {{<Aside type="note">}}


### PR DESCRIPTION
These dashes are the wrong character & don't work when being copy/pasted into a terminal

![image](https://user-images.githubusercontent.com/94662631/169006831-034d3dd0-f7cc-4da4-ba03-ccc07d07066c.png)
