### PR TITLE
[Search] Css bug

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4314,7 +4314,6 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   .DocsSearch--input-wrapper:focus-within {
     --highlight-opacity: 0.2;
     background-color: rgba(var(--orange-rgb), var(--highlight-opacity));
-    color: black;
   }
 
   .DocsSearch--input:focus::-webkit-input-placeholder {


### PR DESCRIPTION
Fixes issue with #6979, which is that I accidentally added a property override the dark mode colors when the search box is highlighted.

Current behavior (https://developers.cloudflare.com/analytics/)
<img width="1325" alt="Screenshot 2022-12-12 at 11 46 52 AM" src="https://user-images.githubusercontent.com/26727299/207128869-e61fa88c-f720-486b-abe4-55243e6d028a.png">

Updated behavior (https://searchbox-dark-fix.cloudflare-docs-7ou.pages.dev/analytics/)
<img width="1325" alt="Screenshot 2022-12-12 at 11 48 24 AM" src="https://user-images.githubusercontent.com/26727299/207129138-d4924114-19b5-44bd-920a-604659468eed.png">
