### PR TITLE
[R2] Cleanup S3 operations

### DIFF
--- a/content/r2/data-access/s3-api/_index.md
+++ b/content/r2/data-access/s3-api/_index.md
@@ -6,4 +6,20 @@ weight: 2
 
 # S3 API
 
+Amazon's [S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API) is a popular API for working with
+large object storage systems. There's many SDKs and tools available for interfacing with it. If
+you're interested in shifting your existing S3 application to R2, we've got you covered with a REST
+API that is compatible so all you have to do in your code is change the URL you're pointing to and
+add R2 credentials. We have a wide list of [examples](/r2/examples/)
+to help you get started using your favorite SDK or tool.
+
+R2's S3 REST endpoint will be available at `https://<BUCKET>.<ACCOUNT>.r2.cloudflarestorage.com`.
+If you make your [bucket public](/r2/data-access/public-buckets/),
+it'll be available on a separate HTTP REST endpoint.
+
+If you're building a new application from scratch you may want to consider using the
+[Workers platform](/r2/data-access/workers-api) instead to build your application. It's a more
+secure alternative as there's no need to manage credentials and applications you write only have
+access to the specific buckets you choose to grant them access to.
+
 {{<directory-listing>}}

--- a/content/r2/data-access/s3-api/api.md
+++ b/content/r2/data-access/s3-api/api.md
@@ -27,9 +27,27 @@ When using the S3 API, the region for an R2 bucket is `auto`. For compatibility 
 
 This also applies to the `LocationConstraint` for the `CreateBucket` API.
 
+## Account-level operations
+
+The following tables are related to operations you perform directly on the account itself. The URL
+will be `https://<ACCOUNT>.r2.cloudflarestorage.com/`. There may be search parameters but there
+is no additional path in the URL.
+
+### Implemented account-level operations
+
+| API Name                                | Feature                           |
+| --------------------------------------- |---------------------------------- |
+| ✅ [ListBuckets](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html)     |                                    |
+| ✅ [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html)       | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
+| ✅ [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)   | ❌ ACL: <br> &emsp;  ❌ x-amz-acl <br> &emsp;  ❌ x-amz-grant-full-control <br> &emsp;  ❌ x-amz-grant-read <br> &emsp;  ❌ x-amz-grant-read-acp  <br> &emsp;  ❌ x-amz-grant-write <br> &emsp;  ❌ x-amz-grant-write-acp <br> ❌ Object Locking: <br> &emsp;  ❌ x-amz-bucket-object-lock-enabled <br>  ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
+| ✅ [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html)   | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
+
 ## Bucket-level operations
 
-The following tables are related to bucket-level operations.
+The following tables are related to operations you perform on the bucket for a given account. The URL
+will be `http://<BUCKET>.<ACCOUNT>.r2.cloudflarestorage.com/` (or `https://<ACCOUNT>.r2.cloudflarestorage.com/<BUCKET>`
+if using [path-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html)).
+There may be search parameters but there is no additional path in the URL.
 
 ### Implemented bucket-level operations
 
@@ -39,15 +57,13 @@ Below is a list of implemented bucket-level operations. Refer to the Feature col
 
 | API Name                                | Feature                           |
 | --------------------------------------- |---------------------------------- |
-| ✅ [ListBuckets](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html)     |                                    |
-| ✅ [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html)       | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
-| ✅ [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)   | ❌ ACL: <br> &emsp;  ❌ x-amz-acl <br> &emsp;  ❌ x-amz-grant-full-control <br> &emsp;  ❌ x-amz-grant-read <br> &emsp;  ❌ x-amz-grant-read-acp  <br> &emsp;  ❌ x-amz-grant-write <br> &emsp;  ❌ x-amz-grant-write-acp <br> ❌ Object Locking: <br> &emsp;  ❌ x-amz-bucket-object-lock-enabled <br>  ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
-| ✅ [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html)   | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
 | ✅ [DeleteBucketCors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html) | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
 | ✅ [GetBucketCors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html) | ❌ Bucket Owner: <br> &emsp; ❌ x-amz-expected-bucket-owner |
 | ✅ [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html)  | ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
 | ✅ [GetBucketEncryption](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html) | | ❌ Bucket Owner: <br> ❌ x-amz-expected-bucket-owner |
 | ✅ [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) | | ❌ Bucket Owner: <br> ❌ x-amz-expected-bucket-owner |
