### PR TITLE
Update availability for IPv6 reverse zones

### DIFF
--- a/content/dns/additional-options/reverse-zones.md
+++ b/content/dns/additional-options/reverse-zones.md
@@ -28,8 +28,7 @@ Any customer can create PTR records, but only Enterprise customers can create re
 
 The following Cloudflare customers can create reverse zones (for example, `2.0.192.in-addr.arpa`):
 
-- Enterprise customers with an IPv4 address space can add the IPv4 reverse zone for their IP space to their account, and create the required PTR records for forward resolution.
-- Enterprise customers with an IPv6 address space need to contact their account team to get the IPv6 reverse zone added to their account.
+- Enterprise customers with an IPv4 or IPv6 address space can add the IPv4 or IPv6 reverse zone for their IP space to their account, and create the required PTR records for forward resolution.
 - DNS Firewall customers need to contact their account team to add PTR records for the IPs used for their DNS Firewall clusters.
 
 If your account does not meet these qualifications and you do not own the IP prefix you want to add PTR records on, contact the owner of the IP address based on a [whois lookup](https://whois.icann.org/en).


### PR DESCRIPTION
IPv6 reverse zones are now self-serve for all Enterprise.

@kodster28 simple change I decided to just directly create the PR for :-)