### PR TITLE
IMAGES: support for customid in direct upload v2

### DIFF
--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -59,4 +59,4 @@ When [serving images](/images/cloudflare-images/serve-images), you can include n
 
 ## Custom IDs and private images
 
-Images with a [custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private using [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens).
+Images with a [custom ID](/images/cloudflare-images/upload-images/custom-id/) cannot be made private using [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens/).

--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -56,3 +56,7 @@ Refer to [Make your first API request](/images/cloudflare-images/api-request/) t
 ## Custom IDs in delivery URLs
 
 When [serving images](/images/cloudflare-images/serve-images), you can include non URL-encoded Custom IDs directly in the image URLs. However, any `%` characters present in Custom IDs must be encoded to `%25` in the image delivery URLs.
+
+## Custom IDs and Private Images
+
+Please note that images with a [Custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [Private Images](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature.

--- a/content/images/cloudflare-images/upload-images/custom-id.md
+++ b/content/images/cloudflare-images/upload-images/custom-id.md
@@ -57,6 +57,6 @@ Refer to [Make your first API request](/images/cloudflare-images/api-request/) t
 
 When [serving images](/images/cloudflare-images/serve-images), you can include non URL-encoded Custom IDs directly in the image URLs. However, any `%` characters present in Custom IDs must be encoded to `%25` in the image delivery URLs.
 
-## Custom IDs and Private Images
+## Custom IDs and private images
 
-Please note that images with a [Custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [Private Images](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature.
+Images with a [custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private using [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens).

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -35,7 +35,7 @@ You will receive a response similar to this:
 
 In the example above, `id` is a future image identifier that will be uploaded by a creator.
 
-A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](https://developers.cloudflare.com/api/operations/cloudflare-images-list-images), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
+A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](/api/operations/cloudflare-images-list-images), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
@@ -97,12 +97,12 @@ The expiry value must be a minimum of two minutes and maximum of six hours in th
 
 ## Direct Creator Upload with Custom ID
 
-You can specify a [Custom ID](/images/cloudflare-images/upload-images/custom-id) when first requesting a one-time upload URL, instead of using the automatically generated id for your image.
+You can specify a [custom ID](/images/cloudflare-images/upload-images/custom-id) when first requesting a one-time upload URL, instead of using the automatically generated ID for your image.
 
-To do so, pass a form field of name `id` with the corresponding Custom ID value to the cURL command:
+To do so, pass a form field of name `id` with the corresponding custom ID value to the cURL command:
 
 ```bash
 --form 'id=this/is/my-customid'
 ```
 
-Please note that images with a [Custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [Private Images](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature (`--requireSignedURLs=true`).
+Note that images with a [custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature (`--requireSignedURLs=true`).

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -6,9 +6,9 @@ weight: 2
 
 # Direct Creator Upload
 
-The Direct Creator Upload feature in Cloudflare Images lets your users upload pictures with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing [your API key or token](/images/cloudflare-images/api-request/) to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
+The Direct Creator Upload feature in Cloudflare Images lets your users upload images with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing [your API key or token](/images/cloudflare-images/api-request/) to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
 
-To request a one-time upload URL, call the [`direct_upload` endpoint](https://developers.cloudflare.com/api/operations/cloudflare-images-create-authenticated-direct-upload-url) in your back-end (or Worker script):
+To request a one-time upload URL, call the [`v2/direct_upload` endpoint](https://developers.cloudflare.com/api/operations/cloudflare-images-create-authenticated-direct-upload-url-v-2) in your back-end (or Worker script):
 
 ```bash
 curl --request POST \
@@ -24,7 +24,7 @@ You will receive a response similar to this:
 {
   "result": {
     "id": "2cdc28f0-017a-49c4-9ed7-87056c83901",
-    "uploadURL": "https://upload.imagedelivery.net/2cdc28f0-017a-49c4-9ed7-87056c83901"
+    "uploadURL": "https://upload.imagedelivery.net/Vi7wi5KSItxGFsWRG2Us6Q/2cdc28f0-017a-49c4-9ed7-87056c83901"
   },
   "result_info": null,
   "success": true,
@@ -35,13 +35,7 @@ You will receive a response similar to this:
 
 In the example above, `id` is a future image identifier that will be uploaded by a creator.
 
-{{<Aside type="note" header="Note">}}
-
-Previously, in version 1 of the `direct_upload` endpoint, the ID was an identifier of a request, not an image. Therefore, there was no way to know if an image had been really uploaded.
-
-{{</Aside>}}
-
-With version 2 of `direct_upload`, a new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](https://developers.cloudflare.com/api/operations/cloudflare-images-list-images), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
+A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](https://developers.cloudflare.com/api/operations/cloudflare-images-list-images), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
@@ -100,3 +94,15 @@ To override this option, add the following argument to the cURL command:
 ```
 
 The expiry value must be a minimum of two minutes and maximum of six hours in the future.
+
+## Direct Creator Upload with Custom ID
+
+You can specify a [Custom ID](/images/cloudflare-images/upload-images/custom-id) when first requesting a one-time upload URL, instead of using the automatically generated id for your image.
+
+To do so, pass a form field of name `id` with the corresponding Custom ID value to the cURL command:
+
+```bash
+--form 'id=this/is/my-customid'
+```
+
+Please note that images with a [Custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [Private Images](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature (`--requireSignedURLs=true`).

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -8,7 +8,7 @@ weight: 2
 
 The Direct Creator Upload feature in Cloudflare Images lets your users upload images with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing [your API key or token](/images/cloudflare-images/api-request/) to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
 
-To request a one-time upload URL, call the [`v2/direct_upload` endpoint](/api/operations/cloudflare-images-create-authenticated-direct-upload-url-v-2) in your back-end (or Worker script):
+To request a one-time upload URL, call the [`v2/direct_upload` endpoint](https://developers.cloudflare.com/api/operations/cloudflare-images-create-authenticated-direct-upload-url-v-2) in your back-end (or Worker script):
 
 ```bash
 curl --request POST \
@@ -35,7 +35,7 @@ You will receive a response similar to this:
 
 In the example above, `id` is a future image identifier that will be uploaded by a creator.
 
-A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](/api/operations/cloudflare-images-list-images/), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
+A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](https://developers.cloudflare.com/api/operations/cloudflare-images-list-images/), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \

--- a/content/images/cloudflare-images/upload-images/direct-creator-upload.md
+++ b/content/images/cloudflare-images/upload-images/direct-creator-upload.md
@@ -8,7 +8,7 @@ weight: 2
 
 The Direct Creator Upload feature in Cloudflare Images lets your users upload images with a one-time upload URL. By using Direct Creator Upload, you can accept uploads without exposing [your API key or token](/images/cloudflare-images/api-request/) to the client. It also eliminates the need for an intermediary storage bucket and the storage/egress costs associated with it.
 
-To request a one-time upload URL, call the [`v2/direct_upload` endpoint](https://developers.cloudflare.com/api/operations/cloudflare-images-create-authenticated-direct-upload-url-v-2) in your back-end (or Worker script):
+To request a one-time upload URL, call the [`v2/direct_upload` endpoint](/api/operations/cloudflare-images-create-authenticated-direct-upload-url-v-2) in your back-end (or Worker script):
 
 ```bash
 curl --request POST \
@@ -35,7 +35,7 @@ You will receive a response similar to this:
 
 In the example above, `id` is a future image identifier that will be uploaded by a creator.
 
-A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](/api/operations/cloudflare-images-list-images), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
+A new draft image record is created when you invoke this endpoint. It will not appear on a [list of images](/api/operations/cloudflare-images-list-images/), but  it is possible to fetch an image record with the provided ID to check its current status. In the example below, `<IMAGE_ID>` is the `id` received from the response when requesting a one-time upload URL with the `direct_upload` endpoint.
 
 ```bash
 curl  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1/<IMAGE_ID> \
@@ -97,7 +97,7 @@ The expiry value must be a minimum of two minutes and maximum of six hours in th
 
 ## Direct Creator Upload with Custom ID
 
-You can specify a [custom ID](/images/cloudflare-images/upload-images/custom-id) when first requesting a one-time upload URL, instead of using the automatically generated ID for your image.
+You can specify a [custom ID](/images/cloudflare-images/upload-images/custom-id/) when first requesting a one-time upload URL, instead of using the automatically generated ID for your image.
 
 To do so, pass a form field of name `id` with the corresponding custom ID value to the cURL command:
 
@@ -105,4 +105,4 @@ To do so, pass a form field of name `id` with the corresponding custom ID value 
 --form 'id=this/is/my-customid'
 ```
 
-Note that images with a [custom ID](/images/cloudflare-images/upload-images/custom-id) cannot be made private with the [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens) feature (`--requireSignedURLs=true`).
+Note that images with a [custom ID](/images/cloudflare-images/upload-images/custom-id/) cannot be made private with the [signed URL tokens](/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens/) feature (`--requireSignedURLs=true`).


### PR DESCRIPTION
* Document support for custom id in direct upload v2
* Remove documentation for direct upload v1 (deprecated and feature sunset)
