### PR TITLE
[Workers] Clarified How Workers Works page

### DIFF
--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -55,10 +55,9 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 ## Distributed execution
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
-
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. While you do *not* have to program with concurrency in mind, other requests may be processed during awaiting any `async` tasks (such as fetch). If there are many requests queued, the Workers runtime may initialize another isolate to help handle the load but this is not guaranteed to happen at any specific number of incoming requests.
   
-Because of this, there is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
+Therefore we do *not* recommend you set or mutate global state within the event handler to avoid any concurrency issues.
   
 
 ## Related resources

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -57,7 +57,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
   
 Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
-Therefore we do *not* recommend you set or mutate global state within the event handler to avoid any concurrency issues.
+Therefore we do not recommend you set or mutate global state within the event handler to avoid any concurrency issues.
   
 
 ## Related resources

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
   
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may (or may not) be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
 Therefore we do not recommend you set or mutate global state within the event handler to avoid any concurrency issues.
   
 

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
 
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. For example, if Cloudflare receives 10 HTTP requests for the same Worker at exactly the same time, the Workers runtime will start 10 instances of that Worker. Any single Worker instance will never receive more than one request at the same time but may do so one after another.
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. While you do *not* have to program with concurrency in mind, other requests may be processed during awaiting any `async` tasks (such as fetch). If there are many requests queued, the Workers runtime may initialize another isolate to help handle the load but this is not guaranteed to happen at any specific number of incoming requests.
   
 Because of this, there is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
   

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
   
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may (or may not) be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may (or may not) be processed during awaiting any `async` tasks (such as `fetch`) if other requests come in while processing a request. 
 Because there is no guarantee that any two user requests will be routed to the same or a different instance of your Worker, we recommend you do not use or mutate global state.
 
 ## Related resources

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -57,7 +57,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
   
 Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may (or may not) be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
-Because there is no guarantee that any two user requests will be routed to the same or a different instance of your Worker, we do not recommend you use or mutate global state.
+Because there is no guarantee that any two user requests will be routed to the same or a different instance of your Worker, we recommend you do not use or mutate global state.
 
 ## Related resources
 

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
 
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. For example, if Cloudflare receives 10 HTTP requests for the same Worker at exactly the same time, the Cloudflare runtime will start 10 instances of that Worker. Any single Worker instance will never receive more than one request at the same time but may do so one after another.
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. For example, if Cloudflare receives 10 HTTP requests for the same Worker at exactly the same time, the Workers runtime will start 10 instances of that Worker. Any single Worker instance will never receive more than one request at the same time but may do so one after another.
   
 Because of this, there is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
   

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,10 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
 
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop, meaning only one request is processed at a time but multiple requests may come in one after another. There is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. For example, if Cloudflare receives 10 HTTP requests for the same Worker at exactly the same time, the Cloudflare runtime will start 10 instances of that Worker. Any single Worker instance will never receive more than one request at the same time but may do so one after another.
+  
+Because of this, there is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
+  
 
 ## Related resources
 

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -56,7 +56,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
 
-Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. There is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
+Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop, meaning only one request is processed at a time but multiple requests may come in one after another. There is no guarantee whatsoever whether any two requests will land in the same instance; therefore it is inadvisable to set or mutate global state within the event handler.
 
 ## Related resources
 

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -57,8 +57,7 @@ When a request to your `*.workers.dev` subdomain or to your Cloudflare-managed d
 Isolates are resilient and continuously available for the duration of a request, but in rare instances isolates may be evicted. When a script hits official [limits](/workers/platform/limits/) or when resources are exceptionally tight on the machine the request is running on, the runtime will selectively evict isolates after their events are properly resolved.
   
 Like all other JavaScript platforms, a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop. That means that other requests may (or may not) be processed during awaiting any `async` tasks (such as fetch) if other requests come in while processing a request. 
-Therefore we do not recommend you set or mutate global state within the event handler to avoid any concurrency issues.
-  
+Because there is no guarantee that any two user requests will be routed to the same or a different instance of your Worker, we do not recommend you use or mutate global state.
 
 ## Related resources
 


### PR DESCRIPTION
- In the bottom paragraph of How Workers Works, it is stated that "a single Workers instance may handle multiple requests including concurrent requests in a single-threaded event loop."
- The confusing wording here is the word "concurrent". While a single Workers instance may handle multiple request sequentially (an "event loop") the processing of an instance of a Worker is never occurring at the same time on the same instance.
- This PR clarifies the wording to add an additional addendum that should help clarify.
- Changes are welcome, the main thing to avoid was users thinking that they would have to lock state and similar concepts that only apply when handling state in multiple threads. 