### PR TITLE
fix: detect invalid range requests correctly

### DIFF
--- a/content/r2/examples/demo-worker.md
+++ b/content/r2/examples/demo-worker.md
@@ -18,7 +18,7 @@ function parseRange(encoded: string | null): undefined | { offset: number, end: 
     return
   }
 
-  const parts = encoded.split("bytes=")[1]?.split("-") ?? []
+  const parts = encoded.split("bytes=")[1]?.split("-").filter(Boolean) ?? []
   if (parts.length !== 2) {
     throw new Error('Not supported to skip specifying the beginning/ending byte at this time')
   }


### PR DESCRIPTION
When making a range request, chrome can send a request with only a beginning point (eg: `0-`, note that there's no "end" byte). In the code for the sample R2 worker, we spit the string and check the length; however, splitting this string generates 2 parts anyway ['0', '']. We need to remove empty strings from the array before testing it's length. Hence the proposed fix to filter with a `Boolean` predicate, which removes empty strings.