### PR TITLE
[Workers] Fix wrangler configuration inline tables

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -87,7 +87,7 @@ kv_namespaces = [
 [durable_objects]
   bindings = [
     { name = "TEST_OBJECT", class_name = "", script_name = "" }
-]
+  ]
 
 # A list of migrations that should be uploaded with your Worker.
 # These define changes in your Durable Object declarations.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -68,30 +68,26 @@ KEY = "value"
 # To learn more about KV namespaces, refer to:
 # https://developers.cloudflare.com/workers/learning/how-kv-works
 # @default `[]`
+# @param {string} binding The binding name used to refer to the KV namespace
+# @param {string} id The ID of the KV namespace at the edge
+# @param {string} preview_id The ID of the KV namespace used during `wrangler dev`
 # not inherited
-kv_namespaces = [{
-  # The binding name used to refer to the KV namespace
-  binding = "TEST_NAMESPACE",
-  # The ID of the KV namespace at the edge
-  id = "",
-  # The ID of the KV namespace used during `wrangler dev`
-  preview_id = ""
-  }]
+kv_namespaces = [
+  { binding = "TEST_NAMESPACE", id = "", preview_id = "" }
+]
 
 # A list of Durable Objects that your Worker should be bound to.
 # To learn more about Durable Objects, refer to:
 # https://developers.cloudflare.com/workers/learning/using-durable-objects
 # @default `{bindings:[]}`
+# @param {string} name The name of the binding used to refer to the Durable Object
+# @param {string} class_name The exported class name of the Durable Object
+# @param {string} script_name The script where the Durable Object is defined (if it is external to this Worker)
 # not inherited
 [durable_objects]
-  bindings = [{
-    # The name of the binding used to refer to the Durable Object
-    name = "TEST_OBJECT",
-    # The exported class name of the Durable Object
-    class_name = "",
-    # The script where the Durable Object is defined (if it is external to this Worker)
-    script_name = ""
-  }]
+  bindings = [
+    { name = "TEST_OBJECT", class_name = "", script_name = "" }
+]
 
 # A list of migrations that should be uploaded with your Worker.
 # These define changes in your Durable Object declarations.
@@ -108,15 +104,13 @@ kv_namespaces = [{
 
 # Specifies R2 buckets that are bound to this Worker environment.
 # @default `[]`
+# @param {string} binding The binding name used to refer to the R2 bucket in the Worker.
+# @param {string} bucket_name The name of this R2 bucket at the edge.
+# @param {string} preview_bucket_name The preview name of this R2 used during `wrangler dev`
 # not inherited
-r2_buckets  = [{
-  # The binding name used to refer to the R2 bucket in the Worker.
-  binding = "TEST_BUCKET",
-  # The name of this R2 bucket at the edge.
-  bucket_name = "",
-  # The preview name of this R2 used during `wrangler dev`
-  preview_bucket_name =  ""
-}]
+r2_buckets  = [
+  { binding = "TEST_BUCKET", bucket_name = "", preview_bucket_name =  "" }
+]
 
 # Configures a custom build step to be run by Wrangler when building your Worker.
 # Refer to the [custom builds documentation](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build)
@@ -216,13 +210,11 @@ compatibility_flags = [
 ]
 
 # A list of other Cloudflare services bound to this service.
-services = [{
-  # The binding name used to refer to the bound service.
-  binding: string;
-  # The name of the service.
-  service: string;
-  # The environment of the service (For example, production, staging, etc) (optional).
-  environment: string;
-}]
-
+# @default `[]`
+# @param {string} binding The binding name used to refer to the bound service.
+# @param {string} service The name of the service.
+# @param {string} environment The environment of the service (For example, production, staging, etc) (optional).
+services = [
+  { binding = "TEST_BINDING", service = "", environment = "" }
+]
 ```


### PR DESCRIPTION
RE: https://github.com/cloudflare/cloudflare-docs/issues/4695

Moved the code comments to match the existing JSDoc/TSDoc (or whatever they're called) notation used already for the `@default` since we can no-longer have them on newlines.

![image](https://user-images.githubusercontent.com/94662631/172369292-110bd3d8-75ff-4a3a-924e-24712dd1be77.png)

@jkup @deadlypants1973