### PR TITLE
[ZT] add PKCE option to supported IdP setup guides

### DIFF
--- a/content/cloudflare-one/identity/idp-integration/azuread.md
+++ b/content/cloudflare-one/identity/idp-integration/azuread.md
@@ -80,7 +80,9 @@ You can integrate Microsoft Azure AD® (Active Directory) with Cloudflare Zero T
 
 19. (Optional) If you are using Azure AD groups, toggle **Support Groups** slider **On** in the **Edit your Azure AD identity provider** window.
 
-20. Click **Save**.
+20. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/). PKCE will be performed on all login attempts.
+
+21. Click **Save**.
 
 To test that your connection is working, navigate to **Authentication** > **Login methods** and click **Test** next to Azure AD.
 

--- a/content/cloudflare-one/identity/idp-integration/facebook-login.md
+++ b/content/cloudflare-one/identity/idp-integration/facebook-login.md
@@ -38,15 +38,19 @@ Use these steps to set up Facebook as your identity provider.
 
 1.  Click **Continue**. Ignore any JavaScript page that suggests that you install it on your site.
 
-1.  Click **Settings > Basic** on the left-hand menu.
+1.  Click **Settings > Basic**.
 
     ![Facebook Settings](/cloudflare-one/static/documentation/identity/facebook/fb6.png)
 
