### PR TITLE
Refactor Cloudflare GraphQL API's getting started and limit blocks of…

### DIFF
--- a/content/analytics/graphql-api/features/data-sets/index.md
+++ b/content/analytics/graphql-api/features/data-sets/index.md
@@ -11,9 +11,9 @@ Cloudflare Analytics offers a range of datasets, including both general and
 product-specific ones. Datasets use a consistent naming scheme that explicitly
 identifies the type of data they return:
 
-* **Domain** - Each dataset is named after the field it describes and associated
-  with a set of nodes. Product-specific data nodes incorporate the name of the
-  relevant product, as set of `loadBalancingRequests*` nodes.
+* **Domain** - Each dataset is named after the field it describes and is
+  associated with a set of nodes. Product-specific data nodes incorporate the
+  name of the relevant product, for instance `loadBalancingRequests*` nodes.
 
 * **Adaptive Sampling** - Nodes that represent data acquired using adaptive
   sampling incorporate the `Adaptive` suffix. For more details, please see

--- a/content/analytics/graphql-api/features/data-sets/index.md
+++ b/content/analytics/graphql-api/features/data-sets/index.md
@@ -7,76 +7,31 @@ layout: single
 
 # Datasets (tables)
 
-Cloudflare Analytics offers a range of datasets, including both general and product-specific datasets. Datasets use a consistent naming scheme that explicitly identifies the type of data they return:
+Cloudflare Analytics offers a range of datasets, including both general and
+product-specific ones. Datasets use a consistent naming scheme that explicitly
+identifies the type of data they return:
 
-*   **Domain** - Each dataset is named after the domain it describes and is associated with a set of nodes. Data nodes are typically named after the domain they represent. Product-specific data nodes incorporate the name of the relevant product, as in `loadBalancingRequests`. Network Analytics data nodes incorporate the `ipFlows` label.
+* **Domain** - Each dataset is named after the field it describes and associated
+  with a set of nodes. Product-specific data nodes incorporate the name of the
+  relevant product, as set of `loadBalancingRequests*` nodes.
 
-*   **Aggregated data** - Nodes that represent aggregated data include the `Groups` suffix. For example, the `loadBalancingRequestsGroups` node represents aggregated data for Load Balancing requests. Aggregated data returns in an array of `...Group` objects. If the data represented by a node is aggregated prior to query time, the aggregation period is also specified. For example, `requests1mGroups` represents data aggregated into a collection of minute-wise roll-up reports.
+* **Adaptive Sampling** - Nodes that represent data acquired using adaptive
+  sampling incorporate the `Adaptive` suffix. For more details, please see
+  [sampling][1].
 
-*   **Raw data** - Raw data nodes, such as `loadBalancingRequests`, are not aggregated and so do not incorporate the `Groups` suffix. Raw data returns in arrays containing objects of the relevant data type. For example, a query to `loadBalancingRequests` returns an array of `LoadBalancingRequest` objects.
+* **Aggregated data** - Nodes that represent aggregated data include the
+  `Groups` suffix. For example, the `loadBalancingRequestsAdaptiveGroups` node
+  represents aggregated data for Load Balancing requests. Aggregated data is
+  returned in an array of `...Group` objects.
 
-*   **Adaptive Sampling** - Nodes that represent data acquired using adaptive sampling incorporate the `Adaptive` suffix. (For details, refer to [Sampling](/analytics/graphql-api/sampling/)).
+* **Raw data** - Raw data nodes, such as `loadBalancingRequestsAdaptive`, are
+  not aggregated and so do not incorporate the `Groups` suffix. Raw data is
+  returned in arrays containing objects of the relevant data type. For example,
+  a query to `loadBalancingRequestsAdaptive` returns a variety of
+  `LoadBalancingRequest` objects.
 
