### PR TITLE
[Workers] fix parameter link for environment variables

### DIFF
--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -9,7 +9,7 @@ In the Workers platform, environment variables, secrets, and KV namespaces are k
 
 ## Environmental variables with module workers
 
-When deploying a Module Worker, any [bindings](/workers/platform/environment-variables/) will not be available as global runtime variables. Instead, they are passed to the handler as a [parameter](#parameters) – refer to the `FetchEvent` [documentation for further comparisons and examples](/workers/runtime-apis/fetch-event/#bindings-1).
+When deploying a Module Worker, any [bindings](/workers/platform/environment-variables/) will not be available as global runtime variables. Instead, they are passed to the handler as a [parameter](/workers/runtime-apis/fetch-event/#parameters) – refer to the `FetchEvent` [documentation for further comparisons and examples](/workers/runtime-apis/fetch-event/#bindings-1).
 
 ## Environment variables via wrangler
 


### PR DESCRIPTION
This simply fixes the parameter link for access environment variables within module workers.