### PR TITLE
Fixed incorrect mkdocs.com to mkdocs.org

### DIFF
--- a/content/pages/framework-guides/deploy-an-mkdocs-site.md
+++ b/content/pages/framework-guides/deploy-an-mkdocs-site.md
@@ -5,7 +5,7 @@ title: Deploy an Mkdocs site
 
 # Deploy an Mkdocs site
 
-[Mkdocs](https://Mkdocs.com) is a modern documentation platform where teams can document products, internal knowledge bases and APIs.
+[Mkdocs](https://Mkdocs.org) is a modern documentation platform where teams can document products, internal knowledge bases and APIs.
 
 ## Install Mkdocs
 


### PR DESCRIPTION
mkdocs.com is not the correct url, fixed it to point to the right mkdocs.org site.