### PR TITLE
[Wrangler] update route override warning and link to deprecation guide.

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -643,6 +643,6 @@ It is a recommended best practice to treat `wrangler.toml` as a source of truth 
 
 If you change your environment variables in the Cloudflare dashboard, Wrangler will override them the next time you deploy. If you want to disable this behavior, add `keep_vars = true` to your `wrangler.toml`.
 
-If you change your routes in the dashboard, Wrangler will override them in the next deploy with the routes you have set in your `wrangler.toml`. Currently, there is no way to disable this behaviour.
+If you change your routes in the dashboard, Wrangler will override them in the next deploy with the routes you have set in your `wrangler.toml`. To manage routes via the Cloudflare dashboard only, remove any route and routes keys from and add workers_dev = false to your wrangler.toml file. For more information, view the Wrangler v1 [deprecation guide](/workers/wrangler/migration/deprecations/#other-deprecated-behaviour).
 
 Note that Wrangler will not delete your secrets (encrypted environment variables) unless you run `wrangler secret delete <key>`.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -643,6 +643,6 @@ It is a recommended best practice to treat `wrangler.toml` as a source of truth 
 
 If you change your environment variables in the Cloudflare dashboard, Wrangler will override them the next time you deploy. If you want to disable this behavior, add `keep_vars = true` to your `wrangler.toml`.
 
-If you change your routes in the dashboard, Wrangler will override them in the next deploy with the routes you have set in your `wrangler.toml`. To manage routes via the Cloudflare dashboard only, remove any route and routes keys from and add workers_dev = false to your wrangler.toml file. For more information, view the Wrangler v1 [deprecation guide](/workers/wrangler/migration/deprecations/#other-deprecated-behaviour).
+If you change your routes in the dashboard, Wrangler will override them in the next deploy with the routes you have set in your `wrangler.toml`. To manage routes via the Cloudflare dashboard only, remove any route and routes keys from your `wrangler.toml` file. Then add `workers_dev = false` to your `wrangler.toml` file. For more information, refer to the Wrangler 1 [deprecation guide](/workers/wrangler/migration/deprecations/#other-deprecated-behaviour).
 
 Note that Wrangler will not delete your secrets (encrypted environment variables) unless you run `wrangler secret delete <key>`.


### PR DESCRIPTION
This removes a line indicating that there was no solution to disable overriding routes with the current solution and a link to the v1 deprecation guide.

Fixes #6862  