### PR TITLE
[Logs] Update Log fields to make each description full sentences

### DIFF
--- a/content/logs/reference/log-fields/account/access_requests.md
+++ b/content/logs/reference/log-fields/account/access_requests.md
@@ -14,20 +14,20 @@ The descriptions below detail the fields available for `access_requests`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| Action | What type of record is this. <em>login</em> \| <em>logout</em> | string |
-| Allowed |  |  |
-| AppDomain | The domain of the Application that Access is protecting | string |
-| AppUUID | Access Application UUID | string |
-| Connection | Identity provider used for the login | string |
-| Country | Request's country of origin | string |
-| CreatedAt | The date and time the corresponding access request was made (for example, '2021-07-27T00:01:07Z') | int or string |
-| Email | Email of the user who logged in | string |
-| IPAddress | The IP address of the client | string |
-| PurposeJustificationPrompt | Message prompted to the client when accessing the application | string |
-| PurposeJustificationResponse | Justification given by the client when accessing the application | string |
-| RayID | Identifier of the request | string |
-| TemporaryAccessApprovers | List of approvers for this access request | array[string] |
-| TemporaryAccessDuration | Approved duration for this access request | int |
-| UserUID | The uid of the user who logged in | string |
+| Action | What type of record is this. <em>login</em> \| <em>logout</em>. | string |
+| Allowed | If request was allowed or denied. | bool |
+| AppDomain | The domain of the Application that Access is protecting. | string |
+| AppUUID | Access Application UUID. | string |
+| Connection | Identity provider used for the login. | string |
+| Country | Request's country of origin. | string |
+| CreatedAt | The date and time the corresponding access request was made (for example, '2021-07-27T00:01:07Z'). | int or string |
+| Email | Email of the user who logged in. | string |
+| IPAddress | The IP address of the client. | string |
+| PurposeJustificationPrompt | Message prompted to the client when accessing the application. | string |
+| PurposeJustificationResponse | Justification given by the client when accessing the application. | string |
+| RayID | Identifier of the request. | string |
+| TemporaryAccessApprovers | List of approvers for this access request. | array[string] |
+| TemporaryAccessDuration | Approved duration for this access request. | int |
+| UserUID | The uid of the user who logged in. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/audit_logs.md
+++ b/content/logs/reference/log-fields/account/audit_logs.md
@@ -14,20 +14,20 @@ The descriptions below detail the fields available for `audit_logs`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| ActionResult | Whether the action was successful | bool |
-| ActionType | Type of action taken | string |
-| ActorEmail | Email of the actor | string |
-| ActorID | Unique identifier of the actor in Cloudflare's system | string |
-| ActorIP | Physical network address of the actor | string |
-| ActorType | Type of user that started the audit trail | string |
-| ID | Unique identifier of an audit log | string |
-| Interface | Entry point or interface of the audit log | string |
+| ActionResult | Whether the action was successful. | bool |
+| ActionType | Type of action taken. | string |
+| ActorEmail | Email of the actor. | string |
+| ActorID | Unique identifier of the actor in Cloudflare's system. | string |
+| ActorIP | Physical network address of the actor. | string |
+| ActorType | Type of user that started the audit trail. | string |
+| ID | Unique identifier of an audit log. | string |
+| Interface | Entry point or interface of the audit log. | string |
 | Metadata | Additional audit log-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by ResourceType. | object |
-| NewValue | Contains the new value for the audited item | object |
-| OldValue | Contains the old value for the audited item | object |
+| NewValue | Contains the new value for the audited item. | object |
+| OldValue | Contains the old value for the audited item. | object |
 | OwnerID | The identifier of the user that was acting or was acted on behalf of. If a user did the action themselves, this value will be the same as the ActorID. | string |
-| ResourceID | Unique identifier of the resource within Cloudflare's system | string |
-| ResourceType | The type of resource that was changed | string |
-| When | When the change happened | int or string |
+| ResourceID | Unique identifier of the resource within Cloudflare's system. | string |
+| ResourceType | The type of resource that was changed. | string |
+| When | When the change happened. | int or string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/dns_firewall_logs.md
+++ b/content/logs/reference/log-fields/account/dns_firewall_logs.md
@@ -14,23 +14,23 @@ The descriptions below detail the fields available for `dns_firewall_logs`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| ClientResponseCode | Integer value of response code. <br />See here: [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6) | int |
-| ClusterID | The ID of the cluster which handled this request | string |
-| ColoCode | IATA airport code of data center that received the request | string |
-| EDNSSubnet | EDNS Client Subnet (IPv4 or IPv6). <br />See here: [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs) | string |
-| EDNSSubnetLength | EDNS Client Subnet length. <br />See here: [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs) | int |
-| QueryDO | Indicates if the client is capable of handling a signed response (DNSSEC answer OK) | bool |
-| QueryName | Name of the query that was sent | string |
-| QueryRD | Indicates if the client means a recursive query (Recursion Desired) | bool |
-| QuerySize | The size of the query sent from the client in bytes | int |
-| QueryTCP | Indicates if the query from the client was made via TCP (if false, then UDP) | bool |
-| QueryType | Integer value of query type. <br />See here: [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4) | int |
-| ResponseCached | Whether the response was cached or not | bool |
+| ClientResponseCode | Integer value of response code. For more information refer to [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6). | int |
+| ClusterID | The ID of the cluster which handled this request. | string |
+| ColoCode | IATA airport code of data center that received the request. | string |
+| EDNSSubnet | EDNS Client Subnet (IPv4 or IPv6). For more information refer to [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs). | string |
+| EDNSSubnetLength | EDNS Client Subnet length. For more information refer to [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs). | int |
+| QueryDO | Indicates if the client is capable of handling a signed response (DNSSEC answer OK). | bool |
+| QueryName | Name of the query that was sent. | string |
+| QueryRD | Indicates if the client means a recursive query (Recursion Desired). | bool |
+| QuerySize | The size of the query sent from the client in bytes. | int |
+| QueryTCP | Indicates if the query from the client was made via TCP (if false, then UDP). | bool |
+| QueryType | Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4). | int |
+| ResponseCached | Whether the response was cached or not. | bool |
 | ResponseCachedStale | Whether the response was cached stale. In other words, the TTL had expired and the upstream nameserver was not reachable. | bool |
-| SourceIP | IP address of the client (IPv4 or IPv6) | string |
-| Timestamp | Timestamp at which the query occurred | int or string |
-| UpstreamIP | IP of the upstream nameserver (IPv4 or IPv6) | string |
-| UpstreamResponseCode | Integer value of response code from the upstream nameserver. <br />See here: [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6) | int |
+| SourceIP | IP address of the client (IPv4 or IPv6). | string |
+| Timestamp | Timestamp at which the query occurred. | int or string |
+| UpstreamIP | IP of the upstream nameserver (IPv4 or IPv6). | string |
+| UpstreamResponseCode | Integer value of response code from the upstream nameserver. For more information refer to [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6). | int |
 | UpstreamResponseTimeMs | Upstream response time in milliseconds. | int |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/gateway_dns.md
+++ b/content/logs/reference/log-fields/account/gateway_dns.md
@@ -15,34 +15,34 @@ The descriptions below detail the fields available for `gateway_dns`.
 | Field | Value | Type |
 | -- | -- | -- |
 | ApplicationID | ID of the application the domain belongs to (for example, 1, 2). Set to 0 when no ApplicationID is matched. | int |
-| ColoCode | The name of the colo that received the DNS query (for example, 'SJC', 'MIA', 'IAD') | string |
-| ColoID | The ID of the colo that received the DNS query (for example, 46, 72, 397) | int |
-| Datetime | The date and time the corresponding DNS request was made (for example, '2021-07-27T00:01:07Z') | int or string |
-| DeviceID | UUID of the device where the HTTP request originated from (for example, 'dad71818-0429-11ec-a0dc-000000000000') | string |
-| DstIP | The destination IP address the DNS query was made to (for example, '104.16.132.2290') | string |
+| ColoCode | The name of the colo that received the DNS query (for example, 'SJC', 'MIA', 'IAD'). | string |
+| ColoID | The ID of the colo that received the DNS query (for example, 46, 72, 397). | int |
+| Datetime | The date and time the corresponding DNS request was made (for example, '2021-07-27T00:01:07Z'). | int or string |
+| DeviceID | UUID of the device where the HTTP request originated from (for example, 'dad71818-0429-11ec-a0dc-000000000000'). | string |
+| DstIP | The destination IP address the DNS query was made to (for example, '104.16.132.2290'). | string |
 | DstPort | The destination port used at the edge. The port changes based on the protocol used by the DNS query (for example, 0). | int |
