### PR TITLE
Polish compat date API

### DIFF
--- a/bin/crawl.ts
+++ b/bin/crawl.ts
@@ -120,11 +120,7 @@ async function task(file: string) {
 
       if (!/https?/.test(resolved.protocol)) return;
 
-      if (
-        resolved.hostname === "developers.cloudflare.com" &&
-        // Add an exception allowing absolute URLs in the Workers Compatibility Dates page
-        url.pathname !== "/workers/platform/compatibility-dates/"
-      ) {
+      if (resolved.hostname === "developers.cloudflare.com") {
         messages.push({
           type: "warn",
           html: content,

--- a/bin/crawl.ts
+++ b/bin/crawl.ts
@@ -120,7 +120,11 @@ async function task(file: string) {
 
       if (!/https?/.test(resolved.protocol)) return;
 
-      if (resolved.hostname === "developers.cloudflare.com") {
+      if (
+        resolved.hostname === "developers.cloudflare.com" &&
+        // Add an exception allowing absolute URLs in the Workers Compatibility Dates page
+        url.pathname !== "/workers/platform/compatibility-dates/"
+      ) {
         messages.push({
           type: "warn",
           html: content,

--- a/content/workers/_partials/_platform-compatibility-dates/fetch-improperly-interprets-unknown-protocols-as-http.md
+++ b/content/workers/_partials/_platform-compatibility-dates/fetch-improperly-interprets-unknown-protocols-as-http.md
@@ -5,8 +5,8 @@ _build:
   list: never
 
 name: "`fetch()` improperly interprets unknown protocols as HTTP"
-date: "2022-11-10"
-enable_date: "2022-11-10"
+date: "2021-11-10"
+enable_date: "2021-11-10"
 enable_flag: "fetch_refuses_unknown_protocols"
 disable_flag: "fetch_treats_unknown_protocols_as_http"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
@@ -11,9 +11,9 @@ enable_flag: "streams_byob_reader_detaches_buffer"
 disable_flag: "streams_byob_reader_does_not_detach_buffer"
 ---
 
-Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](/workers/runtime-apis/streams/readablestreambyobreader/#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change makes Workers conform to the spec.
+Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestreambyobreader/#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change makes Workers conform to the spec.
 
-User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](/workers/runtime-apis/streams/readablestreambyobreader/#methods). Instead, user code can re-use the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
+User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestreambyobreader/#methods). Instead, user code can re-use the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
 
 ```js
 // Consume and discard `readable` using a single 4KiB buffer.

--- a/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
@@ -13,7 +13,7 @@ disable_flag: "streams_byob_reader_does_not_detach_buffer"
 
 Originally, the Workers runtime did not detach the `ArrayBuffer`s from user-provided TypedArrays when using the [BYOB reader's `read()` method](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestreambyobreader/#methods), as required by the Streams spec, meaning it was possible to inadvertently reuse the same buffer for multiple `read()` calls. This change makes Workers conform to the spec.
 
-User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestreambyobreader/#methods). Instead, user code can re-use the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
+User code should never try to reuse an `ArrayBuffer` that has been passed into a [BYOB reader's `read()` method](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestreambyobreader/#methods). Instead, user code can reuse the `ArrayBuffer` backing the result of the `read()` promise, as in the example below.
 
 ```js
 // Consume and discard `readable` using a single 4KiB buffer.

--- a/functions/workers/platform/compatibility-dates.json.ts
+++ b/functions/workers/platform/compatibility-dates.json.ts
@@ -1,0 +1,5 @@
+// Will replace this with rewrites/proxying when eventually supported
+
+export const onRequest = ({ request, next }) => {
+  return next("/workers/platform/compatibility-dates/index.json", request);
+};


### PR DESCRIPTION
Serves the compatibility date API at `/workers/platform/compatibility-dates.json` and makes the URLs referenced absolute.