### PR TITLE
[R2] fix overlap between s3 api content and page index

### DIFF
--- a/content/r2/data-access/s3-api/api.md
+++ b/content/r2/data-access/s3-api/api.md
@@ -54,7 +54,7 @@ Below is a list of implemented bucket-level operations. Refer to the Feature col
 <details>
 <summary> Click to expand a list of unimplemented bucket-level operations. </summary>
 
-{{<table-wrap style="width:123%">}}
+{{<table-wrap style="width:110%">}}
 
 | API Name       | Feature                           |
 | ---------------| --------------------------------- |
@@ -127,7 +127,7 @@ This does not apply to concurrent uploads for different files.
 
 {{</Aside>}}
 
-{{<table-wrap style="width:123%">}}
+{{<table-wrap style="width:110%">}}
 
 | API Name                | Feature                   |
 | ------------------------| ------------------------- |


### PR DESCRIPTION
closes #6205

Fixes overlap without introducing any wrapping of the existing headers.