### PR TITLE
[DNS] Change proxy status in MX records example in email-records.md

### DIFF
--- a/content/dns/manage-dns-records/how-to/email-records.md
+++ b/content/dns/manage-dns-records/how-to/email-records.md
@@ -18,7 +18,7 @@ To route emails to your mail server, you need to [create two DNS records](/dns/m
 
      | **Type** | **Name** | **IPv4 address** | **Proxy status** |
      | -------- | -------- | ---------------- | ---------------- |
-     | A        | `mail`   | `192.0.2.1`      | Proxied          |
+     | A        | `mail`   | `192.0.2.1`      | Unproxied          |
 
 2.  An **MX** record that points to that subdomain.
 


### PR DESCRIPTION
The A/AAAA record used to refer to a mailserver should not be proxied, as this will cause email delivery problems because Cloudflare does not proxy port 25 (https://support.cloudflare.com/hc/en-us/articles/200168876-Email-undeliverable-when-using-Cloudflare).