### PR TITLE
Queues: now in open beta

### DIFF
--- a/content/queues/_index.md
+++ b/content/queues/_index.md
@@ -13,7 +13,7 @@ Cloudflare Queues allows developers to send and receive messages with guaranteed
 
 {{<Aside>}}
 
-Cloudflare Queues is now in open Beta. Join the [`#queues-beta`](https://discord.gg/rrZXVVcKQF) channel in our Developer Discord to learn more.
+[Cloudflare Queues is now in open Beta](https://blog.cloudflare.com/cloudflare-queues-open-beta/). Join the [`#queues-beta`](https://discord.gg/rrZXVVcKQF) channel in our Developer Discord to learn more.
 
 {{</Aside>}}
 

--- a/content/queues/_index.md
+++ b/content/queues/_index.md
@@ -13,7 +13,7 @@ Cloudflare Queues allows developers to send and receive messages with guaranteed
 
 {{<Aside>}}
 
-Cloudflare Queues is in private Beta. [Register](https://www.cloudflare.com/lp/queues) to get on the waitlist or join the [`#queues-beta`](https://discord.gg/rrZXVVcKQF) channel in our Developer Discord to learn more.
+Cloudflare Queues is now in open Beta. Join the [`#queues-beta`](https://discord.gg/rrZXVVcKQF) channel in our Developer Discord to learn more.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Queues is now in open beta (https://blog.cloudflare.com/cloudflare-queues-open-beta/); this PR updates this info in the doc.