### PR TITLE
Add link to ExoPlayer tutorial in Android example

### DIFF
--- a/content/stream/examples/android.md
+++ b/content/stream/examples/android.md
@@ -15,7 +15,7 @@ layout: example
 
 ### Download and run an example app
 
-1. Download [this example app](https://github.com/googlecodelabs/exoplayer-intro.git) from the official Android developer docs.
+1. Download [this example app](https://github.com/googlecodelabs/exoplayer-intro.git) from the official Android developer docs, following [this guide](https://developer.android.com/codelabs/exoplayer-intro#4).
 2. Open and run the [exoplayer-codelab-04 example app](https://github.com/googlecodelabs/exoplayer-intro/tree/main/exoplayer-codelab-04) using [Android Studio](https://developer.android.com/studio).
 3. Replace the `media_url_dash` URL on [this line](https://github.com/googlecodelabs/exoplayer-intro/blob/main/exoplayer-codelab-04/src/main/res/values/strings.xml#L21) with the DASH manifest URL for your video.
 


### PR DESCRIPTION
Add https://developer.android.com/codelabs/exoplayer-intro#4 to the Android <> Cloudflare Stream example, for reference and better guidance.