-| Email | Email used to authenticate the client (for example, 'user@test.com') | string |
-| Location | Name of the location the DNS request is coming from. Location is created by the customer (for example, 'Office NYC') | string |
-| LocationID | UUID of the location the DNS request is coming from. Location is created by the customer (for example, '7bdc7a9c-81d3-4816-8e56-000000000000') | string |
-| MatchedCategoryIDs | ID or IDs of category that the domain was matched with the policy (for example, [7,12,28,122,129,163]) | array[int] |
-| MatchedCategoryNames | Name or names of category that the domain was matched with the policy (for example, ['Photography', 'Weather']) | array[string] |
-| Policy | Name of the policy that was applied (if any) (for example, '7bdc7a9c-81d3-4816-8e56-de1acad3dec5') | string |
-| PolicyID | Id of the policy/rule that was applied (if any) | string |
-| Protocol | The protocol used for the DNS query by the client (for example, 'udp') | string |
-| QueryCategoryIDs | ID or IDs of category that the domain belongs to (for example, [7,12,28,122,129,163]) | array[int] |
-| QueryCategoryNames | Name or names of category that the domain belongs to (for example, ['Photography', 'Weather']) | array[string] |
-| QueryName | The query name (for example, 'example.com') | string |
-| QueryNameReversed | Query name in reverse (for example, 'com.example') | string |
-| QuerySize | The size of the DNS request in bytes (for example, 151) | int |
-| QueryType | The type of DNS query (for example, '1', '28', '15', or '16') | string |
-| QueryTypeName | The type of DNS query (for example, 'A', 'AAAA', 'MX', or 'TXT') | string |
-| RCode | The return code sent back by the DNS resolver | int |
+| Email | Email used to authenticate the client (for example, 'user@test.com'). | string |
+| Location | Name of the location the DNS request is coming from. Location is created by the customer (for example, 'Office NYC'). | string |
+| LocationID | UUID of the location the DNS request is coming from. Location is created by the customer (for example, '7bdc7a9c-81d3-4816-8e56-000000000000'). | string |
+| MatchedCategoryIDs | ID or IDs of category that the domain was matched with the policy (for example, [7,12,28,122,129,163]). | array[int] |
+| MatchedCategoryNames | Name or names of category that the domain was matched with the policy (for example, ['Photography', 'Weather']). | array[string] |
+| Policy | Name of the policy that was applied (if any) (for example, '7bdc7a9c-81d3-4816-8e56-de1acad3dec5'). | string |
+| PolicyID | ID of the policy/rule that was applied (if any). | string |
+| Protocol | The protocol used for the DNS query by the client (for example, 'udp'). | string |
+| QueryCategoryIDs | ID or IDs of category that the domain belongs to (for example, [7,12,28,122,129,163]). | array[int] |
+| QueryCategoryNames | Name or names of category that the domain belongs to (for example, ['Photography', 'Weather']). | array[string] |
+| QueryName | The query name (for example, 'example.com'). | string |
+| QueryNameReversed | Query name in reverse (for example, 'com.example'). | string |
+| QuerySize | The size of the DNS request in bytes (for example, 151). | int |
+| QueryType | The type of DNS query (for example, '1', '28', '15', or '16'). | string |
+| QueryTypeName | The type of DNS query (for example, 'A', 'AAAA', 'MX', or 'TXT'). | string |
+| RCode | The return code sent back by the DNS resolver. | int |
 | RData | The rdata objects (for example, {"type":"5","data":"dns-packet-placeholder..."}) | array[object] |
-| ResolverDecision | Result of the DNS query (for example, 'overrideForSafeSearch') | string |
-| SrcIP | The source IP address making the DNS query (for example, '104.16.132.229') | string |
-| SrcPort | The port used by the client when they sent the DNS request (for example, 0) | int |
-| TimeZone | Time zone used to calculate the current time, if a matched rule was scheduled with it | string |
+| ResolverDecision | Result of the DNS query (for example, 'overrideForSafeSearch'). | string |
+| SrcIP | The source IP address making the DNS query (for example, '104.16.132.229'). | string |
+| SrcPort | The port used by the client when they sent the DNS request (for example, 0). | int |
+| TimeZone | Time zone used to calculate the current time, if a matched rule was scheduled with it. | string |
 | TimeZoneInferredMethod | Method used to pick the time zone for the schedule (from rule/ from user ip/ from local time). | string |
