### PR TITLE
[Access] Add detail about SSH principals to Access short-lived SSH certs

### DIFF
--- a/content/cloudflare-one/_partials/_ssh-restart-server.md
+++ b/content/cloudflare-one/_partials/_ssh-restart-server.md
@@ -5,24 +5,28 @@ _build:
   list: never
 ---
 
-Once you have modified your SSHD configuration, you still need to restart the SSH service on the remote machine.
+Once you have modified your SSHD configuration, restart the SSH service on the remote machine.
 
 ### Debian/Ubuntu
 
+For older Debian/Ubuntu versions:
   ```sh
-  # For older Debian/Ubuntu versions:
   $ sudo service ssh restart
-  
-  # For newer Debian/Ubuntu versions:
+  ```
+
+For newer Debian/Ubuntu versions:
+  ```sh
   $ sudo systemctl restart ssh
   ```
 
 ### CentOS/RHEL
 
+For CentOS/RHEL 6 and older:
   ```sh
-  # For CentOS/RHEL 6 and older:
   $ sudo service sshd restart
+  ```
 
-  # For CentOS/RHEL 7 and newer:
+For CentOS/RHEL 7 and newer:
+  ```sh
   $ sudo systemctl restart sshd
   ```

--- a/content/cloudflare-one/_partials/_ssh-restart-server.md
+++ b/content/cloudflare-one/_partials/_ssh-restart-server.md
@@ -10,13 +10,19 @@ Once you have modified your SSHD configuration, you still need to restart the SS
 ### Debian/Ubuntu
 
   ```sh
+  # For older Debian/Ubuntu versions:
   $ sudo service ssh restart
+  
+  # For newer Debian/Ubuntu versions:
   $ sudo systemctl restart ssh
   ```
 
 ### CentOS/RHEL
 
   ```sh
+  # For CentOS/RHEL 6 and older:
   $ sudo service sshd restart
+
+  # For CentOS/RHEL 7 and newer:
   $ sudo systemctl restart sshd
   ```

--- a/content/cloudflare-one/_partials/_ssh-usernames.md
+++ b/content/cloudflare-one/_partials/_ssh-usernames.md
@@ -5,9 +5,7 @@ _build:
   list: never
 ---
 
-The simplest setup is one where a user's Unix username matches their email address prefix. 
-Issued short-lived certificates will be valid for the user's email address prefix.
-For example, if user `jdoe@example.com` connects to `vm.example.com`, they would try to sign in as the user `jdoe`.
+The simplest setup is one where a user's Unix username matches their email address prefix.  Issued short-lived certificates will be valid for the user's email address prefix. For example, if a user in your Okta or GSuite organization is registered as `jdoe@example.com`, they would log in to the SSH server as `jdoe`.
 
 For testing purposes, you can run the following command to generate a Unix user on the machine:
 
@@ -16,40 +14,35 @@ $ sudo adduser jdoe
 ```
 
 <details>
-<summary>Advanced Setup: Differing usernames</summary>
+<summary>Advanced setup: Differing usernames</summary>
 <div>
 
-SSH certificates have no concept of username, and instead authorize users to a "principal".
-When `jdoe@example.com` tries to connect to `vm.example.com`, the short-lived certificate is authorized for the principal `jdoe`.
+SSH certificates include one or more `principals` in their signature which indicate the Unix usernames the certificate is allowed to log in as. Cloudflare Access will always set the principal to the user's email address prefix. For example, when `jdoe@example.com` tries to connect, Access issues a short-lived certificate authorized for the principal `jdoe`.
 
-By default, an SSH server will authenticate the username against the list of principals in the user's cert.
-However, you can override this behavior by instead offering a command to say which principals are authorized.
+By default, SSH servers authenticate the Unix username against the principals listed in the user's certificate. You can configure your SSH server to accept principals that do not match the Unix username.
 
-If you'd like to allow `jdoe@example.com` to log in as the user `johndoe`, you can add the following to the server's `/etc/ssh/sshd_config`:
-```sh
+**Username matches a different email**
+
+To allow `jdoe@example.com` to log in as the user `johndoe`, add the following to the server's `/etc/ssh/sshd_config`:
+
+```txt
 Match user 'johndoe'
   AuthorizedPrincipalsCommand echo 'jdoe'
   AuthorizedPrincipalsCommandUser nobody
 ```
-This tells the ssh server that, when someone tries to authenticate as the user `johndoe`, check their certificate for the principal `jdoe`.
 
