### PR TITLE
lb: clarify units

### DIFF
--- a/content/load-balancing/understand-basics/limitations.md
+++ b/content/load-balancing/understand-basics/limitations.md
@@ -8,7 +8,7 @@ weight: 18
 | Name | Non-Enterprise | Enterprise | 
 | --- | --- | --- | --- |
 | Load balancers | 20 | 100 |
-| Monitor intervals | 60 (min), 3,600 (max) | 10 (min), 3,600 (max) |
+| Monitor intervals | 60s (min), 3600s (max) | 10s (min), 3600s (max) |
 | Monitors | 1.5x the number of pools | 1.5x the number of pools | 
 | Origin servers | 20 | 250 |
 | Pools | 20 | 100 |


### PR DESCRIPTION
“60 (min)” could be misinterpreted as “60 minutes”, which can result in customer confusion. 

Clarified the units explicitly as seconds (“s”) to separate the min/max limits.