-Detailed descriptions of nodes, their structure, and supported queries are available directly from the GraphQL Analytics API via **introspection** (refer to [Get started: Querying basics](/analytics/graphql-api/getting-started/querying-basics/)). For more on using introspection to ask a GraphQL schema for information about the queries it supports, refer to the [GraphQL documentation](https://graphql.org/learn/introspection/).
-
-## Available datasets
-
-The following datasets (and associated nodes) are available in Cloudflare Analytics:
-
-{{<table-wrap>}}
-
-| Dataset (product)          | Node                                                                                                                           |
-| :-------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
-| Firewall Activity Log       | `firewallEventsAdaptive` `firewallEventsAdaptiveByTimeGroups`                                                                  |
-| Firewall Analytics          | `firewallEventsAdaptiveGroups`                                                                                                 |
-| Gateway Analytics               | `gatewayL4SessionsAdaptiveGroups` `gatewayL7RequestsAdaptiveGroups` `gatewayResolverQueriesAdaptiveGroups` `gatewayResolverByCategoryAdaptiveGroups`              |
-| Health Check Analytics      | `healthCheckEventsAdaptive` `healthCheckEventsAdaptiveGroups`                                                                  |
-| HTTP Requests               | `httpRequestsAdaptiveGroups` `httpRequests1mGroups` `httpRequests1hGroups`  `httpRequests1dGroups`                             |
-| Image Resizing Analytics    | `imageResizingRequests1mGroups`                                                                                                |
-| Load Balancing Analytics    | `loadBalancingRequestsAdaptive` `loadBalancingRequestsAdaptiveGroups`                                                          |
-| Logpush Health Analytic    | `logpushHealthAdaptiveGroups`                                                                                           |
-| Magic Firewall Analytics    | `magicFirewallSamplesAdaptiveGroups`                                                                                           |
-| Network Analytics v2<br/> for Magic Transit customers | `magicTransitNetworkAnalyticsAdaptiveGroups` `dosdNetworkAnalyticsAdaptiveGroups` `dosdAttackAnalyticsGroups` `flowtrackdNetworkAnalyticsAdaptiveGroups` `magicFirewallNetworkAnalyticsAdaptiveGroups` |
-| Network Analytics v2<br/> for Spectrum customers<br/> (Enterprise plans only) | `spectrumNetworkAnalyticsAdaptiveGroups` `dosdNetworkAnalyticsAdaptiveGroups` `dosdAttackAnalyticsGroups` |
-| Stream Analytics  | `videoPlaybackEventsAdaptiveGroups`  
-| Turnstile Widget Analytics  |`turnstileAdaptiveGroups`                                                                                                      |
-| Workers Metrics             | `workersInvocationsAdaptive`                                                                                                   |
-
-{{</table-wrap>}}
-
-## Beta datasets
-
-Beta datasets are available to Enterprise customers for testing and exploration. Do not rely on beta data nodes, since they are subject to change or removal without notice.
-
-{{<table-wrap>}}
-
-| Dataset (product) | Node                                                                                                        |
-| :----------------- | :---------------------------------------------------------------------------------------------------------- |
-| Web Analytics      | `rumPageloadEventsAdaptiveGroups` `rumPerformanceEventsAdaptiveGroups` `rumWebVitalsEventsAdaptiveGroups`   |
-| Waiting Room      | `waitingRoomAnalyticsAdaptive` `waitingRoomAnalyticsAdaptiveGroups`   |
-
-{{</table-wrap>}}
-
-## Deprecated data nodes
-
-The following data nodes are deprecated. To avoid disruption, migrate to replacement nodes before the sunset date.
-
-{{<table-wrap style="font-size: 87%">}}
-
-| Node                         | Replacement node                     | Sunset date        |
-| ---------------------------- | ------------------------------------ | ------------------ |
-| `httpRequestsCacheGroups`    | `httpRequestsAdaptiveGroups`         | March 1, 2021      |
-| `firewallRulePreviewGroups`  | `httpRequestsAdaptiveGroups`         | March 1, 2021      |
-| `healthCheckEvents`          | `healthCheckEventsAdaptive`          | March 1, 2021      |
-| `healthCheckEventsGroups`    | `healthCheckEventsAdaptiveGroups`    | March 1, 2021      |
-| `httpRequests1mByColoGroups` | `httpRequestsAdaptiveGroups`         | September 1, 2021  |
-| `httpRequests1dByColoGroups` | `httpRequestsAdaptiveGroups`         | September 1, 2021  |
-| `loadBalancingRequests`      | `loadBalancingRequestsAdaptive`      | September 30, 2021 |
-| `loadBalancingRequestsGroups`| `loadBalancingRequestsAdaptiveGroups`| September 30, 2021 |
-| `ipFlows1mGroups`<br/> `ipFlows1hGroups`<br/> `ipFlows1dGroups`<br/> `ipFlows1mAttacksGroups` | `spectrumNetworkAnalyticsAdaptiveGroups`<br/> `magicTransitNetworkAnalyticsAdaptiveGroups`<br/> `dosdNetworkAnalyticsAdaptiveGroups`<br/> `dosdAttackAnalyticsGroups`<br/> `flowtrackdNetworkAnalyticsAdaptiveGroups`<br/> `magicFirewallNetworkAnalyticsAdaptiveGroups` | March 31, 2022 |
-| `synAvgPps1mGroups`          | N/A                                  | December 1, 2022   |
-
-{{</table-wrap>}}
+To find out more information about datasets, availability, beta, and deprecation
+statuses, please refer to GraphQL [discovery][2] features.
 
 ## Working with datasets
 
@@ -130,9 +85,9 @@ Unique values are not available as a dimension but can be queried as demonstrate
 
 Every exposed table has a GraphQL type definition. Type definitions observe the following rules:
 
-*   Regular fields represent themselves.
-*   Every field, including nested fields, has a type and represents a list of that type.
-*   The `enum` type represents an enumerated field.
+* Regular fields represent themselves.
+* Every field, including nested fields, has a type and represents a list of that type.
+* The `enum` type represents an enumerated field.
 
 Here is an example type definition for `ContentTypeMapElem`:
 
@@ -164,5 +119,7 @@ type Request {
     trustedClientCategory: TrustedClientCategory!
     # ... other fields
 }
-///
 ```
+
+[1]: </analytics/graphql-api/sampling/>
+[2]: </analytics/graphql-api/features/discovery/>

--- a/content/analytics/graphql-api/features/discovery/_index.md
+++ b/content/analytics/graphql-api/features/discovery/_index.md
@@ -5,6 +5,8 @@ weight: 3
 layout: single
 ---
 
+# Discovery
+
 GraphQL API supports [introspection][1] to explore nodes and provides a way to
 retrieve the user's [limits][2] for every node.
 

--- a/content/analytics/graphql-api/features/discovery/index.md
+++ b/content/analytics/graphql-api/features/discovery/index.md
@@ -1,0 +1,12 @@
+---
+pcx_content_type: reference
+title: Discovery
+weight: 3
+layout: single
+---
+
+GraphQL API supports [introspection][1] to explore nodes and provides a way to
+retrieve the user's [limits][2] for every node.
+
+[1]: </analytics/graphql-api/features/discovery/introspection/>
+[2]: </analytics/graphql-api/features/discovery/settings/>

--- a/content/analytics/graphql-api/features/discovery/introspection.md
+++ b/content/analytics/graphql-api/features/discovery/introspection.md
@@ -6,39 +6,40 @@ weight: 41
 
 # Introspection
 
-Cloudflare GraphQL API has a dynamic schema. We expose more than 70 datasets
-across zone and account scopes and constantly expand the list. We also deprecate
-datasets to replace existing datasets with more capable alternatives.
+Cloudflare GraphQL API has a dynamic schema and exposes more than 70 datasets
+across zone and account scopes. We constantly expand the list and replace
+existing ones with more capable alternatives.
 
 To tackle the schema question, GraphQL provides an [introspection][1] mechanism.
-It is part of GraphQL specification and allows you to explore the graph of the
-datasets and fields.
+It is part of the GraphQL specification and allows you to explore the graph of
+the datasets and fields.
 
 The introspection results provide an overview of ALL available nodes and fields,
 their descriptions and deprecation status.
 
 Although GraphQL has `query`, `subscription`, and `mutation` operations,
-Cloudflare GraphQL API supports only `query` operation.
+Cloudflare GraphQL API only supports `query` operation.
 
 ## Description and Beta mode
 
 With details on data exposed by a given node or a field, descriptions also
-indicate whether it's in the Beta mode or not. Beta nodes are for testing and
+indicate whether it is in Beta mode. Beta nodes (or fields) are for testing and
 exploration and are usually available for customers on more extensive plans.
 Please do not rely on beta data nodes since they are subject to change or
 removal without notice.
 
 ## Deprecation
 
-Introspection provides information about deprecation status. We use it as a
-notification about replacement plans. If the sunset date is provided, please
-migrate to a replacement node(s) before that date to avoid disruption.
+Introspection provides information about deprecation status. Cloudflare uses it
+as a notification about replacement plans. If the sunset date is provided,
+please migrate to a replacement node(s) before that date to avoid any
+disruption.
 
 ## Availability
 
 Some of the nodes might only be available to query for some users. Please refer
-to the [settings][2] node to get a comprehensive picture of availability and
-personal limits on a given node.
+to the [settings][2] node for more details about availability and personal
+limits on a given node.
 
 ## Explore documentation
 
@@ -46,8 +47,8 @@ The most convenient way to introspect the schema is to use a documentation
 [explorer][3] that usually is a part of a GraphQL client (like GraphiQL, Altair,
 etc).
 
-Alternatively, you can do it manually by using `__schema` node with needed
-directives.
+Alternatively, you can also do it manually by using `__schema` node with the
+needed directives.
 
 ```graphql
 ---
@@ -143,7 +144,7 @@ fragment FullType on __Type {
 }
 ```
 
-To get more details on how to send a GraphQL request with curl, please check
+For more details on how to send a GraphQL request with curl, please refer to
 [this guide][4].
 
 [1]: <https://graphql.org/learn/introspection/>

--- a/content/analytics/graphql-api/features/discovery/introspection.md
+++ b/content/analytics/graphql-api/features/discovery/introspection.md
@@ -1,0 +1,152 @@
+---
+pcx_content_type: reference
+title: Introspection
+weight: 41
+---
+
+# Introspection
+
+Cloudflare GraphQL API has a dynamic schema. We expose more than 70 datasets
+across zone and account scopes and constantly expand the list. We also deprecate
+datasets to replace existing datasets with more capable alternatives.
+
+To tackle the schema question, GraphQL provides an [introspection][1] mechanism.
+It is part of GraphQL specification and allows you to explore the graph of the
+datasets and fields.
+
+The introspection results provide an overview of ALL available nodes and fields,
+their descriptions and deprecation status.
+
+Although GraphQL has `query`, `subscription`, and `mutation` operations,
+Cloudflare GraphQL API supports only `query` operation.
+
+## Description and Beta mode
+
+With details on data exposed by a given node or a field, descriptions also
+indicate whether it's in the Beta mode or not. Beta nodes are for testing and
+exploration and are usually available for customers on more extensive plans.
+Please do not rely on beta data nodes since they are subject to change or
+removal without notice.
+
+## Deprecation
+
+Introspection provides information about deprecation status. We use it as a
+notification about replacement plans. If the sunset date is provided, please
+migrate to a replacement node(s) before that date to avoid disruption.
+
+## Availability
+
+Some of the nodes might only be available to query for some users. Please refer
+to the [settings][2] node to get a comprehensive picture of availability and
+personal limits on a given node.
+
+## Explore documentation
+
+The most convenient way to introspect the schema is to use a documentation
+[explorer][3] that usually is a part of a GraphQL client (like GraphiQL, Altair,
+etc).
+
+Alternatively, you can do it manually by using `__schema` node with needed
+directives.
+
+```graphql
+---
+header: A typical introspection query
+---
+{
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+        ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+```
+
+To get more details on how to send a GraphQL request with curl, please check
+[this guide][4].
+
+[1]: <https://graphql.org/learn/introspection/>
+[2]: </analytics/graphql-api/features/discovery/settings/>
+[3]: </analytics/graphql-api/getting-started/explore-graphql-schema/>
+[4]: </analytics/graphql-api/getting-started/execute-graphql-query/>

--- a/content/analytics/graphql-api/features/discovery/settings.md
+++ b/content/analytics/graphql-api/features/discovery/settings.md
@@ -43,15 +43,15 @@ header: Using a settings node on accounts nodes
 
 Every subnode of `settings` node could consist of these fields:
 
-* `enabled` - shows whether the node is available for a requester or not
+* `enabled` - shows whether the node is available for a requester or not;
 * `availableFields` - shows the list of fields available for a requester. If
-  it's a nested field, the path will be returned, like `sum_requests`
+  it's a nested field, the path will be returned, like `sum_requests`;
 * `maxPageSize` - retrieves the maximum number of records that can be returned
 * `maxNumberOfFields` - answers on how many fields could be used in a single
-  query for that node
-* `notOlderThan` - returns a number of seconds on how far back in time query can
-  read
-* `maxDuration` - shows how wide the requested time range could be
+  query for that node;
+* `notOlderThan` - returns a number of seconds on how far back in time a query
+  can read;
+* `maxDuration` - shows how wide the requested time range could be.
 
 ## A sample query
 
@@ -102,7 +102,7 @@ header: firewallEventsAdaptive limits for a given user
 }
 ```
 
-To get more details on how to execute queries, please head to our how to get
+To get more details on how to execute queries, please refer to our how to get
 started [guides][3].
 
 [1]: </analytics/graphql-api/limits/>

--- a/content/analytics/graphql-api/features/discovery/settings.md
+++ b/content/analytics/graphql-api/features/discovery/settings.md
@@ -1,0 +1,110 @@
+---
+pcx_content_type: reference
+title: Settings node
+weight: 43
+---
+
+# Settings node
+
+Cloudflare GraphQL API exposes more than 70 datasets to its customers. These
+datasets represent different Cloudflare products with very different data
+shapes; thus, each has its configuration of [limits][1].
+
+Although we allow access to ALL plans for the essential datasets (like
+`httpRequestsAdaptiveGroups`, `firewallEventsAdaptive`, etc), users on larger
+plans benefit from an extended set of datasets and wider query limits.
+
+In addition to [introspection][2], users can use the Settings node that is
+available for both zones and accounts scopes.
+
+## Format
+
+`Settings` node has all datasets from `zones` and `accounts` as fields.
+
+```graphql
+---
+header: Using a settings node on accounts nodes
+---
+{
+  viewer {
+    accounts(filter: { accountTag : $accountTag }) {
+      settings {
+        # any dataset(s) from accounts
+      }
+    }
+    zones(filter: { zoneTag : $zoneTag }) {
+      settings {
+        # any dataset(s) from zones
+      }
+    }
+  }
+}
+```
+
+Every subnode of `settings` node could consist of these fields:
+
+* `enabled` - shows whether the node is available for a requester or not
+* `availableFields` - shows the list of fields available for a requester. If
+  it's a nested field, the path will be returned, like `sum_requests`
+* `maxPageSize` - retrieves the maximum number of records that can be returned
+* `maxNumberOfFields` - answers on how many fields could be used in a single
+  query for that node
+* `notOlderThan` - returns a number of seconds on how far back in time query can
+  read
+* `maxDuration` - shows how wide the requested time range could be
+
+## A sample query
+
+```graphql
+---
+header: Get boundaries of firewallEventsAdaptive node
+---
+{
+  viewer {
+    zones(filter: { zoneTag: $zoneTag }) {
+      settings {
+        firewallEventsAdaptive {
+          enabled
+          maxDuration
+          maxNumberOfFields
+          maxPageSize
+          notOlderThan
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+---
+header: firewallEventsAdaptive limits for a given user
+---
+{
+  "data": {
+    "viewer": {
+      "zones": [
+        {
+          "settings": {
+            "firewallEventsAdaptive": {
+              "enabled": true,
+              "maxDuration": 259200,
+              "maxNumberOfFields": 30,
+              "maxPageSize": 10000,
+              "notOlderThan": 2678400
+            }
+          }
+        }
+      ]
+    }
+  },
+  "errors": null
+}
+```
+
+To get more details on how to execute queries, please head to our how to get
+started [guides][3].
+
+[1]: </analytics/graphql-api/limits/>
+[2]: </analytics/graphql-api/features/discovery/introspection/>
+[3]: </analytics/graphql-api/getting-started/>

--- a/content/analytics/graphql-api/getting-started/_index.md
+++ b/content/analytics/graphql-api/getting-started/_index.md
@@ -6,12 +6,26 @@ weight: 11
 
 # Get started
 
-Use these articles to get started with the Cloudflare GraphQL Analytics API:
+Use these articles to get started with the Cloudflare GraphQL API:
 
-*   [Authentication](/analytics/graphql-api/getting-started/authentication/) walks you through the options and the steps required to successfully set up your access to Cloudflare API.
-*   [Querying basics](/analytics/graphql-api/getting-started/querying-basics/) brings you simple query examples for you to start exploring the GraphQL Analytics API.
-*   [Explore the GraphQL schema in the GraphQL client](/analytics/graphql-api/getting-started/explore-graphql-schema/) introduces the introspective documentation in the GraphQL API.
-*   [Create a query in a GraphQL client](/analytics/graphql-api/getting-started/compose-graphql-query/) describes how to build and run a query against the Cloudflare GraphQL API in the GraphiQL client.
-*   [Use curl to query the GraphQL API](/analytics/graphql-api/getting-started/execute-graphql-query/) walks you through running a query against the Cloudflare GraphQL API from the command line.
+* [Authentication][1] - walks you through the options and the steps required to
+  set up your access to Cloudflare API successfully,
+* [Querying basics][2] - brings simple query examples for you to start exploring
+  the GraphQL API,
+* [Introspect the GraphQL schema][3] - explains how-to surf the schema with
+  GraphQL client,
+* [Create a query in a GraphQL client][4] - describes how to build and run a
+  query against the Cloudflare GraphQL API in the GraphQL clients,
+* [Use curl to query the GraphQL API][5] - walks you through running a query
+  against the Cloudflare GraphQL API from the command line.
 
-For examples of how to build your own GraphQL Analytics dashboard and query specific information, such as Firewall and Workers events, refer to [Tutorials](/analytics/graphql-api/tutorials/).
+For examples of how to build your own GraphQL Analytics dashboard and query
+specific information, such as Firewall and Workers events, please refer to
+[Tutorials][6].
+
+[1]: </analytics/graphql-api/getting-started/authentication/>
+[2]: </analytics/graphql-api/getting-started/querying-basics/>
+[3]: </analytics/graphql-api/getting-started/explore-graphql-schema/>
+[4]: </analytics/graphql-api/getting-started/compose-graphql-query/>
+[5]: </analytics/graphql-api/getting-started/execute-graphql-query/>
+[6]: </analytics/graphql-api/tutorials/>

--- a/content/analytics/graphql-api/getting-started/compose-graphql-query.md
+++ b/content/analytics/graphql-api/getting-started/compose-graphql-query.md
@@ -1,101 +1,138 @@
 ---
 pcx_content_type: how-to
-title: Create a query in GraphiQL
+title: Compose a query in GraphiQL
 weight: 51
 ---
 
-# Create a query in GraphiQL
+# Compose a query in GraphiQL
 
-You can use a GraphQL client to build and execute queries to the GraphQL API endpoint. The example below uses the [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme) client.
+Many clients could help play around [the semantics][1] of GraphQL and explore
+the possibilities of Cloudflare GraphQL API.
+
+This page details how to use a [GraphiQL client][2] to compose and execute a
+GraphQL query.
 
 ## Prerequisites
 
-This article assumes that you are already familiar with [Querying basics](/analytics/graphql-api/getting-started/querying-basics/).
-
-Before you begin, [configure the API endpoint and HTTP headers](/analytics/graphql-api/getting-started/authentication/graphql-client-headers/) in the GraphiQL client.
-
-{{<Aside type="note" header="Note">}}
-
-To explore the documentation for the datasets and fields in the Cloudflare GraphQL schema, click **Docs** to open the **Documentation Explorer** pane.
-
-For an introduction, see [Explore the GraphQL schema](/analytics/graphql-api/getting-started/explore-graphql-schema/).
-
-{{</Aside>}}
+You can find all details on how to [configure][3] a client here.
 
 ## Set up a query and choose a dataset
 
-Click on the editing pane of GraphiQL and add this base query, replacing `zone-id` with your Cloudflare zone ID:
+Click on the editing pane of GraphiQL and add this base query, replacing
+`zone-id` with your Cloudflare zone ID:
 
-![Adding a base query in the GraphiQL pane](/analytics/static/images/graphiql-base-query.png)
+![Adding a base query in the GraphiQL pane][4]
 
 {{<Aside type="note" header="Note">}}
 
-To find the ID for a zone, log in to your Cloudflare account and click the site for which you want to obtain the zone ID. In the Cloudflare dashboard **Overview** page, scroll to the **API** section in the right sidebar, which displays your zone ID and account ID.
+To find the zone's tag, log in to your Cloudflare account and click the site for
+which you want to obtain the tag. In the Cloudflare dashboard **Overview** page,
+scroll to the **API** section in the right sidebar, which displays your zone and
+account tags.
 
 {{</Aside>}}
 
-To assist query building, the GraphiQL client has word completion. Insert your cursor in the query, in this case on the line below `zones`, and start entering a value to engage the feature. For example, when you type `firewall`, a popup menu displays the datasets that return firewall information:
+To assist query building, the GraphiQL client has word completion. Insert your
+cursor in the query, in this case on the line below `zones`, and start entering
+a value to engage the feature. For example, when you type `firewall`, a popup
+menu displays the datasets that return firewall information:
 
-![GraphiQL word completion assistant to query building](/analytics/static/images/graphiql-word-completion.png)
+![GraphiQL word completion assistant to query building][5]
 
-The text at the bottom of the list displays a short description of the data that the node returns.
+The text at the bottom of the list displays a short description of the data that
+the node returns.
 
-Select the dataset you want to query and insert it. Either click the item in the list, or scroll using arrow keys and press <kbd>Return</kbd>. This example uses the `firewallEventsAdaptive` dataset.
+Select the dataset you want to query and insert it. Either click the item in the
+list, or scroll using arrow keys and press <kbd>Return</kbd>.
 
 ## Supply required parameters
 
-Hover your mouse over a field to display a tooltip that describes the dataset. In this example, hovering over the `firewallEventsAdaptive` node displays this description:
+Hover your mouse over a field to display a tooltip that describes the dataset.
+In this example, hovering over the `firewallEventsAdaptive` node displays this
+description:
 
-![Hovering the mouse over a field to display its description](/analytics/static/images/graphiql-set-up-base-query.png)
+![Hovering the mouse over a field to display its description][6]
 
-To display information about the dataset, including required parameters, click the dataset name (blue text). The **Documentation Explorer** opens and displays details about the dataset:
+To display information about the dataset, including required parameters, click
+the dataset name (blue text). The **Documentation Explorer** opens and displays
+details about the dataset:
 
-![Documentation Explorer window displaying dataset details](/analytics/static/images/graphiql-parameters.png)
+![Documentation Explorer window displaying dataset details][7]
 
-Note that the `filter` and `limit` arguments are required, as indicated by the exclamation mark (`!`) after their type definitions (gold text). In this example, the `orderBy` argument is not required, though when used it requires a value of type `ZoneFirewallEventsAdaptiveOrderBy`.
+Note that the `filter` and `limit` arguments are required, as indicated by the
+exclamation mark (`!`) after their type definitions (gold text). In this
+example, the `orderBy` argument is not required, though when used it requires a
+value of type `ZoneFirewallEventsAdaptiveOrderBy`.
 
-To browse a list of supported filter fields, click the filter type definition (gold text) in the Documentation Explorer. In this example, the type is `ZoneFirewallEventsAdaptiveFilter_InputObject`:
+To browse a list of supported filter fields, click the filter type definition
+(gold text) in the Documentation Explorer. In this example, the type is
+`ZoneFirewallEventsAdaptiveFilter_InputObject`:
 
-![Browsing GraphiQL filter fields](/analytics/static/images/graphiql-filter-fields.png)
+![Browsing GraphiQL filter fields][8]
 
-This example query shows the required `filter` and `limit` arguments for `firewallEventsAdaptive`:
+This example query shows the required `filter` and `limit` arguments for
+`firewallEventsAdaptive` (as well as for the rest of GraphQL nodes):
 
-![Example of GraphiQL query arguments](/analytics/static/images/graphiql-filter-values.png)
+![Example of GraphiQL query arguments][9]
 
-## Define the fields to return with your query
+## Define the fields used by your query
 
-To browse the fields you can return with your query, hover your cursor over the dataset name in your query, and in the tooltip that displays, click the data type definition (gold text):
+To browse the fields you can use with your query, hover your cursor over the
+dataset name in your query, and in the tooltip that displays, click the data
+type definition (gold text):
 
-![Hovering the mouse over a dataset to display available fields](/analytics/static/images/graphiql-set-up-base-query.png)
+![Hovering the mouse over a dataset to display available fields][10]
 
 **The Documentation Explorer** opens and displays a list of fields:
 
-![Documentation Explorer window displaying list of fields](/analytics/static/images/graphiql-return-fields.png)
+![Documentation Explorer window displaying list of fields][11]
 
-To add the data fields that you want to display, type an opening brace (`{`) after the closing parenthesis for the parameters, then start typing the name of a field that you want to fetch. Use word completion to choose a field.
+To add the data fields that you want to read, type an opening brace (`{`) after
+the closing parenthesis for the parameters, then start typing the name of a
+field that you want to fetch. Use word completion to choose a field.
 
-This example query returns the `action`, `datetime`, `clientRequestHTTPHost`, and `userAgent` fields:
+This example query returns the `action`, `datetime`, `clientRequestHTTPHost`,
+and `userAgent` fields:
 
-![Example query with return fields](/analytics/static/images/graphiql-query-return-field-values.png)
+![Example query with return fields][12]
 
-Once you have entered all the fields you want your query to return, click the **Play** button to submit the query. The response pane contains the data fetched from the Cloudflare GraphQL API endpoint.
+Once you have entered all the fields you want to query, click the **Play**
+button to submit the query. The response pane will contain the data fetched from
+the configured GraphQL API endpoint:
 
-![GraphiQL response pane](/analytics/static/images/create-query-fw-data-set-play.png)
+![GraphiQL response pane][13]
 
 ## Variable substitution
 
-The GraphiQL client allows you to create variables for use in your queries.
+The GraphiQL client allows you to use placeholders for value and supply them via
+the `variables` part of the payload.
 
-To add a query variable, click the **Query Variables** pane and enter a JSON object that defines your variable.
+Placeholder names should start with `$` character, and you don't need to wrap
+placeholders in quotes when you use them in the query.
 
-This example JSON object defines a query variable for a zone ID:
+Values for placeholders should be provided in JSON format, in which placeholders
+are addressed without `$` character. As an example, for a placeholder `$zoneTag`
+GraphQL API will read a value from the `zoneTag` field of supplied variables
+object.
 
-```json
-{ "zoneTag": "xxxxxxxxx" }
-```
-
-To use a variable in your query, prepend the `$` character to your variable name and use it to replace the desired value. When using a variable as a value in a query, do not wrap the variable in quotes as you would for a literal value.
+To supply a value for a placeholder, click the **Query Variables** pane and edit
+a JSON object that defines your variables.
 
 This example query uses the `zoneTag` query variable to represent the zone ID:
 
-![Example of GraphiQL query variables](/analytics/static/images/graphiql-query-variables.png)
+![Example of GraphiQL query variables][14]
+
+[1]: </analytics/graphql-api/getting-started/querying-basics/>
+[2]: <https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme>
+[3]: </analytics/graphql-api/getting-started/authentication/graphql-client-headers/>
+[4]: </analytics/static/images/graphiql-base-query.png>
+[5]: </analytics/static/images/graphiql-word-completion.png>
+[6]: </analytics/static/images/graphiql-set-up-base-query.png>
+[7]: </analytics/static/images/graphiql-parameters.png>
+[8]: </analytics/static/images/graphiql-filter-fields.png>
+[9]: </analytics/static/images/graphiql-filter-values.png>
+[10]: </analytics/static/images/graphiql-set-up-base-query.png>
+[11]: </analytics/static/images/graphiql-return-fields.png>
+[12]: </analytics/static/images/graphiql-query-return-field-values.png>
+[13]: </analytics/static/images/create-query-fw-data-set-play.png>
+[14]: </analytics/static/images/graphiql-query-variables.png>

--- a/content/analytics/graphql-api/getting-started/compose-graphql-query.md
+++ b/content/analytics/graphql-api/getting-started/compose-graphql-query.md
@@ -6,7 +6,7 @@ weight: 51
 
 # Compose a query in GraphiQL
 
-Many clients could help play around [the semantics][1] of GraphQL and explore
+Many clients might need help using [the semantics][1] of GraphQL and exploring
 the possibilities of Cloudflare GraphQL API.
 
 This page details how to use a [GraphiQL client][2] to compose and execute a
@@ -107,7 +107,7 @@ the configured GraphQL API endpoint:
 The GraphiQL client allows you to use placeholders for value and supply them via
 the `variables` part of the payload.
 
-Placeholder names should start with `$` character, and you don't need to wrap
+Placeholder names should start with `$` character, and you do not need to wrap
 placeholders in quotes when you use them in the query.
 
 Values for placeholders should be provided in JSON format, in which placeholders

--- a/content/analytics/graphql-api/getting-started/execute-graphql-query.md
+++ b/content/analytics/graphql-api/getting-started/execute-graphql-query.md
@@ -1,72 +1,81 @@
 ---
 pcx_content_type: how-to
-title: Use curl to query the Analytics API
+title: Execute a GraphQL query with curl
 weight: 61
 ---
 
-# Use curl to query the Analytics API
+# Execute a GraphQL query with curl
 
-You can submit a [query built with the GraphiQL client](/analytics/graphql-api/getting-started/compose-graphql-query/) as the payload in the `data` field of a POST request to the Analytics API.
+Using a plain curl to send a query provides the ability to slice-n-dice with the
+results and apply post-processing if needed. For example, [converting][1]
+results received from GraphQL API into a CSV format.
 
-The advantage of executing a request with [curl](https://curl.se/) is that you can redirect the response to a file and execute other post processing methods.
+For more functionality, like auto-completion, schema exploring, etc., you can
+look at GraphQL [clients][2].
 
-The GraphQL endpoint requires valid JSON, so you must pass the query as the `value` part of a JSON `key:value` pair with a key named `query`.
+GraphQL API expects JSON with two essentials fields: "query" and "variables".
 
-Pass the list of variables in another JSON `key:value` pair with a key named `variables`.
+A query should be stripped from newline symbols and sent as a single-line string
+when variables is an object full of values for all placeholders used in the
+query:
 
-The script below returns the firewall events in one zone over the last 24 hours:
+```json
+---
+header: A payload structure for GraphQL API
+---
+{
+  "query": "{viewer { ... }}",
+  "variables": {}
+}
+```
+
+It is still possible to use a human-friendly query though. In the example below
+you can see how `echo` piped together with `tr` to provide a proper payload with
+`curl`:
 
 ```bash
 ---
 header: Example bash script that uses curl to query Analytics API
 ---
-#!/bin/bash
-#
-# This script fetches the last 24 hours of firewall events for the ZoneID passed
-# in as the first parameter using the global key passed in as the second parameter.
-######################################################################################
-
-ZoneID="$1"
-global_key="$2"
-Email="user@domain.com"
-#
-# Calculate 24 hours back and produce the start and end times in the appropriate format.
-back_seconds=60*60*24  # 24 hours
-end_epoch=$(date +'%s')
-let start_epoch=$end_epoch-$back_seconds
-start_date=$(date --date="@$start_epoch" +'%Y-%m-%dT%H:%M:%SZ')
-end_date=$(date --date="@$end_epoch" +'%Y-%m-%dT%H:%M:%SZ')
-
-PAYLOAD='{ "query":
-  "query {
+```bash
+echo '{ "query":
+  "{
     viewer {
       zones(filter: { zoneTag: $zoneTag }) {
-      firewallEventsAdaptive(
-        filter: $filter
-        limit: 10000
-        orderBy: [datetime_DESC, rayName_DESC]
-      ) {
-          action,
-          datetime,
-          rayName,
-          clientRequestHTTPHost,
+        firewallEventsAdaptive(
+          filter: $filter
+          limit: 10
+          orderBy: [datetime_DESC]
+        ) {
+          action
+          clientAsn
+          clientCountryName
+          clientIP
+          clientRequestPath
+          clientRequestQuery
+          datetime
+          source
           userAgent
         }
       }
     }
-  }",'
-PAYLOAD="$PAYLOAD
-
-  \"variables\": {
-    \"zoneTag\": \"$ZoneID\",
-    \"filter\": {
-      \"datetime_gt\": \"$start_date\",
-      \"datetime_leq\": \"$end_date\"
+  }",
+  "variables": {
+    "zoneTag": "<zone-tag>",
+    "filter": {
+      "datetime_geq": "2022-07-24T11:00:00Z",
+      "datetime_leq": "2022-07-24T12:00:00Z"
     }
   }
-}"
-
-# Run query to GraphQL API endpoint
-
-curl -s -X POST -H "Content-Type: application/json" -H "X-Auth-Email: $Email" -H  "X-Auth-Key: $global_key" --data "$(echo $PAYLOAD)" https://api.cloudflare.com/client/v4/graphql/
+}' | tr -d '\n' | curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Auth-Email: CLOUDFLARE_EMAIL" \
+  -H "X-Auth-key: CLOUDFLARE_API_KEY" \
+  -s \
+  -d @- \
+  https://api.cloudflare.com/client/v4/graphql/
 ```
+
+[1]: </analytics/graphql-api/tutorials/export-graphql-to-csv/>
+[2]: </analytics/graphql-api/getting-started/compose-graphql-query/>

--- a/content/analytics/graphql-api/getting-started/execute-graphql-query.md
+++ b/content/analytics/graphql-api/getting-started/execute-graphql-query.md
@@ -16,7 +16,7 @@ look at GraphQL [clients][2].
 GraphQL API expects JSON with two essentials fields: "query" and "variables".
 
 A query should be stripped from newline symbols and sent as a single-line string
-when variables is an object full of values for all placeholders used in the
+when the variables is an object full of values for all placeholders used in the
 query:
 
 ```json

