### PR TITLE
fix: run assign-pr only when (re)opened

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,9 @@
 name: PR Opened
 
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-on: [ pull_request_target ]
+on: 
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   compile:


### PR DESCRIPTION
Running only on (re)opened events should avoid re-assigning on changes. 
(Like here https://github.com/cloudflare/cloudflare-docs/pull/4638#event-6710810179) 