### PR TITLE
Update Workers learning section ordering to reflect more natural order

### DIFF
--- a/content/workers/learning/debugging-workers.md
+++ b/content/workers/learning/debugging-workers.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Debugging Workers
-weight: 0
+weight: 3
 ---
 
 # Debugging Workers

--- a/content/workers/learning/how-kv-works.md
+++ b/content/workers/learning/how-kv-works.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: How KV works
-weight: 0
+weight: 7
 ---
 
 # How KV works

--- a/content/workers/learning/how-the-cache-works.md
+++ b/content/workers/learning/how-the-cache-works.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: How the Cache works
-weight: 0
+weight: 6
 ---
 
 # How the Cache works

--- a/content/workers/learning/how-workers-works.md
+++ b/content/workers/learning/how-workers-works.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: How Workers works
-weight: 0
+weight: 1
 ---
 
 # How Workers works

--- a/content/workers/learning/integrations.md
+++ b/content/workers/learning/integrations.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Integrations
-weight: 0
+weight: 14
 ---
 
 # Integrations

--- a/content/workers/learning/logging-workers.md
+++ b/content/workers/learning/logging-workers.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Logging from Workers
-weight: 0
+weight: 4
 ---
 
 # Logging from Workers

--- a/content/workers/learning/metrics-and-analytics.md
+++ b/content/workers/learning/metrics-and-analytics.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Metrics and analytics
-weight: 0
+weight: 5
 ---
 
 # Metrics and analytics

--- a/content/workers/learning/migrating-to-module-workers.md
+++ b/content/workers/learning/migrating-to-module-workers.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Migrating to module Workers
-weight: 0
+weight: 8
 ---
 
 # Migrating to module Workers

--- a/content/workers/learning/playground.md
+++ b/content/workers/learning/playground.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Playground
-weight: 0
+weight: 15
 ---
 
 # Playground

--- a/content/workers/learning/security-model/index.md
+++ b/content/workers/learning/security-model/index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Security model
-weight: 0
+weight: 2
 layout: single
 ---
 

--- a/content/workers/learning/service-worker.md
+++ b/content/workers/learning/service-worker.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Using Service Worker syntax
-weight: 0
+weight: 9
 ---
 
 # Using Service Worker syntax

--- a/content/workers/learning/using-durable-objects.md
+++ b/content/workers/learning/using-durable-objects.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Using Durable Objects
-weight: 0
+weight: 10
 ---
 
 # Using Durable Objects

--- a/content/workers/learning/using-services/index.md
+++ b/content/workers/learning/using-services/index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Workers Services
-weight: 0
+weight: 13
 layout: single
 ---
 

--- a/content/workers/learning/using-streams.md
+++ b/content/workers/learning/using-streams.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Using Streams
-weight: 0
+weight: 11
 ---
 
 # Using Streams

--- a/content/workers/learning/using-websockets.md
+++ b/content/workers/learning/using-websockets.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Using WebSockets
-weight: 0
+weight: 12
 ---
 
 # Using WebSockets


### PR DESCRIPTION
Current order: 
<img width="268" alt="Screen Shot 2022-08-03 at 9 26 50 AM" src="https://user-images.githubusercontent.com/2414910/182619452-2394297c-216f-4f3c-b4fc-9bf296806717.png">

Updated order: 
<img width="267" alt="Screen Shot 2022-08-03 at 9 27 16 AM" src="https://user-images.githubusercontent.com/2414910/182619526-218d9624-2c08-4ec0-bcb0-f1a373ca8f9f.png">

Note: as a future iteration, we should have sub-categories like "Workers fundementals", "Understanding Workers Storage", and "Understanding runtime APIs"