--- a/content/analytics/graphql-api/getting-started/explore-graphql-schema.md
+++ b/content/analytics/graphql-api/getting-started/explore-graphql-schema.md
@@ -6,7 +6,7 @@ weight: 41
 
 # Explore the GraphQL schema
 
-Many GraphQL clients are support surfing GraphQL schema by taking care of
+Many GraphQL clients are support browsing GraphQL schema by taking care of
 [introspection][1]. In this page, we will cover GraphiQL and Altair clients.
 
 [GraphiQL][2] and [Altair][3] are open-source GraphQL clients that provide a
@@ -15,17 +15,17 @@ bonus, they also allow you to browse GraphQL schema.
 
 ## Prerequisites
 
-Before you begin, don't forget to [configure][4] the API endpoint and HTTP
+Before you begin, do not forget to [configure][4] the API endpoint and HTTP
 headers.
 
 The screenshots below are done from GraphiQL. However, Altair provides the same
-functionality and you won't find any difficulties following the same
+functionality and you will not find any difficulties following the same
 instructions to explore the schema.
 
 ## Open the Documentation Explorer
 
-To open the GraphiQL Documentation Explorer, click the **Docs** link in header
-of the response pane:
+To open the GraphiQL Documentation Explorer, click the **Docs** link in the
+header of the response pane:
 
 ![Clicking GraphiQL Docs link to open Documentation Explorer][5]
 
