### PR TITLE
[Workers] Remove flag from DO alarms

### DIFF
--- a/content/workers/learning/using-durable-objects.md
+++ b/content/workers/learning/using-durable-objects.md
@@ -151,12 +151,6 @@ Alarms are directly scheduled from within your Durable Object. Cron Triggers, on
 
 {{</Aside>}}
 
-To use alarms, you need to add the `durable_object_alarms` compatibility flag to your `wrangler.toml` file.
-
-```toml
-compatibility_flags = ["durable_object_alarms"]
-```
-
 Alarms can be used to build distributed primitives, like queues or batching of work atop Durable Objects. They also provide a method for guaranteeing work within a Durable Object will complete without relying on incoming requests to keep the object alive. For more discussion about alarms, refer to the [announcement blog post](https://blog.cloudflare.com/durable-objects-alarms).
 
 ## Instantiating and communicating with a Durable Object


### PR DESCRIPTION
The `durable_object_alarms` flag is no-longer required to use DO alarms.

> The durable_object_alarms flag no longer needs to be explicitly provided to use DO alarms.
https://community.cloudflare.com/t/2022-6-18-workers-runtime-release-notes/392389