-If you'd like to authorize multiple users, replace the `AuthorizedPrincipalsCommand` above with one to echo multiple usernames, separated by `\n`.
-For example, to allow `jdoe@example.com` and `bwayne@example.com` to both log in as `vmuser`:
+This tells the SSH server that, when someone tries to authenticate as the user `johndoe`, check their certificate for the principal `jdoe`.
 
-```sh
-Match user 'vmuser'
-  AuthorizedPrincipalsCommand echo -e 'jdoe\nbwayne'
-  AuthorizedPrincipalsCommandUser nobody
-```
+**Username matches multiple emails**
 
-Alternatively, you can specify a list of principals (in this case, usernames from users' emails) in a file, and pass that to ssh instead:
+To allow multiple email addresses to log in as `vmuser`, add the following to the server's `/etc/ssh/sshd_config`:
 
-```sh
+```txt
 Match user 'vmuser'
   AuthorizedPrincipalsFile /etc/ssh/vmusers-list.txt
 ```
 
-Then, in `/etc/ssh/vmusers-list.txt`, list the users that can sign in as `vmuser`, one per line:
+This tells the SSH server to load a list of principles from a file. Then, in `/etc/ssh/vmusers-list.txt`, list the email prefixes that can log in as `vmuser`, one per line:
 
 ```text
 jdoe
@@ -57,35 +50,28 @@ bwayne
 robin
 ```
 
-For any of these configs you'll also need the `TrustedUserCAKeys` option, as documented below.
-</div>
-</details>
+**Username matches all users**
 
-<details>
-<summary>Advanced Setup: Allowing any user to log in</summary>
-<div>
+To allow any Access user to log in as `vmuser`, add the following command to the server's `/etc/ssh/sshd_config`:
 
-If you'd like to allow any user to log in as a particular user, you can add the following command to the server's `/etc/ssh/sshd_config`:
-
-```sh
+```txt
 Match user 'vmuser'
   AuthorizedPrincipalsCommand bash -c "echo '%t %k' | ssh-keygen -L -f - | grep -A1 Principals"
   AuthorizedPrincipalsCommandUser nobody
 ```
 
-(there's no way to tell sshd to allow any verified certificate, so this takes the certificate presented by the user and authorizes whatever principal is listed on it)
+This command takes the certificate presented by the user and authorizes whatever principal is listed on it.
 
-Or, to allow any Access user to log in as any user:
+**Allow all users**
 
-```sh
+To allow any Access user to log in with any username, add the following to the server's `/etc/ssh/sshd_config`:
+
+```txt
 AuthorizedPrincipalsCommand bash -c "echo '%t %k' | ssh-keygen -L -f - | grep -A1 Principals"
 AuthorizedPrincipalsCommandUser nobody
 ```
 
-(the same options, but without the `Match` block above it)
+Since this will put the security of your server entirely dependent on your Access configuration, make sure your [Access policies](/cloudflare-one/policies/access/policy-management/) are correctly configured.
 
-This will put the security of your server entirely dependent on your Access configuration, so make extra sure your [access policies](/cloudflare-one/policies/access/policy-management/) are correctly configured.
-
-For any of these configs you'll also need the `TrustedUserCAKeys` option, as documented below.
 </div>
 </details>

--- a/content/cloudflare-one/_partials/_ssh-usernames.md
+++ b/content/cloudflare-one/_partials/_ssh-usernames.md
@@ -5,12 +5,87 @@ _build:
   list: never
 ---
 
-In order to match a user to their SSO identity, the user's Unix username must match their email address prefix. For example, `jdoe` must be registered in your Okta or GSuite organization as `jdoe@example.com`.
-
-You can create a user entry with duplicate `uid`, `gid`, and home directory to link an identity to an existing user with a different username. You will need to create a password for it separately and add it to the same groups to replicate permissions.
+The simplest setup is one where a user's Unix username matches their email address prefix. 
+Issued short-lived certificates will be valid for the user's email address prefix.
+For example, if user `jdoe@example.com` connects to `vm.example.com`, they would try to sign in as the user `jdoe`.
 
 For testing purposes, you can run the following command to generate a Unix user on the machine:
 
 ```sh
 $ sudo adduser jdoe
 ```
+
+<details>
+<summary>Advanced Setup: Differing usernames</summary>
+<div>
+
+SSH certificates have no concept of username, and instead authorize users to a "principal".
+When `jdoe@example.com` tries to connect to `vm.example.com`, the short-lived certificate is authorized for the principal `jdoe`.
+
+By default, an SSH server will authenticate the username against the list of principals in the user's cert.
+However, you can override this behavior by instead offering a command to say which principals are authorized.
+
+If you'd like to allow `jdoe@example.com` to log in as the user `johndoe`, you can add the following to the server's `/etc/ssh/sshd_config`:
+```sh
+Match user 'johndoe'
+  AuthorizedPrincipalsCommand echo 'jdoe'
+  AuthorizedPrincipalsCommandUser nobody
+```
+This tells the ssh server that, when someone tries to authenticate as the user `johndoe`, check their certificate for the principal `jdoe`.
+
+If you'd like to authorize multiple users, replace the `AuthorizedPrincipalsCommand` above with one to echo multiple usernames, separated by `\n`.
+For example, to allow `jdoe@example.com` and `bwayne@example.com` to both log in as `vmuser`:
+
+```sh
+Match user 'vmuser'
+  AuthorizedPrincipalsCommand echo -e 'jdoe\nbwayne'
+  AuthorizedPrincipalsCommandUser nobody
+```
+
+Alternatively, you can specify a list of principals (in this case, usernames from users' emails) in a file, and pass that to ssh instead:
+
+```sh
+Match user 'vmuser'
+  AuthorizedPrincipalsFile /etc/ssh/vmusers-list.txt
+```
+
+Then, in `/etc/ssh/vmusers-list.txt`, list the users that can sign in as `vmuser`, one per line:
+
+```text
+jdoe
+bwayne
+robin
+```
+
+For any of these configs you'll also need the `TrustedUserCAKeys` option, as documented below.
+</div>
+</details>
+
+<details>
+<summary>Advanced Setup: Allowing any user to log in</summary>
+<div>
+
+If you'd like to allow any user to log in as a particular user, you can add the following command to the server's `/etc/ssh/sshd_config`:
+
+```sh
+Match user 'vmuser'
+  AuthorizedPrincipalsCommand bash -c "echo '%t %k' | ssh-keygen -L -f - | grep -A1 Principals"
+  AuthorizedPrincipalsCommandUser nobody
+```
+
+(there's no way to tell sshd to allow any verified certificate, so this takes the certificate presented by the user and authorizes whatever principal is listed on it)
+
+Or, to allow any Access user to log in as any user:
+
+```sh
+AuthorizedPrincipalsCommand bash -c "echo '%t %k' | ssh-keygen -L -f - | grep -A1 Principals"
+AuthorizedPrincipalsCommandUser nobody
+```
+
+(the same options, but without the `Match` block above it)
+
+This will put the security of your server entirely dependent on your Access configuration, so make extra sure your [access policies](/cloudflare-one/policies/access/policy-management/) are correctly configured.
+
+For any of these configs you'll also need the `TrustedUserCAKeys` option, as documented below.
+</div>
+</details>

--- a/content/cloudflare-one/identity/users/short-lived-certificates.md
+++ b/content/cloudflare-one/identity/users/short-lived-certificates.md
@@ -14,14 +14,9 @@ Cloudflare Access removes the burden on the end user of generating a key, while 
 
 ## 1. Secure a server behind Cloudflare Access
 
-To protect a resource behind Cloudflare Access, first follow [these instructions](/cloudflare-one/connections/connect-apps/use_cases/ssh/) to secure the server.
+Cloudflare Access short-lived certificates can work with any modern SSH server, whether it is behind Access or not. However, we recommend putting your server behind Access for added security and features, such as auditability and browser-based terminals.
 
-{{<Aside type="note">}}
-
-Cloudflare Access short lived certificates can work with any modern SSH server, whether it's behind Access or not.
-However, we recommend putting your server behind Access for added security and features, such as auditability and browser-based terminals.
-
-{{</Aside>}}
+To secure your server behind Cloudflare Access, follow [these instructions](/cloudflare-one/connections/connect-apps/use_cases/ssh/).
 
 ## 2. Ensure Unix usernames match user SSO identities
 
@@ -62,7 +57,7 @@ Cloudflare Access will take the identity from a token and, using short-lived cer
 
 ### Configure your client SSH config
 
-On the client side, follow [this tutorial](/cloudflare-one/connections/connect-apps/use_cases/ssh/) to configure your device to use Cloudflare Access to reach the protected machine. To use short-lived certificates, you must include the following settings in your SSH config file (`~/.ssh/config`).
+On the client side, [configure your device](/cloudflare-one/connections/connect-apps/use_cases/ssh/) to use Cloudflare Access to reach the protected machine. To use short-lived certificates, you must include the following settings in your SSH config file (`~/.ssh/config`).
 
 To save time, you can use the following cloudflared command to print the required configuration command:
 

--- a/content/cloudflare-one/identity/users/short-lived-certificates.md
+++ b/content/cloudflare-one/identity/users/short-lived-certificates.md
@@ -16,6 +16,13 @@ Cloudflare Access removes the burden on the end user of generating a key, while 
 
 To protect a resource behind Cloudflare Access, first follow [these instructions](/cloudflare-one/connections/connect-apps/use_cases/ssh/) to secure the server.
 
+{{<Aside type="note">}}
+
+Cloudflare Access short lived certificates can work with any modern SSH server, whether it's behind Access or not.
+However, we recommend putting your server behind Access for added security and features, such as auditability and browser-based terminals.
+
+{{</Aside>}}
+
 ## 2. Ensure Unix usernames match user SSO identities
 
 Cloudflare Access will take the identity from a token and, using short-lived certificates, authorize the user on the target infrastructure.

--- a/content/cloudflare-one/tutorials/ssh-cert-bastion.md
+++ b/content/cloudflare-one/tutorials/ssh-cert-bastion.md
@@ -151,7 +151,6 @@ When users authenticate through Cloudflare Access, Cloudflare will generate a ce
 
 {{<Aside type="note">}}
 
-The username in the identity provider must match the username on the SSH server.  
-To use with a server where the usernames don't match, see the advanced setup in [Short-Lived Certificates](/cloudflare-one/identity/users/short-lived-certificates/)
+The setup described in this tutorial requires the username in the identity provider to match the username on the SSH server. To use with a server where the usernames do not match, refer to the [advanced setup instructions](/cloudflare-one/identity/users/short-lived-certificates/#2-ensure-unix-usernames-match-user-sso-identities).
 
 {{</Aside>}}

--- a/content/cloudflare-one/tutorials/ssh-cert-bastion.md
+++ b/content/cloudflare-one/tutorials/ssh-cert-bastion.md
@@ -140,20 +140,18 @@ $ cloudflared access ssh-config --hostname ssh-bastion.widgetcorp.tech --short-l
 `cloudflared` will generate the required lines to append to the SSH configuration file, similar to the example output below.
 
 ```txt
-Host ssh-bastion.widgetcorp.tech
-  ProxyCommand bash -c '/usr/local/bin/cloudflared access ssh-gen --hostname %h; ssh -tt %r@cfpipe-ssh-bastion.widgetcorp.tech >&2 <&1'
-
-Host cfpipe-ssh-bastion.widgetcorp.tech
-  HostName ssh-bastion.widgetcorp.tech
-  ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
-  IdentityFile ~/.cloudflared/ssh-bastion.widgetcorp.tech-cf_key
-  CertificateFile ~/.cloudflared/ssh-bastion.widgetcorp.tech-cf_key-cert.pub
+Match host ssh-bastion.widgetcorp.tech exec "/usr/local/bin/cloudflared access ssh-gen --hostname %h"
+    HostName ssh-bastion.widgetcorp.tech
+    ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
+    IdentityFile ~/.cloudflared/vm.example.com-cf_key
+    CertificateFile ~/.cloudflared/vm.example.com-cf_key-cert.pub
 ```
 
 When users authenticate through Cloudflare Access, Cloudflare will generate a certificate for the individual using the username from the identity provider (stripped of the email domain). That certificate will then be presented to the SSH server.
 
 {{<Aside type="note">}}
 
-The username in the identity provider must match the username on the SSH server.
+The username in the identity provider must match the username on the SSH server.  
+To use with a server where the usernames don't match, see the advanced setup in [Short-Lived Certificates](/cloudflare-one/identity/users/short-lived-certificates/)
 
 {{</Aside>}}


### PR DESCRIPTION
re: #6547

The current docs aren't great, since they say your Access usernames have to match the *nix username of the box you sign into (not true), and the recommended workaround for if they don't (adding another user with a username that matches, and using the same uid and gid) is janky at best.

I simplified the docs into a basic description at the top, then a dropdown section for username aliasing, and another for allowing anyone (with Access perms) to sign in as a particular user (or any user).

This could definitely use some copyediting, but all the crucial information should be there.

Also did some spiffing up throughout other parts of the page and updated the SSH example config in the tutorial I apparently missed in #6546 