### PR TITLE
[R2] Add aws-sdk-go-v2 example

### DIFF
--- a/content/r2/examples/aws-sdk-go.md
+++ b/content/r2/examples/aws-sdk-go.md
@@ -47,14 +47,14 @@ func main() {
 
 	client := s3.NewFromConfig(cfg)
 
-	ListObjectsOutput, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
-		Bucket: aws.String(BucketName),
+	listObjectsOutput, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+		Bucket: &bucketName,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, object := range ListObjectsOutput.Contents {
+	for _, object := range listObjectsOutput.Contents {
 		obj, _ := json.MarshalIndent(object, "", "\t")
 		fmt.Println(string(obj))
 	}

--- a/content/r2/examples/aws-sdk-go.md
+++ b/content/r2/examples/aws-sdk-go.md
@@ -25,21 +25,20 @@ import (
 )
 
 func main() {
-	var BucketName = "sdk-example"
-	var AccountId = "<accountid>"
-	var AccessKeyId = "<access_key_id>"
-	var AccessKeySecret = "<access_key_secret>"
+	var bucketName = "sdk-example"
+	var accountId = "<accountid>"
+	var accessKeyId = "<access_key_id>"
+	var accessKeySecret = "<access_key_secret>"
 
-	R2Resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+	r2Resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
-			URL:           fmt.Sprintf("https://%s.r2.cloudflarestorage.com", AccountId),
-			SigningRegion: "auto",
+			URL: fmt.Sprintf("https://%s.r2.cloudflarestorage.com", accountId),
 		}, nil
 	})
 
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithEndpointResolverWithOptions(R2Resolver),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(AccessKeyId, AccessKeySecret, "")),
+		config.WithEndpointResolverWithOptions(r2Resolver),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyId, accessKeySecret, "")),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/content/r2/examples/aws-sdk-go.md
+++ b/content/r2/examples/aws-sdk-go.md
@@ -1,0 +1,87 @@
+---
+title: Configure `aws-sdk-go` for R2
+summary: Example of how to configure `aws-sdk-go` to use R2.
+pcx-content-type: configuration
+weight: 1001
+layout: example
+---
+
+You must [generate an Access Key](/r2/platform/s3-compatibility/tokens/) before getting started. All examples will utilitize `access_key_id` and `access_key_secret` variables which represent the **Access Key ID** and **Secret Access Key** values you generated.
+
+This example uses version 2 of the [aws-sdk-go](https://github.com/aws/aws-sdk-go-v2) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"log"
+)
+
+func main() {
+	var BucketName = "sdk-example"
+	var AccountId = "<accountid>"
+	var AccessKeyId = "<access_key_id>"
+	var AccessKeySecret = "<access_key_secret>"
+
+	R2Resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		return aws.Endpoint{
+			URL:           fmt.Sprintf("https://%s.r2.cloudflarestorage.com", AccountId),
+			SigningRegion: "auto",
+		}, nil
+	})
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithEndpointResolverWithOptions(R2Resolver),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(AccessKeyId, AccessKeySecret, "")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	ListObjectsOutput, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(BucketName),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, object := range ListObjectsOutput.Contents {
+		obj, _ := json.MarshalIndent(object, "", "\t")
+		fmt.Println(string(obj))
+	}
+
+	//  {
+	//  	"ChecksumAlgorithm": null,
+	//  	"ETag": "\"eb2b891dc67b81755d2b726d9110af16\"",
+	//  	"Key": "ferriswasm.png",
+	//  	"LastModified": "2022-05-18T17:20:21.67Z",
+	//  	"Owner": null,
+	//  	"Size": 87671,
+	//  	"StorageClass": "STANDARD"
+	//  }
+
+	ListBucketsOutput, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, object := range ListBucketsOutput.Buckets {
+		obj, _ := json.MarshalIndent(object, "", "\t")
+		fmt.Println(string(obj))
+	}
+
+	// {
+	// 		"CreationDate": "2022-05-18T17:19:59.645Z",
+	// 		"Name": "sdk-example"
+	// }
+}
+```

--- a/content/r2/examples/aws-sdk-go.md
+++ b/content/r2/examples/aws-sdk-go.md
@@ -69,12 +69,12 @@ func main() {
 	//  	"StorageClass": "STANDARD"
 	//  }
 
-	ListBucketsOutput, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	listBucketsOutput, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, object := range ListBucketsOutput.Buckets {
+	for _, object := range listBucketsOutput.Buckets {
 		obj, _ := json.MarshalIndent(object, "", "\t")
 		fmt.Println(string(obj))
 	}


### PR DESCRIPTION
An example demonstrating how to connect to R2's S3 API using `aws-sdk-go-v2`.

~~NOTE: This example was made to work using a patched `aws-sdk-go-v2` pending a bug fix in R2 that won't require this workaround, so it should not be merged yet.~~ The bug in R2 has been fixed in production so this PR can be safely merged.

Since it's a bit of a longer example and I'm not massively experienced with Go (or the code style of it), please suggest any improvements/formatting/etc.

cc: @ImJasonH @vlovich 