### PR TITLE
Swap Verizon Edgecast IP addresses

### DIFF
--- a/content/ruleset-engine/rules-language/operators.md
+++ b/content/ruleset-engine/rules-language/operators.md
@@ -75,7 +75,7 @@ Access to the `matches` operator requires a Cloudflare Business or Enterprise pl
       <td>&#x2705;</td>
       <td>&#x2705;</td>
       <td>
-         <code class="InlineCode">ip.src <strong>ne</strong> 93.184.216.0</code>
+         <code class="InlineCode">ip.src <strong>ne</strong> 203.0.113.0</code>
       </td>
     </tr>
     <tr>
@@ -152,7 +152,7 @@ Access to the `matches` operator requires a Cloudflare Business or Enterprise pl
       <td>&#x2705;</td>
       <td>&#x2705;</td>
       <td>
-         <code class="InlineCode">ip.src <strong>in</strong> { 93.184.216.0 93.184.216.1 }</code>
+         <code class="InlineCode">ip.src <strong>in</strong> { 203.0.113.0 203.0.113.1 }</code>
       </td>
     </tr>
   </tbody>
@@ -189,7 +189,7 @@ Each logical operator has an [order of precedence](#order-of-precedence). The or
       <td><code class="InlineCode">not</code></td>
       <td><code class="InlineCode">!</code></td>
       <td>
-         <code class="InlineCode"><strong>not</strong> ( http.host eq "www.cloudflare.com" and ip.src in 93.184.216.0/24 )</code>
+         <code class="InlineCode"><strong>not</strong> ( http.host eq "www.cloudflare.com" and ip.src in 203.0.113.0/24 )</code>
       </td>
       <td>1</td>
    </tr>
@@ -198,7 +198,7 @@ Each logical operator has an [order of precedence](#order-of-precedence). The or
       <td><code class="InlineCode">and</code></td>
       <td><code class="InlineCode">&amp;&amp;</code></td>
       <td>
-         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>and</strong> ip.src in 93.184.216.0/24</code>
+         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>and</strong> ip.src in 203.0.113.0/24</code>
       </td>
       <td>2</td>
    </tr>
@@ -208,7 +208,7 @@ Each logical operator has an [order of precedence](#order-of-precedence). The or
       <td><code class="InlineCode">xor</code></td>
       <td><code class="InlineCode">^^</code></td>
       <td>
-         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>xor</strong> ip.src in 93.184.216.0/24</code>
+         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>xor</strong> ip.src in 203.0.113.0/24</code>
       </td>
       <td>3</td>
    </tr>
@@ -217,7 +217,7 @@ Each logical operator has an [order of precedence](#order-of-precedence). The or
       <td><code class="InlineCode">or</code></td>
       <td><code class="InlineCode">||</code></td>
       <td>
-         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>or</strong> ip.src in 93.184.216.0/24</code>
+         <code class="InlineCode">http.host eq "www.cloudflare.com" <strong>or</strong> ip.src in 203.0.113.0/24</code>
       </td>
       <td>4</td>
    </tr>


### PR DESCRIPTION
IP addresses in Documentation should be compliant with https://datatracker.ietf.org/doc/html/rfc5737 I swapped 93.xxx addresses from Verizon Edgecast with RFC-compliant IP addresses