### PR TITLE
[Docs] Fix space issue in Overview page footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
         />
       </svg>
       <span class="DocsFooter--content-additional-wrapper">
-        Learn more at the {{- with .File -}} {{- $url := (printf
+        Learn more at the {{ with .File }} {{- $url := (printf
         "https://www.cloudflare.com/learning/") -}} {{- partial "external.link"
         (dict "text" "Learning Center" "url" $url) }} {{- end -}}
       </span>
@@ -52,7 +52,7 @@
       </svg>
 
       <span class="DocsFooter--content-additional-wrapper">
-        Engage with the community on the {{- with .File -}} {{- $url := (printf
+        Engage with the community on the {{ with .File }} {{- $url := (printf
         "https://community.cloudflare.com/") -}} {{- partial "external.link"
         (dict "text" "Community Forum" "url" $url) }} {{- end -}}
       </span>
@@ -73,7 +73,7 @@
       </svg>
 
       <span class="DocsFooter--content-additional-wrapper">
-        Get answers to common questions and issues from the {{- with .File -}}
+        Get answers to common questions and issues from the {{ with .File }}
         {{- $url := (printf "https://support.cloudflare.com/") -}} {{- partial
         "external.link" (dict "text" "Help Center" "url" $url) }} {{- end -}}
       </span>


### PR DESCRIPTION
Fix a small issue in the footer of Overview pages, where there's a space in the footer links themselves, instead of right before the links.

![image](https://user-images.githubusercontent.com/680496/187217614-a02cd718-1dbe-4b01-8cc9-661ed4e715fa.png)

Context on the proposed change: [Whitespace](https://gohugo.io/templates/introduction/#whitespace) (Hugo documentation).