### PR TITLE
Wrangler: Replace references to `create-cloudflare` with `wrangler generate`

### DIFF
--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -13,7 +13,7 @@ layout: list
 Quickstarts are GitHub repos that are designed to be a starting point for building a new Cloudflare Workers project. For the projects below, you simply run:
 
 ```sh
-$ npm init cloudflare <new-project-name> <github-repo-url>
+$ npx wrangler generate <new-project-name> <github-repo-url>
 ```
 
 {{<definitions>}}

--- a/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
+++ b/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
@@ -56,7 +56,7 @@ $ curl --request POST \
  --header 'Authorization: Bearer <API_TOKEN>' \
  --form 'url=<PATH_TO_IMAGE>' \
  --form 'metadata={"key":"value"}' \
- --form 'requireSignedURLs=false' 
+ --form 'requireSignedURLs=false'
 
 ```
 
@@ -94,7 +94,7 @@ Now that we've uploaded the image we'll be using it as a background for our thum
 The next phase of this tutorial is to create a worker that will enable you to transform text to image so this can be used as an overlay on the background image we uploaded. We will use the [rustwasm-worker-template](https://github.com/cloudflare/templates/tree/main/worker-rust). Go ahead and clone the repository and run it locally.
 
 ```sh
-$ npm init cloudflare worker-to-text worker-rust
+$ npx wrangler generate worker-to-text worker-rust
 ```
 
 In the `lib.rs` file, add the following code block:
@@ -496,7 +496,7 @@ fetch(imageURL, {
      height: 720,
      draw: [
        {
-         url: 'https://text-to-image.examples.workers.dev',         
+         url: 'https://text-to-image.examples.workers.dev',
          left: 40,
        },
      ],

--- a/layouts/shortcodes/worker-starter.html
+++ b/layouts/shortcodes/worker-starter.html
@@ -3,7 +3,7 @@
 {{- $descr := .Get "description" -}}
 
 {{- $remote := printf "https://github.com/%s" $repo -}}
-{{- $command := printf "npm init cloudflare my-app %s" $remote -}}
+{{- $command := printf "npx wrangler generate my-app %s" $remote -}}
 
 <div class="WorkerStarter">
   <div class="WorkerStarter--title">


### PR DESCRIPTION
[`create-cloudflare`](https://github.com/cloudflare/templates/tree/main/packages/create-cloudflare) has been deprecated in favor of `wrangler generate`. This PR updates the docs to reflect that.

See: https://github.com/cloudflare/wrangler2/issues/1669