### PR TITLE
[Pages] Replaced instances of CF_ with CLOUDFLARE_ in *Use Direct Upload with CI* docs

### DIFF
--- a/content/pages/how-to/use-direct-upload-with-continuous-integration.md
+++ b/content/pages/how-to/use-direct-upload-with-continuous-integration.md
@@ -13,7 +13,7 @@ In your project directory, install [Wrangler](/workers/wrangler/get-started/) so
 
 ```sh
 # Publish created project
-$ CF_ACCOUNT_ID=<ACCOUNT_ID> npx wrangler pages publish <DIRECTORY> --project-name=<PROJECT_NAME>
+$ CLOUDFLARE_ACCOUNT_ID=<ACCOUNT_ID> npx wrangler pages publish <DIRECTORY> --project-name=<PROJECT_NAME>
 ```
 
 ## Get credentials from Cloudflare
@@ -52,7 +52,7 @@ In the GitHub Action you have set up, environment variables are needed to push y
 2.  Under your repository's name, select **Settings**.
 3.  Select **Secrets** > **Actions** > **New repository secret**.
 4.  Create one secret and put **CLOUDFLARE_ACCOUNT_ID** as the name with the value being your Cloudflare account ID.
-5.  Create another secret and put **CF_API_TOKEN** as the name with the value being your Cloudflare API token.
+5.  Create another secret and put **CLOUDFLARE_API_TOKEN** as the name with the value being your Cloudflare API token.
 
 This will ensure that the secrets are secure. Each time your GitHub Actions runs, it will access these secrets.
 


### PR DESCRIPTION
The page https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/ has a couple of occurrences of environment variables such as **CF_ACCOUNT_ID** and **CF_API_TOKEN**.

In the same article, **CLOUDFLARE_ACCOUNT_ID** AND **CLOUDFLARE_API_TOKEN** are also mentioned. This is quite confusing.

Since **CLOUDFLARE_** seems to be the accurate prefix, judging from the fact that it is mentioned more often, I have replaced both instances of **CF_** in the docs with **CLOUDFLARE_**