### PR TITLE
Clarify dual purpose of background image resizing parameter

### DIFF
--- a/content/images/_partials/_supported-properties.md
+++ b/content/images/_partials/_supported-properties.md
@@ -25,7 +25,7 @@ cf: {image: {anim: false}}
 
 #### `background`
 
-Background color to add underneath the image. Applies only to images with transparency (for example, PNG). Accepts any CSS color, such as `#RRGGBB` and `rgba(…)`. Example:
+Background color to add underneath the image. Applies to images with transparency (for example, PNG) and images resized with `fit=pad`. Accepts any CSS color, such as `#RRGGBB` and `rgba(…)`. Example:
 
 ```js
 ---


### PR DESCRIPTION
I'd read through the docs several times looking for a way to fill empty areas of a resized/cropped image. I started by looking at `background` and gave up because it said it only applied to transparent images.