### PR TITLE
Update macOS name capitalization

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/configuration/remote-management.md
+++ b/content/cloudflare-one/connections/connect-apps/configuration/remote-management.md
@@ -36,9 +36,9 @@ On Linux, Cloudflare Tunnel installs itself as a system service using `systemctl
     RestartSec=5s
     ```
 
-## MacOS
+## macOS
 
-On MacOS, Cloudflare Tunnel installs itself as a launch agent using `launchctl`. By default, the agent will be called `com.cloudflare.cloudflared`. To configure your tunnel on MacOS:
+On macOS, Cloudflare Tunnel installs itself as a launch agent using `launchctl`. By default, the agent will be called `com.cloudflare.cloudflared`. To configure your tunnel on macOS:
 
 1. Stop the `cloudflared` service.
 

--- a/content/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-useful-terms.md
+++ b/content/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-useful-terms.md
@@ -33,7 +33,7 @@ You can create and configure a tunnel once and run it as multiple different `clo
 | OS                          | Path to default directory                                                              |
 | --------------------------- | -------------------------------------------------------------------------------------- |
 | Windows                     | `%USERPROFILE%\.cloudflared`                                                           |
-| MacOS and Unix-like systems | `~/.cloudflared`, `/etc/cloudflared`, and `/usr/local/etc/cloudflared`, in this order. |
+| macOS and Unix-like systems | `~/.cloudflared`, `/etc/cloudflared`, and `/usr/local/etc/cloudflared`, in this order. |
 
 ## Configuration file
 

--- a/content/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/macos.md
+++ b/content/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/macos.md
@@ -1,6 +1,6 @@
 ---
 pcx-content-type: how-to
-title: MacOS
+title: macOS
 weight: 31
 meta:
   title: Run as a service on macOS

--- a/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -49,7 +49,7 @@ F5:E1:56:C4:89:78:77:AD:79:3A:1E:83:FA:77:83:F1:9C:B0:C6:1B:58:2C:2F:50:11:B3:37
 
 ## Add the certificate to your system
 
-### MacOS
+### macOS
 
 You will need to install the root certificate in the **Keychain Access** application. In the application, you can choose the keychain in which you want to install the certificate. macOS offers three options, each having a different impact on which users will be affected by trusting the root certificate.
 
@@ -69,21 +69,21 @@ To install the certificate in **Keychain Access**:
 
 3. In the pop-up message, choose the option that suits your needs (_login_, _Local Items_, or _System_) and click **Add**.
 
-![MacOS popup window for adding certificates](/cloudflare-one/static/documentation/connections/keychain-popup.png)
+![macOS popup window for adding certificates](/cloudflare-one/static/documentation/connections/keychain-popup.png)
 
 The certificate is now listed in your preferred keychain within the **Keychain Access** application. You can always move the certificate under a different keychain by dragging and dropping the certificate onto the desired keychain on the left.
 
-![Viewing certificate in MacOS Keychain Access application](/cloudflare-one/static/documentation/connections/listed-in-keych.png)
+![Viewing certificate in macOS Keychain Access application](/cloudflare-one/static/documentation/connections/listed-in-keych.png)
 
 4. Double-click the certificate.
 
 5. Click **Trust**.
 
-![MacOS window for certificate configuration](/cloudflare-one/static/documentation/connections/cert-click-on-trust.png)
+![macOS window for certificate configuration](/cloudflare-one/static/documentation/connections/cert-click-on-trust.png)
 
 6. From the **When using this certificate** drop-down menu, select **Always Trust**.
 
-![MacOS window for configuring certificate trust settings](/cloudflare-one/static/documentation/connections/cert-select-always-trust.png)
+![macOS window for configuring certificate trust settings](/cloudflare-one/static/documentation/connections/cert-select-always-trust.png)
 
 7. Close the menu.
 

--- a/content/cloudflare-one/identity/devices/mutual-tls-authentication.md
+++ b/content/cloudflare-one/identity/devices/mutual-tls-authentication.md
@@ -216,9 +216,9 @@ Returning to the terminal, generate a client certificate that will authenticate 
 
 ### Testing in the browser
 
-The instructions here cover usage with a computer running MacOS.
+The instructions here cover usage with a computer running macOS.
 
-1.  In the same working directory, run the following command to add the client certificate into the MacOS Keychain.
+1.  In the same working directory, run the following command to add the client certificate into the macOS Keychain.
 
     {{<Aside type="warning" header="Important">}}
 The command adds the client certificate to the trusted store on your device. **Only** proceed if you are comfortable doing so and intend to keep these testing certificates safeguarded.

--- a/content/cloudflare-one/tutorials/rdp.md
+++ b/content/cloudflare-one/tutorials/rdp.md
@@ -229,7 +229,7 @@ You can help end users connect without requiring the command line by providing t
 
 - Ensure that RDP is enabled on the target Windows machine. If not, you may encounter an error: `No connection could be made because the target machine actively refused it`.
 
-### MacOS
+### macOS
 
 {{<Aside type="note">}}
 
@@ -237,7 +237,7 @@ Before you start, make sure you download an RDP client for macOS.
 
 {{</Aside>}}
 
-MacOS users can save a command shortcut that will launch the RDP flow.
+macOS users can save a command shortcut that will launch the RDP flow.
 
 1.  The command below can be saved as a `.command` file that can be launched on login:
 
@@ -267,4 +267,4 @@ MacOS users can save a command shortcut that will launch the RDP flow.
 
 5.  Double click on the previously created `CF-RDP-Tunnel.command` file.
 
-    The default behavior in MacOS is for the Terminal window to stay open. You can configure it to close automatically.
+    The default behavior in macOS is for the Terminal window to stay open. You can configure it to close automatically.

--- a/content/http3/tutorials/curl-brew.md
+++ b/content/http3/tutorials/curl-brew.md
@@ -5,7 +5,7 @@ title: Curl + Quiche
 
 # Curl + Quiche
 
-Follow the guidelines below to build and test HTTP/3 on MacOS.
+Follow the guidelines below to build and test HTTP/3 on macOS.
 
 ## Requirements
 

--- a/content/images/polish/_index.md
+++ b/content/images/polish/_index.md
@@ -32,7 +32,7 @@ Lossy attempts to strip most metadata and compresses images by approximately 15 
 
 ### WebP
 
-WebP is a modern image format providing superior lossless and lossy compression for images. WebP lossless images are approximately 26 percent smaller than PNGs, while lossy images are 25 to 34 percent smaller than JPEGs. WebP is supported in all browsers except for Internet Explorer and KaiOS. Safari supports WebP from iOS 14 and MacOS 11 (Big Sur). You can learn more in our [blog post](https://blog.cloudflare.com/a-very-webp-new-year-from-cloudflare/).
+WebP is a modern image format providing superior lossless and lossy compression for images. WebP lossless images are approximately 26 percent smaller than PNGs, while lossy images are 25 to 34 percent smaller than JPEGs. WebP is supported in all browsers except for Internet Explorer and KaiOS. Safari supports WebP from iOS 14 and macOS 11 (Big Sur). You can learn more in our [blog post](https://blog.cloudflare.com/a-very-webp-new-year-from-cloudflare/).
 
 Polish creates and caches a WebP version of the image and delivers it to the browser if the `Accept` header from the browser includes WebP, and the compressed image is significantly smaller than the lossy or lossless compression:
 

--- a/content/pages/framework-guides/deploy-a-sphinx-site.md
+++ b/content/pages/framework-guides/deploy-a-sphinx-site.md
@@ -33,7 +33,7 @@ Refer to the official Python documentation for installation guidance:
 
 - [Windows](https://www.python.org/downloads/windows/)
 - [Linux/UNIX](https://www.python.org/downloads/source/)
-- [Mac OS X](https://www.python.org/downloads/mac-osx/)
+- [macOS](https://www.python.org/downloads/macos/)
 - [Other](https://www.python.org/download/other/)
 
 ### Installing Pipenv

--- a/content/pub-sub/learning/client-libraries.md
+++ b/content/pub-sub/learning/client-libraries.md
@@ -13,7 +13,7 @@ The list of client libraries are not formally supported by Cloudflare but have b
 
 |      Platform/Language          |    Source                                 |
 |---------------------------------|-------------------------------------------|
-| MacOS, Windows, Linux           | https://mqttx.app/ (GUI tool)             |
+| macOS, Windows, Linux           | https://mqttx.app/ (GUI tool)             |
 | JavaScript (Node.js, TypeScript)| https://github.com/mqttjs/MQTT.js         |
 | Go (MQTT v5.0 specific library) | https://github.com/eclipse/paho.golang    |
 | Python                          | https://pypi.org/project/paho-mqtt/       |

--- a/content/ssl/edge-certificates/additional-options/tls-13.md
+++ b/content/ssl/edge-certificates/additional-options/tls-13.md
@@ -39,7 +39,7 @@ After enabling TLS 1.3, visit a site with TLS 1.3 enabled over HTTPS. Then:
 
 1.  Open Chrome **Developer Tools**.
 2.  Click the **Security** tab.
-3.  Reload the page (Command-R in Mac OS, Ctrl-R in Windows).
+3.  Reload the page (Command-R in macOS, Ctrl-R in Windows).
 4.  Click on the site under **Main origin**.
 5.  Under **Connection**, confirm that the protocol is **TLS 1.3**.
 

--- a/content/ssl/keyless-ssl/hardware-security-modules/azure-managed-hsm.md
+++ b/content/ssl/keyless-ssl/hardware-security-modules/azure-managed-hsm.md
@@ -35,7 +35,7 @@ Follow [these instructions](/ssl/keyless-ssl/configuration/##step-3--set-up-and-
 
 Set up the Azure CLI (used to access the private key).
 
-For example, if you were using MacOS:
+For example, if you were using macOS:
 
     brew install azure-cli
 

--- a/content/terraform/advanced-topics/import-cloudflare-resources.md
+++ b/content/terraform/advanced-topics/import-cloudflare-resources.md
@@ -22,7 +22,7 @@ If you configured Cloudflare through other means, for example, by logging in to 
 
 Before you start, you must install `cf-terraforming`.
 
-If you use Homebrew on MacOS, open a terminal and run the following commands:
+If you use Homebrew on macOS, open a terminal and run the following commands:
 
 ```sh
 $ brew tap cloudflare/cloudflare

--- a/content/time-services/ntp/usage.md
+++ b/content/time-services/ntp/usage.md
@@ -22,7 +22,7 @@ To have your Mac to synchronize time from `time.cloudflare.com`:
 4.  Enter your password.
 5.  Next to **Set date and time automatically**, enter `time.cloudflare.com`.
 
-![Screenshot of updating the Date & Time settings on machine running MacOS](/time-services/static/mactime.png)
+![Screenshot of updating the Date & Time settings on machine running macOS](/time-services/static/mactime.png)
 
 ## Windows
 


### PR DESCRIPTION
Updates capitalisation of macOS operating system so that it's correct and consistent throughout documentation.

Single instance of "OS X" not updated as per this list of macOS version names: https://support.apple.com/en-au/HT201260#latest