### PR TITLE
Remove duplicated curl from the PATCH example

### DIFF
--- a/content/cloudflare-for-saas/performance/early-hints-for-saas.md
+++ b/content/cloudflare-for-saas/performance/early-hints-for-saas.md
@@ -58,8 +58,7 @@ curl -X GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnam
 Then make an API call such as the example below, specifying `"early_hints": "on"`:
 
 ```json
-$ curl -sXPATCH \
-curl -X PATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/CUSTOM_HOSTNAME_ID" \
+$ curl -sXPATCH "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/CUSTOM_HOSTNAME_ID" \
     -H "X-Auth-Email: {email}" \
     -H "X-Auth-Key: {key}" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
There was a duplicated curl in the last example.

Also... it could be worth to mention that sending a PATCH to change ANY "settings" value will reset all other values. But that's up to you. ;)

For example:
Before:
```
      "settings": {
        "min_tls_version": "1.2"
      },
```
After:
```
      "settings": {
        "early_hints": "on"
      },
```