### PR TITLE
[GraphQL API Docs] Improve tutorials

### DIFF
--- a/content/analytics/graphql-api/tutorials/end-customer-analytics/index.md
+++ b/content/analytics/graphql-api/tutorials/end-customer-analytics/index.md
@@ -11,12 +11,38 @@ The following API call will request the number of visits and edge response bytes
  
 ## API Call
  
-```json
-curl 'https://api.cloudflare.com/client/v4/graphql' \
--H 'Accept: application/json' \
--H 'Authorization: Bearer CLOUDFLARE_API_TOKEN \
---data-binary '{"query":"query RequestsAndDataTransferByHostname($zoneTag: string, $filter:filter) {\n      viewer {\n        zones(filter: {zoneTag: $zoneTag}) {\n          httpRequestsAdaptiveGroups(limit: 10, filter: $filter)\n           {\n            sum {\n              visits\n              edgeResponseBytes\n            }\n            dimensions{\n              datetimeHour\n            }\n          }\n        }\n      }\n    }","variables":{"zoneTag":"CLOUDFLARE_ZONE_ID","filter":{"datetime_geq":"2022-07-20T11:00:00Z","datetime_lt":"2022-07-24T12:00:00Z","clientRequestHTTPHost":"hostname.example.com","requestSource":"eyeball"}}}' \
---compressed | jq .
+```bash
+echo '{ "query":
+  "query RequestsAndDataTransferByHostname($zoneTag: string, $filter:filter) {
+    viewer {
+      zones(filter: {zoneTag: $zoneTag}) {
+        httpRequestsAdaptiveGroups(limit: 10, filter: $filter) {
+          sum {
+            visits
+            edgeResponseBytes
+          }
+          dimensions {
+            datetimeHour
+          }
+        }
+      }
+    }
+  }",
+  "variables": {
+    "zoneTag": "CLOUDFLARE_ZONE_ID",
+    "filter": {
+      "datetime_geq": "2022-07-20T11:00:00Z",
+      "datetime_lt": "2022-07-24T12:00:00Z",
+      "clientRequestHTTPHost": "hostname.example.com",
+      "requestSource": "eyeball"
+    }
+  }
+}' | tr -d '\n' | curl \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer CLOUDFLARE_API_TOKEN' \
+  -s \
+  -d @-  \
+  https://api.cloudflare.com/client/v4/graphql | jq .
 ```
  
 The returned results will be in JSON format (as requested), so piping the output to `jq` will make them easier to read, like in the following example:

--- a/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
@@ -12,8 +12,8 @@ The following API call will request Firewall Events over a one hour period, and 
 ## API Call
 
 ```bash
