### PR TITLE
Change several instances of "Partner" to "Channel and Alliance partner"

### DIFF
--- a/content/tenant/_index.md
+++ b/content/tenant/_index.md
@@ -8,7 +8,7 @@ meta:
 
 # Cloudflare Tenant
 
-The Cloudflare Tenant API is a provisioning mechanism to help partners set up and manage Cloudflare accounts and services for their customers. 
+The Cloudflare Tenant API is a provisioning mechanism to help Channel and Alliance partners set up and manage Cloudflare accounts and services for their customers. 
 
 These APIs are built into our Client v4 API library to provide a streamlined onboarding and setup experience.
 

--- a/content/tenant/get-started/index.md
+++ b/content/tenant/get-started/index.md
@@ -10,7 +10,7 @@ Having access to Cloudflare’s provisioning capabilities allows you to more eas
 
 ## Before you begin
 
-### Partner account setup
+### Channel and Alliance partner account setup
 
 Before using the Tenant API, you need to [create an account](/fundamentals/account-and-billing/account-setup/create-account/), [verify your email address](/fundamentals/account-and-billing/account-setup/verify-email-address/), and [add your billing information](/fundamentals/account-and-billing/account-setup/create-billing-profile/).
 

--- a/content/tenant/structure.md
+++ b/content/tenant/structure.md
@@ -6,7 +6,7 @@ weight: 1
 
 # Tenant structure
 
-Cloudflare helps partners manage their and their customers' accounts through a Tenant structure.
+Cloudflare helps Channel and Alliance partners manage their and their customers' accounts through a Tenant structure.
 
 ![Partner accounts contain a tenant, which is a container for customer accounts and zones. For more details, keep reading.](/tenant/static/tenant-diagram.png)
 


### PR DESCRIPTION
This increases the specificity of Tenant docs and differentiates it from our Technology Partner program. 