### PR TITLE
[Firewall Rules, Rules] Update names and links to Rules API methods

### DIFF
--- a/content/firewall/api/_index.md
+++ b/content/firewall/api/_index.md
@@ -15,4 +15,4 @@ These APIs are the following:
 
 * [**Firewall Rules API**](/firewall/api/cf-firewall-rules/): Manage firewall rules and their actions, based on criteria separately defined through filters.
 * [**Filters API**](/firewall/api/cf-filters/): Manage the filters that enable rule matching.
-* [**Rules Lists API**](/firewall/api/cf-lists/): Manage named lists of IP addresses that you can use in firewall rules to filter traffic.
+* [**Lists API**](/firewall/api/cf-lists/): Manage named lists of IP addresses that you can use in firewall rules to filter traffic.

--- a/content/firewall/api/cf-lists/_index.md
+++ b/content/firewall/api/cf-lists/_index.md
@@ -1,19 +1,19 @@
 ---
 pcx_content_type: navigation
-title: Rules Lists API
+title: Lists API
 weight: 3
 layout: single
 ---
 
-# Rules Lists API
+# Lists API
 
-The Rules Lists API supports different types of lists:
+The Lists API supports different types of lists:
 
 *   Use [IP Lists](/firewall/cf-firewall-rules/rules-lists/) to create a group of IP addresses and refer to them collectively, by name, in your firewall rule expressions.
 
 *   Use [Bulk Redirect Lists](/rules/url-forwarding/bulk-redirects/) to define lists of redirects that you enable by creating a Bulk Redirect Rule.
 
