### PR TITLE
[workers] Fix broken images on Cron Triggers page

### DIFF
--- a/content/workers/platform/cron-triggers/index.md
+++ b/content/workers/platform/cron-triggers/index.md
@@ -19,7 +19,7 @@ To respond to a Cron Trigger, you must add a [`"scheduled"` event](/workers/runt
 
 {{</Aside>}}
 
-![After selecting Triggers, add a trigger to execute time-based Workers](./media/workers-schedule-editor.png)
+![After selecting Triggers, add a trigger to execute time-based Workers](/workers/platform/cron-triggers/media/workers-schedule-editor.png)
 
 ## Supported cron expressions
 
@@ -82,7 +82,7 @@ A recommended way for testing your Cron Trigger is to first deploy it to a test 
 
 Users can review the execution history of their Cron Triggers in **Past Events** under [**Triggers**](https://dash.cloudflare.com/?to=/:account/workers) or through Cloudflare's [GraphQL Analytics API](/analytics/graphql-api).
 
-![Review the activity log of past cron triggers in Past Events](./media/workers-past-events.png)
+![Review the activity log of past cron triggers in Past Events](/workers/platform/cron-triggers/media/workers-past-events.png)
 
 It can take up to 30 minutes before events are displayed in **Past Events** when creating a new Worker or changing a Worker's name.
 


### PR DESCRIPTION
Before: 
<img width="766" alt="Screen Shot 2022-07-13 at 1 53 55 PM" src="https://user-images.githubusercontent.com/922353/178810927-265cc059-4e36-4864-a5e9-c2868221ee58.png">

After: 
<img width="756" alt="Screen Shot 2022-07-13 at 1 59 52 PM" src="https://user-images.githubusercontent.com/922353/178810950-6316767b-8890-472c-9a19-ca7e8010c0b9.png">
