### PR TITLE
[Pages] Update secret name for Cloudflare API token in use-direct-upload-with-continuous-integration.md

### DIFF
--- a/content/pages/how-to/use-direct-upload-with-continuous-integration.md
+++ b/content/pages/how-to/use-direct-upload-with-continuous-integration.md
@@ -52,7 +52,7 @@ In the GitHub Action you have set up, environment variables are needed to push y
 2.  Under your repository's name, select **Settings**.
 3.  Select **Secrets** > **Actions** > **New repository secret**.
 4.  Create one secret and put **CLOUDFLARE_ACCOUNT_ID** as the name with the value being your Cloudflare account ID.
-5.  Create another secret and put **CF_API_TOKEN** as the name with the value being your Cloudflare API token.
+5.  Create another secret and put **CLOUDFLARE_API_TOKEN** as the name with the value being your Cloudflare API token.
 
 This will ensure that the secrets are secure. Each time your GitHub Actions runs, it will access these secrets.
 


### PR DESCRIPTION
- Updated the secret name given in step 5 of the [Add Cloudflare credentials to GitHub secrets](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#add-cloudflare-credentials-to-github-secrets) section of the guide on how to use Direct Upload with continuous integration.

In step 5 currently is written that the name of the GitHub secret holding the Cloudflare API token should be `CF_API_TOKEN`, while both in the text below the step guide and in the workflow template in the [Set up a workflow](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#set-up-a-workflow) section use the secret name `CLOUDFLARE_API_TOKEN` for the Cloudflare API token. This causes confusion and failed runs of the action for those who just copy paste the workflow snippet into their GitHub repository without making further edits that aren't instructed in the guide.