-PAYLOAD='{
-  "query": "query ListFirewallEvents($zoneTag: string, $filter: FirewallEventsAdaptiveFilter_InputObject) {
+echo '{ "query":
+  "query ListFirewallEvents($zoneTag: string, $filter: FirewallEventsAdaptiveFilter_InputObject) {
     viewer {
       zones(filter: { zoneTag: $zoneTag }) {
         firewallEventsAdaptive(
@@ -37,30 +37,30 @@ PAYLOAD='{
   "variables": {
     "zoneTag": "CLOUDFLARE_ZONE_ID",
     "filter": {
-      "datetime_geq": "2020-04-24T11:00:00Z",
-      "datetime_leq": "2020-04-24T12:00:00Z"
+      "datetime_geq": "2022-07-24T11:00:00Z",
+      "datetime_leq": "2022-07-24T12:00:00Z"
     }
   }
-}'
-
-curl \
+}' | tr -d '\n' | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/
 ```
 
 The results returned will be in JSON (as requested), so piping the output to `jq` will make them easier to read, e.g.,:
 
 ```bash
-curl \
+... | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 #=> {
 #=>   "data": {

--- a/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
@@ -12,54 +12,54 @@ The following API call will request Magic Firewall Samples over a one hour perio
 ## API Call
 
 ```bash
-PAYLOAD='{ "query":
+echo '{ "query":
   "query MFWActivity {
-      viewer {
-        accounts(filter: { accountTag: $accountTag }) {
-          magicFirewallSamplesAdaptiveGroups(
-            filter: $filter
-            limit: 10
-            orderBy: [datetimeFiveMinute_DESC]
-          ) {
-            sum {
-              bits
-              packets
-            }
-            dimensions {
-              datetimeFiveMinute
-              ruleId
-            }
+    viewer {
+      accounts(filter: { accountTag: $accountTag }) {
+        magicFirewallSamplesAdaptiveGroups(
+          filter: $filter
+          limit: 10
+          orderBy: [datetimeFiveMinute_DESC]
+        ) {
+          sum {
+            bits
+            packets
+          }
+          dimensions {
+            datetimeFiveMinute
+            ruleId
           }
         }
       }
-    }",
-    "variables": {
-      "accountTag": "$CLOUDFLARE_ACCOUNT_ID",
-      "filter": {
-        "datetime_geq": "2021-04-24T11:00:00Z",
-        "datetime_leq": "2021-04-24T12:00:00Z"
-      }
     }
-  }'
-
-curl \
+  }",
+  "variables": {
+    "accountTag": "CLOUDFLARE_ACCOUNT_ID",
+    "filter": {
+      "datetime_geq": "2022-07-24T11:00:00Z",
+      "datetime_leq": "2022-07-24T11:10:00Z"
+    }
+  }
+}' | tr -d '\n' | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/
 ```
 
 The returned values represent the total number of packets and bits received during the five minute interval for a particular rule. The result will be in JSON (as requested), so piping the output to `jq` will make it easier to read, like in the following example:
 
 ```bash
-curl \
+... | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 #=> {
 #=>   "data": {

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
@@ -7,66 +7,64 @@ title: Querying Magic Transit tunnel bandwidth analytics with GraphQL
 
 In this example, you are going to use the GraphQL Analytics API to query Magic Transit Ingress Tunnel Traffic over a specified time period.
 
-The following API call will request Magic Transit Ingress Tunnel Traffic over a one-hour period and output the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetime_geq` and `datetime_leq `values as needed. 
+The following API call will request Magic Transit Ingress Tunnel Traffic over a one-hour period and output the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetime_geq` and `datetime_leq` values as needed.
 
 The following example queries for ingress traffic. To query for egress, change the value in the direction filter.
 
 ## API Call
 
 ```bash
-CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
-CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
-PAYLOAD='{ "query":
+echo '{ "query":
   "query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
-    {
-      viewer {
-        accounts(filter: {accountTag: $accountTag}) {
-          magicTransitTunnelTrafficAdaptiveGroups(
-            limit: 100,
-            filter: {
-              datetime_geq: $datetimeStart,
-              datetime_lt:  $datetimeEnd,
-              direction: "ingress"             }
-          ) {
-            avg {
-              bitRateFiveMinutes
-            }
-            dimensions {
-              tunnelName
-              datetimeFiveMinutes
-            }
+    viewer {
+      accounts(filter: {accountTag: $accountTag}) {
+        magicTransitTunnelTrafficAdaptiveGroups(
+          limit: 100,
+          filter: {
+            datetime_geq: $datetimeStart,
+            datetime_lt:  $datetimeEnd,
+            direction: $direction
+          }
+        ) {
+          avg {
+            bitRateFiveMinutes
+          }
+          dimensions {
+            tunnelName
+            datetimeFiveMinutes
           }
         }
       }
     }
   }",
-    "variables": {
-      "accountTag": "90f518ca7113dc0a91513972ba243ba5",
-      "datetimeStart": "2020-05-04T11:00:00.000Z",
-      "datetimeEnd": "2020-05-04T12:00:00.000Z"
-    }
-  }'
- 
-curl \
+  "variables": {
+    "accountTag": "CLOUDFLARE_ACCOUNT_ID",
+    "datetimeStart": "2022-08-04T00:00:00.000Z",
+    "datetimeEnd": "2022-08-04T01:00:00.000Z",
+    "direction": "ingress"
+  }
+}' | tr -d '\n' | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/
-  ```
+```
 
 The returned values represent the total bandwidth in bits/second during the five minute interval for a particular tunnel. To use aggregations other than five minutes, make sure that you use the same window for both your metric and date time. For example, to see hourly groups, use `bitRateHour` and `datetimeHour`.
 
 The result will be in JSON (as requested), so piping the output to `jq` will make it easier to read, like in the following example:
 
 ```bash
-curl \
+... | curl \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "X-Auth-Email: <CLOUDFLARE_EMAIL>" \
-  -H "X-Auth-key: <CLOUDFLARE_API_KEY>" \
-  --data "$(echo $PAYLOAD)" \
+  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
+  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 #=> {
 #=>   "data": {

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
@@ -7,65 +7,61 @@ title: Querying Magic Transit Tunnel Health Check Results with GraphQL
 
 In this example, you are going to use the GraphQL Analytics API to query Magic Transit Health check results which are aggregated from individual health checks carried out by Cloudflare servers to GRE tunnels you have set up to work with Magic Transit during the [onboarding process](/magic-transit/get-started/). You can query up to one week of data for dates up to three months ago.
 
-The following API call will request a particular account's tunnel health checks over a one day period for a particular Cloudflare colo, and outputs the requested fields. Be sure to replace `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetimeStart`, `datetimeEnd` and `accountTag` variables as needed.
+The following API call will request a particular account's tunnel health checks over a one day period for a particular Cloudflare colo, and outputs the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your API credentials, and adjust the `datetimeStart`, `datetimeEnd` variables as needed.
 
 It will return the tunnel health check results by Cloudflare colo. The result for each colo is aggregated from the healthchecks conducted on individual servers. The tunnel state field in the value represents the [state of the tunnel](/magic-transit/about/health-checks/#tunnel-health-checks). These states are used by Magic Transit for [routing](/magic-transit/about/health-checks/#tunnel-health-checks). The value `0` for the tunnel state represents it being down, the value `0.5` being degraded and the value `1` as healthy.
 
 ## API Call
 
 ```bash
-CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
-CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
-PAYLOAD='{ "query":
+echo '{ "query":
   "query GetTunnelHealthCheckResults($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
-    {
-      viewer {
-        accounts(filter: {accountTag: $accountTag}) {
-          magicTransitTunnelHealthChecksAdaptiveGroups(
-            limit: 100,
-            filter: {
-              datetime_geq: $datetimeStart,
-              datetime_lt:  $datetimeEnd,
-            }
-          ) {
-            avg {
-              tunnelState
-            }
-            dimensions {
-              tunnelName
-              edgeColoName
-            }
+    viewer {
+      accounts(filter: {accountTag: $accountTag}) {
+        magicTransitTunnelHealthChecksAdaptiveGroups(
+          limit: 100,
+          filter: {
+            datetime_geq: $datetimeStart,
+            datetime_lt:  $datetimeEnd,
+          }
+        ) {
+          avg {
+            tunnelState
+          }
+          dimensions {
+            tunnelName
+            edgeColoName
           }
         }
       }
     }
   }",
-    "variables": {
-      "accountTag": "90f518ca7113dc0a91513972ba243ba5",
-      "datetimeStart": "2020-05-04T00:00:00.000Z",
-      "datetimeEnd": "2020-05-04T00:00:00.000Z"
-    }
-  }'
-
-curl \
+  "variables": {
+    "accountTag": "CLOUDFLARE_ACCOUNT_ID",
+    "datetimeStart": "2022-08-04T00:00:00.000Z",
+    "datetimeEnd": "2022-08-04T01:00:00.000Z"
+  }
+}' | tr -d '\n' | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/
 ```
 
 The results returned will be in JSON (as requested), so piping the output to `jq` will make them easier to read, like in the following example:
 
 ```bash
-curl \
--X POST \
--H "Content-Type: application/json" \
--H "X-Auth-Email: CLOUDFLARE_EMAIL" \
--H "X-Auth-key: CLOUDFLARE_API_KEY" \
---data "$(echo $PAYLOAD)" \
-https://api.cloudflare.com/client/v4/graphql/ | jq .
+... | curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
+  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -s \
+  -d @- \
+  https://api.cloudflare.com/client/v4/graphql/ | jq .
 #=> {
 #=>   "data": {
 #=>     "viewer": {

--- a/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
@@ -7,66 +7,64 @@ pcx_content_type: tutorial
 
 In this example, we are going to use the GraphQL Analytics API to query for Workers Metrics over a specified time period. We can query up to one week of data for dates up to three months ago.
 
-The following API call will request a Worker script's metrics over a one day period, and output the requested fields. Be sure to replace `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` with your email and API credentials, and adjust the `datetimeStart`, `datetimeEnd`, `accountTag`, and `scriptName` variables as needed.
+The following API call will request a Worker script's metrics over a one day period, and output the requested fields. Be sure to replace `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_EMAIL`, and `CLOUDFLARE_API_KEY` with your API credentials, and adjust the `datetimeStart`, `datetimeEnd`, and `scriptName` variables as needed.
 
 ## API Call
 
 ```bash
-CLOUDFLARE_EMAIL=<CLOUDFLARE_EMAIL>
-CLOUDFLARE_API_KEY=<CLOUDFLARE_API_KEY>
-PAYLOAD='{ "query":
+echo '{ "query":
   "query GetWorkersAnalytics($accountTag: string, $datetimeStart: string, $datetimeEnd: string, $scriptName: string) {
-      viewer {
-        accounts(filter: {accountTag: $accountTag}) {
-          workersInvocationsAdaptive(limit: 100, filter: {
-            scriptName: $scriptName,
-            datetime_geq: $datetimeStart,
-            datetime_leq: $datetimeEnd
-          }) {
-            sum {
-              subrequests
-              requests
-              errors
-            }
-            quantiles {
-              cpuTimeP50
-              cpuTimeP99
-            }
-            dimensions{
-              datetime
-              scriptName
-              status
-            }
+    viewer {
+      accounts(filter: {accountTag: $accountTag}) {
+        workersInvocationsAdaptive(limit: 100, filter: {
+          scriptName: $scriptName,
+          datetime_geq: $datetimeStart,
+          datetime_leq: $datetimeEnd
+        }) {
+          sum {
+            subrequests
+            requests
+            errors
+          }
+          quantiles {
+            cpuTimeP50
+            cpuTimeP99
+          }
+          dimensions{
+            datetime
+            scriptName
+            status
           }
         }
       }
-    }",
-    "variables": {
-      "accountTag": "90f518ca7113dc0a91513972ba243ba5",
-      "datetimeStart": "2020-05-04T00:00:00.000Z",
-      "datetimeEnd": "2020-05-04T00:00:00.000Z",
-      "scriptName": "worker-subrequest-test-client"
     }
-  }'
-
-curl \
+  }",
+  "variables": {
+    "accountTag": "CLOUDFLARE_ACCOUNT_ID",
+    "datetimeStart": "2022-08-04T00:00:00.000Z",
+    "datetimeEnd": "2022-08-04T01:00:00.000Z",
+    "scriptName": "worker-subrequest-test-client"
+  }
+}' | tr -d '\n' | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/
 ```
 
 The results returned will be in JSON (as requested), so piping the output to `jq` will make them easier to read, like in the following example:
 
 ```bash
-curl \
+... | curl \
   -X POST \
   -H "Content-Type: application/json" \
   -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
   -H "X-Auth-key: CLOUDFLARE_API_KEY" \
-  --data "$(echo $PAYLOAD)" \
+  -s \
+  -d @- \
   https://api.cloudflare.com/client/v4/graphql/ | jq .
 #=> {
 #=>   "data": {


### PR DESCRIPTION
This commit updates api calls in tutorials so they can be used as
is directly from a bash command line (accountTags and other
credentials should be provided though).

This commit also fixes a couple of tutorials that appeared to be
broken. All the queries were executed and successful results were
received.