### PR TITLE
[Fundamentals] Clarified how to resolve "Domain does not exist" errors

### DIFF
--- a/content/fundamentals/get-started/setup/troubleshooting/unregistered-domains.md
+++ b/content/fundamentals/get-started/setup/troubleshooting/unregistered-domains.md
@@ -26,5 +26,7 @@ If you have already own your domain but Cloudflare does not recognize your domai
 If you add Cloudflare's nameservers at your registrar **before** [adding that domain](/fundamentals/get-started/setup/add-site/) to Cloudflare, your `NS` records will be considered invalid.
 
 You need to add your domain to Cloudflare first, and only then add our nameservers at your registrar.
+  
+If you've already changed your nameservers to Cloudflare's and are now getting this error, resetting them to your registrar's default ones, waiting for a few hours, and then [adding that domain](/fundamentals/get-started/setup/add-site/) should work.
 
 {{</Aside>}}


### PR DESCRIPTION
- Recently a change was PRed to the docs about why you might get the "domain does not exist" error on adding a domain to Cloudflare.
- Previously this page told you that you shouldn't change nameservers to Cloudflare before adding but *didn't* tell you what to do if you already have.
- This PR adds an addendum to clarify the steps to resolve this (resetting NS to default, waiting, then adding).