### PR TITLE
[WAF] Remove link in "generate key pair" page to make instructions generic

### DIFF
--- a/content/waf/managed-rules/payload-logging/command-line/generate-key-pair.md
+++ b/content/waf/managed-rules/payload-logging/command-line/generate-key-pair.md
@@ -34,4 +34,4 @@ Do the following:
     }
     ```
 
-After generating the key pair, copy the public key value and enter it in the [payload logging configuration](/waf/managed-rules/payload-logging/configure/).
+After generating the key pair, copy the public key value and enter it in the payload logging configuration.


### PR DESCRIPTION
These instructions will be linked from the Zero Trust documentation.