### PR TITLE
Improve clarity about startup script in GCP deployment guide

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/deployment-guides/google-cloud-platform.md
+++ b/content/cloudflare-one/connections/connect-apps/deployment-guides/google-cloud-platform.md
@@ -39,7 +39,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
     - **Firewall:** Allow HTTP/HTTPS traffic (if necessary)
     - **Networking, Disks, Security, Management, Sole-Tenancy:** Management
 
-1.  Add a startup script for testing access. This can be added in the Management section of the Advanced options. Here is an example:
+1.  In the **Management** section, add a startup script for testing access. Here is an example:
 
     ```sh
     #!/bin/bash

--- a/content/cloudflare-one/connections/connect-apps/deployment-guides/google-cloud-platform.md
+++ b/content/cloudflare-one/connections/connect-apps/deployment-guides/google-cloud-platform.md
@@ -39,7 +39,7 @@ To start, you will need to navigate to the Google Cloud Console and create a pro
     - **Firewall:** Allow HTTP/HTTPS traffic (if necessary)
     - **Networking, Disks, Security, Management, Sole-Tenancy:** Management
 
-1.  Add a startup script for testing access. Here is an example:
+1.  Add a startup script for testing access. This can be added in the Management section of the Advanced options. Here is an example:
 
     ```sh
     #!/bin/bash


### PR DESCRIPTION
While the guide gives a startup script for testing purposes it was unclear where it can be inputted