-The [Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) provides an interface for programmatically managing these types of lists.
+The [Lists API](https://api.cloudflare.com/#lists-properties) provides an interface for programmatically managing these types of lists.
 
 To use an IP List in a rule expression, refer to [Values: Lists](/ruleset-engine/rules-language/values/#lists) in the Rules language documentation.
 

--- a/content/firewall/api/cf-lists/endpoints.md
+++ b/content/firewall/api/cf-lists/endpoints.md
@@ -9,7 +9,7 @@ layout: list
 
 {{<content-column>}}
 
-To invoke a [Cloudflare Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) operation, append the endpoint to the Cloudflare API base URL:
+To invoke a [Lists API](https://api.cloudflare.com/#lists-properties) operation, append the endpoint to the Cloudflare API base URL:
 
 `https://api.cloudflare.com/client/v4/`
 
@@ -19,13 +19,13 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](ht
 
 {{<Aside type="note">}}
 
-The Rules Lists API endpoints require a value for `<ACCOUNT_ID>`.
+The Lists API endpoints require a value for `<ACCOUNT_ID>`.
 
 To retrieve a list of accounts to which you have access, use the [List Accounts](https://api.cloudflare.com/#accounts-list-accounts) operation and note the IDs of the accounts you want to manage.
 
 {{</Aside>}}
 
-The Cloudflare Rules Lists API supports the operations outlined below. Visit the associated links for examples.
+The Lists API supports the operations outlined below. Visit the associated links for examples.
 
 {{</content-column>}}
 
@@ -42,7 +42,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
   <tbody>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-create-list">Create a List</a>
+        <a href="https://api.cloudflare.com/#lists-create-a-list">Create a list</a>
       </td>
       <td>
         <code class="InlineCode">POST accounts/&lt;ACCOUNT_ID&gt;/rules/lists</code>
@@ -51,7 +51,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-list-lists">List Lists</a>
+        <a href="https://api.cloudflare.com/#lists-get-lists">Get lists</a>
       </td>
       <td>
         <code class="InlineCode">GET accounts/&lt;ACCOUNT_ID&gt;/rules/lists</code>
@@ -62,7 +62,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-get-list">Get a List</a>
+        <a href="https://api.cloudflare.com/#lists-get-a-list">Get a list</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -76,7 +76,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-update-list">Update a List</a>
+        <a href="https://api.cloudflare.com/#lists-update-a-list">Update a list</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -88,13 +88,13 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
           Updates the <code class="InlineCode">description</code> of a list. You cannot edit the <code class="InlineCode">name</code> or <code class="InlineCode">kind</code>, and you cannot update items in a list.
         </p>
         <p>
-          To update an item in a list, use the <a href="https://api.cloudflare.com/#rules-lists-replace-list-items">Replace List Items</a> operation.
+          To update an item in a list, use the <a href="https://api.cloudflare.com/#lists-update-all-list-items">Update all list items</a> operation.
         </p>
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-delete-list">Delete a List</a>
+        <a href="https://api.cloudflare.com/#lists-delete-a-list">Delete a list</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -114,7 +114,7 @@ The Cloudflare Rules Lists API supports the operations outlined below. Visit the
 
 Nearly all the operations for managing items in a list are asynchronous. When you add or delete a large amount of items to or from a list, there may be a delay before the bulk operation is complete.
 
-Asynchronous list operations return an `operation_id`, which you can use to monitor the status of an API operation. To monitor the status of an asynchronous operation, use the [Get Bulk Operation](https://api.cloudflare.com/#rules-lists-get-bulk-operation) endpoint and specify the ID of the operation you want to monitor.
+Asynchronous list operations return an `operation_id`, which you can use to monitor the status of an API operation. To monitor the status of an asynchronous operation, use the [Get bulk operation status](https://api.cloudflare.com/#lists-get-bulk-operation-status) endpoint and specify the ID of the operation you want to monitor.
 
 When you make requests to a list while a bulk operation on that list is in progress, the requests are queued and processed in sequence (first in, first out). Requests for successful asynchronous operations return an `HTTP 201` status code.
 
@@ -131,7 +131,7 @@ When you make requests to a list while a bulk operation on that list is in progr
   <tbody>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-list-list-items">List Items</a>
+        <a href="https://api.cloudflare.com/#lists-get-list-items">Get list items</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -146,7 +146,7 @@ When you make requests to a list while a bulk operation on that list is in progr
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-get-list-item">Get a List Item</a>
+        <a href="https://api.cloudflare.com/#lists-get-a-list-item">Get a list item</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -159,7 +159,7 @@ When you make requests to a list while a bulk operation on that list is in progr
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-create-list-items">Create List Items</a>
+        <a href="https://api.cloudflare.com/#lists-create-list-items">Create list items</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -179,7 +179,7 @@ When you make requests to a list while a bulk operation on that list is in progr
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-replace-list-items">Replace List Items</a>
+        <a href="https://api.cloudflare.com/#lists-update-all-list-items">Update all list items</a>
       </td>
       <td>
         <code class="InlineCode">
@@ -201,7 +201,7 @@ When you make requests to a list while a bulk operation on that list is in progr
     </tr>
     <tr>
       <td>
-        <a href="https://api.cloudflare.com/#rules-lists-delete-list-items">Delete List Items</a>
+        <a href="https://api.cloudflare.com/#lists-delete-list-items">Delete list items</a>
       </td>
       <td>
         <code class="InlineCode">

--- a/content/firewall/api/cf-lists/json-object.md
+++ b/content/firewall/api/cf-lists/json-object.md
@@ -10,7 +10,7 @@ meta:
 
 ## List object structure and properties
 
-A JSON response for the [Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) has this structure:
+A JSON response for the [Lists API](https://api.cloudflare.com/#lists-properties) has this structure:
 
 ```json
 {
@@ -183,4 +183,4 @@ The JSON object properties for a list item are defined as follows:
   </table>
 {{</table-wrap>}}
 
-For a detailed specification, refer to the [Rules Lists API](https://api.cloudflare.com/#rules-lists-properties) documentation.
+For a detailed specification, refer to the [Lists API](https://api.cloudflare.com/#lists-properties) documentation.

--- a/content/firewall/cf-dashboard/rules-lists/manage-items.md
+++ b/content/firewall/cf-dashboard/rules-lists/manage-items.md
@@ -18,7 +18,7 @@ The list of items displays sorted by IP address, ascending:
 
 {{<Aside type="note" header="Note">}}
 
-You cannot download a list in CSV format from the dashboard. If you need to download the contents of a list to your device, use the [Get Lists](https://api.cloudflare.com/#rules-lists-list-lists) operation to fetch them.
+You cannot download a list in CSV format from the dashboard. If you need to download the contents of a list to your device, use the [Get lists](https://api.cloudflare.com/#lists-get-lists) operation to fetch them.
 
 {{</Aside>}}
 
@@ -71,7 +71,7 @@ To add items to an IP List:
 
 Importing a CSV file to a list only updates descriptions or adds items to the list. It does not delete items from a list.
 
-If you need to replace the entire contents of a list, format the data as an array and use the Update Lists operation in the [Rules Lists API](/firewall/api/cf-lists/endpoints/).
+If you need to replace the entire contents of a list, format the data as an array and use the Update all list items operation in the [Lists API](/firewall/api/cf-lists/endpoints/).
 
 {{</Aside>}}
 

--- a/content/magic-firewall/how-to/use-rules-list.md
+++ b/content/magic-firewall/how-to/use-rules-list.md
@@ -1,16 +1,16 @@
 ---
-title: Use rules lists
+title: Use lists
 weight: 3
 pcx_content_type: how-to
 meta:
-  title: Define a Rules List
+  title: Define a List
 ---
 
-# Define a Rules List
+# Define a List
 
-[Rules Lists](/firewall/cf-dashboard/rules-lists/#access-the-lists-interface) defined at the account level can be used to match against `ip.src` and `ip.dst` fields. Currently only IPv4 addresses in these lists are used as IPv6 is currently not supported in Magic Firewall.
+[Lists](/firewall/cf-dashboard/rules-lists/#access-the-lists-interface) defined at the account level can be used to match against `ip.src` and `ip.dst` fields. Currently only IPv4 addresses in these lists are used as IPv6 is currently not supported in Magic Firewall.
 
-In order to use this feature first [create a new list](https://api.cloudflare.com/#rules-lists-create-list).
+To use this feature first [create a new IP list](https://api.cloudflare.com/#lists-create-a-list).
 
 ```bash
 curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rules/lists \
@@ -26,7 +26,7 @@ curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rules/l
 
 ## Add IPs to the List
 
-Next [create list items](https://api.cloudflare.com/#rules-lists-create-list-items). This will add elements to the current list.
+Next [create list items](https://api.cloudflare.com/#lists-create-list-items). This will add elements to the current list.
 
 ```bash
     curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rules/lists/${list_id}/items \
@@ -37,11 +37,11 @@ Next [create list items](https://api.cloudflare.com/#rules-lists-create-list-ite
         {"ip":"10.0.0.1"},
         {"ip":"10.10.0.0/24"}
     ]'
-```    
+```
 
 ## Use the List in a Rule
 
-Finally add a Magic Firewall rule referencing the Rules List into an existing ruleset:
+Finally add a Magic Firewall rule referencing the List into an existing ruleset:
 
 ```bash
     curl -X POST https://api.cloudflare.com/client/v4/accounts/${account_id}/rulesets/${ruleset_id}/rules \

--- a/content/rules/url-forwarding/bulk-redirects/create-api.md
+++ b/content/rules/url-forwarding/bulk-redirects/create-api.md
@@ -19,7 +19,7 @@ The API token used in API requests to manage Bulk Redirects objects (lists, list
 
 ## 1. Create a Bulk Redirect List via API
 
-Use the [Create list](https://api.cloudflare.com/#rules-lists-create-list) operation to create a new Bulk Redirect List. The list `kind` must be `redirect`.
+Use the [Create a list](https://api.cloudflare.com/#lists-create-a-list) operation to create a new Bulk Redirect List. The list `kind` must be `redirect`.
 
 ```json
 curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists" \
@@ -52,11 +52,11 @@ The response will be similar to the following:
 }
 ```
 
-For more information on list operations, refer to the [Rules Lists API](/firewall/api/cf-lists/) documentation.
+For more information on list operations, refer to the [Lists API](/firewall/api/cf-lists/) documentation.
 
 ## 2. Add items to the list
 
-Use the [Create list items](https://api.cloudflare.com/#rules-lists-create-list-items) operation to add URL Redirect items to the list:
+Use the [Create list items](https://api.cloudflare.com/#lists-create-list-items) operation to add URL Redirect items to the list:
 
 ```json
 curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists/f848b6ccb07647749411f504d6f88794/items" \
@@ -92,7 +92,7 @@ The response will be similar to the following:
 }
 ```
 
-This is an asynchronous operation. The response will contain an `operation_id` which you will use to check if the operation completed successfully using the [Get bulk operation](https://api.cloudflare.com/#rules-lists-get-bulk-operation) method:
+This is an asynchronous operation. The response will contain an `operation_id` which you will use to check if the operation completed successfully using the [Get bulk operation status](https://api.cloudflare.com/#lists-get-bulk-operation-status) method:
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rules/lists/bulk_operations/92558f8b296d4dbe9d0419e0e53f6622" \


### PR DESCRIPTION
Follow-up to the work done to apply the API content strategy.
The names of some operations were incorrect and some of the links to the API site were broken.