### PR TITLE
Broken link to Spectrum Community site

### DIFF
--- a/content/spectrum/get-started/index.md
+++ b/content/spectrum/get-started/index.md
@@ -213,4 +213,4 @@ curl -X POST 'https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/spectrum/apps
 
 You can now proxy traffic through Cloudflare without additional configuration. As you run traffic through Cloudflare, you will see the last minute of traffic from **Spectrum** in the dashboard.
 
-If you have any feedback, please [let us know](https://community.cloudflare.com/c/security/spectrum).
+If you have any feedback, please [let us know](https://community.cloudflare.com/c/website-application-performance/spectrum/48).

--- a/data/spectrum.yml
+++ b/data/spectrum.yml
@@ -12,9 +12,9 @@ meta:
   image: /core-services-preview.png
 
 resources:
-  community: https://community.cloudflare.com/c/security/spectrum/48
+  community: https://community.cloudflare.com/c/website-application-performance/spectrum/48
   dashboard_link: https://dash.cloudflare.com/?to=/:account/:zone/spectrum
-  
+
 externals:
   - title: Cloudflare homepage
     url: https://cloudflare.com


### PR DESCRIPTION
Moved URL to https://community.cloudflare.com/c/website-application-performance/spectrum/48
was: https://community.cloudflare.com/c/security/spectrum