### PR TITLE
[Docs] Add new snippet for collapsible details section

### DIFF
--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -119,4 +119,19 @@
         "description": "Adds a new tabs section with two tabs for dashboard and API instructions",
         "scope": "markdown"
     },
+    "Create collapsible details section": {
+      "prefix": ["detailssection", "collapsible"],
+      "body": [
+        "<details>",
+        "<summary>${1:header}</summary>",
+        "<div>",
+        "",
+        "$0$TM_SELECTED_TEXT",
+        "",
+        "</div>",
+        "</details>",
+      ],
+      "description": "Creates a new collapsible <details> element with a title and a body",
+      "scope": "markdown"
+  },
 }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Prefixes | Description
 `headerpartialfile` | Inserts a header for a partial Markdown file.
 `partialinclude` or `renderpartial` | Inserts a `render` shortcode to include content from a partial in the current document.
 `twotabs` or `addtabs` | Inserts a new tabs section with two tabs for dashboard and API instructions.
+`detailssection` or `collapsible` | Inserts a collapsible `<details>` HTML element.
 
 Triggering one of the available snippets will insert their body content at the current cursor position.
 
@@ -75,6 +76,7 @@ Additionally, the following snippets support surrounding existing text:
 * `Aside without header`
 * `Surround with content-column`
 * `Surround with table-wrap`
+* `Create collapsible details section`
 
 ### How to use
 


### PR DESCRIPTION
Adds a new VSCode snippet for collapsible `<details>` sections similar to the following:

<details><summary>API call example</summary>This collapsed section would contain an API example.</details>