### PR TITLE
Update billing examples to realistic use cases

### DIFF
--- a/content/r2/platform/pricing.md
+++ b/content/r2/platform/pricing.md
@@ -19,17 +19,17 @@ All included usage is on a monthly basis.
 
 {{<table-wrap>}}
 
-|                    | Free                         | Paid - Rates                       | 
+|                    | Free                         | Paid - Rates                       |
 | ------------------ | ---------------------------- | ---------------------------------- |
 | Storage            | 10 GB / month                | $0.015 / GB-month                  |
-| Class A Operations | 1 million requests / month   | $4.50 / million requests           | 
-| Class B Operations | 10 million requests / month  | $0.36 / million requests           | 
+| Class A Operations | 1 million requests / month   | $4.50 / million requests           |
+| Class B Operations | 10 million requests / month  | $0.36 / million requests           |
 
 {{</table-wrap>}}
 
 ### Storage usage
 
-Storage is billed using gigabyte-month (GB-month) as the billing metric. A GB-month is calculated by recording total bytes stored for the duration of the month. 
+Storage is billed using gigabyte-month (GB-month) as the billing metric. A GB-month is calculated by recording total bytes stored for the duration of the month.
 
 For example:
 
@@ -50,9 +50,9 @@ Free operations include `DeleteObject`, `DeleteBucket` and `AbortMultipartUpload
 
 ## R2 billing examples
 
-#### Example 1
+#### Data Storage
 
-If a user writes 1,000 objects in R2 for 1 month and each object is 1 GB in size and requested 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
 
 {{<table-wrap>}}
 |                    | Usage                                      | Free Tier    | Billable Quantity | Price      |
@@ -63,15 +63,15 @@ If a user writes 1,000 objects in R2 for 1 month and each object is 1 GB in size
 | **TOTAL**          |                                            |              |                   | **$14.85** |
 {{</table-wrap>}}
 
-#### Example 2
+#### Asset Hosting
 
-If a user writes the same 1 GB object 1,000,000 times a day and the object is read 10,000,000 times a day, the estimated cost in a month would be: 
+If a user writes 100,000 files with an average size of 100 KB object and reads 10,000,000 objects per day, the estimated cost in a month would be: 
 
 {{<table-wrap>}}
 |                    | Usage                                               | Free Tier    | Billable Quantity | Price       |
 |--------------------|-----------------------------------------------------|--------------|-------------------|-------------|
-| Class B Operations | (1 object) * (10,000,000 reads per day) * (30 days) |   10 million |       290,000,000 |     $104.40 |
-| Class A Operations | (1 object) * (1,000,000 writes per day) * (30 days) |    1 million |        29,000,000 |     $130.50 |
-| Storage            | (1 object) * (1GB per object)                       | 10 GB-months |       0 GB-months |        $0.00 |
-| **TOTAL**          |                                                     |              |                   | **$234.90** |
+| Class B Operations | (10,000,000 reads per day) * (30 days)              |   10 million |       290,000,000 |     $104.40 |
+| Class A Operations | (100,000 writes)                                    |    1 million |                 0 |       $0.00 |
+| Storage            | (100,000 objects) * (100KB per object)              | 10 GB-months |       0 GB-months |       $0.00 |
+| **TOTAL**          |                                                     |              |                   | **$104.40** |
 {{</table-wrap>}}


### PR DESCRIPTION
Prior example was a behavior that would have meant writing the same 1GB object 11 times per second (not a realistic scenario) so updated to actual use cases.