### PR TITLE
Update nameservers.md

### DIFF
--- a/content/dns/zone-setups/troubleshooting/nameservers.md
+++ b/content/dns/zone-setups/troubleshooting/nameservers.md
@@ -23,7 +23,3 @@ If the nameservers in your registrar do not exactly match those provided by Clou
 ## Are additional nameservers listed at your registrar?
 
 You should have only Cloudflare nameservers listed at your registrar.
-
-## Are you using a European registrar?
-
-Certain European registrars have a different nameserver registration process. Contact [Cloudflare support](https://support.cloudflare.com/hc/articles/200172476) if you experience issues.


### PR DESCRIPTION
Previously this guidance was necessary because of a catch-22 situation whereby they cannot set the nameservers at the registrar because the registrar detects the lack of a proper SOA response.

However, now this issue is no longer present - since we now respond with the Start of Authority (SOA) record on the correct set of nameservers for the pending domain. Therefore we should remove this section entirely.