### PR TITLE
[Docs] Fix issues in code blocks (indent, formatting, text truncation)

### DIFF
--- a/bin/highlight.ts
+++ b/bin/highlight.ts
@@ -78,7 +78,7 @@ async function markdown(file: string): Promise<void> {
     let html = highlight(inner, lang);
 
     // prevent hugo from looking at "{{<" pattern
-    output += '{{<raw>}}' + html.replace(/\{\{\</g, '{\\{<') + '{{</raw>}}';
+    output += "\n\n" + ' '.repeat(spaces?.length ?? 0) + '{{<raw>}}' + html.replace(/\{\{\</g, '{\\{<') + '{{</raw>}}';
 
     last = current + full.length;
   }

--- a/bin/highlight.ts
+++ b/bin/highlight.ts
@@ -56,7 +56,7 @@ async function markdown(file: string): Promise<void> {
   let output = '';
   let match: RegExpExecArray | null;
   let input = await fs.readFile(file, 'utf8');
-  let BACKTICKS = /^(\s+)?([`]{3})([A-Za-z]+?)\r?\n([^]+?)(\2)/gm;
+  let BACKTICKS = /^(\s+)?([`]{3})([A-Za-z]+)?\r?\n([^]+?)(\2)/gm;
 
   while ((match = BACKTICKS.exec(input))) {
     let current = match.index;

--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -234,7 +234,9 @@ export function highlight(code: string, lang: string): string {
     header?: string;
   } = {};
 
-  if (code.substring(0, 3) === '---') {
+  // Check for a YAML frontmatter,
+  // and ensure it's not something like -----BEGIN CERTIFICATE-----
+  if (code.substring(0, 3) === '---' && code[3] != '-') {
     let index = code.indexOf('---', 3);
     if (index > 3) {
       index += 3;


### PR DESCRIPTION
Fixes the following issues:

## Issue 1
A code block immediately following a list would also be indented, as part of the last element of the list:

Before and after:

![image](https://user-images.githubusercontent.com/680496/191736769-26600b53-a76b-4eeb-8fea-f1e2fc04a623.png)

https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/#step-1-generate-a-unique-one-time-upload-url
https://pedro-fix-highlight.cloudflare-docs-7ou.pages.dev/stream/uploading-videos/direct-creator-uploads/#step-1-generate-a-unique-one-time-upload-url

This issue was also identified in PR #5732.

## Issue 2
Code blocks starting with `---` — which includes `-----BEGIN CERTIFICATE`, for example — where being truncated.

Before and after:

![image](https://user-images.githubusercontent.com/680496/191737382-c4994bdc-27ae-4647-a059-196500626de5.png)

https://developers.cloudflare.com/cloudflare-one/tutorials/google-workspace-saas/#2-create-a-certificate-from-your-public-key
https://pedro-fix-highlight.cloudflare-docs-7ou.pages.dev/cloudflare-one/tutorials/google-workspace-saas/#2-create-a-certificate-from-your-public-key

## Issue 3

Code blocks without any assigned language were rendered as monospaced text, but did not have the usual code block formatting (grey background with round corners):

Before and after:

![image](https://user-images.githubusercontent.com/680496/191737866-d851e3fb-eceb-4e7b-ae19-5751e1f64d93.png)

https://developers.cloudflare.com/pages/platform/custom-domains/#caa-records
https://pedro-fix-highlight.cloudflare-docs-7ou.pages.dev/pages/platform/custom-domains/#caa-records

--- 

## Regression (visual) tests

Tabs (both "code" and "no-code" versions) still work as expected:
https://pedro-fix-highlight.cloudflare-docs-7ou.pages.dev/workers/examples/images-workers/
https://pedro-fix-highlight.cloudflare-docs-7ou.pages.dev/ssl/edge-certificates/custom-certificates/uploading/#update-a-certificate

Feel free to check any other cases I didn't think of.