### PR TITLE
[R2] Add suffix and optional behaviour to R2Range

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -168,9 +168,9 @@ async function handleRequest(request) {
 
 There are 3 variations of arguments that can be used in a range:
 
-* An offset with an optional length
-* An optional offset with a length
-* A suffix
+* An offset with an optional length.
+* An optional offset with a length.
+* A suffix.
 
 {{<definitions>}}
 

--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -162,9 +162,15 @@ async function handleRequest(request) {
 
 {{</definitions>}}
 
-### Ranged reads
+#### Ranged reads
 
-`R2GetOptions` accepts a `range` parameter, which restricts data returned in `body` to be `range` bytes, starting from `offset`, inclusive.
+`R2GetOptions` accepts a `range` parameter, which can be used to restrict the data returned in `body`.
+
+There are 3 variations of arguments that can be used in a range:
+
+* An offset with an optional length
+* An optional offset with a length
+* A suffix
 
 {{<definitions>}}
 
@@ -175,6 +181,10 @@ async function handleRequest(request) {
 - {{<code>}}range{{<param-type>}}number{{</param-type>}}{{</code>}}
 
   - The number of bytes to return. If more bytes are requested than exist in the object, fewer bytes than this number may be returned.
+  
+- {{<code>}}suffix{{<param-type>}}number{{</param-type>}}{{</code>}}
+
+  - The number of bytes to return from the end of the file, starting from the last byte. If more bytes are requested than exist in the object, fewer bytes than this number may be returned.
 
 {{</definitions>}}
 

--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -178,7 +178,7 @@ There are 3 variations of arguments that can be used in a range:
 
   - The byte to begin returning data from, inclusive.
 
-- {{<code>}}range{{<param-type>}}number{{</param-type>}}{{</code>}}
+- {{<code>}}length{{<param-type>}}number{{</param-type>}}{{</code>}}
 
   - The number of bytes to return. If more bytes are requested than exist in the object, fewer bytes than this number may be returned.
   


### PR DESCRIPTION
`R2Range` changed in the 19-05-2022 runtime update to allow optional offset/length as well as allow a suffix instead.

Ref: [R2 bindings now support ranges that have an offset and an optional length, a length and an optional offset, or a suffix (returns the last N bytes of a file).](https://community.cloudflare.com/t/2022-5-19-workers-runtime-release-notes/385028)

```ts
declare type R2Range =
  | { offset: number; length?: number }
  | { offset?: number; length: number }
  | { suffix: number };
```

Additionally, changed `Ranged reads` from a `h3` to a `h4` since it's exclusively to the above `R2GetOptions` but appears on it's own on the right sidebar at the moment.

Not sure how to handle the parameters which *can* be optional outside of the '3 variations' example I made. i.e `offset` is optional *if* `length` exists, and vice versa.

closes #4436 