### PR TITLE
[R2]: Document the endpoint location on the tokens page

### DIFF
--- a/content/r2/platform/s3-compatibility/api.md
+++ b/content/r2/platform/s3-compatibility/api.md
@@ -6,6 +6,7 @@ pcx-content-type: reference
 # S3 API compatibility
 
 R2 implements the S3 API to allow users and their applications to migrate easily. When comparing to AWS S3, Cloudflare has removed some API operations' features and added others. The S3 API operations are listed below with their current implementation status. Feature implementation is currently in progress. Refer back to this page for updates.
+The API is available via the `https://<account>.r2.cloudflarestorage.com` endpoint.
 
 ## How to read this page
 

--- a/content/r2/platform/s3-compatibility/api.md
+++ b/content/r2/platform/s3-compatibility/api.md
@@ -6,7 +6,7 @@ pcx-content-type: reference
 # S3 API compatibility
 
 R2 implements the S3 API to allow users and their applications to migrate easily. When comparing to AWS S3, Cloudflare has removed some API operations' features and added others. The S3 API operations are listed below with their current implementation status. Feature implementation is currently in progress. Refer back to this page for updates.
-The API is available via the `https://<account>.r2.cloudflarestorage.com` endpoint.
+The API is available via the `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` endpoint. Find your [account ID in the Cloudflare dashboard](https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
 
 ## How to read this page
 

--- a/content/r2/platform/s3-compatibility/tokens.md
+++ b/content/r2/platform/s3-compatibility/tokens.md
@@ -26,4 +26,4 @@ You will not be able to access your **Secret Access Key** again after this step.
 
 {{</Aside>}}
 
-
+The S3 endpoint is available via `https://<account>.r2.cloudflarestorage.com`.

--- a/content/r2/platform/s3-compatibility/tokens.md
+++ b/content/r2/platform/s3-compatibility/tokens.md
@@ -26,4 +26,4 @@ You will not be able to access your **Secret Access Key** again after this step.
 
 {{</Aside>}}
 
-The S3 endpoint is available via `https://<account>.r2.cloudflarestorage.com`.
+The S3 endpoint is available via `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` endpoint. Find your [account ID in the Cloudflare dashboard](https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).


### PR DESCRIPTION
Doesn't appear to actually be referenced anywhere.