### PR TITLE
pages/functions: correct route path mappings

### DIFF
--- a/content/pages/platform/functions/_index.md
+++ b/content/pages/platform/functions/_index.md
@@ -48,8 +48,8 @@ The following routes will be generated based on the file structure, mapping the 
     /api/todos => ./functions/api/todos/index.ts
     /api/todos/* => ./functions/api/todos/[id].ts
     /api/todos/*/** => ./functions/api/todos/[[path]].ts
-    /*/profile => ./functions/api/[username]/profile.ts
-    /** => ./functions/api/[[path]].ts
+    /api/*/profile => ./functions/api/[username]/profile.ts
+    /api/** => ./functions/api/[[path]].ts
 
 ### Path segments
 


### PR DESCRIPTION
Previously the docs incorrectly suggested that the `/api` prefix is not required for some of the wildcard routes.