+| ✅ [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html)      | Query Parameters: <br> &emsp;  ✅ delimiter <br> &emsp;  ✅ encoding-type <br> &emsp; ✅ marker <br> &emsp;  ✅ max-keys <br> &emsp;  ✅ prefix <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
+| ✅ [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html) | Query Parameters: <br> &emsp;  ✅ list-type <br> &emsp;  ✅ continuation-token <br> &emsp;  ✅ delimiter <br> &emsp;  ✅ encoding-type <br> &emsp;  ✅ fetch-owner <br> &emsp;  ✅ max-keys <br> &emsp;  ✅ prefix <br> &emsp;  ✅ start-after <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner                   |
 | ✅ [PutBucketCors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html) | ❌ Checksums: <br> &emsp; ❌ x-amz-sdk-checksum-algorithm <br> &emsp; ❌ x-amz-checksum-algorithm <br> ❌ Bucket Owner: <br> &emsp; ❌ x-amz-expected-bucket-owner |
 
 {{</table-wrap>}}
@@ -112,9 +128,19 @@ Below is a list of implemented bucket-level operations. Refer to the Feature col
 {{</table-wrap>}}
 </details>
 
+{{<Aside type="warning">}}
+
+Even though `ListObjects` is a supported operation, it is recommended that you use `ListObjectsV2` instead when developing applications. For more information, refer to [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html).
+
+{{</Aside>}}
+
 ## Object-level operations
 
-The following tables are related to object-level operations.
+The following tables are related to operations you perform on a single object in a given bucket and
+account. The URL will be `http://<BUCKET>.<ACCOUNT>.r2.cloudflarestorage.com/<OBJECT NAME>` (or
+`https://<ACCOUNT>.r2.cloudflarestorage.com/<BUCKET>/<OBJECT NAME>` if using
+[path-style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html)).
+There may also be additional search parameters depending on the operation.
 
 ### Implemented object-level operations
 
@@ -133,8 +159,6 @@ This does not apply to concurrent uploads for different files.
 | API Name                | Feature                   |
 | ------------------------| ------------------------- |
 | ✅ [HeadObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)       | ✅ Conditional Operations: <br> &emsp;   ✅ If-Match <br> &emsp;  ✅ If-Modified-Since <br> &emsp;  ✅ If-None-Match <br> &emsp;  ✅ If-Unmodified-Since <br> ✅ Range: <br> &emsp;  ✅ Range (has no effect in HeadObject) <br> &emsp;  ✅ partNumber <br> ❌ SSE-C: <br> &emsp;  ❌ x-amz-server-side-encryption-customer-algorithm <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key-MD5 <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner  |
