### PR TITLE
[Workers][Platform] Remove R2 Storage from list of betas

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -14,7 +14,6 @@ These are the betas relevant to Cloudflare Workers.
 | D1 Database                   | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-d1/)                         |
 | Green Compute                 |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       | ✅           |              |[Docs](/pub-sub)                                                            |
-| R2 Storage                    |              |  ✅          |[Docs](/r2)                                                                 |
 | TCP Workers                   | ✅           |             |[Blog](https://blog.cloudflare.com/introducing-socket-workers/) |
 | Workers Analytics Engine      | ✅           |              |[Blog](https://blog.cloudflare.com/workers-analytics-engine/)               |
 | Workers for Platforms         | ✅           |               | [Blog](https://blog.cloudflare.com/workers-for-platforms/)                  |


### PR DESCRIPTION
As R2 has now transitioned out of public beta to GA ([https://blog.cloudflare.com/r2-ga/](https://blog.cloudflare.com/r2-ga/)) it should be removed from the list of platform betas.