### PR TITLE
[Ruleset-Engine] fix http.request.version field type from Number -> String

### DIFF
--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -179,7 +179,7 @@ The Cloudflare Rules language supports these standard fields:
       </td>
    </tr>
    <tr id="field-http-request-version">
-      <td valign="top"><code>http.request.version</code><br />{{<type>}}Number{{</type>}}</td>
+      <td valign="top"><code>http.request.version</code><br />{{<type>}}String{{</type>}}</td>
       <td>
          <p>Represents the version of the HTTP protocol used. Use this field when you require different checks for different versions.
          </p>


### PR DESCRIPTION
Minor Bug:
- `http.request.version` is a String and not a Number
- It is clear by the example values, but I also confirmed internally :)
