### PR TITLE
Remove live input limits, find better homes for live streaming FAQ content

### DIFF
--- a/content/stream/faq/index.md
+++ b/content/stream/faq/index.md
@@ -144,29 +144,3 @@ Content-Security-Policy: connect-src 'self' *.videodelivery.net *.cloudflarestre
 ```
 
 To ensure **only** videos from **your** Cloudflare Stream account can be played on your website, replace `*` in `*.cloudflarestream.com` and `*.videodelivery.net` in the examples above with `customer-<CODE>`, replacing `<CODE>` with your unique customer code, which can be found in the Stream Dashboard [here](https://dash.cloudflare.com/?to=/:account/stream). This code is unique to your Cloudflare Account.
-
-## Stream Live
-
-### Do I need a separate Stream Live subscription to use Stream Live?
-
-As long as you have a Cloudflare Stream subscription, you can use all the features of Stream Live. You do not need to add another subscription.
-
-### How does billing work for Stream Live?
-
-Stream Live billing works the same way as Stream On-demand:
-
-- You pay $5 per 1000 minutes of recorded video.
-- You pay $1 per 1000 minutes of delivered video.
-
-All Stream Live videos are automatically recorded. There is no additional cost for encoding and packaging live videos.
-
-### How many live inputs can I create? Are there any other limits?
-
-- You can configure up to 50 outputs per live input.
-- You should use a maximum recommended bitrate of 12000 kbps.
-
-If your use case requires the limits to be increased, please contact support.
-
-### How does Stream Live handle RTMP reconnections?
-
-As long as your streaming software reconnects, Stream Live will continue to ingest and stream your live video. Make sure the streaming software you use to push RTMP feeds automatically reconnects if the connection breaks. Some apps like OBS reconnect automatically while other apps like FFmpeg require custom configuration.

--- a/content/stream/faq/index.md
+++ b/content/stream/faq/index.md
@@ -162,7 +162,6 @@ All Stream Live videos are automatically recorded. There is no additional cost f
 
 ### How many live inputs can I create? Are there any other limits?
 
-- You can create up to 1000 live inputs per account.
 - You can configure up to 50 outputs per live input.
 - You should use a maximum recommended bitrate of 12000 kbps.
 

--- a/content/stream/stream-live/_index.md
+++ b/content/stream/stream-live/_index.md
@@ -19,3 +19,18 @@ Stream handles video streaming end-to-end, from ingestion through delivery.
 
 
 ![Diagram the explains the live stream workflow](/stream/static/live-stream-workflow.png)
+
+### How does Stream Live handle RTMP reconnections?
+
+As long as your streaming software reconnects, Stream Live will continue to ingest and stream your live video. Make sure the streaming software you use to push RTMP feeds automatically reconnects if the connection breaks. Some apps like OBS reconnect automatically while other apps like FFmpeg require custom configuration.
+
+### How does billing work for Stream Live?
+
+Stream Live is billed identically to the rest of Cloudflare Stream.
+
+- You pay $5 per 1000 minutes of recorded video.
+- You pay $1 per 1000 minutes of delivered video.
+
+All Stream Live videos are automatically recorded. There is no additional cost for encoding and packaging live videos.
+
+For more, see [Billing for Cloudflare Stream](https://support.cloudflare.com/hc/en-us/articles/360016450871-Billing-for-Cloudflare-Stream).

--- a/content/stream/stream-live/simulcasting.md
+++ b/content/stream/stream-live/simulcasting.md
@@ -6,7 +6,7 @@ weight: 5
 
 # Simulcast (restream) videos
 
-Simulcasting lets you forward your live stream to third-party platforms such as YouTube Live and Facebook Live. To begin simulcasting, select an input and add one or more Outputs.
+Simulcasting lets you forward your live stream to third-party platforms such as Twitch, YouTube, Facebook, Twitter, and more. You can simulcast to up to 50 concurrent destinations from each live input. To begin simulcasting, select an input and add one or more Outputs.
 
 ## Add an Output using the API
 

--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -111,13 +111,14 @@ curl -X DELETE \
 
 ### Requirements
 
-- You must set [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) to be between 2 to 10 seconds. The default in most encoding software, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream.
-- Closed GOPs required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoding software such as OBS.
+- Stream supports a maximum bitrate of 12000 Kbps.
+- You must set [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) of between 2 to 10 seconds. The default in most encoding software, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream.
+- Closed GOPs are required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoding software such as OBS.
 - Stream Live only supports H.264 video and AAC audio codecs as inputs. This requirement does not apply to inputs that are relayed to Stream Connect outputs. Stream Live supports ADTS but does not presently support LATM.
 - Clients must be configured to reconnect when a disconnection occurs. Stream Live is designed to handle reconnection gracefully by continuing the live stream.
 
 ### Known limitations
 
-- Stream Live currently only supports HLS (HTTP Live Streaming), and recordings are only kept for the last seven days of the stream.
+- DASH playback is not currently supported
 - Watermarks cannot yet be used with live videos.
 - If a live video exceeds seven days in length, the recording will be truncated to seven days and not be viewable.

--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -111,7 +111,7 @@ curl -X DELETE \
 
 ### Requirements
 
-- Stream supports a maximum bitrate of 12000 Kbps.
+- Stream supports a maximum ingest bitrate of 12000 Kbps.
 - You must set [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) of between 2 to 10 seconds. The default in most encoding software, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream.
 - Closed GOPs are required. This means that if there are any B frames in the video, they should always refer to frames within the same GOP. This setting is default in most encoding software such as OBS.
 - Stream Live only supports H.264 video and AAC audio codecs as inputs. This requirement does not apply to inputs that are relayed to Stream Connect outputs. Stream Live supports ADTS but does not presently support LATM.

--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -119,6 +119,6 @@ curl -X DELETE \
 
 ### Known limitations
 
-- DASH playback is not currently supported
+- Playback of live streams using DASH is not currently supported
 - Watermarks cannot yet be used with live videos.
 - If a live video exceeds seven days in length, the recording will be truncated to seven days and not be viewable.


### PR DESCRIPTION
- Removes all live streaming content from the FAQ
- Adds RTMP reconnection and billing content to main Stream Live page
- Moves simulcast limit to simulcasting section, clarify intro sentence
- Clarify DASH limitation to be more specific
- Remove duplicate content around recording last 7 days of content