### PR TITLE
Fix broken graphql queries for Magic Transit health checking and bandwidth analytics

### DIFF
--- a/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
@@ -46,8 +46,8 @@ PAYLOAD='{
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+  -H "X-Auth-key: ${CLOUDFLARE_API_KEY}" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```

--- a/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
@@ -45,8 +45,8 @@ PAYLOAD='{ "query":
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+  -H "X-Auth-key: ${CLOUDFLARE_API_KEY}" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
@@ -7,7 +7,7 @@ title: Querying Magic Transit tunnel bandwidth analytics with GraphQL
 
 In this example, you are going to use the GraphQL Analytics API to query Magic Transit Ingress Tunnel Traffic over a specified time period.
 
-The following API call will request Magic Transit Ingress Tunnel Traffic over a one-hour period and output the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetime_geq` and `datetime_leq `values as needed. 
+The following API call will request Magic Transit Ingress Tunnel Traffic over a one-hour period and output the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetime_geq` and `datetime_leq `values as needed.
 
 The following example queries for ingress traffic. To query for egress, change the value in the direction filter.
 
@@ -18,7 +18,6 @@ CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
 CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
 PAYLOAD='{ "query":
   "query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
-    {
       viewer {
         accounts(filter: {accountTag: $accountTag}) {
           magicTransitTunnelTrafficAdaptiveGroups(
@@ -38,7 +37,6 @@ PAYLOAD='{ "query":
           }
         }
       }
-    }
   }",
     "variables": {
       "accountTag": "90f518ca7113dc0a91513972ba243ba5",
@@ -46,12 +44,12 @@ PAYLOAD='{ "query":
       "datetimeEnd": "2020-05-04T12:00:00.000Z"
     }
   }'
- 
+
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+  -H "X-Auth-key: ${CLOUDFLARE_API_KEY}" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
   ```

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
@@ -18,7 +18,6 @@ CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
 CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
 PAYLOAD='{ "query":
   "query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
-    {
       viewer {
         accounts(filter: {accountTag: $accountTag}) {
           magicTransitTunnelHealthChecksAdaptiveGroups(
@@ -38,7 +37,6 @@ PAYLOAD='{ "query":
           }
         }
       }
-    }
   }",
     "variables": {
       "accountTag": "90f518ca7113dc0a91513972ba243ba5",
@@ -47,11 +45,20 @@ PAYLOAD='{ "query":
     }
   }'
 
+# With an API Key
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+  -H "X-Auth-key: ${CLOUDFLARE_API_KEY}" \
+  --data "$(echo $PAYLOAD)" \
+  https://api.cloudflare.com/client/v4/graphql/
+
+# With an API Token
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```

--- a/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
@@ -52,8 +52,8 @@ PAYLOAD='{ "query":
 curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
-  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+  -H "X-Auth-key: ${CLOUDFLARE_API_KEY}" \
   --data "$(echo $PAYLOAD)" \
   https://api.cloudflare.com/client/v4/graphql/
 ```


### PR DESCRIPTION
Also allows the curl command to be copy/pastable.

The errors I was seeing from the incorrect graphql were:
```
{
  "data": null,
  "errors": [
    {
      "message": "Syntax Error GraphQL (1:107) Expected Name, found {\n\n1: query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {    {      viewer {        accounts(filter: {accountTag: $accountTag}) {          magicTransitTunnelHealthChecksAdaptiveGroups(            limit: 100,            filter: {              datetime_geq: $datetimeStart,              datetime_lt:  $datetimeEnd,            }          ) {            avg {              tunnelState            }            dimensions {              tunnelName              edgeColoName            }          }        }      }    }  }\n                                                                                                             ^\n",
      "path": null,
      "extensions": {
        "timestamp": "2022-05-24T21:18:05.438801274Z"
      }
    }
  ]
}
```

While a fixed query returns
```
{
  "data": {
    "viewer": {
      "accounts": [
        {
          "magicTransitTunnelHealthChecksAdaptiveGroups": [
            {
              "avg": {
                "tunnelState": 0
              },
              "dimensions": {
                "edgeColoName": "oua01",
                "tunnelName": "GRE_1_....
....
...
```