### PR TITLE
[Cache] update zone_tag to zone_id to avoid confusion

### DIFF
--- a/content/cache/how-to/purge-cache.md
+++ b/content/cache/how-to/purge-cache.md
@@ -232,7 +232,7 @@ For a Cache Key based on device type, purge the asset by passing the `CF-Device-
 See the example API request below to purge all mobile assets on the root web page.
 
 ```bash
-    curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone_tag}/purge_cache"
+    curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache"
     -H "X-Auth-Email: user@example.com" -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41"
     -H "Content-Type: application/json" --data '{"files":[{"url":"http://my.website.com/","headers":{"CF-Device-Type":"mobile"}}]}'
 ```
@@ -242,7 +242,7 @@ See the example API request below to purge all mobile assets on the root web pag
 Purge resources for a location-based Cache Key by specifying the two-letter country code. Spain is used in the example below.
 
 ```bash
-    curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone_tag}/purge_cache"
+    curl -X POST "https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache"
     -H "X-Auth-Email: user@example.com"
     -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" -H "Content-Type: application/json" --data '{"files":[{"url":"http://my.website.com/", "headers":{"Cf-Ipcountry":"ES"}}]}'
 ```


### PR DESCRIPTION
Present, in [api.cloudflare.com](https://api.cloudflare.com/#origin-ca-list-certificates) doc [zone identifier tag](https://api.cloudflare.com/#origin-ca-list-certificates:~:text=Zone%20identifier%20tag.) was called `zone_id` but in [developers.cloudflare.com](https://developers.cloudflare.com/cache/how-to/purge-cache/) doc is `zone_tag`. This could be confuse others. Please fix it