-| UserID | User identity where the HTTP request originated from (for example, '00000000-0000-0000-0000-000000000000') | string |
+| UserID | User identity where the HTTP request originated from (for example, '00000000-0000-0000-0000-000000000000'). | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/gateway_http.md
+++ b/content/logs/reference/log-fields/account/gateway_http.md
@@ -14,32 +14,32 @@ The descriptions below detail the fields available for `gateway_http`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| AccountID | Cloudflare account tag | string |
-| Action | Action performed by gateway on the HTTP request | string |
-| BlockedFileHash | Hash of the file blocked in the response, if any | string |
-| BlockedFileName | File name blocked in the request, if any | string |
-| BlockedFileReason | Reason file was blocked in the response, if any | string |
-| BlockedFileSize | File size(bytes) blocked in the response, if any | string |
-| BlockedFileType | File type blocked in the response eg. exe, bin, if any | string |
-| Datetime | The date and time the corresponding HTTP request was made | int or string |
-| DestinationIP | Destination ip of the request | string |
-| DestinationPort | Destination port of the request | string |
-| DeviceID | UUID of the device where the HTTP request originated from | string |
-| DownloadedFileNames | List of files downloaded in the HTTP request | array[string] |
-| Email | Email used to authenticate the client | string |
-| HTTPHost | Content of the host header in the HTTP request | string |
-| HTTPMethod | HTTP request method | string |
-| HTTPVersion | Version name for the HTTP request | string |
-| IsIsolated | If the requested was isolated with Cloudflare Browser Isolation or not | bool |
-| PolicyID | The gateway policy UUID applied to the request, if any | string |
-| PolicyName | The name of the gateway policy applied to the request, if any | string |
-| Referer | Contents of the referer header in the HTTP request | string |
-| RequestID | Cloudflare request ID. This might be empty on bypass action | string |
-| SourceIP | Source ip of the request | string |
-| SourcePort | Source port of the request | string |
-| URL | HTTP request URL | string |
-| UploadedFileNames | List of files uploaded in the HTTP request | array[string] |
-| UserAgent | Contents of the user agent header in the HTTP request | string |
-| UserID | User identity where the HTTP request originated from | string |
+| AccountID | Cloudflare account tag. | string |
+| Action | Action performed by gateway on the HTTP request. | string |
+| BlockedFileHash | Hash of the file blocked in the response, if any. | string |
+| BlockedFileName | File name blocked in the request, if any. | string |
+| BlockedFileReason | Reason file was blocked in the response, if any. | string |
+| BlockedFileSize | File size(bytes) blocked in the response, if any. | string |
+| BlockedFileType | File type blocked in the response eg. exe, bin, if any. | string |
+| Datetime | The date and time the corresponding HTTP request was made. | int or string |
+| DestinationIP | Destination ip of the request. | string |
+| DestinationPort | Destination port of the request. | string |
+| DeviceID | UUID of the device where the HTTP request originated from. | string |
+| DownloadedFileNames | List of files downloaded in the HTTP request. | array[string] |
+| Email | Email used to authenticate the client. | string |
+| HTTPHost | Content of the host header in the HTTP request. | string |
+| HTTPMethod | HTTP request method. | string |
+| HTTPVersion | Version name for the HTTP request. | string |
+| IsIsolated | If the requested was isolated with Cloudflare Browser Isolation or not. | bool |
+| PolicyID | The gateway policy UUID applied to the request, if any. | string |
+| PolicyName | The name of the gateway policy applied to the request, if any. | string |
+| Referer | Contents of the referer header in the HTTP request. | string |
+| RequestID | Cloudflare request ID. This might be empty on bypass action. | string |
+| SourceIP | Source ip of the request. | string |
+| SourcePort | Source port of the request. | string |
+| URL | HTTP request URL. | string |
+| UploadedFileNames | List of files uploaded in the HTTP request. | array[string] |
+| UserAgent | Contents of the user agent header in the HTTP request. | string |
+| UserID | User identity where the HTTP request originated from. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/gateway_network.md
+++ b/content/logs/reference/log-fields/account/gateway_network.md
@@ -14,22 +14,22 @@ The descriptions below detail the fields available for `gateway_network`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| AccountID | Cloudflare account tag | string |
-| Action | Action performed by gateway on the session | string |
-| Datetime | The date and time the corresponding network session was made (for example, '2021-07-27T00:01:07Z') | int or string |
-| DestinationIP | Destination IP of the network session | string |
-| DestinationPort | Destination port of the network session | int |
-| DeviceID | UUID of the device where the network session originated from | string |
-| Email | Email associated with the user identity where the network sesion originated from | string |
-| OverrideIP | Overriden IP of the network session, if any | string |
-| OverridePort | Overriden port of the network session, if any | int |
-| PolicyID | Identifier of the policy/rule that was applied, if any | string |
-| PolicyName | The name of the gateway policy applied to the request, if any | string |
-| SNI | Content of the SNI for the TLS network session, if any | string |
-| SessionID | The session identifier of this network session | string |
-| SourceIP | Source IP of the network session | string |
-| SourcePort | Source port of the network session | int |
-| Transport | Transport protocol used for this session. <br />Possible values are <em>tcp</em> \| <em>quic</em> \| <em>udp</em> | string |
-| UserID | User identity where the network session originated from | string |
+| AccountID | Cloudflare account tag. | string |
+| Action | Action performed by gateway on the session. | string |
+| Datetime | The date and time the corresponding network session was made (for example, '2021-07-27T00:01:07Z'). | int or string |
+| DestinationIP | Destination IP of the network session. | string |
+| DestinationPort | Destination port of the network session. | int |
+| DeviceID | UUID of the device where the network session originated from. | string |
+| Email | Email associated with the user identity where the network sesion originated from. | string |
+| OverrideIP | Overriden IP of the network session, if any. | string |
+| OverridePort | Overriden port of the network session, if any. | int |
+| PolicyID | Identifier of the policy/rule that was applied, if any. | string |
+| PolicyName | The name of the gateway policy applied to the request, if any. | string |
+| SNI | Content of the SNI for the TLS network session, if any. | string |
+| SessionID | The session identifier of this network session. | string |
+| SourceIP | Source IP of the network session. | string |
+| SourcePort | Source port of the network session. | int |
+| Transport | Transport protocol used for this session. <br />Possible values are <em>tcp</em> \| <em>quic</em> \| <em>udp</em>. | string |
+| UserID | User identity where the network session originated from. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/network_analytics_logs.md
+++ b/content/logs/reference/log-fields/account/network_analytics_logs.md
@@ -14,84 +14,84 @@ The descriptions below detail the fields available for `network_analytics_logs`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| AttackCampaignID | Unique identifier of the attack campaign that this packet was a part of, if any | string |
-| AttackID | Unique identifier of the mitigation that matched the packet, if any | string |
-| ColoCity | The city where the Cloudflare datacenter that received the packet is located | string |
-| ColoCode | The Cloudflare datacenter that received the packet (nearest IATA airport code) | string |
-| ColoCountry | The country where the Cloudflare datacenter that received the packet is located (ISO 3166-1 alpha-2) | string |
-| ColoGeoHash | The latitude and longitude where the colo that received the packet is located (Geohash encoding) | string |
-| ColoName | The unique site identifier of the Cloudflare datacenter that received the packet (for example, 'ams01', 'sjc01', 'lhr01') | string |
-| Datetime | The date and time the event occurred at the edge | int or string |
-| DestinationASN | The ASN associated with the destination IP of the packet | int |
-| DestinationASNName | The name of the ASN associated with the destination IP of the packet | string |
-| DestinationCountry | The country where the destination IP of the packet is located (ISO 3166-1 alpha-2) | string |
-| DestinationGeoHash | The latitude and longitude where the destination IP of the packet is located (Geohash encoding) | string |
-| DestinationPort | Value of the Destination Port header field in the TCP or UDP packet | int |
-| Direction | The direction in relation to customer network. <br />Possible values are <em>ingress</em> \| <em>egress</em> | string |
-| GREChecksum | Value of the Checksum header field in the GRE packet | int |
-| GREEtherType | Value of the EtherType header field in the GRE packet | int |
-| GREHeaderLength | Length of the GRE packet header, in bytes | int |
-| GREKey | Value of the Key header field in the GRE packet | int |
-| GRESequenceNumber | Value of the Sequence Number header field in the GRE packet | int |
-| GREVersion | Value of the Version header field in the GRE packet | int |
-| ICMPChecksum | Value of the Checksum header field in the ICMP packet | int |
-| ICMPCode | Value of the Code header field in the ICMP packet | int |
-| ICMPType | Value of the Type header field in the ICMP packet | int |
-| IPDestinationAddress | Value of the Destination Address header field in the IPv4 or IPv6 packet | string |
-| IPDestinationSubnet | Computed subnet of the Destination Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6) | string |
-| IPFragmentOffset | Value of the Fragment Offset header field in the IPv4 or IPv6 packet | int |
-| IPHeaderLength | Length of the IPv4 or IPv6 packet header, in bytes | int |
-| IPMoreFragments | Value of the More Fragments header field in the IPv4 or IPv6 packet | int |
-| IPProtocol | Value of the Protocol header field in the IPv4 or IPv6 packet | int |
-| IPProtocolName | Name of the protocol specified by the Protocol header field in the IPv4 or IPv6 packet | string |
-| IPSourceAddress | Value of the Source Address header field in the IPv4 or IPv6 packet | string |
-| IPSourceSubnet | Computed subnet of the Source Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6) | string |
-| IPTTL | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet | int |
-| IPTTLBuckets | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet, with the last digit truncated | int |
-| IPTotalLength | Total length of the IPv4 or IPv6 packet, in bytes | int |
-| IPTotalLengthBuckets | Total length of the IPv4 or IPv6 packet, in bytes, with the last two digits truncated | int |
-| IPv4Checksum | Value of the Checksum header field in the IPv4 packet | int |
-| IPv4DSCP | Value of the Differentiated Services Code Point header field in the IPv4 packet | int |
-| IPv4DontFragment | Value of the Don't Fragment header field in the IPv4 packet | int |
-| IPv4ECN | Value of the Explicit Congestion Notification header field in the IPv4 packet | int |
-| IPv4Identification | Value of the Identification header field in the IPv4 packet | int |
-| IPv4Options | List of Options numbers included in the IPv4 packet header | string |
-| IPv6DSCP | Value of the Differentiated Services Code Point header field in the IPv6 packet | int |
-| IPv6ECN | Value of the Explicit Congestion Notification header field in the IPv6 packet | int |
-| IPv6ExtensionHeaders | List of Extension Header numbers included in the IPv6 packet header | string |
-| IPv6FlowLabel | Value of the Flow Label header field in the IPv6 packet | int |
-| IPv6Identification | Value of the Identification extension header field in the IPv6 packet | int |
-| MitigationReason | Reason for applying a mitigation to the packet, if any. <br />Possible values are <em>BLOCKED</em> \| <em>RATE_LIMITED</em> \|<em>UNEXPECTED</em> \| <em>CHALLENGE_NEEDED</em> \| <em>CHALLENGE_PASSED</em> \| <em>NOT_FOUND</em> \| <em>OUT_OF_SEQUENCE</em> \| <em>ALREADY_CLOSED</em> | string |
-| MitigationScope | Whether the packet matched a local or global mitigation, if any. <br />Possible values are <em>local</em> \| <em>global</em> | string |
-| MitigationSystem | Which Cloudflare system sampled the packet. <br />Possible values are <em>dosd</em> \| <em>flowtrackd</em> \| <em>magic-firewall</em> | string |
-| Outcome | The action that Cloudflare systems took on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em> | string |
-| ProtocolState | State of the packet in the context of the protocol, if any. <br />Possible values are <em>OPEN</em> \| <em>NEW</em> \| <em>CLOSING</em> \| <em>CLOSED</em> | string |
-| RuleID | Unique identifier of the rule contained with the Cloudflare L3/4 managed ruleset that this packet matched, if any | string |
-| RulesetID | Unique identifier of the Cloudflare L3/4 managed ruleset containing the rule that this packet matched, if any. <br />Possible values are <em>3b64149bfa6e4220bbbc2bd6db589552</em> | string |
-| RulesetOverrideID | Unique identifier of the rule within the accounts root ddos_l4 phase ruleset which resulted in an override of the default sensitivity or action being applied/evaluated, if any | string |
+| AttackCampaignID | Unique identifier of the attack campaign that this packet was a part of, if any. | string |
+| AttackID | Unique identifier of the mitigation that matched the packet, if any. | string |
+| ColoCity | The city where the Cloudflare datacenter that received the packet is located. | string |
+| ColoCode | The Cloudflare datacenter that received the packet (nearest IATA airport code). | string |
+| ColoCountry | The country where the Cloudflare datacenter that received the packet is located (ISO 3166-1 alpha-2). | string |
+| ColoGeoHash | The latitude and longitude where the colo that received the packet is located (Geohash encoding). | string |
+| ColoName | The unique site identifier of the Cloudflare datacenter that received the packet (for example, 'ams01', 'sjc01', 'lhr01'). | string |
+| Datetime | The date and time the event occurred at the edge. | int or string |
+| DestinationASN | The ASN associated with the destination IP of the packet. | int |
+| DestinationASNName | The name of the ASN associated with the destination IP of the packet. | string |
+| DestinationCountry | The country where the destination IP of the packet is located (ISO 3166-1 alpha-2). | string |
+| DestinationGeoHash | The latitude and longitude where the destination IP of the packet is located (Geohash encoding). | string |
+| DestinationPort | Value of the Destination Port header field in the TCP or UDP packet. | int |
+| Direction | The direction in relation to customer network. <br />Possible values are <em>ingress</em> \| <em>egress</em>. | string |
+| GREChecksum | Value of the Checksum header field in the GRE packet. | int |
+| GREEtherType | Value of the EtherType header field in the GRE packet. | int |
+| GREHeaderLength | Length of the GRE packet header, in bytes. | int |
+| GREKey | Value of the Key header field in the GRE packet. | int |
+| GRESequenceNumber | Value of the Sequence Number header field in the GRE packet. | int |
+| GREVersion | Value of the Version header field in the GRE packet. | int |
+| ICMPChecksum | Value of the Checksum header field in the ICMP packet. | int |
+| ICMPCode | Value of the Code header field in the ICMP packet. | int |
+| ICMPType | Value of the Type header field in the ICMP packet. | int |
+| IPDestinationAddress | Value of the Destination Address header field in the IPv4 or IPv6 packet. | string |
+| IPDestinationSubnet | Computed subnet of the Destination Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6). | string |
+| IPFragmentOffset | Value of the Fragment Offset header field in the IPv4 or IPv6 packet. | int |
+| IPHeaderLength | Length of the IPv4 or IPv6 packet header, in bytes. | int |
+| IPMoreFragments | Value of the More Fragments header field in the IPv4 or IPv6 packet. | int |
+| IPProtocol | Value of the Protocol header field in the IPv4 or IPv6 packet. | int |
+| IPProtocolName | Name of the protocol specified by the Protocol header field in the IPv4 or IPv6 packet. | string |
+| IPSourceAddress | Value of the Source Address header field in the IPv4 or IPv6 packet. | string |
+| IPSourceSubnet | Computed subnet of the Source Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6). | string |
+| IPTTL | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet. | int |
+| IPTTLBuckets | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet, with the last digit truncated. | int |
+| IPTotalLength | Total length of the IPv4 or IPv6 packet, in bytes. | int |
+| IPTotalLengthBuckets | Total length of the IPv4 or IPv6 packet, in bytes, with the last two digits truncated. | int |
+| IPv4Checksum | Value of the Checksum header field in the IPv4 packet. | int |
+| IPv4DSCP | Value of the Differentiated Services Code Point header field in the IPv4 packet. | int |
+| IPv4DontFragment | Value of the Don't Fragment header field in the IPv4 packet. | int |
+| IPv4ECN | Value of the Explicit Congestion Notification header field in the IPv4 packet. | int |
+| IPv4Identification | Value of the Identification header field in the IPv4 packet. | int |
+| IPv4Options | List of Options numbers included in the IPv4 packet header. | string |
+| IPv6DSCP | Value of the Differentiated Services Code Point header field in the IPv6 packet. | int |
+| IPv6ECN | Value of the Explicit Congestion Notification header field in the IPv6 packet. | int |
+| IPv6ExtensionHeaders | List of Extension Header numbers included in the IPv6 packet header. | string |
+| IPv6FlowLabel | Value of the Flow Label header field in the IPv6 packet. | int |
+| IPv6Identification | Value of the Identification extension header field in the IPv6 packet. | int |
+| MitigationReason | Reason for applying a mitigation to the packet, if any. <br />Possible values are <em>BLOCKED</em> \| <em>RATE_LIMITED</em> \|<em>UNEXPECTED</em> \| <em>CHALLENGE_NEEDED</em> \| <em>CHALLENGE_PASSED</em> \| <em>NOT_FOUND</em> \| <em>OUT_OF_SEQUENCE</em> \| <em>ALREADY_CLOSED</em>. | string |
+| MitigationScope | Whether the packet matched a local or global mitigation, if any. <br />Possible values are <em>local</em> \| <em>global</em>. | string |
+| MitigationSystem | Which Cloudflare system sampled the packet. <br />Possible values are <em>dosd</em> \| <em>flowtrackd</em> \| <em>magic-firewall</em>. | string |
+| Outcome | The action that Cloudflare systems took on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>. | string |
+| ProtocolState | State of the packet in the context of the protocol, if any. <br />Possible values are <em>OPEN</em> \| <em>NEW</em> \| <em>CLOSING</em> \| <em>CLOSED</em>. | string |
+| RuleID | Unique identifier of the rule contained with the Cloudflare L3/4 managed ruleset that this packet matched, if any. | string |
+| RulesetID | Unique identifier of the Cloudflare L3/4 managed ruleset containing the rule that this packet matched, if any. <br />Possible values are <em>3b64149bfa6e4220bbbc2bd6db589552</em>. | string |
+| RulesetOverrideID | Unique identifier of the rule within the accounts root ddos_l4 phase ruleset which resulted in an override of the default sensitivity or action being applied/evaluated, if any. | string |
 | SampleInterval | The sample interval is the inverse of the sample rate. For example, a sample interval of 1000 means that this packet was randomly sampled from 1 in 1000 packets. Sample rates are dynamic and based on the volume of traffic. | int |
