### PR TITLE
Snippets

### DIFF
--- a/content/pages/how-to/use-bulk-redirects.md
+++ b/content/pages/how-to/use-bulk-redirects.md
@@ -5,7 +5,7 @@ title: Handle redirects with Bulk Redirects
 
 # Handle redirects with Bulk Redirects
 
-In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the 1,100 redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects.
+In this tutorial, you will learn how to use [Bulk Redirects (beta)](/rules/bulk-redirects/) to handle redirects that surpasses the {{<snippet id="cf-pages-limits-redirects">}} redirect rules limit set by Pages. A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of {{<snippet id="cf-pages-limits-redirects-long">}}.
 
 {{<Aside type="Note">}}
 

--- a/content/pages/migrations/migrating-from-netlify/index.md
+++ b/content/pages/migrations/migrating-from-netlify/index.md
@@ -29,7 +29,7 @@ In the **Build & Deploy** tab, find the **Build settings** panel, which will hav
 
 ## Migrating redirects and headers
 
-If your site includes a `_redirects` file in your publish directory, you can use the same file in Cloudflare Pages and your redirects will execute successfully. If your redirects are in your `netlify.toml` file, you will need to add them to the `_redirects` folder. Cloudflare Pages currently offers limited [supports for advanced redirects](/pages/platform/redirects/). In the case where you have over 2000 static and/or 100 dynamic redirects rules, it is recommended to use [Bulk Redirects](/rules/bulk-redirects/create-dashboard/).
+If your site includes a `_redirects` file in your publish directory, you can use the same file in Cloudflare Pages and your redirects will execute successfully. If your redirects are in your `netlify.toml` file, you will need to add them to the `_redirects` folder. Cloudflare Pages currently offers limited [supports for advanced redirects](/pages/platform/redirects/). In the case where you have over {{<snippet id="cf-pages-limits-redirects-andor">}}, it is recommended to use [Bulk Redirects](/rules/bulk-redirects/create-dashboard/).
 
 Your header files can also be moved into a `_headers` folder in your publish directory. It is important to note that custom headers defined in the `_headers` file are not currently applied to responses from functions, even if the function route matches the URL pattern. To learn more about how to [handle headers, refer to Headers](/pages/platform/headers/).
 

