### PR TITLE
Update about YARN_VERSION

### DIFF
--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -107,26 +107,26 @@ Here are the pinned versions for tools included in the Cloudflare Workers build 
 
 Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
 
-| Tools       | Default version                             | Supported versions               | Environment variable |
-| ----------- | --------------------------------------------| -------------------------------- | -------------------- |
-| Boot        | 2.5.2                                       | 2.5.2                            |                      |
-| Bower       |                                             |                                  |                      |
-| Cask        |                                             |                                  |                      |
-| Composer    |                                             |                                  |                      |
-| Doxygen     | Version 1.8.6                               |                                  |                      |
-| Emacs       | Version 25                                  |                                  |                      |
-| Gutenberg   | (requires environment variable)             | Any version                      | `GUTENBERG_VERSION`  |
-| Hugo        | Version 0.54.0                              | Any version                      | `HUGO_VERSION`       |
-| GNU Make    | Version 3.8.1                               |                                  |                      |
-| ImageMagick | Version 6.7.7                               |                                  |                      |
-| jq          | Version 1.5                                 |                                  |                      |
-| Leiningen   |                                             |                                  |                      |
-| OptiPNG     | Version 0.6.4                               |                                  |                      |
-| NPM         | Corresponds with Node.js version            | Any version                      | `NPM_VERSION`        |
-| pip         | Version corresponding with Python version   |                                  |                      |
-| Pipenv      | Latest version                              |                                  |                      |
-| sqlite3     | Version 3.11.0                              |                                  |                      |
-| Yarn        | Version 1.22.10                             | Any version                      | `YARN_VERSION`       |
-| Zola        | (requires environment variable)             | Any version from 0.5.0 to 0.14.0 | `ZOLA_VERSION`       |
+| Tools       | Default version                             | Supported versions                | Environment variable |
+| ----------- | --------------------------------------------| --------------------------------- | -------------------- |
+| Boot        | 2.5.2                                       | 2.5.2                             |                      |
+| Bower       |                                             |                                   |                      |
+| Cask        |                                             |                                   |                      |
+| Composer    |                                             |                                   |                      |
+| Doxygen     | Version 1.8.6                               |                                   |                      |
+| Emacs       | Version 25                                  |                                   |                      |
+| Gutenberg   | (requires environment variable)             | Any version                       | `GUTENBERG_VERSION`  |
+| Hugo        | Version 0.54.0                              | Any version                       | `HUGO_VERSION`       |
+| GNU Make    | Version 3.8.1                               |                                   |                      |
+| ImageMagick | Version 6.7.7                               |                                   |                      |
+| jq          | Version 1.5                                 |                                   |                      |
+| Leiningen   |                                             |                                   |                      |
+| OptiPNG     | Version 0.6.4                               |                                   |                      |
+| NPM         | Corresponds with Node.js version            | Any version                       | `NPM_VERSION`        |
+| pip         | Version corresponding with Python version   |                                   |                      |
+| Pipenv      | Latest version                              |                                   |                      |
+| sqlite3     | Version 3.11.0                              | Any version                       |                      |
+| Yarn        | Version 1.22.10                             | Any version from 0.2.0 to 1.22.19 | `YARN_VERSION`       |
+| Zola        | (requires environment variable)             | Any version from 0.5.0 to 0.14.0  | `ZOLA_VERSION`       |
 
 If you want to set a specific version of a framework your Cloudflare Pages project is using, note that Pages will respect your package manager of choice during your build process. For example, if you use Gatsby.js, your `package.json` should indicate a version of the `gatsby` npm package, which will be installed using `npm install` as your project builds on Cloudflare Pages.

--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -125,7 +125,7 @@ Many common tools have been pre-installed as well. The environment variable avai
 | NPM         | Corresponds with Node.js version            | Any version                       | `NPM_VERSION`        |
 | pip         | Version corresponding with Python version   |                                   |                      |
 | Pipenv      | Latest version                              |                                   |                      |
-| sqlite3     | Version 3.11.0                              | Any version                       |                      |
+| sqlite3     | Version 3.11.0                              |                                   |                      |
 | Yarn        | Version 1.22.10                             | Any version from 0.2.0 to 1.22.19 | `YARN_VERSION`       |
 | Zola        | (requires environment variable)             | Any version from 0.5.0 to 0.14.0  | `ZOLA_VERSION`       |
 


### PR DESCRIPTION
The script downloads version from https://github.com/yarnpkg/yarn/releases

The download of v2 or v3 are not yet possible. Those versions are delivered through Corepack https://yarnpkg.com/getting-started/instal