@@ -46,7 +46,8 @@ When you first open the **Documentation Explorer** pane, the `mutation` and
 
 ![Documentation Explorer displaying mutation and query nodes][7]
 
-In this example `query` is the name of a root, and `Query` is the type definition.
+In this example, `query` is the name of a root, and `Query` is the type
+definition.
 
 ## Find the fields available for a type definition
 

--- a/content/analytics/graphql-api/getting-started/explore-graphql-schema.md
+++ b/content/analytics/graphql-api/getting-started/explore-graphql-schema.md
@@ -1,95 +1,135 @@
 ---
 pcx_content_type: how-to
-title: Explore the Analytics schema with GraphiQL
+title: Explore the GraphQL schema
 weight: 41
 ---
 
-# Explore the Analytics schema with GraphiQL
+# Explore the GraphQL schema
 
-The GraphQL API offers [introspection](https://graphql.org/learn/introspection/), which allows you to explore the graph (by making API calls) to see the available datasets, fields, and operations you can perform.
+Many GraphQL clients are support surfing GraphQL schema by taking care of
+[introspection][1]. In this page, we will cover GraphiQL and Altair clients.
 
-[GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme) is a GraphQL client that uses introspection to provide the **Documentation Explorer**, a tool with which you can visually browse a GraphQL schema.
-
-This article provides an introduction to browsing the Analytics GraphQL schema with the Documentation Explorer.
+[GraphiQL][2] and [Altair][3] are open-source GraphQL clients that provide a
+descent tool to compose a query, execute it, and inspect the results. And as a
+bonus, they also allow you to browse GraphQL schema.
 
 ## Prerequisites
 
-Before you begin, [configure the API endpoint and HTTP headers](/analytics/graphql-api/getting-started/authentication/graphql-client-headers/) in the GraphiQL client.
+Before you begin, don't forget to [configure][4] the API endpoint and HTTP
+headers.
+
+The screenshots below are done from GraphiQL. However, Altair provides the same
+functionality and you won't find any difficulties following the same
+instructions to explore the schema.
 
 ## Open the Documentation Explorer
 
-To open the GraphiQL Documentation Explorer, click the **Docs** link in header of the response pane:
+To open the GraphiQL Documentation Explorer, click the **Docs** link in header
+of the response pane:
 
-![Clicking GraphiQL Docs link to open Documentation Explorer](/analytics/static/images/graphiql-docs-link.png)
+![Clicking GraphiQL Docs link to open Documentation Explorer][5]
 
 The **Documentation Explorer** opens and displays a list of available objects:
 
-![GraphiQl Doc Explorer pane](/analytics/static/images/graphiql-doc-explorer.png)
+![GraphiQl Doc Explorer pane][6]
 
 Objects in the **Documentation Explorer** use this syntax:
 
-    object-name: object-type-definition
+```code
+  object-name: object-type-definition
+```
 
 ## Find the type definition of an object
 
-When you first open the **Documentation Explorer** pane, the `mutation` and `query` root types display:
+When you first open the **Documentation Explorer** pane, the `mutation` and
+`query` root types display:
 
-![Documentation Explorer displaying mutation and query nodes](/analytics/static/images/graphiql-doc-explorer-query-mutations.png)
+![Documentation Explorer displaying mutation and query nodes][7]
 
 In this example `query` is the name of a root, and `Query` is the type definition.
 
 ## Find the fields available for a type definition
 
-Click on the **type definition** of a node to view the fields that it provides. The **Documentation Explorer** also displays descriptions of the nodes.
+Click on the **type definition** of a node to view the fields that it provides.
+The **Documentation Explorer** also displays descriptions of the nodes.
 
-For example, click the **Query** type definition. The **Documentation Explorer** displays the fields that `Query` provides. In this example, the fields are `cost` and `viewer`:
+For example, click the **Query** type definition. The **Documentation Explorer**
+displays the fields that `Query` provides. In this example, the fields are
+`cost` and `viewer`:
 
-![Documentation Explorer displaying cost and viewer fields](/analytics/static/images/graphiql-doc-explorer-view-cost.png)
+![Documentation Explorer displaying cost and viewer fields][8]
 
-To explore the schema, click the names of objects and definitions. You can also use the search input (magnifying glass icon) and breadcrumb links in the header.
+To explore the schema, click the names of objects and definitions. You can also
+use the search input (magnifying glass icon) and breadcrumb links in the header.
 
 ## Find the arguments associated with a field
 
-Click the type definition of the `viewer` field (gold text) to list its sub-fields. The `viewer` field provides sub-fields that allow you to query `accounts` or `zones` data:
+Click the type definition of the `viewer` field (gold text) to list its
+sub-fields. The `viewer` field provides sub-fields that allow you to query
+`accounts` or `zones` data:
 
-![Displaying viewer fields](/analytics/static/images/graphiql-doc-explorer-viewer-fields.png)
+![Displaying viewer fields][9]
 
-The `accounts` and `zones` fields take arguments to specify which dataset to query.
+The `accounts` and `zones` nodes take arguments to specify which dataset to
+query.
 
-For example, `zones` can take a filter of `ZoneFilter_InputObject` type as an argument. To view the fields available to filter, click **ZoneFilter_InputObject**.
+For example, `zones` can take a filter of `ZoneFilter_InputObject` type as an
+argument. To view the fields available to filter, click
+**ZoneFilter_InputObject**.
 
 ## Find the datasets available for a zone
 
-To view a list of the datasets available to query, click the **zone** type definition (gold text):
+To view a list of the datasets available to query, click the **zone** type
+definition (gold text):
 
-![Clicking zone type definition](/analytics/static/images/graphiql-doc-explorer-zones.png)
+![Clicking zone type definition][10]
 
-A list of datasets displays in the **Fields** section, each with list of valid arguments and a brief description. Arguments that end with an exclamation mark (`!`) are required.
+A list of datasets displays in the **Fields** section, each with list of valid
+arguments and a brief description. Arguments that end with an exclamation mark
+(`!`) are required.
 
-![Fields section displaying datasets available](/analytics/static/images/graphiql-doc-explorer-zone-fields.png)
+![Fields section displaying datasets available][11]
 
 Use the search input (magnifying glass icon) to find specific datasets:
 
-![Searching a dataset in the Documentation Explorer](/analytics/static/images/graphiql-doc-explorer-find-firewall.png)
+![Searching a dataset in the Documentation Explorer][12]
 
 To select a dataset, click its name.
 
-The definition for the dataset displays. This example shows the `firewallEventsAdaptive` dataset:
+The definition for the dataset displays. This example shows the
+`firewallEventsAdaptive` dataset:
 
-![Example of a dataset definition](/analytics/static/images/graphiql-doc-explorer-firewallevents-definition.png)
-
-Refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/) for details on the nomenclature and behavior of these nodes.
+![Example of a dataset definition][13]
 
 ## Find the fields available for a dataset
 
