### PR TITLE
[R2] Make cursor of R2Objects optional

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -242,7 +242,7 @@ An object containing an `R2Object` array, returned by `BUCKET_BINDING.list()`.
 
   - If true, indicates there are more results to be retrieved for the current `list` request.
 
-- {{<code>}}cursor{{<param-type>}}string{{</param-type>}}{{</code>}}
+- {{<code>}}cursor{{<param-type>}}string{{<prop-meta>}}optional{{</prop-meta>}}{{</param-type>}}{{</code>}}
 
   - A token that can be passed to future `list` calls to resume listing from that point. Only present if truncated is true.
 


### PR DESCRIPTION
As per the description next to it (`Only present if truncated is true.`) and the [workers-types](https://github.com/cloudflare/workers-types/blob/92f8e38fc62e23801b9bd6cc153b6cb44b96834e/index.d.ts#L1124) definitions, `cursor` is optional and only appears if necessary (`list` operation didn't return all eligible objects).

```ts
interface R2Objects {
  objects: R2Object[];
  truncated: boolean;
  cursor?: string;
  delimitedPrefixes: string[];
}
```