### PR TITLE
[Docs] Add new VSCode snippet for tabs

### DIFF
--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -100,4 +100,23 @@
         "description": "Includes content from a partial in the current document",
         "scope": "markdown"
     },
+    "Adds two tabs for dashboard/API instructions": {
+        "prefix": ["addtabs", "twotabs"],
+        "body": [
+            "{{<tabs labels=\"Dashboard | API\">}}",
+            "{{<tab label=\"dashboard\" no-code=\"true\">}}",
+            "",
+            "$0",
+            "",
+            "{{</tab>}}",
+            "{{<tab label=\"api\" no-code=\"true\">}}",
+            "",
+            "",
+            "",
+            "{{</tab>}}",
+            "{{</tabs>}}",
+        ],
+        "description": "Adds a new tabs section with two tabs for dashboard and API instructions",
+        "scope": "markdown"
+    },
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Prefixes | Description
 `metatitle` | Inserts meta title fields in existing Markdown header. Used to complement a full file header.
 `headerpartialfile` | Inserts a header for a partial Markdown file.
 `partialinclude` or `renderpartial` | Inserts a `render` shortcode to include content from a partial in the current document.
+`twotabs` or `addtabs` | Inserts a new tabs section with two tabs for dashboard and API instructions.
 
 Triggering one of the available snippets will insert their body content at the current cursor position.
 


### PR DESCRIPTION
Adds a new snippet for the tabs-related shortcodes. You can trigger the new snippet using one of the following prefixes: `twotabs` or `addtabs`.