### PR TITLE
[WAF, Ruleset Engine] Update sub-expression to ensure ENT zone requirement

### DIFF
--- a/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
+++ b/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
@@ -15,7 +15,7 @@ Before you begin:
 To deploy a custom ruleset, add a rule that executes the custom ruleset. Define the rule scope in the rule expression.
 
 {{<Aside type="warning">}}
-Regarding the expression of the rule deploying the ruleset, you must use parentheses to enclose any custom conditions and end your expression with `and (cf.zone.plan eq "ENT")` or else the API operation will fail.
+Regarding the expression of the rule deploying the ruleset, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` or else the API operation will fail.
 {{</Aside>}}
 
 ## Example

--- a/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
@@ -17,14 +17,14 @@ Use the following workflow to deploy a Managed Ruleset to a phase at the account
 1. Get your account ID.
 2. Get the ID of the Managed Ruleset you wish to deploy. Refer to [List existing rulesets](/ruleset-engine/rulesets-api/view/#list-existing-rulesets) for details.
 3. Identify the phase where you want to deploy the Managed Ruleset. Ensure that the Managed Ruleset belongs to the same phase where you want to deploy it. To learn more about the available phases supported by each Cloudflare product, check the specific documentation for that product.
-4. Add a rule to the account-level phase entry point ruleset that executes the Managed Ruleset. Regarding the rule expression, you must use parentheses to enclose any custom conditions and end your expression with `and (cf.zone.plan eq "ENT")` so that it only applies to zones on an Enterprise plan.
+4. Add a rule to the account-level phase entry point ruleset that executes the Managed Ruleset. Regarding the rule expression, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` so that it only applies to zones on an Enterprise plan.
 
 ### Example
 
 The following example deploys a Managed Ruleset to the `http_request_firewall_managed` phase of your account (`<ACCOUNT_ID>`) by creating a rule that executes the Managed Ruleset. The rules in the Managed Ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
 
 {{<Aside type="warning">}}
-Managed Rulesets deployed at the account level will only apply to incoming traffic of zones on an Enterprise plan. The expression of your `execute` rule must end with `and (cf.zone.plan eq "ENT")` or else the API operation will fail.
+Managed Rulesets deployed at the account level will only apply to incoming traffic of zones on an Enterprise plan. The expression of your `execute` rule must end with `and cf.zone.plan eq "ENT"` or else the API operation will fail.
 {{</Aside>}}
 
 ```json

--- a/content/waf/custom-rulesets/create-api.md
+++ b/content/waf/custom-rulesets/create-api.md
@@ -21,7 +21,7 @@ For more information, refer to [Work with custom rulesets](/ruleset-engine/custo
 
 {{<Aside type="warning" header="Important">}}
 
-* Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. Regarding the expression of the rule deploying the custom ruleset, you must use parentheses to enclose any custom conditions and end your expression with `and (cf.zone.plan eq "ENT")` or else the API operation will fail.
+* Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. Regarding the expression of the rule deploying the custom ruleset, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` or else the API operation will fail.
 
 * Currently, you can only deploy custom rulesets to a phase at the account level.
 

--- a/content/waf/custom-rulesets/create-dashboard.md
+++ b/content/waf/custom-rulesets/create-dashboard.md
@@ -58,7 +58,7 @@ To enable the custom ruleset you created, you must deploy it to your account.
 6. Under **Execution scope**, review the scope of the deployed custom ruleset. If necessary, select **Edit scope** and configure the expression that will determine the scope of the current rule.
 
     {{<Aside type="warning">}}
-Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. The Expression Builder will automatically include this filter. If you define a custom expression using the Expression Editor, you must use parentheses to enclose any custom conditions and end your expression with `and (cf.zone.plan eq "ENT")` so that the rule only applies to domains on an Enterprise plan.
+Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. The Expression Builder will automatically include this filter. If you define a custom expression using the Expression Editor, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` so that the rule only applies to domains on an Enterprise plan.
     {{</Aside>}}
 
 7. To deploy your rule immediately, select **Deploy**. If you are not ready to deploy your rule, select **Save as draft**.

--- a/content/waf/managed-rulesets/deploy-account-dashboard.md
+++ b/content/waf/managed-rulesets/deploy-account-dashboard.md
@@ -33,7 +33,7 @@ To deploy a Managed Ruleset for a single zone, refer to [Deploy a Managed Rulese
 6. Under **Execution scope**, review the scope of the deployed Managed Ruleset. If necessary, select **Edit scope** and configure the expression that will determine the scope of the current rule.
 
     {{<Aside type="warning">}}
-Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. The Expression Builder will automatically include this filter. If you define a custom expression using the Expression Editor, you must use parentheses to enclose any custom conditions and end your expression with `and (cf.zone.plan eq "ENT")` so that the rule only applies to domains on an Enterprise plan.
+Deployed custom rulesets will only apply to incoming traffic of Enterprise domains. The Expression Builder will automatically include this filter. If you define a custom expression using the Expression Editor, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` so that the rule only applies to domains on an Enterprise plan.
     {{</Aside>}}
 
 7. (Optional) Specify overrides for [all the rules in the Managed Ruleset](#configure-field-values-for-all-the-rules). You can also create overrides for [specific rules or tags](#configure-rules-in-bulk-in-a-managed-ruleset).


### PR DESCRIPTION
Follow-up to the work done in MR-1568.

The sub-expression to ensure the Enterprise zone requirement no longer requires parentheses.