### PR TITLE
[Magic Firewall] Document new ip.{src,dst}.country fields

### DIFF
--- a/content/magic-firewall/reference/magic-firewall-fields.md
+++ b/content/magic-firewall/reference/magic-firewall-fields.md
@@ -71,6 +71,16 @@ pcx-content-type: reference
         </td>
     </tr>
     <tr>
+        <td><p><code>ip.dst.country</code><br />{{<type>}}String{{</type>}}</p>
+        </td>
+        <td>
+         Represents the 2-letter country code associated with the server IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
+         Example value:
+         <code class="InlineCode">GB</code>
+         <p>For more information on the ISO 3166-1 Alpha 2 format, see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
+        </td>
+    </tr>
+    <tr>
         <td><p><code>ip.geoip.country</code><br />{{<type>}}String{{</type>}}</p>
         </td>
         <td>
@@ -121,6 +131,16 @@ pcx-content-type: reference
         </td>
         <td>
         The source address of the IP Packet.
+        </td>
+    </tr>
+    <tr>
+        <td><p><code>ip.src.country</code><br />{{<type>}}String{{</type>}}</p>
+        </td>
+        <td>
+         Represents the 2-letter country code associated with the client IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
+         Example value:
+         <code class="InlineCode">GB</code>
+         <p>For more information on the ISO 3166-1 Alpha 2 format, see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
         </td>
     </tr>
     <tr>

--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -549,6 +549,16 @@ The Cloudflare Rules language supports these dynamic fields:
          <code class="InlineCode">192.0.2.2</code>
         </td>
     </tr>
+    <tr id="field-ip-dst-country">
+        <td><p><code>ip.dst.country</code><br />{{<type>}}String{{</type>}}</p>
+        </td>
+        <td>
+         Represents the 2-letter country code associated with the server IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
+         Example value:
+         <code class="InlineCode">GB</code>
+         <p>For more information on the ISO 3166-1 Alpha 2 format, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
+        </td>
+    </tr>
     <tr id="field-ip-geoip-country">
         <td><p><code>ip.geoip.country</code><br />{{<type>}}String{{</type>}}</p>
         </td>
@@ -599,6 +609,16 @@ The Cloudflare Rules language supports these dynamic fields:
         </td>
         <td>
         The source address of the IP Packet.
+        </td>
+    </tr>
+    <tr id="field-ip-src-country">
+        <td><p><code>ip.src.country</code><br />{{<type>}}String{{</type>}}</p>
+        </td>
+        <td>
+         Represents the 2-letter country code associated with the client IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
+         Example value:
+         <code class="InlineCode">GB</code>
+         <p>For more information on the ISO 3166-1 Alpha 2 format, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
         </td>
     </tr>
     <tr id="field-ip-ttl">


### PR DESCRIPTION
Eventually we'll want to deprecate `ip.geoip.country`.