### PR TITLE
[Ruleset Engine] Remove extra parentheses in example expressions

### DIFF
--- a/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
+++ b/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
@@ -34,7 +34,7 @@ curl -X PUT \
     {
       "action":"execute",
       "description":"Execute custom ruleset",
-      "expression": "(cf.zone.name == \"example.com\") and (cf.zone.plan eq \"ENT\")",
+      "expression": "(cf.zone.name == \"example.com\") and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id":"<CUSTOM_RULESET_ID>"
       }
@@ -72,7 +72,7 @@ header: Response
           "id": "<CUSTOM_RULESET_ID>",
           "version": "latest"
         },
-        "expression": "(cf.zone.name == \"example.com\") and (cf.zone.plan eq \"ENT\")",
+        "expression": "(cf.zone.name == \"example.com\") and cf.zone.plan eq \"ENT\"",
         "last_updated": "2021-03-18T18:35:14.135697Z",
         "ref": "<PHASE_RULE_REF>",
         "enabled": true
@@ -85,7 +85,7 @@ header: Response
           "id": "<EXECUTED_RULESET_ID_1>",
           "version": "latest"
         },
-        "expression": "(cf.zone.name eq \"example.com\") and (cf.zone.plan eq \"ENT\")",
+        "expression": "(cf.zone.name eq \"example.com\") and cf.zone.plan eq \"ENT\"",
         "last_updated": "2021-03-16T15:51:49.180378Z",
         "ref": "<EXISTING_PHASE_RULE_REF_1>",
         "enabled": true
@@ -98,7 +98,7 @@ header: Response
           "id": "<EXECUTED_RULESET_ID_2>",
           "version": "latest"
         },
-        "expression": "(cf.zone.name eq \"example.com\") and (cf.zone.plan eq \"ENT\")",
+        "expression": "(cf.zone.name eq \"example.com\") and cf.zone.plan eq \"ENT\"",
         "last_updated": "2021-03-16T15:50:29.861157Z",
         "ref": "<EXISTING_PHASE_RULE_REF_2>",
         "enabled": true

--- a/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
@@ -41,7 +41,7 @@ curl -X PUT \
       "action_parameters": {
         "id": "<CLOUDFLARE_MANAGED_RULESET_ID>"
       },
-      "expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and (cf.zone.plan eq \"ENT\")",
+      "expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and cf.zone.plan eq \"ENT\"",
       "description": "Execute Cloudflare Managed Ruleset on my account-level phase entry point"
     }
   ]
@@ -68,7 +68,7 @@ header: Response
           "id": "<CLOUDFLARE_MANAGED_RULESET_ID>",
           "version": "latest"
         },
-        "expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and (cf.zone.plan eq \"ENT\")",
+        "expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and cf.zone.plan eq \"ENT\"",
         "description": "Execute Cloudflare Managed Ruleset on my account-level phase entry point",
         "last_updated": "2021-03-18T18:30:08.122758Z",
         "ref": "<RULE_REF>",

--- a/content/ruleset-engine/managed-rulesets/override-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/override-managed-ruleset.md
@@ -126,7 +126,7 @@ curl -X PUT \
   "rules": [
     {
       "action": "execute",
-      "expression": "(cf.zone.name eq \"example.com\") and (cf.zone.plan eq \"ENT\")",
+      "expression": "(cf.zone.name eq \"example.com\") and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {


### PR DESCRIPTION
Remove parentheses in Enterprise zone sub-expressions since they're no longer required.