### PR TITLE
Remove sh from codeblock for module install command

### DIFF
--- a/content/workers/wrangler/migration/eject-webpack.md
+++ b/content/workers/wrangler/migration/eject-webpack.md
@@ -46,7 +46,7 @@ Wrangler 2 drops support for project types, including `type = webpack` and confi
 
 To do that, you will need to add it as a dependency:
 
-```sh
+```
 npm install --save-dev webpack@^4.46.0 webpack-cli wranglerjs-compat-webpack-plugin
 # or
 yarn add --dev webpack@4.46.0 webpack-cli wranglerjs-compat-webpack-plugin


### PR DESCRIPTION
- Version published on website does't allow copying because the `sh` type set for the block.  `sh` tag doesn't provide any other apparent value.