### PR TITLE
ANODE-496 API Shield now supports request body validation

### DIFF
--- a/content/api-shield/security/schema-validation/_index.md
+++ b/content/api-shield/security/schema-validation/_index.md
@@ -28,7 +28,7 @@ The accepted file formats are YAML (`.yml` or `.yaml` file extension) and JSON (
 
 ## Limitations
 
-Currently, API Shield cannot validate some features of API schemas, including the following: request body validations, all responses, external references, non-basic path templating, or unique items.
+Currently, API Shield cannot validate some features of API schemas, including the following: all responses, external references, non-basic path templating, or unique items.
 
 Regular expression support is a paid add-on in the Enterprise plan.
 


### PR DESCRIPTION
Remove "request body validations" from API Shield Limitations section.