### PR TITLE
Document the `capture_async_api_throws` compatibility flag

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Don't throw from async functions"
+date: "2022-10-10"
+enable_flag: "capture_async_api_throws"
+disable_flag: "do_not_capture_async_api_throws"
+---
+
+The `capture_async_api_throws` compatibility flag will ensure that, in conformity with the standards API, async functions will only ever reject if they throw an error. The inverse `do_not_capture_async_api_throws` flag means that async functions which contain an error may throw that error synchronously rather than rejecting.

--- a/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
@@ -4,7 +4,7 @@ _build:
   render: never
   list: never
 
-name: "Don't throw from async functions"
+name: "Do not throw from async functions"
 date: "2022-10-10"
 enable_flag: "capture_async_api_throws"
 disable_flag: "do_not_capture_async_api_throws"


### PR DESCRIPTION
https://github.com/cloudflare/workerd/blob/9e4fbb510cee0ce08ff08ebd8b09eba82c385e51/src/workerd/io/compatibility-date.capnp#L162