-| SourceASN | The ASN associated with the source IP of the packet | int |
-| SourceASNName | The name of the ASN associated with the source IP of the packet | string |
-| SourceCountry | The country where the source IP of the packet is located (ISO 3166-1 alpha-2) | string |
-| SourceGeoHash | The latitude and longitude where the source IP of the packet is located (Geohash encoding) | string |
-| SourcePort | Value of the Source Port header field in the TCP or UDP packet | int |
-| TCPAcknowledgementNumber | Value of the Acknowledgement Number header field in the TCP packet | int |
-| TCPChecksum | Value of the Checksum header field in the TCP packet | int |
-| TCPDataOffset | Value of the Data Offset header field in the TCP packet | int |
-| TCPFlags | Value of the Flags header field in the TCP packet | int |
-| TCPFlagsString | Human-readable string representation of the Flags header field in the TCP packet | string |
-| TCPMSS | Value of the MSS option header field in the TCP packet | int |
-| TCPOptions | List of Options numbers included in the TCP packet header | string |
-| TCPSACKBlocks | List of the SACK Blocks option header in the TCP packet | string |
-| TCPSACKPermitted | Value of the SACK Permitted option header in the TCP packet | int |
-| TCPSequenceNumber | Value of the Sequence Number header field in the TCP packet | int |
-| TCPTimestampECR | Value of the Timestamp Echo Reply option header in the TCP packet | int |
-| TCPTimestampValue | Value of the Timestamp option header in the TCP packet | int |
-| TCPUrgentPointer | Value of the Urgent Pointer header field in the TCP packet | int |
-| TCPWindowScale | Value of the Window Scale option header in the TCP packet | int |
-| TCPWindowSize | Value of the Window Size header field in the TCP packet | int |
-| UDPChecksum | Value of the Checksum header field in the UDP packet | int |
-| UDPPayloadLength | Value of the Payload Length header field in the UDP packet | int |
-| Verdict | The action that Cloudflare systems think should be taken on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em> | string |
+| SourceASN | The ASN associated with the source IP of the packet. | int |
+| SourceASNName | The name of the ASN associated with the source IP of the packet. | string |
+| SourceCountry | The country where the source IP of the packet is located (ISO 3166-1 alpha-2). | string |
+| SourceGeoHash | The latitude and longitude where the source IP of the packet is located (Geohash encoding). | string |
+| SourcePort | Value of the Source Port header field in the TCP or UDP packet. | int |
+| TCPAcknowledgementNumber | Value of the Acknowledgement Number header field in the TCP packet. | int |
+| TCPChecksum | Value of the Checksum header field in the TCP packet. | int |
+| TCPDataOffset | Value of the Data Offset header field in the TCP packet. | int |
+| TCPFlags | Value of the Flags header field in the TCP packet. | int |
+| TCPFlagsString | Human-readable string representation of the Flags header field in the TCP packet. | string |
+| TCPMSS | Value of the MSS option header field in the TCP packet. | int |
+| TCPOptions | List of Options numbers included in the TCP packet header. | string |
+| TCPSACKBlocks | List of the SACK Blocks option header in the TCP packet. | string |
+| TCPSACKPermitted | Value of the SACK Permitted option header in the TCP packet. | int |
+| TCPSequenceNumber | Value of the Sequence Number header field in the TCP packet. | int |
+| TCPTimestampECR | Value of the Timestamp Echo Reply option header in the TCP packet. | int |
+| TCPTimestampValue | Value of the Timestamp option header in the TCP packet. | int |
+| TCPUrgentPointer | Value of the Urgent Pointer header field in the TCP packet. | int |
+| TCPWindowScale | Value of the Window Scale option header in the TCP packet. | int |
+| TCPWindowSize | Value of the Window Size header field in the TCP packet. | int |
+| UDPChecksum | Value of the Checksum header field in the UDP packet. | int |
+| UDPPayloadLength | Value of the Payload Length header field in the UDP packet. | int |
+| Verdict | The action that Cloudflare systems think should be taken on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/account/workers_trace_events.md
+++ b/content/logs/reference/log-fields/account/workers_trace_events.md
@@ -14,13 +14,13 @@ The descriptions below detail the fields available for `workers_trace_events`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| DispatchNamespace | The Cloudflare Worker dispatch namespace | string |
-| Event | Details about the source event | object |
-| EventTimestampMs | The timestamp of when the event was received, in milliseconds | int |
-| EventType | The event type that triggered the invocation. <br />Possible values are <em>fetch</em> | string |
-| Exceptions | List of uncaught exceptions during the invocation | array[object] |
-| Logs | List of console messages emitted during the invocation | array[object] |
-| Outcome | The outcome of the worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em> | string |
-| ScriptName | The Cloudflare Worker script name | string |
+| DispatchNamespace | The Cloudflare Worker dispatch namespace. | string |
+| Event | Details about the source event. | object |
+| EventTimestampMs | The timestamp of when the event was received, in milliseconds. | int |
+| EventType | The event type that triggered the invocation. <br />Possible values are <em>fetch</em>. | string |
+| Exceptions | List of uncaught exceptions during the invocation. | array[object] |
+| Logs | List of console messages emitted during the invocation. | array[object] |
+| Outcome | The outcome of the worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em>. | string |
+| ScriptName | The Cloudflare Worker script name. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/zone/dns_logs.md
+++ b/content/logs/reference/log-fields/zone/dns_logs.md
@@ -14,14 +14,14 @@ The descriptions below detail the fields available for `dns_logs`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| ColoCode | IATA airport code of data center that received the request | string |
-| EDNSSubnet | EDNS Client Subnet (IPv4 or IPv6). <br />See here: [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs) | string |
-| EDNSSubnetLength | EDNS Client Subnet length. <br />See here: [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs) | int |
-| QueryName | Name of the query that was sent | string |
-| QueryType | Integer value of query type. <br />See here: [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4) | int |
-| ResponseCached | Whether the response was cached or not | bool |
-| ResponseCode | Integer value of response code. <br />See here: [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6) | int |
-| SourceIP | IP address of the client (IPv4 or IPv6) | string |
-| Timestamp | Timestamp at which the query occurred | int or string |
+| ColoCode | IATA airport code of data center that received the request. | string |
+| EDNSSubnet | EDNS Client Subnet (IPv4 or IPv6). For more information refer to [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs). | string |
+| EDNSSubnetLength | EDNS Client Subnet length. For more information refer to [EDNS Client Subnet](/logs/reference/glossary/#edns-client-subnet-ecs). | int |
+| QueryName | Name of the query that was sent. | string |
+| QueryType | Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4). | int |
+| ResponseCached | Whether the response was cached or not. | bool |
+| ResponseCode | Integer value of response code. For more information refer to  [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6). | int |
+| SourceIP | IP address of the client (IPv4 or IPv6). | string |
+| Timestamp | Timestamp at which the query occurred. | int or string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/zone/firewall_events.md
+++ b/content/logs/reference/log-fields/zone/firewall_events.md
@@ -14,33 +14,33 @@ The descriptions below detail the fields available for `firewall_events`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| Action | The code of the first-class action the Cloudflare Firewall took on this request. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionclose</em> \| <em>challengesolved</em> \| <em>challengefailed</em> \| <em>challengebypassed</em> \| <em>jschallengesolved</em> \| <em>jschallengefailed</em> \| <em>jschallengebypassed</em> \| <em>bypass</em> \| <em>managedchallenge</em> \| <em>managedchallengeskipped</em> \| <em>managedchallengenoninteractivesolved</em> \| <em>managedchallengeinteractivesolved</em> \| <em>managedchallengebypassed</em> | string |
-| ClientASN | The ASN number of the visitor | int |
-| ClientASNDescription | The ASN of the visitor as string | string |
-| ClientCountry | Country from which request originated | string |
-| ClientIP | The visitor's IP address (IPv4 or IPv6) | string |
-| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em> | string |
-| ClientRefererHost | The referer host | string |
-| ClientRefererPath | The referer path requested by visitor | string |
-| ClientRefererQuery | The referer query-string was requested by the visitor | string |
-| ClientRefererScheme | The referer URL scheme requested by the visitor | string |
-| ClientRequestHost | The HTTP hostname requested by the visitor | string |
-| ClientRequestMethod | The HTTP method used by the visitor | string |
-| ClientRequestPath | The path requested by visitor | string |
-| ClientRequestProtocol | The version of HTTP protocol requested by the visitor | string |
-| ClientRequestQuery | The query-string was requested by the visitor | string |
-| ClientRequestScheme | The URL scheme requested by the visitor | string |
-| ClientRequestUserAgent | Visitor's user-agent string | string |
-| Datetime | The date and time the event occurred at the edge | int or string |
-| EdgeColoCode | The airport code of the Cloudflare datacenter that served this request | string |
-| EdgeResponseStatus | HTTP response status code returned to browser | int |
-| Kind | The kind of event, currently only possible values are: <em>firewall</em> | string |
-| MatchIndex | Rules match index in the chain | int |
-| Metadata | Additional product-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by Cloudflare security product and can change over time | object |
-| OriginResponseStatus | HTTP origin response status code returned to browser | int |
-| OriginatorRayID | The RayID of the request that issued the challenge/jschallenge | string |
-| RayID | The RayID of the request | string |
-| RuleID | The Cloudflare security product-specific RuleID triggered by this request | string |
-| Source | The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> | string |
+| Action | The code of the first-class action the Cloudflare Firewall took on this request. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionclose</em> \| <em>challengesolved</em> \| <em>challengefailed</em> \| <em>challengebypassed</em> \| <em>jschallengesolved</em> \| <em>jschallengefailed</em> \| <em>jschallengebypassed</em> \| <em>bypass</em> \| <em>managedchallenge</em> \| <em>managedchallengeskipped</em> \| <em>managedchallengenoninteractivesolved</em> \| <em>managedchallengeinteractivesolved</em> \| <em>managedchallengebypassed</em>. | string |
+| ClientASN | The ASN number of the visitor. | int |
+| ClientASNDescription | The ASN of the visitor as string. | string |
+| ClientCountry | Country from which request originated. | string |
+| ClientIP | The visitor's IP address (IPv4 or IPv6). | string |
+| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>. | string |
+| ClientRefererHost | The referer host. | string |
+| ClientRefererPath | The referer path requested by visitor. | string |
+| ClientRefererQuery | The referer query-string was requested by the visitor. | string |
+| ClientRefererScheme | The referer URL scheme requested by the visitor. | string |
+| ClientRequestHost | The HTTP hostname requested by the visitor. | string |
+| ClientRequestMethod | The HTTP method used by the visitor. | string |
+| ClientRequestPath | The path requested by visitor. | string |
+| ClientRequestProtocol | The version of HTTP protocol requested by the visitor. | string |
+| ClientRequestQuery | The query-string was requested by the visitor. | string |
+| ClientRequestScheme | The URL scheme requested by the visitor. | string |
+| ClientRequestUserAgent | Visitor's user-agent string. | string |
+| Datetime | The date and time the event occurred at the edge. | int or string |
+| EdgeColoCode | The airport code of the Cloudflare datacenter that served this request. | string |
+| EdgeResponseStatus | HTTP response status code returned to browser. | int |
+| Kind | The kind of event, currently only possible values are: <em>firewall</em>. | string |
+| MatchIndex | Rules match index in the chain. | int |
+| Metadata | Additional product-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by Cloudflare security product and can change over time. | object |
+| OriginResponseStatus | HTTP origin response status code returned to browser. | int |
+| OriginatorRayID | The RayID of the request that issued the challenge/jschallenge. | string |
+| RayID | The RayID of the request. | string |
+| RuleID | The Cloudflare security product-specific RuleID triggered by this request. | string |
+| Source | The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em>. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/zone/http_requests.md
+++ b/content/logs/reference/log-fields/zone/http_requests.md
@@ -16,96 +16,96 @@ The descriptions below detail the fields available for `http_requests`.
 | -- | -- | -- |
 | BotDetectionIDs | List of IDs that correlate to the Bot Management Heuristic detections made on a request. Available in Logpush v2 only. | array[int] |
 | BotScore | Cloudflare Bot Score. Scores below 30 are commonly associated with automated traffic. Available for Bot Management customers (please contact your account team to enable). | int |
