### PR TITLE
fix: Remove extra spacing after links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -3,7 +3,5 @@
 {{- if strings.HasPrefix $href "http" -}}
   {{- partial "external.link" (dict "url" $href "text" $text) -}}
 {{- else -}}
-  <a href={{ $href }} class="DocsMarkdown--link">
-    <span class="DocsMarkdown--link-content">{{- $text -}}</span>
-  </a>
+  <a href={{ $href }} class="DocsMarkdown--link"><span class="DocsMarkdown--link-content">{{- $text -}}</span></a>
 {{- end -}}


### PR DESCRIPTION
Internal links have some extra empty space when they are followed by a punctuation mark. 

This seems to be caused by the newline between `</span>` and `</a>` in `render-link.html`. Removing the spaces right before the closing `</a>` didn't solve the issue, so I put all the HTML in the same line.

![image](https://user-images.githubusercontent.com/680496/171847318-dccaed58-2956-4ee8-8d9a-ceb974333a00.png)
