### PR TITLE
Pages Functions s/context.param/context.params/ ??

### DIFF
--- a/content/pages/platform/functions/api-reference.md
+++ b/content/pages/platform/functions/api-reference.md
@@ -67,7 +67,7 @@ The following are the properties on the context object which are passed through 
       Passes the request through to the next Function or to the asset server if no other Function is available. 
   
   - `env` [{{<type>}}EnvWithFetch{{</type>}}](#envwithfetch)
-  - `param` [{{<type>}}Params&lt;P&gt;{{</type>}}](#params)
+  - `params` [{{<type>}}Params&lt;P&gt;{{</type>}}](#params)
   - `data` [{{<type>}}Data{{</type>}}](#data)
   
 {{</definitions>}}


### PR DESCRIPTION
According to the Pages Functions [`EventContext` reference documentation](https://developers.cloudflare.com/pages/platform/functions/api-reference/#data), the parameter "values from the [dynamic routes](https://developers.cloudflare.com/pages/platform/functions/routing/#dynamic-routes)" are accessible at `context.param.<parameter>`. 

If I'm following correctly, then the following example should work: 

* Pages Function: `/functions/api/users/[user].js` 
* Request route: `/functions/api/users/janedoe` 
* EventContext param: `context.param.user` (value: `janedoe`)

In my testing I was unable to fetch valid dynamic route parameters at `context.param.user`, but I could fetch them at `context.params.user` (`s/param/params`). This also matches the `functions/user/[user].js` example provided in the [Dynamic Routes documentation](https://developers.cloudflare.com/pages/platform/functions/routing/#dynamic-routes).

Note: apologies in advance as it seems this PR might be against the contributing guidelines, which I didn't see until just before I hit submit. 🤦‍♂️ Looks like I should open an issue instead? No worries if y'all need to close this and cherry pick. It seemed like such a small change that I figured I'd just open a PR. Old habits die hard. 😅 

Thank you for Pages Functions! I'm having a lot of fun with them!! 🎉 