### PR TITLE
Update docs to clarify how to set GOP duration for live streams

### DIFF
--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -71,13 +71,13 @@ curl -X DELETE \ -H "Authorization: Bearer <API_TOKEN>" \https://api.cloudflare.
 
 ### Requirements
 
-- Stream Live currently only supports HLS (HTTP Live Streaming), and recordings are only kept for the last seven days of the stream.
-- Stream Live requires input GOP duration (keyframe interval) to be between 4 to 10 seconds.
-- Closed GOPs required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoder software such as OBS.
+- You must set [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) to be between 2 to 10 seconds. The default in most encoding software, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream.
+- Closed GOPs required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoding software such as OBS.
 - Stream Live only supports H.264 video and AAC audio codecs as inputs. This requirement does not apply to inputs that are relayed to Stream Connect outputs. Stream Live supports ADTS but does not presently support LATM.
 - Clients must be configured to reconnect when a disconnection occurs. Stream Live is designed to handle reconnection gracefully by continuing the live stream.
 
 ### Known limitations:
 
+- Stream Live currently only supports HLS (HTTP Live Streaming), and recordings are only kept for the last seven days of the stream.
 - Watermarks cannot yet be used with live videos.
 - If a live video exceeds seven days in length, the recording will be truncated to seven days and not be viewable.


### PR DESCRIPTION
- We now support a minimum GOP duration of 2 seconds (previously 4)
- Add docs to explain tradeoffs, and why one might want to set this value higher or lower
- Move limitations to limitations section, fix a typo