### PR TITLE
Clarify DO reverse list() behavior when used with a start/end key

### DIFF
--- a/content/workers/runtime-apis/durable-objects.md
+++ b/content/workers/runtime-apis/durable-objects.md
@@ -222,6 +222,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
     - {{<code>}}reverse{{<param-type>}}boolean{{</param-type>}}{{</code>}}
 
       - If true, return results in descending lexicographic order instead of the default ascending order.
+      - Note that enabling this does not change the meaning of `start`, `startKey`, or `endKey`. `start` still defines the smallest key in lexicographic order that can be returned (inclusive), effectively serving as the endpoint for a reverse-order list. `end` still defines the largest key in lexicographic order that the list should consider (exclusive), effectively serving as the starting point for a reverse-order list.
 
     - {{<code>}}limit{{<param-type>}}number{{</param-type>}}{{</code>}}
 


### PR DESCRIPTION
I'm not sold that this is the best explanation or that the `start`/`startKey`/`end` bullet points shouldn't be improved as well. It's also likely that examples would help.

But here's something that hopefully at least improves things even if it isn't ideal. Suggestions for other improvements are very welcome.