### PR TITLE
[turnstile] Add changelog

### DIFF
--- a/content/turnstile/changelog.md
+++ b/content/turnstile/changelog.md
@@ -1,0 +1,16 @@
+---
+pcx_content_type: changelog
+title: Changelog
+weight: 10
+---
+
+# Changelog
+
+## 2022-10-13
+
+- Added validation for action: `/^[a-z0-9_-]{0,32}$/i`
+- Added validation for cData: `/^[a-z0-9_-]{0,255}$/i`
+
+## 2022-10-11
+
+- Added `turnstile.remove`

--- a/content/turnstile/changelog.md
+++ b/content/turnstile/changelog.md
@@ -13,4 +13,4 @@ weight: 10
 
 ## 2022-10-11
 
-- Added `turnstile.remove`
+- Added [`turnstile.remove`](/turnstile/get-started/client-side-rendering/#remove-a-widget)


### PR DESCRIPTION
Adds changelog for new documented features/things introduced after open beta started.

Dates are when the feature was documented, not when it was added. (eg turnstile.remove was added a week earlier but not documented)