### PR TITLE
[Analytics Engine] Document new time-related SQL features

### DIFF
--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -47,7 +47,7 @@ SELECT <expression_list>
 [FROM <table>|(<subquery>)]
 [WHERE <expression>]
 [GROUP BY <expression>, ...]
-[ORDER BY <expression_list>] 
+[ORDER BY <expression_list>]
 [LIMIT <n>|ALL]
 [FORMAT <format>]
 ```
@@ -74,13 +74,13 @@ SELECT *
 
 -- alias columns to more descriptive names
 SELECT
-    blob2 AS probe_name, 
-    double3 AS temperature 
+    blob2 AS probe_name,
+    double3 AS temperature
 ```
 
 Additionally, expressions using supported [functions](#supported-functions) and [operators](#supported-operators) can be used in place of column names:
 ```SQL
-SELECT 
+SELECT
     blob2 AS probe_name,
     double3 AS temp_c,
     double3*1.8+32 AS temp_f -- compute a value
@@ -106,11 +106,11 @@ FROM <table_name>|(subquery)
 Examples:
 ```SQL
 -- query data written to a workers dataset called "temperatures"
-FROM temperatures  
+FROM temperatures
 
 -- use a subquery to manipulate the table
 FROM (
-    SELECT 
+    SELECT
         blob1 AS probe_name,
         count() as num_readings
     FROM
@@ -166,8 +166,8 @@ GROUP BY <expression>, ...
 For example. If you had a table of temperature readings:
 ```SQL
 -- return the average temperature for each probe
-SELECT 
-    blob1 AS probe_name, 
+SELECT
+    blob1 AS probe_name,
     avg(double1) AS average_temp
 FROM temperature_readings
 GROUP BY probe_name
@@ -185,7 +185,7 @@ Usage:
 ORDER BY <expression> [ASC|DESC], ...
 ```
 
-`<expression>` can just be a column name. 
+`<expression>` can just be a column name.
 
 `ASC` or `DESC` determines if the ordering is ascending or descending. `ASC` is the default, and can be omitted.
 
@@ -379,7 +379,7 @@ max(item_cost)
 
 Usage:
 ```SQL
-quantileWeighted(q, column_name, weight_column_name) 
+quantileWeighted(q, column_name, weight_column_name)
 ```
 
 `quantileWeighted` is an aggregation function that returns the value at the q<sup>th</sup> quantile in the named column across all rows in each group or results set. Each row will be weighted by the value in `weight_column_name`. Typically this would be `_sample_interval` (refer to [how sampling works](../sql-api/#sampling), for more information).
@@ -387,7 +387,7 @@ quantileWeighted(q, column_name, weight_column_name)
 Example:
 ```SQL
 -- estimate the median value of <double1>
-quantileWeighted(0.5, double1, _sample_interval) 
+quantileWeighted(0.5, double1, _sample_interval)
 
 -- in a table of query times, estimate the 95th centile query time
 quantileWeighted(0.95, query_time, _sample_interval)
@@ -537,7 +537,7 @@ SELECT position(':' IN blob1) AS p FROM your_dataset;
 
 Usage:
 ```SQL
-substring({string}, {offset:integer}[. {length:integer}]) 
+substring({string}, {offset:integer}[. {length:integer}])
 ```
 
 Extracts part of a string, starting at the Unicode code point indicated by the offset and returning the number of code points requested by the length. As previously mentioned, in SQL, indexes are usually 1-based. That means that the offset provided to substring should be at least `1`.

--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -679,7 +679,7 @@ extract(<time unit> from <datetime>)
 Examples:
 ```SQL
 -- extract the number of seconds from a timestamp (returns 15 in this example)
-extract(SECOND from toDateTime('2022-06-06 11:15:15'))
+extract(SECOND from toDateTime('2022-06-06 11:30:15'))
 ```
 
 ## Supported operators

--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -8,7 +8,7 @@ meta:
 
 # Workers Analytics Engine SQL Reference
 
-## `SHOW TABLES` statement
+## SHOW TABLES statement
 
 `SHOW TABLES` can be used to list the tables on your account. The table name is the name you specified as `dataset` when configuring the workers binding (refer to [Get started with Workers Analytics Engine](../get-started/#1-configure-your-dataset-and-binding-in-wrangler), for more information). The table is automatically created when you write event data in your worker.
 
@@ -19,7 +19,7 @@ SHOW TABLES
 
 Refer to [FORMAT clause](#format-clause) for the available `FORMAT` options.
 
-## `SHOW TIMEZONES` statement
+## SHOW TIMEZONES statement
 
 `SHOW TIMEZONES` can be used to list all of the timezones supported by the SQL API. Most common timezones are supported.
 
@@ -28,7 +28,7 @@ SHOW TIMEZONES
 [FORMAT <format>]
 ```
 
-## `SHOW TIMEZONE` statement
+## SHOW TIMEZONE statement
 
 `SHOW TIMEZONE` responds with the current default timezone in use by SQL API. This should always be `Etc/UTC`.
 
@@ -568,10 +568,10 @@ See also: [formatDateTime](#formatDateTime)
 
 Usage:
 ```SQL
-toDateTime(<expression>)
+toDateTime(<expression>[, 'timezone string'])
 ```
 
-`toDateTime` converts an expression to a datetime.
+`toDateTime` converts an expression to a datetime. This function does not support ISO 8601-style timezones; if your time is not in UTC then you must provide the timezone using the second optional argument.
 
 Examples:
 ```SQL
@@ -585,6 +585,9 @@ toDateTime(blob1)
 toDateTime(355924804) -- unix timestamp
 toDateTime('355924804') -- string containing unix timestamp
 toDateTime('1981-04-12 12:00:04') -- string with datetime in 'YYYY-MM-DD hh:mm:ss' format
+
+-- interpret a date relative to New York time
+toDateTime('2022-12-01 16:17:00', 'America/New_York')
 ```
 
 ### now
@@ -595,24 +598,6 @@ now()
 ```
 
 Returns the current time as a DateTime.
-
-### toDateTime
-
-Usage:
-```SQL
-toDateTime('<a date string>'[, 'timezone string'])
-```
-
-`toDateTime` converts either an integer or string into a `DateTime`. Integers will be interpreted as Unix timestamps. Strings should be in `YYYY-MM-DD HH:MM:SS` format. This function does not support ISO 8601-style timezones in strings, instead you must provide the timezone using the second optional argument.
-
-Examples:
-```SQL
--- intepret a date in the default timezone (UTC)
-toDateTime('2022-12-01 16:17:00')
-
--- interpret a date relative to New York time
-toDateTime('2022-12-01 16:17:00', 'America/New_York')
-```
 
 ### toUnixTimestamp
 
@@ -636,7 +621,9 @@ Usage:
 formatDateTime(<datetime expression>, <format string>[, <timezone string>])
 ```
 
-`formatDateTime` prints a datetime as a string according to a provided format string. The format
+`formatDateTime` prints a datetime as a string according to a provided format string. See
+[ClickHouse's docs](https://clickhouse.com/docs/en/sql-reference/functions/date-time-functions/#formatdatetime)
+for a list of supported formatting options.
 
 Examples:
 ```SQL

--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -562,7 +562,7 @@ Examples:
 SELECT format('blob1: {}', blob1) AS s FROM dataset;
 ```
 
-See also: [formatDateTime](#formatDateTime)
+See also: [formatDateTime](#formatdatetime)
 
 ### toDateTime
 


### PR DESCRIPTION
This PR adds documentation for a variety of new time-related SQL features in Analytics Engine. They're already live but mostly unannounced until this PR is merged.

New show statements:
  - `SHOW TIMEZONE`
  - `SHOW TIMEZONES`

New comparison operators:
  - `BETWEEN`

New functions:
  - `formatDateTime`
  - `toUnixTimestamp`
  - `toStartOfInterval`
  - `extract`