### PR TITLE
Fix custom domain route example

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -220,7 +220,7 @@ This will use a Custom Domain as opposed to a route. Refer to [Custom Domains](/
 
 - `pattern` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
-  - The pattern that your Worker should be run on, for example, `"example.com/*"`.
+  - The pattern that your Worker should be run on, for example, `"example.com"`.
 
 - `custom_domain` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
@@ -234,7 +234,7 @@ Example:
 ---
 header: wrangler.toml
 ---
-route = { pattern = "example.com/*", custom_domain: true }
+route = { pattern = "example.com", custom_domain: true }
 ```
 
 ## Triggers


### PR DESCRIPTION
Custom domain workers routes should not include the wildcard, and wrangler throws an error for this
`X [ERROR] Cannot use "example.com/*" as a Custom Domain; wildcard operators (*) are not allowed`