### PR TITLE
[Pages] Fixed broken gitlab redirect linked from dash

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -358,7 +358,8 @@
 /pages/how-to/deploy-a-vue-application/ /pages/framework-guides/deploy-a-vue-application/ 301
 /pages/how-to/deploy-a-zola-site/ /pages/framework-guides/deploy-a-zola-site/ 301
 /pages/how-to/elderjs/ /pages/framework-guides/elderjs/ 301
-/pages/platform/github-integration/ /pages/platform/git-integration/ 301 
+/pages/platform/github-integration/ /pages/platform/git-integration/ 301
+/pages/platform/gitlab-integration/ /pages/platform/git-integration/ 301
 
 # page-shield
 /page-shield/script-monitor/ /page-shield/ 301


### PR DESCRIPTION
This link is currently on pages dash https://developers.cloudflare.com/pages/platform/gitlab-integration, it should redirect to https://developers.cloudflare.com/pages/platform/git-integration