### PR TITLE
MFW-1026: Add how-to doc using Logpush with IDS

### DIFF
--- a/content/magic-firewall/how-to/use-logpush-with-ids.md
+++ b/content/magic-firewall/how-to/use-logpush-with-ids.md
@@ -1,0 +1,19 @@
+---
+title: Use Logpush with IDS
+---
+
+# Configure a Logpush Destination
+
+First consult the [Logpush Destination docs](/logs/get-started/api-configuration#destination) to see what destinations logpush supports. After picking a destination, the docs will also show how to correctly format the destination URL for Logpush.
+
+Next, follow the [Manage Lopush with cURL](/logs/tutorials/examples/example-logpush-curl) tutorial to validate your Logpush destination and define a Logpush job. 
+
+A few notes on using Logpush with IDS:
+
+- Magic IDS is an account-scoped dataset. This means the string `/zone/<ZONE_ID>` in the Cloudflare API URLs in the tutorial should be replaced with `/account/<ACCOUNT_ID>`.
+
+- Consult the [Magic IDS Detection fields doc](/logs/reference/log-fields/account/magic_ids_detections) to know what fields you want configured for the job.
+
+- When creating the Logpush job, the dataset field should equal `magic_ids_detections`.
+
+- Timestamps by default are unixnano. Consult the [Logpush Options docs](/logs/get-started/api-configuration#options) to see what format you can choose that will be compatible with your destination and/or expectations. Note that all options must be added *after* all fields you want from the Logpush job, akin to URL parameters.


### PR DESCRIPTION
Add a guide for how to use Logpush with Magic IDS. Mostly referencing the source Logpush documentation while adding details specific to using with Magic IDS.