-To view the fields available for a particular dataset, click on its type definition (gold text).
+To view the fields available for a particular dataset, click on its type
+definition (gold text).
 
-For example, click the **ZoneFirewallEventsAdaptive** type definition to view the fields available for the `firewallEventsAdaptive` dataset:
+For example, click the **ZoneFirewallEventsAdaptive** type definition to view
+the fields available for the `firewallEventsAdaptive` dataset:
 
-![Clicking type definition to visualize fields available for a dataset](/analytics/static/images/graphiql-doc-explorer-firewall-type-definition.png)
+![Clicking type definition to visualize fields available for a dataset][14]
 
 The list of fields displays:
 
-![Displaying available fields for a dataset](/analytics/static/images/graphiql-doc-explorer-firewall-fields.png)
+![Displaying available fields for a dataset][15]
 
-For more on working with the Analytics API in GraphiQL, refer to [Create a query in GraphiQL](/analytics/graphql-api/getting-started/compose-graphql-query/).
+For more information on using GraphiQL, please visit this [guide][16].
+
+[1]: </analytics/graphql-api/features/discovery/introspection/>
+[2]: <https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme>
+[3]: <https://altairgraphql.dev/#download>
+[4]: </analytics/graphql-api/getting-started/authentication/graphql-client-headers/>
+[5]: </analytics/static/images/graphiql-docs-link.png>
+[6]: </analytics/static/images/graphiql-doc-explorer.png>
+[7]: </analytics/static/images/graphiql-doc-explorer-query-mutations.png>
+[8]: </analytics/static/images/graphiql-doc-explorer-view-cost.png>
+[9]: </analytics/static/images/graphiql-doc-explorer-viewer-fields.png>
+[10]: </analytics/static/images/graphiql-doc-explorer-zones.png>
+[11]: </analytics/static/images/graphiql-doc-explorer-zone-fields.png>
+[12]: </analytics/static/images/graphiql-doc-explorer-find-firewall.png>
+[13]: </analytics/static/images/graphiql-doc-explorer-firewallevents-definition.png>
+[14]: </analytics/static/images/graphiql-doc-explorer-firewall-type-definition.png>
+[15]: </analytics/static/images/graphiql-doc-explorer-firewall-fields.png>
+[16]: </analytics/graphql-api/getting-started/compose-graphql-query/>

