### PR TITLE
Remove note about a fetch handler being required alongside DOs

### DIFF
--- a/content/workers/learning/using-durable-objects.md
+++ b/content/workers/learning/using-durable-objects.md
@@ -173,7 +173,7 @@ When a Worker talks to a Durable Object, it does so through a stub object. The c
 
 The fetch handler in the example below implements the Worker that talks to the Durable Object. Note that the fetch handler is written using a new kind of Workers syntax based on ES Modules. This syntax is required for scripts that export Durable Objects classes, but is not required for scripts that make calls to Durable Objects. However, Workers written in the modules syntax (including Durable Objects) cannot share a script with Workers written in the Service Worker syntax.
 
-We recommend following this approach of implementing Durable Objects and a corresponding fetch handler in the same script (written in the modules format) not only because it is convenient, but also because as of today it is not possible to upload a script to the runtime that does not implement a fetch handler.
+We recommend following this approach of implementing Durable Objects and a corresponding fetch handler in the same script (written in the modules format) for convenience, but it is not required.
 
 ES Modules differ from regular JavaScript files in that they have imports and exports. [As shown earlier](/workers/learning/using-durable-objects/#writing-a-class-that-defines-a-durable-object), you wrote `export class DurableObjectExample` when defining our class. To implement a fetch handler, you must export a method named `fetch` in an `export default {}` block.
 


### PR DESCRIPTION
Because we're removing that requirement on script upload. It's still
often a good idea to bundle a fetch handler with a DO class, but will no
longer be required.