### PR TITLE
[Docs] Update out of date astro deploy guide

### DIFF
--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -13,7 +13,7 @@ In this guide, you will create a new Astro application and deploy it using Cloud
 
 ## Setting up a new project
 
-Get a new Astro project up and running locally with our helpful `create-astro` CLI wizard!
+Get a new Astro project up and running locally with the helpful `create-astro` CLI wizard!
 
 ```sh
 $ npm create astro@latest

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -68,7 +68,7 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 {{<Aside type="warning" header="Important">}}
 
-Astro requires Node.js `v14.18.0` or higher to build successfully. You must expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `14` or greater.
+Cloudflare requires [node v16.13](https://miniflare.dev/get-started/cli#installation), which is a more recent version than Astro’s out-of-the-box minmimum. You can expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16.13` or greater and also check the version of node you’re using locally (`node -v`) matches the version you’re specifying in the environment variable.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -7,7 +7,7 @@ title: Deploy an Astro site
 
 [Astro](https://astro.build) Astro is an **all-in-one web framework** for building fast, **content-focused websites**. By default, Astro builds websites that have zero JavaScript runtime code.
 
-Check out the detailed [Why Astro](https://docs.astro.build/en/concepts/why-astro/) breakdown to learn more about what makes Astro special. ✨
+Visit the [Astro Docs](https://docs.astro.build/) to learn more about Astro or for any assistance with an Astro project.  
 
 In this guide, you will create a new Astro application and deploy it using Cloudflare Pages.
 

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -21,7 +21,8 @@ $ npm create astro@latest
 
 Astro will ask you which project type you would like to set up. Your answers will not affect the rest of this tutorial. Select an answer ideal for your project.
 
-Any issues, consult [Astro's docs](https://docs.astro.build/en/guides/deploy/cloudflare/)
+> **Note**
+> You can explore Astro's available templates at [astro.new](https://astro.new)
 
 
 {{<render file="_tutorials-before-you-start.md">}}

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -5,15 +5,15 @@ title: Deploy an Astro site
 
 # Deploy an Astro site
 
-[Astro](https://astro.build) Astro is an **all-in-one web framework** for building fast, **content-focused websites**. By default, Astro builds websites that have zero JavaScript runtime code.
+[Astro](https://astro.build) is an all-in-one web framework for building fast, content-focused websites. By default, Astro builds websites that have zero JavaScript runtime code.
 
-Visit the [Astro Docs](https://docs.astro.build/) to learn more about Astro or for any assistance with an Astro project.  
+Refer to the [Astro Docs](https://docs.astro.build/) to learn more about Astro or for assistance with an Astro project.  
 
 In this guide, you will create a new Astro application and deploy it using Cloudflare Pages.
 
 ## Setting up a new project
 
-Get a new Astro project up and running locally with the helpful `create-astro` CLI wizard!
+Create a new Astro project and run it locally with the `create-astro` CLI wizard:
 
 ```sh
 npm create astro@latest
@@ -21,8 +21,9 @@ npm create astro@latest
 
 Astro will ask you which project type you would like to set up. Your answers will not affect the rest of this tutorial. Select an answer ideal for your project.
 
-> **Note**
-> You can explore Astro's available templates at [astro.new](https://astro.new)
+{{<Aside type="note">}}
+Refer to Astro's available templates at [astro.new](https://astro.new).
+{{</Aside>}}
 
 
 {{<render file="_tutorials-before-you-start.md">}}
@@ -68,7 +69,7 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 {{<Aside type="warning" header="Important">}}
 
-Cloudflare requires [node v16.13](https://miniflare.dev/get-started/cli#installation), which is a more recent version than Astro’s out-of-the-box minmimum. You can expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16.13` or greater and also check the version of node you’re using locally (`node -v`) matches the version you’re specifying in the environment variable.
+Cloudflare requires [node v16.13](https://miniflare.dev/get-started/cli#installation), which is a more recent version than Astro’s out-of-the-box minmimum. Go to your **Pages** project > **Settings** > **Environment Variables (advanced)** and add a `NODE_VERSION` variable with a value of `16.13` or greater. Check the version of node you are using locally (by running `node -v`) matches the version you are specifying in the environment variable.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -5,26 +5,24 @@ title: Deploy an Astro site
 
 # Deploy an Astro site
 
-[Astro](https://astro.build) is a new static-site generator that allows you to build faster, SEO-friendly websites that use less client-side JavaScript code. By default, Astro builds websites that have zero JavaScript runtime code.
+[Astro](https://astro.build) Astro is an **all-in-one web framework** for building fast, **content-focused websites**. By default, Astro builds websites that have zero JavaScript runtime code.
+
+Check out the detailed [Why Astro](https://docs.astro.build/en/concepts/why-astro/) breakdown to learn more about what makes Astro special. ✨
 
 In this guide, you will create a new Astro application and deploy it using Cloudflare Pages.
 
-{{<Aside type="warning">}}
-
-At the time of publication, Astro is in early beta. Refer to the Astro [GitHub repository](https://github.com/snowpackjs/astro) to stay current with the project's status.
-
-{{</Aside>}}
-
 ## Setting up a new project
 
-Create a new project directory (for example, `astro-site`) and then initiate Astro's official setup tool by running [`npm init`](https://docs.npmjs.com/cli/v6/commands/npm-init) in your terminal inside that new `astro-site` directory:
+Get a new Astro project up and running locally with our helpful `create-astro` CLI wizard!
 
 ```sh
-$ mkdir astro-site && cd astro-site
-$ npm init astro
+$ npm create astro@latest
 ```
 
-During `init`, Astro will ask you which project type you would like to set up. Your answers will not affect the rest of this tutorial. Select an answer ideal for your project.
+Astro will ask you which project type you would like to set up. Your answers will not affect the rest of this tutorial. Select an answer ideal for your project.
+
+Any issues, consult [Astro's docs](https://docs.astro.build/en/guides/deploy/cloudflare/)
+
 
 {{<render file="_tutorials-before-you-start.md">}}
 
@@ -69,7 +67,7 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 {{<Aside type="warning" header="Important">}}
 
-Astro requires Node.js v14.x or later to build successfully. You must expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `14` or greater.
+Astro requires Node.js `v14.18.0` or higher to build successfully. You must expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `14` or greater.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -16,7 +16,7 @@ In this guide, you will create a new Astro application and deploy it using Cloud
 Get a new Astro project up and running locally with the helpful `create-astro` CLI wizard!
 
 ```sh
-$ npm create astro@latest
+npm create astro@latest
 ```
 
 Astro will ask you which project type you would like to set up. Your answers will not affect the rest of this tutorial. Select an answer ideal for your project.


### PR DESCRIPTION
## Changes
- Update the out of date docs for astro.
- Remove warning as astro is no more in early beta.
- Add a backlink to "**Deploying with Cloudflare Pages**" page