### PR TITLE
Remove asides about missing wrangler / UI support for Queues

### DIFF
--- a/content/queues/configuration.md
+++ b/content/queues/configuration.md
@@ -12,18 +12,6 @@ Cloudflare Queues can be configured using [Wrangler](/workers/wrangler/get-start
 
 Each Worker has a `wrangler.toml` configuration file that specifies environment variables, triggers, and resources, such as a Queue. Use the options below to configure your Queue.
 
-{{<Aside type="warning" header="Warning">}}
-
-Queues support is not yet available in a full Wrangler release. It will be soon, but in the meantime please instead install the `wrangler@queues` npm package by running `npm install -D wrangler@queues` within your project.
-
-{{</Aside>}}
-
-{{<Aside type="note">}}
-
-Queues are currently only configurable via [Wrangler](/workers/wrangler/get-started/). Support for configuring Queues in the dashboard will be coming soon.
-
-{{</Aside>}}
-
 {{<Aside type="note">}}
 
 Below are options for Queues, refer to the Wrangler documentation for a full reference of [`wrangler.toml`](/workers/wrangler/configuration/).


### PR DESCRIPTION
They're both now supported. Although there are still caveats -- the main one that comes to mind is support for queues in the preview service. I don't think that merits mention in such a prominent place but it would be something I'd document if we had a place we thought was good for mentioning beta limitations. I guess the "Limits" page, but that's more about limits on usage than things that don't work yet.