### PR TITLE
Update terraform.md to include region for when using aws/s3 tf provider

### DIFF
--- a/content/r2/examples/terraform.md
+++ b/content/r2/examples/terraform.md
@@ -21,6 +21,7 @@ terraform {
 }
 
 provider "aws" {
+  region     = "us-east-1" 
   access_key = <R2 Access Key>
   secret_key = <R2 Secret Key>
   skip_credentials_validation = true


### PR DESCRIPTION
- us-east-1 region is needed in order for the aws-terraform provider to work gracefully.  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3control_multi_region_access_point
- Not setting a region results in terraform asking to set to "auto" region and that causes continuous attempts to `ec2.auto.amazonaws.com` 

```
caused by: Post "https://ec2.auto.amazonaws.com/": dial tcp: lookup ec2.auto.amazonaws.com on 192.168.112.1:53: no such host: timestamp=2022-11-24T14:19:35.482Z
```