### PR TITLE
[CSS] Set tab-size to 2 for codeblocks

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -671,6 +671,7 @@ html {
   padding: var(--padding-vertical) var(--padding-horizontal);
   font-family: inherit;
   cursor: default;
+  tab-size: 2;
 }
 .CodeBlock > code > * {
   cursor: text;


### PR DESCRIPTION
It currently defaults to 8 which makes any tab-indented code not fit within a codeblock.

![image](https://user-images.githubusercontent.com/94662631/177006587-5194e00a-42e2-4dc2-921e-a342adaacaed.png)

Whereas with `tab-size; 2`

![image](https://user-images.githubusercontent.com/94662631/177006604-825abd4e-7ab7-4aa9-95f7-c8502bfe85e3.png)

This is the same tab width used by wrangler2 in their refactor from spaces to tabs

https://github.com/cloudflare/wrangler2/commit/e5a6aca696108cda8c3890b8ce2ec44c6cc09a0e#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR7