### PR TITLE
Use the domain variable to get the zone for the record

### DIFF
--- a/content/terraform/tutorial/initialize-terraform.md
+++ b/content/terraform/tutorial/initialize-terraform.md
@@ -32,16 +32,16 @@ provider "cloudflare" {
   api_token = "your-api-token"
 }
 
-variable "zone_id" {
-  default = "e097e1136dc79bc1149e32a8a6bde5ef"
-}
-
 variable "domain" {
   default = "example.com"
 }
 
+data "cloudflare_zone" "Zone" {
+  name = var.domain
+}
+
 resource "cloudflare_record" "www" {
-  zone_id = var.zone_id
+  zone_id = data.cloudflare_zone.Zone.zone_id
   name    = "www"
   value   = "203.0.113.10"
   type    = "A"


### PR DESCRIPTION
Use the domain variable to get the zone for the record
- var.domain is currently not used?

I think the above is more user friendly for first time users of the cloudflare provider as the domain var seems redundant previously however using it to get the zone id streamlines the process?