### PR TITLE
Fix mermaid import

### DIFF
--- a/assets/main.ts
+++ b/assets/main.ts
@@ -1,7 +1,7 @@
 import * as events from "./events";
 import * as contents from "./contents";
 import * as timeago from "./timeago";
-import * as mermaid from "./mermaid";
+import * as mermaid from "./mermaid-diagrams";
 import * as navs from "./navlinks";
 
 declare global {

--- a/assets/mermaid-diagrams.ts
+++ b/assets/mermaid-diagrams.ts
@@ -1,4 +1,4 @@
-import mermaid from 'mermaid/dist/mermaid.min.js';
+import mermaid from 'mermaid';
 
 export function init() {
   mermaid.initialize({ startOnLoad: true, 'theme': 'neutral' })

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -2,6 +2,7 @@
  "compilerOptions": {
   "target": "es2015",
   "baseUrl": ".",
+  "moduleResolution": "node",
   "paths": {
    "*": [
     "*"


### PR DESCRIPTION
Importing paths of a module can cause issues, it's better to just import the module itself. However, TS was picking up the file rather than the module (which is I'm guessing why the path was added).

I have renamed the file so it doesn't pick that up and made sure it imports the node module correctly now.
This will fix the failing builds.