### PR TITLE
chore: link to ipfs docs at the new domain

### DIFF
--- a/content/web3/how-to/use-ipfs-gateway.md
+++ b/content/web3/how-to/use-ipfs-gateway.md
@@ -22,7 +22,7 @@ The request path will vary based on the type of content you are serving.
 
 If a request path is `/ipfs/<CID_HASH>`, that tells the gateway that you want the content with the CID that immediately follows. Because the content is addressed by CID, the gateway's response is immutable and will never change. An example would be https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/, which is a mirror of Wikipedia and an immutable `/ipfs/` link.
 
-If a request path is `/ipns/<DOMAIN>`, that tells the gateway that you want it to lookup the CID associated with a given domain in DNS and then serve whatever content corresponds to the CID it happens to find. Because DNS can change over time, so will the gateway's response. An example would be https://cloudflare-ipfs.com/ipns/ipfs.io/, which is IPFS's marketing site and can be changed at any time by modifying the [DNSLink record](/web3/ipfs-gateway/concepts/dnslink/) associated with the `ipfs.io` domain.
+If a request path is `/ipns/<DOMAIN>`, that tells the gateway that you want it to lookup the CID associated with a given domain in DNS and then serve whatever content corresponds to the CID it happens to find. Because DNS can change over time, so will the gateway's response. An example would be https://cloudflare-ipfs.com/ipns/ipfs.tech/, which is IPFS's marketing site and can be changed at any time by modifying the [DNSLink record](/web3/ipfs-gateway/concepts/dnslink/) associated with the `ipfs.tech` domain.
 
 ## Write to the network
 

--- a/content/web3/ipfs-gateway/concepts/_index.md
+++ b/content/web3/ipfs-gateway/concepts/_index.md
@@ -13,5 +13,5 @@ As you get started with Cloudflare's IPFS Gateway, you may want to read through 
 {{<directory-listing>}}
 
 {{<Aside type="note">}}
-For help with additional concepts, refer to the [IPFS documentation](https://docs.ipfs.io/concepts/).
+For help with additional concepts, refer to the [IPFS documentation](https://docs.ipfs.tech/concepts/).
 {{</Aside>}}

--- a/content/web3/ipfs-gateway/concepts/dnslink.md
+++ b/content/web3/ipfs-gateway/concepts/dnslink.md
@@ -17,7 +17,7 @@ The problem is solved the same way, via a DNS record. To make a website hosted o
 DNSLink records also help with content maintenance. When a new version of your website is ready to be published, you can update your DNSLink DNS record to point to the new CID and the gateway will start serving the new version automatically.
 
 {{<Aside type="note">}}
-For additional details, refer to the official [IPFS documentation](https://docs.ipfs.io/concepts/dnslink/).
+For additional details, refer to the official [IPFS documentation](https://docs.ipfs.tech/concepts/dnslink/).
 {{</Aside>}}
 
 ## How is it used with Cloudflare?

--- a/content/web3/ipfs-gateway/concepts/ipfs.md
+++ b/content/web3/ipfs-gateway/concepts/ipfs.md
@@ -76,4 +76,4 @@ the directory.
 
 ## Related resources
 
-For help with additional concepts, refer to the [IPFS](https://docs.ipfs.io/concepts/) documentation.
+For help with additional concepts, refer to the [IPFS](https://docs.ipfs.tech/concepts/) documentation.

--- a/content/web3/ipfs-gateway/reference/updating-for-ipfs.md
+++ b/content/web3/ipfs-gateway/reference/updating-for-ipfs.md
@@ -8,8 +8,8 @@ weight: 5
 
 Though it is not required, it is strongly recommended that websites hosted on IPFS use only relative links, unless linking to a different domain. This is because data can be accessed in many different (but ultimately equivalent) ways:
 
-- From your custom domain: `https://ipfs.io/index.html`
-- From a gateway: `https://cloudflare-ipfs.com/ipns/ipfs.io/index.html`
+- From your custom domain: `https://ipfs.tech/index.html`
+- From a gateway: `https://cloudflare-ipfs.com/ipns/ipfs.tech/index.html`
 - By immutable hash: `https://cloudflare-ipfs.com/ipfs/QmNksJqvwHzNtAtYZVqFZFfdCVciY4ojTU2oFZQSFG9U7B/index.html`
 
 Using only relative links within a web application supports all of these at once, and gives the most flexibility to the user. The exact method for switching to relative links, if you do not use them already, depends on the framework you use.


### PR DESCRIPTION
This PR updates links to point at the new domain to avoid delay caused by redirects.

### Context

IPFS project website and docs got moved away from ipfs.io to isolate them from the public gateway (to avoid problems like https://nft.storage/blog/post/2022-04-29-gateways-and-gatekeepers/)

