### PR TITLE
[Docs site - Accessibility] Add "Skip to main content" link as first tabbable item

### DIFF
--- a/content/dns/zone-setups/partial-setup/setup.md
+++ b/content/dns/zone-setups/partial-setup/setup.md
@@ -88,3 +88,6 @@ If your domain is already live with a partial DNS setup — with Cloudflare or a
         </details>
 
     3.  Repeat this process for each subdomain proxied to Cloudflare.
+
+        1. test
+        2. test

--- a/content/dns/zone-setups/partial-setup/setup.md
+++ b/content/dns/zone-setups/partial-setup/setup.md
@@ -88,6 +88,3 @@ If your domain is already live with a partial DNS setup — with Cloudflare or a
         </details>
 
     3.  Repeat this process for each subdomain proxied to Cloudflare.
-
-        1. test
-        2. test

--- a/layouts/_default/example.html
+++ b/layouts/_default/example.html
@@ -2,6 +2,7 @@
   {{- $type := default "overview" .Params.type -}}
 
   <div class="DocsPage">
+    {{- partial "skipcontent" . -}}
     {{- partial "topbar.mobile" . -}}
     {{- partial "sidebar.nav" . -}}
 
@@ -13,7 +14,7 @@
     <main class="DocsBody">
       <div id="docs-content" data-reach-skip-nav-content></div>
 
-      <div class="DocsContent" page-type="{{ $type }}">
+      <div class="DocsContent" id="main" page-type="{{ $type }}">
         <article class="DocsMarkdown">
           <h1>{{ .Title }}</h1>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,6 +2,7 @@
   {{- $type := default "overview" .Params.type -}}
 
   <div class="DocsPage">
+    {{- partial "skipcontent" . -}}
     {{- partial "topbar.mobile" . -}}
     {{- partial "sidebar.nav" . -}}
 
@@ -13,7 +14,7 @@
     <main class="DocsBody">
       <div id="docs-content" data-reach-skip-nav-content></div>
 
-      <div class="DocsContent" page-type="{{ $type }}">
+      <div class="DocsContent" id="main" page-type="{{ $type }}">
         <article class="DocsMarkdown">
           {{- .Content -}}
         </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
   <div class="DocsPage">
+    {{- partial "skipcontent" . -}}
     {{- partial "topbar.mobile" . -}}
     {{- partial "sidebar.nav" . -}}
 
@@ -13,7 +14,7 @@
 
       <div id="docs-content" data-reach-skip-nav-content></div>
 
-      <div class="DocsContent" page-type="document">
+      <div class="DocsContent" id="main" page-type="document">
         <article class="DocsMarkdown">
           {{- .Content -}}
         </article>

--- a/layouts/_default/table.html
+++ b/layouts/_default/table.html
@@ -8,6 +8,7 @@
   {{- $pages := (where .Site.Pages "Section" .Page.Section).ByParam "updated" -}}
 
   <div class="DocsPage">
+    {{- partial "skipcontent" . -}}
     {{- partial "topbar.mobile" . -}}
     {{- partial "sidebar.nav" . -}}
 
@@ -19,7 +20,7 @@
     <main class="DocsBody">
       <div id="docs-content" data-reach-skip-nav-content></div>
 
-      <div class="DocsContent" page-type="{{ $type }}">
+      <div class="DocsContent"  id="main" page-type="{{ $type }}">
         <article class="DocsMarkdown">
           {{- .Content -}}
 

--- a/layouts/partials/skipcontent.html
+++ b/layouts/partials/skipcontent.html
@@ -1,1 +1,3 @@
-<a class="skip-link" href='#main'>Skip to content</a>
+<div>
+    <a class="skip-link" href='#main'>Skip to content</a>
+</div>

--- a/layouts/partials/skipcontent.html
+++ b/layouts/partials/skipcontent.html
@@ -1,0 +1,1 @@
+<a class="skip-link" href='#main'>Skip to content</a>

--- a/static/style.css
+++ b/static/style.css
@@ -4455,12 +4455,11 @@ pre {
 
 .skip-link:focus {
   transform: translateY(0%);
-  -webkit-transform: translateY(0%);
 }
 
 @media (max-width: 600px) {
-  .skip-link {
-    margin-top: 3em;
+  .skip-link:focus {
+    transform: translateY(100%);
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -4437,7 +4437,7 @@ pre {
 
 .skip-link {
   background: #f3f3f4;
-  z-index: -1;
+  z-index: 1;
   color: inherit;
   font-weight: 700;
   left: 50%;
@@ -4445,6 +4445,7 @@ pre {
   position: absolute;
   transform: translateY(-100%);
   transition: transform 0.3s;
+  opacity: 1;
 }
 
 [theme=dark] .skip-link {
@@ -4454,11 +4455,12 @@ pre {
 
 .skip-link:focus {
   transform: translateY(0%);
+  -webkit-transform: translateY(0%);
 }
 
 @media (max-width: 600px) {
   .skip-link {
-    margin-top: 2em;
+    margin-top: 3em;
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -4457,7 +4457,7 @@ pre {
   transform: translateY(0%);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .skip-link:focus {
     transform: translateY(100%);
   }

--- a/static/style.css
+++ b/static/style.css
@@ -4434,3 +4434,31 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 pre {
   overflow: auto;
 }
+
+.skip-link {
+  background: #f3f3f4;
+  z-index: -1;
+  color: inherit;
+  font-weight: 700;
+  left: 50%;
+  padding: 20px;
+  position: absolute;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+[theme=dark] .skip-link {
+  background: #242628;
+  color: inherit;
+}
+
+.skip-link:focus {
+  transform: translateY(0%);
+}
+
+@media (max-width: 600px) {
+  .skip-link {
+    margin-top: 2em;
+  }
+}
+


### PR DESCRIPTION
Did some personal testing and it works on Firefox/Chrome/Safari.

Helps implement best practices for accessibility documented in https://www.w3.org/TR/WCAG20-TECHS/G1.html

For safari, you do have to enable specific settings on your machine if you want it to actually hit the tabbed interface... [details](https://stackoverflow.com/a/2292336).