### PR TITLE
Transform Rules troublshooting - link to evaluation explanation

### DIFF
--- a/content/rules/transform/troubleshooting.md
+++ b/content/rules/transform/troubleshooting.md
@@ -8,8 +8,6 @@ meta:
 
 # Troubleshoot Transform Rules
 
-When troubleshooting Transform Rules, keep in mind how & when they are evaluated on each request by reading [Transform Rules evaluation](https://developers.cloudflare.com/rules/transform/#transform-rules-evaluation).
+When troubleshooting a rule configuration, review the [Transform Rules evaluation](/rules/transform/#transform-rules-evaluation) section to understand how and when your Transform Rule is evaluated for each request.
 
-After configuring a Transform Rule, you may get runtime errors related to the rule configuration.
-
-For more information on these errors, refer to [Troubleshooting Cloudflare 1XXX errors](https://support.cloudflare.com/hc/articles/360029779472).
+For more information on runtime errors related to Transform Rules configuration, refer to [Troubleshooting Cloudflare 1XXX errors](https://support.cloudflare.com/hc/articles/360029779472).

--- a/content/rules/transform/troubleshooting.md
+++ b/content/rules/transform/troubleshooting.md
@@ -8,6 +8,8 @@ meta:
 
 # Troubleshoot Transform Rules
 
+When troubleshooting Transform Rules, keep in mind how & when they are evaluated on each request by reading [Transform Rules evaluation](https://developers.cloudflare.com/rules/transform/#transform-rules-evaluation).
+
 After configuring a Transform Rule, you may get runtime errors related to the rule configuration.
 
 For more information on these errors, refer to [Troubleshooting Cloudflare 1XXX errors](https://support.cloudflare.com/hc/articles/360029779472).


### PR DESCRIPTION
I found that the fundamental information about Transform Rule evaluation might be missed on the summary page, especially when troubleshooting - so I've added a link to it from troubleshooting.