--- a/content/analytics/graphql-api/getting-started/querying-basics.md
+++ b/content/analytics/graphql-api/getting-started/querying-basics.md
@@ -27,10 +27,10 @@ A typical query against the Cloudflare GraphQL schema is made up of four main
 components:
 
 * `viewer` - is the root node,
-* `zones` or `accounts` - indicates the scope of the query, i.e. the domain area
-  or account you want to query. The `viewer` can access one `zones` or
+* `zones` or `accounts` - indicate the scope of the query, that is the domain
+  area or account you want to query. The `viewer` can access one `zones` or
   `accounts`, or both,
-* **data node** or **dataset** - represents the data you want to query. `zones`
+* **data node** or **dataset** - represent the data you want to query. `zones`
   or `accounts` may contain one or more datasets. To find out more about
   discovering nodes, please refer to [introspection][1],
 * **fieldset** - a set of fields or nested fields of the **dataset**.
@@ -133,8 +133,8 @@ header: A sample of a response for a query above
 
 ## Query multiple datasets in a single GraphQL API request
 
-As discussed above, a query might contain one or multiple nodes (datasets). At
-the API level, the data extraction would be done simultaneously, but the
+As previously mentioned, a query might contain one or multiple nodes (datasets).
+At the API level, the data extraction would be done simultaneously, but the
 response would be delayed until all dataset queries got their results. If any
 fails during the execution, the entire query will be terminated, and the error
 will be returned.

--- a/content/analytics/graphql-api/getting-started/querying-basics.md
+++ b/content/analytics/graphql-api/getting-started/querying-basics.md
@@ -8,83 +8,103 @@ weight: 21
 
 ## Structure of a GraphQL query
 
-GraphQL structures data as a graph. GraphQL uses a schema to define the objects and their hierarchy in your data graph. You can explore the edges of the graph by using queries to get the data you need. These queries must respect the structure of the schema.
+GraphQL structures data as a graph. GraphQL uses a schema to define the objects
+and their hierarchy in your data graph. You can explore the edges of the graph
+by using queries to get the needed data. These queries must respect the
+structure of the schema.
 
-At the core of a GraphQL query is a **node**, followed by its **fields**. The node is an object of a certain **type**; the type specifies the fields that make up the object.
+A **node**, followed by its **fields**, is at the core of a GraphQL query. A
+node is an object of a specific **type**; the type specifies the fields that
+make up the object.
 
-A field can be another node, in which case the appropriate query would contain nested elements. Some nodes look like functions that can take on arguments to limit the scope of what they can act on. You can apply filters at each node.
+A field can be another node where the appropriate query would contain nested
+elements. Some nodes look like functions that can take on arguments to limit the
+scope of what they can act on. You can apply filters at each node.
 
-## Query against the Cloudflare GraphQL schema
+## Cloudflare GraphQL schema
 
-A typical query against the Cloudflare GraphQL schema is made up of five components:
+A typical query against the Cloudflare GraphQL schema is made up of four main
+components:
 
-*   `query` - The root node.
-*   `viewer` - A nested node indicating to GraphQL that you want to view the results. The `viewer` component represents the initial node of the user running the query.
-*   `zones` or `account` - A nested node indicating the domain area or account you want to query against. The `viewer` can access one or more zones or accounts. Each zone or account contains a collection of datasets.
-*   **Leaf node** - This specifies the dataset you want to query against in a zone or account. `firewallEventsAdaptive` is an example of a leaf node that represents a dataset for firewall events in a `zone` node.
-*   **Field** - The fields in a query specify the set of metrics that you want to fetch. The `firewallEventsAdaptive` leaf node includes the `clientIP` field. If your leaf node queries requests, possible fields would include response bytes or the time at which requests were received.
+* `viewer` - is the root node,
+* `zones` or `accounts` - indicates the scope of the query, i.e. the domain area
+  or account you want to query. The `viewer` can access one `zones` or
+  `accounts`, or both,
+* **data node** or **dataset** - represents the data you want to query. `zones`
+  or `accounts` may contain one or more datasets. To find out more about
+  discovering nodes, please refer to [introspection][1],
+* **fieldset** - a set of fields or nested fields of the **dataset**.
 
-The following example shows the format for a firewall query:
+The query to Cloudflare GraphQL API must be sent over HTTP POST request with
+payload in JSON format that consists of these fields:
 
-```code
-
-query{
-  viewer {
-      zones(filter: {...}) {
-         firewallEventsAdaptive( limit: 10, orderBy: [...], filter: {...} ) {
-           datetime, clientCountryName, action, ...
-         }
-      }
-  }
+```json
+{
+  "query": "",
+  "variables": {}
 }
 ```
 
-### Example Query
+From the above structure, the `query` field must contain a GraphQL query
+formatted as a **single line** string (meaning all newline symbols should be
+stripped / escaped), when `variables` is an object that contains all values of
+used placeholders in the query itself.
 
-The following query searches data from a zone for firewall events that occurred during a time interval. It sorts the results, limits the amount of results returned, and displays a set of fields for each firewall event.
+## A single dataset example
 
-```json
+In the following example, the GraphQL query fetches a `datetime`, `action`, and
+client request HTTP host as `host` field of 2 WAF events from zone-scoped
+`firewallEventsAdaptive` dataset.
+
+```code
 ---
-header: Query Firewall events for a specific time interval
+header: A GraphQL query
 ---
-query
 {
-  viewer
-  {
-    zones(filter: { zoneTag: "11111111"})
-    {
+  viewer {
+    zones(filter: { zoneTag: $tag }) {
       firewallEventsAdaptive(
-          filter: {
-            datetime_gt: "2020-08-03T02:07:05Z",
-            datetime_lt: "2020-08-03T17:07:05Z",
-            requestSource: "eyeball" 
-          },
-          limit: 2,
-          orderBy: [datetime_DESC, rayName_DESC])
-      {
+        filter: {
+          datetime_gt: $start
+          datetime_lt: $end
+        }
+        limit: 2
+        orderBy: [
+          datetime_DESC
+        ]
+      ) {
         action
         datetime
-        rayName
-        clientRequestHTTPHost
-        userAgent
+        host: clientRequestHTTPHost
       }
     }
   }
 }
 ```
 
