### PR TITLE
[Pages] Clarify individual header length limit

### DIFF
--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -56,7 +56,7 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{</table-wrap>}}
 
-A project is limited to 100 header rules. Each line in the _headers file has a 1,000 character limit. The entire line including spacing, header name and value all count towards this limit.
+A project is limited to 100 header rules. Each line in the `_headers` file has a 1,000 character limit. The entire line, including spacing, header name, and value, counts towards this limit.
 
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator. Headers defined in the `_headers` file override what Cloudflare Pages ordinarily sends, so be aware when setting security headers. Cloudflare reserves the right to attach new headers to Pages projects at any time in order to improve performance or harden the security of your deployments.
 

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -56,6 +56,8 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{</table-wrap>}}
 
+A project is limited to 100 header rules. Each header declaration has a 1,000-character limit.
+
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator. Headers defined in the `_headers` file override what Cloudflare Pages ordinarily sends, so be aware when setting security headers. Cloudflare reserves the right to attach new headers to Pages projects at any time in order to improve performance or harden the security of your deployments.
 
 ### Matching

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -56,7 +56,7 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{</table-wrap>}}
 
-A project is limited to 100 header rules. Each header declaration has a 1,000-character limit.
+A project is limited to 100 header rules. Each header declaration has a 2,000-character limit.
 
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator. Headers defined in the `_headers` file override what Cloudflare Pages ordinarily sends, so be aware when setting security headers. Cloudflare reserves the right to attach new headers to Pages projects at any time in order to improve performance or harden the security of your deployments.
 

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -56,7 +56,7 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{</table-wrap>}}
 
-A project is limited to 100 header rules. Each header declaration has a 2,000-character limit.
+A project is limited to 100 header rules. Each line in the _headers file has a 1,000 character limit. The entire line including spacing, header name and value all count towards this limit.
 
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator. Headers defined in the `_headers` file override what Cloudflare Pages ordinarily sends, so be aware when setting security headers. Cloudflare reserves the right to attach new headers to Pages projects at any time in order to improve performance or harden the security of your deployments.
 


### PR DESCRIPTION
Similar to the redirects documentation, we should include the amount of headers you can declare and the maximum length of a given header value.

Ref:
https://developers.cloudflare.com/pages/platform/limits/#headers
https://community.cloudflare.com/t/cloudflare-pages-header-file-line-limit/387052/5?u=kiannh