### PR TITLE
[cloudflare-one] Fixes #5208

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/migrate-legacy-tunnels.md
+++ b/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/migrate-legacy-tunnels.md
@@ -41,13 +41,7 @@ To migrate your legacy tunnels to the named tunnels architecture:
     $ cloudflared tunnel route lb <TUNNEL-NAME> <LOAD-BALANCER-NAME> <LOAD-BALANCER-POOL>
     ```
 
-1.  After configuring DNS/LB records for each zone you want to serve, follow the [Configure a Tunnel](/cloudflare-one/connections/connect-apps/configuration/local-management/configuration-file/) instructions to create a config file with ingress rules. The ingress rules describe how to dispatch requests to your origins based on hostname and path. For example, if you used to run:
-
-    ```bash
-    $ cloudflared tunnel --hostname tunnel.example.com --url https://localhost:3000
-    ```
-
-    You can have an equivalent ingress rule:
+1.  After configuring DNS/LB records for each zone you want to serve, follow the [Configure a Tunnel](/cloudflare-one/connections/connect-apps/configuration/local-management/configuration-file/) instructions to *create a config file with ingress rules*. The ingress rules describe how to dispatch requests to your origins based on hostname and path. For example, if in the past you used to run `cloudflared tunnel --hostname tunnel.example.com --url https://localhost:3000`, you need have an equivalent ingress rule now:
 
     ```yml
     ingress:


### PR DESCRIPTION
The formatting and the wording does not make it clear enough that ingress rules should be used now instead of the command line args. It implies rather that command line args can be used as a replacement.