### PR TITLE
Fix HTML entities causing an issue in the Early Hints example

### DIFF
--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -113,8 +113,8 @@ const ESCAPE = /[&"<>]/g;
 const CHARS = {
   '"': '&quot;',
   '&': '&amp;',
-  '<': '&lt',
-  '>': '&gt',
+  '<': '&lt;',
+  '>': '&gt;',
 };
 
 // @see lukeed/tempura


### PR DESCRIPTION
Fix for the Early Hints example doc - https://developers.cloudflare.com/workers/examples/103-early-hints/

In postbuild we transform the Markdown into HTML. As part of that, we turn some characters into their HTML entity. When we transform `>` it was turning into `&gt`. With the semicolon (which is required in EH's case - `</test.css>;`) it was turning into `&gt;` (valid and preferred entity syntax).

This fix will just correctly transform `>` now into `&gt;`. In EH's case it now will result in `&gt;;` which shows up correctly :)

![Screenshot 2022-08-12 at 13 51 59](https://user-images.githubusercontent.com/8492901/184358506-2efa1e7c-e107-4a05-b540-36575a7ad3b8.png)

Gotta love a bit of bug hunting in the morning