### PR TITLE
Fix broker create line

### DIFF
--- a/content/pub-sub/get-started/guide.md
+++ b/content/pub-sub/get-started/guide.md
@@ -143,7 +143,7 @@ To create a new MQTT Broker called `example-broker` in the `my-namespace` namesp
 
 
 ```sh
-$ wrangler pubsub namespace create example-broker --namespace=my-namespace
+$ wrangler pubsub broker create example-broker --namespace=my-namespace
 ```
 
 You should receive a success response that resembles the following:


### PR DESCRIPTION
The command to create broker was wrong.
FIxed the line with the proper command.

When I tried the command it failed, I was stuck at this for a while, until I figured it out that the command in the documentation is wrong.