### PR TITLE
[WAF] Small fix in rate limiting how-to instructions

### DIFF
--- a/content/waf/rate-limiting-rules/create-zone-dashboard.md
+++ b/content/waf/rate-limiting-rules/create-zone-dashboard.md
@@ -23,7 +23,7 @@ To create a new rate limiting rule:
 
 2. Navigate to **Security** > **WAF** > **Rate limiting rules**.
 
-3. In **Advanced rate limiting**, select **Create rate limiting rule**.
+3. Select **Create rate limiting rule**.
 
 4. In the page that displays, enter a descriptive name for the rule in **Rule name**.
 


### PR DESCRIPTION
The UI card name varies according to the customer's plan/subscriptions, so removing it for now.