### PR TITLE
early_hints should be in SSL settings instead

### DIFF
--- a/content/cloudflare-for-saas/related-products/early-hints-for-saas.md
+++ b/content/cloudflare-for-saas/related-products/early-hints-for-saas.md
@@ -43,10 +43,10 @@ $ curl -sXPATCH \
 -H "Content-Type: application/json" \
 -d '{
  "ssl": {
-   "method": "http",
-   "type":"dv",
-   "settings": {
-    "early_hints": "on"
+  "method": "http",
+  "type": "dv",
+  "settings": {
+   "early_hints": "on"
   }
  }
 }'

--- a/content/cloudflare-for-saas/related-products/early-hints-for-saas.md
+++ b/content/cloudflare-for-saas/related-products/early-hints-for-saas.md
@@ -32,7 +32,7 @@ curl -X GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnam
 
 ```
 
-4. Make an API call such as the example below, specifying `”early_hints”:”on”` within the [custom metadata](/cloudflare-for-saas/ssl/hostname-specific-behavior/custom-metadata/):
+4. Make an API call such as the example below, specifying `”early_hints”:”on”` within the [SSL settings](https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname):
 
 ```json
 $ curl -sXPATCH \
@@ -44,11 +44,10 @@ $ curl -sXPATCH \
 -d '{
  "ssl": {
    "method": "http",
-   "type":"dv"
- },
- "custom_metadata": {
-   "customer_id": "12345",
-   "early_hints”:”on”
+   "type":"dv",
+   "settings": {
+    "early_hints": "on"
+  }
  }
 }'
 


### PR DESCRIPTION
`early_hints` should be in SSL settings instead of custom metadata. 
API doc: https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname