### PR TITLE
[R2] remove service and region from aws4fetch

### DIFF
--- a/content/r2/examples/aws4fetch.md
+++ b/content/r2/examples/aws4fetch.md
@@ -20,8 +20,6 @@ const R2_URL = `https://${ACCOUNT_ID}.r2.cloudflarestorage.com`;
 const client = new AwsClient({
   accessKeyId: ACCESS_KEY_ID,
   secretAccessKey: SECRET_ACCESS_KEY,
-  service: "s3",
-  region: "auto",
 });
 
 const ListBucketsResult = await client.fetch(R2_URL);


### PR DESCRIPTION
These are not required anymore when using an R2 URL. See: https://github.com/mhart/aws4fetch/blob/master/src/main.js#L388-L390