### PR TITLE
[workers] remove beta label from R2 in storage-objects.md

### DIFF
--- a/content/workers/platform/storage-objects.md
+++ b/content/workers/platform/storage-objects.md
@@ -47,7 +47,7 @@ To get started with R2:
 
 {{<table-wrap>}}
 
-| Feature                                       | KV           | R2 (beta)    |
+| Feature                                       | KV           | R2           |
 | --------------------------------------------- | ------------ | ------------ |
 | Maximum size per value                        | 25 MiB       | 5 TB         |
 | Consistency model                             | Eventual     | Strong       |


### PR DESCRIPTION
R2 is not longer in beta