### PR TITLE
[R2] Explicitly define `range` on R2GetOptions

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -159,6 +159,10 @@ async function handleRequest(request) {
 - {{<code>}}onlyIf{{<param-type>}}R2Conditional{{</param-type>}}{{</code>}}
 
   - Specifies that the object should only be returned given satisfaction of certain conditions in the `R2Conditional`. Refer to [Conditional operations](#conditional-operations).
+  
+- {{<code>}}range{{<param-type>}}R2Range{{</param-type>}}{{</code>}}
+
+  - Specifies that only a specific length (from an optional offset) or suffix of bytes from the object should be returned. Refer to [Ranged reads](#ranged-reads).
 
 {{</definitions>}}
 


### PR DESCRIPTION
My wording is probably horrible, I'm not good at being concise.

Anyhow - thought it should be explicit that `range` is apart of `R2GetOptions` by defining it similar to `onlyIf` which refers to the particular section that expands upon that property.