### PR TITLE
Remove outdated Stream Live caveats

### DIFF
--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -80,6 +80,4 @@ curl -X DELETE \ -H "Authorization: Bearer $TOKEN" \https://api.cloudflare.com/c
 ### Known limitations:
 
 - Watermarks cannot yet be used with live videos.
-- The live videos feature does not yet work on older iOS versions: iOS 10, launched in 2016, and below.
-- Hardware video encoding on Apple devices is not yet supported. When using encoder software such as OBS, x264 software encoding is required.
 - If a live video exceeds seven days in length, the recording will be truncated to seven days and not be viewable.


### PR DESCRIPTION
- Remove caveat about older iOS versions (iOS 10 / 2016 era devices are way too old to be relevant to anyone reading these docs at this point)
- Remove caveat about hardware video encoding (old and misleading)