### PR TITLE
Webhook Notifications - Add Instructions for Microsoft Teams

### DIFF
--- a/content/fundamentals/notifications/create-notifications/configure-webhooks.md
+++ b/content/fundamentals/notifications/create-notifications/configure-webhooks.md
@@ -99,6 +99,12 @@ Cloudflare has an [example tool](https://github.com/cloudflare/cf-webhook-relay/
          <p>3. SSL must be enabled on the server.</p>         
       </td>
    </tr>
+      <!-- Teams    -->
+   <tr>
+      <td valign="top"> <a target="_blank" rel="noopener noreferrer" href="https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook">Sack</a></td>
+      <td>The secret is part of the URL. Cloudflare parses this information automatically and there is no input needed from the user.</td>
+      <td>URL is provided by Teams when the Incoming Webhook connector is created.</td>
+   </tr>
    <!-- generic webhook    -->
    <tr>
       <td valign="top">Generic webhook</td>


### PR DESCRIPTION
This minor change adds a row on how to enable Webhook notifications for Microsoft Teams.