### PR TITLE
[Workers] Update compat date enable dates

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
+++ b/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "CommonJS modules do not export a module namespace"
-date: "2022-10-10"
+date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "export_commonjs_default"
 disable_flag: "export_commonjs_namespace"

--- a/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
+++ b/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "CommonJS modules do not export a module namespace"
-date: "2022-10-31"
+sort_date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "export_commonjs_default"
 disable_flag: "export_commonjs_namespace"

--- a/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
+++ b/content/workers/_partials/_platform-compatibility-dates/commonjs-modules-dont-export-a-module-namespace.md
@@ -6,6 +6,7 @@ _build:
 
 name: "CommonJS modules do not export a module namespace"
 date: "2022-10-10"
+enable_date: "2022-10-31"
 enable_flag: "export_commonjs_default"
 disable_flag: "export_commonjs_namespace"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/dont-substitute-null-on-type-error.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-substitute-null-on-type-error.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Do not substitute `null` on `TypeError`"
-date: "2022-06-01"
+sort_date: "2022-06-01"
 enable_date: "2022-06-01"
 enable_flag: "dont_substitute_null_on_type_error"
 disable_flag: "substitute_null_on_type_error"

--- a/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Do not throw from async functions"
-date: "2022-10-10"
+date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "capture_async_api_throws"
 disable_flag: "do_not_capture_async_api_throws"

--- a/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Do not throw from async functions"
-date: "2022-10-31"
+sort_date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "capture_async_api_throws"
 disable_flag: "do_not_capture_async_api_throws"

--- a/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-throw-from-async-functions.md
@@ -6,6 +6,7 @@ _build:
 
 name: "Do not throw from async functions"
 date: "2022-10-10"
+enable_date: "2022-10-31"
 enable_flag: "capture_async_api_throws"
 disable_flag: "do_not_capture_async_api_throws"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/dont-use-the-custom-origin-trust-store-for-external-subrequests.md
+++ b/content/workers/_partials/_platform-compatibility-dates/dont-use-the-custom-origin-trust-store-for-external-subrequests.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Do not use the Custom Origin Trust Store for external subrequests"
-date: "2022-03-08"
+sort_date: "2022-03-08"
 enable_date: "2022-03-08"
 enable_flag: "no_cots_on_external_fetch"
 disable_flag: "cots_on_external_fetch"

--- a/content/workers/_partials/_platform-compatibility-dates/durable-object-stub-fetch-requires-a-full-url.md
+++ b/content/workers/_partials/_platform-compatibility-dates/durable-object-stub-fetch-requires-a-full-url.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Durable Object `stub.fetch()` requires a full URL"
-date: "2021-11-10"
+sort_date: "2021-11-10"
 enable_date: "2021-11-10"
 enable_flag: "durable_object_fetch_requires_full_url"
 disable_flag: "durable_object_fetch_allows_relative_url"

--- a/content/workers/_partials/_platform-compatibility-dates/fetch-improperly-interprets-unknown-protocols-as-http.md
+++ b/content/workers/_partials/_platform-compatibility-dates/fetch-improperly-interprets-unknown-protocols-as-http.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "`fetch()` improperly interprets unknown protocols as HTTP"
-date: "2021-11-10"
+sort_date: "2021-11-10"
 enable_date: "2021-11-10"
 enable_flag: "fetch_refuses_unknown_protocols"
 disable_flag: "fetch_treats_unknown_protocols_as_http"

--- a/content/workers/_partials/_platform-compatibility-dates/formdata-parsing-supports-file.md
+++ b/content/workers/_partials/_platform-compatibility-dates/formdata-parsing-supports-file.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "`FormData` parsing supports `File`"
-date: "2021-11-03"
+sort_date: "2021-11-03"
 enable_date: "2021-11-03"
 enable_flag: "formdata_parser_supports_files"
 disable_flag: "formdata_parser_converts_files_to_strings"

--- a/content/workers/_partials/_platform-compatibility-dates/global-navigator.md
+++ b/content/workers/_partials/_platform-compatibility-dates/global-navigator.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Global `navigator`"
-date: "2022-03-21"
+sort_date: "2022-03-21"
 enable_date: "2022-03-21"
 enable_flag: "global_navigator"
 disable_flag: "no_global_navigator"

--- a/content/workers/_partials/_platform-compatibility-dates/htmlrewriter-handling-of-esi-include.md
+++ b/content/workers/_partials/_platform-compatibility-dates/htmlrewriter-handling-of-esi-include.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "`HTMLRewriter` handling of `<esi:include>`"
-date: "2021-11-02"
+sort_date: "2021-11-02"
 experimental: true
 enable_flag: "html_rewriter_treats_esi_include_as_void_tag"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/minimal-subrequests.md
+++ b/content/workers/_partials/_platform-compatibility-dates/minimal-subrequests.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Minimal subrequests"
-date: "2022-04-05"
+sort_date: "2022-04-05"
 enable_date: "2022-04-05"
 enable_flag: "minimal_subrequests"
 disable_flag: "no_minimal_subrequests"

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "New URL parser implementation"
-date: "2021-11-11"
+date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "url_standard"
 disable_flag: "url_original"

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -6,6 +6,7 @@ _build:
 
 name: "New URL parser implementation"
 date: "2021-11-11"
