### PR TITLE
Remove note about GCS retention policy

### DIFF
--- a/content/logs/get-started/enable-destinations/google-cloud-storage/index.md
+++ b/content/logs/get-started/enable-destinations/google-cloud-storage/index.md
@@ -58,11 +58,5 @@ To enable Logpush to GCS:
 2.  In **Storage** > **Browser** > **Bucket** > **Permissions**, add the member `logpush@cloudflare-data.iam.gserviceaccount.com` with `Storage Object Admin` permission.
 
 {{<Aside type="note" header="Note">}}
-
-Logpush will not work if there is a retention policy on your bucket because this policy prevents overwrites. If you are using the policy to enforce deletion, you can use a lifecycle rule instead. Refer to [object lifecycle management from GCS](https://cloud.google.com/storage/docs/lifecycle).
-
-{{</Aside>}}
-
-{{<Aside type="note" header="Note">}}
 To analyze your Cloudflare Logs data using the Google Cloud Platform (GCP), follow the steps in the [Google Cloud Analytics integration page](/fundamentals/data-products/analytics-integrations/google-cloud/).
 {{</Aside>}}


### PR DESCRIPTION
With Logpush v2, it's no longer a requirement that buckets do not have a retention policy