### PR TITLE
fix: update example port to number instead of string

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -551,7 +551,7 @@ header: wrangler.toml
 ---
 [dev]
 ip = "192.168.1.1"
-port = "8080"
+port = 8080
 local_protocol = "http"
 ```
 


### PR DESCRIPTION
Using an example throw the following error:

```bash
[exchange:dev:*server] ✘ [ERROR] Processing wrangler.toml configuration:
[exchange:dev:*server]
[exchange:dev:*server]     - Expected "dev.port" to be of type number but got "3000".
```