### PR TITLE
[Webiste]: Fix Workers limit highlight in darkmode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4418,6 +4418,12 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   color: var(--code--orange);
 }
 
+[theme="dark"] .DocsMarkdown--link > .DocsMarkdown--link-content {
+  background-color: var(--background-color);
+  color: var(--code-orange);
+  border-bottom: 1px solid rgba(var(--border-bottom-color-rgb), var(--border-bottom-color-alpha));
+}
+
 [theme="dark"] .InlineCodeLink .InlineCode {
   background-color: var(--background-color);
   color: var(--code-orange);


### PR DESCRIPTION
This PR address the highlight colour in dark mode. 
![Screenshot 2022-07-25 at 14 11 24](https://user-images.githubusercontent.com/35943047/180785468-0ddba58a-6f69-4d54-be36-375e1d24b065.png) 
to 
![Screenshot 2022-07-25 at 14 11 00](https://user-images.githubusercontent.com/35943047/180785455-a42ce64c-c52a-469a-945e-4ae93f3f3f91.png)


