### PR TITLE
Update limits.md to reflect purge ratelimits

### DIFF
--- a/content/api/limits.md
+++ b/content/api/limits.md
@@ -8,7 +8,8 @@ weight: 13
 
 The global rate limit for our API is 1200 requests per 5 minutes. If you exceed this, all API calls for the next 5 minutes will be blocked, receiving a HTTP 429 response.
 
-Some specific API calls have their own limits and are documented separately, such as the Cache Purge APIs:
+Some specific API calls do not count towards the global rate limit and instead have their own limits documented separately, such as the Cache Purge APIs:
 
 * https://api.cloudflare.com/#zone-purge-files-by-url
 * https://api.cloudflare.com/#zone-purge-files-by-cache-tags,-host-or-prefix
+


### PR DESCRIPTION
It's my understanding from talking to support and doing my own testing that purge-by-url doesn't count towards the 1200/5m limit. The docs were ambiguous whether the purge ratelimits are instead of, or in addition to, the global rate limit.

I think this is important information to spell out explicitly, since our team previously read this page to mean that the 1200/5m limit DID apply, which caused us to build unnecessary purging infrastructure, and might cause others to avoid using cloudflare.

Feel free to disregard this if the 1200/5m limit is meant to apply here, although be aware that it is not applied currently. Thanks!