### PR TITLE
Document extra incoming headers on Cloudflare Workers

### DIFF
--- a/content/workers/runtime-apis/headers.md
+++ b/content/workers/runtime-apis/headers.md
@@ -80,3 +80,48 @@ Used for loop detection, similar to the `CDN-Loop` [header](https://blog.cloudfl
 
 </div>
 </details>
+
+<details>
+<summary>Accept-Encoding</summary>
+<div>
+
+For incoming requests, the value of this header will always be set to `gzip`. If the client set a different value, such as `*` or `br`, it will be overwritten.
+
+</div>
+</details>
+
+<details>
+<summary>Connection</summary>
+<div>
+
+For incoming requests, the value of this header will always be set to `Keep-Alive`. If the client set a different value, such as `close`, it will be overwritten. Note that is also the case when the client uses HTTP/2 or HTTP/3 to connect.
+
+</div>
+</details>
+
+<details>
+<summary>X-Forwarded-For</summary>
+<div>
+
+For incoming requests, this header has no special behaviour. It reflects the `X-Forwarded-For` header as sent by the client. Cloudflare will not add the `X-Forwarded-For` header to `request.headers` if it was not sent by the client, and will not change it if the client provided it.
+
+</div>
+</details>
+
+<details>
+<summary>X-Forwarded-Proto</summary>
+<div>
+
+For incoming requests, the value of this header will be set to the protocol the client used (`http` or `https`). If the client set a different value, it will be overwritten.
+
+</div>
+</details>
+
+<details>
+<summary>X-Real-IP</summary>
+<div>
+
+For incoming requests, the value of this header will be set to the client's IP address. If the client set a different value, it will be overwritten. The value has the same semantics as [`CF-Connecting-IP`](/fundamentals/get-started/reference/http-request-headers/#cf-connecting-ip) and [`True-Client-IP`](/fundamentals/get-started/reference/http-request-headers/#true-client-ip-enterprise-plan-only).
+
+</div>
+</details>

--- a/content/workers/runtime-apis/headers.md
+++ b/content/workers/runtime-apis/headers.md
@@ -85,7 +85,7 @@ Used for loop detection, similar to the `CDN-Loop` [header](https://blog.cloudfl
 <summary>Accept-Encoding</summary>
 <div>
 
-For incoming requests, the value of this header will always be set to `gzip`. If the client set a different value, such as `*` or `br`, it will be overwritten.
+For incoming requests, the value of this header will always be set to `gzip`. If the client set a different value, such as `*` or `br`, it will be overwritten and the original value will be available in `request.cf.clientAcceptEncoding`.
 
 </div>
 </details>


### PR DESCRIPTION
When making a request to a Worker, extra headers are added by Cloudflare not reflected in the documentation. Additionally, headers provided by a client are modified.

Here's an example of `request.headers` in a JS CFW. `>>` are headers by Cloudflare, `!!` are headers added by Cloudflare which are not documented or have suprising behaviour.


```
﻿    aaa: xxx
    accept: */*
!!  accept-encoding: gzip
    bbb: xxx
    ccc: xxx, xxx
>>  cf-connecting-ip: 37.120.218.158
>>  cf-ipcountry: BE
>>  cf-ray: 745e2165bd1f72a2
>>  cf-visitor: {"scheme":"https"}
!!  connection: Keep-Alive
    ddd: xxx
    host: worker-example.ttdv.workers.dev
    user-agent: curl/7.79.1
>>  x-forwarded-proto: https
!!  x-real-ip: 37.120.218.158
```

As a user of Cloudflare Workers, I would expect the headers available in my Worker to be exactly as the client sent them. Some of these headers are logical when doing reverse proxying (such as `Accept-Encoding`: the reverse proxy need not tell the origin what the client supports, but what it supports), others are overwritten (can't get access to the `X-Real-IP` header sent by the client), and for `X-Forwarded-For` and `X-Forwarded-Proto` there's a discrepancy (`X-Forwarded-Proto` is set, but `X-Forwarded-For` is not).

This PR documents the behaviour of those headers for incoming requests to CFW (`request.headers`).
