### PR TITLE
Update Direct Creator Upload docs with examples

### DIFF
--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -24,8 +24,9 @@ Use this if your users upload videos under 200MB, and you do not need to allow r
 
 ### Step 1: Generate a unique one-time upload URL
 
-[End-to-end code example on Stackblitz](https://workers.new/stream/upload/direct-creator-uploads)
-[API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
+- [End-to-end code example on Stackblitz](https://workers.new/stream/upload/direct-creator-uploads)
+- [API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
+
 
 ```bash
 ---

--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -6,92 +6,42 @@ weight: 4
 
 # Direct creator uploads
 
-Direct creator uploads allow users to upload videos without API tokens. A common place to
-use Direct creator uploads is on web apps, client side applications, or on mobile apps
-where users upload content directly to Stream.
+Direct creator uploads let your end users to upload videos directly to Cloudflare Stream, without exposing your API token to clients.
 
-{{<Aside>}}
+**Two options:**
 
-Pending uploads count towards your storage limit.
+1. For videos under 200MB, [generate URLs that accept simple HTTP POST requests](/stream/uploading-videos/direct-creator-uploads#basic-upload-flow-for-small-videos).
+2. For videos over 200MB, or if you need to allow users to resume uploads that may be interrupted by poor network connections or users closing apps while videos are still uploading, [generate URLs that use the TUS protocol](/stream/uploading-videos/direct-creator-uploads#tus).
 
-{{</Aside>}}
+### Example Apps
 
-## Generate a unique one-time upload URL
+- [Direct Creator Uploads (using simple POST requests)](https://workers.new/stream/upload/direct-creator-uploads)
+- [Direct Creator Uploads (using TUS for resumable, multi-part uploads)](https://workers.new/stream/upload/direct-creator-uploads-tus)
 
-To give users the ability to directly upload their videos, first generate and
-provide them with a unique one-time upload URL with the following API request.
+## Basic upload flow, for small videos
 
-To make API requests you will need your [Cloudflare API token](https://www.cloudflare.com/a/account/my-account) and your Cloudflare [account ID](https://www.cloudflare.com/a/overview/).
+Use this if your users upload videos under 200MB, and you do not need to allow resumable uploads.
 
-### Upload constraints
-
-There are several constraints you can enforce on your user's uploads through the
-body of the `POST` request:
-
-{{<definitions>}}
-
-- `maxDurationSeconds` {{<type>}}integer{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-
-  - Enforces the maximum duration in seconds for a video the user uploads. For direct uploads, Stream requires videos are at least 1 second in length, and restricts to a maximum of 6 hours. Therefore, this field must be greater than 1 and less than 21,600.
-
-- `expiry` {{<type>}}string (date){{</type>}} {{<prop-meta>}}default: now + 30 minutes{{</prop-meta>}}
-  - Optional string field that enforces the time after which the unique one-time upload URL is invalid. The time value must be formatted in RFC3339 layout and will be interpreted against UTC time zone. If an expiry is set, it must be no less than two minutes in the future, and not more than 6 hours in the future. If an expiry is not set, the upload URL will expire 30 minutes after it's creation.
-
-{{</definitions>}}
-
-Additionally, you can control security features through these fields:
-
-{{<definitions>}}
-
-- `requireSignedURLs` {{<type>}}boolean{{</type>}} {{<prop-meta>}}default: false{{</prop-meta>}}
-
-  - Limits the permission to view the video to only [signed URLs](/stream/viewing-videos/securing-your-stream/).
-
-- `allowedOrigins` {{<type>}}array of strings{{</type>}} {{<prop-meta>}}default: _empty_{{</prop-meta>}}
-
-  - Limit the domains this video can be embedded on. Learn more about [allowed origins](/stream/viewing-videos/securing-your-stream/).
-
-- `thumbnailTimestampPct` {{<type>}}float{{</type>}} {{<prop-meta>}}default: 0{{</prop-meta>}}
-
-  - Sets the timestamp location of [thumbnail](/stream/viewing-videos/displaying-thumbnails/) image to a percentage location of the video from 0 to 1.
-
-- `watermark` {{<type>}}string{{</type>}} {{<prop-meta>}}default: _none_{{</prop-meta>}}
-
-  - `uid` of the watermark profile to be included in this video. Video uploaded by the link will be [watermarks](/stream/edit-videos/applying-watermarks/) automatically.
-
-- `meta` {{<type>}}json map{{</type>}} {{<prop-meta>}}default: _none_{{</prop-meta>}}
-  - Set the video's `name` along with any other additional arbitrary keys for metadata to be stored.
-
-{{</definitions>}}
-
-## Using Basic Uploads
-
-If the uploads from your creators are under 200MB, you can use basic uploads. For videos over 200 MB, use TUS uploads (described later in this article.)
-
-The first step is to request a token by calling the `direct_upload` end point from your server:
+### Step 1: Generate a unique one-time upload URL
 
 ```bash
+---
+header: Request
+---
 curl -X POST \
  -H 'Authorization: Bearer <API_TOKEN>' \
 https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/direct_upload \
  --data '{
     "maxDurationSeconds": 3600,
-    "expiry": "2020-04-06T02:20:00Z",
-    "requireSignedURLs": true,
-    "allowedOrigins": ["example.com"],
-    "thumbnailTimestampPct": 0.568427,
-    "watermark": {
-        "uid": "<WATERMARK_UID>"
-    }
+    "expiry": "2020-04-06T02:20:00Z"
  }'
 ```
 
-### Example responses
-
-A successful response looks like:
-
 <!-- videodelivery.net is correct domain. See STREAM-4364 -->
 ```bash
+---
+header: Response
+---
 {
   "result": {
     "uploadURL": "https://upload.videodelivery.net/f65014bc6ff5419ea86e7972a047ba22",
@@ -103,148 +53,83 @@ A successful response looks like:
 }
 ```
 
-An unsuccessful response might look like:
+<!-- TODO: Make sure these are up-to-date, look at old content from this page -->
+[API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
 
-```bash
-{
-  "result": null,
-  "success": false,
-  "errors": [
-    {
-      "code": 10005,
-      "message": "Bad Request"
-    }
-  ],
-  "messages": [
-    {
-      "code": 10005,
-      "message": "required field maxDurationSeconds is missing"
-    }
-  ]
-}
-```
-
-The `uploadURL` provided in the `result` body of a successful request should be passed along to the end-user to make their upload request.
-
-The `uid` references the reserved media object's unique identifier and can be kept as a reference to query our [API](/stream/manage-video-library/searching/).
-
-## Direct creator upload request from end users
+## Step 2: Use the upload URL in your app 
 
 Using the `uploadURL` provided in the previous request, users can upload video
 files. Uploads are limited to 200 MB in size.
 
 <!-- videodelivery.net is correct domain. See STREAM-4364 -->
 ```bash
+---
+header: Upload a video file to the unique one-time upload URL
+---
 curl -X POST \
   -F file=@/Users/mickie/Downloads/example_video.mp4 \
   https://upload.videodelivery.net/f65014bc6ff5419ea86e7972a047ba22
 ```
 
-A successful upload will receive a `200` response. If the upload does not meet
+A successful upload will receive a `200` HTTP status code response. If the upload does not meet
 the upload constraints defined at time of creation or is larger than 200 MB in
-size, the user will receive a `4xx` response.
+size, you will receive a `4xx` HTTP status code response.
 
-### Example
+## Advanced upload flow using TUS, for large videos
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head></head>
-  <body>
-    <form id="form">
-      <input type="file" accept="video/*" id="video" />
-      <button type="submit">Upload Video</button>
-    </form>
-    <script>
-      async function getOneTimeUploadUrl() {
-        // The real implementation of this function should make an API call to your server
-        // where a unique one-time upload URL should be generated and returned to the browser.
-        // Here we will use a fake one that looks real but won't actually work.
-        return 'https://upload.videodelivery.net/f65014bc6ff5419ea86e7972a047ba22';
-      }
+[tus](https://tus.io/) is a protocol that supports resumable uploads. Use TUS if your users upload videos over 200MB **or** you need to allow resumable uploads. If your users upload via a mobile app or often use your app or website using a mobile network (ex: LTE, 5G), we strongly encourage you to use TUS.
 
-      const form = document.getElementById('form');
-      const videoInput = document.getElementById('video');
+### Step 1: Create your own API endpoint that returns an upload URL
 
-      form.addEventListener('submit', async e => {
-        e.preventDefault();
-        const oneTimeUploadUrl = await getOneTimeUploadUrl();
-        const video = videoInput.files[0];
-        const formData = new FormData();
-        formData.append('file', video);
-        const uploadResult = await fetch(oneTimeUploadUrl, {
-          method: 'POST',
-          body: formData,
-        });
-        form.innerHTML = '<h3>Upload successful!</h3>';
-      });
-    </script>
-  </body>
-</html>
-```
+[Run and edit this code in your browser using Stackblitz](https://workers.new/stream/upload/direct-creator-uploads-tus)
 
-## Using tus (recommended for videos over 200MB)
+<!-- TODO: The direct_user query param is not in our API docs -->
+```javascript
+---
+header: Example API endpoint that requests a TUS upload URL, and returns it in the location header
+---
+export async function onRequest(context) {
+	const { request, env } = context;
+	const { CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN } = env;
+	const endpoint = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream?direct_user=true`;
 
-tus is a protocol that supports resumable uploads and works best for larger files.
+	const response = await fetch(endpoint, {
+		method: 'POST',
+		headers: {
+			'Authorization': `bearer ${CLOUDFLARE_API_TOKEN}`,
+			'Tus-Resumable': '1.0.0',
+			'Upload-Length': request.headers.get('Upload-Length'),
+			'Upload-Metadata': request.headers.get('Upload-Metadata'),
+		},
+	});
 
-Typically, tus uploads require the authentication information to be sent with every request. This is not ideal for direct creators uploads because it exposes your API key (or token) to the end user.
+	const destination = response.headers.get('Location');
 
-To get around this, you can request a one-time tokenized URL by making a POST request to the `/stream?direct_user=true` end point:
-
-```bash
-curl -H "Authorization: bearer <API_TOKEN>" -X POST -H 'Tus-Resumable: 1.0.0' -H 'Upload-Length: <VIDEO_SIZE>' 'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream?direct_user=true'
-```
-In the example above, replace `<VIDEO_SIZE>` with your video's size in bytes, as per the [TUS specification](https://tus.io/protocols/resumable-upload.html).
-
-The response will contain a `Location` header which provides the one-time URL the client can use to upload the video using tus.
-
-Here is a demo Cloudflare Worker script which returns the one-time upload URL:
-
-```js
-addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request));
-});
-
-/**
- * Respond to the request
- * @param {Request} request
- */
-async function handleRequest(request) {
-  const response = await fetch(
-    'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream?direct_user=true',
-    {
-      method: 'POST',
-      headers: {
-        'Authorization': 'bearer <API_TOKEN>',
-        'Tus-Resumable': '1.0.0',
-        'Upload-Length': request.headers.get('Upload-Length'),
-        'Upload-Metadata': request.headers.get('Upload-Metadata'),
-      },
-    }
-  );
-
-  const destination = response.headers.get('Location');
-
-  return new Response(null, {
-    headers: {
-      'Access-Control-Expose-Headers': 'Location',
-      'Access-Control-Allow-Headers': '*',
-      'Access-Control-Allow-Origin': '*',
-      'Location': destination,
-    },
-  });
+	return new Response(null, {
+		headers: {
+			'Access-Control-Expose-Headers': 'Location',
+			'Access-Control-Allow-Headers': '*',
+			'Access-Control-Allow-Origin': '*',
+			'Location': destination,
+		},
+	});
 }
 ```
 
-Once you have an endpoint that returns the tokenized upload URL from the `location` header, you can use it by setting the tus client to make a request to _your_ endpoint. For details on using a tus client, refer to the [Resumable uploads with tus ](/stream/uploading-videos/upload-video-file/#resumable-uploads-with-tus-for-large-files) article.
+Note in the example above that the one-time upload URL is returned in the `Location` header of the response, not in the response body.
 
-### Testing your Direct Creator Upload Endpoint
+### Step 2: Use this API endpoint with your TUS client
 
-Once you have built your endpoint which calls Stream and returns the tokenized URL in the location header, you can test it with this [tus codepen demo](https://codepen.io/cfzf/pen/wvGMRXe). In the demo codepen, paste your end point URL in the `Upload endpoint` field and then try to upload a video.
+[Run and edit this code in your browser using Stackblitz](https://workers.new/stream/upload/direct-creator-uploads-tus)
 
-When using Direct Creator Uploads, the `Upload endpoint` field in the demo should contain the url to your endpoint, not to the videodelivery.net tokenized URL. This is the most common reason Direct Creator Uploads fail using tus. Customers often set the tus url to the videodelivery.net URL instead of to their endpoint which _returns_ the videodelivery.net URL.
+```
+---
+header: Upload a video, using your API endpoint with a TUS client
+---
+<!-- TODO: Super minimal TUS example, maybe use node client? -->
+```
 
-Please note that if you are developing on localhost, your test using the codepen may fail. Before testing, it is best to push your endpoint to a server with an IP and/or domain so you are not using localhost. Alternatively, you can setup a Worker with the example code provided above.
+For more details on using a tus and example client code, refer to [Resumable uploads with tus](/stream/uploading-videos/upload-video-file/#resumable-uploads-with-tus-for-large-files).
 
 ### Upload-Metadata header syntax
 
@@ -270,3 +155,9 @@ You can do that two ways:
 
 2.  You can [create a webhook subscription](/stream/manage-video-library/using-webhooks/) to receive notifications
     regarding the status of videos. These notifications include the video's UID.
+
+
+
+### Billing considerations
+
+- Pending uploads count towards your storage limit.

--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -201,4 +201,4 @@ You can do that two ways:
 
 ### Billing considerations
 
-- Pending uploads count towards your storage limit.
+- One-time upload URLs count towards your storage limit, even if your users have not yet uploaded video to this URL. For example, if you generate a one-time upload URL with a `maxDurationSeconds` value of `60`, that expires 30 minutes from now (the default value of `expiry`), until the upload URL expires, this will count as one minute of video stored. This ensures that you do not inadvertently generate upload URLs that fail for your users once you've reached your storage limit. You can add storage to your subscription anytime via the Cloudflare Dashboard, and customize the `expiry` to a duration of your choosing. We recommend setting a short duration and generating this URL on-demand, at the moment when the user needs to upload a video.

--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -24,7 +24,7 @@ Use this if your users upload videos under 200MB, and you do not need to allow r
 
 ### Step 1: Generate a unique one-time upload URL
 
-- [End-to-end code example on Stackblitz](https://workers.new/stream/upload/direct-creator-uploads)
+- [End-to-end code example on Stackblitz](https://workers.new/stream/direct-creator-uploads)
 - [API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
 
 
@@ -81,7 +81,7 @@ size, you will receive a `4xx` HTTP status code response.
 
 ### Step 1: Create your own API endpoint that returns an upload URL
 
-[Run and edit this code in your browser using Stackblitz](https://workers.new/stream/upload/direct-creator-uploads-tus)
+[Run and edit this code in your browser using Stackblitz](https://workers.new/stream/direct-creator-uploads-tus)
 
 ```javascript
 ---

--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -24,8 +24,8 @@ Use this if your users upload videos under 200MB, and you do not need to allow r
 
 ### Step 1: Generate a unique one-time upload URL
 
-- [End-to-end code example on Stackblitz](https://workers.new/stream/upload/direct-creator-uploads)
-- [API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
+[End-to-end code example on Stackblitz](https://workers.new/stream/upload/direct-creator-uploads)
+[API Reference Docs for `/direct_upload`](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls)
 
 ```bash
 ---
@@ -84,7 +84,7 @@ size, you will receive a `4xx` HTTP status code response.
 
 ```javascript
 ---
-header: Example API endpoint that requests a tus upload URL, and returns it in the location header
+header: Example API endpoint that requests a one-time tus upload URL from Cloudflare Stream, and returns it in the location header
 ---
 export async function onRequest(context) {
 	const { request, env } = context;
@@ -117,6 +117,8 @@ export async function onRequest(context) {
 Note in the example above that the one-time upload URL is returned in the `Location` header of the response, not in the response body.
 
 ### Step 2: Use this API endpoint with your tus client
+
+Use this API endpoint **directly** in your tus client. A common mistake is to extract the upload URL from your new API endpoint, and use this directly. See below for a complete example of how to use the API from Step 1 with the uppy tus client.
 
 [Run and edit this code in your browser using Stackblitz](https://workers.new/stream/upload/direct-creator-uploads-tus)
 
@@ -169,7 +171,7 @@ header: Upload a video, using your API endpoint using the uppy tus client
 </html>
 ```
 
-For more details on using a tus and example client code, refer to [Resumable uploads with tus](/stream/uploading-videos/upload-video-file/#resumable-uploads-with-tus-for-large-files).
+For more details on using tus and example client code, refer to [Resumable uploads with tus](/stream/uploading-videos/upload-video-file/#resumable-uploads-with-tus-for-large-files).
 
 ### Upload-Metadata header syntax
 

--- a/content/stream/uploading-videos/direct-creator-uploads.md
+++ b/content/stream/uploading-videos/direct-creator-uploads.md
@@ -176,7 +176,7 @@ For more details on using tus and example client code, refer to [Resumable uploa
 
 ### Upload-Metadata header syntax
 
-You can apply the same constraints as Direct Creator Upload via basic upload when using tus. To do so, you must pass the expiry and maxDurationSeconds as part of the `Upload-Metadata` request header as part of the first request (made by the Worker in the example above.) The `Upload-Metadata` values are ignored from subsequent requests that do the actual file upload.
+You can apply the [same constraints](https://api.cloudflare.com/#stream-videos-upload-videos-via-direct-upload-urls) as Direct Creator Upload via basic upload when using tus. To do so, you must pass the `expiry` and `maxDurationSeconds` as part of the `Upload-Metadata` request header as part of the first request (made by the Worker in the example above.) The `Upload-Metadata` values are ignored from subsequent requests that do the actual file upload.
 
 Upload-Metadata header should contain key-value pairs. The keys are text and the values should be base64. Separate the key and values by a space, _not_ an equal sign. To join multiple key-value pairs, include a comma with no additional spaces.
 


### PR DESCRIPTION
Updates the Direct Creator Upload docs to be simpler, shorter, and link to runnable examples.

Preview: https://3608f320.cloudflare-docs-7ou.pages.dev/stream/uploading-videos/direct-creator-uploads/

- [x] Merge https://github.com/cloudflare/templates/pull/98 first