### PR TITLE
Remove API only mention ?

### DIFF
--- a/content/rules/custom-error-responses/_index.md
+++ b/content/rules/custom-error-responses/_index.md
@@ -17,8 +17,6 @@ To configure a custom error response, create a custom error response rule at the
 
 During the beta, you can define custom error responses using inline templates and specify the response's content type and HTTP status code.
 
-Additionally, at this stage you can only create custom error response rules [using the API](/rules/custom-error-responses/create-api/).
-
 {{</Aside>}}
 
 ## How it works


### PR DESCRIPTION
Unless I'm missing something, the feature can be configured using the Cloudflare Dashboard. API is still available but it's not "required" as the only way to configure Custom Error Response. Right ?