### PR TITLE
queues: add _index.md to learning/

### DIFF
--- a/content/queues/examples/_index.md
+++ b/content/queues/examples/_index.md
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 type: overview
 title: Examples
-weight: 4
+weight: 3
 meta:
   title: Cloudflare Queues - Examples
 layout: list

--- a/content/queues/learning/_index.md
+++ b/content/queues/learning/_index.md
@@ -1,0 +1,9 @@
+---
+title: Learning
+pcx_content_type: overview
+weight: 4
+---
+
+# Learning
+
+{{<directory-listing>}}


### PR DESCRIPTION
Forgot to add `_index.md` to `/learning` so it didn't show up in the sidebar.

cc/ @deadlypants1973 