### PR TITLE
Add note about ensuring traffic is inside tunnel

### DIFF
--- a/content/cloudflare-one/identity/devices/_index.md
+++ b/content/cloudflare-one/identity/devices/_index.md
@@ -35,7 +35,7 @@ You can now use your device posture check in an [Access policy](/cloudflare-one/
 
 ## 4. Ensure traffic is going through WARP
 
-[WARP client](/cloudflare-one/identity/devices/warp-client-checks/) and [Service-to-service](/cloudflare-one/identity/devices/service-providers/) posture checks rely on traffic going through WARP to properly lookup posture information for a device. You may have to [configure split tunnel](/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/) rules such that the following is included in the tunnel where appropriate.
+[WARP client](/cloudflare-one/identity/devices/warp-client-checks/) and [Service-to-service](/cloudflare-one/identity/devices/service-providers/) posture checks rely on traffic going through WARP to properly lookup posture information for a device. In your [Split Tunnel configuration](/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/), ensure that the following domains are included in WARP:
 
 * The IdP used to authenticate to Cloudflare Zero Trust if posture check is part of an Access policy.
 * `<your-team-name>.cloudflareaccess.com` if posture check is part of an Access policy.

--- a/content/cloudflare-one/identity/devices/_index.md
+++ b/content/cloudflare-one/identity/devices/_index.md
@@ -28,6 +28,15 @@ Before integrating a device posture check in a Gateway or Access policy, you sho
 
 ![Device posture results in the Zero Trust dashboard](/cloudflare-one/static/documentation/identity/devices/device-posture-dash-result.png)
 
+
 ## 3. Build a device posture policy
 
 You can now use your device posture check in an [Access policy](/cloudflare-one/policies/access/) or a Gateway [network policy](/cloudflare-one/policies/filtering/network-policies/common-policies/#enforce-device-posture). In Access, the enabled device posture attributes will appear in the list of available [selectors](/cloudflare-one/policies/access/#selectors). In Gateway, the attributes will appear when you choose the [Passed Device Posture Check](/cloudflare-one/policies/filtering/network-policies/#device-posture) selector.
+
+## 4. Ensure traffic is going through WARP
+
+[WARP client](/cloudflare-one/identity/devices/warp-client-checks/) and [Service-to-service](/cloudflare-one/identity/devices/service-providers/) posture checks rely on traffic going through WARP to properly lookup posture information for a device. You may have to [configure split tunnel](/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/) rules such that the following is included in the tunnel where appropriate.
+
+* The IdP used to authenticate to Cloudflare Zero Trust if posture check is part of an Access policy.
+* `<your-team-name>.cloudflareaccess.com` if posture check is part of an Access policy.
+* The application protected by the Access or Gateway policy.


### PR DESCRIPTION
Ensure folks understand that traffic is inside the tunnel for posture checks to work. We had this information buried in https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/#cloudflare-zero-trust-domains but wanted to also bubble it up as part of things folks need to care about when creating posture rules.