### PR TITLE
pubsub: curl -> wrangler

### DIFF
--- a/content/pub-sub/get-started/guide.md
+++ b/content/pub-sub/get-started/guide.md
@@ -31,9 +31,46 @@ In order to use Pub/Sub, you need a [Cloudflare account](/fundamentals/account-a
 
 During the Private Beta, your account will need to be explicitly granted access. If you have not, sign up for the waitlist, and we will contact you when you are granted access.
 
-## 2. Fetch your credentials
+## 2. Install Wrangler (Cloudflare CLI)
 
-To make requests against the Pub/Sub API, you'll need to create an **API Token** with `pubsub:write` permissions.
+{{<Aside type="note">}}
+
+Pub/Sub support in Wrangler requires wrangler `2.0.16` or above. If you're using an older version of Wrangler, ensure you [update the installed version](https://developers.cloudflare.com/workers/wrangler/get-started/#update).
+
+{{</Aside>}}
+
+Installing `wrangler`, the Workers command-line interface (CLI), allows you to [`init`](/workers/wrangler/commands/#init), [`dev`](/workers/wrangler/commands/#dev), and [`publish`](/workers/wrangler/commands/#publish) your Workers projects.
+
+To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://www.npmjs.com/get-npm), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to easily change Node.js versions. Then run:
+
+```sh
+$ npm install -g wrangler
+```
+
+or install with `yarn`:
+
+```sh
+$ yarn global add wrangler
+```
+
+Validate that you have a version of `wrangler` that supports Pub/Sub:
+
+```
+wrangler --version
+2.0.16 # should show 2.0.16 or greater - e.g. 2.0.17 or 2.1.0
+```
+
+With `wrangler` installed, we can now create a Pub/Sub API token for `wrangler` to use.
+
+## 3. Fetch your credentials
+
+To use Wrangler with Pub/Sub, you'll need an API Token that has permissions to both read and write for Pub/Sub. The `wrangler login` flow does not issue you an API Token with valid Pub/Sub permissions.
+
+{{<Aside type="note">}}
+
+This API token requirement will be lifted prior to Pub/Sub becoming Generally Available.
+
+{{</Aside>}}
 
 1. From the [Cloudflare dashboard](https://dash.cloudflare.com), click on the profile icon and select **My Profile**.
 2. Under **My Profile**, click **API Tokens**.
@@ -44,7 +81,7 @@ To make requests against the Pub/Sub API, you'll need to create an **API Token**
 7. Click **Continue to Summary** at the bottom of the page, where you should see _All accounts - Pub/Sub:Edit_ as the permission
 8. Click **Create Token**, and copy the token value.
 
-In your terminal, configure a `CLOUDFLARE_API_TOKEN` environmental variable with your Pub/Sub token, so you do not have to type it out in each command:
+In your terminal, configure a `CLOUDFLARE_API_TOKEN` environmental variable with your Pub/Sub token. When this variable is set, `wrangler` will use it to authenticate against the Cloudflare API.
 
 ```sh
 $ export CLOUDFLARE_API_TOKEN="pasteyourtokenhere"
@@ -56,15 +93,9 @@ This token should be kept secret and not committed to source code or placed in a
 
 {{</Aside>}}
 
-Once you have your token set, you will also need to set your [Cloudflare Account ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/). Back in your terminal, add your Account ID as an environmental variable.
+With this environmental variable configured, you can now create your first Pub/Sub Broker!
 
-```sh
-$ export CLOUDFLARE_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
-```
-
-With these two (2) environmental variables set up, you can now create your first Pub/Sub Broker!
-
-## 3. Create your first namespace
+## 4. Create your first namespace
 
 A namespace represents a collection of Pub/Sub Brokers, and they can be used to separate different environments (production vs. staging), infrastructure teams, and in the future, permissions.
 
@@ -79,31 +110,24 @@ For example, a namespace of `my-namespace` and a broker of `staging` would creat
 With this in mind, create a new namespace. This example will use `my-namespace` as a placeholder:
 
 ```bash
-$ curl -s -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pubsub/namespaces" --data '{"name": "my-namespace" }'
+$ wrangler pubsub namespace create my-namespace 
 ```
 
 You should receive a HTTP 200 response that resembles the following:
 
 ```json
 {
-  "result": {
-    "id": "817170399d784d4ea8b6b90ae558c611",
-    "name": "my-namespace",
-    "description": "",
-    "created_on": "2022-05-11T23:13:08.383232Z",
-    "modified_on": "2022-05-11T23:13:08.383232Z"
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
+  "id": "817170399d784d4ea8b6b90ae558c611",
+  "name": "my-namespace",
+  "description": "",
+  "created_on": "2022-05-11T23:13:08.383232Z",
+  "modified_on": "2022-05-11T23:13:08.383232Z"
 }
 ```
 
 If you receive an HTTP 403 (Forbidden) response, check that your credentials are correct and that you have not pasted erroneous spaces or characters.
 
-If you receive an HTTP 400 (Bad Request), make sure you have correctly quoted the `data` payload and that you are not missing any quotes.
-
-## 4. Create a broker
+## 5. Create a broker
 
 A broker, in MQTT terms, is a collection of connected clients that publish messages to topics, and clients that subscribe to those topics and receive messages. The broker acts as a relay, and with Cloudflare Pub/Sub, a Cloudflare Worker can be configured to act on every message published to it.
 
@@ -118,29 +142,20 @@ Broker names must be:
 To create a new MQTT Broker called `example-broker` in the `my-namespace` namespace from the example above:
 
 ```bash
-# Set the $DEFAULT_NAMESPACE env var to make our lives easier (make sure to set this to the name you chose)
-export DEFAULT_NAMESPACE="my-namespace"
-
-# Create the Broker
-$ curl -s -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pubsub/namespaces/${DEFAULT_NAMESPACE}/brokers" --data '{"name": "example-broker", "authType": "TOKEN" }'
+$ wrangler pubsub namespace create example-broker --namespace=my-namespace
 ```
 
-You should receive an HTTP 200 response that resembles the following:
+You should receive a success response that resembles the following:
 
 ```json
 {
-  "result": {
-    "id": "4c63fa30ee13414ba95be5b56d896fea",
-    "name": "example-broker",
-    "authType": "TOKEN",
-    "created_on": "2022-05-11T23:19:24.356324Z",
-    "modified_on": "2022-05-11T23:19:24.356324Z",
-    "expiration": null,
-    "endpoint": "mqtts://example-broker.namespace.cloudflarepubsub.com:8883"
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
+  "id": "4c63fa30ee13414ba95be5b56d896fea",
+  "name": "example-broker",
+  "authType": "TOKEN",
+  "created_on": "2022-05-11T23:19:24.356324Z",
+  "modified_on": "2022-05-11T23:19:24.356324Z",
+  "expiration": null,
+  "endpoint": "mqtts://example-broker.namespace.cloudflarepubsub.com:8883"
 }
 ```
 
@@ -150,7 +165,7 @@ In the example above, a broker is created with an endpoint of `mqtts://example-b
 * The hostname is `example-broker.my-namespace.cloudflarepubsub.com`
 * [Token authentication](/pub-sub/platform/authentication-authorization/) is required to clients to connect.
 
-## 5. Create credentials for your broker
+## 6. Create credentials for your broker
 
 In order to connect to a Pub/Sub Broker, you need to securely authenticate. Credentials are scoped to each broker and credentials issued for `broker-a` cannot be used to connect to `broker-b`.
 
@@ -167,33 +182,25 @@ Ensure you do not commit your credentials to source control, such as GitHub. A v
 
 {{</Aside>}}
 
-To generate two tokens for your broker:
+To generate two tokens for a broker called `example-broker` with a 48 hour expiry:
 
 ```bash
-# Set the $BROKER_NAME env var to make our lives easier (make sure to set this to the name you chose)
-export BROKER_NAME="example-broker"
-
-$ curl -s -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pubsub/namespaces/${DEFAULT_NAMESPACE}/brokers/${BROKER_NAME}/credentials?number=2&type=TOKEN&topicAcl=#"
+$ wrangler pubsub broker issue example-broker --namespace=NAMESPACE_NAME --number=5 --expiration=48h
 ```
 
-You should receive a HTTP 200 response that resembles the example below, which is a map of Client IDs and their associated tokens.
+You should receive a scucess response that resembles the example below, which is a map of Client IDs and their associated tokens.
 
 ```json
 {
-  "result": {
-    "my-broker01G3A5GBJE5P3GPXJZ72X4X8SA": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.
-    not-a-real-token.ZZL7PNittVwJOeMpFMn2CnVTgIz4AcaWXP9NqMQK0D_iavcRv_p2DVshg6FPe5xCdlhIzbatT6gMyjMrOA2wBg",
-    "my-broker01G3A5GBJECX5DX47P9RV1C5TV": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.also-not-a-real-token.WrhK-VTs_IzOEALB-T958OojHK5AjYBC5ZT9xiI_6ekdQrKz2kSPGnvZdUXUsTVFDf9Kce1Smh-mw1sF2rSQAQ",
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
+  "01G3A5GBJE5P3GPXJZ72X4X8SA": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.
+  not-a-real-token.ZZL7PNittVwJOeMpFMn2CnVTgIz4AcaWXP9NqMQK0D_iavcRv_p2DVshg6FPe5xCdlhIzbatT6gMyjMrOA2wBg",
+  "01G3A5GBJECX5DX47P9RV1C5TV": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.also-not-a-real-token.WrhK-VTs_IzOEALB-T958OojHK5AjYBC5ZT9xiI_6ekdQrKz2kSPGnvZdUXUsTVFDf9Kce1Smh-mw1sF2rSQAQ",
 }
 ```
 
 Each token allows you to publish or subscribe to the associated broker. 
 
-## 6. Subscribe and publish messages to a topic
+## 7. Subscribe and publish messages to a topic
 
 Your broker is now created and ready to accept messages from authenticated clients. Because Pub/Sub is based on the MQTT protocol, there are client libraries for most popular programming languages. Refer to the list of [recommended client libraries](/pub-sub/learning/client-libraries/).
 

--- a/content/pub-sub/learning/command-line-wrangler.md
+++ b/content/pub-sub/learning/command-line-wrangler.md
@@ -1,0 +1,134 @@
+---
+title: Using Wrangler (Command Line Interface)
+pcx-content-type: reference
+type: example
+summary: How to manage Pub/Sub with Wrangler, the Cloudflare CLI.
+---
+
+# What is Wrangler?
+
+Wrangler is a command-line tool for building and managing Cloudflare's Developer Platform, including [Cloudflare Workers](https://workers.cloudflare.com/), [R2 Storage](https://developers.cloudflare.com/r2) and [Cloudflare Pub/Sub](https://developers.cloudflare.com/pub-sub/).
+
+{{<Aside type="note">}}
+
+Pub/Sub support in Wrangler requires wrangler `2.0.16` or above. If you're using an older version of Wrangler, ensure you [update the installed version](https://developers.cloudflare.com/workers/wrangler/get-started/#update).
+
+{{</Aside>}}
+
+# Authenticating Wrangler
+
+To use Wrangler with Pub/Sub, you'll need an API Token that has permissions to both read and write for Pub/Sub. The `wrangler login` flow does not issue you an API Token with valid Pub/Sub permissions.
+
+{{<Aside type="note">}}
+
+This API token requirement will be lifted prior to Pub/Sub becoming Generally Available.
+
+{{</Aside>}}
+
+To create an API Token that Wrangler can use:
+
+1. From the [Cloudflare dashboard](https://dash.cloudflare.com), click on the profile icon and select **My Profile**.
+2. Under **My Profile**, click **API Tokens**.
+3. On the [**API Tokens**](https://dash.cloudflare.com/profile/api-tokens) page, click **Create Token**
+4. Choose **Get Started** next to **Create Custom Token** 
+5. Name the token - e.g. "Pub/Sub Write Access"
+6. Under the **Permissions** heading, choose **Account**, select **Pub/Sub** from the first drop-down, and **Edit** as the permission.
+7. Click **Continue to Summary** at the bottom of the page, where you should see _All accounts - Pub/Sub:Edit_ as the permission
+8. Click **Create Token**, and copy the token value.
+
+In your terminal, configure a `CLOUDFLARE_API_TOKEN` environmental variable with your Pub/Sub token. When this variable is set, `wrangler` will use it to authenticate against the Cloudflare API.
+
+```sh
+$ export CLOUDFLARE_API_TOKEN="pasteyourtokenhere"
+```
+
+{{<Aside type="warning" header="Warning">}}
+
+This token should be kept secret and not committed to source code or placed in any client-side code.
+
+{{</Aside>}}
+
+# Pub/Sub Commands
+
+Wrangler exposes two groups of commands for managing your Pub/Sub configurations:
+
+1. `wrangler pubsub namespace`, which manages the [namespaces](https://developers.cloudflare.com/pub-sub/learning/how-pubsub-works/#brokers-and-namespaces) your brokers are grouped into.
+2. `wrangler pubsub broker` for managing your individual brokers, issuing and revoking credentials, and updating your [Worker integrations](https://developers.cloudflare.com/pub-sub/learning/integrate-workers/).
+
+The available `wrangler pubsub namespace` sub-commands include:
+
+```sh
+$ wrangler pubsub namespace --help
+
+Manage your Pub/Sub Namespaces
+
+Commands:
+  wrangler pubsub namespace create <name>    Create a new Pub/Sub Namespace
+  wrangler pubsub namespace list             List your existing Pub/Sub Namespaces
+  wrangler pubsub namespace delete <name>    Delete a Pub/Sub Namespace
+  wrangler pubsub namespace describe <name>  Describe a Pub/Sub Namespace
+```
+
+The available `wrangler pubsub broker` sub-commands include:
+
+```sh
+$ wrangler pubsub broker --help
+
+Interact with your Pub/Sub Brokers
+
+Commands:
+  wrangler pubsub broker create <name>            Create a new Pub/Sub Broker
+  wrangler pubsub broker update <name>            Update an existing Pub/Sub Broker's configuration.
+  wrangler pubsub broker list                     List the Pub/Sub Brokers within a Namespace
+  wrangler pubsub broker delete <name>            Delete an existing Pub/Sub Broker
+  wrangler pubsub broker describe <name>          Describe an existing Pub/Sub Broker.
+  wrangler pubsub broker issue <name>             Issue new client credentials for a specific Pub/Sub Broker.
+  wrangler pubsub broker revoke <name>            Revoke a set of active client credentials associated with the given Broker
+  wrangler pubsub broker unrevoke <name>          Restore access to a set of previously revoked client credentials.
+  wrangler pubsub broker show-revocations <name>  Show all previously revoked client credentials.
+  wrangler pubsub broker public-keys <name>       Show the public keys used for verifying on-publish hooks and credentials for a Broker.
+```
+
+## Create a Namespace
+
+To create a [Namespace](https://developers.cloudflare.com/pub-sub/learning/how-pubsub-works/#brokers-and-namespaces):
+
+```sh
+wrangler pubsub namespace create NAMESPACE_NAME
+```
+
+## Create a Broker
+
+To create a [Broker](https://developers.cloudflare.com/pub-sub/learning/how-pubsub-works/#brokers-and-namespaces) within a Namespace:
+
+```sh
+wrangler pubsub broker create BROKER_NAME --namespace=NAMESPACE_NAME
+```
+
+## Issue an Auth Token
+
+You can issue client credentials for a Pub/Sub Broker directly via Wrangler. Note that:
+
+* Tokens are scoped per Broker
+* You can issue multiple tokens at once
+* Tokens currently allow a client to publish and/or subscribe to _any_ topic on the Broker.
+
+To issue a single token:
+
+```sh
+wrangler pubsub broker issue BROKER_NAME --namespace=NAMESPACE_NAME 
+```
+
+You can use `--number=<NUM>` to issue multiple tokens at once, and `--expiration=<DURATION>` to set an expiry (e.g. `4h` or `30d`) on the issued tokens. 
+
+## Revoke a Token
+
+To revoke one or more tokens—which will immediately prevent that token from being used to authenticate—use the `revoke` sub-command and pass the unique token ID (or `JTI`):
+
+```sh
+wrangler pubsub broker revoke BROKER_NAME --namespace=NAMESPACE_NAME --jti=JTI_ONE --jti=JTI_TWO
+```
+
+# Filing Bugs
+
+If you've found a bug with one of the `wrangler pubsub [...]` commands, please [file a bug on GitHub](https://github.com/cloudflare/wrangler2/issues/new/choose), and include the version of `wrangler` you're using with `wrangler --version`.

--- a/content/pub-sub/learning/integrate-workers.md
+++ b/content/pub-sub/learning/integrate-workers.md
@@ -55,32 +55,30 @@ You should be familiar with setting up a [Worker](/workers/get-started/guide/) b
 To ensure your Worker can validate incoming requests, you must make the public keys available to your Worker via an [environmental variable](/workers/platform/environment-variables/). To do so, we can fetch the public keys from our Broker:
 
 ```bash
-$ curl -s -H "X-Auth-Email: ${CF_API_EMAIL}" -H "X-Auth-Key: ${CF_API_KEY}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pubsub/namespaces/${DEFAULT_NAMESPACE}/brokers/${BROKER_NAME}/publickeys
+$ wrangler pubsub broker public-keys YOUR_BROKER --namespace=NAMESPACE_NAME
 ```
 
-You should receive a HTTP 200 response that resembles the example below, with the public key set from your Worker:
+You should receive a success response that resembles the example below, with the public key set from your Worker:
 
 ```json
-{
-  "keys": [
-    {
-      "use": "sig",
-      "kty": "OKP",
-      "kid": "JDPuYJqHOvqzlakkNFQ9kfN7WsYs5uHndp_ziRdmOCU",
-      "crv": "Ed25519",
-      "alg": "EdDSA",
-      "x": "Phf82R8tG1FdY475-AgtlaWIwH1lLFlfWu5LrsKhyjw"
-    },
-    {
-      "use": "sig",
-      "kty": "OKP",
-      "kid": "qk7Z4hbN738v-m2CKdVaKTav9pU32MAaQXB2tDaQ-_o",
-      "crv": "Ed25519",
-      "alg": "EdDSA",
-      "x": "Bt4kQWcK_XhZP1ZxEflsoYbqaBm9rEDk_jNWPdhxwTI"
-    }
-  ]
-}
+"keys": [
+  {
+    "use": "sig",
+    "kty": "OKP",
+    "kid": "JDPuYJqHOvqzlakkNFQ9kfN7WsYs5uHndp_ziRdmOCU",
+    "crv": "Ed25519",
+    "alg": "EdDSA",
+    "x": "Phf82R8tG1FdY475-AgtlaWIwH1lLFlfWu5LrsKhyjw"
+  },
+  {
+    "use": "sig",
+    "kty": "OKP",
+    "kid": "qk7Z4hbN738v-m2CKdVaKTav9pU32MAaQXB2tDaQ-_o",
+    "crv": "Ed25519",
+    "alg": "EdDSA",
+    "x": "Bt4kQWcK_XhZP1ZxEflsoYbqaBm9rEDk_jNWPdhxwTI"
+  }
+]
 ```
 
 Copy the array of public keys into your `wrangler.toml` as an environmental variable:
@@ -204,30 +202,25 @@ const worker = {
 export default worker;
 ```
 
-Once you've published your Worker using `wrangler publish`, you will need to configure your Broker to invoke the Worker. This is done by setting the `on_publish.url` field of your Broker to the _publicly accessible_ URL of your Worker:
+Once you've published your Worker using `wrangler publish`, you will need to configure your Broker to invoke the Worker. This is done by setting the `--on-publish-url` value of your Broker to the _publicly accessible_ URL of your Worker:
 
 ```bash
-$ curl -s -X PATCH -H "X-Auth-Email: ${CF_API_EMAIL}" -H "X-Auth-Key: ${CF_API_KEY}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pubsub/namespaces/${DEFAULT_NAMESPACE}/brokers/${BROKER_NAME}" --data '{"on_publish":{"url":"https://your.worker.workers.dev"}}'
+$ wrangler pubsub broker update YOUR_BROKER --namespace=NAMESPACE_NAME --on-publish-url="https://your.worker.workers.dev"
 ```
 
-You should receive a HTTP 200 response that resembles the example below, with the URL of your Worker:
+You should receive a success response that resembles the example below, with the URL of your Worker:
 
 ```json
 {
-  "result": {
-    "id": "4c63fa30ee13414ba95be5b56d896fea",
-    "name": "example-broker",
-    "authType": "TOKEN",
-    "created_on": "2022-05-11T23:19:24.356324Z",
-    "modified_on": "2022-05-11T23:19:24.356324Z",
-    "expiration": null,
-    "endpoint": "mqtts://example-broker.namespace.cloudflarepubsub.com:8883",
-    "on_publish": {
-      "url": "https://your-worker.your-account.workers.dev"
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
+  "id": "4c63fa30ee13414ba95be5b56d896fea",
+  "name": "example-broker",
+  "authType": "TOKEN",
+  "created_on": "2022-05-11T23:19:24.356324Z",
+  "modified_on": "2022-05-11T23:19:24.356324Z",
+  "expiration": null,
+  "endpoint": "mqtts://example-broker.namespace.cloudflarepubsub.com:8883",
+  "on_publish": {
+    "url": "https://your-worker.your-account.workers.dev"
 }
 ```
 

--- a/content/pub-sub/platform/authentication-authorization.md
+++ b/content/pub-sub/platform/authentication-authorization.md
@@ -37,17 +37,17 @@ To generate a single token for a broker named `example-broker` in `your-namespac
 For example, to generate five valid tokens with an automatically generated Client ID for each token:
 
 ```bash
-# GET /accounts/:account_id/pubsub/namespaces/:namespace_name/brokers/:broker_name/credentials
-curl https://api.cloudflare.com/client/v4/accounts/<abcdef>/brokers/namespaces/your-namespace/brokers/example-broker/credentials?number=5&type=TOKEN&topicAcl="#"
+$ wrangler pubsub broker issue example-broker --number=5 --expiration=48h
 ```
 
-This will return an array of Client IDs and signed JSON Web Tokens. Each Client ID has the name of the broker it is associated with prepended to the token to simplify debugging and troubleshooting:
+You should receive a scucess response that resembles the example below, which is a map of Client IDs and their associated tokens.
 
-```bash
-[
-   "yourbroker01G18XKFVJ53DVBNK3KFPH9CX9": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJicm9rZXIiOiJicm9rZXIubmFtZXNwYWNlIiwiZXhwIjoxNTE2MjQyNjIyLCJpYXQiOjE1MTYyMzkwMjIsImNsaWVudElkIjoiMDFHMThXWEdTRkFOU0VGSEdOQ1E4SFc5QjMiLCJqdGkiOiIwMUcxOFhLRlZKNTNEVkJOSzNLRlBIOUNYOSJ9.qw_GcI5gxvqTabnhYYpvEW_WqSs48IjBSSAp2NAdDkE"
-   // four other tokens
-]
+```json
+{
+  "01G3A5GBJE5P3GPXJZ72X4X8SA": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.
+  not-a-real-token.ZZL7PNittVwJOeMpFMn2CnVTgIz4AcaWXP9NqMQK0D_iavcRv_p2DVshg6FPe5xCdlhIzbatT6gMyjMrOA2wBg",
+  "01G3A5GBJECX5DX47P9RV1C5TV": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.also-not-a-real-token.WrhK-VTs_IzOEALB-T958OojHK5AjYBC5ZT9xiI_6ekdQrKz2kSPGnvZdUXUsTVFDf9Kce1Smh-mw1sF2rSQAQ",
+}
 ```
 
 ## Configuring Clients
@@ -75,17 +75,17 @@ An JSON Web Token (JWT) issued by Pub/Sub will include the following claims.
 
 ## Revoking Credentials
 
-To revoke a credential, which immediately invalidates it and prevents any clients from connecting with it, issue a POST request to the `/revocations` endpoint of the Pub/Sub API with the `jti` (unique token identifier) as a query parameter.
+To revoke a credential, which immediately invalidates it and prevents any clients from connecting with it, you can use `wrangler pubsub broker revoke [...]` or issue a POST request to the `/revocations` endpoint of the Pub/Sub API with the `jti` (unique token identifier).
 
 This will add the token to a revocation list. When using JWTs, you can revoke the JWT based on its unique `jti` claim. To revoke multiple tokens at once, provide a list of token identifiers.
 
 ```bash
-# POST /accounts/:account_id/brokers/namespaces/:namespace_name/brokers/:broker_name/revocations
-curl -X POST https://api.cloudflare.com/client/v4/accounts/<abcdef>/brokers/namespaces/your-namespace/brokers/example-broker/revocations?jti=01G18XX6VC9ZEYZQ7AYD5D5TVP,01G18XXDR6JG9VTB605VQKPQZ2
-# Will return a HTTP 200 - OK
+$ wrangler pubsub broker revoke example-broker --namespace=NAMESPACE_NAME --jti=JTI_ONE --jti=JTI_TWO
 ```
 
-You can also list all currently revoked tokens by making a GET request to the `/revocations` endpoint, or unrevoke a token by issuing a DELETE request to the `/revocations` endpoint with the `jti` as a query parameter.
+You can also list all currently revoked tokens by using `wrangler pubsub broker show-revocations [...]` or by making a GET request to the `/revocations` endpoint.
+
+You can _unrevoke_ a token by using `wrangler pubsub broker unrevoke [...]` or by issuing a DELETE request to the `/revocations` endpoint with the `jti` as a query parameter.
 
 ## Credential Lifetime and Expiration
 
@@ -94,19 +94,28 @@ Credentials can be set to expire at a Broker-level that applies to all credentia
 * By default, credentials do not expire, in order to simplify credential management.
 * Credentials will inherit the shortest of the expirations set, if both the Broker and the issued credential have an expiration set.
 
-To set an expiry for each set of credentials issued by setting the `expiration` value when requesting credentials: in this case, we specify `86400` seconds (1 day). 
+To set an expiry for each set of credentials issued by setting the `expiration` value when requesting credentials: in this case, we specify 1 day (`1d`):
 
 ```bash
-# GET /accounts/:account_id/pubsub/namespaces/:namespace_name/brokers/:broker_name/credentials
-curl https://api.cloudflare.com/client/v4/accounts/<abcdef>/brokers/namespaces/your-namespace/brokers/example-broker/credentials?number=5&type=TOKEN&topicAcl="#"&expiration=86400`
+$ wrangler pubsub broker issue example-broker --namespace=NAMESPACE_NAME --expiration=1d
+```
+
+This will return a token that expires 1 day (24 hours) from issuance:
+
+```json
+{
+  "01G3A5GBJE5P3GPXJZ72X4X8SA": "eyJhbGciOiJFZERTQSIsImtpZCI6IkpEUHVZSnFIT3Zxemxha2tORlE5a2ZON1dzWXM1dUhuZHBfemlSZG1PQ1UifQ.
+  not-a-real-token.ZZL7PNittVwJOeMpFMn2CnVTgIz4AcaWXP9NqMQK0D_iavcRv_p2DVshg6FPe5xCdlhIzbatT6gMyjMrOA2wBg"
+}
 ```
 
 To set a Broker-level global expiration on an existing Pub/Sub Broker, set the `expiration` field on the Broker to the seconds any credentials issued should inherit:
 
 ```bash
-# PATCH /accounts/:account_id/pubsub/namespaces/:namespace_name/brokers/:broker_name
-curl https://api.cloudflare.com/client/v4/accounts/<abcdef>/brokers/namespaces/your-namespace/brokers/example-broker --data '{"expiration":604800}'
+$ wrangler pubsub broker update YOUR_BROKER --namespace=NAMESPACE_NAME --expiration=7d
 ```
+
+This will cause any token issued by the Broker to have a default expiration of 7 days. You can make this _shorter_ by passing the `--expiration` flag to `wrangler pubsub broker issue [...]`. If you set a longer `--expiration` than the Broker itself has, the Broker's expiration will be used instead (shortest wins).
 
 ### Best Practices
 


### PR DESCRIPTION
Updates the Pub/Sub docs to show Wrangler usage, replacing `curl` commands.

This includes:

- [x] The guide
- [x] The authentication docs
- [x] A new 'Wrangler' page
- [x] The Workers integration page

cc/ @dcpena @cehrig 