### PR TITLE
Fixed inconsistency in CR Beta ops Billing

### DIFF
--- a/content/cache/about/cache-reserve.md
+++ b/content/cache/about/cache-reserve.md
@@ -89,8 +89,8 @@ Class B operations are performed when data needs to be fetched from Cache Reserv
 
 #### Operations billing examples
 
-- 10,000 writes in a month will be charged $4.50.
-- One read in a month will be charged $0.36.
+- 1,000,000 writes in a month will be charged $4.50.
+- 1,000,000 in a month will be charged $0.36.
 - 2,999,000 writes will be charged $9.00.
 
 #### Free operations

--- a/content/cache/about/cache-reserve.md
+++ b/content/cache/about/cache-reserve.md
@@ -90,7 +90,7 @@ Class B operations are performed when data needs to be fetched from Cache Reserv
 #### Operations billing examples
 
 - 1,000,000 writes in a month will be charged $4.50.
-- 1,000,000 in a month will be charged $0.36.
+- 1,000,000 reads in a month will be charged $0.36.
 - 2,999,000 writes will be charged $9.00.
 
 #### Free operations


### PR DESCRIPTION
The old Operations Billing Examples was wildly inconsistent with R2 plan pricing and the information above the examples.