-1.  On the Zero Trust dashboard, navigate to **Settings > Authentication**.
+1.  Copy the **App ID** and **App Secret**.
+
+1.  On the [Zero Trust dashboard](https://dash.teams.cloudflare.com), navigate to **Settings > Authentication**.
 
 1.  Under **Login methods**, click **Add new**.
 
-1.  Copy the App ID and App Secret into the **OAuth ID** and **OAuth Secret** fields.
+1.  Fill in the **App ID** and **App Secret** obtained from Facebook.
+
+1.  (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/). PKCE will be performed on all login attempts.
 
 1.  Click **Save**.
 
@@ -61,8 +65,6 @@ Use these steps to set up Facebook as your identity provider.
     ```
 
 1.  Click **Save Changes**.
-
-1.  On the Zero Trust dashboard, click **Save**.
 
 To test that your connection is working, navigate to **Authentication > Login methods** and click **Test** next to Facebook.
 

--- a/content/cloudflare-one/identity/idp-integration/generic-oidc.md
+++ b/content/cloudflare-one/identity/idp-integration/generic-oidc.md
@@ -8,43 +8,39 @@ weight: 12
 
 Cloudflare Access has a generic OpenID Connect (OIDC) connector to help you integrate IdPs not already set in Access.
 
-At the moment, Access does not support sending custom parameters to identity providers. If you need to send custom parameters to your identity provider, consider setting it up through [SAML](/cloudflare-one/identity/idp-integration/generic-saml/).
+## Set up a generic OIDC
 
-## Setting up a generic OIDC
+1. Visit your identity provider and create a client/app.
 
-To set up a generic OIDC:
-
-1.  Visit your identity provider and create a client/app.
-
-1.  When creating a client/app, your IdP may request an **authorized redirect URI**. Enter your [team domain](/cloudflare-one/glossary/#team-domain) followed by this callback at the end of the path: `/cdn-cgi/access/callback`. For example:
+2. When creating a client/app, your IdP may request an **authorized redirect URI**. Enter your [team domain](/cloudflare-one/glossary/#team-domain) followed by this callback at the end of the path: `/cdn-cgi/access/callback`. For example:
 
     ```txt
     https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
     ```
 
-1.  Copy the content of these fields:
+3. Copy the content of these fields:
 
     - Client ID
     - Client secret
     - Auth URL: The `authorization_endpoint` URL of your IdP
-    - Token URL: The token_endpoint URL of your IdP
+    - Token URL: The `token_endpoint` URL of your IdP
     - Certificate URL: The `jwks_uri` endpoint of your IdP to allow the IdP keys to sign the tokens
 
-    You can find these values on your identity provider’s **OIDC discovery endpoint**. Some providers call this the “well-known URL.”
+    You can find these values on your identity provider’s **OIDC discovery endpoint**. Some providers call this the “well-known URL”.
 
-1.  On the Zero Trust dashboard, navigate to **Settings > Authentication**.
+4. On the [Zero Trust dashboard](https://dash.teams.cloudflare.com), navigate to **Settings** > **Authentication**.
 
-1.  Under **Login methods**, click **Add new**.
+5. Under **Login methods**, click **Add new**.
 
-1.  Choose **OpenID Connect** on the next page.
+6. Choose **OpenID Connect**..
 
-1.  In the **Name** field, enter your IdP. Then, paste in the **Client ID** and **Client secret**.
+7. Name your identity provider and fill in the required fields with the information obtained in Step 3.
 
-1.  Click **Save**.
+8. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/) if it is supported by your IdP. PKCE will be performed on all login attempts.
 
-1.  To test that your connection is working, navigate to **Authentication > Login methods** and click **Test** next to the login method you want to test.
+9. Click **Save**.
 
-On success, a confirmation screen displays.
+To test that your connection is working, navigate to **Authentication** > **Login methods** and click **Test** next to the login method you want to test. On success, a confirmation screen displays.
 
 ## Example API Configuration
 

--- a/content/cloudflare-one/identity/idp-integration/generic-oidc.md
+++ b/content/cloudflare-one/identity/idp-integration/generic-oidc.md
@@ -36,7 +36,7 @@ Cloudflare Access has a generic OpenID Connect (OIDC) connector to help you inte
 
 7. Name your identity provider and fill in the required fields with the information obtained in Step 3.
 
-8. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/) if it is supported by your IdP. PKCE will be performed on all login attempts.
+8. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/) if the protocol is supported by your IdP. PKCE will be performed on all login attempts.
 
 9. Click **Save**.
 

--- a/content/cloudflare-one/identity/idp-integration/google.md
+++ b/content/cloudflare-one/identity/idp-integration/google.md
@@ -72,6 +72,8 @@ You can review the summary information and return to the dashboard at the bottom
 
 1.  Input the Client ID and Client Secret fields generated previously.
 
+1.  (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/). PKCE will be performed on all login attempts.
+
 1.  Click **Save**.
 
 To test that your connection is working, navigate to **Authentication > Login methods** and click **Test** next to Google.

--- a/content/cloudflare-one/identity/idp-integration/gsuite.md
+++ b/content/cloudflare-one/identity/idp-integration/gsuite.md
@@ -92,9 +92,13 @@ https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
 
 19. Select **Google Workspace**.
 
-20. Input the Client ID and Client Secret fields generated previously. Additionally, input the domain of your Google Workspace account. Click **Save**.
+20. Input the Client ID and Client Secret fields generated previously. Additionally, input the domain of your Google Workspace account.
 
-21. To complete setup, you must scroll below and visit the link generated. If you are not the Google Workspace administrator, share the link with the administrator.
+21. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/). PKCE will be performed on all login attempts.
+
+22. Click **Save**.
+
+23. To complete setup, you must scroll below and visit the link generated. If you are not the Google Workspace administrator, share the link with the administrator.
 
   {{<Aside type="note">}}
   
@@ -106,7 +110,7 @@ https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
 
   {{</Aside>}}
 
-22. The generated link will prompt you to login to your Google account and to authorize Cloudflare Access to view group information.
+24. The generated link will prompt you to login to your Google account and to authorize Cloudflare Access to view group information.
 
     ![Authorize Groups](/cloudflare-one/static/documentation/identity/gsuite/authorize-groups.png)
 
@@ -114,7 +118,7 @@ https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
 
     ![Group Success](/cloudflare-one/static/documentation/identity/gsuite/group-success.png)
 
-23. You can now return to the list of identity providers in the **Authentication** page of the Cloudflare Zero Trust dashboard. Select Google Workspace and click **Test**.
+25. You can now return to the list of identity providers in the **Authentication** page of the Cloudflare Zero Trust dashboard. Select Google Workspace and click **Test**.
 
     Your user identity and group membership should return.
 

--- a/content/cloudflare-one/identity/idp-integration/okta.md
+++ b/content/cloudflare-one/identity/idp-integration/okta.md
@@ -50,7 +50,9 @@ Okta provides cloud software that helps companies manage and secure user authent
 
 15. (Optional) Create an Okta API token and enter it in the Zero Trust dashboard (the token can be read-only). This will prevent your Okta groups from failing if you have more than 100 groups.
 
-16. Click **Save**.
+16. (Optional) Enable [Proof of Key Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/). PKCE will be performed on all login attempts.
+
+17. Click **Save**.
 
 To test that your connection is working, navigate to **Settings** > **Authentication** > **Login methods** and click **Test** next to Okta.
 


### PR DESCRIPTION
I did not make content strategy/maintenance updates to the named IdP pages.