### PR TITLE
Gateway vs WARP clarification in Access Policy 

### DIFF
--- a/content/cloudflare-one/policies/access/_index.md
+++ b/content/cloudflare-one/policies/access/_index.md
@@ -146,7 +146,8 @@ Here is a list of all the criteria you can apply:
 - **Login Methods** - checks the identity provider used at the time of login.
 - **Authentication Method** - checks the [multifactor authentication](/cloudflare-one/policies/access/mfa-requirements/) method used by the user, if supported by the identity provider.
 - **Identity provider groups** — employs the user groups (if supported) you configured with your identity provider (IdP) or LDAP with Access. The IdP group option only displays if you use an OIDC or SAML identity provider.
-- **Warp** - checks that the device is connected to your Zero Trust instance through the [WARP client](/cloudflare-one/connections/connect-devices/warp/).
+- **Warp** - checks that the device is connected to WARP, including the consumer version.
+- **Gateway** - checks that the device is connected to your Zero Trust instance through the [WARP client](/cloudflare-one/connections/connect-devices/warp/).
 
 ## Order of execution
 


### PR DESCRIPTION
WARP vs. Gateway has always been confusing.  In testing this Gateway means the ZT Version, WARP means the Consumer mode.  Our documentation over in the following locations is correct:

https://developers.cloudflare.com/cloudflare-one/identity/devices/warp-client-checks/require-gateway/ https://developers.cloudflare.com/cloudflare-one/identity/devices/warp-client-checks/require-warp/