### PR TITLE
Update bfd.md

### DIFF
--- a/content/network-interconnect/about/bfd.md
+++ b/content/network-interconnect/about/bfd.md
@@ -1,12 +1,12 @@
 ---
 pcx_content_type: concept
-title: Bidirectional Forwarding Direction
+title: Bidirectional Forwarding Detection
 ---
 
-# Bidirectional Forwarding Direction
+# Bidirectional Forwarding Detection
 
-Bidirectional Forwarding Direction (BFD) is a networking protocol that constantly monitors links and BGP sessions down to the second by sending a constant stream of traffic across the session.
+Bidirectional Forwarding Detection (BFD) is a networking protocol that constantly monitors links and BGP sessions down to the second by sending a constant stream of traffic across the session.
 
 If a small number of packets does not make it to the other side of the session, the session is considered down. This solution is useful for users who cannot tolerate any amount of packet loss during a session.
 
-Bidirectional Forwarding Direction is only supported for users with private network interconnects (PNI). To begin using BFD, contact your account manager.
+Bidirectional Forwarding Detection is only supported for users with private network interconnects (PNI). To begin using BFD, contact your account manager.


### PR DESCRIPTION
Article incorrectly described BFD as "Bidirectional Forwarding Direction" instead of Bidirectional Forwarding Detection (https://www.rfc-editor.org/rfc/rfc5881) The direction is bidirectional after all.