### PR TITLE
Previous Electron URL was a 404

### DIFF
--- a/content/analytics/graphql-api/getting-started/authentication/graphql-client-headers.md
+++ b/content/analytics/graphql-api/getting-started/authentication/graphql-client-headers.md
@@ -6,7 +6,7 @@ weight: 41
 
 # Configure GraphQL client endpoint and HTTP headers
 
-1.  Launch [GraphiQL](https://electronjs.org/apps/graphiql).
+1.  Launch [GraphiQL](https://graphql.org/swapi-graphql).
 2.  Click **Edit HTTP Headers**.
     ![Clicking Edit HTTP Headers](/analytics/static/images/GraphiQL-edit-http-headers.png)
     The **Edit HTTP Headers** window appears.


### PR DESCRIPTION
Issue is the GraphiQL client changed drastically, it doesn't look like the documented screenshots anymore...