### PR TITLE
Removing 365 days option

### DIFF
--- a/content/ssl/edge-certificates/advanced-certificate-manager/_index.md
+++ b/content/ssl/edge-certificates/advanced-certificate-manager/_index.md
@@ -17,7 +17,7 @@ Advanced certificates allow you multiple customization options:
 *   Include the zone apex and less than 50 hosts as covered hostnames.
 *   Cover more than one level of subdomain.
 *   Select the preferred validation method (HTTP, TXT, or Email).
-*   Choose the certificate validity period (14, 30, 90, or 365 days).
+*   Choose the certificate validity period (14, 30, or 90 days).
 *   Choose the Certificate Authority to issue the certificate.
 *   Remove Cloudflare branding that are normally present on Universal certificates.
 *   Select a custom trust store for origin authentication.


### PR DESCRIPTION
With the removal of DigiCert, should the "365 days" certificate validity be removed ?