### PR TITLE
Update Workers Server Push example to use Early Hints

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -922,6 +922,7 @@
 /workers/writing-workers/resource-limits/ /workers/about/limits/ 301
 /workers/runtime-apis/r2/ /r2/runtime-apis/ 301
 /workers/tutorials/deploy-a-react-app-with-create-react-app/ /pages/framework-guides/deploy-a-react-application/ 301
+/workers/examples/http2-server-push/ /workers/examples/103-early-hints/ 301
 
 # zaraz
 

--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -9,11 +9,15 @@ title: 103 Early Hints
 weight: 1001
 layout: example
 ---
-To ensure Early Hints are enabled, go to the [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/:zone/speed/optimization) under Your Domain -> Speed -> Optimization and enable the Early Hints toggle.
+To ensure Early Hints are enabled:
+
+1. Log in to the [Cloudflare Dashboard](https://dash.cloudflare.com) and select your account and website.
+2. Go to **Speed** -> **Optimization**.
+3. Enable the **Early Hints** toggle to on.
 
 {{<Aside type="note">}}
 
-At the time of writing, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date info on which browsers support Early Hints, check [here](https://caniuse.com/mdn-http_status_103).
+Currently, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date information on which browsers support Early Hints, refer to [caniuse.com](https://caniuse.com/mdn-http_status_103).
 
 {{</Aside>}}
 

--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -9,6 +9,13 @@ title: 103 Early Hints
 weight: 1001
 layout: example
 ---
+To ensure Early Hints are enabled, go to the [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/:zone/speed/optimization) under Your Domain -> Speed -> Optimization and enable the Early Hints toggle.
+
+{{<Aside type="note">}}
+
+At the time of writing, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date info on which browsers support Early Hints, check [here](https://caniuse.com/mdn-http_status_103).
+
+{{</Aside>}}
 
 ```js
 const CSS = `body { color: red; }`;
@@ -49,9 +56,3 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request));
 });
 ```
-
-{{<Aside type="note">}}
-
-At the time of writing, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date info on which browsers support Early Hints, check [here](https://caniuse.com/mdn-http_status_103).
-
-{{</Aside>}}

--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -49,3 +49,9 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request));
 });
 ```
+
+{{<Aside type="note">}}
+
+At the time of writing, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date info on which browsers support Early Hints, check [here](https://caniuse.com/mdn-http_status_103).
+
+{{</Aside>}}

--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -17,7 +17,7 @@ To ensure Early Hints are enabled:
 
 {{<Aside type="note">}}
 
-Currently, 103 Early Hints are only supported in Chrome 103 or later. To view up-to-date information on which browsers support Early Hints, refer to [caniuse.com](https://caniuse.com/mdn-http_status_103).
+Currently, `103 Early Hints` are only supported in Chrome 103 or later. To view up-to-date information on which browsers support Early Hints, refer to [caniuse.com](https://caniuse.com/mdn-http_status_103).
 
 {{</Aside>}}
 

--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -1,11 +1,11 @@
 ---
 type: example
-summary: Push static assets to a client's browser without waiting for HTML to render.
+summary: Allow a client to request static assets while waiting for the HTML response.
 tags:
   - Middleware
   - Headers
 pcx_content_type: configuration
-title: HTTP2 server push
+title: 103 Early Hints
 weight: 1001
 layout: example
 ---
@@ -17,11 +17,11 @@ const HTML = `
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Server push test</title>
-    <link rel="stylesheet" href="http2_push/h2p/test.css">
+    <title>Early Hints test</title>
+    <link rel="stylesheet" href="/test.css">
 </head>
 <body>
-    <h1>Server push test page</h1>
+    <h1>Early Hints test page</h1>
 </body>
 </html>
 `;
@@ -35,11 +35,11 @@ async function handleRequest(request) {
       },
     });
   } else {
-    // Serve raw HTML using HTTP/2 for the CSS file
+    // Serve raw HTML using Early Hints for the CSS file
     return new Response(HTML, {
       headers: {
         'content-type': 'text/html',
-        'Link': '</http2_push/h2p/test.css>; rel=preload; as=style',
+        'Link': '</test.css>; rel=preload; as=style',
       },
     });
   }


### PR DESCRIPTION
- HTTP/2 Server Push is now deprecated and per [this thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/K3rYLvmQUBY/m/0o4J1GEjAgAJ) Chrome has plans to stop supporting it shortly (once Early Hints are stable, which they now are).
- The replacement is Early Hints (supported by some browsers).
- This PR updates the old HTTP/2 Server Push Workers example to use 103 Early Hints instead.