### PR TITLE
Add more domains to firewall docs

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
@@ -6,12 +6,11 @@ weight: 9
 
 # WARP with firewall
 
-If your organization uses a firewall or other policies to restrict or intercept Internet traffic, you may need to make a few changes to allow the agent to connect.
+If your organization uses a firewall or other policies to restrict or intercept Internet traffic, you may need to exempt the following IP addresses and domains to allow the WARP client to connect.
 
-## Client Orchestration API
+## Client orchestration API
 
 The WARP client talks with our edge via a standard HTTPS connection outside the tunnel for operations like registration or settings changes. To perform these operations, you must allow `zero-trust-client.cloudflareclient.com` which will lookup the following IP addresses:
-
 
 - IPv4 API Endpoint: `162.159.137.105` and `162.159.138.105`
 - IPv6 API Endpoint: `2606:4700:7::a29f:8969` and `2606:4700:7::a29f:8a69`
@@ -23,35 +22,39 @@ All DNS requests through WARP are sent outside the tunnel via DoH (DNS over HTTP
 - IPv4 DoH Address: `162.159.36.1`
 - IPv6 DoH Address: `2606:4700:4700::1111`
 
-## WARP Ingress IP
+## WARP ingress IP
 
 These are the IP addresses that the WARP client will connect to. All traffic from your device to the Cloudflare edge will go through these IP addresses.
 
 - IPv4 Range: `162.159.193.0/24`
 - IPv6 Range: `2606:4700:100::/48`
 
-### WARP UDP Ports
+### WARP UDP ports
 
-WARP utilizes UDP for all of its communications. By default, the UDP Port required for WARP is: UDP 2408. WARP can fallback to: UDP 500, UDP 1701, or UDP 4500.
+WARP utilizes UDP for all of its communications. By default, the UDP port required for WARP is `UDP 2408`. WARP can fallback to `UDP 500`, `UDP 1701`, or `UDP 4500`.
 
 ## Creating firewall rules
 
-If your organization does not currently allow Inbound/Outbound communication over the IP addresses and ports described above you must manually add an exception. The rule at a minimum needs to be scoped to the following process based on your platform:
+If your organization does not currently allow inbound/outbound communication over the IP addresses and ports described above, you must manually add an exception. The rule at a minimum needs to be scoped to the following process based on your platform:
 
 - Windows: `C:\Program Files\Cloudflare\Cloudflare WARP\warp-svc.exe`
 - macOS: `/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP`
 
-## Captive Portal
-The following domains are used as part of our captive portal check
-- cloudflareportal.com
-- cloudflareok.com
-- cloudflarecp.com
+## Captive portal
+
+The following domains are used as part of our captive portal check:
+
+- `cloudflareportal.com`
+- `cloudflareok.com`
+- `cloudflarecp.com`
 
 ## Connectivity check
-As part of establishing the WARP connection, the angent will check the follows URLs to validate a succesfull connection. 
-- Outside the tunnel: engage.cloudflareclient.com
-- Inside the tunnel: connectivity.cloudflareclient.com
 
-## NEL Reporting
-While not required for the agent to function, we will report connectivity issues to our NEL endpoint via the following URL. This is not technically required to operate but will result in errors in our logs if not excluded properly.
-- a.nel.cloudflare.com
+As part of establishing the WARP connection, the client will check the following URLs to validate a successful connection:
+
+- `engage.cloudflareclient.com` applies to routes excluded from WARP in your Split Tunnel configuration.
+- `connectivity.cloudflareclient.com` applies to routes included in WARP in your Split Tunnel configuration.
+
+## NEL reporting
+
+While not required for the WARP client to function, we will report connectivity issues to our NEL endpoint via `a.nel.cloudflare.com`. This is not technically required to operate but will result in errors in our logs if not excluded properly.

--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
@@ -6,7 +6,7 @@ weight: 9
 
 # WARP with firewall
 
-If your organization uses a firewall or other policies to restrict Internet traffic, you may need to make a few changes to allow WARP to connect.
+If your organization uses a firewall or other policies to restrict or intercept Internet traffic, you may need to make a few changes to allow the agent to connect.
 
 ## Client Orchestration API
 
@@ -40,3 +40,18 @@ If your organization does not currently allow Inbound/Outbound communication ove
 
 - Windows: `C:\Program Files\Cloudflare\Cloudflare WARP\warp-svc.exe`
 - macOS: `/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP`
+
+## Captive Portal
+The following domains are used as part of our captive portal check
+- cloudflareportal.com
+- cloudflareok.com
+- cloudflarecp.com
+
+## Connectivity check
+As part of establishing the WARP connection, the angent will check the follows URLs to validate a succesfull connection. 
+- Outside the tunnel: engage.cloudflareclient.com
+- Inside the tunnel: connectivity.cloudflareclient.com
+
+## NEL Reporting
+While not required for the agent to function, we will report connectivity issues to our NEL endpoint via the following URL. This is not technically required to operate but will result in errors in our logs if not excluded properly.
+- a.nel.cloudflare.com


### PR DESCRIPTION
In CUSTESC-22498 we discovered that some 3rd party inspection tools could run lower in the filter driver stack than us resulting in some of our checks still failing. This update more fully documents all the URL's required for the WARP Agent to run