### PR TITLE
[Magic Transit] Added RPKI check as optional step

### DIFF
--- a/content/magic-transit/prerequisites.md
+++ b/content/magic-transit/prerequisites.md
@@ -38,6 +38,12 @@ Verify your Internet Routing Registry (IRR) entries match corresponding origin a
 
 If you are using a Cloudflare IP, you do not need to verify your IRR entries.
 
+### Optional: RPKI check for prefix validation
+
+You can also use the Resource Public Key Infrastructure (RPKI) as an additional option to validate your prefixes.
+
+To check your prefixes, you can use [Cloudflare's RPKI Portal](https://rpki.cloudflare.com/?view=validator).
+
 ## Set maximum segment size
 
 ![Breakdown of packet maximum segment size as it moves through Magic Transit workflow](/magic-transit/static/mss-values-and-packet.png)


### PR DESCRIPTION
Added section about using RPKI as optional step to validate prefixes. Addresses PCX-4671.