### PR TITLE
[Workers] Improve Request reconstruction example in runtime-apis/request.md

### DIFF
--- a/content/workers/runtime-apis/request.md
+++ b/content/workers/runtime-apis/request.md
@@ -29,12 +29,7 @@ addEventListener("fetch", event => {
   const request = event.request
   const url = "https://example.com"
 
-  const modifiedRequest = new Request(url, {
-    body: request.body,
-    headers: request.headers,
-    method: request.method,
-    redirect: request.redirect
-  })
+  const modifiedRequest = new Request(url, request)
 
   // ...
 })


### PR DESCRIPTION
The existing example dropped a few Request properties (that is, `fetcher`, `signal`, and `cf` -- plus any that we might add in the future), and threw an exception if the `event.request` object was a GET request with a body. Reconstructing a Request object by passing the original object as one of the two parameters to the Request constructor avoids both of these issues.