### PR TITLE
[Workers] Fix indent errors in definition blocks

### DIFF
--- a/content/workers/runtime-apis/streams/readablestream.md
+++ b/content/workers/runtime-apis/streams/readablestream.md
@@ -31,9 +31,9 @@ cannot be created directly using the `ReadableStream` constructor.
 
   - Gets an instance of `ReadableStreamDefaultReader` and locks the `ReadableStream` to that reader instance. This method accepts an object argument indicating options. The only supported option is `mode`, which can be set to `byob` to create a [`ReadableStreamBYOBReader`](/workers/runtime-apis/streams/readablestreambyobreader/), as shown here:
 
-    ```js
-    let reader = readable.getReader({ mode: 'byob' });
-    ```
+```js
+let reader = readable.getReader({ mode: 'byob' });
+```
 
 {{</definitions>}}
 

--- a/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
+++ b/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
@@ -60,14 +60,14 @@ Any data not yet written is lost upon abort.
 
   - Releases the writer’s lock on the stream. Once released, the writer is no longer active. You can call this method before all pending `write(chunk)` calls are resolved. This allows you to queue a `write` operation, release the lock, and begin piping into the writable stream from another source, as shown in the example below.
 
-    ```js
-    let writer = writable.getWriter();
-    // Write a preamble.
-    writer.write(new TextEncoder().encode('foo bar'));
-    // While that’s still writing, pipe the rest of the body from somewhere else.
-    writer.releaseLock();
-    await someResponse.body.pipeTo(writable);
-    ```
+```js
+let writer = writable.getWriter();
+// Write a preamble.
+writer.write(new TextEncoder().encode('foo bar'));
+// While that’s still writing, pipe the rest of the body from somewhere else.
+writer.releaseLock();
+await someResponse.body.pipeTo(writable);
+```
 
 - {{<code>}}write(chunk{{<param-type>}}any{{</param-type>}}){{</code>}} {{<type>}}Promise\<void>{{</type>}}
 

--- a/content/workers/runtime-apis/web-crypto.md
+++ b/content/workers/runtime-apis/web-crypto.md
@@ -209,14 +209,14 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
     - Returns a Promise that fulfills with a newly-generated `CryptoKey`, for symmetrical algorithms, or a `CryptoKeyPair`, containing two newly generated keys, for asymmetrical algorithms. For example, to generate a new AES-GCM key:
 
 ```js
-    let keyPair = await crypto.subtle.generateKey(
-      {
-        name: 'AES-GCM',
-        length: '256',
-      },
-      true,
-      ['encrypt', 'decrypt']
-    );
+let keyPair = await crypto.subtle.generateKey(
+  {
+    name: 'AES-GCM',
+    length: '256',
+  },
+  true,
+  ['encrypt', 'decrypt']
+);
 ```
 
   **Parameters:**

--- a/content/workers/runtime-apis/web-crypto.md
+++ b/content/workers/runtime-apis/web-crypto.md
@@ -208,7 +208,9 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
 
     - Returns a Promise that fulfills with a newly-generated `CryptoKey`, for symmetrical algorithms, or a `CryptoKeyPair`, containing two newly generated keys, for asymmetrical algorithms. For example, to generate a new AES-GCM key:
 
-    ```js
+{{<tabs labels="example">}}
+{{<tab label="example" no-code="true">}}
+```js
     let keyPair = await crypto.subtle.generateKey(
       {
         name: 'AES-GCM',
@@ -218,6 +220,8 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
       ['encrypt', 'decrypt']
     );
     ```
+{{</tab>}}
+{{</tabs>}}
 
   **Parameters:**
 

--- a/content/workers/runtime-apis/web-crypto.md
+++ b/content/workers/runtime-apis/web-crypto.md
@@ -208,8 +208,6 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
 
     - Returns a Promise that fulfills with a newly-generated `CryptoKey`, for symmetrical algorithms, or a `CryptoKeyPair`, containing two newly generated keys, for asymmetrical algorithms. For example, to generate a new AES-GCM key:
 
-{{<tabs labels="example">}}
-{{<tab label="example" no-code="true">}}
 ```js
     let keyPair = await crypto.subtle.generateKey(
       {
@@ -219,9 +217,7 @@ These methods are all accessed via `crypto.subtle`, which is also [documented in
       true,
       ['encrypt', 'decrypt']
     );
-    ```
-{{</tab>}}
-{{</tabs>}}
+```
 
   **Parameters:**
 

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,9 +1,13 @@
 {{- $text := .Get "labels" -}} {{- $labels := split $text " | " -}}
 {{ $unique_id := substr (md5 .Inner) 0 16 }}
+
 <div class="tabs-wrapper" tab-wrapper-id="{{$unique_id}}">
   <nav role="navigation" class="tabs">
     <ul class="tab-active" block-id="{{$unique_id}}">
       {{ range $idx, $txt := $labels }} {{- $link := replace $txt "/" "-"}}
+      <script>
+        console.log({{$idx}})
+        </script>
       <li class="tab-label-wrapper">
         {{ if (eq $link "js") }}
         <a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -5,9 +5,6 @@
   <nav role="navigation" class="tabs">
     <ul class="tab-active" block-id="{{$unique_id}}">
       {{ range $idx, $txt := $labels }} {{- $link := replace $txt "/" "-"}}
-      <script>
-        console.log({{$idx}})
-        </script>
       <li class="tab-label-wrapper">
         {{ if (eq $link "js") }}
         <a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">


### PR DESCRIPTION
Addresses #6431 

- [Previous](https://developers.cloudflare.com/workers/runtime-apis/streams/readablestream/) vs [new](https://fix-indent-errors.cloudflare-docs-7ou.pages.dev/workers/runtime-apis/streams/readablestream/)
- [Previous](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/) vs [new](https://fix-indent-errors.cloudflare-docs-7ou.pages.dev/workers/runtime-apis/web-crypto/)
- [Previous](https://developers.cloudflare.com/workers/runtime-apis/streams/writablestreamdefaultwriter/) vs [new](https://fix-indent-errors.cloudflare-docs-7ou.pages.dev/workers/runtime-apis/streams/writablestreamdefaultwriter/)