### PR TITLE
[WAF] Clarify known limitation for Firewall Analytics

### DIFF
--- a/content/waf/analytics/_index.md
+++ b/content/waf/analytics/_index.md
@@ -44,7 +44,7 @@ L4 DoS attacks mitigated | –                   | –                   | –  
 
 Firewall Analytics currently has these limitations:
 
-*   Firewall Analytics may use sampled data to improve performance.
+*   Firewall Analytics may use sampled data to improve performance. If sampled data is applied to your search, you might not see all Firewall Events and filters might not return the expected results. In order to see more events, please select a very small timeframe so it is small enough to display only few events.
 
 *   The UI may show an inaccurate number of events per page. Data queries are highly optimized, but this means that pagination may not always work due to the fact that the source data may have been sampled. The GraphQL Analytics API does not have this pagination issue.
 

--- a/content/waf/analytics/_index.md
+++ b/content/waf/analytics/_index.md
@@ -44,8 +44,8 @@ L4 DoS attacks mitigated | –                   | –                   | –  
 
 Firewall Analytics currently has these limitations:
 
-*   Firewall Analytics may use sampled data to improve performance. If sampled data is applied to your search, you might not see all Firewall Events and filters might not return the expected results. In order to see more events, please select a very small timeframe so it is small enough to display only few events.
+*   Firewall Analytics may use sampled data to improve performance. If your search uses sampled data, Firewall Events might not display all events and filters might not return the expected results. To display more events, select a smaller time frame.
 
-*   The UI may show an inaccurate number of events per page. Data queries are highly optimized, but this means that pagination may not always work due to the fact that the source data may have been sampled. The GraphQL Analytics API does not have this pagination issue.
+*   The UI may show an inaccurate number of events per page. Data queries are highly optimized, but this means that pagination may not always work because the source data may have been sampled. The GraphQL Analytics API does not have this pagination issue.
 
 *   Triggered OWASP rules appear in the Firewall Analytics page under **Additional logs**, but they are not included in exported JSON files.


### PR DESCRIPTION
[WAF] Clarify known limitation for Firewall Analytics: customers are wondering why they can't find events when filtering for specific ray id. (PSPEC-1315)