### PR TITLE
workers: remove deprecated experimental-enable-local-persistence flag in commands.md

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -154,13 +154,6 @@ None of the options for this command are required. Many of these options can be 
 - `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(default: false){{</prop-meta>}}
 
   - Run the preview of the Worker directly on your local machine.
-
-    {{<Aside type="warning">}}
-
-This runs an ephemeral local version of your Worker, and will not be able to access data stored on Cloudflare's Edge (for instance, this includes your data stored on KV). If you'd like to persist data locally, the experimental option `--experimental-enable-local-persistence` will store data in the `wrangler-local-state` subdirectory.
-
-{{</Aside>}}
-
 - `--experimental-local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(default: false){{</prop-meta>}}
   - Run the preview of the Worker directly on your local machine using the [open source Cloudflare Workers runtime](https://github.com/cloudflare/workerd).
 - `--minify` {{<type>}}boolean{{</type>}}


### PR DESCRIPTION
The flag `--experimental-enable-local-persistence` is deprecated and no longer available.

When attempting to use this flag, wrangler says:

```
🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
▲ [WARNING] --experimental-enable-local-persistence is deprecated.

  Move any existing data to .wrangler/state and use --persist, or
  use --persist-to=./wrangler-local-state to keep using the old path.
```