### PR TITLE
[R2] Update Get Started example with new bindings

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -146,30 +146,41 @@ An R2 bucket is able to READ, LIST, WRITE, and DELETE objects. You can see an ex
 
 ```js
 export default {
-  async fetch(request, env, ctx) {
-    const url = new URL(request.url);
-    const key = url.pathname.slice(1);
+    async fetch(request, env) {
+        const url = new URL(request.url);
+        const key = url.pathname.slice(1);
 
-    switch (request.method) {
-      case "PUT":
-        await env.MY_BUCKET.put(key, request.body);
-        return new Response(`Put ${key} successfully!`);
-      case "GET":
-        const object = await env.MY_BUCKET.get(key);
+        switch (request.method) {
+            case "PUT":
+                await env.MY_BUCKET.put(key, request.body);
+                return new Response(`Put ${key} successfully!`);
+            case "GET":
+                const object = await env.MY_BUCKET.get(key);
 
-        if (!object || !object.value) {
-          return new Response("Object Not Found", { status: 404 });
+                if (!object || !object.body) {
+                    return new Response("Object Not Found", {status: 404});
+                }
+
+                const headers = new Headers()
+                object.writeHttpMetadata(headers)
+                headers.set('etag', object.httpEtag)
+
+                return new Response(object.body, {
+                    headers
+                });
+            case "DELETE":
+                await env.MY_BUCKET.delete(key);
+                return new Response("Deleted!");
+
+            default:
+                return new Response("Method Not Allowed", {
+                    status: 405,
+                    headers: {
+                        Allow: 'PUT, GET, DELETE'
+                    }
+                });
         }
-
-        return new Response(object.value);
-      case "DELETE":
-        await env.MY_BUCKET.delete(key);
-        return new Response("Deleted!");
-
-      default:
-        return new Response("Method Not Allowed", { status: 405 });
     }
-  }
 };
 ```
 

--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -146,41 +146,41 @@ An R2 bucket is able to READ, LIST, WRITE, and DELETE objects. You can see an ex
 
 ```js
 export default {
-    async fetch(request, env) {
-        const url = new URL(request.url);
-        const key = url.pathname.slice(1);
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const key = url.pathname.slice(1);
 
-        switch (request.method) {
-            case "PUT":
-                await env.MY_BUCKET.put(key, request.body);
-                return new Response(`Put ${key} successfully!`);
-            case "GET":
-                const object = await env.MY_BUCKET.get(key);
+    switch (request.method) {
+      case 'PUT':
+        await env.MY_BUCKET.put(key, request.body);
+        return new Response(`Put ${key} successfully!`);
+      case 'GET':
+        const object = await env.MY_BUCKET.get(key);
 
-                if (!object || !object.body) {
-                    return new Response("Object Not Found", {status: 404});
-                }
-
-                const headers = new Headers()
-                object.writeHttpMetadata(headers)
-                headers.set('etag', object.httpEtag)
-
-                return new Response(object.body, {
-                    headers
-                });
-            case "DELETE":
-                await env.MY_BUCKET.delete(key);
-                return new Response("Deleted!");
-
-            default:
-                return new Response("Method Not Allowed", {
-                    status: 405,
-                    headers: {
-                        Allow: 'PUT, GET, DELETE'
-                    }
-                });
+        if (!object || !object.body) {
+          return new Response('Object Not Found', { status: 404 });
         }
+
+        const headers = new Headers();
+        object.writeHttpMetadata(headers);
+        headers.set('etag', object.httpEtag);
+
+        return new Response(object.body, {
+          headers,
+        });
+      case 'DELETE':
+        await env.MY_BUCKET.delete(key);
+        return new Response('Deleted!');
+
+      default:
+        return new Response('Method Not Allowed', {
+          status: 405,
+          headers: {
+            Allow: 'PUT, GET, DELETE',
+          },
+        });
     }
+  },
 };
 ```
 


### PR DESCRIPTION
Closes https://github.com/cloudflare/cloudflare-docs/issues/4751

Other changes:
- Rename `value` to `body` 
- Write the httpMetadata onto the returned object
- Return the proper `Allow` header with the `405` response since this is 'mandatory' - https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
- Don't pass `ctx` to the FetchEvent handler since it's unused