### PR TITLE
[Docs Site] Add noscript alert to docs search

### DIFF
--- a/content/search.html
+++ b/content/search.html
@@ -3,6 +3,12 @@ title: Search results
 type: home
 layout: home
 ---
+<noscript>
+  <h2>Search</h2>
+  <p>
+    JavaScript is disabled in your browser. You must enable it in order to search the docs.
+  </p>
+</noscript>
 <div id="searchresults" class="CoveoSearchInterface" data-enable-history="true">
   <script class="CoveoPipelineContext" type="text/context"></script>
   <div class="CoveoFolding"></div>
@@ -86,4 +92,4 @@ layout: home
       <div class="CoveoResultsPerPage"></div>
     </div>
   </div>
-</div> 
+</div>


### PR DESCRIPTION
Currently when attempting to search and with JavaScript disabled, or when it's not present for any reason, you just get a blank white page like so: ![](https://up.jross.me/pbn7q9b9)

With this PR, the page now at least renders a warning to users like so: ![](https://up.jross.me/b9rg2dae)

---

Ideally, a server-side search mechanism would be in place so that users can still search the docs when they have JS disabled (or it doesn't load for any reason - [there's lots](https://kryogenix.org/code/browser/everyonehasjs.html)), but this will at least serve as a good solution in the short term.

