### PR TITLE
[R2] Document r2_list_honor_include compat flag.

### DIFF
--- a/content/r2/data-access/workers-api/workers-api-reference.md
+++ b/content/r2/data-access/workers-api/workers-api-reference.md
@@ -242,7 +242,7 @@ There are 3 variations of arguments that can be used in a range:
 
   - Note that there is a limit on the total amount of data that a single `list` operation can return. If you request data, you may recieve fewer than `limit` results in your response to accomodate metadata.
 
-  - The [compatibility date](/workers/platform/compatibility-dates/) must be set to `2022-08-04` or later in your `wrangler.toml` file. If not, then the `r2_list_honor_include` compatibility flag must be set. Otherwise, it is treated as `include: ['httpMetadata', 'customMetadata']` regardless of the `include` option provided.
+  - The [compatibility date](/workers/platform/compatibility-dates/) must be set to `2022-08-04` or later in your `wrangler.toml` file. If not, then the `r2_list_honor_include` compatibility flag must be set. Otherwise it is treated as `include: ['httpMetadata', 'customMetadata']` regardless of what the `include` option provided actually is.
 
   This means applications must be careful to avoid comparing the amount of returned objects against your `limit`. Instead, use the `truncated` property to determine if the `list` request has more data to be returned.
 

--- a/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
+++ b/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
@@ -10,4 +10,6 @@ enable_date: "2022-08-04"
 enable_flag: "r2_list_honor_include"
 ---
 
-With the `r2_list_honor_include` flag set, the `include` argument to R2 `list` options is honored. With an older compatability date and without this flag, the `include` argument behaves implicitly as `include: ["httpMetadata", "customMetadata"]`.
+With the `r2_list_honor_include` flag set, the `include` argument to R2 `list` options is honored.
+With an older compatability date and without this flag, the `include` argument behaves implicitly
+as `include: ["httpMetadata", "customMetadata"]`.

--- a/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
+++ b/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
@@ -10,6 +10,4 @@ enable_date: "2022-08-04"
 enable_flag: "r2_list_honor_include"
 ---
 
-With the `r2_list_honor_include` flag set, the `include` argument to R2 `list` options is honored.
-With an older compatability date and without this flag, the `include` argument behaves implicitly
-as `include: ["httpMetadata", "customMetadata"]`.
+With the `r2_list_honor_include` flag set, the `include` argument to R2 `list` options is honored. With an older compatability date and without this flag, the `include` argument behaves implicitly as `include: ["httpMetadata", "customMetadata"]`.


### PR DESCRIPTION
Looks like the previous merge discarded some important wording fixes. Not sure how that happened.