### PR TITLE
Emergency release for CVE-2022-42889, Apache commons RCE

### DIFF
--- a/content/waf/change-log/2022-10-18---emergency-release.md
+++ b/content/waf/change-log/2022-10-18---emergency-release.md
@@ -1,0 +1,36 @@
+---
+title: 2022-10-18 - Emergency
+type: table
+pcx_content_type: changelog
+weight: 884
+layout: list
+---
+
+# 2022-10-18 - Emergency Release
+
+{{<table-wrap>}}
+<table style="width: 100%">
+  <thead>
+    <tr>
+      <th>Ruleset</th>
+      <th>Rule ID</th>
+      <th>Legacy Rule ID</th>
+      <th>Description</th>
+      <th>Previous Action</th>
+      <th>New Action</th>
+      <th>Comments</th>
+    </tr>
+  </thead>
+  <tbody>
+       <tr>
+      <td>Cloudflare Specials</td>
+      <td>...66edb651</td>
+      <td>100555</td>
+      <td>Apache Commons Text - Code Injection - CVE:CVE-2022-42889</td>
+      <td>N/A</td>
+      <td>Block</td>
+      <td>N/A</td>
+    </tr>
+  </tbody>
+</table>
+{{</table-wrap>}}


### PR DESCRIPTION
Emergency release for CVE-2022-42889, Apache commons RCE