### PR TITLE
Change buildModules value

### DIFF
--- a/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
+++ b/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
@@ -119,7 +119,7 @@ Finally, add `@nuxtjs/sanity` as a **build module** in your Nuxt configuration:
 filename: nuxt.config.js
 ---
 {
-  buildModules: ['@nuxtjs/sanity/module'];
+  buildModules: ['@nuxtjs/sanity'];
 }
 ```
 


### PR DESCRIPTION
The value in 'buildModules' should be '["@nuxtjs/sanity"],' not '['@nuxtjs/sanity/module'];'

Nuxt Fatal Error
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './module' is not defined by "exports" in
.../node_modules/@nuxtjs/sanity/package.json