### PR TITLE
Mobile styles for content cards

### DIFF
--- a/static/home.css
+++ b/static/home.css
@@ -565,6 +565,13 @@ html[is-site-page] .DocsContent {
     justify-content: center;
 }
 
+@media (max-width: 570px) {
+    .CommunityBlock {
+        padding-left: 0;
+        padding-right: 2em;
+    }
+}
+
 .CommunityBlock img {
     height: 2.5em;
     width: 2.5em;
@@ -578,7 +585,6 @@ html[is-site-page] .DocsContent {
 
 .TriBlockGrid {
     display: flex;
-    max-width: 100%;
     flex-wrap: wrap;
     padding-left: .75em;
     padding-right: .75em;
@@ -587,13 +593,24 @@ html[is-site-page] .DocsContent {
     justify-content: space-between;
 }
 
-.TriBlock {
+.TriBlock {    
+    display: flex;
     width: 20em;
     height: 16.5em;
     background: #f3f3f4;
-    padding-top: .5em;
-    padding-left: 2em;
+    padding: .5em 2em;
     margin-bottom: 1em;
+}
+
+@media (max-width: 780px) {
+    .TriBlock {
+        width: unset;
+    }
+
+    .TriBlockGrid {
+        display: inline-block;
+        width: 100%;
+    }
 }
 
 [theme=dark] .TriBlock {
@@ -4496,6 +4513,16 @@ blockquote .DocsMarkdown--header-anchor-positioner {
     border-top: 0;
     border-bottom-left-radius: .25em;
     border-bottom-right-radius: .25em
+}
+
+@media (max-width:560px) {
+    .DocsMarkdown details summary+div {
+        padding: 1em;
+    }
+
+    .ProductGrid {
+        padding: 0;
+    }
 }
 
 .DocsMarkdown details[open] {

--- a/static/home.css
+++ b/static/home.css
@@ -673,6 +673,12 @@ html[is-site-page] .DocsContent {
     padding-top: 1.25em;
 }
 
+@media (max-width:570px)  {
+    .FeaturedContentBlock {
+        width: unset;
+    };
+}
+
 [theme=dark] .FeaturedContentBlock {
     background: #242628
 }


### PR DESCRIPTION
a few more fixes for mobile styles for content cards, making them full-width at lower px viewports and adjusting alignment to be left aligned when necessary

![Screen Shot 2022-07-29 at 3 01 52 PM](https://user-images.githubusercontent.com/776987/181839820-c64fd083-aa75-4ece-bd42-c74354852cac.png)
![Screen Shot 2022-07-29 at 4 32 40 PM](https://user-images.githubusercontent.com/776987/181839830-f377fd67-af79-4fb4-84e9-22e58e082b67.png)
![Screen Shot 2022-07-29 at 4 37 38 PM](https://user-images.githubusercontent.com/776987/181839838-d8482f69-d8be-4838-b059-73354875ffe9.png)
![Screen Shot 2022-07-29 at 3 27 51 PM](https://user-images.githubusercontent.com/776987/181839897-0f571b74-a789-4871-afc2-28f63a23d8bc.png)

