### PR TITLE
[R2] example for using cache-api with R2

### DIFF
--- a/content/r2/examples/cache-api.md
+++ b/content/r2/examples/cache-api.md
@@ -12,50 +12,50 @@ layout: example
 ---
 
 ```js
-async function handleRequest(event) {
-  const request = event.request;
-  const cacheUrl = new URL(request.url);
 
-  // Construct the cache key from the cache URL
-  const cacheKey = new Request(cacheUrl.toString(), request);
-  const cache = caches.default;
+export default {
+  async fetch(request, env, context) {
+    try {
+      const cacheUrl = new URL(request.url);
 
-  // Check whether the value is already available in the cache
-  // if not, you will need to fetch it from origin, and store it in the cache
-  // for future access
-  let response = await cache.match(cacheKey);
+      // Construct the cache key from the cache URL
+      const cacheKey = new Request(cacheUrl.toString(), request);
+      const cache = caches.default;
 
-  if (!response) {
-    console.log(
-      `Response for request url: ${request.url} not present in cache. Fetching and caching request.`
-    );
-    // If not in cache, get it from origin
-    response = await fetch(request);
+      // Check whether the value is already available in the cache
+      // if not, you will need to fetch it from origin, and store it in the cache
+      // for future access
+      let response = await cache.match(cacheKey);
 
-    // Must use Response constructor to inherit all of response's fields
-    response = new Response(response.body, response);
+      if (response) {
+        console.log(`Cache hit for: ${request.url}.`);
+        return response
+      }
 
-    // Cache API respects Cache-Control headers. Setting s-max-age to 10
-    // will limit the response to be in cache for 10 seconds max
+      console.log(
+        `Response for request url: ${request.url} not present in cache. Fetching and caching request.`
+      );
+      // If not in cache, get it from origin
+      response = await fetch(request);
 
-    // Any changes made to the response here will be reflected in the cached value
-    response.headers.append('Cache-Control', 's-maxage=10');
+      // Must use Response constructor to inherit all of response's fields
+      response = new Response(response.body, response);
 
-    // Store the fetched response as cacheKey
-    // Use waitUntil so you can return the response without blocking on
-    // writing to cache
-    event.waitUntil(cache.put(cacheKey, response.clone()));
-  } else {
-    console.log(`Cache hit for: ${request.url}.`);
-  }
-  return response;
-}
+      // Cache API respects Cache-Control headers. Setting s-max-age to 10
+      // will limit the response to be in cache for 10 seconds max
 
-addEventListener('fetch', event => {
-  try {
-    return event.respondWith(handleRequest(event));
-  } catch (e) {
-    return event.respondWith(new Response('Error thrown ' + e.message));
-  }
-});
+      // Any changes made to the response here will be reflected in the cached value
+      response.headers.append('Cache-Control', 's-maxage=10');
+
+      // Store the fetched response as cacheKey
+      // Use waitUntil so you can return the response without blocking on
+      // writing to cache
+      context.waitUntil(cache.put(cacheKey, response.clone()));
+
+      return response;
+    } catch (e) {
+      return new Response('Error thrown ' + e.message);
+    }
+  },
+};
 ```

