### PR TITLE
[Workers] Document new cacheTags feature

### DIFF
--- a/content/workers/examples/cache-tags.md
+++ b/content/workers/examples/cache-tags.md
@@ -1,0 +1,67 @@
+---
+type: example
+summary: Send Additional Cache Tags using Workers
+tags:
+  - Caching
+  - Cache Tags
+pcx-content-type: configuration
+title: Cache Tags using Workers
+weight: 1001
+layout: example
+---
+
+```js
+addEventListener("fetch", (event) => {
+  event.respondWith(
+    handleRequest(event.request).catch(
+      (err) => new Response(err.stack, { status: 500 })
+    )
+  );
+});
+
+
+async function handleRequest(request) {
+  const requestUrl = new URL(request.url);
+  const params = requestUrl.searchParams;
+  const tags = params && params.has('tags') 
+    ? params.get('tags').split(',')
+    : [];
+  
+  const url = params && params.has('uri')
+    ? JSON.parse(params.get('uri'))
+    : '';
+  
+  if (!url) {
+    const errorObject = {
+      error: "URL cannot be empty"
+    }
+    return new Response(JSON.stringify(errorObject), { status: 400 })
+  }
+
+  
+  const init = {
+    cf: {
+      cacheTags: tags
+    }
+  }
+    
+  return fetch(url, init)
+    .then((result) => {
+      const cacheStatus = result.headers.get('cf-cache-status');
+      const lastModified = result.headers.get('last-modified');
+
+      const response = {
+        cache: cacheStatus,
+        lastModified: lastModified
+      };
+      return new Response(JSON.stringify(response), { status: result.status })
+    })
+    .catch((err) => {
+      const errorObject = {
+        error: err.message
+      };
+
+      return new Response(JSON.stringify(errorObject), { status: 500 })
+    });
+}
+```

--- a/content/workers/runtime-apis/request.md
+++ b/content/workers/runtime-apis/request.md
@@ -126,7 +126,7 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
 *   `cacheTags` {{<type>}}Array\<string\>{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-    *   This option appends additional [**Cache-Tag**](https://developers.cloudflare.com/cache/how-to/purge-cache/#cache-tags-enterprise-only) headers to the response from the origin. Allowing for purges of cached content based on tags provided by the worker, without modifications to the origin. This is performed utilizing the [**Purge by Tag**](https://developers.cloudflare.com/cache/how-to/purge-cache/#purge-using-cache-tags) feature, which is currently only available to enterprise customers. If this option is used in a non-enterprise account the additional headers will not be appended.
+    *   This option appends additional [**Cache-Tag**](/cache/how-to/purge-cache/#cache-tags-enterprise-only) headers to the response from the origin server. This allows for purges of cached content based on tags provided by the Worker, without modifications to the origin server. This is performed utilizing the [**Purge by Tag**](/cache/how-to/purge-cache/#purge-using-cache-tags) feature, which is currently only available to Enterprise customers. If this option is used in a non-Enterprise account, the additional headers will not be appended.
 
 *   `cacheTtl` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/workers/runtime-apis/request.md
+++ b/content/workers/runtime-apis/request.md
@@ -124,6 +124,10 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
     *   A request’s cache key is what determines if two requests are the same for caching purposes. If a request has the same cache key as some previous request, then Cloudflare can serve the same cached response for both.
 
+*   `cacheTags` {{<type>}}Array\<string\>{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+    *   This option appends additional [**Cache-Tag**](https://developers.cloudflare.com/cache/how-to/purge-cache/#cache-tags-enterprise-only) headers to the response from the origin. Allowing for purges of cached content based on tags provided by the worker, without modifications to the origin. This is performed utilizing the [**Purge by Tag**](https://developers.cloudflare.com/cache/how-to/purge-cache/#purge-using-cache-tags) feature, which is currently only available to enterprise customers. If this option is used in a non-enterprise account the additional headers will not be appended.
+
 *   `cacheTtl` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
     *   This option forces Cloudflare to cache the response for this request, regardless of what headers are seen on the response. This is equivalent to setting two Page Rules: [**Edge Cache TTL**](https://support.cloudflare.com/hc/en-us/articles/200168376-What-does-edge-cache-expire-TTL-mean-) and [**Cache Level** (to **Cache Everything**)](https://support.cloudflare.com/hc/en-us/articles/200172266). The value must be zero or a positive number. A value of `0` indicates that the cache asset expires immediately. This option applies to `GET` and `HEAD` request methods only.


### PR DESCRIPTION
Adds documentation and examples around the new cacheTags feature for the workers `fetch()` API. 