### PR TITLE
[Docs site] Fix definition block margins and bulleted sub-lists

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3367,7 +3367,7 @@ p.DocsMarkdown--small-header {
   padding: 0;
 }
 
-.DocsMarkdown--definitions ul li:not(:last-child) {
+.DocsMarkdown--definitions>ul>li:not(:last-child) {
   margin-bottom: 1.5em;
 }
 
@@ -3382,9 +3382,12 @@ p.DocsMarkdown--small-header {
   --padding: 0 0.3em;
 }
 
-.DocsMarkdown--definitions ul li>ul {
+.DocsMarkdown--definitions>ul>li>ul {
   list-style: none;
   padding-left: 2em;
+}
+
+.DocsMarkdown--definitions ul>li>ul {
   margin-top: 0.25em;
 }
 


### PR DESCRIPTION
Addresses the remaining issues in #3865 regarding definition blocks:

* ~The first "inline code" in each paragraph of a definition item is displayed in bold.~  
    ⟶ _Already fixed in #5320_
* There's too much space between paragraphs.
* Bulleted lists inside a definition item don't display a circle (bullet) before each item.

Example page with changes:
https://pedro-fix-code-block-spacing.cloudflare-docs-7ou.pages.dev/waf/custom-rules/skip/options/