### PR TITLE
[Docs] Update actions/checkout and actions/setup-node to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Compiles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - uses: peaceiris/actions-hugo@v2
@@ -40,8 +40,8 @@ jobs:
   #   name: Lint
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
   #       with:
   #         node-version: 16
   #     - name: (env) pnpm


### PR DESCRIPTION
We're getting the following warning in the workflow runs of the `ci.yml` workflow:
```
Node.js 12 actions are deprecated. 
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. 
Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2
```
([example](https://github.com/cloudflare/cloudflare-docs/actions/runs/3447036322))

We're still using `v2` of the `actions/checkout` and `actions/setup-node` actions and there's a `v3` with NodeJS 16 support. This PR updates the two actions to `v3`. We're already using `actions/checkout@v3` in the other two workflows: `issue.yml` and `pr.yml`.

For context, here are the changelogs for the two `v3` major versions:
https://github.com/actions/checkout/releases/tag/v3.0.0
https://github.com/actions/setup-node/releases/tag/v3.0.0 (with breaking changes that do not affect our `ci.yml` action)
