### PR TITLE
[Magic Transit & WAN] Updated private IP space options

### DIFF
--- a/content/magic-transit/how-to/configure-tunnels.md
+++ b/content/magic-transit/how-to/configure-tunnels.md
@@ -16,6 +16,7 @@ To configure the GRE tunnel(s) between Cloudflare and your data centers, you mus
   - 10.0.0.0–10.255.255.255
   - 172.16.0.0–172.31.255.255
   - 192.168.0.0–192.168.255.255
+  - 169.254.244.0/20
 - **TTL** — Time to Live (TTL) in number of hops for the GRE tunnel. The default value is 64.
 - **MTU** — Maximum Transmission Unit (MTU) in bytes for the GRE tunnel. The default value is 1476.
 

--- a/content/magic-wan/how-to/configure-tunnels.md
+++ b/content/magic-wan/how-to/configure-tunnels.md
@@ -15,6 +15,7 @@ To configure the Anycast GRE or IPsec tunnels between Cloudflare and your locati
   - 10.0.0.0–10.255.255.255
   - 172.16.0.0–172.31.255.255
   - 192.168.0.0–192.168.255.255
+  - 169.254.244.0/20
 - **Private IP addresses** — The private IP address assigned to the **Cloudflare** and **customer** sides of the tunnel
 
 For an example Anycast GRE or IPsec tunnel configuration, see [Anycast GRE configuration example](/magic-wan/reference/configuration-examples/#gre-tunnel-configuration-example).


### PR DESCRIPTION
Updated the private IP space options to address [PCX-3974](https://jira.cfops.it/browse/PCX-3974).