### PR TITLE
Clarify how to enable UDP

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/private-net/private-hostnames-ips.md
+++ b/content/cloudflare-one/connections/connect-apps/private-net/private-hostnames-ips.md
@@ -58,7 +58,7 @@ While on the Network Settings page, ensure that **Split Tunnels** are configured
 
 ## Update `cloudflared`
 
-Next, update your Cloudflare Tunnel configuration to ensure it is using QUIC as the default transport protocol. To do this, you can either set the `protocol: quic` property in your [configuration file](/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/configuration-file/) or [pass the `–-protocol quic` flag](/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/) directly through your CLI.
+Next, update your Cloudflare Tunnel configuration to ensure it is using QUIC as the default transport protocol. This will enable `cloudflared` to proxy UDP-based traffic which is required in most cases to resolve DNS queries. To do this, you can either set the `protocol: quic` property in your [configuration file](/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/configuration-file/) or [pass the `–-protocol quic` flag](/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/) directly through your CLI.
 
 Finally, update to the latest available version (2021.12.3 as of the time of writing) of cloudflared running on your target private network.
 


### PR DESCRIPTION
In this guide, we explicitly state that QUIC is required to complete this setup, but we don't fully cover why. Adding a sentence to clarify what QUIC provides in the context of this guide.