### PR TITLE
[Magic Transit & WAN] Added partial for ECMP flow hashing

### DIFF
--- a/content/magic-transit/_partials/_ecmp-flow-hashing.md
+++ b/content/magic-transit/_partials/_ecmp-flow-hashing.md
@@ -8,3 +8,5 @@ _build:
 {{<Aside type="note" header="Note:">}}
 
 Packets in the same flow use the same tunnel unless the tunnel priority changes. Packets for different flows can use different tunnels depending on which tunnel the flow's 4-tuple – source and destination IP and source and destination port – hash to.
+  
+{{</Aside>}}  

--- a/content/magic-transit/_partials/_ecmp-flow-hashing.md
+++ b/content/magic-transit/_partials/_ecmp-flow-hashing.md
@@ -1,0 +1,10 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="note" header="Note:">}}
+
+Packets in the same flow use the same tunnel unless the tunnel priority changes. Packets for different flows can use different tunnels depending on which tunnel the flow's 4-tuple – source and destination IP and source and destination port – hash to.

--- a/content/magic-transit/about/traffic-steering.md
+++ b/content/magic-transit/about/traffic-steering.md
@@ -32,6 +32,8 @@ Using ECMP has a number of consequences:
 
 As a result, ECMP provides load balancing across tunnels with the same priority.
 
+{{<render file="_ecmp-flow-hashing.md">}}
+
 ### Examples
 
 This diagram illustrates how ECMP distributes traffic equally across 2 paths with the same priority.

--- a/content/magic-wan/about/traffic-steering.md
+++ b/content/magic-wan/about/traffic-steering.md
@@ -29,6 +29,9 @@ Using ECMP has a number of consequences:
 
 - Routing changes in the number of equal-cost next hops can cause traffic to use different tunnels. For example, dynamic prioritization triggered by health check events can cause traffic to use different tunnels.
 
+{{<render file="../../magic-transit/_partials/_ecmp-flow-hashing.md">}}
+
+
 ### Examples
 
 This diagram illustrates how ECMP distributes traffic equally across 2 paths with the same priority.


### PR DESCRIPTION
Added note about ECMP flow hashing to address [PCX-3834](https://jira.cfops.it/browse/PCX-3834).