### PR TITLE
[Workers] Fix smart-quotes for thumbnails tutorial

### DIFF
--- a/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
+++ b/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
@@ -474,7 +474,7 @@ filename: index.js
 highlight: [2, 3]
 ---
 if (url.pathname === '/thumbnail') {
- const imageURL = “https://github.com/lauragift21/social-image-demo/blob/1ed9044463b891561b7438ecdecbdd9da48cdb03/assets/cover.png?raw=true”
+ const imageURL = "https://github.com/lauragift21/social-image-demo/blob/1ed9044463b891561b7438ecdecbdd9da48cdb03/assets/cover.png?raw=true"
  fetch(imageURL, {
    cf: {
      image: {}


### PR DESCRIPTION
MacOS is back at it again, throwing smart quotes in & breaking code.