### PR TITLE
[ZT] Clarify CSV lists valid format

### DIFF
--- a/content/cloudflare-one/policies/filtering/lists.md
+++ b/content/cloudflare-one/policies/filtering/lists.md
@@ -19,7 +19,9 @@ You can create a list by:
 
 ## Create a list from a CSV file
 
-If you would like to test how this feature works, here is a [sample CSV file](/cloudflare-one/static/documentation/list-test.csv)of URLs. You can upload it to the Zero Trust dashboard by following the instructions below:
+If you would like to test how this feature works, here is a [sample CSV file](/cloudflare-one/static/documentation/list-test.csv) of URLs. 
+Each line should be a single entry, no trailing whitespace is allowed, CRLF (Windows) and LF (Unix) line endings are valid.
+You can upload it to the Zero Trust dashboard by following the instructions below:
 
 1. On the [Zero Trust dashboard](https://dash.teams.cloudflare.com), navigate to **My Team** > **Lists**.
 2. Click **Upload CSV**.

--- a/content/cloudflare-one/static/documentation/list-test.csv
+++ b/content/cloudflare-one/static/documentation/list-test.csv
@@ -1,2 +1,2 @@
-https://example.com,
-https://example1.com,
+https://example.com
+https://example1.com


### PR DESCRIPTION
Clarifies:
- no whitespace before line ending allowed
- trailing commas not needed (allowed because second column "description" is optional, but that's never mentioned anywhere, so the example file was very confusing)