### PR TITLE
Update cloudflared deployment example

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
+++ b/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
@@ -87,7 +87,7 @@ spec:
         - cloudflared
         - tunnel
         # In a k8s environment, the metrics server needs to listen outside the pod it runs on. 
-        # The address `0.0.0.0:2000` allows any pod in the namespace.
+        # The address 0.0.0.0:2000 allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
         - run

--- a/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
+++ b/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
@@ -86,12 +86,24 @@ spec:
       - command:
         - cloudflared
         - tunnel
+        # Metrics is a tunnel command and not a subcommand so it must come before the run command
+        - --metrics
+        - 0.0.0.0:2000
         - run
         args:
         - --token
         - <token value>
         image: cloudflare/cloudflared:latest
         name: cloudflared
+        livenessProbe:
+          httpGet:
+          # Cloudflared has a /ready endpoint which returns 200 if and only if
+          # it has an active connection to the edge.
+            path: /ready
+            port: 2000
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10
 ```
 This file will be deployed with the following command.
 ```sh

--- a/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
+++ b/content/cloudflare-one/connections/connect-apps/deployment-guides/kubernetes.md
@@ -86,7 +86,8 @@ spec:
       - command:
         - cloudflared
         - tunnel
-        # Metrics is a tunnel command and not a subcommand so it must come before the run command
+        # In a k8s environment, the metrics server needs to listen outside the pod it runs on. 
+        # The address `0.0.0.0:2000` allows any pod in the namespace.
         - --metrics
         - 0.0.0.0:2000
         - run


### PR DESCRIPTION
Aligning example with boiler plate at https://github.com/cloudflare/argo-tunnel-examples/blob/master/named-tunnel-k8s/cloudflared.yaml. Additional content now includes metric server and livinessProbe.