### PR TITLE
Fix logic in block-ip-reputation.md

### DIFF
--- a/content/firewall/recipes/block-ip-reputation.md
+++ b/content/firewall/recipes/block-ip-reputation.md
@@ -20,7 +20,7 @@ This example blocks requests based on country code ([ISO 3166-1 Alpha 2](https:/
     <tr>
       <td>
         <code>
-          (ip.geoip.country in {"CN" "TW" "US" "GB"}) or cf.threat_score > 0
+          (ip.geoip.country in {"CN" "TW" "US" "GB"}) and cf.threat_score > 0
         </code>
       </td>
       <td>


### PR DESCRIPTION
Current logic seems to block all traffic from CN, TW, US, and GB even if the threat_score is 0