--- a/content/r2/examples/cache-api.md
+++ b/content/r2/examples/cache-api.md
@@ -1,0 +1,61 @@
+---
+type: example
+summary: Use the Cache API to store responses in Cloudflare's cache.
+tags:
+  - Cache API
+  - Middleware
+  - Caching
+pcx-content-type: configuration
+title: Using the Cache API
+weight: 1001
+layout: example
+---
+
+```js
+async function handleRequest(event) {
+  const request = event.request;
+  const cacheUrl = new URL(request.url);
+
+  // Construct the cache key from the cache URL
+  const cacheKey = new Request(cacheUrl.toString(), request);
+  const cache = caches.default;
+
+  // Check whether the value is already available in the cache
+  // if not, you will need to fetch it from origin, and store it in the cache
+  // for future access
+  let response = await cache.match(cacheKey);
+
+  if (!response) {
+    console.log(
+      `Response for request url: ${request.url} not present in cache. Fetching and caching request.`
+    );
+    // If not in cache, get it from origin
+    response = await fetch(request);
+
+    // Must use Response constructor to inherit all of response's fields
+    response = new Response(response.body, response);
+
+    // Cache API respects Cache-Control headers. Setting s-max-age to 10
+    // will limit the response to be in cache for 10 seconds max
+
+    // Any changes made to the response here will be reflected in the cached value
+    response.headers.append('Cache-Control', 's-maxage=10');
+
+    // Store the fetched response as cacheKey
+    // Use waitUntil so you can return the response without blocking on
+    // writing to cache
+    event.waitUntil(cache.put(cacheKey, response.clone()));
+  } else {
+    console.log(`Cache hit for: ${request.url}.`);
+  }
+  return response;
+}
+
+addEventListener('fetch', event => {
+  try {
+    return event.respondWith(handleRequest(event));
+  } catch (e) {
+    return event.respondWith(new Response('Error thrown ' + e.message));
+  }
+});
+```

--- a/content/r2/examples/cache-api.md
+++ b/content/r2/examples/cache-api.md
@@ -38,7 +38,7 @@ export default {
       // If not in cache, get it from R2
       const objectKey = url.pathname.slice(1);
       const object = await env.MY_BUCKET.get(objectKey);
-      if (!object || !object.body) {
+      if (object === null) {
         return new Response('Object Not Found', { status: 404 });
       }
 

--- a/content/r2/examples/demo-worker.md
+++ b/content/r2/examples/demo-worker.md
@@ -10,7 +10,7 @@ Below is an example Worker that exposes an R2 bucket to the Internet and demonst
 
 ```ts
 interface Env {
-  BUCKET: R2Bucket
+  MY_BUCKET: R2Bucket
 }
 
 function parseRange(encoded: string | null): undefined | { offset: number, length: number } {
@@ -59,7 +59,7 @@ export default {
         }
         console.log(JSON.stringify(options))
 
-        const listing = await env.BUCKET.list(options)
+        const listing = await env.MY_BUCKET.list(options)
         return new Response(JSON.stringify(listing), {headers: {
           'content-type': 'application/json; charset=UTF-8',
         }})
@@ -67,7 +67,7 @@ export default {
 
       if (request.method === 'GET') {
         const range = parseRange(request.headers.get('range'))
-        const object = await env.BUCKET.get(objectName, {
+        const object = await env.MY_BUCKET.get(objectName, {
           range,
           onlyIf: request.headers,
         })
@@ -86,7 +86,7 @@ export default {
         })
       }
 
-      const object = await env.BUCKET.head(objectName, {
+      const object = await env.MY_BUCKET.head(objectName, {
         onlyIf: request.headers,
       })
 
@@ -102,7 +102,7 @@ export default {
       })
     }
     if (request.method === 'PUT' || request.method == 'POST') {
-      const object = await env.BUCKET.put(objectName, request.body, {
+      const object = await env.MY_BUCKET.put(objectName, request.body, {
         httpMetadata: request.headers,
       })
       return new Response(null, {
@@ -112,7 +112,7 @@ export default {
       })
     }
     if (request.method === 'DELETE') {
-      await env.BUCKET.delete(url.pathname.slice(1))
+      await env.MY_BUCKET.delete(url.pathname.slice(1))
       return new Response()
     }
 

--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -157,7 +157,7 @@ export default {
       case 'GET':
         const object = await env.MY_BUCKET.get(key);
 
-        if (!object || !object.body) {
+        if (object === null) {
           return new Response('Object Not Found', { status: 404 });
         }
 


### PR DESCRIPTION
This creates an R2-specific cache-api example, by embedding the R2 [get-started-snippet](https://developers.cloudflare.com/r2/get-started/#5-access-your-r2-bucket-from-your-worker) into the [cache-api-example](https://developers.cloudflare.com/workers/examples/cache-api/)
