### PR TITLE
update suggested NODE_VERSION for SvelteKit from 17 to 16

### DIFF
--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -161,7 +161,7 @@ When deploying with [`@sveltejs/adapter-cloudflare`](https://www.npmjs.com/packa
 | Production branch     | `main`                  |
 | Build command         | `npm run build`         |
 | Build directory       | `.svelte-kit/cloudflare`|
-| Environment Variables | `NODE_VERSION: 17 `|
+| Environment Variables | `NODE_VERSION: 18 `|
 
 </div>
 

--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -161,7 +161,7 @@ When deploying with [`@sveltejs/adapter-cloudflare`](https://www.npmjs.com/packa
 | Production branch     | `main`                  |
 | Build command         | `npm run build`         |
 | Build directory       | `.svelte-kit/cloudflare`|
-| Environment Variables | `NODE_VERSION: 18 `|
+| Environment Variables | `NODE_VERSION: 16 `|
 
 </div>
 

--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -161,7 +161,7 @@ When deploying with [`@sveltejs/adapter-cloudflare`](https://www.npmjs.com/packa
 | Production branch     | `main`                  |
 | Build command         | `npm run build`         |
 | Build directory       | `.svelte-kit/cloudflare`|
-| Environment Variables | `NODE_VERSION: 16 `|
+| Environment Variables | `NODE_VERSION: 16` |
 
 </div>
 


### PR DESCRIPTION
We never intended to still be claiming to support Node 17, and we recently merged a PR (https://github.com/sveltejs/kit/pull/8174) to tighten up our `pkg.engines.node` to exclude Node 17. No one should be using Node 17 for anything now anyway because it reached EOL on June 1.