### PR TITLE
[Docs] Fix text color in no-code tabs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5215,6 +5215,7 @@ pre {
   background: linear-gradient(var(--background-color),
     rgba(var(--background-color-rgb)));
   border: 1px solid rgb(216 216 218);
+  color: inherit;
 }
 
 [theme="dark"] .noCodeTab {


### PR DESCRIPTION
Text in light mode had a blue-ish tone, and in dark mode the text in an aside was unreadable.

![image](https://user-images.githubusercontent.com/680496/187692561-a4331b5f-9020-4489-8129-a5d9aba26e3a.png)

![image](https://user-images.githubusercontent.com/680496/187692975-20b42c85-b151-40ac-951a-a64f34744649.png)

No impact on code-based tabs:
https://pedro-2022-08-31-fix-text-co.cloudflare-docs-7ou.pages.dev/workers/examples/images-workers/

