### PR TITLE
[Registrar] Updated language on transfer lock

### DIFF
--- a/content/registrar/_partials/_restrictions.md
+++ b/content/registrar/_partials/_restrictions.md
@@ -17,6 +17,6 @@ The transfer of an expired domain may result in an additional year NOT being add
 * Your domain cannot be a premium domain as Cloudflare currently does not support them. Some registries designate a domain name as premium and charge higher wholesale rates for these domains. In most cases Cloudflare is able to identify premium (non-standard priced) domains during the transfer eligibility step. However, this check might fail. When this happens, Cloudflare will not be able to determine the domain's premium status until the transfer is initiated.
 * Your domain cannot be an internationalized domain name (IDNs) as Cloudflare does not currently support them. These domains are also known as unicode.
 * Domains that have a status of `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod` may not be transferred.
-* Domains that have a status of `clientTransferProhibited` (Transfer Lock) will show as available for transfer. However, the Transfer Lock must be removed at your current registrar before the transfer can begin.
+* Domains that have a status of `clientTransferProhibited` (Transfer Lock) will not show as available for transfer. You will have to unlock the domain at your current registrar before being able to proceed.
 
 If your domain is listed as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.


### PR DESCRIPTION
* Clarifies that transfer lock has to be removed at current registrar before being able to transfer domain to Cloudflare Registrar
* Addressed PCX-4953