### PR TITLE
[Pages] Update CircleCI config in direct upload docs

### DIFF
--- a/content/pages/how-to/use-direct-upload-with-continuous-integration.md
+++ b/content/pages/how-to/use-direct-upload-with-continuous-integration.md
@@ -128,10 +128,7 @@ version: 2.1
 jobs:
  Publish-to-Pages:
    docker:
-     - image: cimg/node:18
-     environment:
-        CLOUDFLARE_ACCOUNT_ID: $CLOUDFLARE_ACCOUNT_ID
-        CLOUDFLARE_API_TOKEN: $CLOUDFLARE_API_TOKEN
+     - image: cimg/node:18.7.0
 
    steps:
      - checkout


### PR DESCRIPTION
The current CircleCI config fails because of the environment variables are incorrectly overridden and the docker image version is invalid

Co-authored with @GregBrimble @jahands @CarmenPopoviciu @evanderkoogh 