### PR TITLE
docs: use working CIDs in DNSLink docs

### DIFF
--- a/content/web3/ipfs-gateway/concepts/dnslink.md
+++ b/content/web3/ipfs-gateway/concepts/dnslink.md
@@ -8,11 +8,11 @@ weight: 4
 
 ## What is it?
 
-When you upload anything to the [IPFS](/web3/ipfs-gateway/concepts/ipfs/), that item gets a unique content identifier (CID) similar to `QmdbaSQbGU6Wo9i5LyWWVLuU8g6WrYpWh2K4Li4QuuE8Fr`.
+When you import anything to the [IPFS](/web3/ipfs-gateway/concepts/ipfs/), that item gets a unique content identifier ([CID](https://docs.ipfs.io/concepts/glossary/#cid)) similar to `bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze`.
 
-Such a long CID can cause issues when you want others to be able to access a website hosted on IPFS (`https://cloudflare-ipfs.com/ipfs/QmdbaSQbGU6Wo9i5LyWWVLuU8g6WrYpWh2K4Li4QuuE8Fr`). It is a similar problem to websites in general, where end users would have difficulty remembering an IP address (`192.0.2.1`) instead of a domain name (`google.com`).
+Such a long CID can cause issues when you want others to be able to access a website hosted on IPFS (`https://cf-ipfs.com/ipfs/bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze`). It is a similar problem to websites in general, where end users would have difficulty remembering an IP address (`192.0.2.1`) instead of a domain name (`google.com`).
 
-The problem is solved the same way, via a DNS record. To make a website hosted on IPFS more accessible, you can put your entire website inside of a directory and create a **DNS Link** record for that CID. End users can then make requests to a URL like `https://cloudflare-ipfs.com/ipns/index.html` and have their requests translated to the correct CID in the background.
+The problem is solved the same way, via a DNS record. To make a website hosted on IPFS more accessible, you can put your entire website inside of a directory and create a **DNSLink** record for that CID. End users can then make requests to a Universal Gateway URL like `https://cf-ipfs.com/ipns/en.wikipedia-on-ipfs.org/` and have their requests translated to the correct CID in the background.
 
 DNSLink records also help with content maintenance. When a new version of your website is ready to be published, you can update your DNSLink DNS record to point to the new CID and the gateway will start serving the new version automatically.
 
@@ -22,7 +22,7 @@ For additional details, refer to the official [IPFS documentation](https://docs.
 
 ## How is it used with Cloudflare?
 
-You have the option to specify the DNS Link when you [create an IPFS gateway](/web3/how-to/manage-gateways/#create-a-gateway), which serves as a custom hostname that directs users to a website already hosted on IPFS.
+You have the option to specify the DNSLink when you [create an IPFS gateway](/web3/how-to/manage-gateways/#create-a-gateway), which serves as a custom hostname that directs users to a website already hosted on IPFS.
 
 By default, your DNSLink path is `/ipns/onboarding.ipfs.cloudflare.com`. If you choose to put your website in a different content folder hosted at your own IPFS node or with a pinning service, you will need to specify that value.
 


### PR DESCRIPTION
Cosmetic changes:

- Replaces old CID with working one (wikipedia snapshot, pinned by many nodes)
- Fixes `/ipns/` content path to include example of a real and working DNSLink name
- Replaced path gateway with subdomain one
- Replaced "DNS Link" with "DNSLink", making it easier for people to search 