### PR TITLE
[Turnstile] Removed domain example

### DIFF
--- a/content/turnstile/get-started/domain-management.md
+++ b/content/turnstile/get-started/domain-management.md
@@ -21,7 +21,6 @@ For example, using the `www.example.com` value will allow widgets on the followi
 but not on the following domains:
 * `example.com`
 * `dash.example.com`
-* `attacker-website.cf`
 * `not-example.com`
 
 When the widget is embedded on a domain not listed, it will show an error message.

--- a/content/turnstile/get-started/domain-management.md
+++ b/content/turnstile/get-started/domain-management.md
@@ -21,7 +21,7 @@ For example, using the `www.example.com` value will allow widgets on the followi
 but not on the following domains:
 * `example.com`
 * `dash.example.com`
-* `not-example.com`
+* `workerd.dev`
 
 When the widget is embedded on a domain not listed, it will show an error message.
 

--- a/content/turnstile/get-started/domain-management.md
+++ b/content/turnstile/get-started/domain-management.md
@@ -21,7 +21,7 @@ For example, using the `www.example.com` value will allow widgets on the followi
 but not on the following domains:
 * `example.com`
 * `dash.example.com`
-* `workerd.dev`
+* `cloudflare.com`
 
 When the widget is embedded on a domain not listed, it will show an error message.
 


### PR DESCRIPTION
- In the Turnstile docs, several domains are provided as examples for how Domain Management works.
- One of the example domains was previously unregistered, has now been registered (not by Cloudflare) and now redirects to a Discord link not associated with Cloudflare.
- This PR removes this domain from the docs, as a precaution in case someone pastes the link into an address bar or otherwise visits the domain and is redirected away from what they are looking for.

On an unrelated note, I'm questioning the `:8080` part on the second example domain as the text in the paragraph above says a port shouldn't be specified?