### PR TITLE
[Rules] Fix custom error response example

### DIFF
--- a/content/rules/custom-error-responses/create-api.md
+++ b/content/rules/custom-error-responses/create-api.md
@@ -90,7 +90,7 @@ Note that this `PUT` request, corresponding to the [Update zone entry point rule
 
 ### Custom HTML response with updated status code
 
-This example configures a custom HTML error response for origin responses with a `500` HTTP status code, and redefines the response status code to `503`.
+This example configures a custom HTML error response for responses with a `500` HTTP status code, and redefines the response status code to `503`.
 
 ```json
 $ curl -X PUT \
@@ -103,11 +103,11 @@ $ curl -X PUT \
       "action": "serve_error",
       "action_parameters": {
         "content": "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Application unavailable</title></head><body><h1>Application temporarily unavailable</h1><p>Please try again later.</p></body></html>",
-        "content_type": "text/html"
+        "content_type": "text/html",
+        "status_code": 503
       },
       "expression": "http.response.code eq 500",
-      "enabled": true,
-      "status_code": 503
+      "enabled": true
     }
   ]
 }'

--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -1138,7 +1138,7 @@ The Cloudflare Rules language supports these HTTP response fields:
    <tr id="field-http-response-code">
       <td valign="top"><code>http.response.code</code><br />{{<type>}}Integer{{</type>}}</td>
       <td>
-         <p>Represents the HTTP status code returned by the origin.
+         <p>Represents the HTTP status code returned to the client, either set by a Cloudflare product or returned by the origin server.
          </p>
          <p>Example value:
          <br /><code class="InlineCode">403</code>


### PR DESCRIPTION
Also updates the `http.response.code` field description in the Fields reference page (related to PSPEC-1466).

Reported via internal chat.