-| ✅ [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html)      | Query Parameters: <br> &emsp;  ✅ delimiter <br> &emsp;  ✅ encoding-type <br> &emsp; ✅ marker <br> &emsp;  ✅ max-keys <br> &emsp;  ✅ prefix <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
-| ✅ [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html) | Query Parameters: <br> &emsp;  ✅ list-type <br> &emsp;  ✅ continuation-token <br> &emsp;  ✅ delimiter <br> &emsp;  ✅ encoding-type <br> &emsp;  ✅ fetch-owner <br> &emsp;  ✅ max-keys <br> &emsp;  ✅ prefix <br> &emsp;  ✅ start-after <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner                   |
 | ✅ [GetObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)         | ✅ Conditional Operations: <br> &emsp;  ✅ If-Match <br> &emsp;  ✅ If-Modified-Since <br> &emsp;  ✅ If-None-Match <br> &emsp;  ✅ If-Unmodified-Since <br> ✅ Range: <br> &emsp;  ✅ Range <br> &emsp;  ✅ PartNumber <br> ❌ SSE-C: <br> &emsp;  ❌ x-amz-server-side-encryption-customer-algorithm <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key-MD5 <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
 | ✅ [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)         | ✅ System Metadata: <br> &emsp;  ✅ Content-Type <br> &emsp;  ✅ Cache-Control <br> &emsp;  ✅ Content-Disposition <br> &emsp;  ✅ Content-Encoding <br> &emsp;  ✅ Content-Language <br> &emsp;  ✅ Expires <br> &emsp;  ✅ Content-MD5 <br> ❌ Object Lifecycle <br> ❌ Website: <br> &emsp;  ❌ x-amz-website-redirect-location <br> ❌ SSE-C: <br> &emsp;  ❌ x-amz-server-side-encryption <br> &emsp;  ❌ x-amz-server-side-encryption-customer-algorithm <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key <br> &emsp;  ❌ x-amz-server-side-encryption-customer-key-MD5 <br> &emsp;  ❌ x-amz-server-side-encryption-aws-kms-key-id <br> &emsp;  ❌ x-amz-server-side-encryption-context <br> &emsp;  ❌ x-amz-server-side-encryption-bucket-key-enabled <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Tagging: <br> &emsp;  ❌ x-amz-tagging <br> ❌ Object Locking: <br> &emsp;  ❌ x-amz-object-lock-mode <br> &emsp;  ❌ x-amz-object-lock-retain-until-date <br> &emsp;  ❌ x-amz-object-lock-legal-hold <br> ❌ ACL: <br> &emsp;  ❌ x-amz-acl <br> &emsp;  ❌ x-amz-grant-full-control <br> &emsp;  ❌ x-amz-grant-read <br> &emsp;  ❌ x-amz-grant-read-acp <br> &emsp;  ❌ x-amz-grant-write-acp <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
 | ✅ [DeleteObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html)| ❌ Multi-factor authentication: <br> &emsp;  ❌ x-amz-mfa <br> ❌ Object Locking: <br> &emsp;  ❌ x-amz-bypass-governance-retention <br> ❌ Request Payer: <br> &emsp;  ❌ x-amz-request-payer <br> ❌ Bucket Owner: <br> &emsp;  ❌ x-amz-expected-bucket-owner |
@@ -160,9 +184,3 @@ Below is a list of unimplemented object-level operations.
 | ❌ [ListParts](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html)          | ❌ Query Parameters: <br> &emsp;  ❌ max-parts <br> &emsp;  ❌ part-number-marker <br> ❌ Bucket Owner: <br> &emsp; ❌ x-amz-expected-bucket-owner <br> ❌ Request Payer: <br> &emsp; ❌ x-amz-request-payer |
 
 {{</table-wrap>}}
-
-{{<Aside type="warning">}}
-
-Even though `ListObjects` is a supported operation, it is recommended that you use `ListObjectsV2` instead when developing applications. For more information, refer to [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html).
-
-{{</Aside>}}

--- a/content/r2/data-access/workers-api/_index.md
+++ b/content/r2/data-access/workers-api/_index.md
@@ -6,4 +6,16 @@ weight: 1
 
 # Workers API
 
+The Workers API is how you can interface with R2 using a JavaScript/TypeScript API on top of the
+[Workers platform](https://workers.cloudflare.com/).
+
+The Workers platform lets you write applications that meet your users directly at the edge to meet
+your client requests wherever they get generated without needing to manage any servers or worry
+about scaling up your application. Write code, deploy with one click, and sit back as your application
+is deployed worldwide within a minute with access to R2: a large object storage system with 0 egress
+fees and scale to meet your business needs.
+
+If you have an existing project using an S3 REST API, our [S3 compatibility layer](/r2/data-access/s3-api)
+is an excellent way to migrate your existing project with minimal friction.
+
 {{<directory-listing>}}


### PR DESCRIPTION
Add "account level" operations and reorder the ops on the page so that everything is correct (ListObjects for example was incorrectly listed as an object-level operation).

Add some color commentary to the `data-access/s3-api` and `data-access/workers-api` pages so that it's a bit of a softer landing explaining how those things work (e.g. if you link to these from some other piece, we should describe a bit as to what they are instead of only providing a table of contents).

