### PR TITLE
[turnstile] document `refresh-expired`

### DIFF
--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -143,6 +143,7 @@ Once a widget is no longer needed, it can be removed from the page using `turnst
 | `size` | `data-size` | The widget size. Can take the following values: `normal`, `compact`. |
 | `retry` | `data-retry` | Controls whether the widget should automatically retry to obtain a token if it did not succeed. The default is `auto`, which will retry automatically. This can be set to `never` to disable retry upon failure. |
 | `retry-interval` | `data-retry-interval` | When `retry` is set to `auto`, `retry-interval` controls the time between retry attempts in milliseconds. Value must be a positive integer less than `900000`, defaults to `8000`. |
+| `refresh-expired` | `data-refresh-expired` | Automatically refreshes the token when it expires. Can take `auto`, `manual` or `never`, defaults to `auto`. |
 
 ## Widget size
 


### PR DESCRIPTION
This is live in staging and production.

- `auto` will automatically refresh the widget
- `manual` will show a button to refresh the widget
- `never` will continue showing the "Verified" text forever