### PR TITLE
Document `IN` operator in Analytics Engine

### DIFF
--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -471,6 +471,7 @@ The following operators are supported:
 | `>=` | greater than or equal to |
 | `<>` or `!=` | not equal |
 | `IN` | true if the preceding expression's value is in the list<br>`column IN ('a', 'list', 'of', 'values')` |
+| `NOT IN` | true if the preceding expression's value is not in the list<br>`column NOT IN ('a', 'list', 'of', 'values')` |
 
 {{</table-wrap>}}
 

--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -470,6 +470,7 @@ The following operators are supported:
 | `<=` | less than or equal to |
 | `>=` | greater than or equal to |
 | `<>` or `!=` | not equal |
+| `IN` | true if the preceding expression's value is in the list<br>`column IN ('a', 'list', 'of', 'values')` |
 
 {{</table-wrap>}}
 


### PR DESCRIPTION
Analytics Engine now supports the `IN` operator:

```sql
SELECT * FROM dataset WHERE blob1 IN ('a', 'list', 'of', 'values', 'to', 'filter', 'by');
```

This commit adds it to the list of supported operators, with a short usage example for anyone who hasn't seen it before