### PR TITLE
MFW-980 fix ownership destination_conf in response

### DIFF
--- a/content/magic-firewall/how-to/pcaps-bucket-setup.md
+++ b/content/magic-firewall/how-to/pcaps-bucket-setup.md
@@ -82,7 +82,7 @@ header: Ownership challenge response example
     "status": "pending",
     "submitted": "2022-04-22T18:54:13.397413Z",
     "validated": "",
-    "destinaton_conf": "gs://bucket-test",
+    "destination_conf": "gs://bucket-test",
     "filename": "ownership-challenge-1234.txt"
   },
   "success": true,
@@ -117,7 +117,7 @@ header: Bucket validation response
     "status": "success",
     "submitted": "2022-04-22T18:54:13.397413Z",
     "validated": "2022-04-27T14:54:46.440548Z",
-    "destinaton_conf": "gs://bucket-test",
+    "destination_conf": "gs://bucket-test",
     "filename": "ownership-challenge-1234.txt"
   },
   "success": true,
@@ -174,7 +174,7 @@ header: Bucket list response example
       "status": "success",
       "submitted": "2022-04-26T16:58:24.550762Z",
       "validated": "2022-04-26T17:01:18.426458Z",
-      "destinaton_conf": "s3://test-bucket?region=us-east-1",
+      "destination_conf": "s3://test-bucket?region=us-east-1",
       "filename": "ownership-challenge-1234.txt"
     },
   ],


### PR DESCRIPTION
We recently fixed the "destination_conf" field in the API response for the ownership endpoints. Previously the field was called "destinaton_conf" and the docs also has the misspelled field. Now that we're returning the right field name we can also update the documentation. The response will return both "destinaton_conf" and "destination_conf" to avoid a breaking change.