### PR TITLE
queues: clearer activation note

### DIFF
--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -20,7 +20,7 @@ Queues is currently in [Public Beta](https://blog.cloudflare.com/cloudflare-queu
 
 {{<Aside type="note">}}
 
-Before you can use Queues for the first time, you **must** enable it via [the dashboard](https://dash.cloudflare.com/?to=/:account/workers/queues). You need a Paid Workers plan to enable Queues.
+Before you can use Queues, you must enable it via [the Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/queues). You need a Paid Workers plan to enable Queues.
 
 {{</Aside>}}
 

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -16,7 +16,15 @@ In order to use Queues, you need a [Cloudflare account](/fundamentals/account-an
 
 ## 1. Enable Queues
 
-Queues is in [Public Beta](https://blog.cloudflare.com/cloudflare-queues-open-beta/). You need a Paid Workers plan to enable Queues. To enable Queues:
+Queues is currently in [Public Beta](https://blog.cloudflare.com/cloudflare-queues-open-beta/).
+
+{{<Aside type="note">}}
+
+Before you can use Queues for the first time, you **must** enable it via [the dashboard](https://dash.cloudflare.com/?to=/:account/workers/queues). You need a Paid Workers plan to enable Queues.
+
+{{</Aside>}}
+
+To enable Queues:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
 2. Go to **Workers** > [**Queues**](https://dash.cloudflare.com/?to=/:account/workers/queues).


### PR DESCRIPTION
Make it clearer than the 'first time' setup requires a visit to the dashboard.