### PR TITLE
Added note for frameworks

### DIFF
--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -36,7 +36,11 @@ filename: _redirects
 ```
 {{<Aside type= "note">}}
 
-Since the _redirects file needs to be present in the served root directory, some frameworks may not work right now as Cloudflare only deploys the build directory like the _site folder in case of Jekyll.
+In the case of some frameworks, such as Jekyll, you may need to manually copy and paste your `_redirects` file to the build output directory. To do this:
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Go to **Pages** > your Pages project > **Settings** > **Builds & deployments**.
+3. Go to **Build configurations** > **Edit configurations** > change the build command to `jekyll build && cp _redirects _site/_redirects` and select **Save**.
 
 {{</Aside>}}
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -34,6 +34,11 @@ filename: _redirects
 /blog/* https://blog.my.domain/:splat
 /products/:code/:name /products?code=:code&name=:name
 ```
+{{<Aside type= "note">}}
+
+Since the _redirects file needs to be present in the served root directory, some frameworks may not work right now as Cloudflare only deploys the build directory like the _site folder in case of Jekyll.
+
+{{</Aside>}}
 
 A project is limited to 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
 


### PR DESCRIPTION
Added a note that states an issue with Cloudflare Pages according to which Redirects would only work if the site does not have any framework. 

The issue here is with the way some of these frameworks like Jekyll work, by generating a simple and static HTML/CSS/JS version of an entire project inside of a _site folder (in which we cannot write any extra file manually) and that's probably what is finally being deployed to Cloudflare's network. Because of this, even if the root folder of a project had a _redirects file, it would not be found in the deployed directory.