### PR TITLE
[ZT] Fix python instructions in install-cloudflare-cert.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert.md
@@ -104,7 +104,7 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 4. Update the OpenSSL CA Store to include the Cloudflare certificate:
 
 ```bash
-sudo cat Cloudflare_CA.pem >> /usr/local/etc/openssl/cert.pem
+echo | sudo cat - Cloudflare_CA.pem >> /usr/local/etc/openssl/cert.pem
 ```
 
 ### iOS
@@ -347,7 +347,7 @@ This command will output:
 3. Append the Cloudflare certificate to this CA Store by running:
 
 ```bash
-cat /Library/Keychains/System.keychain Cloudflare_CA.crt >> $(python -m certifi)
+echo | cat - Cloudflare_CA.pem >> $(python -m certifi)
 ```
 
 4. If needed, configure system variables to point to this CA Store.


### PR DESCRIPTION
* Append the .pem (not .crt) certificate to the python CA store.
* Do not append System.keychain to the python CA store as System.keychain is not in PEM format and isn't mentioned in the accompanying instructions.
* Use 'echo' to insert newlines first when appending to avoid corrupting CA store files.