### PR TITLE
Update DO example to allow for easily switching between DOs

### DIFF
--- a/content/workers/learning/using-durable-objects.md
+++ b/content/workers/learning/using-durable-objects.md
@@ -453,12 +453,30 @@ export default {
 };
 
 async function handleRequest(request, env) {
-  let id = env.COUNTER.idFromName("A");
+  let url = new URL(request.url);
+  let name = url.searchParams.get("name");
+  if (!name) {
+    return new Response(
+      "Select a Durable Object to contact by using" +
+        " the `name` URL query string parameter. e.g. ?name=A"
+    );
+  }
+
+  // Every unique ID refers to an individual instance of the Counter class that
+  // has its own state. `idFromName()` always returns the same ID when given the
+  // same string as input (and called on the same class), but never the same
+  // ID for two different strings (or for different classes).
+  let id = env.COUNTER.idFromName(name);
+
+  // Construct the stub for the Durable Object using the ID. A stub is a
+  // client object used to send messages to the Durable Object.
   let obj = env.COUNTER.get(id);
+
+  // Send a request to the Durable Object, then await its response.
   let resp = await obj.fetch(request.url);
   let count = await resp.text();
 
-  return new Response("Durable Object 'A' count: " + count);
+  return new Response(`Durable Object '${name}' count: ${count}`);
 }
 
 // Durable Object


### PR DESCRIPTION
I use this example as a starting point when I want to do simple testing or show someone something, and the first thing I _always_ do is make the object itself an argument.

I think hard coding `"A"` does new readers a disservice and could confuse them about DO namespaces/objects.

Most of the commentary is copy pasted from elsewhere in this document, FWIW.