### PR TITLE
[R2] Amend snippet for truncated list responses

### DIFF
--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -255,15 +255,19 @@ There are 3 variations of arguments that can be used in a range:
   let truncated = listed.truncated;
   let cursor = truncated ? listed.cursor : undefined;
 
-  // ❌ - if your limit can't fit into a single response or your bucket
-  // has less objects than the limit, it will be stuck here permanently
+  // ❌ - if your limit can't fit into a single response or your
+  // bucket has less objects than the limit, it will get stuck here.
   while (listed.objects.length < options.limit) {
     // ...
   }
 
-  // ✅ - use the truncated property to check if there are more objects to be returned
+  // ✅ - use the truncated property to check if there are more
+  // objects to be returned
   while (truncated) {
-      const next = await env.MY_BUCKET.list({ ...options, cursor: cursor})
+      const next = await env.MY_BUCKET.list({
+        ...options,
+        cursor: cursor,
+      });
       listed.objects.push(...next.objects);
 
       truncated = next.truncated;

--- a/content/r2/runtime-apis.md
+++ b/content/r2/runtime-apis.md
@@ -242,14 +242,34 @@ There are 3 variations of arguments that can be used in a range:
 
   - Note that there is a limit on the total amount of data that a single `list` operation can return. If you request data, you may recieve fewer than `limit` results in your response to accomodate metadata.
 
-  This means applications must be careful to avoid code like the following:
+  This means applications must be careful to avoid comparing the amount of returned objects against your `limit`. Instead, use the `truncated` property to determine if the `list` request has more data to be returned.
 
   ```js
-    while (listed.length < limit) {
-      listed = myBucket.list({ limit, include: ['customMetadata'] })
-    }
+  const options = {
+      limit: 500,
+      include: ['customMetadata'],
+  }
+
+  const listed = await env.MY_BUCKET.list(options);
+
+  let truncated = listed.truncated;
+  let cursor = truncated ? listed.cursor : undefined;
+
+  // ❌ - if your limit can't fit into a single response or your bucket
+  // has less objects than the limit, it will be stuck here permanently
+  while (listed.objects.length < options.limit) {
+    // ...
+  }
+
+  // ✅ - use the truncated property to check if there are more objects to be returned
+  while (truncated) {
+      const next = await env.MY_BUCKET.list({ ...options, cursor: cursor})
+      listed.objects.push(...next.objects);
+
+      truncated = next.truncated;
+      cursor = next.cursor
+  }
   ```
-  Instead, use the `truncated` property to determine if the `list` request has more data to be returned.
 
 {{</definitions>}}
 


### PR DESCRIPTION
Amends the snippet to give a 'here's what you should do' as opposed to just 'here's what you shouldn't do' - whilst the existing snippet was there just to show you what condition (`listed.length < limit`) you *shouldn't* do, `length` doesn't exist on `R2Objects` (assuming `listed` was the result of `list()`, if it wasn't then it would be when overwritten in the block) and the operation wasn't awaited either.

Also prefixed the binding with `env.` to match the other examples in the R2 docs which now use Module Workers instead of Service Workers.

Whilst those might be obvious to someone experienced with JavaScript, a beginner who copy/pastes it would be confused for a long time.