### PR TITLE
[Workers] Document wrangler's new unstable_dev API

### DIFF
--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -75,7 +75,7 @@ In each test case, call `await worker.fetch()`, and check that the response is w
 To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
-{{<tab label="js">}}
+{{<tab label="js" default="true">}}
 ```js
 ---
 filename: src/index.test.js
@@ -107,7 +107,7 @@ describe("Worker", () => {
 });
 ```
 {{</tab>}}
-{{<tab label="ts" default="true">}}
+{{<tab label="ts" >}}
 ```ts
 ---
 filename: src/index.test.ts

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -13,7 +13,9 @@ Wrangler offers an experimental API to programmatically manage your Cloudflare W
 
 ## unstable_dev
 
-Start a local server for testing your Worker.
+Start a local HTTP server for testing your Worker. 
+
+Once called, `unstable_dev` will return a `fetch` function for invoking your Worker without needing to know the address or port, as well as a `stop` function to shut-down the HTTP server.
 
 {{<Aside type="note">}}
 
@@ -47,26 +49,71 @@ const worker = await unstable_dev(script, options, apiOptions)
 {{</definitions>}}
 ### Usage
 
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 ```js
 ---
 filename: src/index.test.js
 ---
 import { unstable_dev } from 'wrangler'
 
-describe("worker", () => {
-	it("should return Hello World", async () => {
-		const worker = await unstable_dev(
+describe("Worker", () => {
+	let worker;
+
+	beforeAll(async () => {
+		worker = await unstable_dev(
 			"src/index.js",
 			{},
 			{ disableExperimentalWarning: true }
 		);
+	});
+
+	afterAll(async () => {
+		await worker.stop();
+	});
+
+	it("should return Hello World", async () => {
 		const resp = await worker.fetch();
 		if (resp) {
 			const text = await resp.text();
 			expect(text).toMatchInlineSnapshot(`"Hello World!"`);
 		}
-		await worker.stop();
 	});
 });
 ```
+{{</tab>}}
+{{<tab label="ts">}}
+```ts
+---
+filename: src/index.test.ts
+---
+import { unstable_dev } from "wrangler";
+import type { UnstableDevWorker } from "wrangler";
+
+describe("Worker", () => {
+	let worker: UnstableDevWorker;
+
+	beforeAll(async () => {
+		worker = await unstable_dev(
+			"src/index.ts",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+	});
+
+	afterAll(async () => {
+		await worker.stop();
+	});
+
+	it("should return Hello World", async () => {
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello World!"`);
+		}
+	});
+});
+```
+{{</tab>}}
+{{</tabs>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -68,7 +68,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 ### Usage
 
-Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
+When initiating each test suite, use a `beforeAll` function to start `unstable_dev`. The `beforeAll` function is used to minimize overhead: starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
 
 In each test case, call `await worker.fetch()`, and check that the response is what you expect. 
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -6,7 +6,7 @@ weight: 12
 
 # Wrangler API
 
-Wrangler offers an API to programmatically manage your Cloudflare Workers
+Wrangler offers an experimental API to programmatically manage your Cloudflare Workers
 
 - [`unstable_dev`](#unstable_dev) - Start a local server for running integration tests against your Worker.
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -15,11 +15,11 @@ Wrangler offers an experimental API to programmatically manage your Cloudflare W
 
 Start a local HTTP server for testing your Worker. 
 
-Once called, `unstable_dev` will return a `fetch` function for invoking your Worker without needing to know the address or port, as well as a `stop` function to shut down the HTTP server.
+Once called, `unstable_dev` will return a `fetch()` function for invoking your Worker without needing to know the address or port, as well as a `stop()` function to shut down the HTTP server.
 
 {{<Aside type="note">}}
 
-The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. 
+The `unstable_dev()` function has an `unstable_` prefix because the API may change in the future. 
 
 There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will review the issue.
 
@@ -68,7 +68,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 ### Usage
 
-When initiating each test suite, use a `beforeAll` function to start `unstable_dev`. The `beforeAll` function is used to minimize overhead: starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
+When initiating each test suite, use a `beforeAll()` function to start `unstable_dev()`. The `beforeAll()` function is used to minimize overhead: starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
 
 In each test case, call `await worker.fetch()`, and check that the response is what you expect. 
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -17,7 +17,7 @@ Start a local server for testing your Worker.
 
 {{<Aside type="note">}}
 
-The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will patch them as soon as possible.
+The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we'll fix them as soon as possible.
 
 
 {{</Aside>}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -38,7 +38,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 *   `script` {{<type>}}string{{</type>}}
 
-    *   A string containing a path to your Worker script.
+    *   A string containing a path to your Worker script, relative to your Worker project's root directory.
 
 *   `options` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -52,7 +52,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 ### Return Type
 
-`unstable_dev` returns an object containing the following methods:
+`unstable_dev()` returns an object containing the following methods:
 
 {{<definitions>}}
 
@@ -60,7 +60,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
     *   Send a request to your Worker. Returns a Promise that resolves with a [`Response`](/workers/runtime-apis/response) object.
 
-*   `stop` {{<type>}}Promise\<void>{{</type>}}
+*   `stop()` {{<type>}}Promise\<void>{{</type>}}
 
     *   Shuts down the dev server. 
 
@@ -68,26 +68,27 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 ### Usage
 
-Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
+Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev()`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
 
 In each test case, call `await worker.fetch()`, and check that the response is what you expect. 
 
 To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
-{{<tabs labels="js | ts">}}
-{{<tab label="js">}}
-```js
+{{<tabs labels="ts | js">}}
+{{<tab label="ts" default="true">}}
+```ts
 ---
-filename: src/index.test.js
+filename: src/index.test.ts
 ---
-import { unstable_dev } from 'wrangler'
+import { unstable_dev } from "wrangler";
+import type { UnstableDevWorker } from "wrangler";
 
 describe("Worker", () => {
-	let worker;
+	let worker: UnstableDevWorker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(
-			"src/index.js",
+			"src/index.ts",
 			{},
 			{ disableExperimentalWarning: true }
 		);
@@ -107,20 +108,19 @@ describe("Worker", () => {
 });
 ```
 {{</tab>}}
-{{<tab label="ts" default="true">}}
-```ts
+{{<tab label="js">}}
+```js
 ---
-filename: src/index.test.ts
+filename: src/index.test.js
 ---
-import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import { unstable_dev } from 'wrangler'
 
 describe("Worker", () => {
-	let worker: UnstableDevWorker;
+	let worker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(
-			"src/index.ts",
+			"src/index.js",
 			{},
 			{ disableExperimentalWarning: true }
 		);

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -4,14 +4,14 @@ title: API
 weight: 12
 ---
 
-## Wrangler API
+# Wrangler API
 
 Wrangler offers an API to programmatically manage your Cloudflare Workers
 
 - [`unstable_dev`](#unstable_dev) - Start a local server for running integration tests against your Worker.
 
 
-### unstable_dev
+## unstable_dev
 
 Start a local server for testing your Worker.
 
@@ -22,8 +22,35 @@ The `unstable_dev` function has an `unstable_` prefix because the API may change
 
 {{</Aside>}}
 
+### Constructor
+
 ```js
-//src/index.test.js
+const worker = unstable_dev(script, options, apiOptions)
+```
+
+### Parameters
+
+{{<definitions>}}
+
+*   `script` {{<type>}}string{{</type>}}
+
+    *   A string containing a path to your Worker script.
+
+*   `options` {{<type>}}object{{</type>}}{{<prop-meta>}}optional{{</prop-meta>}}
+
+    *   Optional options object containing `wrangler dev` configuration settings.
+
+*   `apiOptions` {{<type>}}object{{</type>}}{{<prop-meta>}}optional{{</prop-meta>}}
+
+    *   Optional API options object containing `disableExperimentalWarning`. Set `disableExperimentalWarning` to true to disable wrangler's warning about using `unstable_` prefixed APIs.
+
+{{</definitions>}}
+### Usage
+
+```js
+---
+filename: src/index.test.js
+---
 import { unstable_dev } from 'wrangler'
 
 describe("worker", () => {

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -75,7 +75,7 @@ In each test case, call `await worker.fetch()`, and check that the response is w
 To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
-{{<tab label="js" default="true">}}
+{{<tab label="js">}}
 ```js
 ---
 filename: src/index.test.js
@@ -107,7 +107,7 @@ describe("Worker", () => {
 });
 ```
 {{</tab>}}
-{{<tab label="ts" >}}
+{{<tab label="ts" default="true">}}
 ```ts
 ---
 filename: src/index.test.ts

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -47,7 +47,30 @@ const worker = await unstable_dev(script, options, apiOptions)
     *   Optional API options object containing `disableExperimentalWarning`. Set `disableExperimentalWarning` to true to disable wrangler's warning about using `unstable_` prefixed APIs.
 
 {{</definitions>}}
+
+### Return Type
+
+`unstable_dev` returns an object containing the following functions:
+
+{{<definitions>}}
+
+*   `fetch` {{<type>}}Promise\<Response>{{</type>}}
+
+    *   Send a request to your worker. Returns a promise that resolves with a [`Response`](/workers/runtime-apis/response) object
+
+*   `stop` {{<type>}}Promise\<void>{{</type>}}
+
+    *   Shuts down the dev server. 
+
+{{</definitions>}}
+
 ### Usage
+
+Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
+
+In each test case you'll call `await worker.fetch`, and check that the response is what you expect. 
+
+To wrap up a test suite, you should call `await worker.stop` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -80,7 +80,7 @@ To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 ---
 filename: src/index.test.js
 ---
-import { unstable_dev } from 'wrangler'
+const { unstable_dev } = require("wrangler");
 
 describe("Worker", () => {
 	let worker;

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -25,7 +25,7 @@ The `unstable_dev` function has an `unstable_` prefix because the API may change
 ### Constructor
 
 ```js
-const worker = unstable_dev(script, options, apiOptions)
+const worker = await unstable_dev(script, options, apiOptions)
 ```
 
 ### Parameters

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -17,13 +17,13 @@ Start a local server for testing your Worker.
 
 {{<Aside type="note">}}
 
-The `unstable_dev` function has the `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will patch them as soon as possible.
+The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will patch them as soon as possible.
 
 
 {{</Aside>}}
 
 ```js
-//index.test.js
+//src/index.test.js
 import { unstable_dev } from 'wrangler'
 
 describe("worker", () => {

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -6,7 +6,7 @@ weight: 12
 
 # Wrangler API
 
-Wrangler offers an experimental API to programmatically manage your Cloudflare Workers
+Wrangler offers an experimental API to programmatically manage your Cloudflare Workers.
 
 - [`unstable_dev`](#unstable_dev) - Start a local server for running integration tests against your Worker.
 
@@ -15,13 +15,13 @@ Wrangler offers an experimental API to programmatically manage your Cloudflare W
 
 Start a local HTTP server for testing your Worker. 
 
-Once called, `unstable_dev` will return a `fetch` function for invoking your Worker without needing to know the address or port, as well as a `stop` function to shut-down the HTTP server.
+Once called, `unstable_dev` will return a `fetch` function for invoking your Worker without needing to know the address or port, as well as a `stop` function to shut down the HTTP server.
 
 {{<Aside type="note">}}
 
 The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. 
 
-There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we'll fix them as soon as possible.
+There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will review the issue.
 
 
 {{</Aside>}}
@@ -46,7 +46,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 *   `apiOptions` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-    *   Optional API options object containing `disableExperimentalWarning`. Set `disableExperimentalWarning` to true to disable wrangler's warning about using `unstable_` prefixed APIs.
+    *   Optional API options object containing `disableExperimentalWarning`. Set `disableExperimentalWarning` to true to disable Wrangler's warning about using `unstable_` prefixed APIs.
 
 {{</definitions>}}
 
@@ -58,7 +58,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 *   `fetch` {{<type>}}Promise\<Response>{{</type>}}
 
-    *   Send a request to your worker. Returns a promise that resolves with a [`Response`](/workers/runtime-apis/response) object.
+    *   Send a request to your Worker. Returns a Promise that resolves with a [`Response`](/workers/runtime-apis/response) object.
 
 *   `stop` {{<type>}}Promise\<void>{{</type>}}
 
@@ -70,9 +70,9 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
 
-In each test case you'll call `await worker.fetch`, and check that the response is what you expect. 
+In each test case, call `await worker.fetch`, and check that the response is what you expect. 
 
-To wrap up a test suite, you should call `await worker.stop` in an `afterAll` function.
+To wrap up a test suite, call `await worker.stop` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -52,7 +52,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 ### Return Type
 
-`unstable_dev` returns an object containing the following functions:
+`unstable_dev` returns an object containing the following methods:
 
 {{<definitions>}}
 
@@ -75,7 +75,7 @@ In each test case, call `await worker.fetch()`, and check that the response is w
 To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
-{{<tab label="js" default="true">}}
+{{<tab label="js">}}
 ```js
 ---
 filename: src/index.test.js
@@ -107,7 +107,7 @@ describe("Worker", () => {
 });
 ```
 {{</tab>}}
-{{<tab label="ts">}}
+{{<tab label="ts" default="true">}}
 ```ts
 ---
 filename: src/index.test.ts

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -19,7 +19,9 @@ Once called, `unstable_dev` will return a `fetch` function for invoking your Wor
 
 {{<Aside type="note">}}
 
-The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we'll fix them as soon as possible.
+The `unstable_dev` function has an `unstable_` prefix because the API may change in the future. 
+
+There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we'll fix them as soon as possible.
 
 
 {{</Aside>}}
@@ -56,7 +58,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 *   `fetch` {{<type>}}Promise\<Response>{{</type>}}
 
-    *   Send a request to your worker. Returns a promise that resolves with a [`Response`](/workers/runtime-apis/response) object
+    *   Send a request to your worker. Returns a promise that resolves with a [`Response`](/workers/runtime-apis/response) object.
 
 *   `stop` {{<type>}}Promise\<void>{{</type>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -74,21 +74,20 @@ In each test case, call `await worker.fetch()`, and check that the response is w
 
 To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
-{{<tabs labels="ts | js">}}
-{{<tab label="ts" default="true">}}
-```ts
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
+```js
 ---
-filename: src/index.test.ts
+filename: src/index.test.js
 ---
-import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import { unstable_dev } from 'wrangler'
 
 describe("Worker", () => {
-	let worker: UnstableDevWorker;
+	let worker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(
-			"src/index.ts",
+			"src/index.js",
 			{},
 			{ disableExperimentalWarning: true }
 		);
@@ -108,19 +107,20 @@ describe("Worker", () => {
 });
 ```
 {{</tab>}}
-{{<tab label="js">}}
-```js
+{{<tab label="ts" >}}
+```ts
 ---
-filename: src/index.test.js
+filename: src/index.test.ts
 ---
-import { unstable_dev } from 'wrangler'
+import { unstable_dev } from "wrangler";
+import type { UnstableDevWorker } from "wrangler";
 
 describe("Worker", () => {
-	let worker;
+	let worker: UnstableDevWorker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(
-			"src/index.js",
+			"src/index.ts",
 			{},
 			{ disableExperimentalWarning: true }
 		);

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -1,0 +1,45 @@
+---
+pcx_content_type: how-to
+title: API
+weight: 12
+---
+
+## Wrangler API
+
+Wrangler offers an API to programmatically manage your Cloudflare Workers
+
+- [`unstable_dev`](#unstable_dev) - Start a local server for running integration tests against your Worker.
+
+
+### unstable_dev
+
+Start a local server for testing your Worker.
+
+{{<Aside type="note">}}
+
+The `unstable_dev` function has the `unstable_` prefix because the API may change in the future. There are no known bugs at the moment and it is safe to use. If you discover any issues, please do report them as a [GitHub Issue](https://github.com/cloudflare/wrangler2/issues/new/choose) and we will patch them as soon as possible.
+
+
+{{</Aside>}}
+
+```js
+//index.test.js
+import { unstable_dev } from 'wrangler'
+
+describe("worker", () => {
+	it("should return Hello World", async () => {
+		const worker = await unstable_dev(
+			"src/index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello World!"`);
+		}
+		await worker.stop();
+	});
+});
+```
+

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -56,7 +56,7 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 {{<definitions>}}
 
-*   `fetch` {{<type>}}Promise\<Response>{{</type>}}
+*   `fetch()` {{<type>}}Promise\<Response>{{</type>}}
 
     *   Send a request to your Worker. Returns a Promise that resolves with a [`Response`](/workers/runtime-apis/response) object.
 
@@ -70,9 +70,9 @@ const worker = await unstable_dev(script, options, apiOptions)
 
 Typically, you'll want to start each test suite with a `beforeAll` function that starts `unstable_dev`. We use the `beforeAll` function because starting the dev server takes a few hundred milliseconds, starting and stopping for each individual test adds up quickly, slowing your tests down.
 
-In each test case, call `await worker.fetch`, and check that the response is what you expect. 
+In each test case, call `await worker.fetch()`, and check that the response is what you expect. 
 
-To wrap up a test suite, call `await worker.stop` in an `afterAll` function.
+To wrap up a test suite, call `await worker.stop()` in an `afterAll` function.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -36,11 +36,11 @@ const worker = await unstable_dev(script, options, apiOptions)
 
     *   A string containing a path to your Worker script.
 
-*   `options` {{<type>}}object{{</type>}}{{<prop-meta>}}optional{{</prop-meta>}}
+*   `options` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
     *   Optional options object containing `wrangler dev` configuration settings.
 
-*   `apiOptions` {{<type>}}object{{</type>}}{{<prop-meta>}}optional{{</prop-meta>}}
+*   `apiOptions` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
     *   Optional API options object containing `disableExperimentalWarning`. Set `disableExperimentalWarning` to true to disable wrangler's warning about using `unstable_` prefixed APIs.
 


### PR DESCRIPTION
Just an initial commit to create a page (so folks know the function exists), will shortly iterate on content.

TODO: 
- [x] Add tabs to switch between JS and TS - example: https://github.com/cloudflare/cloudflare-docs/pull/5015/files#diff-94567dfc906ec6a15a06570a81e1cb645786a8afdc44c33b452a997408b663eeR25-R44
- [x] Add Pete's suggestions

Closes #5721