### PR TITLE
[Stream] Removed invalid option from Node TUS upload example

### DIFF
--- a/content/stream/uploading-videos/upload-video-file.md
+++ b/content/stream/uploading-videos/upload-video-file.md
@@ -203,6 +203,7 @@ var options = {
     Authorization: 'Bearer $TOKEN',
   },
   chunkSize: 50 * 1024 * 1024, // Required a minimum chunk size of 5MB, here we use 50MB.
+  retryDelays: [0, 3000, 5000, 10000, 20000], // Indicates to tus-js-client the delays after which it will retry if the upload fails
   metadata: {
     filename: 'test.mp4',
     filetype: 'video/mp4',

--- a/content/stream/uploading-videos/upload-video-file.md
+++ b/content/stream/uploading-videos/upload-video-file.md
@@ -203,7 +203,6 @@ var options = {
     Authorization: 'Bearer $TOKEN',
   },
   chunkSize: 50 * 1024 * 1024, // Required a minimum chunk size of 5MB, here we use 50MB.
-  resume: true,
   metadata: {
     filename: 'test.mp4',
     filetype: 'video/mp4',


### PR DESCRIPTION
- The option indicated in the TUS upload example docs for Node.JS, called `retry`, is invalid. The package specified (`tus-js-client`) doesn't have a retry option.
- Instead, the option `retryDelays` should be used with an array of delays after which retries will occur.
- This removed the `retry` option from the example, and adds the correct argument.