### PR TITLE
[Magic Firewall] Added note about cdn-cgi trace

### DIFF
--- a/content/magic-firewall/how-to/collect-pcaps.md
+++ b/content/magic-firewall/how-to/collect-pcaps.md
@@ -23,6 +23,12 @@ Cloudflare supports two types of packet captures:
 - **Simple**: Simple packets are best for debugging and providing a global picture across all data centers. Simple packets generate single, smaller files and only contain the first 160 bytes of the payload. Sampled packets are collected across all edge metals to build a PCAP file.
 - **Full**: Full packets are best for targeted data collection with a detailed view into a single data center. Full packets generate multiple large files, and they are captured within a given data center and sent to either a GCP or AWS bucket specified by the user.
 
+{{<Aside type="note" header="Note:">}}
+
+For help determining which data center to select for a packet capture, visit https://cloudflare.com/cdn-cgi/trace and refer to the `colo` field.
+
+{{</Aside>}}
+
 <details>
 <summary>
   API


### PR DESCRIPTION
Added note about cdn-cgi trace to help users choose a data center when starting a packet capture. Addresses PCX-4097.