### PR TITLE
[R2] Remove compatibility flag from Get Started

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -111,21 +111,11 @@ Find your Account ID by logging in to the Cloudflare dashboard > **Overview** > 
 
 ```toml
 name = "<YOUR_WORKER_NAME>"
-type = "javascript"
-compatibility_date = "2022-04-18"
+main = "src/index.js"
+compatibility_date = "2022-06-30"
 
 account_id = "YOUR_ACCOUNT_ID" # ← Replace with your Account ID.
 workers_dev = true
-```
-
-If you need to use an older compatibility date, you need to enable the `r2_public_beta_bindings` [compatibility flag](/workers/platform/compatibility-dates/).
-
-To do this, update your `wrangler.toml` file to include the following:
-
-```toml
-# An example date older than "2022-04-18"
-compatibility_date = "2022-02-10"
-compatibility_flags = ["r2_public_beta_bindings"]
 ```
 
 To bind your R2 bucket to your Worker, add the following to your `wrangler.toml` file. Update the `binding` property to a valid JavaScript variable identifier and `bucket_name` to the `<YOUR_BUCKET_NAME>` you used to create your bucket in [step 3](#create-your-bucket):


### PR DESCRIPTION
The compatibility flag is no-longer valid, regardless of compatibility date.

The recommended additions to `wrangler.toml` which this PR is removing will throw an error.

```
✘ [ERROR] Received a bad response from the API

  
    The compatibility flag r2_public_beta_bindings is the default, so does not need to be specified
    anymore.
     [code: 10021]
```

Also updating the `wrangler.toml` to reflect how `wrangler2` would show it (type is ignored) & revising the `compatibility_date` to be more modern.