-*   `zones(filter: { zoneTag: "11111111"})` confines the query to search to one zone.
-*   `firewallEventsAdaptive` is the large dataset that you want to query against. The set of data returned is defined by the following:
-    *   `filter:{}` limits the scope to firewall events between two times: `datetime_gt` (greater than) and `datetime_lt` (less than). Adding the `requestSource` filter for `eyeball` returns data only about the end users of your website and excludes actions taken by Cloudflare products (for example, cache purge, healthchecks, Workers subrequests).
-    *   `limit: 2` limits the results to 2 (the maximum value is 10,000).
-    *   `orderBy` sorts the results, first by `datetime_DESC`, the datetime field , in descending order, and then by the rayname, also in descending order.
-    *   The list of fields: `action` (Allow, Block, Challenge), `datetime`, `rayName` (the RayID), `clientRequestHTTPHost` (the host the client requested), and `userAgent`.
-
-You can send the query with an API call or by clicking **Play** in the GraphiQL client. The format of the response is in JSON:
+In the query above, we have variable placeholders: $tag, $start, and $end. We
+provide values for those placeholders alongside the query by placing them into
+`variables` field of the payload.
 
 ```json
 ---
-header: Query response from firewallEventsAdaptive
+header: A set of variables
+---
+{
+  "tag": "<zone-tag>",
+  "start": "2020-08-03T02:07:05Z",
+  "end": "2020-08-03T17:07:05Z"
+}
+```
+
+There are multiple ways to send your query to Cloudflare GraphQL API. You can
+use you favourite GraphQL client or CLI to send a request via curl. We have a
+[how-to guide][2] about using GraphiQL client, also check a guide on how to
+execute a query with a curl [here][3].
+
+```json
+---
+header: A sample of a response for a query above
 ---
 {
   "data": {
@@ -94,17 +114,13 @@ header: Query response from firewallEventsAdaptive
           "firewallEventsAdaptive": [
             {
               "action": "log",
-              "clientRequestHTTPHost": "cloudflare.guru",
-              "datetime": "2020-08-03T17:07:03Z",
-              "rayName": "5bd1a1fc584357ed",
-              "userAgent": "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 08c774cde2f3c385)"
+              "host": "cloudflare.guru",
+              "datetime": "2020-08-03T17:07:03Z"
             },
             {
               "action": "log",
-              "clientRequestHTTPHost": "cloudflare.guru",
-              "datetime": "2020-08-03T17:07:01Z",
-              "rayName": "5bd1a1ef3bb5d296",
-              "userAgent": "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 764497f790f6a070)"
+              "host": "cloudflare.guru",
+              "datetime": "2020-08-03T17:07:01Z"
             }
           ]
         }
@@ -115,35 +131,47 @@ header: Query response from firewallEventsAdaptive
 }
 ```
 
-## Query two datasets in a single API call
+## Query multiple datasets in a single GraphQL API request
 
-This example query employs a broad range of GraphQL functionality. The example queries two datasets for the specified zone simultaneously, applies filters and aggregations, and sets a limit on the number of records returned. Note that you must include the `limit` argument, which can be equal or up to 10,000.
+As discussed above, a query might contain one or multiple nodes (datasets). At
+the API level, the data extraction would be done simultaneously, but the
+response would be delayed until all dataset queries got their results. If any
+fails during the execution, the entire query will be terminated, and the error
+will be returned.
 
-```json
+```code
 ---
-header: Query two datasets simultaneously
+header: A sample query for two datasets in a one go
 ---
