### PR TITLE
Use docs link for Analytics Engine Beta

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -15,4 +15,4 @@ These are the betas relevant to Cloudflare Workers.
 | Pub/Sub                       | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        | ✅          |               |[Docs](/queues)                                                             |
 | TCP Workers                   | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
-| Workers Analytics Engine      |             | ✅            |[Blog](https://blog.cloudflare.com/workers-analytics-engine/)               |
+| Workers Analytics Engine      |             | ✅            |[Docs](/analytics/analytics-engine/)                                        |


### PR DESCRIPTION
In line with the others, which show docs instead of blog if docs exist