### PR TITLE
[Docs] Improved error message for highlight errors

### DIFF
--- a/bin/highlight.ts
+++ b/bin/highlight.ts
@@ -75,7 +75,7 @@ async function markdown(file: string): Promise<void> {
       inner = inner.replace(rgx, '');
     }
 
-    let html = highlight(inner, lang);
+    let html = highlight(inner, lang, file.substring(ROOTLEN));
 
     // prevent hugo from looking at "{{<" pattern
     output += "\n\n" + ' '.repeat(spaces?.length ?? 0) + '{{<raw>}}' + html.replace(/\{\{\</g, '{\\{<') + '{{</raw>}}';

--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -220,7 +220,7 @@ function normalize(tokens: (Token | string)[]) {
   return lines;
 }
 
-export function highlight(code: string, lang: string): string {
+export function highlight(code: string, lang: string, file: string): string {
   lang = langs[lang] || lang || 'txt';
   let grammar = Prism.languages[lang.toLowerCase()];
 
@@ -257,7 +257,15 @@ export function highlight(code: string, lang: string): string {
     }
   }
 
-  let highlights = new Set(JSON.parse(frontmatter.highlight || '[]').map((x: number) => x - 1));
+  let highlights: Set<number>;
+
+  try {
+    highlights = new Set(JSON.parse(frontmatter.highlight || '[]').map((x: number) => x - 1));
+  } catch (err) {
+    process.stderr.write(`[ERROR] ${file}\nSyntax highlighting error: You must specify the lines to highlight as an array (e.g., '[2]'). Found '${frontmatter.highlight}'.\n`);
+    // still throwing the original error because it could be something else
+    throw err;
+  }
 
   // tokenize & build custom string output
   let tokens = Prism.tokenize(code, grammar);


### PR DESCRIPTION
Example of new error message:
```
(...)
[SKIP] content/pub-sub/faq.md
[SKIP] content/pub-sub/_index.md
[ERROR] content/queues/get-started.md
Syntax highlighting error: You must specify the lines to highlight as an array (e.g., '[2]'). Found '4'.
TypeError: JSON.parse(...).map is not a function
    at highlight (file:///C:/docs/cloudflare-docs/bin/prism.config.ts:209:68)
    at markdown (file:///C:/docs/cloudflare-docs/bin/highlight.ts:58:16)
    at async Promise.all (index 3)
    at async walk (file:///C:/docs/cloudflare-docs/bin/highlight.ts:14:3)
    at async Promise.all (index 38)
    at async walk (file:///C:/docs/cloudflare-docs/bin/highlight.ts:14:3)
    at async file:///C:/docs/cloudflare-docs/bin/highlight.ts:76:3
error Command failed with exit code 1.
```