### PR TITLE
Fix typo in curl to create live input, format docs

### DIFF
--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -22,17 +22,19 @@ After you have created a Live Input, you can retrieve the RTMPS URL and Key, or 
 To start a live stream programmatically, make a `POST` request to the `/live_inputs` endpoint:
 
 ```bash
-curl -X POST \ -H "Authorization: Bearer <API_TOKEN>" \https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs --data '{"meta": {"name":"test stream 1"},"recording": { "mode": "automatic", "timeoutSeconds": 10, "requireSignedURLs": false, "allowedOrigins": ["*.example.com"] }}'
+---
+header: Request
+---
+curl -X POST \
+-H "Authorization: Bearer <API_TOKEN>" \
+-D '{"meta": {"name":"test stream"},"recording": { "mode": "automatic" }}' \
+https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs
 ```
 
-- When the mode property is set to `automatic`, it means the live stream will be automatically available for viewing using HLS/DASH. In addition, the live stream will be automatically recorded for later replays.
-- The `timeoutSeconds` property specifies how long a live feed can be disconnected before it results in a new video being created.
-- The `requireSignedURLs` property indicates if signed URLs are required to view the video. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
-- The `allowedOrigins` property can optionally be invoked to provide a list of allowed origins. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
-
-A successful response will return information about the live input.
-
 ```json
+---
+header: Response
+---
 {
   "uid": "f256e6ea9341d51eea64c9454659e576",
   "rtmps": {
@@ -42,16 +44,40 @@ A successful response will return information about the live input.
   "created": "2021-09-23T05:05:53.451415Z",
   "modified": "2021-09-23T05:05:53.451415Z",
   "meta": {
-    "name": "My Live Stream"
+    "name": "test stream"
   },
   "status": null,
   "recording": {
     "mode": "automatic",
     "requireSignedURLs": false,
-    "allowedOrigins": ["*.example.com"]
+    "allowedOrigins": null
   }
 }
 ```
+
+#### Optional API parameters
+
+[API Reference Docs for `/live_inputs`](https://api.cloudflare.com/#stream-live-inputs-create-live-inputs)
+
+{{<definitions>}}
+
+- `mode` {{<type>}}string{{</type>}} {{<prop-meta>}}default: `off`{{</prop-meta>}}
+
+  - When the mode property is set to `automatic`, the live stream will be automatically available for viewing using HLS/DASH. In addition, the live stream will be automatically recorded for later replays. By default, recording mode is set to `off`, and the input will not be recorded or available for playback.
+
+- `timeoutSeconds` {{<type>}}integer{{</type>}} {{<prop-meta>}}default: `0`{{</prop-meta>}}
+
+  -  The `timeoutSeconds` property specifies how long a live feed can be disconnected before it results in a new video being created.
+
+- `requireSignedURLs` {{<type>}}boolean{{</type>}} {{<prop-meta>}}default: `false`{{</prop-meta>}}
+
+  - The `requireSignedURLs` property indicates if signed URLs are required to view the video. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
+
+- `allowedOrigins` {{<type>}}integer{{</type>}} {{<prop-meta>}}default: `null` (any){{</prop-meta>}}
+
+  - The `allowedOrigins` property can optionally be invoked to provide a list of allowed origins. This setting is applied by default to all videos recorded from the input. In addition, if viewing a video via the live input ID, this field takes effect over any video-level settings.
+
+{{</definitions>}}
 
 ## Managing live inputs
 


### PR DESCRIPTION
- Fixes the existing `curl` request to create a new live input
- Simplifies `curl` request by using only necessary fields, breaks request into multiple lines
- Formats docs to connect request and response without scrolling through optional params
- Uses `{{<definitions>}}` block for optional params

**Preview:** https://dad8e6f7.cloudflare-docs-7ou.pages.dev/stream/stream-live/start-stream-live/