### PR TITLE
[Homepage] Small link styling fix

### DIFF
--- a/static/home.css
+++ b/static/home.css
@@ -603,9 +603,8 @@ html[is-site-page] .DocsContent {
 .TriBlock a {
     font-size: .90em;
     color: #0055DC;
-    text-decoration: underline;
     --background-color: transparent;
-    --border-bottom-color-rgb: #0055DC;
+    --border-bottom-color-rgb: 0, 85, 220;
     --border-bottom-color-alpha: .3;
 }
 


### PR DESCRIPTION
Fixed light mode so it matches dark mode by fixing the border color