### PR TITLE
Corrected cloudflare development discord URL among multiple files

### DIFF
--- a/content/fundamentals/account-and-billing/non-contract-products.md
+++ b/content/fundamentals/account-and-billing/non-contract-products.md
@@ -26,7 +26,7 @@ To enable a non-contract service, use the **Dashboard link** in the following ta
 | Stream | [Stream dashboard](https://dash.cloudflare.com/?to=/:account/stream) | [Stream docs](/stream/) | [Stream community](https://community.cloudflare.com/tag/cloudflarestream) |
 | Waiting Room | [Waiting Room Room dashboard](https://dash.cloudflare.com/?to=/:account/:zone/traffic/waiting-rooms) | [Waiting Room docs](/waiting-room/) | [Waiting Room community](https://community.cloudflare.com/) |
 | Web3 | [Web3 dashboard](https://dash.cloudflare.com/?to=/:account/:zone/web3) | [Web3 docs](/web3/) | [Web3 discord](https://discord.com/channels/595317990191398933/1024792052313096192) |
-| Workers | [Workers dashboard](https://dash.cloudflare.com/?to=/:account/workers) | [Workers docs](/workers/) | [Workers discord](https://discord.com/channels/595317990191398933/779390076219686943) |
+| Workers | [Workers dashboard](https://dash.cloudflare.com/?to=/:account/workers) | [Workers docs](/workers/) | [Workers discord](https://discord.com/invite/cloudflaredev) |
 | Zero Trust | [Zero Trust dashboard](https://dash.teams.cloudflare.com/) | [Zero Trust docs](/cloudflare-one/) | [Zero Trust community](https://community.cloudflare.com/c/security/access/51) |
 
 Once you enable the product or feature, it will not be an officially contracted service until you purchase it. Cloudflare will reach out in case you have any questions or feedback, and provide you with a sales quote if you are enjoying the product.

--- a/data/d1.yml
+++ b/data/d1.yml
@@ -13,7 +13,7 @@ meta:
 
 resources:
   dashboard_link: https://dash.cloudflare.com/?to=/:account/workers
-  discord: https://discord.com/channels/595317990191398933/779390076219686943
+  discord: https://discord.com/invite/cloudflaredev
 
 externals:
   - title: Workers home

--- a/data/workers.yml
+++ b/data/workers.yml
@@ -17,7 +17,7 @@ resources:
   community: https://community.cloudflare.com/c/developers/workers/40
   dashboard_link: https://dash.cloudflare.com/?to=/:account/workers
   learning_center: https://www.cloudflare.com/learning/serverless/what-is-serverless/
-  discord: https://discord.com/channels/595317990191398933/779390076219686943
+  discord: https://discord.com/invite/cloudflaredev
 
 externals:
   - title: Workers home


### PR DESCRIPTION
The previous URL ([https://discord.com/channels/595317990191398933/779390076219686943](https://discord.com/channels/595317990191398933/779390076219686943)) has been corrected to [https://discord.com/invite/cloudflaredev](https://discord.com/invite/cloudflaredev) 

The former urlis a direct link to the #workers channel & the new url is the server invite.
The old link works if you're already a member of the server which was probably the cause of confusion.