### PR TITLE
chore: use `path.Join` to avoid double slashes

### DIFF
--- a/layouts/shortcodes/type-link.html
+++ b/layouts/shortcodes/type-link.html
@@ -8,7 +8,7 @@
 {{- else if strings.HasPrefix $href "#" -}}
 <a href="{{ $href }}" class="DocsMarkdown--link">
 {{- else -}}
-{{ $url := printf "%s%s" $section $href }}
+{{ $url := path.Join $section $href }}
 <a href="{{ $url }}" class="DocsMarkdown--link">
 {{- end -}}
   <span class="DocsMarkdown--link-content">


### PR DESCRIPTION
In the shortcode for generating type links, `printf` is used, generating links like these: `http://localhost:1313/workers//runtime-apis/response`. Using `path.Join`, hugo handles the link generation/url massage `http://localhost:1313/workers/runtime-apis/response`.

(Example links taken from https://developers.cloudflare.com/workers/runtime-apis/cache)