### PR TITLE
[Search] Remove product name from top navbar

### DIFF
--- a/layouts/partials/topbar.search.html
+++ b/layouts/partials/topbar.search.html
@@ -4,7 +4,7 @@
 <div class="DocsToolbar--search CoveoSearchInterface">
   <div class="DocsSearch">
     <div class="DocsSearch--input-wrapper">
-      <input type="text" id="DocsSearch--input" class="DocsSearch--input CoveoCustomSearchBox" spellcheck="false" autoComplete="false" placeholder="Search {{ $title }} docs..."/>
+      <input type="text" id="DocsSearch--input" class="DocsSearch--input CoveoCustomSearchBox" spellcheck="false" autoComplete="false" placeholder="Search docs..."/>
 
       <div class="DocsSearch--input-icon">
         <svg viewBox="0 0 16 16" fill="currentColor" role="img" aria-labelledby="title-9701125841014673" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Updated topbar.search.html to remove the product name from top nav bar, since our search technically now looks at all the docs (and not just those associated with the specific product area).