### PR TITLE
Increase queues per account limit from 10 to 100

### DIFF
--- a/content/queues/limits.md
+++ b/content/queues/limits.md
@@ -18,7 +18,7 @@ Many of these limits will increase during the Public Beta of Queues. If you have
 
 | Feature                                 | Limit                             |
 | --------------------------------------- | --------------------------------- |
-| Queues                                  | 10 per account                    |
+| Queues                                  | 100 per account                    |
 | Maximum message size                    | 128 KB                            |
 | Maximum message retries                 | 100                               |
 | Maximum batch size                      | 100 messages                      |


### PR DESCRIPTION
I don't know if we have any good place to announce changes like this (e.g. a changelog), but if so we should put it there too because otherwise nobody's going to notice this. If nothing else, we could always put it in the Discord and possibly the weekly Workers release notes (even though this isn't technically a Workers-specific product).