### PR TITLE
[ZT] fix warning casing typos in Aside partials

### DIFF
--- a/content/cloudflare-one/_partials/_cloudflared-new-ui.md
+++ b/content/cloudflare-one/_partials/_cloudflared-new-ui.md
@@ -5,7 +5,7 @@ _build:
   list: never
 ---
 
-{{<Aside type="Warning">}}
+{{<Aside type="warning">}}
 
 **New!** Set up and manage your Cloudflare Tunnel environment on the Zero Trust dashboard. You will be able to install `cloudflared` as a service, create and run tunnels, and get an overview of your active and inactive connectors.
 

--- a/content/cloudflare-one/connections/connect-devices/agentless/_index.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/_index.md
@@ -6,7 +6,7 @@ weight: 3
 
 # Agentless options
 
-{{<Aside type="Warning">}}
+{{<Aside type="warning">}}
 
 Enrolling devices using static IP addresses may prevent users from connecting to some public Wi-Fi networks that use captive portals.
 

--- a/content/cloudflare-one/connections/connect-devices/agentless/native-os.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/native-os.md
@@ -6,7 +6,7 @@ weight: 4
 
 # Native OS
 
-{{<Aside type="Warning" header="Warning">}}
+{{<Aside type="warning" header="Warning">}}
 
 Enrolling devices using static IP addresses may prevent users from connecting to some of the public Wi-Fi networks that use captive portals. If users are experiencing connectivity issues related to captive portals, they should:
 

--- a/content/cloudflare-one/policies/access/cors.md
+++ b/content/cloudflare-one/policies/access/cors.md
@@ -14,7 +14,7 @@ When you protect a site with Cloudflare Access, Cloudflare checks every HTTP req
 
 - [Preflighted requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) cause the browser to send an OPTIONS request before sending the actual request. The OPTIONS request checks which methods and headers are allowed by the origin.
 
-{{<Aside type="Warning" header="Important">}}
+{{<Aside type="warning" header="Important">}}
 
 - Do not troubleshoot CORS in Incognito mode, as this will cause disruptions with Access due to `CF-Authorization` being blocked as a third-party cookie on cross origin requests.
 
@@ -240,6 +240,6 @@ In general, we recommend the following steps when troubleshooting CORS issues:
 2. Ensure that the application has set `credentials: 'same-origin'` in all fetch or XHR requests.
 3. If you are using the [cross-origin setting](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) on script tags, these must be set to "use-credentials".
 
-{{<Aside type="Warning" header="CORS is failing on the same domain">}}
+{{<Aside type="warning" header="CORS is failing on the same domain">}}
 CORS checks do not occur on the same domain. If this error occurs, it is likely the request is being sent without the `CF-Authorization` cookie.
 {{</Aside>}}

--- a/content/cloudflare-one/policies/filtering/dns-policies/locations/_index.md
+++ b/content/cloudflare-one/policies/filtering/dns-policies/locations/_index.md
@@ -51,7 +51,7 @@ If you think someone else is wrongfully using this IPv4 address, [let us know](h
 
 You can now apply [DNS policies](/cloudflare-one/policies/filtering/dns-policies/) to your location using the [Location](/cloudflare-one/policies/filtering/dns-policies/#location) selector.
 
-{{<Aside type="Warning" header="Warning">}}
+{{<Aside type="warning" header="Warning">}}
 
 Deploying Gateway DNS filtering using static IP addresses may prevent users from connecting to public Wi-Fi networks through captive portals. To avoid this issue, use the [WARP client](/cloudflare-one/connections/connect-devices/warp/) to connect your devices to Cloudflare Zero Trust.
 

--- a/content/cloudflare-one/policies/filtering/enforce-sessions.md
+++ b/content/cloudflare-one/policies/filtering/enforce-sessions.md
@@ -15,7 +15,7 @@ You can configure a WARP session for any Allow policy. To configure a session:
 1.  Under **Step 4 - Configure policy settings**, select a session expiration time.
 1.  Save the policy.
 
-{{<Aside type="Warning">}}
+{{<Aside type="warning">}}
 
 For WARP sessions to function correctly with Gateway policies, end users must have the latest beta version of the WARP client installed on their devices. Gateway policies with WARP sessions configured will automatically block users who do not have the latest beta version of the client installed.
 

--- a/content/cloudflare-one/policies/filtering/http-policies/_index.md
+++ b/content/cloudflare-one/policies/filtering/http-policies/_index.md
@@ -53,7 +53,7 @@ For more information on this action, refer to the documentation on [Browser Isol
 
 ### Do Not Inspect
 
-{{<Aside type="Warning" header="Warning">}}
+{{<Aside type="warning" header="Warning">}}
 
 When a *Do Not Inspect* rule is created for a given hostname, application, or app type, no traffic will be inspected.
 

--- a/content/cloudflare-one/tutorials/aws-sso-saas.md
+++ b/content/cloudflare-one/tutorials/aws-sso-saas.md
@@ -95,9 +95,9 @@ For this tutorial, you will need:
 
 1.  Set Provisioning to _Manual_.
 
-        ![AWS settings](/cloudflare-one/static/zero-trust-security/aws-sso-saas/aws-settings.png)
+    ![AWS settings](/cloudflare-one/static/zero-trust-security/aws-sso-saas/aws-settings.png)
 
-         {{<Aside type="Warning" header="Important">}}
+    {{<Aside type="warning" header="Important">}}
 
     Access for SaaS does not currently support System for Cross-domain Identity Management (SCIM). Please make sure that:
 


### PR DESCRIPTION
Note `content/cloudflare-one/tutorials/aws-sso-saas.md` also contains the indentation fix in #5063