### PR TITLE
[R2] Document range property on R2Object

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -146,7 +146,7 @@ async function handleRequest(request) {
   
 - {{<code>}}range{{</code>}} {{<param-type>}}R2Range{{</param-type>}}
 
-  - A R2Range object containing the returned range of the object.
+  - A `R2Range` object containing the returned range of the object.
 
 - {{<code>}}writeHttpMetadata(headers{{<param-type>}}Headers{{</param-type>}}){{</code>}} {{<type>}}void{{</type>}}
 

--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -143,6 +143,10 @@ async function handleRequest(request) {
 - {{<code>}}customMetadata{{<param-type>}}Record\<string, string>{{</param-type>}}{{</code>}}
 
   - A map of custom, user-defined metadata associated with the object.
+  
+- {{<code>}}range{{</code>}} {{<param-type>}}R2Range{{</param-type>}}
+
+  - A R2Range object containing the returned range of the object.
 
 - {{<code>}}writeHttpMetadata(headers{{<param-type>}}Headers{{</param-type>}}){{</code>}} {{<type>}}void{{</type>}}
 


### PR DESCRIPTION
> R2 GET requests made with the range option now contain the returned range in the GetObject’s range parameter.
https://community.cloudflare.com/t/2022-6-24-workers-runtime-release-notes/394109?u=kiannh