### PR TITLE
[Pages] fix: pages functions headers modify code example

### DIFF
--- a/content/pages/platform/functions/_index.md
+++ b/content/pages/platform/functions/_index.md
@@ -181,7 +181,8 @@ const errorHandler = async ({ next }) => {
 };
 
 const hello = async ({ next }) => {
-  const response = await next();
+  const rawResponse = await next();
+  const response = new Response(rawResponse.body, rawResponse); // clone response to create mutable headers
   response.headers.set('X-Hello', 'Hello from functions Middleware!');
   return response;
 };


### PR DESCRIPTION
This fixes an issue with the example in the Pages Functions docs.

The example works in _local development_, but fails in production. My suggested change works in both environments, until local and production can operate the same way (cc @GregBrimble).

This tripped someone up as recently as yesterday [in Discord](https://canary.discord.com/channels/595317990191398933/910978223968518144/984591489998946354) as they started seeing errors in production despite things working fine in local dev.