--- a/content/pages/migrations/migrating-from-workers/index.md
+++ b/content/pages/migrations/migrating-from-workers/index.md
@@ -12,9 +12,9 @@ In this tutorial, you will learn how to migrate an existing [Cloudflare Workers 
 
 As a prerequisite, you should have a Cloudflare Workers Sites project, created with [Wrangler](https://github.com/cloudflare/wrangler).
 
-Cloudflare Pages provides built-in defaults for every aspect of serving your site. You can port custom behavior in your Worker — such as custom caching logic — to your Cloudflare Pages project using [Functions](/pages/platform/functions/). This enables an easy-to-use, file-based routing system. You can also migrate your custom headers and redirects to Pages. 
+Cloudflare Pages provides built-in defaults for every aspect of serving your site. You can port custom behavior in your Worker — such as custom caching logic — to your Cloudflare Pages project using [Functions](/pages/platform/functions/). This enables an easy-to-use, file-based routing system. You can also migrate your custom headers and redirects to Pages.
 
-You may already have a reasonably complex Worker and/or it would be tedious to splice it up into Pages' file-based routing system. For these cases, Pages offers developers the ability to define a `_worker.js` file in the output directory of your Pages project. 
+You may already have a reasonably complex Worker and/or it would be tedious to splice it up into Pages' file-based routing system. For these cases, Pages offers developers the ability to define a `_worker.js` file in the output directory of your Pages project.
 
 {{<Aside type="note">}}
 
@@ -36,17 +36,17 @@ When moving to Cloudflare Pages, remove the Workers application and any associat
 
 ## Migrate headers and redirects
 
-You can migrate your redirects to Pages, by creating a `_redirects` file in your output directory. Pages currently offers limited support for advanced redirects. More support will be added in the future. For a list of support types, refer to the [Redirects documentaion](/pages/platform/redirects/). 
+You can migrate your redirects to Pages, by creating a `_redirects` file in your output directory. Pages currently offers limited support for advanced redirects. More support will be added in the future. For a list of support types, refer to the [Redirects documentaion](/pages/platform/redirects/).
 
 {{<Aside type="note">}}
 
-A project is limited to 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same source path, the topmost redirect is applied. 
+A project is limited to {{<snippet id="cf-pages-limits-redirects-long">}}. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same source path, the topmost redirect is applied.
 
 Make sure that static redirects are before dynamic redirects in your `_redirects` file.
 
 {{</Aside>}}
 
-In addition to an `_redirects` file, Cloudflare also offers [Bulk Redirects (beta)](/pages/how-to/use-bulk-redirects/), which handles redirects that surpasses the 2,100 redirect rules limit set by Pages.
+In addition to an `_redirects` file, Cloudflare also offers [Bulk Redirects (beta)](/pages/how-to/use-bulk-redirects/), which handles redirects that surpasses the {{<snippet id="cf-pages-limits-redirects">}} redirect rules limit set by Pages.
 
 Your custom headers can also be moved into a `_headers` file in your output directory. It is important to note that custom headers defined in the `_headers` file are not currently applied to responses from Functions, even if the Function route matches the URL pattern. To learn more about handling headers, refer to [Headers](/pages/platform/headers/).
 
@@ -57,7 +57,7 @@ Your custom headers can also be moved into a `_headers` file in your output dire
 
 After you have recorded your **build command** and **build directory** in a separate location, remove everything else from your application, and push the new version of your project up to your git provider. Follow the [Get started guide](/pages/get-started/) to add your project to Cloudflare Pages, using the **build command** and **build directory** that you saved earlier.
 
-If you choose to use a custom domain for your Pages project, you can set it to the same custom domain as your currently deployed Workers application. Follow the steps for [adding a custom domain](/pages/get-started/#adding-a-custom-domain) to your Pages project. 
+If you choose to use a custom domain for your Pages project, you can set it to the same custom domain as your currently deployed Workers application. Follow the steps for [adding a custom domain](/pages/get-started/#adding-a-custom-domain) to your Pages project.
 
 {{<Aside type="note">}}
 
@@ -67,9 +67,9 @@ Before you deploy, you will need to delete your old Workers routes to start send
 
 ### Using Direct Upload
 
-If your Workers site has its custom build settings, you can bring your prebuilt assets to Pages with [Direct Uploads](/pages/platform/direct-upload/). In addition, you can serve your website's assets right to the Cloudflare edge network by either using the [Wrangler CLI](/workers/wrangler/get-started/) or the drag and drop option. 
+If your Workers site has its custom build settings, you can bring your prebuilt assets to Pages with [Direct Uploads](/pages/platform/direct-upload/). In addition, you can serve your website's assets right to the Cloudflare edge network by either using the [Wrangler CLI](/workers/wrangler/get-started/) or the drag and drop option.
 
-These options allow you to create and name a new project from the CLI or dashboard. After your project deployment is complete, you can set the custom domain by following the [adding a custom domain](/pages/get-started/#adding-a-custom-domain) steps to your Pages project. 
+These options allow you to create and name a new project from the CLI or dashboard. After your project deployment is complete, you can set the custom domain by following the [adding a custom domain](/pages/get-started/#adding-a-custom-domain) steps to your Pages project.
 
 ## Cleaning up your old application and assigning the domain
 

--- a/content/pages/platform/direct-upload.md
+++ b/content/pages/platform/direct-upload.md
@@ -9,13 +9,13 @@ Direct Uploads enable you to upload your prebuilt assets to the Pages platform a
 
 ## Upload methods
 
-After you have your prebuilt assets ready, there are two ways to begin uploading: 
+After you have your prebuilt assets ready, there are two ways to begin uploading:
 
 * [Wrangler](/pages/platform/direct-upload/#wrangler-cli).
 * [Drag and Drop](/pages/platform/direct-upload/#drag-and-drop).
 
 {{<Aside type= "note">}}
-  
+
 Within a Direct Uploads project, you can switch between creating deployments with either Wrangler or Drag and Drop. However, you cannot create deployments with Direct Uploads on a project that you created through Git integration on the dashboard. Only projects created with Direct Uploads can be updated with Direct Uploads.
 
 {{</Aside>}}
@@ -26,7 +26,7 @@ Below is the supported file types for each Direct Upload options:
 * Wrangler: A single folder of assets. (Zip files are not supported.)
 * Drag and Drop: A zip file or single folder of assets.
 
-## Wrangler CLI 
+## Wrangler CLI
 
 ### Set up Wrangler
 
@@ -40,7 +40,7 @@ Log in to Wrangler with the `wrangler login` command then run the following comm
 $ wrangler pages project create
 ```
 
-You will then be prompted to specify the project name. Your project will be served at `<PROJECT_NAME>.pages.dev` (or your project name plus a few random characters if your project name is already taken). You will also be prompted to specify your production branch. 
+You will then be prompted to specify the project name. Your project will be served at `<PROJECT_NAME>.pages.dev` (or your project name plus a few random characters if your project name is already taken). You will also be prompted to specify your production branch.
 
 Subsequent deployments will reuse both of these values (saved in your `node_modules/.cache/wrangler` folder).
 
@@ -54,20 +54,20 @@ $ wrangler pages publish <OUTPUT_DIRECTORY>
 ```
 
 Your production deployment will be available at `<PROJECT_NAME>.pages.dev`.
- 
+
 {{<Aside type= "note">}}
 
-Before using the `wrangler publish` command, you will need to make sure you are inside the project. If not, you can also pass in the project path. 
+Before using the `wrangler publish` command, you will need to make sure you are inside the project. If not, you can also pass in the project path.
 
 {{</Aside>}}
- 
-However, to publish assets to a preview environment, run: 
+
+However, to publish assets to a preview environment, run:
 
 ```sh
 $ wrangler pages publish <OUTPUT_DIRECTORY> --branch=<BRANCH_NAME>
 ```
 
-For every branch you create, a branch alias will be available to you at `<BRANCH_NAME>.<PROJECT_NAME>.pages.dev`. 
+For every branch you create, a branch alias will be available to you at `<BRANCH_NAME>.<PROJECT_NAME>.pages.dev`.
 
 {{<Aside type= "note">}}
 
@@ -75,7 +75,7 @@ If you are in a Git workspace, Wrangler will automatically pull the branch infor
 
 {{</Aside>}}
 
-If you would like to streamline the project creation and asset publishing steps, you can also use the publish command to both create and publish assets at the same time. If you execute this command first, you will still be prompted to specify your project name and production branch. These values will still be cached for subsequent deployments as stated above. If the cache already exists and you would like to create a new project, you will need to run the [`create` command](#create-your-project). 
+If you would like to streamline the project creation and asset publishing steps, you can also use the publish command to both create and publish assets at the same time. If you execute this command first, you will still be prompted to specify your project name and production branch. These values will still be cached for subsequent deployments as stated above. If the cache already exists and you would like to create a new project, you will need to run the [`create` command](#create-your-project).
 
 #### Other useful commands
 
@@ -91,7 +91,7 @@ If you would like to use Wrangler to obtain a list of all unique preview URLs fo
 $ wrangler pages deployment list
 ```
 
-For step-by-step directions on how to use Wrangler and continuous integration tools like GitHub Actions, Circle CI, and Travis CI together for continuous deployment, refer to [Use Direct Upload with continuous integration](/pages/how-to/use-direct-upload-with-continuous-integration/). 
+For step-by-step directions on how to use Wrangler and continuous integration tools like GitHub Actions, Circle CI, and Travis CI together for continuous deployment, refer to [Use Direct Upload with continuous integration](/pages/how-to/use-direct-upload-with-continuous-integration/).
 
 ## Drag and drop
 
@@ -101,13 +101,13 @@ To deploy with drag and drop:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login).
 2. In **Account Home**, select your account > **Pages**.
-3. Select **Create a project** > **Direct Upload** > enter your project name in the provided field > **Create project**. 
+3. Select **Create a project** > **Direct Upload** > enter your project name in the provided field > **Create project**.
 
-Your project will be served from `<PROJECT_NAME>.pages.dev`. Next drag and drop your build output directory into the uploading frame. Once your files have been successfully uploaded, select **Save and Deploy** and continue to your newly deployed project. 
+Your project will be served from `<PROJECT_NAME>.pages.dev`. Next drag and drop your build output directory into the uploading frame. Once your files have been successfully uploaded, select **Save and Deploy** and continue to your newly deployed project.
 
 #### Create a new deployment
 
-After you have your project created, select **Create a new deployment** to begin a new version of your site. Next, choose whether your new deployment will be made to your production or preview environment. If choosing preview, you can create a new deployment branch or enter an existing one. 
+After you have your project created, select **Create a new deployment** to begin a new version of your site. Next, choose whether your new deployment will be made to your production or preview environment. If choosing preview, you can create a new deployment branch or enter an existing one.
 
 ## Troubleshoot
 
@@ -115,10 +115,10 @@ After you have your project created, select **Create a new deployment** to begin
 
 Regarding file count:
 
-* For Wrangler uploads, there is a 20,000 file limit.
-* For Drag and Drop uploads, there is a 1,000 file limit.
+* For Wrangler uploads, there is a {{<snippet id="cf-pages-limits-file-count">}} file limit.
+* For Drag and Drop uploads, there is a {{<snippet id="cf-pages-limits-drag-and-drop-file-count">}} file limit.
 
-On both upload methods, there is a 25 MiB limit in place for individual file size. 
+On both upload methods, there is a {{<snippet id="cf-pages-limits-file-size">}} limit in place for individual file size.
 
 
 If using the Drag and Drop method, a red warning symbol will appear next to an asset if too large and thus unsuccessfully uploaded. In this case, you may choose to delete that asset but you cannot replace it. In order to do so, you must reupload the entire project.

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -56,7 +56,7 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{</table-wrap>}}
 
-A project is limited to 100 header rules. Each line in the `_headers` file has a 1,000 character limit. The entire line, including spacing, header name, and value, counts towards this limit.
+A project is limited to {{<snippet id="cf-pages-limits-headers">}} header rules. Each line in the `_headers` file has a {{<snippet id="cf-pages-limits-headers-char-limit">}} character limit. The entire line, including spacing, header name, and value, counts towards this limit.
 
 If a header is applied twice in the `_headers` file, the values are joined with a comma separator. Headers defined in the `_headers` file override what Cloudflare Pages ordinarily sends, so be aware when setting security headers. Cloudflare reserves the right to attach new headers to Pages projects at any time in order to improve performance or harden the security of your deployments.
 

--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -9,7 +9,7 @@ Below are limits observed by the Cloudflare Free plan. For more details on remov
 
 {{<Aside type="note">}}
 
-We want to encourage you to build any application you can dream up, and realize that doesn't always fit within our limits. 
+We want to encourage you to build any application you can dream up, and realize that doesn't always fit within our limits.
 
 To increase any of our limits, [please fill out our form!](https://forms.gle/ukpeZVLWLnKeixDu7)
 
@@ -27,15 +27,15 @@ A Cloudflare Pages project can be attached to a maximum of ten (10) custom domai
 
 ## Files
 
-Pages uploads each file on your site to Cloudflare's globally distributed network to deliver a low latency experience to every user that visits your site. Cloudflare Pages sites can contain up to 20,000 files.
+Pages uploads each file on your site to Cloudflare's globally distributed network to deliver a low latency experience to every user that visits your site. Cloudflare Pages sites can contain up to {{<snippet id="cf-pages-limits-file-count">}} files.
 
 ## File size
 
-The maximum file size for a single Cloudflare Pages site asset is 25 MiB.
+The maximum file size for a single Cloudflare Pages site asset is {{<snippet id="cf-pages-limits-file-size">}}.
 
 ## Headers
 
-A `_headers` file can have a maximum of 100 header rules.
+A `_headers` file can have a maximum of {{<snippet id="cf-pages-limits-headers">}} header rules.
 
 ## Preview deployments
 
@@ -43,7 +43,7 @@ You can have an unlimited number of [preview deployments](/pages/platform/previe
 
 ## Redirects
 
-A `_redirects` file can have a maximum of 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have a need for more than the `_redirects` file supports.
+A `_redirects` file can have a maximum of {{<snippet id="cf-pages-limits-redirects-long">}}. It is recommended to use [Bulk Redirects](/pages/how-to/use-bulk-redirects/) when you have a need for more than the `_redirects` file supports.
 
 ## Users
 
@@ -51,6 +51,6 @@ Your Pages site can be managed by an unlimited number of users via the Cloudflar
 
 ## Sites
 
-Cloudflare Pages supports deploying 100 sites to your account. If you need to raise this limit, contact your Cloudflare account team.
+Cloudflare Pages supports deploying {{<snippet id="cf-pages-limits-projects">}} sites to your account. If you need to raise this limit, contact your Cloudflare account team.
 
 In order to protect against abuse of the service, Cloudflare may temporarily disable your ability to create new Pages projects, if you are deploying a large number of applications in a short amount of time. Email workers-support@cloudflare.com if you need this restriction removed.

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -35,7 +35,7 @@ filename: _redirects
 /products/:code/:name /products?code=:code&name=:name
 ```
 
-A project is limited to 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
+A project is limited to {{<snippet id="cf-pages-limits-redirects-long">}}. Each redirect declaration has a 1,000-character limit. Malformed definitions are ignored. If there are multiple redirects for the same `source` path, the topmost redirect is applied.
 
 {{<Aside type= "note">}}
 

--- a/layouts/shortcodes/snippet.html
+++ b/layouts/shortcodes/snippet.html
@@ -1,0 +1,23 @@
+{{- $id := .Get "id" -}}
+
+<!-- Pages -->
+{{ if (eq $id "cf-pages-limits-redirects-long") }}
+2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects
+{{ else if (eq $id "cf-pages-limits-redirects-andor") }}
+2,000 static redirects and/or 100 dynamic redirects
+{{ else if (eq $id "cf-pages-limits-redirects") }}
+2,100
+{{ else if (eq $id "cf-pages-limits-headers") }}
+100
+{{ else if (eq $id "cf-pages-limits-headers-char-limit") }}
+1,000
+{{ else if (eq $id "cf-pages-limits-file-size") }}
+25 MiB
+{{ else if (eq $id "cf-pages-limits-file-count") }}
+20,000
+{{ else if (eq $id "cf-pages-limits-drag-and-drop-file-count") }}
+1,000
+{{ else if (eq $id "cf-pages-limits-projects") }}
+100
+
+{{ end }}


### PR DESCRIPTION
Products have a lot of limits. These limits are referred to all over the place which creates a problem... when we up (or remove) a limit, updating all the instances is often hard to do. This leads to there being different limits listed on different pages.

This has bugged me for a while as we've fixed multiple occurrences of this in the Pages docs. So, I wanted to solve it!

Introducing: Snippets

These are as you'd expect, little snippets of text that we can use all over the doc. This means we have a single source of truth rather than multiple. I have updated the Pages docs to use these and I'd encourage other teams to adopt them too!

(this even fixed a case where a limit was outdated, great way to show why this is needed)

Example pages:
- https://walshy-snippets.cloudflare-docs-7ou.pages.dev/pages/how-to/use-bulk-redirects/
- https://walshy-snippets.cloudflare-docs-7ou.pages.dev/pages/platform/limits/