### PR TITLE
[DDoS Protection] Remove references to rule IDs with GB prefix

### DIFF
--- a/content/ddos-protection/managed-rulesets/http/override-parameters.md
+++ b/content/ddos-protection/managed-rulesets/http/override-parameters.md
@@ -45,9 +45,9 @@ The action that will be performed for requests that match specific rules of Clou
 
 {{<Aside type="note">}}
 
-You cannot configure the rule action to _Log_ for rules with the `gatebot` tag or any rule whose `id` starts with `GB`.
+You cannot configure the rule action to _Log_ for rules with the `gatebot` tag.
 
-However, you can use the _Log_ action in the global ruleset configuration. In this case, any rule with the `gatebot` tag or whose `id` starts with `GB` will ignore the ruleset configuration and use the default action as defined in the Managed Ruleset. To prevent `gatebot` rules from executing their default action in _Log_ mode, set the sensitivity level of these rules to _Essentially Off_.
+However, you can use the _Log_ action in the global ruleset configuration. In this case, any rule with the `gatebot` tag will ignore the ruleset configuration and use the default action as defined in the Managed Ruleset. To prevent `gatebot` rules from executing their default action in _Log_ mode, set the sensitivity level of these rules to _Essentially Off_.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Rules with the `GB` have been discontinued.