### PR TITLE
[Turnstile] Document that `action` can only contain alphanumeric, `-` and `_` chars

### DIFF
--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -125,7 +125,7 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | --- | --- | --- |
 | `sitekey` | `data-sitekey` | Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. |
 | `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This can only contain up to 32 lowercase alphanumeric characters including `_` and `-`. |
-| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. This can only contain up to 255 lowercase alphanumeric characters including `_`, and `-`.  |
+| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. This can only contain up to 255 lowercase alphanumeric characters including `_` and `-`.  |
 | `callback` | `data-callback` | A JavaScript callback that is invoked upon success of the challenge. The callback is passed a token that can be validated. |
 | `expired-callback` | `data-expired-callback` | A JavaScript callback that is invoked when a challenge expires. |
 | `error-callback` | `data-error-callback` | A JavaScript callback that is invoked when there is a network error. |

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -124,8 +124,8 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | JavaScript Render Parameters | Data Attribute | Description |
 | --- | --- | --- |
 | `sitekey` | `data-sitekey` | Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. |
-| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This should only contain alphanumeric characters, `_` and `-`. |
-| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. |
+| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This can only contain up to 32 lowercase alphanumeric characters, `_` and `-`. |
+| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. This can only contain up to 255 lowercase alphanumeric characters, `_` and `-`.  |
 | `callback` | `data-callback` | A JavaScript callback that is invoked upon success of the challenge. The callback is passed a token that can be validated. |
 | `expired-callback` | `data-expired-callback` | A JavaScript callback that is invoked when a challenge expires. |
 | `error-callback` | `data-error-callback` | A JavaScript callback that is invoked when there is a network error. |

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -124,8 +124,8 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | JavaScript Render Parameters | Data Attribute | Description |
 | --- | --- | --- |
 | `sitekey` | `data-sitekey` | Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. |
-| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This can only contain up to 32 lowercase alphanumeric characters, `_` and `-`. |
-| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. This can only contain up to 255 lowercase alphanumeric characters, `_` and `-`.  |
+| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This can only contain up to 32 lowercase alphanumeric characters including `_` and `-`. |
+| `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. This can only contain up to 255 lowercase alphanumeric characters including `_`, and `-`.  |
 | `callback` | `data-callback` | A JavaScript callback that is invoked upon success of the challenge. The callback is passed a token that can be validated. |
 | `expired-callback` | `data-expired-callback` | A JavaScript callback that is invoked when a challenge expires. |
 | `error-callback` | `data-error-callback` | A JavaScript callback that is invoked when there is a network error. |

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -124,7 +124,7 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | JavaScript Render Parameters | Data Attribute | Description |
 | --- | --- | --- |
 | `sitekey` | `data-sitekey` | Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. |
-| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. |
+| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This cannot contain any whitespace. |
 | `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. |
 | `callback` | `data-callback` | A JavaScript callback that is invoked upon success of the challenge. The callback is passed a token that can be validated. |
 | `expired-callback` | `data-expired-callback` | A JavaScript callback that is invoked when a challenge expires. |

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -124,7 +124,7 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | JavaScript Render Parameters | Data Attribute | Description |
 | --- | --- | --- |
 | `sitekey` | `data-sitekey` | Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. |
-| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This cannot contain any whitespace. |
+| `action` | `data-action` | A customer value that can be used to differentiate widgets under the same sitekey in analytics and which is returned upon validation. This should only contain alphanumeric characters, `_` and `-`. |
 | `cData` | `data-cdata` | A customer payload that can be used to attach customer data to the challenge throughout its issuance and which is returned upon validation. |
 | `callback` | `data-callback` | A JavaScript callback that is invoked upon success of the challenge. The callback is passed a token that can be validated. |
 | `expired-callback` | `data-expired-callback` | A JavaScript callback that is invoked when a challenge expires. |


### PR DESCRIPTION
Having some special chars within the `action` attribute causes HTTP 400 errors when the component attempts to validate a user.