+enable_date: "2022-10-31"
 enable_flag: "url_standard"
 disable_flag: "url_original"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "New URL parser implementation"
-date: "2022-10-31"
+sort_date: "2022-10-31"
 enable_date: "2022-10-31"
 enable_flag: "url_standard"
 disable_flag: "url_original"

--- a/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
+++ b/content/workers/_partials/_platform-compatibility-dates/r2-list-honor-includes.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "`R2` bucket `list` respects the `include` option"
-date: "2022-08-04"
+sort_date: "2022-08-04"
 enable_date: "2022-08-04"
 enable_flag: "r2_list_honor_include"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/setters-getters-on-api-object-prototypes.md
+++ b/content/workers/_partials/_platform-compatibility-dates/setters-getters-on-api-object-prototypes.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Setters/getters on API object prototypes"
-date: "2022-01-31"
+sort_date: "2022-01-31"
 enable_date: "2022-01-31"
 enable_flag: "workers_api_getters_setters_on_prototype"
 disable_flag: "workers_api_getters_setters_on_instance"

--- a/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-byob-reader-detaches-buffer.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Streams BYOB reader detaches buffer"
-date: "2021-11-10"
+sort_date: "2021-11-10"
 enable_date: "2021-11-10"
 enable_flag: "streams_byob_reader_detaches_buffer"
 disable_flag: "streams_byob_reader_does_not_detach_buffer"

--- a/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Streams Constructors"
-date: "2022-10-10"
+date: "2022-11-30"
 enable_date: "2022-11-30"
 enable_flag: "streams_enable_constructors"
 disable_flag: "streams_disable_constructors"

--- a/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
@@ -6,6 +6,7 @@ _build:
 
 name: "Streams Constructors"
 date: "2022-10-10"
+enable_date: "2022-11-30"
 enable_flag: "streams_enable_constructors"
 disable_flag: "streams_disable_constructors"
 ---

--- a/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
+++ b/content/workers/_partials/_platform-compatibility-dates/streams-constructors.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Streams Constructors"
-date: "2022-11-30"
+sort_date: "2022-11-30"
 enable_date: "2022-11-30"
 enable_flag: "streams_enable_constructors"
 disable_flag: "streams_disable_constructors"

--- a/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
+++ b/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Compliant TransformStream constructor"
-date: "2022-11-30"
+sort_date: "2022-11-30"
 enable_date: "2022-11-30"
 enable_flag: "transformstream_enable_standard_constructor"
 disable_flag: "transformstream_disable_standard_constructor"

--- a/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
+++ b/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
@@ -5,7 +5,7 @@ _build:
   list: never
 
 name: "Compliant TransformStream constructor"
-date: "2022-10-10"
+date: "2022-11-30"
 enable_date: "2022-11-30"
 enable_flag: "transformstream_enable_standard_constructor"
 disable_flag: "transformstream_disable_standard_constructor"

--- a/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
+++ b/content/workers/_partials/_platform-compatibility-dates/transformstream-standard-constructor.md
@@ -6,6 +6,7 @@ _build:
 
 name: "Compliant TransformStream constructor"
 date: "2022-10-10"
+enable_date: "2022-11-30"
 enable_flag: "transformstream_enable_standard_constructor"
 disable_flag: "transformstream_disable_standard_constructor"
 ---

--- a/layouts/_default/compatibility-dates.json.json
+++ b/layouts/_default/compatibility-dates.json.json
@@ -4,7 +4,7 @@
     {{- $files = $files | append (dict "name" .Params.name "date" .Params.date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .RawContent "\n")) -}}
   {{- end -}}
 {{- end -}}
-{{- $files = sort $files "date" "desc" -}}
+{{- $files = sort $files "sort_date" "desc" -}}
 {{- $flags := slice -}}
 {{- range $files -}}
   {{- $flags = $flags | append (dict "name" .name "experimental" .experimental "enable_date" .enable_date "enable_flag" .enable_flag "disable_flag" .disable_flag "description" .content) }}

--- a/layouts/shortcodes/compatibility-dates.html
+++ b/layouts/shortcodes/compatibility-dates.html
@@ -4,7 +4,7 @@
     {{- $files = $files | append (dict "name" .Params.name "date" .Params.date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .Content "\n")) -}}
   {{- end -}}
 {{- end -}}
-{{- $files = sort $files "date" "desc" -}}
+{{- $files = sort $files "sort_date" "desc" -}}
 {{- $experimental := lower (default "false" (.Get "experimental")) -}}
 {{- range $files -}}
   {{- if or (and .experimental (eq $experimental "true")) (and (not .experimental) (eq $experimental "false")) -}}


### PR DESCRIPTION
Enable dates were added here: https://github.com/cloudflare/workerd/pull/86/files

https://walshy-update-enable-dates.cloudflare-docs-7ou.pages.dev/workers/platform/compatibility-dates/