### PR TITLE
[Docs site] Fix breaking Pages builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "node-html-parser": "5.2.0",
     "prettier": "2.5.1",
     "prismjs": "1.26.0",
-    "tsm": "2.2.1"
+    "tsm": "2.2.2"
   }
 }


### PR DESCRIPTION
We're seeing errors similar to those mentioned in https://github.com/lukeed/tsm/issues/36, so maybe upgrading to the latest version (that has the fix) will help?