### PR TITLE
Last reviewed prototype

### DIFF
--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -1,6 +1,7 @@
 ---
 pcx-content-type: concept
 title: Headers
+last-reviewed: "2022-05-01"
 ---
 
 # Headers
@@ -46,8 +47,8 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{<table-wrap>}}
 
-| Request URL                                   | Headers                                                                                                                               |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Request URL                                     | Headers                                                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `https://custom.domain/secure/page`             | `X-Frame-Options: DENY` <br /> `X-Content-Type-Options: nosniff ` <br /> `Referrer-Policy: no-referrer`                               |
 | `https://custom.domain/static/image.jpg`        | `Access-Control-Allow-Origin: *` <br /> `X-Robots-Tag: nosnippet`                                                                     |
 | `https://myproject.pages.dev/home`              | `X-Robots-Tag: noindex`                                                                                                               |

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,19 +2,25 @@
   <div class="DocsFooter--content">
     <div>
       <span class="DocsFooter--edit-on-gh-link-wrapper">
-        {{- with .File -}}
-          {{- $url := (printf "https://github.com/cloudflare/cloudflare-docs/blob/production/content/%s" .Path) -}}
-          {{- partial "external.link" (dict "text" "Edit on GitHub" "url" $url) }}
-        {{- end -}}
+        {{- with .File -}} {{- $url := (printf
+        "https://github.com/cloudflare/cloudflare-docs/blob/production/content/%s"
+        .Path) -}} {{- partial "external.link" (dict "text" "Edit on GitHub"
+        "url" $url) }} {{- end -}}
       </span>
 
-      <span class="DocsFooter--content-dot-spacer">
-        &nbsp; · &nbsp;
-      </span>
+      <span class="DocsFooter--content-dot-spacer"> &nbsp; · &nbsp; </span>
 
       <span class="DocsFooter--content-time">
         Updated {{ partial "datetime" .Lastmod }}
       </span>
+
+      {{ with .Param "last-reviewed" }}
+      <span class="DocsFooter--content-dot-spacer"> &nbsp; · &nbsp; </span>
+
+      <span class="DocsFooter--content-time">
+        Reviewed {{ partial "datetime" (. | time) }}
+      </span>
+      {{ end }}
     </div>
   </div>
 </footer>

--- a/static/style.css
+++ b/static/style.css
@@ -4127,7 +4127,8 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   display: flex;
 }
 @media (max-width: 414px) {
-  .DocsFooter--edit-on-gh-link-wrapper {
+  .DocsFooter--edit-on-gh-link-wrapper,
+  .DocsFooter--content-time {
     display: block;
     margin-bottom: 0.5em;
   }


### PR DESCRIPTION
Adds a "last reviewed" date to the footer, pulling from a page's "last-reviewed" front matter attribute.

Example page: https://last-reviewed-prototype.cloudflare-docs-7ou.pages.dev/pages/platform/headers/