### PR TITLE
[Pages] Add header length limit

### DIFF
--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -29,6 +29,8 @@ The maximum file size for a single Cloudflare Pages site asset is 25 MiB.
 
 A `_headers` file can have a maximum of 100 header rules.
 
+The maximum length for a header is 1000 characters.
+
 ## Preview deployments
 
 You can have an unlimited number of [preview deployments](/pages/platform/preview-deployments/) active on your project at a time.


### PR DESCRIPTION
* Adds a note to pages headers limit about max header length of 1000