### PR TITLE
Fix compatibility date sorting

### DIFF
--- a/layouts/_default/compatibility-dates.json.json
+++ b/layouts/_default/compatibility-dates.json.json
@@ -1,7 +1,7 @@
 {{- $files := slice -}}
 {{- range os.ReadDir "content/workers/_partials/_platform-compatibility-dates" -}}
   {{- with $.Site.GetPage (path.Join "workers/_partials/_platform-compatibility-dates/" .Name) -}}
-    {{- $files = $files | append (dict "name" .Params.name "date" .Params.date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .RawContent "\n")) -}}
+    {{- $files = $files | append (dict "name" .Params.name "sort_date" .Params.sort_date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .RawContent "\n")) -}}
   {{- end -}}
 {{- end -}}
 {{- $files = sort $files "sort_date" "desc" -}}

--- a/layouts/shortcodes/compatibility-dates.html
+++ b/layouts/shortcodes/compatibility-dates.html
@@ -1,7 +1,7 @@
 {{- $files := slice -}}
 {{- range os.ReadDir "content/workers/_partials/_platform-compatibility-dates" -}}
   {{- with $.Site.GetPage (path.Join "workers/_partials/_platform-compatibility-dates/" .Name) -}}
-    {{- $files = $files | append (dict "name" .Params.name "date" .Params.date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .Content "\n")) -}}
+    {{- $files = $files | append (dict "name" .Params.name "sort_date" .Params.sort_date "experimental" (default false .Params.experimental) "enable_date" .Params.enable_date "enable_flag" .Params.enable_flag "disable_flag" .Params.disable_flag "content" (trim .Content "\n")) -}}
   {{- end -}}
 {{- end -}}
 {{- $files = sort $files "sort_date" "desc" -}}


### PR DESCRIPTION
We moved away from `date` because apparently that has magical weird properties to `sort_date` instead. But forgot to change this in a couple of places.