### PR TITLE
[MFW] Added in missing sip value

### DIFF
--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -646,6 +646,15 @@ The Cloudflare Rules language supports these dynamic fields:
         Example values: <code class="InlineCode">54</code>
         </td>
     </tr>
+    <tr>
+        <td><p><code>sip</code><br />{{<type>}}Boolean{{</type>}}</p>
+        </td>
+        <td>
+       Determines if packets are valid L7 protocol <a href="https://datatracker.ietf.org/doc/html/rfc2543">SIP</a>. Requires UDP packets to operate. <br />
+       Use a guard clause as shown below to ensure the packet is UDP (wirefilter)<br />
+       <code class="InlineCode">ip.proto == "udp"</code>
+        </td>
+    </tr>
     <tr id="field-tcp">
         <td><p><code>tcp</code><br />{{<type>}}String{{</type>}}</p>
         </td>

--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -646,12 +646,12 @@ The Cloudflare Rules language supports these dynamic fields:
         Example values: <code class="InlineCode">54</code>
         </td>
     </tr>
-    <tr>
+    <tr id="field-sip">
         <td><p><code>sip</code><br />{{<type>}}Boolean{{</type>}}</p>
         </td>
         <td>
        Determines if packets are valid L7 protocol <a href="https://datatracker.ietf.org/doc/html/rfc2543">SIP</a>. Requires UDP packets to operate. <br />
-       Use a guard clause as shown below to ensure the packet is UDP (wirefilter)<br />
+       Use a guard clause as shown below to ensure the packet is UDP (wirefilter):<br />
        <code class="InlineCode">ip.proto == "udp"</code>
         </td>
     </tr>


### PR DESCRIPTION
Adding back in the `sip` value that was added to the former Magic Firewall fields page but not in the Ruleset Engine docs list. Addresses PCX-5040.