### PR TITLE
[Docs] Fix margin of last element in no-code tab

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5223,6 +5223,14 @@ pre {
   background-color: rgb(var(--background-color-rgb));
 }
 
+.noCodeTab > pre {
+  margin-bottom: 2em;
+}
+
+.noCodeTab > *:last-child {
+  margin-bottom: 0;
+}
+
 .noCodeLabel {
   font-family: var(--sans-serif-font-family);
 }


### PR DESCRIPTION
Includes the following changes:
* Restores the bottom margin of `pre` elements inside a no-code tab.
* Removes the bottom margin of the last element in a no-code tab (regardless of the element type).

Examples:
https://pedro-2022-08-30-fix-tabs-ma.cloudflare-docs-7ou.pages.dev/images/cloudflare-images/transform/delete-images/
https://pedro-2022-08-30-fix-tabs-ma.cloudflare-docs-7ou.pages.dev/images/cloudflare-images/transform/resize-images/
https://pedro-2022-08-30-fix-tabs-ma.cloudflare-docs-7ou.pages.dev/images/cloudflare-images/transform/delete-variants/
https://pedro-2022-08-30-fix-tabs-ma.cloudflare-docs-7ou.pages.dev/load-balancing/get-started/

Also, this change doesn't break code-based tabs. For example:
https://pedro-2022-08-30-fix-tabs-ma.cloudflare-docs-7ou.pages.dev/workers/examples/images-workers/
