### PR TITLE
add default-src none - more restrictive

### DIFF
--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -158,5 +158,5 @@ filename: _headers
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
   Permissions-Policy: document-domain=()
-  Content-Security-Policy: script-src 'self'; frame-ancestors 'none';
+  Content-Security-Policy: default-src 'none'; script-src 'self'; frame-ancestors 'none';
 ```


### PR DESCRIPTION
as defined by the CSP standards:

for the hardening is to set default-src 'none';

If no CSP is specified for a directive, it falls back to default-src.

If there is no default-src CSP, it does not fall back on any directive and as a result it allows everything.

As far as everything that falls back (that is allowed) https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src

By adding none - this should be a more restrictive policy