### PR TITLE
Extend handling of range headers in the sample

### DIFF
--- a/content/r2/examples/demo-worker.md
+++ b/content/r2/examples/demo-worker.md
@@ -22,6 +22,18 @@ function parseRange(encoded: string | null): undefined | { offset: number, lengt
   if (parts.length !== 2) {
     throw new Error('Not supported to skip specifying the beginning/ending byte at this time')
   }
+  
+  if (parts[0].length == 0) {
+		return {
+			suffix: Number(parts[1]),
+		}
+  }
+
+	if (parts[1].length == 0) {
+		return {
+			offset: Number(parts[0]),
+		}
+  }
 
   return {
     offset: Number(parts[0]),
@@ -80,9 +92,13 @@ export default {
         const headers = new Headers()
         object.writeHttpMetadata(headers)
         headers.set('etag', object.httpEtag)
+        headers.set('accept-ranges', 'bytes')
         if (range) {
-          headers.set("content-range", `bytes ${range.offset}-${range.end}/${object.size}`)
-        }
+			    if(range.suffix !== undefined)
+				    headers.set("content-range", `bytes ${object.size - range.suffix}-${object.size}/${object.size}`)
+			    else
+				    headers.set("content-range", `bytes ${range.offset}-${range?.end ?? object.size}/${object.size}`)
+		    }
         const status = object.body ? (range ? 206 : 200) : 304
         return new Response(object.body, {
           headers,


### PR DESCRIPTION
When testing the R2 with this worker sample, I ran into some applications (e.g. VLC) failing to read the data and failing immediately, due to corrupted network stream errors.

This was because they perform range requests which have optionally the offset or end missing, which the original sample doesn't handle correctly. This adds proper handling for those headers, which fixes those applications not working with this sample.

It also adds the "accept-ranges" header. Some apps seem to be confused when it's missing, while some ignore it, but change their behavior (how they send the range headers) when it's present.

I'm not sure if there are any unexpected side effects to these changes, but from my testing so far, it seems to work pretty well and I figure it might help other be less confused when their apps fail to work with the sample.