### PR TITLE
[Vite Deploy] Update to correct build command

### DIFF
--- a/content/pages/framework-guides/deploy-a-vite3-project.md
+++ b/content/pages/framework-guides/deploy-a-vite3-project.md
@@ -46,7 +46,7 @@ To deploy your project with Pages:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **Pages** > **Create a project** > **Connect to git**.
 3. Select your new GitHub repository.
-4. In the **Set up builds and deployments**, set `npm run dev` as the **Build command**, and `dist` as the **Build output directory**.
+4. In the **Set up builds and deployments**, set `npm run build` as the **Build command**, and `dist` as the **Build output directory**.
 5. Select **Environment variables (advanced)** > **+ Add variable** > configure a `NODE_VERSION` variable with a value of any version of Node greater than `14.18` -- this example uses `16`:
 
 After completing configuration, select **Save and Deploy**.


### PR DESCRIPTION
How to reproduce issue:

Deploy a standard vite (react) project from a GitHub repo. Set `npm run dev` as the Build Command as per existing documentation. The build will stall as the build command started a server on Cloudflare build machine instead of building the actual vite (react) app.

Setting the build command as `npm run build` solves the issue for me.

The Github repo of the Vite project I was trying to deploy: https://github.com/lonewanderer27/h_and_f_commissions 