-| BotScoreSrc | Detection engine responsible for generating the Bot Score. <br />Possible values are <em>Not Computed</em> \| <em>Heuristics</em> \| <em>Machine Learning</em> \| <em>Behavioral Analysis</em> \| <em>Verified Bot</em> \| <em>JS Fingerprinting</em> \| <em>Cloudflare Service</em> | string |
+| BotScoreSrc | Detection engine responsible for generating the Bot Score. <br />Possible values are <em>Not Computed</em> \| <em>Heuristics</em> \| <em>Machine Learning</em> \| <em>Behavioral Analysis</em> \| <em>Verified Bot</em> \| <em>JS Fingerprinting</em> \| <em>Cloudflare Service</em>. | string |
 | BotTags | Type of bot traffic (if available). Refer to [Bot Tags](/bots/concepts/cloudflare-bot-tags/) for the list of potential values. Available in Logpush v2 only. | array[string] |
 | CacheCacheStatus | Cache status. <br />Possible values are <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> <br />"dynamic" means that a request is not eligible for cache. This can mean, for example that it was blocked by the firewall. Refer to [Cloudflare cache responses](/cache/about/default-cache-behavior/#cloudflare-cache-responses) for more details. | string |
 | CacheReserveUsed | Cache Reserve was used to serve this request. Available in Logpush v2 only. | bool |
-| CacheResponseBytes | Number of bytes returned by the cache | int |
+| CacheResponseBytes | Number of bytes returned by the cache. | int |
 | CacheResponseStatus (deprecated) | HTTP status code returned by the cache to the edge. All requests (including non-cacheable ones) go through the cache. Refer also to CacheCacheStatus field. | int |
-| CacheTieredFill | Tiered Cache was used to serve this request | bool |
-| ClientASN | Client AS number | int |
-| ClientCountry | 2-letter ISO-3166 country code of the client IP address | string |
-| ClientDeviceType | Client device type | string |
-| ClientIP | IP address of the client | string |
-| ClientIPClass | <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em> | string |
+| CacheTieredFill | Tiered Cache was used to serve this request. | bool |
+| ClientASN | Client AS number. | int |
+| ClientCountry | 2-letter ISO-3166 country code of the client IP address. | string |
+| ClientDeviceType | Client device type. | string |
+| ClientIP | IP address of the client. | string |
+| ClientIPClass | Client IP class. <br />Possible values are <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>. | string |
 | ClientMTLSAuthCertFingerprint | The SHA256 fingerprint of the certificate presented by the client during mTLS authentication. Only populated on the first request on an mTLS connection. Available in Logpush v2 only. | string |
-| ClientMTLSAuthStatus | The status of mTLS authentication. Only populated on the first request on an mTLS connection. Available in Logpush v2 only. <br />Possible values are <em>unknown</em> \| <em>ok</em> \| <em>absent</em> \| <em>untrusted</em> \| <em>notyetvalid</em> \| <em>expired</em> | string |
-| ClientRegionCode | The ISO-3166-2 region code of the client IP address | string |
-| ClientRequestBytes | Number of bytes in the client request | int |
-| ClientRequestHost | Host requested by the client | string |
-| ClientRequestMethod | HTTP method of client request | string |
-| ClientRequestPath | URI path requested by the client | string |
-| ClientRequestProtocol | HTTP protocol of client request | string |
-| ClientRequestReferer | HTTP request referrer | string |
+| ClientMTLSAuthStatus | The status of mTLS authentication. Only populated on the first request on an mTLS connection. Available in Logpush v2 only. <br />Possible values are <em>unknown</em> \| <em>ok</em> \| <em>absent</em> \| <em>untrusted</em> \| <em>notyetvalid</em> \| <em>expired</em>. | string |
+| ClientRegionCode | The ISO-3166-2 region code of the client IP address. | string |
+| ClientRequestBytes | Number of bytes in the client request. | int |
+| ClientRequestHost | Host requested by the client. | string |
+| ClientRequestMethod | HTTP method of client request. | string |
+| ClientRequestPath | URI path requested by the client. | string |
+| ClientRequestProtocol | HTTP protocol of client request. | string |
+| ClientRequestReferer | HTTP request referrer. | string |
 | ClientRequestScheme | The URL scheme requested by the visitor. Available in Logpush v2 only. | string |
 | ClientRequestSource | Identifies requests as coming from an external source or another service within Cloudflare. Refer to [ClientRequestSource field](/logs/reference/clientrequestsource/) for the list of potential values. Available in Logpush v2 only. | string |
-| ClientRequestURI | URI requested by the client | string |
-| ClientRequestUserAgent | User agent reported by the client | string |
-| ClientSSLCipher | Client SSL cipher | string |
+| ClientRequestURI | URI requested by the client. | string |
+| ClientRequestUserAgent | User agent reported by the client. | string |
+| ClientSSLCipher | Client SSL cipher. | string |
 | ClientSSLProtocol | Client SSL (TLS) protocol. The value "none" means that SSL was not used. | string |
-| ClientSrcPort | Client source port | int |
+| ClientSrcPort | Client source port. | int |
 | ClientTCPRTTMs | The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received. Available in Logpush v2 only. | int |
-| ClientXRequestedWith | X-Requested-With HTTP header | string |
-| ContentScanObjResults | List of content scan results | array[string] |
-| ContentScanObjTypes | List of content types | array[string] |
-| Cookies | String key-value pairs for Cookies | object |
+| ClientXRequestedWith | X-Requested-With HTTP header. | string |
+| ContentScanObjResults | List of content scan results. | array[string] |
+| ContentScanObjTypes | List of content types. | array[string] |
+| Cookies | String key-value pairs for Cookies. | object |
 | EdgeCFConnectingO2O | True if the request looped through multiple zones on the Cloudflare edge. This is considered an orange to orange (o2o) request. Available in Logpush v2 only. | bool |
-| EdgeColoCode | IATA airport code of data center that received the request | string |
-| EdgeColoID | Cloudflare edge colo id | int |
-| EdgeEndTimestamp | Timestamp at which the edge finished sending response to the client | int or string |
-| EdgePathingOp | Indicates what type of response was issued for this request (unknown = no specific action) | string |
-| EdgePathingSrc | Details how the request was classified based on security checks (unknown = no specific classification) | string |
-| EdgePathingStatus | Indicates what data was used to determine the handling of this request (unknown = no data) | string |
-| EdgeRateLimitAction | The action taken by the blocking rule; empty if no action taken. <br />Possible values are <em>unknown</em> \| <em>simulate</em> \| <em>ban</em> \| <em>challenge</em> \| <em>jsChallenge</em> | string |
+| EdgeColoCode | IATA airport code of data center that received the request. | string |
+| EdgeColoID | Cloudflare edge colo id. | int |
+| EdgeEndTimestamp | Timestamp at which the edge finished sending response to the client. | int or string |
+| EdgePathingOp | Indicates what type of response was issued for this request (unknown = no specific action). | string |
+| EdgePathingSrc | Details how the request was classified based on security checks (unknown = no specific classification). | string |
+| EdgePathingStatus | Indicates what data was used to determine the handling of this request (unknown = no data). | string |
+| EdgeRateLimitAction | The action taken by the blocking rule; empty if no action taken. <br />Possible values are <em>unknown</em> \| <em>simulate</em> \| <em>ban</em> \| <em>challenge</em> \| <em>jsChallenge</em>. | string |
 | EdgeRateLimitID | The internal rule ID of the rate-limiting rule that triggered a block (ban) or log action. 0 if no action taken. | int |
-| EdgeRequestHost | Host header on the request from the edge to the origin | string |
+| EdgeRequestHost | Host header on the request from the edge to the origin. | string |
 | EdgeResponseBodyBytes | Size of the HTTP response body returned to clients. Available in Logpush v2 only. | int |
-| EdgeResponseBytes | Number of bytes returned by the edge to the client | int |
-| EdgeResponseCompressionRatio | Edge response compression ratio | float |
-| EdgeResponseContentType | Edge response Content-Type header value | string |
-| EdgeResponseStatus | HTTP status code returned by Cloudflare to the client | int |
+| EdgeResponseBytes | Number of bytes returned by the edge to the client. | int |
+| EdgeResponseCompressionRatio | Edge response compression ratio. | float |
+| EdgeResponseContentType | Edge response Content-Type header value. | string |
+| EdgeResponseStatus | HTTP status code returned by Cloudflare to the client. | int |
 | EdgeServerIP | IP of the edge server making a request to the origin. Possible responses are string in IPv4 or IPv6 format, or empty string. Empty string means that there was no request made to the origin server. | string |
-| EdgeStartTimestamp | Timestamp at which the edge received request from the client | int or string |
+| EdgeStartTimestamp | Timestamp at which the edge received request from the client. | int or string |
 | EdgeTimeToFirstByteMs | Total view of Time To First Byte as measured at Cloudflare's edge. Starts after a TCP connection is established and ends when Cloudflare begins returning the first byte of a response to eyeballs. Includes TLS handshake time (for new connections) and origin response time. Available in Logpush v2 only. | int |
-| FirewallMatchesActions | Array of actions the Cloudflare firewall products performed on this request. The individual firewall products associated with this action be found in FirewallMatchesSources and their respective RuleIds can be found in FirewallMatchesRuleIDs. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesSources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionClose</em> \| <em>challengeSolved</em> \| <em>challengeFailed</em> \| <em>challengeBypassed</em> \| <em>jschallengeSolved</em> \| <em>jschallengeFailed</em> \| <em>jschallengeBypassed</em> \| <em>bypass</em> \| <em>managedChallenge</em> \| <em>managedChallengeSkipped</em> \| <em>managedChallengeNonInteractiveSolved</em> \| <em>managedChallengeInteractiveSolved</em> \| <em>managedChallengeBypassed</em> | array[string] |
+| FirewallMatchesActions | Array of actions the Cloudflare firewall products performed on this request. The individual firewall products associated with this action be found in FirewallMatchesSources and their respective RuleIds can be found in FirewallMatchesRuleIDs. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesSources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionClose</em> \| <em>challengeSolved</em> \| <em>challengeFailed</em> \| <em>challengeBypassed</em> \| <em>jschallengeSolved</em> \| <em>jschallengeFailed</em> \| <em>jschallengeBypassed</em> \| <em>bypass</em> \| <em>managedChallenge</em> \| <em>managedChallengeSkipped</em> \| <em>managedChallengeNonInteractiveSolved</em> \| <em>managedChallengeInteractiveSolved</em> \| <em>managedChallengeBypassed</em>. | array[string] |
 | FirewallMatchesRuleIDs | Array of RuleIDs of the firewall product that has matched the request. The firewall product associated with the RuleID can be found in FirewallMatchesSources. The length of the array is the same as FirewallMatchesActions and FirewallMatchesSources. | array[string] |
-| FirewallMatchesSources | The firewall products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The RuleIDs can be found in FirewallMatchesRuleIDs, the actions can be found in FirewallMatchesActions. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>ipRange</em> \| <em>securityLevel</em> \| <em>zoneLockdown</em> \| <em>waf</em> \| <em>firewallRules</em> \| <em>uaBlock</em> \| <em>rateLimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>botFight</em> \| <em>apiShield</em> \| <em>botManagement</em> \| <em>dlp</em> \| <em>firewallManaged</em> \| <em>firewallCustom</em> | array[string] |
+| FirewallMatchesSources | The firewall products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The RuleIDs can be found in FirewallMatchesRuleIDs, the actions can be found in FirewallMatchesActions. The length of the array is the same as FirewallMatchesRuleIDs and FirewallMatchesActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>ipRange</em> \| <em>securityLevel</em> \| <em>zoneLockdown</em> \| <em>waf</em> \| <em>firewallRules</em> \| <em>uaBlock</em> \| <em>rateLimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>botFight</em> \| <em>apiShield</em> \| <em>botManagement</em> \| <em>dlp</em> \| <em>firewallManaged</em> \| <em>firewallCustom</em>. | array[string] |
 | JA3Hash | The MD5 hash of the JA3 fingerprint used to profile SSL/TLS clients. Available in Logpush v2 only. | string |
 | OriginDNSResponseTimeMs | Time taken to receive a DNS response for an origin name. Usually takes a few milliseconds, but may be longer if a CNAME record is used. Available in Logpush v2 only. | int |
-| OriginIP | IP of the origin server | string |
-| OriginRequestHeaderSendDurationMs | Time taken to send request headers to origin after establishing a connection. Note that this value is usually 0. Available in Logpush v2 only. | int |
-| OriginResponseBytes (deprecated) | Number of bytes returned by the origin server | int |
+| OriginIP | IP of the origin server. | string |
+| OriginRequestHeaderSendDurationMs | Time taken to send request headers to origin after establishing a connection. Note that this value is usually 0. Available in Logpush v2 only. | int |
+| OriginResponseBytes (deprecated) | Number of bytes returned by the origin server. | int |
 | OriginResponseDurationMs | Upstream response time, measured from the first datacenter that receives a request. Includes time taken by Argo Smart Routing and Tiered Cache, plus time to connect and receive a response from origin servers. This field replaces OriginResponseTime. Available in Logpush v2 only. | int |
-| OriginResponseHTTPExpires | Value of the origin 'expires' header in RFC1123 format | string |
-| OriginResponseHTTPLastModified | Value of the origin 'last-modified' header in RFC1123 format | string |
+| OriginResponseHTTPExpires | Value of the origin 'expires' header in RFC1123 format. | string |
+| OriginResponseHTTPLastModified | Value of the origin 'last-modified' header in RFC1123 format. | string |
 | OriginResponseHeaderReceiveDurationMs | Time taken for origin to return response headers after Cloudflare finishes sending request headers. Available in Logpush v2 only. | int |
 | OriginResponseStatus | Status returned by the origin server. The value 0 means that there was no request made to the origin server and the response was served by Cloudflare's Edge. | int |
-| OriginResponseTime (deprecated) | Number of nanoseconds it took the origin to return the response to edge | int |
-| OriginSSLProtocol | SSL (TLS) protocol used to connect to the origin | string |
+| OriginResponseTime (deprecated) | Number of nanoseconds it took the origin to return the response to edge. | int |
+| OriginSSLProtocol | SSL (TLS) protocol used to connect to the origin. | string |
 | OriginTCPHandshakeDurationMs | Time taken to complete TCP handshake with origin. This will be 0 if an origin connection is reused. Available in Logpush v2 only. | int |
 | OriginTLSHandshakeDurationMs | Time taken to complete TLS handshake with origin. This will be 0 if an origin connection is reused. Available in Logpush v2 only. | int |
-| ParentRayID | Ray ID of the parent request if this request was made using a Worker script | string |
-| RayID | ID of the request | string |
-| RequestHeaders | String key-value pairs for RequestHeaders | object |
-| ResponseHeaders | String key-value pairs for ResponseHeaders | object |
+| ParentRayID | Ray ID of the parent request if this request was made using a Worker script. | string |
+| RayID | ID of the request. | string |
+| RequestHeaders | String key-value pairs for RequestHeaders. | object |
+| ResponseHeaders | String key-value pairs for ResponseHeaders. | object |
 | SecurityLevel | The security level configured at the time of this request. This is used to determine the sensitivity of the IP Reputation system. | string |
 | SmartRouteColoID | The Cloudflare datacenter used to connect to the origin server if Argo Smart Routing is used. Available in Logpush v2 only. | int |
 | UpperTierColoID | The "upper tier" datacenter that was checked for a cached copy if Tiered Cache is used. Available in Logpush v2 only. | int |
-| WAFAction | Action taken by the WAF, if triggered | string |
-| WAFAttackScore | Overall request score generated by the WAF detection module | int |
-| WAFFlags (deprecated) | Additional configuration flags: <em>simulate (0x1)</em> \| <em>null</em> | string |
-| WAFMatchedVar (deprecated) | The full name of the most-recently matched variable | string |
-| WAFProfile | <em>low</em> \| <em>med</em> \| <em>high</em> | string |
-| WAFRCEAttackScore | WAF score for an RCE attack | int |
-| WAFRuleID | ID of the applied WAF rule | string |
-| WAFRuleMessage | Rule message associated with the triggered rule | string |
-| WAFSQLiAttackScore | WAF score for an SQLi attack | int |
-| WAFXSSAttackScore | WAF score for an XSS attack | int |
-| WorkerCPUTime | Amount of time in microseconds spent executing a worker, if any | int |
-| WorkerStatus | Status returned from worker daemon | string |
-| WorkerSubrequest | Whether or not this request was a worker subrequest | bool |
-| WorkerSubrequestCount | Number of subrequests issued by a worker when handling this request | int |
-| WorkerWallTimeUs | Real-time in microseconds elapsed between start and end of worker invocation | int |
+| WAFAction | Action taken by the WAF, if triggered. | string |
+| WAFAttackScore | Overall request score generated by the WAF detection module. | int |
+| WAFFlags (deprecated) | Additional configuration flags: <em>simulate (0x1)</em> \| <em>null</em>. | string |
+| WAFMatchedVar (deprecated) | The full name of the most-recently matched variable. | string |
+| WAFProfile | WAF profile. <br />Possible values are <em>low</em> \| <em>med</em> \| <em>high</em>. | string |
+| WAFRCEAttackScore | WAF score for an RCE attack. | int |
+| WAFRuleID | ID of the applied WAF rule. | string |
+| WAFRuleMessage | Rule message associated with the triggered rule. | string |
+| WAFSQLiAttackScore | WAF score for an SQLi attack. | int |
+| WAFXSSAttackScore | WAF score for an XSS attack. | int |
+| WorkerCPUTime | Amount of time in microseconds spent executing a worker, if any. | int |
+| WorkerStatus | Status returned from worker daemon. | string |
+| WorkerSubrequest | Whether or not this request was a worker subrequest. | bool |
+| WorkerSubrequestCount | Number of subrequests issued by a worker when handling this request. | int |
+| WorkerWallTimeUs | Real-time in microseconds elapsed between start and end of worker invocation. | int |
 | ZoneName | The human-readable name of the zone (e.g. 'cloudflare.com'). Available in Logpush v2 only. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/zone/nel_reports.md
+++ b/content/logs/reference/log-fields/zone/nel_reports.md
@@ -14,12 +14,12 @@ The descriptions below detail the fields available for `nel_reports`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| ClientIPASN | Client ASN | int |
-| ClientIPASNDescription | Client ASN description | string |
-| ClientIPCountry | Client country | string |
-| LastKnownGoodColoCode | IATA airport code of colo client connected to | string |
-| Phase | The phase of connection the error occurred in; <em>dns</em> \| <em>connection</em> \| <em>application</em> \| <em>unknown</em> | string |
-| Timestamp | Timestamp for error report | int or string |
-| Type | The type of error in the phase | string |
+| ClientIPASN | Client ASN. | int |
+| ClientIPASNDescription | Client ASN description. | string |
+| ClientIPCountry | Client country. | string |
+| LastKnownGoodColoCode | IATA airport code of colo client connected to. | string |
+| Phase | The phase of connection the error occurred in; <em>dns</em> \| <em>connection</em> \| <em>application</em> \| <em>unknown</em>. | string |
+| Timestamp | Timestamp for error report. | int or string |
+| Type | The type of error in the phase. | string |
 
 {{</table-wrap>}}

--- a/content/logs/reference/log-fields/zone/spectrum_events.md
+++ b/content/logs/reference/log-fields/zone/spectrum_events.md
@@ -14,36 +14,36 @@ The descriptions below detail the fields available for `spectrum_events`.
 
 | Field | Value | Type |
 | -- | -- | -- |
-| Application | The unique public ID of the application on which the event occurred | string |
-| ClientAsn | Client AS number | int |
-| ClientBytes | The number of bytes read from the client by the Spectrum service | int |
-| ClientCountry | Country of the client IP address | string |
-| ClientIP | Client IP address | string |
-| ClientMatchedIpFirewall | Whether the connection matched any IP Firewall rules. UNKNOWN = No match or Firewall not enabled for spectrum; <em>UNKNOWN</em> \| <em>ALLOW</em> \| <em>BLOCK_ERROR</em> \| <em>BLOCK_IP</em> \| <em>BLOCK_COUNTRY</em> \| <em>BLOCK_ASN</em> \| <em>WHITELIST_IP</em> \| <em>WHITELIST_COUNTRY</em> \| <em>WHITELIST_ASN</em> | string |
-| ClientPort | Client port | int |
-| ClientProto | Transport protocol used by client; <em>tcp</em> \| <em>udp</em> \| <em>unix</em> | string |
-| ClientTcpRtt | The TCP round-trip time in nanoseconds between the client and Spectrum | int |
+| Application | The unique public ID of the application on which the event occurred. | string |
+| ClientAsn | Client AS number. | int |
+| ClientBytes | The number of bytes read from the client by the Spectrum service. | int |
+| ClientCountry | Country of the client IP address. | string |
+| ClientIP | Client IP address. | string |
+| ClientMatchedIpFirewall | Whether the connection matched any IP Firewall rules. UNKNOWN = No match or Firewall not enabled for spectrum; <em>UNKNOWN</em> \| <em>ALLOW</em> \| <em>BLOCK_ERROR</em> \| <em>BLOCK_IP</em> \| <em>BLOCK_COUNTRY</em> \| <em>BLOCK_ASN</em> \| <em>WHITELIST_IP</em> \| <em>WHITELIST_COUNTRY</em> \| <em>WHITELIST_ASN</em>. | string |
+| ClientPort | Client port. | int |
+| ClientProto | Transport protocol used by client; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>. | string |
+| ClientTcpRtt | The TCP round-trip time in nanoseconds between the client and Spectrum. | int |
 | ClientTlsCipher | The cipher negotiated between the client and Spectrum. In v1, an unknown cipher returned as "Unknown." In v2, it's returned as "UNK." | string |
-| ClientTlsClientHelloServerName | The server name in the Client Hello message from client to Spectrum | string |
-| ClientTlsProtocol | The TLS version negotiated between the client and Spectrum; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em> | string |
-| ClientTlsStatus | Indicates state of TLS session from the client to Spectrum; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em> | string |
-| ColoCode | IATA airport code of data center that received the request | string |
-| ConnectTimestamp | Timestamp at which both legs of the connection (client/edge, edge/origin or nexthop) were established | int or string |
-| DisconnectTimestamp | Timestamp at which the connection was closed | int or string |
-| Event | <em>connect</em> \| <em>disconnect</em> \| <em>clientFiltered</em> \| <em>tlsError</em> \| <em>resolveOrigin</em> \| <em>originError</em> | string |
-| IpFirewall | Whether IP Firewall was enabled at time of connection | bool |
-| OriginBytes | The number of bytes read from the origin by Spectrum | int |
-| OriginIP | Origin IP address | string |
-| OriginPort | Origin port | int |
-| OriginProto | Transport protocol used by origin; <em>tcp</em> \| <em>udp</em> \| <em>unix</em> | string |
-| OriginTcpRtt | The TCP round-trip time in nanoseconds between Spectrum and the origin | int |
+| ClientTlsClientHelloServerName | The server name in the Client Hello message from client to Spectrum. | string |
+| ClientTlsProtocol | The TLS version negotiated between the client and Spectrum; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>. | string |
+| ClientTlsStatus | Indicates state of TLS session from the client to Spectrum; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>. | string |
+| ColoCode | IATA airport code of data center that received the request. | string |
+| ConnectTimestamp | Timestamp at which both legs of the connection (client/edge, edge/origin or nexthop) were established. | int or string |
+| DisconnectTimestamp | Timestamp at which the connection was closed. | int or string |
+| Event | <em>connect</em> \| <em>disconnect</em> \| <em>clientFiltered</em> \| <em>tlsError</em> \| <em>resolveOrigin</em> \| <em>originError</em>. | string |
+| IpFirewall | Whether IP Firewall was enabled at time of connection. | bool |
+| OriginBytes | The number of bytes read from the origin by Spectrum. | int |
+| OriginIP | Origin IP address. | string |
+| OriginPort | Origin port. | int |
+| OriginProto | Transport protocol used by origin; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>. | string |
+| OriginTcpRtt | The TCP round-trip time in nanoseconds between Spectrum and the origin. | int |
 | OriginTlsCipher | The cipher negotiated between Spectrum and the origin. In v1, an unknown cipher returned as "Unknown." In v2, it's returned as "UNK." | string |
 | OriginTlsFingerprint | SHA256 hash of origin certificate. In v1, an unknown SHA256 hash is returned as "0000000000000000000000000000000000000000000000000000000000000000." In v2, it's returned as an empty string. | string |
-| OriginTlsMode | If and how the upstream connection is encrypted; <em>unknown</em> \| <em>off</em> \| <em>flexible</em> \| <em>full</em> \| <em>strict</em> | string |
-| OriginTlsProtocol | The TLS version negotiated between Spectrum and the origin; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em> | string |
-| OriginTlsStatus | The state of the TLS session from Spectrum to the origin; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em> | string |
-| ProxyProtocol | Which form of proxy protocol is applied to the given connection; <em>off</em> \| <em>v1</em> \| <em>v2</em> \| <em>simple</em> | string |
-| Status | A code indicating reason for connection closure | int |
-| Timestamp | Timestamp at which the event took place | int or string |
+| OriginTlsMode | If and how the upstream connection is encrypted; <em>unknown</em> \| <em>off</em> \| <em>flexible</em> \| <em>full</em> \| <em>strict</em>. | string |
+| OriginTlsProtocol | The TLS version negotiated between Spectrum and the origin; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>. | string |
+| OriginTlsStatus | The state of the TLS session from Spectrum to the origin; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>. | string |
+| ProxyProtocol | Which form of proxy protocol is applied to the given connection; <em>off</em> \| <em>v1</em> \| <em>v2</em> \| <em>simple</em>. | string |
+| Status | A code indicating reason for connection closure. | int |
+| Timestamp | Timestamp at which the event took place. | int or string |
 
 {{</table-wrap>}}


### PR DESCRIPTION
This updates Log fieldsto to make each description full sentences.

It is synced from internal `logshare-api` repo's fields templates.
Related internal ticket: DS-12863