### PR TITLE
Use constant time function to compare HMACs

### DIFF
--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -166,7 +166,7 @@ async function checkSignature(formData, headers) {
   let expectedSignature = await createHexSignature(formData);
   let actualSignature = headers.get('X-Hub-Signature');
 
-  return expectedSignature === actualSignature;
+  return crypto.timingSafeEqual(Buffer.from(expectedSignature, 'hex'), Buffer.from(actualSignature, 'hex'));
 }
 ```
 

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -166,7 +166,10 @@ async function checkSignature(formData, headers) {
   let expectedSignature = await createHexSignature(formData);
   let actualSignature = headers.get('X-Hub-Signature');
 
-  return crypto.timingSafeEqual(Buffer.from(expectedSignature, 'hex'), Buffer.from(actualSignature, 'hex'));
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+  const actualBuffer = Buffer.from(actualSignature, 'hex');
+  return expectedBuffer.byteLength == actualBuffer.byteLength &&
+             crypto.timingSafeEqual(expectedBuffer, actualBuffer);
 }
 ```
 


### PR DESCRIPTION
Using simple string comparison to compare a HMACs is not recommended as it may allow a timing-based side channel attack.