### PR TITLE
[ZT] Fix some code blocks

### DIFF
--- a/content/cloudflare-one/tutorials/kubectl.md
+++ b/content/cloudflare-one/tutorials/kubectl.md
@@ -1,5 +1,5 @@
 ---
-updated: 2022-07-12
+updated: 2022-07-19
 category: 🔐 Zero Trust
 pcx-content-type: tutorial
 title: Connect through Cloudflare Access using kubectl
@@ -45,8 +45,8 @@ Cloudflare Tunnel creates a secure, outbound-only connection between this machin
 Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install `cloudflared` with the commands below. You can find releases for other operating systems [here](https://github.com/cloudflare/cloudflared/releases).
 
 ```sh
-sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
-sudo dpkg -i ./cloudflared-linux-amd64.deb
+$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+$ sudo dpkg -i ./cloudflared-linux-amd64.deb
 ```
 
 ## Authenticate `cloudflared`
@@ -57,7 +57,7 @@ Run the following command to authenticate cloudflared into your Cloudflare accou
 $ cloudflared tunnel login
 ```
 
-`cloudflared` will open a browser window and prompt you to login to your Cloudflare account. If you are working on a machine that does not have a browser, or a browser window does not launch, you can copy the URL from the command-line output and visit the URL in a browser on any machine.
+`cloudflared` will open a browser window and prompt you to log in to your Cloudflare account. If you are working on a machine that does not have a browser, or a browser window does not launch, you can copy the URL from the command-line output and visit the URL in a browser on any machine.
 
 Choose any hostname presented in the list. Cloudflare will issue a certificate scoped to your account. You do not need to pick the specific hostname where you will serve the Tunnel.
 
@@ -109,7 +109,7 @@ You can now create a DNS record that will route traffic to this Tunnel. Multiple
 
 1. Log in to the [Cloudflare Dashboard](https://dash.cloudflare.com/) and select your account. Select your domain and go to **DNS**.
 
-2. Select **+ Add record**. Choose `CNAME` as the record type. For **Name**, choose the hostname where you want to create a Tunnel. This should match the hostname of the Access policy.
+2. Select **Add record**. Choose `CNAME` as the record type. For **Name**, choose the hostname where you want to create a Tunnel. This should match the hostname of the Access policy.
 
 3. For **Target**, input the ID of your Tunnel followed by `.cfargotunnel.com`. For example:
   
@@ -124,7 +124,7 @@ You can now create a DNS record that will route traffic to this Tunnel. Multiple
 You can now run the Tunnel to connect the target service to Cloudflare. Use the following command to run the Tunnel, replacing `<NAME>` with the name created for your Tunnel.
 
 ```sh
-cloudflared tunnel run <NAME>
+$ cloudflared tunnel run <NAME>
 ```
 
 We recommend that you run `cloudflared` [as a service](/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/) that is configured to launch on start.
@@ -135,7 +135,9 @@ You can now connect from a client machine using `cloudflared`.
 
 This example uses a macOS laptop. On macOS, you can install `cloudflared` with the following command using Homebrew.
 
-    $ brew install cloudflare/cloudflare/cloudflared
+```sh
+$ brew install cloudflare/cloudflare/cloudflared
+```
 
 Run the following command to create a connection from the device to Cloudflare. Any available port can be specified.
 


### PR DESCRIPTION
Readers could not copy some of the commands, and not all code blocks had the same formatting.
Includes a couple of other changes, following the guidelines in our style guide.