### PR TITLE
Fix required modes improperly set to "WARP with Gateway"

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/exclude-traffic/local-domains.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/exclude-traffic/local-domains.md
@@ -12,7 +12,7 @@ weight: 6
 
 | Operating Systems | [WARP mode required](/cloudflare-one/connections/connect-devices/warp/#warp-client-modes) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
 | ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| All systems       | WARP with Gateway                                                                         | All plans                                                     |
+| All systems       | Any mode                                                                         | All plans                                                     |
 
 </div>
 </details>

--- a/content/cloudflare-one/connections/connect-devices/warp/warp-settings.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/warp-settings.md
@@ -73,7 +73,7 @@ Cloudflare Zero Trust allows you to establish which users in your organization c
 
 | Operating Systems | [WARP mode required](/cloudflare-one/connections/connect-devices/warp/#warp-client-modes) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
 | ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| All systems    | WARP with Gateway                                                                         | All plans                                                     |
+| All systems    | Any mode                                                                         | All plans                                                     |
 
 </div>
 </details>
@@ -90,7 +90,7 @@ When the toggle is enabled, the WARP client will automatically turn off when it 
 
 | Operating Systems     | [WARP mode required](/cloudflare-one/connections/connect-devices/warp/#warp-client-modes) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
 | --------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| All systems | WARP with Gateway                                                                         | All plans                                                     |
+| All systems | Any mode                                                                         | All plans                                                     |
 
 </div>
 </details>


### PR DESCRIPTION
Local Domain Fallback works in either WARP with Gateway or WARP with DoH modes. In either case, the local DNS server can change where the DNS lookups are sent.

You can mode switch no matter which mode you are in

We do captive portal detection in both modes