### PR TITLE
Clarified DDoS managed ruleset customers scope

### DIFF
--- a/content/ddos-protection/change-log/network/_index.md
+++ b/content/ddos-protection/change-log/network/_index.md
@@ -11,7 +11,7 @@ meta:
 This section contains past and upcoming changes to the [Network-layer DDoS Attack Protection Managed Ruleset](/ddos-protection/managed-rulesets/network/).
 
 {{<Aside type="note">}}
-This ruleset is available only for [Spectrum](/spectrum/) and [Magic transit](/magic-transit/) customers.
+The Network-layer DDoS Attack Protection Managed Ruleset protects Cloudflare customers on all plans. However, only [Magic transit](/magic-transit/) and [Spectrum](/spectrum/) customers on an Enterprise plan can customize the Managed Ruleset.
 {{</Aside>}}
 
 {{<button type="primary" href="/ddos-protection/change-log/network/scheduled-changes/">}}View scheduled changes{{</button>}}


### PR DESCRIPTION
I found the previous statement to lead to think that only MT and Spectrum benefit from it. I took the statement found on: https://developers.cloudflare.com/ddos-protection/managed-rulesets/network/