### PR TITLE
Add NETCAT explanation - Visible ports

### DIFF
--- a/content/firewall/_partials/_open-ports-blocked-traffic.md
+++ b/content/firewall/_partials/_open-ports-blocked-traffic.md
@@ -1,0 +1,8 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+Due to the nature of Cloudflare's Anycast network, ports other than 80 and 443 will be open so that Cloudflare can serve traffic for other customers on these ports. Tools like Netcat will report these non-standard HTTP ports as open.

--- a/content/firewall/recipes/require-specific-http-ports.md
+++ b/content/firewall/recipes/require-specific-http-ports.md
@@ -30,10 +30,12 @@ This example blocks requests to `www.example.com` that are not on ports 80 or 44
   </tbody>
 </table>
 
+Alternatively, if you are using [WAF managed rules](https://support.cloudflare.com/hc/articles/200172016) and you do not need to specify a custom expression, enable rule ID 100015: "Anomaly:Port - Non Standard Port (not 80 or 443)" to block all requests to your zone on non-standard HTTP ports.
+
 {{<Aside type="note" header="Open server ports and blocked traffic">}}
 
-Due to the nature of Cloudflare's Anycast network, ports other than `80` and `443` will be open so that Cloudflare can serve traffic for other customers on these ports.
+{{<render file="_open-ports-blocked-traffic.md">}}
 
-The above firewall rule will block traffic at the application layer (layer 7 in the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/)), preventing HTTP/HTTPS requests over non-standard ports from reaching the origin server.
+Firewall rules and WAF managed rules can block traffic at the application layer (layer 7 in the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/)), preventing HTTP/HTTPS requests over non-standard ports from reaching the origin server.
 
 {{</Aside>}}

--- a/content/fundamentals/get-started/reference/network-ports.md
+++ b/content/fundamentals/get-started/reference/network-ports.md
@@ -79,6 +79,9 @@ Ports 80 and 443 are the only ports compatible with:
 - HTTP/HTTPS traffic within China data centers for domains that have the **China Network** enabled, and
 - Proxying of [Cloudflare Apps](https://www.cloudflare.com/apps/developer/docs/getting-started)
 
+
+By using this WAF rule, Cloudflare will not forward any data on non standard ports. This action will virtually close the ports, depiste the ports will still visible using a network tool like Netcat.
+
 {{<Aside type="note">}}
 
 [Cloudflare Access](/cloudflare-one/) does not support port numbers in URLs. Port numbers are stripped from requests for URLs protected through Cloudflare Access.

--- a/content/fundamentals/get-started/reference/network-ports.md
+++ b/content/fundamentals/get-started/reference/network-ports.md
@@ -71,6 +71,7 @@ Block traffic on ports other than 80 and 443 in Cloudflare paid plans by doing o
 
 - If you are using [WAF managed rules](https://support.cloudflare.com/hc/articles/200172016), enable rule ID 100015: "Anomaly:Port - Non Standard Port (not 80 or 443)".
 - If you are using the new [Cloudflare Web Application Firewall (WAF)](/waf/), create a [custom rule](/waf/custom-rules/) for this purpose (rule ID 100015 was deprecated in the new WAF). For example, you could use a rule configuration similar to the following:
+
   - Expression: `not (cf.edge.server_port in {80 443})`
   - Action: _Block_
 
@@ -79,8 +80,9 @@ Ports 80 and 443 are the only ports compatible with:
 - HTTP/HTTPS traffic within China data centers for domains that have the **China Network** enabled, and
 - Proxying of [Cloudflare Apps](https://www.cloudflare.com/apps/developer/docs/getting-started)
 
+{{<render file="../../firewall/_partials/_open-ports-blocked-traffic.md">}}
 
-By using this WAF rule, Cloudflare will not forward any data on non standard ports. The ports will remain visible using a network tool like Netcat, but Cloudflare will stop the traffic from being forwarded to the origin at the HTTP layer.
+WAF managed rules or the new Cloudflare Web Application Firewall (WAF) will block traffic at the application layer (layer 7 in the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/)), preventing HTTP/HTTPS requests over non-standard ports from reaching the origin server.
 
 {{<Aside type="note">}}
 

--- a/content/fundamentals/get-started/reference/network-ports.md
+++ b/content/fundamentals/get-started/reference/network-ports.md
@@ -80,7 +80,7 @@ Ports 80 and 443 are the only ports compatible with:
 - Proxying of [Cloudflare Apps](https://www.cloudflare.com/apps/developer/docs/getting-started)
 
 
-By using this WAF rule, Cloudflare will not forward any data on non standard ports. This action will virtually close the ports, depiste the ports will still visible using a network tool like Netcat.
+By using this WAF rule, Cloudflare will not forward any data on non standard ports. The ports will remain visible using a network tool like Netcat, but Cloudflare will stop the traffic from being forwarded to the origin at the HTTP layer.
 
 {{<Aside type="note">}}
 


### PR DESCRIPTION
I saw several people complaining that ports are still open despite using this WAF rule. Customer's usually advise they can see the ports open using netcat. 
This WAF rule will not CLOSE the port as the ports will still open. This rule will just stop forwarding data on non standar ports. 
Adding this can reduce this kind of tickets from customers. 
Example JIRA: https://jira.cfops.it/browse/CUSTESC-18238

Thanks!
Xabier from CSUP team in EMEA