### PR TITLE
[SSL] Correct the custom cert name

### DIFF
--- a/content/ssl/ssl-tls/certificate-and-hostname-priority.md
+++ b/content/ssl/ssl-tls/certificate-and-hostname-priority.md
@@ -23,7 +23,7 @@ For any given hostname, Cloudflare uses the following order to determine which c
     | Priority | Certificate Type                                                 |
     | -------- | ---------------------------------------------------------------- |
     | 1        | [Custom Legacy](/ssl/edge-certificates/custom-certificates/)     |
-    | 2        | [Custom SNI-Only](/ssl/edge-certificates/custom-certificates/)   |
+    | 2        | [Custom Modern](/ssl/edge-certificates/custom-certificates/)   |
     | 3        | [Custom Hostname (SSL for SaaS)](/cloudflare-for-saas/)             |
     | 4        | [Advanced](/ssl/edge-certificates/advanced-certificate-manager/) |
     | 5        | [Universal](/ssl/edge-certificates/universal-ssl/)               |


### PR DESCRIPTION
In dashboard it is `Custom Modern` by default, let's keep the consistency here.