### PR TITLE
Update start-from-scratch.md

### DIFF
--- a/content/workers/platform/sites/start-from-scratch.md
+++ b/content/workers/platform/sites/start-from-scratch.md
@@ -22,13 +22,12 @@ This guide shows how to quickly start a new Workers Sites project from scratch.
     ```sh
     $ git clone --depth=1 --branch=wrangler2 https://github.com/cloudflare/worker-sites-template my-site
     ```
-
+2.  Run `npm install` to install all dependencies.
 3.  You can preview your site by running the [`wrangler dev`](/workers/wrangler/cli-wrangler/commands/#dev) command:
 
     ```sh
     $ wrangler dev
     ```
-
 4.  Publish your site to Cloudflare:
 
     ```sh


### PR DESCRIPTION
Without `npm install` the steps are incomplete.
If you assume that the user will run `npm install` without the need to write it, please reject the PR.