### PR TITLE
[R2] Add upload/download examples to rclone example

### DIFF
--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -64,7 +64,7 @@ $ rclone tree r2demo:my-bucket-name
 # └── todos.txt
 ```
 
-## Upload and retrieving objects
+## Upload and retrieve objects
 
 The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5 TB maximum object size that R2 supports.
   

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -64,7 +64,7 @@ $ rclone tree r2demo:my-bucket-name
 # └── todos.txt
 ```
 
-## Uploading & retrieving objects
+## Upload and retrieving objects
 
 The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5TB maximum object size that R2 supports.
   

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -36,7 +36,7 @@ filename: ~/.config/rclone/rclone.conf
 ---
 [r2demo]
 type = s3
-provider = Other
+provider = Cloudflare
 access_key_id = abc123 # Your access_key_id
 secret_access_key = xyz456 # Your access_key_secret
 endpoint = https://<accountid>.r2.cloudflarestorage.com
@@ -44,6 +44,10 @@ acl = private
 ```
 
 You may then use the new `rclone` provider for any of your normal workflows.
+
+## Listing buckets & objects
+
+The [rclone tree](https://rclone.org/commands/rclone_tree/) command can be used to list the contents of the remote, in this case Cloudflare R2.
 
 ```sh
 $ rclone tree r2demo:
@@ -60,7 +64,25 @@ $ rclone tree r2demo:my-bucket-name
 # └── todos.txt
 ```
 
-You can also generate presigned links which allow you to share public access to a file temporarily.
+## Uploading & retrieving objects
+
+The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5TB maximum object size that R2 supports.
+  
+```sh
+# Upload dog.txt to the user-uploads bucket
+$ rclone copy dog.txt r2demo:user-uploads/dog.txt
+$ rclone tree r2demo:user-uploads
+# /
+# ├── foobar.png
+# └── dog.txt
+
+# Download dog.txt from the user-uploads bucket
+$ rclone copy r2demo:user-uploads/dog.txt dog.txt
+```
+
+## Generating presigned URLs
+
+You can also generate presigned links which allow you to share public access to a file temporarily using the [rclone link](https://rclone.org/commands/rclone_link/) command.
 
 ```sh
 # You can pass the --expire flag to determine how long the presigned link is valid.

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -66,7 +66,7 @@ $ rclone tree r2demo:my-bucket-name
 
 ## Upload and retrieving objects
 
-The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5TB maximum object size that R2 supports.
+The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5 TB maximum object size that R2 supports.
   
 ```sh
 # Upload dog.txt to the user-uploads bucket

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -80,7 +80,7 @@ $ rclone tree r2demo:user-uploads
 $ rclone copy r2demo:user-uploads/dog.txt dog.txt
 ```
 
-## Generating presigned URLs
+## Generate presigned URLs
 
 You can also generate presigned links which allow you to share public access to a file temporarily using the [rclone link](https://rclone.org/commands/rclone_link/) command.
 

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -45,7 +45,7 @@ acl = private
 
 You may then use the new `rclone` provider for any of your normal workflows.
 
-## Listing buckets & objects
+## List buckets & objects
 
 The [rclone tree](https://rclone.org/commands/rclone_tree/) command can be used to list the contents of the remote, in this case Cloudflare R2.
 


### PR DESCRIPTION
Changed provider to `Cloudflare` which is supported in 1.59 - 1.59 is now in stable