### PR TITLE
[Workers] Simplify sha256 in cache-post-request.md

### DIFF
--- a/content/workers/examples/cache-post-request.md
+++ b/content/workers/examples/cache-post-request.md
@@ -19,12 +19,8 @@ async function sha256(message) {
   // hash the message
   const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
 
-  // convert ArrayBuffer to Array
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-
   // convert bytes to hex string
-  const hashHex = hashArray.map(b => ('00' + b.toString(16)).slice(-2)).join('');
-  return hashHex;
+  return [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
 async function handlePostRequest(event) {


### PR DESCRIPTION
Use spread syntax instead of `Array.from()` and `padStart()` instead of concatenation followed by `slice()`.