### PR TITLE
Remove third-party caching misconception

### DIFF
--- a/content/analytics/web-analytics/understanding-web-analytics/data-origin-and-collection.md
+++ b/content/analytics/web-analytics/understanding-web-analytics/data-origin-and-collection.md
@@ -14,6 +14,6 @@ Refer to the [W3C Processing Model](https://www.w3.org/TR/navigation-timing-2/#p
 
 Web Analytics collects the minimum amount of information - timing metrics - to show customers how their websites perform. Cloudflare does not track individual end users across our customers’ Internet properties.
 
-The Web Analytics performance beacon loads from <https://static.cloudflareinsights.com/beacon.min.js>. You may need to update your [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) settings to load this script.
+The Web Analytics performance beacon loads from `https://static.cloudflareinsights.com/beacon.min.js`. You may need to update your [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) settings to load this script.
 
 Beacon data is sent to `https://<yourdomainname>/cdn-cgi/rum` for sites proxied through Cloudflare or `https://cloudflareinsights.com/cdn-cgi/rum` for sites not proxied through Cloudflare. Core Web Vital metrics are reported when the `visibilityState` is hidden for the first time after the page load event is triggered.

--- a/content/analytics/web-analytics/understanding-web-analytics/data-origin-and-collection.md
+++ b/content/analytics/web-analytics/understanding-web-analytics/data-origin-and-collection.md
@@ -14,6 +14,6 @@ Refer to the [W3C Processing Model](https://www.w3.org/TR/navigation-timing-2/#p
 
 Web Analytics collects the minimum amount of information - timing metrics - to show customers how their websites perform. Cloudflare does not track individual end users across our customers’ Internet properties.
 
-The Web Analytics performance beacon loads from <https://static.cloudflareinsights.com/beacon.min.js> and uses a third-party domain so that the script is cached across website loads. You may need to update your [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) settings to load this script.
+The Web Analytics performance beacon loads from <https://static.cloudflareinsights.com/beacon.min.js>. You may need to update your [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) settings to load this script.
 
 Beacon data is sent to `https://<yourdomainname>/cdn-cgi/rum` for sites proxied through Cloudflare or `https://cloudflareinsights.com/cdn-cgi/rum` for sites not proxied through Cloudflare. Core Web Vital metrics are reported when the `visibilityState` is hidden for the first time after the page load event is triggered.


### PR DESCRIPTION
With [double-keyed cache](https://github.com/whatwg/fetch/issues/904) enabled in all main browsers, cached resources will not be shared across webistes.