### PR TITLE
[Docs site] Fix active tab highlighting for non-code how-tos

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -194,7 +194,7 @@ export function activeTab() {
       for (var i = 0; i < tabs.length; i++) {
         (tabs[i] as HTMLElement).addEventListener("click", function name() {
           let current = block.querySelector(`.active`);
-
+          console.log(current)
           current.classList.remove("active");
           this.classList.add("active");
         });

--- a/assets/events.ts
+++ b/assets/events.ts
@@ -194,7 +194,6 @@ export function activeTab() {
       for (var i = 0; i < tabs.length; i++) {
         (tabs[i] as HTMLElement).addEventListener("click", function name() {
           let current = block.querySelector(`.active`);
-          console.log(current)
           current.classList.remove("active");
           this.classList.add("active");
         });

--- a/content/load-balancing/how-to/create-load-balancer.md
+++ b/content/load-balancing/how-to/create-load-balancer.md
@@ -12,13 +12,18 @@ For more details about load balancers, refer to [Load balancers](/load-balancing
 
 ## Create a load balancer
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 {{<render file="_load-balancer-create.md">}}
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 {{<render file="_load-balancer-create-api.md">}}
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ### Sharing your load balancer with other sites
 
@@ -30,18 +35,25 @@ You can also configure separate load balancers for each domain and reuse monitor
 
 ## Edit a load balancer
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To edit a load balancer in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
 2.  On a specific load balancer, click **Edit**.
 3.  While going through the [creation workflow](#create-a-load-balancer), update settings as needed.
 4.  On the **Review** step, click **Save**.
-
-### Via the API
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
+When you edit a load balancer with the API, your request type depends on how much you want to edit.
 
 To update specific settings without having to resubmit the entire configuration, use a [PATCH](https://api.cloudflare.com/#load-balancers-patch-load-balancer) request. For broader changes, use a [PUT](https://api.cloudflare.com/#load-balancers-update-load-balancer) request.
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
@@ -49,13 +61,18 @@ To update specific settings without having to resubmit the entire configuration,
 
 If you delete or disable a load balancer, your origin's response to requests will depend on your [existing DNS records](/load-balancing/reference/dns-records/#disabling-a-load-balancer).
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To delete a load balancer in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
 2.  On a specific load balancer, click **Delete**.
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 To delete a load balancer using the API, send a [DELETE](https://api.cloudflare.com/#load-balancers-delete-load-balancer) request.
+ 
+{{</tab>}}
+{{</tabs>}}

--- a/content/load-balancing/how-to/create-monitor.md
+++ b/content/load-balancing/how-to/create-monitor.md
@@ -14,17 +14,18 @@ For more details about monitors, refer to [Monitors](/load-balancing/understand-
 
 ## Create a monitor
 
-### Via the dashboard
-
-#### Set up the monitor
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
+**Set up the monitor**
 
 {{<render file="_monitor-create.md">}}
 
-#### Prepare your servers
+**Prepare your servers**
 
 {{<render file="_monitor-prepare-server.md">}}
 
-#### Attach the monitor to a pool
+**Attach the monitor to a pool**
 
 Once your monitor is created, you need to attach it to an origin pool:
 
@@ -41,29 +42,32 @@ Once your monitor is created, you need to attach it to an origin pool:
     - **Notification E-mail:** Contains email addresses that receive notifications (individual, mailing list address, PagerDuty address).
 
 5.  Click **Save**. The status of your health check will be _unknown_ until the results of the first check are available.
-
----
-
-### Via the API
-
-#### Set up the monitor
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
+**Set up the monitor**
 
 {{<render file="_monitor-create-api.md">}}
 
-#### Prepare your servers
+**Prepare your servers**
 
 {{<render file="_monitor-prepare-server.md">}}
 
-#### Attach the monitor to a pool
+**Attach the monitor to a pool**
 
 Once your monitor is created, save its `id` property. Include this value in the `monitor` parameter when [creating your pool](/load-balancing/how-to/create-pool/#via-the-api).
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
 ## Edit a monitor
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To edit a monitor in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
@@ -71,23 +75,34 @@ To edit a monitor in the dashboard:
 3.  On a specific monitor, click **Edit**.
 4.  Update settings as needed.
 5.  Click **Save**.
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
 
-### Via the API
-
+When you edit a monitor with the API, your request type depends on how much you want to edit.
+ 
 To update specific settings without having to resubmit the entire configuration, use a [PATCH](https://api.cloudflare.com/#account-load-balancer-monitors-patch-monitor) request. For broader changes, use a [PUT](https://api.cloudflare.com/#account-load-balancer-monitors-update-monitor) request.
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
 ## Delete a monitor
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To delete a monitor in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
 2.  Click **Manage Monitors**.
 3.  On a specific monitor, click **Delete**.
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 To delete a monitor using the API, send a [DELETE](https://api.cloudflare.com/#account-load-balancer-monitors-delete-monitor) request.
+ 
+{{</tab>}}
+{{</tabs>}}

--- a/content/load-balancing/how-to/create-monitor.md
+++ b/content/load-balancing/how-to/create-monitor.md
@@ -50,6 +50,7 @@ Once your monitor is created, you need to attach it to an origin pool:
 
 {{<render file="_monitor-create-api.md">}}
 
+
 **Prepare your servers**
 
 {{<render file="_monitor-prepare-server.md">}}

--- a/content/load-balancing/how-to/create-pool.md
+++ b/content/load-balancing/how-to/create-pool.md
@@ -16,20 +16,26 @@ For more background information on pools, refer to [Origin pools](/load-balancin
 
 ## Create a pool
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 {{<render file="_pool-create.md">}}
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 {{<render file="_pool-create-api.md">}}
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
 ## Edit a pool
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To edit a pool in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
@@ -37,23 +43,34 @@ To edit a pool in the dashboard:
 3.  On a specific pool, click **Edit**.
 4.  Update settings as needed.
 5.  Click **Save**.
-
-### Via the API
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
+When you edit a pool with the API, your request type depends on how much you want to edit.
 
 To update specific settings without having to resubmit the entire configuration, use a [PATCH](https://api.cloudflare.com/#account-load-balancer-pools-patch-pool) request. For broader changes, use a [PUT](https://api.cloudflare.com/#account-load-balancer-pools-update-pool) request.
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
 ## Delete a pool
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To delete a pool in the dashboard:
 
 1.  Go to **Traffic** > **Load Balancing**.
 2.  Click **Manage Pools**.
 3.  On a specific pool, click **Delete**.
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 To delete a pool using the API, send a [DELETE](https://api.cloudflare.com/#account-load-balancer-pools-delete-pool) request.
+ 
+{{</tab>}}
+{{</tabs>}}

--- a/content/web3/how-to/manage-gateways.md
+++ b/content/web3/how-to/manage-gateways.md
@@ -10,15 +10,20 @@ A Cloudflare Web3 gateway provides HTTP-accessible interfaces to various Web3 ne
 
 ## Create a gateway
 
-{{<render file="_post-creation-steps.md">}}
-
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 {{<render file="_create-gateway-dashboard.md">}}
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 {{<render file="_create-gateway-api.md">}}
+ 
+{{</tab>}}
+{{</tabs>}}
+
+{{<render file="_post-creation-steps.md">}}
 
 ---
 
@@ -28,8 +33,9 @@ Once you have [created a gateway](#create-a-gateway), you can only edit the **Ga
 
 If you need to edit other fields, [delete the gateway](#delete-a-gateway) and create a new one.
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To edit a gateway using the dashboard:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
@@ -38,10 +44,14 @@ To edit a gateway using the dashboard:
 4. On a specific gateway, click **Edit**.
 5. Update the **Gateway Description** and — if editing an **IPFS** gateway — the value for the [DNSLink](/web3/ipfs-gateway/concepts/dnslink/).
 6. Click **Reapply**.
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 To edit specific settings for a gateway, use a [PATCH](https://api.cloudflare.com/#web3-hostname-edit-web3-hostname) request.
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
@@ -49,18 +59,23 @@ To edit specific settings for a gateway, use a [PATCH](https://api.cloudflare.co
 
 When your gateway is stuck in an **Error** [status](/web3/reference/gateway-status/), you should try refreshing the gateway, which attempts to re-create the associated DNS records for the hostname.
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To refresh a gateway using the dashboard:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
 2. Select your account and website.
 3. Go to **Web3**.
 4. On a specific gateway, click the dropdown then **Refresh**.
-
-### Via the API
-
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
+ 
 To refresh a gateway using the API, send a [PATCH](https://api.cloudflare.com/#web3-hostname-edit-web3-hostname) request with an empty request body.
+ 
+{{</tab>}}
+{{</tabs>}}
 
 ---
 
@@ -68,8 +83,9 @@ To refresh a gateway using the API, send a [PATCH](https://api.cloudflare.com/#w
 
 When you delete a gateway, Cloudflare will automatically remove all associated hostname DNS records. This action will impact your traffic and cannot be undone.
 
-### Via the dashboard
-
+{{<tabs labels="Dashboard | API">}}
+{{<tab label="dashboard" no-code="true">}}
+ 
 To delete a gateway using the dashboard: 
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
@@ -77,7 +93,11 @@ To delete a gateway using the dashboard:
 3. Go to **Web3**.
 4. On a specific gateway, click the dropdown then **Remove**.
 5. Click **Delete hostname**.
-
-### Via the API
+ 
+{{</tab>}}
+{{<tab label="api" no-code="true">}}
 
 To delete a gateway using the API, send a [DELETE](https://api.cloudflare.com/#web3-hostname-delete-web3-hostname) request.
+ 
+{{</tab>}}
+{{</tabs>}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -5,7 +5,6 @@
     <ul class="tab-active" block-id="{{$unique_id}}">
       {{ range $idx, $txt := $labels }} {{- $link := replace $txt "/" "-"}}
       <li class="tab-label-wrapper">
-
         {{ if or (eq $link "js") }}
         <a class="tab-label active" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
           <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
@@ -73,7 +72,7 @@
           </svg>ES Modules</a
         >
         {{ else }}
-        <a class="tab-label" href="#" data-link="tab-{{lower $link}}" data-id="{{lower $unique_id}}">
+        <a class="tab-label {{ if eq $idx 0 }} active {{ end }}" href="#" data-link="tab-{{lower $link}}" data-id="{{lower $unique_id}}">
           {{$link}}</a>
         {{ end }}
       </li>

--- a/static/style.css
+++ b/static/style.css
@@ -5107,7 +5107,7 @@ pre {
 }
 
 [theme="dark"] .tabs > ul {
-  background-color: rgb(var(--accent-color-rgb));
+  background-color: rgba(var(--color-rgb),.1)
 }
 
 .tabs > ul > li {
@@ -5214,11 +5214,12 @@ pre {
   padding: 1em .75em .75em .5em;
   background: linear-gradient(var(--background-color),
     rgba(var(--background-color-rgb)));
-  border: 1px solid #242628;
+  border: 1px solid rgb(216 216 218);
 }
 
 [theme="dark"] .noCodeTab {
-  border: 1px solid #f3f3f4;
+  border: 1px solid #404242;
+  border-top: none;
   background-color: rgb(var(--background-color-rgb));
 }
 


### PR DESCRIPTION
Also, apply tab structure to Web3 and Load Balancing how-tos.

See https://active-tab-highlighting.cloudflare-docs-7ou.pages.dev/dns/manage-dns-records/how-to/create-dns-records/ for an example.