### PR TITLE
Remove API keys limitation from Stream analytics

### DIFF
--- a/content/stream/getting-analytics/fetching-bulk-analytics.md
+++ b/content/stream/getting-analytics/fetching-bulk-analytics.md
@@ -337,6 +337,5 @@ Here are the steps to implementing pagination:
 
 ## Limitations
 
-*   Only Cloudflare API keys, not API tokens can be used with the Stream GraphQL API for now
 *   Maximum query interval in a single query is 31 days
 *   Maximum data retention period is 90 days


### PR DESCRIPTION
refs https://jira.cfops.it/browse/PCX-4384

API tokens work with the Stream GraphQL API now, as already shown in the example above in our docs.