### PR TITLE
[Docs Site] clipboard: do not copy unselectable elements from codeblocks.

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -92,19 +92,28 @@ function $clicktoClipboard(ev: MouseEvent) {
   const button = ev.target as HTMLElement;
   const pre = button.parentElement;
   if (pre) {
-    const code = pre.getElementsByTagName("code")[0];
-    const text = code.innerText;
-    if (text) {
-      try {
-        //copy to clipboard
-        navigator.clipboard.writeText(text);
-        //change SVG
-        button.innerHTML = `<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"  style= "width:1rem; pointer-events: none;"  aria-label="Copied to clipboard button" focusable="true"><title>Copied Button</title><path d="M8.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L2.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093L8.95 4.992a.252.252 0 0 1 .02-.022zm-.92 5.14.92.92a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 1 0-1.091-1.028L9.477 9.417l-.485-.486-.943 1.179z"></path></svg>`;
-        setTimeout(() => {
-          button.innerHTML = `<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style= "width:1rem; pointer-events: none;" aria-label="Copy to clipboard button" focusable="true"><title>Copy Button</title><path fill="none" d="M0 0h24v24H0z"></path><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"></path></svg>`;
-        }, 1500);
-      } catch (err) {
-        /* no support */
+    const codeNodes = pre.getElementsByTagName("code");
+    if (codeNodes.length >= 1){
+      // the markdown's code blocks adds a class "CodeBlock--token-unselectable", if it is not supposed to be copied.
+      // clone the code node, we do not want to modify the DOM.
+      const code = codeNodes[0].cloneNode(true) as HTMLElement;
+      const unselectableTokens = code.getElementsByClassName("CodeBlock--token-unselectable");
+      for (let i = 0; i < unselectableTokens.length; i++){
+        unselectableTokens[i].remove();
+      }
+      const text = code.innerText;
+      if (text) {
+        try {
+          //copy to clipboard
+          navigator.clipboard.writeText(text);
+          //change SVG
+          button.innerHTML = `<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"  style= "width:1rem; pointer-events: none;"  aria-label="Copied to clipboard button" focusable="true"><title>Copied Button</title><path d="M8.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L2.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093L8.95 4.992a.252.252 0 0 1 .02-.022zm-.92 5.14.92.92a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 1 0-1.091-1.028L9.477 9.417l-.485-.486-.943 1.179z"></path></svg>`;
+          setTimeout(() => {
+            button.innerHTML = `<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg" style= "width:1rem; pointer-events: none;" aria-label="Copy to clipboard button" focusable="true"><title>Copy Button</title><path fill="none" d="M0 0h24v24H0z"></path><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"></path></svg>`;
+          }, 1500);
+        } catch (err) {
+          /* no support */
+        }
       }
     }
   }


### PR DESCRIPTION
The codeblocks seem to tag tokens that should not be copied with the class name`CodeBlock--token-unselectable`. We use that to cloneNode() the code element and remove children with that class name, before getting the innerText.

This safely removes the leading `$` in languages like bash, while keeping it in other languages like JS. Other languages should work as expected according to the syntax definitions.

Fixes #5474 