### PR TITLE
Fix command selection in Pages Direct Upload CI how-to page

### DIFF
--- a/content/pages/how-to/use-direct-upload-with-continuous-integration.md
+++ b/content/pages/how-to/use-direct-upload-with-continuous-integration.md
@@ -13,7 +13,7 @@ In your project directory, install [Wrangler](/workers/wrangler/get-started/) so
 
 ```sh
 # Publish created project
-CF_ACCOUNT_ID=<ACCOUNT_ID> npx wrangler pages publish <DIRECTORY> --project-name=<PROJECT_NAME>
+$ CF_ACCOUNT_ID=<ACCOUNT_ID> npx wrangler pages publish <DIRECTORY> --project-name=<PROJECT_NAME>
 ```
 
 ## Get credentials from Cloudflare


### PR DESCRIPTION
The command line does not start with $ so it is not selectable:

![gif](https://advaith.is-in-hyper.space/0ef53cb032.gif)