### PR TITLE
[Docs site] Fix weird mobile rendering for product name

### DIFF
--- a/layouts/partials/topbar.mobile.html
+++ b/layouts/partials/topbar.mobile.html
@@ -1,6 +1,7 @@
 {{- $root := relURL (printf "/%s/" .Section) -}}
-{{- $title := (title .Section) -}}
 {{- $DATA := (index $.Site.Data .Section) -}}
+
+{{- $title := default (replace (title .Section) "-" " ") $DATA.name -}}
 
 <div class="DocsMobileHeader">
   <a class="DocsMobileHeader--cloudflare-logo-link Link Link-without-underline" href="/">


### PR DESCRIPTION
Current mobile header lowercases certain names (`Dns`) and adds hyphens between spaces (`Waiting-Room`).

To test, shrink your view window and then check the `Waiting Room` docs + `DNS` docs in this version and our current version. 
