### PR TITLE
Turnstile: minor edits all around

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -614,6 +614,9 @@
 /time-services/nts/usage/ /time-services/nts/ 301
 /time-services/roughtime/about/ /time-services/roughtime/ 301
 
+# turnstile
+/turnstile/get-started/domain-management/ /turnstile/reference/domain-management/ 301
+
 # waf
 /waf/ddos-l34-mitigation/ /ddos-protection/managed-rulesets/network/ 301
 /waf/ddos-l34-mitigation/configure-api/ /ddos-protection/managed-rulesets/network/configure-api/ 301

--- a/content/turnstile/frequently-asked-questions.md
+++ b/content/turnstile/frequently-asked-questions.md
@@ -77,7 +77,7 @@ Turnstile is hosted under `challenges.cloudflare.com`.
 
 We currently do not offer an easy and official way to embed Turnstile in a React Native application. 
 
-An HTML page rendered in a [WebView](https://github.com/react-native-webview/react-native-webview) can use Turnstile. The page must be loaded from a domain allowed to use the [sitekey](/turnstile/get-started/domain-management/), either using `uri` or by specifying the `html` and `baseUrl` options.
+An HTML page rendered in a [WebView](https://github.com/react-native-webview/react-native-webview) can use Turnstile. The page must be loaded from a domain allowed to use the [sitekey](/turnstile/reference/domain-management/), either using `uri` or by specifying the `html` and `baseUrl` options.
 
 ## Are there sitekeys and secret keys that can be used for testing?
 

--- a/content/turnstile/get-started/_index.md
+++ b/content/turnstile/get-started/_index.md
@@ -11,7 +11,7 @@ This guide will get you started on setting up the Turnstile widget.
 
 If you are currently using a CAPTCHA service, you can copy and paste our script wherever you have deployed the existing script today. 
  
-## Sitekey and secret key
+## 1. Get a sitekey and secret key
 
 To start using the Turnstile widget, you will need to obtain a sitekey and a secret key. The sitekey and secret key are always associated with one widget and cannot be reused for other widgets.
 
@@ -33,7 +33,7 @@ The sitekey and secret key are generated upon the creation of a widget, allowing
 3. In the widget overview, select **Settings**.
 4. Copy your sitekey and secret key.
 
-## Add the Turnstile widget to your site
+## 2. Add the Turnstile widget to your site
 
 To add the Turnstile widget:
 
@@ -42,9 +42,7 @@ To add the Turnstile widget:
 <div>
 
 ```html
-
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-
 ```
 </div>
 
@@ -54,4 +52,7 @@ To add the Turnstile widget:
     * [Explicit rendering](/turnstile/get-started/client-side-rendering/#explicitly-render-the-turnstile-widget)
     * [Implicit rendering](/turnstile/get-started/client-side-rendering/#implicitly-render-the-turnstile-widget)
 
-3. [Validate the server-side response](/turnstile/get-started/server-side-validation/)
+## 3. Validate the response server-side
+
+After you have installed the Turnstile widget on your site, you must configure your server to validate the Turnstile response.
+Refer to [Validate the server-side response](/turnstile/get-started/server-side-validation/)

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -17,9 +17,7 @@ The HTML is scanned for elements that have a `cf-turnstile` class name:
 <div>
 
 ```html
-
 <div class="cf-turnstile" data-sitekey="yourSitekey" data-callback="javascriptCallback"></div>
-
 ```
 </div>
 
@@ -79,9 +77,7 @@ When using this option, HTML elements with the `cf-turnstile` class will not sho
 <div>
 
 ```html
-
-<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload= onloadTurnstileCallback" async defer></script>
-
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback" async defer></script>
 ```
 </div>
 
@@ -92,14 +88,13 @@ When using this option, HTML elements with the `cf-turnstile` class will not sho
 ```javascript
 
 window.onloadTurnstileCallback = function () {
-   const turnstileOptions = {
-            sitekey: '<YOUR_SITE_KEY>',
-            callback: function(token) {
-               console.log(`Challenge Success ${token}`);
-            }
-   };
-   turnstile.render('#example-container', turnstileOptions); 
-}
+    turnstile.render('#example-container', {
+        sitekey: '<YOUR_SITE_KEY>',
+        callback: function(token) {
+            console.log(`Challenge Success ${token}`);
+        },
+    });
+};
 
 ```
 </div>
@@ -108,7 +103,7 @@ Turnstile can be programmatically loaded by invoking the `turnstile.render()` fu
 
 The `turnstile.render: function (container: string | HTMLElement, params: RenderParameters)` render takes an argument to a HTML widget.
 
-If the invocation is successful, the function returns a `widgetId`. If the invocation is unsuccessful, the function returns `undefined`.
+If the invocation is successful, the function returns a `widgetId (string)`. If the invocation is unsuccessful, the function returns `undefined`.
 
 Check out the [demo](https://demo.turnstile.workers.dev/explicit) and its [source code](https://github.com/cloudflare/turnstile-demo-workers/blob/main/src/explicit.html).
 

--- a/content/turnstile/get-started/migrating-from-recaptcha.md
+++ b/content/turnstile/get-started/migrating-from-recaptcha.md
@@ -18,9 +18,7 @@ To complete the migration, you must obtain the [sitekey and secret key](/turnsti
 <div>
 
 ```html
-
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?compat=recaptcha" async defer></script>
-
 ```
 
 </div>

--- a/content/turnstile/get-started/server-side-validation.md
+++ b/content/turnstile/get-started/server-side-validation.md
@@ -26,9 +26,13 @@ Example using cURL:
 <div>
 
 ```sh
-
-$ curl -L -X POST 'https://challenges.cloudflare.com/turnstile/v0/siteverify' --data 'secret=verysecret&response=<RESPONSE>'
-
+$ curl 'https://challenges.cloudflare.com/turnstile/v0/siteverify' --data 'secret=verysecret&response=<RESPONSE>'
+{
+  "success": true,
+  "error-codes": [],
+  "challenge_ts": "2022-10-06T00:07:23.274Z",
+  "hostname": "example.com"
+}
 ```
 </div>
 
@@ -37,7 +41,6 @@ Example using `fetch` from Cloudflare Workers:
 <div>
 
 ```javascript
-
 // This is the demo secret key. In production, we recommend
 // you store your secret key(s) safely.
 const SECRET_KEY = '1x0000000000000000000000000000000AA';
@@ -66,7 +69,6 @@ async function handlePost(request) {
 		// ...
 	}
 }
-
 ```
 </div>
 
@@ -89,6 +91,10 @@ In case of a successful validation, the response should be similar to the follow
 <div>
 
 ```json
+---
+highlight: [2]
+---
+
 {
   "success": true,
   "challenge_ts": "2022-02-28T15:14:30.096Z",
@@ -111,13 +117,16 @@ In case of a validation failure, the response should be similar to the following
 <div>
 
 ```json
+---
+highlight: [2]
+---
+
 {
   "success": false,
   "error-codes": [
     "invalid-input-response"
   ]
 }
-
 ```
 </div>
 

--- a/content/turnstile/reference/_index.md
+++ b/content/turnstile/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 pcx_content_type: navigation
-weight: 7
+weight: 6
 layout: single
 ---
 

--- a/content/turnstile/reference/domain-management.md
+++ b/content/turnstile/reference/domain-management.md
@@ -1,7 +1,7 @@
 ---
 title: Domain management
 pcx_content_type: get-started
-weight: 6
+weight: 10
 layout: single
 
 ---

--- a/content/turnstile/reference/rotate-secret-key.md
+++ b/content/turnstile/reference/rotate-secret-key.md
@@ -1,7 +1,7 @@
 ---
 title: Rotate secret key
 pcx_content_type: how-to
-weight: 10
+weight: 9
 layout: single
 ---
 # Rotate the secret key

--- a/content/turnstile/reference/turnstile-analytics.md
+++ b/content/turnstile/reference/turnstile-analytics.md
@@ -1,7 +1,7 @@
 ---
 title: Analytics
 pcx_content_type: how-to
-weight: 9
+weight: 8
 layout: single
 ---
 

--- a/content/turnstile/reference/widget-types.md
+++ b/content/turnstile/reference/widget-types.md
@@ -1,7 +1,7 @@
 ---
 title: Widget Types
 pcx_content_type: reference
-weight: 8
+weight: 7
 layout: single
 ---
 


### PR DESCRIPTION
- Add example output for the curl command (looks pretty in docs)
- Simplify the curl command, we don't need -L and -XPOST
- Remove extra space in the onload= script snippet
- Remove extra line at start of code blocks
- Move "Domain management" to Reference
- In server-side validation, highlight the "success" field
- Rename the Get started sections to have numbers

These edits were inspired by the Workers docs, to see what was possible

Screenshots.
*Get started*
![image](https://user-images.githubusercontent.com/1859135/194188218-724ec34a-183b-4f88-ad3b-53a16aad5c3c.png)


*Migrating from reCAPTCHA*
![image](https://user-images.githubusercontent.com/1859135/194188237-82514cec-d6e0-4af2-b872-5f0e4dfb8938.png)

*Explicitly render the widget*
![image](https://user-images.githubusercontent.com/1859135/194188273-2c4fb6fd-b19a-417c-ac41-b1ab6d26f0ac.png)

*siteverify curl*
![image](https://user-images.githubusercontent.com/1859135/194188315-1729a33e-f0f8-4124-a083-2c95ffb8af75.png)

Mouse hover:
![image](https://user-images.githubusercontent.com/1859135/194188331-c65415d3-0482-41eb-a61e-d7bec53955e5.png)


*success*
![image](https://user-images.githubusercontent.com/1859135/194188349-b7246036-3c1d-42fb-874d-a18c204a4d59.png)


*failure*
![image](https://user-images.githubusercontent.com/1859135/194188363-a719fa2b-049b-44ec-96d7-5f8e21cc1246.png)

*sidebar*
![image](https://user-images.githubusercontent.com/1859135/194188609-e4071146-b670-43ba-b0dc-0f04ddefdd01.png)


cc @migueldemoura  @worenga @patriciasantaana 