### PR TITLE
[Partners] Documents API for Tenant details, updates other APIs

### DIFF
--- a/content/tenant/_partials/_create-account.md
+++ b/content/tenant/_partials/_create-account.md
@@ -10,12 +10,18 @@ _build:
 To create an account, make a `POST` request to the `/accounts` endpoint and include the following values:
 
 - `name` {{<type>}}string{{</type>}}
-    
+
     - The name of the account that is displayed in the Cloudflare dashboard.
 
 - `type` {{<type>}}enum{{</type>}}
 
     - Valid values are `standard` (default) and `enterprise`. For self-serve customers, use `standard`. For enterprise customers, use `enterprise`.
+
+- `unit` {{<type>}}object{{</type>}}
+    - Information related to the tenant unit
+
+    - `id` {{<type>}}string{{</type>}}
+        - (optional) ID of the unit to create this account on. Needs to be specified if user administers multiple tenants. Unit ID is the `unit_tag` from your [tenant details](/tenant/how-to/get-tenant-details/).
 
 {{</definitions>}}
 
@@ -27,8 +33,8 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts' \
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
 -H 'x-auth-key: <API_KEY>' \
--d '{ 
-    "name": "<ACCOUNT_NAME>", 
+-d '{
+    "name": "<ACCOUNT_NAME>",
     "type": "standard"
     }'
 ```
@@ -52,4 +58,23 @@ header: Response
   "errors": [],
   "messages": []
 }
+```
+
+A request with a unit ID:
+
+```bash
+---
+header: Request
+---
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts' \
+-H 'Content-Type: application/json' \
+-H 'x-auth-email: <EMAIL>' \
+-H 'x-auth-key: <API_KEY>' \
+-d '{
+    "name": "<ACCOUNT_NAME>",
+    "type": "standard",
+    "unit": {
+      "id": "1a2b3c4d5e6f7g8h",
+    }
+    }'
 ```

--- a/content/tenant/_partials/_create-zone-subscription.md
+++ b/content/tenant/_partials/_create-zone-subscription.md
@@ -10,7 +10,7 @@ _build:
 To create a zone subscription, send a [POST](https://developers.cloudflare.com/api/operations/zone-subscription-create-zone-subscription) request to the `/zones/<ZONE_ID>/subscription` endpoint and include the following values:
 
 - `rate_plan` {{<type>}}object{{</type>}}
-    
+
     - Contains the zone plan corresponding to what customers would order in the dashboard. For a list of available values, refer to [Zone subscriptions](/tenant/reference/subscriptions/#zone-plans/).
 
 - `component_values` {{<type>}}array{{</type>}}
@@ -48,8 +48,8 @@ curl -X POST 'https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/subscription'
     },
     "component_values":[
         {
-        "name":"dedicated_certificates_custom",
-        "value":1
+        "name": "page_rules",
+        "value": 50
         }
     ]
 }

--- a/content/tenant/_partials/_tenant-details-preamble.md
+++ b/content/tenant/_partials/_tenant-details-preamble.md
@@ -1,0 +1,8 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+A [**Tenant Admin**](/tenant/glossary/#tenant-admin)'s unit and membership details will be used for access of resources and all Tenant operations on the API. The unit ID (`unit_tag`), for example, can be used to create an account on a specific unit. This is especially useful when a Tenant Admin has multiple units and wants to create an account on a specific unit. All accounts created are associated with with the units, each of which can have one or more memberships.

--- a/content/tenant/_partials/_tenant-details-preamble.md
+++ b/content/tenant/_partials/_tenant-details-preamble.md
@@ -5,4 +5,6 @@ _build:
   list: never
 ---
 
-A [**Tenant Admin**](/tenant/glossary/#tenant-admin)'s unit and membership details will be used for access of resources and all Tenant operations on the API. The unit ID (`unit_tag`), for example, can be used to create an account on a specific unit. This is especially useful when a Tenant Admin has multiple units and wants to create an account on a specific unit. All accounts created are associated with with the units, each of which can have one or more memberships.
+A [**Tenant Admin**](/tenant/glossary/#tenant-admin)'s unit and membership details will be used for access of resources and all Tenant operations on the API. The unit ID (`unit_tag`), for example, can be used to create an account on a specific unit. 
+
+This is especially useful when a Tenant Admin has multiple units and wants to create an account on a specific unit. All accounts created are associated with the units, each of which can have one or more memberships.

--- a/content/tenant/_partials/_tenant-details.md
+++ b/content/tenant/_partials/_tenant-details.md
@@ -1,0 +1,25 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<definitions>}}
+
+To retreive tenant details, send a `GET` request to the `/user/tenants` endpoint:
+
+{{</definitions>}}
+
+```bash
+---
+header: Request
+---
+curl -X GET 'https://api.cloudflare.com/client/v4/user/tenants' \
+-H 'Content-Type: application/json' \
+-H 'x-auth-email: <EMAIL>' \
+-H 'x-auth-key: <API_KEY>' \
+```
+
+
+A successful request will return an HTTP status of `200` and a response body containing tenant information, unit information, memberships and tenant entitlements for all tenants administered by the user.

--- a/content/tenant/_partials/_tenant-details.md
+++ b/content/tenant/_partials/_tenant-details.md
@@ -22,4 +22,4 @@ curl -X GET 'https://api.cloudflare.com/client/v4/user/tenants' \
 ```
 
 
-A successful request will return an HTTP status of `200` and a response body containing tenant information, unit information, memberships and tenant entitlements for all tenants administered by the user.
+A successful request will return an HTTP status of `200` and a response body containing tenant information, unit information, memberships, and tenant entitlements for all tenants administered by the user.

--- a/content/tenant/_partials/_tenant-details.md
+++ b/content/tenant/_partials/_tenant-details.md
@@ -21,5 +21,4 @@ curl -X GET 'https://api.cloudflare.com/client/v4/user/tenants' \
 -H 'x-auth-key: <API_KEY>' \
 ```
 
-
 A successful request will return an HTTP status of `200` and a response body containing tenant information, unit information, memberships, and tenant entitlements for all tenants administered by the user.

--- a/content/tenant/how-to/get-tenant-details.md
+++ b/content/tenant/how-to/get-tenant-details.md
@@ -1,0 +1,11 @@
+---
+pcx_content_type: how-to
+title: Get tenant details
+weight: 5
+---
+
+# Get tenant details
+
+{{<render file="_tenant-details-preamble.md">}}
+
+{{<render file="_tenant-details.md">}}


### PR DESCRIPTION
Updates `Manage Accounts` and `Manage Subscriptions`:

 - Create Account needs `unit_id`
 - Manage Subscription had deprecated `component_values` in example call
 
Adds `Get Tenant Details`
