### PR TITLE
Fixes code block alignment to text

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -707,7 +707,7 @@ html {
   --outdent: 0rem;
   margin-left: calc(var(--outdent) * 0);
   width: calc(100% + var(--outdent) * 2);
-  max-width: calc(100% + var(--outdent) * 2);
+  max-width: calc(100% + var(--outdent) * 0);
   cursor: text;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -705,7 +705,7 @@ html {
   background: var(--code-block-background-color);
   color: var(--code-block-color);
   --outdent: 0rem;
-  margin-left: calc(var(--outdent) * -1);
+  margin-left: calc(var(--outdent) * 0);
   width: calc(100% + var(--outdent) * 2);
   max-width: calc(100% + var(--outdent) * 2);
   cursor: text;


### PR DESCRIPTION
Fixes code block alignment so that it aligns with the text instead of extending past body text.

Previous text alignment example
![Screen Shot 2022-07-27 at 11 58 14 AM](https://user-images.githubusercontent.com/75506267/181306086-31d0d1ed-8422-4105-9f25-feb81f84a686.png)

After update from PR
![Screen Shot 2022-07-27 at 12 00 10 PM](https://user-images.githubusercontent.com/75506267/181306286-83009dc2-54f3-463c-92a9-090c0953292e.png)

