### PR TITLE
Update content on using local env variables with functions

### DIFF
--- a/content/pages/platform/functions/_index.md
+++ b/content/pages/platform/functions/_index.md
@@ -355,7 +355,7 @@ For example :
 ---
 filename:/.dev.vars
 ---
-Const ENV_NAME = "SUPER_SECRET_KEY"
+ENV_NAME = "SUPER_SECRET_KEY"
 ```
 
 ```js


### PR DESCRIPTION
There's a typo in this example used for illustrating how to use the local `.dev.vars` file in Functions.

It should be defined as the ENV_NAME = "Value" and not with a Const assigned to the environment variable. 

Tested this locally and saw this was a typo.