### PR TITLE
Update custom hugo version instructions

### DIFF
--- a/content/pages/framework-guides/deploy-a-hugo-site.md
+++ b/content/pages/framework-guides/deploy-a-hugo-site.md
@@ -210,7 +210,7 @@ Every time you commit new code to your Hugo site, Cloudflare Pages will automati
 
 ## Using a specific Hugo version
 
-You can set the environment variable `HUGO_VERSION` in your Pages project > **Settings**  > Environment variables, to use a [specific version of Hugo](https://github.com/gohugoio/hugo/releases).
+You can set the `HUGO_VERSION` environment variable in your Pages project > **Settings**  > **Environment variables**, to use a [specific version of Hugo](https://github.com/gohugoio/hugo/releases).
 
 For example, `HUGO_VERSION`: `0.101.0`
 

--- a/content/pages/framework-guides/deploy-a-hugo-site.md
+++ b/content/pages/framework-guides/deploy-a-hugo-site.md
@@ -210,9 +210,9 @@ Every time you commit new code to your Hugo site, Cloudflare Pages will automati
 
 ## Using a specific Hugo version
 
-You can set the environment variable `HUGO_VERSION` in your Worker > **Settings** to use a [specific version of Hugo](https://github.com/gohugoio/hugo/releases).
+You can set the environment variable `HUGO_VERSION` in your Pages project > **Settings**  > Environment variables, to use a [specific version of Hugo](https://github.com/gohugoio/hugo/releases).
 
-For example, `HUGO_VERSION`: `0.98.0`
+For example, `HUGO_VERSION`: `0.101.0`
 
 ## Learn more
 


### PR DESCRIPTION
I was figuring out how to do this, and the documentation talks about "Workers", which is confusing with there actually being Workers. 

The instructions that worked for me are adding the `HUGO_VERSION` variable in the "Production" section of "Environment variables" in the "Settings" tab of the Pages project.