### PR TITLE
[FIX] Misleading secret put example

### DIFF
--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -72,7 +72,7 @@ filename: wrangler.toml
 # - SPARKPOST_KEY
 # - GTOKEN_PRIVKEY
 # - GTOKEN_KID
-# Run `wrangler secret put <NAME> <VALUE>` for each of these
+# Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 ```
 
 {{<Aside type="warning">}}


### PR DESCRIPTION
Address https://github.com/cloudflare/cloudflare-docs/issues/5164

The old example throws an error (second positional is not supported)
The new example works only for systems with no ReadStream (CI etc)