### PR TITLE
[R2] Use the word million on pricing page

### DIFF
--- a/content/r2/platform/pricing.md
+++ b/content/r2/platform/pricing.md
@@ -22,8 +22,8 @@ All included usage is on a monthly basis.
 |                    | Free                         | Paid - Rates                       | 
 | ------------------ | ---------------------------- | ---------------------------------- |
 | Storage            | 10 GB / month                | $0.015 / GB-month                  |
-| Class A Operations | 1,000,000 requests / month   | $4.50 / million requests           | 
-| Class B Operations | 10,000,000 requests / month  | $0.36 / million requests           | 
+| Class A Operations | 1 million requests / month   | $4.50 / million requests           | 
+| Class B Operations | 10 million requests / month  | $0.36 / million requests           | 
 
 {{</table-wrap>}}
 
@@ -57,8 +57,8 @@ If a user writes 1,000 objects in R2 for 1 month and each object is 1 GB in size
 {{<table-wrap>}}
 |                    | Usage                                      | Free Tier    | Billable Quantity | Price      |
 |--------------------|--------------------------------------------|--------------|-------------------|------------|
-| Class B Operations | (1,000 objects) * (1,000 reads per object) |   10,000,000 |                 0 |      $0.00 |
-| Class A Operations | (1,000 objects) * (1 write per object)     |    1,000,000 |                 0 |      $0.00 |
+| Class B Operations | (1,000 objects) * (1,000 reads per object) |   10 million |                 0 |      $0.00 |
+| Class A Operations | (1,000 objects) * (1 write per object)     |    1 million |                 0 |      $0.00 |
 | Storage            | (1,000 objects) * (1GB per object)         | 10 GB-months |     990 GB-months |     $14.85 |
 | **TOTAL**          |                                            |              |                   | **$14.85** |
 {{</table-wrap>}}
@@ -70,8 +70,8 @@ If a user writes the same 1 GB object 1,000,000 times a day and the object is re
 {{<table-wrap>}}
 |                    | Usage                                               | Free Tier    | Billable Quantity | Price       |
 |--------------------|-----------------------------------------------------|--------------|-------------------|-------------|
-| Class B Operations | (1 object) * (10,000,000 reads per day) * (30 days) |   10,000,000 |       290,000,000 |     $104.40 |
-| Class A Operations | (1 object) * (1,000,000 writes per day) * (30 days) |    1,000,000 |        29,000,000 |     $130.50 |
+| Class B Operations | (1 object) * (10,000,000 reads per day) * (30 days) |   10 million |       290,000,000 |     $104.40 |
+| Class A Operations | (1 object) * (1,000,000 writes per day) * (30 days) |    1 million |        29,000,000 |     $130.50 |
 | Storage            | (1 object) * (1GB per object)                       | 10 GB-months |       0 GB-months |        $0.00 |
 | **TOTAL**          |                                                     |              |                   | **$234.90** |
 {{</table-wrap>}}


### PR DESCRIPTION
This makes it more consistent with the Workers Runtime pricing page.