### PR TITLE
[Docs] Fix typographical error

### DIFF
--- a/content/stream/viewing-videos/using-own-player/_index.md
+++ b/content/stream/viewing-videos/using-own-player/_index.md
@@ -86,4 +86,4 @@ We recommend using [ffmpeg-kit](https://github.com/tanersener/ffmpeg-kit) as a c
 
 ## Limitations
 
-[Client-size Analytics](/stream/getting-analytics/#client-side-analytics) are not available if you use your own player.
+[Client-side Analytics](/stream/getting-analytics/#client-side-analytics) are not available if you use your own player.


### PR DESCRIPTION
Fixes the incorrectly named `Client-size Analytics` link to correctly read `Client-side Analytics` in the 'Use your own player' doc page.