### PR TITLE
Document the `export_commonjs_default`/`export_commonjs_namespace` compatibility flags

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
+++ b/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
@@ -4,7 +4,7 @@ _build:
   render: never
   list: never
 
-name: "CommonJS modules don't export a module namespace"
+name: "CommonJS modules do not export a module namespace"
 date: "2022-10-10"
 enable_flag: "export_commonjs_default"
 disable_flag: "export_commonjs_namespace"

--- a/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
+++ b/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "CommonJS modules don't export a module namespace"
+date: "2022-10-10"
+enable_flag: "export_commonjs_default"
+disable_flag: "export_commonjs_namespace"
+---
+
+CommonJS modules were previously exporting a module namespace (an object like `{ default: module.exports }`) rather than exporting only the `module.exports`. When this flag is enabled, the export is fixed.


### PR DESCRIPTION
https://github.com/cloudflare/workerd/blob/9e4fbb510cee0ce08ff08ebd8b09eba82c385e51/src/workerd/io/compatibility-date.capnp#L204