### PR TITLE
Stream GraphQL API docs, deprecate per-video analytics

### DIFF
--- a/assets/json/replace-vpn.json
+++ b/assets/json/replace-vpn.json
@@ -157,7 +157,7 @@
             "additional_description": "For initial testing, users should manually authenticate the client to their organization’s Cloudflare Zero Trust instance."
           },
           {
-            "url_path": "https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/",
+            "url_path": "/cloudflare-one/connections/connect-devices/warp/exclude-traffic/split-tunnels/",
             "link_title": "Define split tunnels settings",
             "additional_description": "This will determine what traffic WARP does and does not proxy.<br/><br/>If you added private network routes in the <code>10.0.0.0</code> range, ensure that these IP addresses are included in WARP."
           },

--- a/content/stream/getting-analytics/_index.md
+++ b/content/stream/getting-analytics/_index.md
@@ -4,6 +4,13 @@ title: Analytics
 weight: 8
 ---
 
-# Getting analytics
+# Analytics
 
-{{<directory-listing>}}
+Stream provides both server-side and client-side analytics that can be used to:
+
+- Identify most viewed video content in your app or platform
+- Identify where content is viewed from and when it is viewed
+- Understand which creators on your platform are publishing the most viewed content, and analyze trends
+- Provide data to your billing system about how many minutes of video each of your customers or end-users stream during a given period
+
+You can access data via the [Stream dashboard](https://dash.cloudflare.com/?to=/:account/stream/analytics) or via the [GraphQL Analytics API](/stream/getting-analytics/fetching-bulk-analytics).

--- a/content/stream/getting-analytics/_index.md
+++ b/content/stream/getting-analytics/_index.md
@@ -8,9 +8,9 @@ weight: 8
 
 Stream provides both server-side and client-side analytics that can be used to:
 
-- Identify most viewed video content in your app or platform
-- Identify where content is viewed from and when it is viewed
-- Understand which creators on your platform are publishing the most viewed content, and analyze trends
-- Provide data to your billing system about how many minutes of video each of your customers or end-users stream during a given period
+- Identify most viewed video content in your app or platform.
+- Identify where content is viewed from and when it is viewed.
+- Understand which creators on your platform are publishing the most viewed content, and analyze trends.
+- Provide data to your billing system about how many minutes of video each of your customers or end-users stream during a given period.
 
 You can access data via the [Stream dashboard](https://dash.cloudflare.com/?to=/:account/stream/analytics) or via the [GraphQL Analytics API](/stream/getting-analytics/fetching-bulk-analytics).

--- a/content/stream/getting-analytics/fetching-bulk-analytics.md
+++ b/content/stream/getting-analytics/fetching-bulk-analytics.md
@@ -1,70 +1,155 @@
 ---
 pcx_content_type: reference
-title: Fetch bulk analytics
+title: GraphQL Analytics API
+weight: 1
 ---
 
-# Fetch bulk analytics
+# GraphQL Analytics API
 
-Cloudflare Stream lets you fetch usage data in bulk using the GraphQL API. Stream's GraphQL API exposes two data sets:
+Stream provides analytics about both live video and video uploaded to Stream, via the GraphQL API described below, as well as in the [Stream dashboard](https://dash.cloudflare.com/?to=/:account/stream/analytics).
 
-- Client-side Metrics: Data collected from the Stream Player. If you use your own player, it will not be reflected in this data set.
-- Server-side Metrics: Data collected from server-side logs and used for billing purposes.
+The Stream Analytics API uses the Cloudflare GraphQL Analytics API, which can be used across many Cloudflare products. For more about GraphQL, rate limits, filters, and sorting, refer to the [Cloudflare GraphQL Analytics API docs](analytics/graphql-api).
 
-For additional information on using GraphQL, refer to [Get started with GraphQL Analytics API](/analytics/graphql-api/getting-started/).
+## Getting started
 
-{{<Aside type="note">}}
+1. [Generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the **Account Analytics** permission.
+2. Use a GraphQL client of your choice to make your first query. [Postman](https://www.postman.com/) has a built-in GraphQL client which can help you run your first query and introspect the GraphQL schema to understand what is possible.
 
-**Prerequisite:** 
-[Generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the **Account Analytics** permission.
+See the sections below for available metrics, dimensions, fields, and example queries.
 
-{{</Aside>}}
+## Server side analytics
 
-## Analytics in the dashboard
+Stream collects data about the number of minutes of video delivered to viewers for all live and on-demand videos played via HLS or DASH, regardless of whether or not you use the [Stream Player](/stream/viewing-videos/using-the-stream-player/).
 
-To view analytics data from the Cloudflare dashboard:
+### Filters and Dimensions
 
-1. Log in to your [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
-2. Click **Stream** > **Analytics**.
-3. From **Stream Analytics**, click **Add filter** to view data related to your filter.
-4. After selecting your filters, click **Apply**.
+| Field               | Description                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `date`              | Date                                                                                                     |
+| `datetime`          | DateTime                                                                                                 |
+| `uid`               | UID of the video                                                                                         |
+| `clientCountryName` | ISO 3166 alpha2 country code from the client who viewed the video                                        |
+| `creator`           | The [Creator ID](/stream/manage-video-library/creator-id/) associated with individual videos, if present |
 
-You can also hover your cursor over interactive portions to view specific data points. 
-
-## Client side analytics
-
-Stream has a GraphQL analytics API that can be used to get bulk analytics for every video in your account with one HTTP request.
+Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, see [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
 
 ### Metrics
 
-*   Number of views (number of times the video playback has been started)
-*   Time viewed in seconds
-*   Number of video buffering events
-*   Number of times quality level has changed
+| Node                                | Field           | Description                                |
+| ----------------------------------- | --------------- | ------------------------------------------ |
+| `streamMinutesViewedAdaptiveGroups` | `minutesViewed` | Minutes of video delivered                 |
+| `streamMinutesViewedAdaptiveGroups` | `count`         | Number of times video playback has started |
 
-### Filters
+### Example
 
-There is no limit on number of filters per query.
+#### Get minutes viewed by country
 
-*   Video UID
-*   Date/time
-*   Country
-*   CreatorID
-*   Device type
-*   Device operating system
-*   Device browser
-*   Quality level (only for quality level metric)
+```graphql
+---
+header: GraphQL request
+---
+query {
+  viewer {
+    accounts(filter:{
+      accountTag:"<ACCOUNT_ID>"
+    }) {
+      streamMinutesViewedAdaptiveGroups(
+        filter: {
+          date_geq: "2022-03-01"
+          date_lt: "2022-02-01"
+        }
+        orderBy:[sum_minutesViewed_DESC]
+        limit: 100
+      ) {
+        sum {
+          minutesViewed
+        }
+        dimensions{
+          uid
+          clientCountryName
+        }
+      }
+    }
+  }
+}
+```
 
-{{<Aside>}}
+```json
+---
+header: GraphQL response
+---
+{
+    "data": {
+        "viewer": {
+            "accounts": [
+                {
+                    "streamMinutesViewedAdaptiveGroups": [
+                        {
+                            "dimensions": {
+                                "clientCountryName": "US",
+                                "uid": "73c514082b154945a753d0011e9d7525"
+                            },
+                            "sum": {
+                                "minutesViewed": 2234
+                            }
+                        },
+                        {
+                            "dimensions": {
+                                "clientCountryName": "CN",
+                                "uid": "73c514082b154945a753d0011e9d7525"
+                            },
+                            "sum": {
+                                "minutesViewed": 700
+                            }
+                        },
+                        {
+                            "dimensions": {
+                                "clientCountryName": "IN",
+                                "uid": "73c514082b154945a753d0011e9d7525"
+                            },
+                            "sum": {
+                                "minutesViewed": 553
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "errors": null
+}
+```
 
-View analytics is collected only when the Stream player is used. If you use a third party player, view metrics will not appear as part of these metrics. Review the example below to retrieve the time viewed for videos on your account in a single query.
+## Client side analytics
 
+Client-side analytics are collected by the Stream Player, in viewers' web browsers. This enables more detailed metrics that can be used to understand the quality of viewers' experience, including how often video playback stops due to buffering or how often the quality level switches during playback.
+
+{{<Aside header="Client-side analytics are only available with the Stream Player">}}
+Client-side analytics are only collected when the [Stream Player](/stream/viewing-videos/using-the-stream-player/) is used. If you use a different player, only server-side analytics will be available.
 {{</Aside>}}
 
-{{<Aside>}}
+### Filters and Dimensions
 
-If you are newer to GraphQL, refer to [Cloudflare GraphQL analytics for HTTP requests](/analytics/graphql-api/getting-started/) for more detailed information getting started with the Cloudflare GraphQL Analytics API.
+| Field               | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `date`              | Date                                                              |
+| `datetime`          | DateTime                                                          |
+| `uid`               | UID of the video                                                  |
+| `clientCountryName` | ISO 3166 alpha2 country code from the client who viewed the video |
+| `deviceBrowser`     | Browser                                                           |
+| `deviceOs`          | Device operating system                                           |
+| `deviceType`        | Device type                                                       |
 
-{{</Aside>}}
+Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, see [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
+
+### Metrics
+
+| Node                                | Field               | Description                                             |
+| ----------------------------------- | ------------------- | ------------------------------------------------------- |
+| `videoPlaybackEventsAdaptiveGroups` | `timeViewedMinutes` | Minutes of video viewed                                 |
+| `videoPlaybackEventsAdaptiveGroups` | `count`             | Number of times video playback has started              |
+| `videoBufferEventsAdaptiveGroups`   | `count`             | Number of times video playback stopped due to buffering |
+| `videoQualityEventsAdaptiveGroups`  | `count`             | Number of times video quality changed during playback   |
 
 ### Examples
 
@@ -147,110 +232,13 @@ header: GraphQL response
 }
 ```
 
-About the response above:
+#### About the response above:
 
-*   Each object inside `videoPlaybackEventsAdaptiveGroups` represents one video.
-*   `uid` represents the unique identifier for the video.
-*   `count` shows the view count for one video during the specified date range.
-*   `timeViewedMinutes` shows the minutes viewed per video during the specified date range.
-*   If a video did not have views in the date range specified, it will NOT be included in the response
-
-## Server side analytics
-
-### Metrics
-
-- Date and time an event occurred at Cloudflare's edge
-- Media source for the minutes viewed
-- Video UID
-- ISO 3166 alpha2 country code from the client
-
-### Filters
-
-- `date`
-- `datetime`
-- `mediaType`
-- `UID`
-- `clientCountryName`
-
-### Example
-
-#### Get minutes viewed by country
-
-```graphql
----
-header: GraphQL request
----
-query {
-  viewer {
-    accounts(filter:{
-      accountTag:"<ACCOUNT_ID>"
-    }) {
-      streamMinutesViewedAdaptiveGroups(
-        filter: {
-          date_geq: "2022-03-01"
-          date_lt: "2022-02-01"
-        }
-        orderBy:[sum_minutesViewed_DESC]
-        limit: 100
-      ) {
-        sum {
-          minutesViewed
-        }
-        dimensions{
-          uid
-          clientCountryName
-        }
-      }
-    }
-  }
-}
-```
-
-```json
----
-header: GraphQL response
----
-{
-    "data": {
-        "viewer": {
-            "accounts": [
-                {
-                    "streamMinutesViewedAdaptiveGroups": [
-                        {
-                            "dimensions": {
-                                "clientCountryName": "US",
-                                "uid": "73c514082b154945a753d0011e9d7525"
-                            },
-                            "sum": {
-                                "minutesViewed": 2234
-                            }
-                        },
-                        {
-                            "dimensions": {
-                                "clientCountryName": "CN",
-                                "uid": "73c514082b154945a753d0011e9d7525"
-                            },
-                            "sum": {
-                                "minutesViewed": 700
-                            }
-                        },
-                        {
-                            "dimensions": {
-                                "clientCountryName": "IN",
-                                "uid": "73c514082b154945a753d0011e9d7525"
-                            },
-                            "sum": {
-                                "minutesViewed": 553
-                            }
-                        }
-                    ]
-                }
-            ]
-        }
-    },
-    "errors": null
-}
-```
+- Each object inside `videoPlaybackEventsAdaptiveGroups` represents one video.
+- `uid` represents the unique identifier for the video.
+- `count` shows the view count for one video during the specified date range.
+- `timeViewedMinutes` shows the minutes viewed per video during the specified date range.
+- If a video did not have views in the date range specified, it will NOT be included in the response
 
 ## Pagination
 
@@ -292,11 +280,13 @@ query {
 
 Here are the steps to implementing pagination:
 
-1.  Call the first query without uid\_gt filter to get the first set of videos
+1.  Call the first query without uid_gt filter to get the first set of videos
 2.  Grab the last video UID from the response from the first query
-3.  Call next query by specifying uid\_gt property and set it to the last video UID. This will return the next set of videos
+3.  Call next query by specifying uid_gt property and set it to the last video UID. This will return the next set of videos
+
+For more on pagination, refer to the [Cloudflare GraphQL Analytics API docs](/analytics/graphql-api/features/pagination/).
 
 ## Limitations
 
-*   Maximum query interval in a single query is 31 days
-*   Maximum data retention period is 90 days
+- The maximum query interval in a single query is 31 days
+- The maximum data retention period is 90 days

--- a/content/stream/getting-analytics/fetching-bulk-analytics.md
+++ b/content/stream/getting-analytics/fetching-bulk-analytics.md
@@ -8,14 +8,14 @@ weight: 1
 
 Stream provides analytics about both live video and video uploaded to Stream, via the GraphQL API described below, as well as in the [Stream dashboard](https://dash.cloudflare.com/?to=/:account/stream/analytics).
 
-The Stream Analytics API uses the Cloudflare GraphQL Analytics API, which can be used across many Cloudflare products. For more about GraphQL, rate limits, filters, and sorting, refer to the [Cloudflare GraphQL Analytics API docs](analytics/graphql-api).
+The Stream Analytics API uses the Cloudflare GraphQL Analytics API, which can be used across many Cloudflare products. For more about GraphQL, rate limits, filters, and sorting, refer to the [Cloudflare GraphQL Analytics API docs](/analytics/graphql-api).
 
 ## Getting started
 
 1. [Generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the **Account Analytics** permission.
 2. Use a GraphQL client of your choice to make your first query. [Postman](https://www.postman.com/) has a built-in GraphQL client which can help you run your first query and introspect the GraphQL schema to understand what is possible.
 
-See the sections below for available metrics, dimensions, fields, and example queries.
+Refer to the sections below for available metrics, dimensions, fields, and example queries.
 
 ## Server side analytics
 
@@ -31,7 +31,7 @@ Stream collects data about the number of minutes of video delivered to viewers f
 | `clientCountryName` | ISO 3166 alpha2 country code from the client who viewed the video                                        |
 | `creator`           | The [Creator ID](/stream/manage-video-library/creator-id/) associated with individual videos, if present |
 
-Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, see [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
+Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, refer to [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
 
 ### Metrics
 
@@ -140,7 +140,7 @@ Client-side analytics are only collected when the [Stream Player](/stream/viewin
 | `deviceOs`          | Device operating system                                           |
 | `deviceType`        | Device type                                                       |
 
-Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, see [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
+Some filters, like `date`, can be used with operators, such as `gt` (greater than) and `lt` (less than), as shown in the example query below. For more advanced filtering options, refer to [filtering](https://developers.cloudflare.com/analytics/graphql-api/features/filtering/).
 
 ### Metrics
 

--- a/content/stream/getting-analytics/fetching-bulk-analytics.md
+++ b/content/stream/getting-analytics/fetching-bulk-analytics.md
@@ -38,7 +38,6 @@ Some filters, like `date`, can be used with operators, such as `gt` (greater tha
 | Node                                | Field           | Description                                |
 | ----------------------------------- | --------------- | ------------------------------------------ |
 | `streamMinutesViewedAdaptiveGroups` | `minutesViewed` | Minutes of video delivered                 |
-| `streamMinutesViewedAdaptiveGroups` | `count`         | Number of times video playback has started |
 
 ### Example
 

--- a/content/stream/getting-analytics/fetching-per-video-analytics.md
+++ b/content/stream/getting-analytics/fetching-per-video-analytics.md
@@ -4,7 +4,11 @@ title: Fetch per-video analytics
 weight: 3
 ---
 
-# Fetch per-video analytics
+# Fetch per-video analytics (deprecated)
+
+{{<Aside type="warning" header="This API is deprecated and will be removed on Feb 1, 2023">}}
+The [Stream GraphQL Analytics API](/stream/getting-analytics/fetching-bulk-analytics) provides the same functionality, with additional filters and metrics, as well as the ability to fetch data about mutliple videos in a single API request. Queries are faster, more reliable, and built on a shared analytics system that you can use across many Cloudflare products.
+{{</Aside>}}
 
 Cloudflare measures the following metrics for every video play:
 

--- a/content/stream/getting-analytics/live-viewer-count.md
+++ b/content/stream/getting-analytics/live-viewer-count.md
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how to
 title: Get live viewer counts
+weight: 2
 ---
 
 # Live viewer counts for third party players
@@ -14,5 +15,5 @@ https://customer-<CODE>.cloudflarestream.com/<INPUT_ID>/views
 Below is a response for a live video with several active viewers:
 
 ```json
-{"liveViewers": 113}
+{ "liveViewers": 113 }
 ```


### PR DESCRIPTION
- Updates and clarifies docs for the Stream GraphQL Analytics API
- Adds deprecation banner to per-video analytics API docs
- Explain example use cases for analytics on the main Analytics page
- Reorders sequence of pages in dropdown to make per-video analytics the last option in the list