### PR TITLE
[Workers] Add Response.json() method to API docs

### DIFF
--- a/content/workers/runtime-apis/response.md
+++ b/content/workers/runtime-apis/response.md
@@ -86,7 +86,12 @@ Valid options for the `options` object include: {{<definitions>}}
 
   - Creates a clone of a [`Response`](#response) object.
 
+- `json()` {{<type-link href="#response">}}Response{{</type-link>}}
+  
+  - Creates a new response with a JSON-serialized payload.
+  
 - `redirect()` {{<type-link href="#response">}}Response{{</type-link>}}
+  
   - Creates a new response with a different URL.
 
 {{</definitions>}}


### PR DESCRIPTION
As per https://github.com/whatwg/fetch/pull/1392 and https://community.cloudflare.com/t/2022-5-26-workers-runtime-release-notes/386584

However, I'd like to add the param/type annotations much like we do with the R2 methods.

![image](https://user-images.githubusercontent.com/94662631/170576989-909fcc85-62cc-42b2-af35-64a599c33586.png)

Is that something that we'd like to do with the existing Workers runtime API docs as well? Happy to add them in as per the type definitions from https://github.com/cloudflare/workers-types/