### PR TITLE
Fix curl error on windows in dns docs

### DIFF
--- a/content/1.1.1.1/encryption/dns-over-https/make-api-requests/_index.md
+++ b/content/1.1.1.1/encryption/dns-over-https/make-api-requests/_index.md
@@ -38,7 +38,7 @@ You can learn more about how DoH works in RFC8484, more specifically [the HTTP l
 Example request:
 
 ```sh
-$ curl --http2 -H "accept: application/dns-json" https://1.1.1.1/dns-query?name=cloudflare.com --next --http2 -H "accept: application/dns-json" https://1.1.1.1/dns-query?name=example.com
+$ curl --http2 -H "accept: application/dns-json" "https://1.1.1.1/dns-query?name=cloudflare.com" --next --http2 -H "accept: application/dns-json" "https://1.1.1.1/dns-query?name=example.com"
 ```
 
 ## Authentication

--- a/content/1.1.1.1/encryption/dns-over-https/make-api-requests/_index.md
+++ b/content/1.1.1.1/encryption/dns-over-https/make-api-requests/_index.md
@@ -38,7 +38,7 @@ You can learn more about how DoH works in RFC8484, more specifically [the HTTP l
 Example request:
 
 ```sh
-$ curl --http2 -H 'accept: application/dns-json' https://1.1.1.1/dns-query?name=cloudflare.com --next --http2 -H 'accept: application/dns-json' https://1.1.1.1/dns-query?name=example.com
+$ curl --http2 -H "accept: application/dns-json" https://1.1.1.1/dns-query?name=cloudflare.com --next --http2 -H "accept: application/dns-json" https://1.1.1.1/dns-query?name=example.com
 ```
 
 ## Authentication


### PR DESCRIPTION
Update single quotes to double to avoid curl error on windows.

On [the dns over https docs](https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/) the command to send multiple questions in a query is wrong, and can cause errors when running in cmd on windows.

Running this command, it currently works in Powershell but not in cmd.
`curl --http2 -H 'accept: application/dns-json' https://1.1.1.1/dns-query?name=cloudflare.com --next --http2 -H 'accept: application/dns-json' https://1.1.1.1/dns-query?name=example.com
`

This is because cmd doesn't interpret `'accept: application/dns-json'` correctly and thinks `application` is the host because of the space after `'accept: `.

Powershell does interpret this correctly, but this can cause confusion down the line when queries to the dns do not resolve on cmd, but they do on Powershell if this command is copy-pasted.

This commit fixes this issue by simply changing the single quotes to double quotes so spaces within them are ignored.