### PR TITLE
Add link to cache rules

### DIFF
--- a/content/r2/data-access/public-buckets.md
+++ b/content/r2/data-access/public-buckets.md
@@ -21,7 +21,7 @@ To configure firewall rules, caching, access controls, or bot management for you
 
 ## Connect your bucket to a custom domain
 
-Domain access through a custom domain allows you to use features such as access management, Cache and bot management.
+Domain access through a custom domain allows you to use features such as access management, [Cache](../../cache/about/cache-rules/), and bot management.
 
 To connect a custom domain to your bucket:
 


### PR DESCRIPTION
Caching seems like an integral part for R2, and so, add a link to emphasize that. 

Perhaps, the R2 docs need a `Caching` section all on its own, but I am ill-placed to start one; and hence this PR, in its stead.