### PR TITLE
[Wrangler] Add required node version

### DIFF
--- a/content/workers/wrangler/get-started.md
+++ b/content/workers/wrangler/get-started.md
@@ -23,7 +23,13 @@ If you previously had Wrangler 1 installed or were working on a Wrangler 1 proje
 
 Installing Wrangler, the Workers CLI, allows you to [`init`](/workers/wrangler/commands/#init), [`dev`](/workers/wrangler/commands/#dev), and [`publish`](/workers/wrangler/commands/#publish) your Workers projects.
 
-To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm` installed](https://docs.npmjs.com/getting-started), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to easily change Node.js versions. Then run:
+To install [`wrangler`](https://github.com/cloudflare/wrangler2), ensure you have [`npm`](https://www.npmjs.com/get-npm) and [`Node.js`](https://nodejs.org/en/) installed. Wrangler requires a Node version of `16.13.0` or later. 
+
+{{<Aside type="note">}}
+Consider using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to easily change Node.js versions.
+{{</Aside>}}
+
+Then run:
 
 ```sh
 $ npm install -g wrangler


### PR DESCRIPTION
Adds required node version to the get-started page for wrangler docs. Noted version is taken from:
https://github.com/cloudflare/wrangler2/blob/6aae958aafc7a2a5be8853214438bc7c1ccda939/package.json#L160

For WC-611