### PR TITLE
[Pages]: Fix CLI copy for direct uploads commands

### DIFF
--- a/content/pages/platform/direct-upload.md
+++ b/content/pages/platform/direct-upload.md
@@ -37,7 +37,7 @@ To begin, [install and set up the latest version of Wrangler](/workers/wrangler/
 Run the following Wrangler command to create a project: 
 
 ```sh
-wrangler pages publish <project directory>
+$ wrangler pages publish <project directory>
 ```
 
 After running `wrangler pages publish`, you will be prompted to choose whether you would like to publish assets for an existing project or if you would like to create a new one. To begin a new project, select create a new project, continue to name your project, and deploy. Subsequent deployments will reuse these values (saved in your `node_modules/.cache/wrangler` folder).
@@ -49,7 +49,7 @@ After you deploy your Project, go to your newly created Pages project in the Clo
 After you have deployed your project, you can continue to add new deployments to that project. Deployments will be available at the following convention: `<DEPLOYMENT>.<PROJECT_NAME>.pages.dev`. 
 
 ```sh
-wrangler pages publish <DIRECTORY> --branch=[BRANCH]
+$ wrangler pages publish <DIRECTORY> --branch=[BRANCH]
 ```
 
 {{<Aside type= "note">}}
@@ -63,13 +63,13 @@ If you are in a Git workspace, Wrangler will automatically pull the branch infor
 If you would like to use Wrangler to obtain a list of all available projects for direct upload, use:
 
 ```sh
-wrangler pages project list
+$ wrangler pages project list
 ```
 
 If you would like to use Wrangler to obtain a list of all unique preview URLs for a particular project, use:
 
 ```sh
-wrangler pages deployment list
+$ wrangler pages deployment list
 ```
 
 For step-by-step directions on how to use Wrangler and continuous integration tools like GitHub Actions, Circle CI, and Travis CI together for continuous deployment, refer to [Use Direct Upload with continuous integration](/pages/how-to/use-direct-upload-with-continuous-integration/). 


### PR DESCRIPTION
Currently, it is not possible to copy CLI commands in direct uploads documentation,
<img width="747" alt="Screenshot 2022-07-02 at 11 42 49" src="https://user-images.githubusercontent.com/35943047/176997440-173777b6-be09-40bf-8c59-d06ec4cb6dcd.png">

This PR fixes that behaviour by adding the `$` before the CLI command 