### PR TITLE
[R2] Fix incorrect operation name

### DIFF
--- a/content/r2/platform/pricing.md
+++ b/content/r2/platform/pricing.md
@@ -45,7 +45,7 @@ Class B Operations include `HeadBucket`, `HeadObject`, and `GetObject`.
 
 ### Free operations
 
-Free operations include `DeleteObject`, `DeleteBucket` and `DeleteMultipartUpload`.
+Free operations include `DeleteObject`, `DeleteBucket` and `AbortMultipartUpload`.
 
 ## R2 billing examples
 


### PR DESCRIPTION
The operation is `AbortMultipartUpload` as opposed to `DeleteMultipartUpload`

https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html