### PR TITLE
[Docs site] Add table of contents highlighting

### DIFF
--- a/assets/contents.ts
+++ b/assets/contents.ts
@@ -2,6 +2,7 @@ type ListItem = HTMLLIElement & {
   h: string;
 };
 
+const ACTIVE_CLASS = 'DocsTableOfContents-link-active';
 export function toc() {
   let target = document.querySelector('ul.DocsTableOfContents');
   let article = target && document.querySelector('article.DocsMarkdown');
@@ -31,6 +32,84 @@ export function toc() {
       last.innerHTML = `<a class="DocsTableOfContents-link" href="#${tmp.id}">${text}</a>`;
       container.appendChild(last);
       last.h = tmp.nodeName;
+    }
+
+    // setup observers to track what elements in TOC are visible
+    const visibleElements = new Map();
+    const tocLinks = target.querySelectorAll('a.DocsTableOfContents-link');
+    const highlightVisibleTocLinks = () => {
+      let topVisibleIndex = null;
+      let h1Visible = false;
+      let footerVisible = false;
+      for (const [element, isVisible] of visibleElements.entries()) {
+        if (!isVisible) {
+          continue;
+        }
+        if (element.tagName === 'H1') {
+          h1Visible = true;
+          break;
+        }
+        if (element.tagName === 'FOOTER') {
+          footerVisible = true;
+          break;
+        }
+        const headingIndex = [...tocLinks].findIndex(
+          link => link.getAttribute('href') === `#${element.id}`
+        );
+        if (topVisibleIndex === null || headingIndex < topVisibleIndex) {
+          topVisibleIndex = headingIndex;
+        }
+      }
+      if (h1Visible) {
+        // we're at the top of the article, remove all highlights
+        for (const link of tocLinks) {
+          link.classList.remove(ACTIVE_CLASS);
+        }
+        return;
+      }
+      if (footerVisible) {
+        // we're at the bottom of the article, highlight last thing
+        for (const [index, link] of tocLinks.entries()) {
+          if (index === tocLinks.length - 1) {
+            link.classList.add(ACTIVE_CLASS);
+          } else {
+            link.classList.remove(ACTIVE_CLASS);
+          }
+        }
+        return;
+      }
+      const topMostVisibleLink = [...tocLinks][topVisibleIndex];
+
+      // find a new link to highlight
+      const highlightLink = [...tocLinks].find(
+        link => link.getAttribute('href') === topMostVisibleLink?.getAttribute?.('href')
+      ) as HTMLAnchorElement;
+      // if we've got a new link to highlight, do it, and unhighlight the old ones
+      if (highlightLink) {
+        for (const contentItem of tocLinks) {
+          if (contentItem.getAttribute('href') === topMostVisibleLink?.getAttribute?.('href')) {
+            contentItem.classList.add(ACTIVE_CLASS);
+          } else {
+            contentItem.classList.remove(ACTIVE_CLASS);
+          }
+        }
+      }
+    };
+    const observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        visibleElements.set(entry.target, entry.isIntersecting);
+      }
+      highlightVisibleTocLinks();
+    });
+
+    // observe headers in article, as well as footer/header for when we're at the top/bottom of the article
+    const observeElements = article.querySelectorAll('h1,h2,h3,h4');
+    const observePagePageElements = document.querySelectorAll('footer,header');
+    for (let i = 0; i < observeElements.length; i++) {
+      observer.observe(observeElements[i]);
+    }
+    for (let i = 0; i < observePagePageElements.length; i++) {
+      observer.observe(observePagePageElements[i]);
     }
 
     target.removeAttribute('hidden');

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -1,0 +1,11 @@
+{
+ "compilerOptions": {
+  "target": "es2015",
+  "baseUrl": ".",
+  "paths": {
+   "*": [
+    "*"
+   ]
+  }
+ }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -3037,6 +3037,10 @@ html[is-docs-page] body {
   margin: -0.2em 0;
 }
 
+.DocsTableOfContents-link-active {
+  color: var(--orange-6);
+}
+
 .DocsTableOfContents-link:hover {
   color: var(--orange);
 }


### PR DESCRIPTION
This PR adds a nice visual indicator to the table of contents in the docs as you scroll into each section. This is extremely useful on longer-form documents, to give users an idea of where abouts they are on the page, and how much they have left to get through.

Here's an example of it in action: https://up.jross.me/wgz6bab8

Do note that this isn't perfect, especially on shorter documents and may "skip" sections as you scroll if they're super close together. There might be an easy way to solve this, but I can't think of one at the moment given the DOM structure. It's a visual improvement and makes it way more digestible to read larger documents in my opinion, either way,

Here's a few examples of pages where it works well, from my docs fork:
- https://f1bbcd3d.cloudflare-docs-57q.pages.dev/pages/platform/functions/
- https://f1bbcd3d.cloudflare-docs-57q.pages.dev/pages/tutorials/build-an-api-with-workers/
- https://f1bbcd3d.cloudflare-docs-57q.pages.dev/stream/edit-manage-videos/edit-videos/video-clipping/
- https://f1bbcd3d.cloudflare-docs-57q.pages.dev/workers/learning/security-model/

Note: I also added a `tsconfig.json` in the `assets` folder and set it to a more modern target than the default `es5`. This is so I could use some more modern DOM iteration APIs without hurting TypeScript.