-query {
+{
   viewer {
-    zones(filter: {zoneTag: "<your zone ID>"}) {
-      httpRequests1mGroups(limit: 5, filter: { datetime_gt: "2019-02-01T04:00:00Z", datetime_lt: "2019-02-01T06:00:00Z"}) {
-        sum {
-          countryMap {
-            bytes
-            clientCountryName
-          }
+    zones(filter: { zoneTag: $tag }) {
+      last10Events: firewallEventsAdaptive(
+        filter: {
+          datetime_gt: $start
+          datetime_lt: $end
         }
-        dimensions {
-          date
-          datetime
-        }
+        limit: 10
+        orderBy: [
+          datetime_DESC
+        ]
+      ) {
+        action
+        datetime
+        host: clientRequestHTTPHost
       }
-      firewallEventsAdaptiveGroups(limit: 10, filter: { datetime_gt: "2019-02-01T04:00:00Z", datetime_lt: "2019-02-01T06:00:00Z"}) {
+      top3DeviceTypes: httpRequestsAdaptiveGroups(
+        filter: {
+          date: $ts
+        }
+        limit: 10
+        orderBy: [
+          count_DESC
+        ]
+      ) {
         count
         dimensions {
-          clientCountryName
-          clientAsn
-          datetimeHour
+          device: clientDeviceType
         }
       }
     }
@@ -151,17 +179,84 @@ query {
 }
 ```
 
-{{<Aside type="note" header="Note">}}
+```json
+---
+header: A set of variables for the query above
+---
+{
+  "tag": "<zone-tag>",
+  "start": "2022-10-02T00:26:49Z",
+  "end": "2022-10-04T14:26:49Z",
+  "ts": "2022-10-04"
+}
+```
 
-This is only an example. You must specify the <code>zoneTag</code> for your domain. Your Cloudflare dashboard lists your Zone ID (<code>zoneTag</code>) on the <em>Overview</em> page.
-
-{{</Aside>}}
-
-## Introspection
-
-The GraphQL API offers [introspection](https://graphql.org/learn/introspection/), which allows you to explore the graph (by making API calls) to see the available datasets, fields, and operations you can perform.
-
-For an introduction to browsing the Analytics GraphQL API, refer to [Explore the Analytics schema with GraphiQL](/analytics/graphql-api/getting-started/explore-graphql-schema/).
+```json
+---
+header: A sample response for the query with variables above
+---
+{
+  "data": {
+    "viewer": {
+      "zones": [
+        {
+          "last10Events": [
+            {
+              "action": "block",
+              "country": "TR",
+              "datetime": "2022-10-04T08:41:09Z"
+            },
+            {
+              "action": "block",
+              "country": "TR",
+              "datetime": "2022-10-04T08:41:09Z"
+            },
+            {
+              "action": "block",
+              "country": "RU",
+              "datetime": "2022-10-04T01:09:36Z"
+            },
+            {
+              "action": "block",
+              "country": "US",
+              "datetime": "2022-10-03T14:26:49Z"
+            },
+            {
+              "action": "block",
+              "country": "US",
+              "datetime": "2022-10-03T14:26:46Z"
+            },
+            {
+              "action": "block",
+              "country": "CN",
+              "datetime": "2022-10-02T23:51:26Z"
+            },
+            {
+              "action": "block",
+              "country": "TR",
+              "datetime": "2022-10-02T23:39:41Z"
+            },
+            {
+              "action": "block",
+              "country": "TR",
+              "datetime": "2022-10-02T23:39:41Z"
+            }
+          ],
+          "top3DeviceTypes": [
+            {
+              "count": 4580,
+              "dimensions": {
+                "device": "desktop"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "errors": null
+}
+```
 
 ## Helpful Resources
 
@@ -169,12 +264,22 @@ Here are some helpful articles about working with the Cloudflare Analytics API a
 
 ### Cloudflare specific
 
-*   [Understanding the Cloudflare dashboard](https://support.cloudflare.com/hc/en-us/articles/205075117-Understanding-the-Cloudflare-dashboard)
-*   [How to find your zoneTag using the API](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/)
+* [Understanding the Cloudflare dashboard][4]
+* [How to find your zoneTag using the API][5]
 
 ### General info on the GraphQL framework
 
-*   [How to use GraphQL (tutorials)](https://www.howtographql.com/)
-*   [Thinking in Graphs](https://graphql.org/learn/thinking-in-graphs/)
-*   [What data can you can query in the GraphQL type system (schemas)](https://graphql.org/learn/schema/)
-*   [How to pass variables in GraphiQL (Medium article with quick tips)](https://medium.com/graphql-mastery/graphql-quick-tip-how-to-pass-variables-into-a-mutation-in-graphiql-23ecff4add57)
+* [How to use GraphQL (tutorials)][6]
+* [Thinking in Graphs][7]
+* [What data can you can query in the GraphQL type system (schemas)][8]
+* [How to pass variables in GraphiQL (Medium article with quick tips)][9]
+
+[1]: </analytics/graphql-api/features/discovery/introspection/>
+[2]: </analytics/graphql-api/getting-started/compose-graphql-query/>
+[3]: </analytics/graphql-api/getting-started/execute-graphql-query/>
+[4]: <https://support.cloudflare.com/hc/en-us/articles/205075117-Understanding-the-Cloudflare-dashboard>
+[5]: </fundamentals/get-started/basic-tasks/find-account-and-zone-ids/>
+[6]: <https://www.howtographql.com/>
+[7]: <https://graphql.org/learn/thinking-in-graphs/>
+[8]: <https://graphql.org/learn/schema/>
+[9]: <https://medium.com/graphql-mastery/graphql-quick-tip-how-to-pass-variables-into-a-mutation-in-graphiql-23ecff4add57>

--- a/content/analytics/graphql-api/limits/index.md
+++ b/content/analytics/graphql-api/limits/index.md
@@ -38,10 +38,10 @@ the Cloudflare API.
 
 Each data node has its limits, such as:
 
-* how far back in time can data be requested
-* the maximum time period (in seconds) that can be requested in one query
-* the maximum number of fields that can be requested in one query
-* the maximum number of records that can be returned in one query
+* how far back in time can data be requested,
+* the maximum time period (in seconds) that can be requested in one query,
+* the maximum number of fields that can be requested in one query,
+* the maximum number of records that can be returned in one query.
 
 Node limits are tied to requested `zoneTag` or `accountTag`. Larger plans have
 access to a greater selection of datasets and can query over broader historical

--- a/content/analytics/graphql-api/limits/index.md
+++ b/content/analytics/graphql-api/limits/index.md
@@ -7,149 +7,47 @@ layout: single
 
 # Limits
 
-## Data accessibility
+Cloudflare GraphQL API exposes more than 70 datasets representing products with
+different configurations and data availability for different zones and accounts
+plans.
 
-The GraphQL Analytics API is available to all Cloudflare users; however, users on larger plans have access to a greater selection of datasets and can query over broader historical intervals.
+To support this variety of products, Cloudflare GraphQL API has three layers of
+limits:
 
-### Data node access (by customer plan)
+* global limits
+* user limits
+* node (dataset) limits
 
-Use the table below to identify which data nodes are included in your customer plan and the range of historical data you can query. For example, Free plans have access to the last 14 days of `firewallEventsAdaptive` data, while Enterprise plans have access to the last 30 days.
+## Global limits
 
-{{<Aside type="note" header="Note">}}
+These limits are applied to every query for every plan:
 
-Access to Network Analytics `*NetworkAnalyticsAdaptiveGroups` nodes is only available to Enterprise customers using Cloudflare [Magic Transit](https://www.cloudflare.com/magic-transit/) or [Cloudflare Spectrum](/spectrum/).
+* A zone-scoped query can include up to **10 zones**
+* An account-scoped query can include only **1 account**
 
-{{</Aside>}}
+## User limits
 
-{{<table-wrap>}}
+Cloudflare GraphQL API limits the number of GraphQL requests each user can send.
+By default, we allow **no more than 1 GraphQL query per second** with bursts of
+up to 300 queries over 5-minute window.
 
-| Data node                                     |     Free |      Pro | Business | Enterprise |
-| :-------------------------------------------- | -------: | -------: | -------: | ---------: |
-| `dosdNetworkAnalyticsAdaptiveGroups`          |      n/a |      n/a |      n/a |    90 days |
-| `dosdAttackAnalyticsGroups`                   |      n/a |      n/a |      n/a |    90 days |
-| `firewallEventsAdaptiveByTimeGroups`          |  14 days |  14 days |  30 days |    30 days |
-| `firewallEventsAdaptiveGroups`                |      n/a |   3 days |  30 days |    30 days |
-| `firewallEventsAdaptive`                      |  14 days |  14 days |  30 days |    30 days |
-| `firewallRulePreviewGroups`                   |      n/a |      n/a |      n/a |    30 days |
-| `flowtrackdNetworkAnalyticsAdaptiveGroups`    |      n/a |      n/a |      n/a |    90 days |
-| `healthCheckEventsGroups`                     |      n/a |   3 days |  30 days |    90 days |
-| `healthCheckEvents`                           |      n/a |   3 days |  30 days |    90 days |
-| `httpRequests1dByColoGroups`                  |      n/a |      n/a |      n/a |   365 days |
-| `httpRequests1dGroups`                        | 365 days | 365 days | 365 days |   365 days |
-| `httpRequests1hGroups`                        |   3 days |   7 days |  30 days |    90 days |
-| `httpRequests1mByColoGroups`                  |      n/a |      n/a |      n/a |     7 days |
-| `httpRequests1mGroups`                        |      n/a | 24 hours |   3 days |     7 days |
-| `ipFlows1mGroups`\*                            |      n/a |      n/a |      n/a |    30 days |
-| `ipFlows1hGroups`\*                            |      n/a |      n/a |      n/a |   6 months |
-| `ipFlows1dGroups`\*                            |      n/a |      n/a |      n/a |     1 year |
-| `ipFlows1mAttackGroups`\*                      |      n/a |      n/a |      n/a |     1 year |
-| `loadBalancingRequestsGroups`                 |      n/a |   3 days |  30 days |    30 days |
-| `loadBalancingRequests`                       |      n/a |   3 days |  30 days |    30 days |
-| `magicFirewallNetworkAnalyticsAdaptiveGroups` |      n/a |      n/a |      n/a |    90 days |
-| `magicFirewallSamplesAdaptiveGroups`          |      n/a |      n/a |      n/a |     7 days |
-| `magicTransitNetworkAnalyticsAdaptiveGroups`  |      n/a |      n/a |      n/a |    90 days |
-| `spectrumNetworkAnalyticsAdaptiveGroups`      |      n/a |      n/a |      n/a |    90 days |
-| `synAvgPps1mGroups`\*                         |      n/a |      n/a |      n/a |     7 days |
-| `rumPerformanceEventsAdaptiveGroups`          | 6 months | 6 months | 6 months |   6 months |
-| `rumPageloadEventsAdaptiveGroups`             | 6 months | 6 months | 6 months |   6 months |
-| `rumWebVitalsEventsAdaptiveGroups`            | 6 months | 6 months | 6 months |   6 months |
+That rate limit is applied in addition to the general rate limits enforced by
+the Cloudflare API.
 
-{{</table-wrap>}}
+## Node limits and availability
 
-\* These nodes are deprecated. Refer to [Deprecated data nodes](/analytics/graphql-api/features/data-sets/#deprecated-data-nodes) for more information.
+Each data node has its limits, such as:
 
-### Query settings for account limits
+* how far back in time can data be requested
+* the maximum time period (in seconds) that can be requested in one query
+* the maximum number of fields that can be requested in one query
+* the maximum number of records that can be returned in one query
 
-To obtain specific information regarding account limits for a particular data node, use the `settings` node.
+Node limits are tied to requested `zoneTag` or `accountTag`. Larger plans have
+access to a greater selection of datasets and can query over broader historical
+intervals.
 
-The example query below demonstrates how to retrieve account limits for the `firewallEventsAdaptive` data node. The example queries the following fields:
+To get exact boundaries and availability for your zone(s) or account, please
+refer to [settings][1].
 
-{{<table-wrap>}}
-
-| Field               | Description                                                                                            |
-| :------------------ | :----------------------------------------------------------------------------------------------------- |
-| `enabled`           | Returns `true` if the dataset (node) is available for the current plan.                               |
-| `maxDuration`       | Defines the maximum time period (in seconds) that can be requested in one query (varies by data node). |
-| `maxNumberOfFields` | Defines the maximum number of fields that can be requested in one query (varies by data node).         |
-| `maxPageSize`       | Defines the maximum number of records that can be returned in one query (varies by data node).         |
-| `notOlderThan`      | Limits how far back in the record a query can search (in seconds, varies by dataset and plan).        |
-
-{{</table-wrap>}}
-
-### Example query
-
-```graphql
-{
-  viewer {
-    zones(filter: { zoneTag: $zoneTag }) {
-      settings {
-        firewallEventsAdaptive {
-          maxDuration
-          maxNumberOfFields
-          maxPageSize
-          enabled
-          notOlderThan
-        }
-      }
-    }
-  }
-}
-```
-
-### Response
-
-```graphql
-{
-  "data": {
-    "viewer": {
-      "zones": [
-        {
-          "settings": {
-            "firewallEventsAdaptive": {
-              "enabled": true,
-              "maxDuration": 259200,
-              "maxNumberOfFields": 30,
-              "maxPageSize": 10000,
-              "notOlderThan": 2678400
-            }
-          }
-        }
-      ]
-    }
-  },
-  "errors": null
-}
-```
-
-## Query limits
-
-In addition to access restrictions, there are limits on the volume of data that a query can return, and there are user limits on daily data volume. The following limits apply in addition to the general rate limits enforced by the Cloudflare API:
-
-*   **A zone-scoped query can include up to 10 zones.**
-*   **Account-scoped queries can aggregate data for up to 1,000 zones** — queries that involve aggregated data across more than 1,000 zones return with an error.
-*   **Queries can request up to 30 fields** — this limit is indicated by `maxNumberOfFields` in `settings`.
-*   **Responses can return up to 10,000 records** — this limit is indicated by `maxPageSize` in `settings`.
-
-Queries must explicitly specify the upper bound of records to return, using the `limit` argument, as in the following example.
-
-```graphql
-{
-  viewer {
-    zones(filter: { zoneTag: $zoneTag }) {
-      firewallEventsAdaptiveGroups(
-        limit: 100
-        filter: {
-          datetime_geq: "2019-10-16T21:08:00Z"
-          datetime_lt: "2019-10-16T21:12:00Z"
-        }
-        orderBy: [datetime_ASC]
-      ) {
-        count
-        dimensions {
-          datetime
-        }
-      }
-    }
-  }
-}
-```
+[1]: </analytics/graphql-api/features/discovery/settings/>


### PR DESCRIPTION
… the documentation

This commit emphasises the importance of schema discovery and how limits are organised in Cloudflare GraphQL API.

Since GraphQL API is a self-documented API, we don't need to keep a list of all available nodes and their limits (max time range, availability, etc.) because, eventually, the list will be outdated and might cause more confusion.

Instead, explaining how-to stay up-to-date with the GraphQL schema, we would help our users discover a continuously expanding list of Cloudflare's datasets.

In this commit I kept all GraphiQL client tutorials as they are very explanatory and don't differ much from others like Altair.

I also reformatted parts that I was updating to keep the formatting consistent across all docs.

This commit addresses #5189.