### PR TITLE
[Pages] Fix link to middleware in Headers

### DIFF
--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -11,7 +11,7 @@ To attach headers to Cloudflare Pages responses, create a `_headers` plain text 
 
 {{<Aside type="warning">}}
 
-Custom headers defined in the `_headers` file are not applied to responses from [Functions](/pages/platform/functions/), even if the Function route matches the URL pattern. If your Pages application uses Functions, you must migrate any behaviors from the `_headers` file to the `Response` object in the appropriate `/functions` route. When altering headers for multiple routes, you may be interested in [adding middleware](/pages/platform/functions/#adding-middleware) for shared behavior.
+Custom headers defined in the `_headers` file are not applied to responses from [Functions](/pages/platform/functions/), even if the Function route matches the URL pattern. If your Pages application uses Functions, you must migrate any behaviors from the `_headers` file to the `Response` object in the appropriate `/functions` route. When altering headers for multiple routes, you may be interested in [adding middleware](/pages/platform/functions/middleware/) for shared behavior.
 
 {{</Aside>}}
 


### PR DESCRIPTION
This is needed since #5015, because middleware now has its own page