### PR TITLE
Update WebRTC beta page to include invite to discord server

### DIFF
--- a/content/stream/webrtc-beta.md
+++ b/content/stream/webrtc-beta.md
@@ -15,7 +15,7 @@ WebRTC is ideal for when you need live video to playback in near real-time, such
 - When you want your end users to be able to easily go live or create their own video content, from a web browser or native app
 
 {{<Aside>}}
-WebRTC streaming is currently in beta, and we'd love to hear what you think. Join our [Discord channel](https://discord.com/channels/595317990191398933/893253103695065128) and let us know what you're buliding with WebRTC!
+WebRTC streaming is currently in beta, and we'd love to hear what you think. Join the Cloudflare Discord server [using this invite](https://discord.com/invite/cloudflaredev/) and hop into our [Discord channel](https://discord.com/channels/595317990191398933/893253103695065128) to let us know what you're building with WebRTC!
 {{</Aside>}}
 
 ## Step 1: Create a live input


### PR DESCRIPTION
@irvinebroque or other reviewers: feel free to edit however makes sense to you, force push to this branch, or merge without me :)

-----

This was reported by a user in our Discord; they had trouble using the link we provided originally, it only works if you were already invited to the server.

This change tweaks that to provide a general invite to the server (the same shared in our community docs) as well as the direct channel link.