### PR TITLE
[Workers] Add environments disabled note in both environments.md

### DIFF
--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -7,6 +7,8 @@ title: Environments
 
 {{<Aside type="note">}}
 
+If you are looking for the new [Service Environments](/workers/learning/using-services/) please note that we have temporarily disabled the creation of Service Environments while we are improving this feature.
+
 You can only use environments with [Wrangler](/workers/wrangler/).
 
 {{</Aside>}}

--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -7,8 +7,6 @@ title: Environments
 
 {{<Aside type="note">}}
 
-If you are looking for the new [Service Environments](/workers/learning/using-services/) note that we have temporarily disabled the creation of Service Environments while we are improving this feature.
-
 You can only use environments with [Wrangler](/workers/wrangler/).
 
 {{</Aside>}}

--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -7,7 +7,7 @@ title: Environments
 
 {{<Aside type="note">}}
 
-If you are looking for the new [Service Environments](/workers/learning/using-services/) please note that we have temporarily disabled the creation of Service Environments while we are improving this feature.
+If you are looking for the new [Service Environments](/workers/learning/using-services/) note that we have temporarily disabled the creation of Service Environments while we are improving this feature.
 
 You can only use environments with [Wrangler](/workers/wrangler/).
 

--- a/content/workers/wrangler/environments.md
+++ b/content/workers/wrangler/environments.md
@@ -8,7 +8,7 @@ weight: 6
 
 {{<Aside type="note">}}
 
-We've temporarily disabled the creation of Service Environments while we are improving this feature.
+We have temporarily disabled the creation of Service Environments while we are improving this feature.
 
 {{</Aside>}}
 


### PR DESCRIPTION
I was looking for the environments drop-down on the dashboard and couldn't find it. It took me a little while to find the note in the docs, as I was primarily landing on the legacy environments docs.

There are 2 pages that include a note:
https://developers.cloudflare.com/workers/learning/using-services/
https://developers.cloudflare.com/workers/wrangler/environments/ (updated the note to match the wording of the first one)

Question: Would it make sense to also update the title of the **Environments** (https://developers.cloudflare.com/workers/platform/environments/) to mention "legacy" or wrangler 1?