### PR TITLE
Update false-negative.md

### DIFF
--- a/content/ddos-protection/managed-rulesets/adjust-rules/false-negative.md
+++ b/content/ddos-protection/managed-rulesets/adjust-rules/false-negative.md
@@ -49,7 +49,7 @@ If you are experiencing a DDoS attack detected by Cloudflare and the applied mit
 
     </div></details>
 
-3. Scroll down to the **Top events by source** >> **HTTP DDoS rules**.
+3. Scroll down to **Top events by source** > **HTTP DDoS rules**.
 
 4. Copy the rule name.
 
@@ -61,7 +61,7 @@ If you are experiencing a DDoS attack detected by Cloudflare and the applied mit
 
 8. Click **Next** and then **Save**.
 
-_\* Available in the Network Analytics v2 Logs or API. Not available in Network Analytics dashboard yet._
+_\* Available in the Network Analytics v2 Logs or API. Not available in the Network Analytics dashboard yet._
 
 Once saved, the rule takes effect within one or two minutes. The rule adjustment should provide immediate remedy, which you can view in the [analytics dashboard](/ddos-protection/reference/analytics/).
 

--- a/content/ddos-protection/managed-rulesets/adjust-rules/false-negative.md
+++ b/content/ddos-protection/managed-rulesets/adjust-rules/false-negative.md
@@ -49,21 +49,19 @@ If you are experiencing a DDoS attack detected by Cloudflare and the applied mit
 
     </div></details>
 
-3. Scroll down to the **Activity log**.
+3. Scroll down to the **Top events by source** >> **HTTP DDoS rules**.
 
-4. Click **Edit columns** and enable **Rule ID**\*.
+4. Copy the rule name.
 
-5. Copy the rule ID from one of the DDoS log entries.
+5. Navigate to **Security** > **DDoS** and click **Configure** next to the Managed Ruleset containing the rule you will adjust.
 
-6. Navigate to **Security** > **DDoS** and click **Configure** next to the Managed Ruleset containing the rule you will adjust.
+6. Click **Browse rules** and paste the Rule ID in the search field.
 
-7. Click **Browse rules** and paste the Rule ID in the search field.
+7. Change the rule’s **Action** to _Block_.
 
-8. Change the rule’s **Action** to _Block_.
+8. Click **Next** and then **Save**.
 
-9. Click **Next** and then **Save**.
-
-_\* Not available in Network Analytics dashboard yet._
+_\* Available in the Network Analytics v2 Logs or API. Not available in Network Analytics dashboard yet._
 
 Once saved, the rule takes effect within one or two minutes. The rule adjustment should provide immediate remedy, which you can view in the [analytics dashboard](/ddos-protection/reference/analytics/).
 


### PR DESCRIPTION
revised the guide to reflect that the HTTP DDoS Managed rule name appears now in the Top-N section of the Security Overview dashboard.