### PR TITLE
Start using Module Syntax as default for overview

### DIFF
--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -50,26 +50,6 @@ View this Hello World example in the Workers playground:
 
 ```js
 ---
-header: Service Worker syntax
----
-addEventListener("fetch", (event) => {
-  event.respondWith(handleRequest(event.request));
-});
-
-async function handleRequest(request) {
-  return new Response("Hello world");
-}
-```
-
-{{<button-group>}}
-{{<button type="primary" href="https://cloudflareworkers.com/#36ebe026bf3510a2e5acace89c09829f:about:blank">}}Launch playground{{</button>}}
-{{<button type="secondary" href="/workers/learning/playground">}}Learn more{{</button>}}
-{{</button-group>}}
-
-Or try inputting the JavaScript modules syntax example:
-
-```js
----
 header: Module syntax
 ---
 export default {
@@ -78,6 +58,11 @@ export default {
   },
 };
 ```
+
+{{<button-group>}}
+{{<button type="primary" href="https://cloudflareworkers.com/?_gl=1*18yfays*_ga*MTUzMDY1NDM1NS4xNjU5NTMxOTI3*_gid*ODI3NTE3MjI0LjE2NTk1MzE5Mjc.#68813a741e791a07c49fd1aa01359cc6:about:blank">}}Launch playground{{</button>}}
+{{<button type="secondary" href="/workers/learning/playground">}}Learn more{{</button>}}
+{{</button-group>}}
 
 ---
 


### PR DESCRIPTION
Since we're not recommending most customers to use module syntax, we should use it as the primary example for the playground.