### PR TITLE
add a worker-src suggestion

### DIFF
--- a/content/bots/reference/javascript-detections.md
+++ b/content/bots/reference/javascript-detections.md
@@ -38,6 +38,7 @@ Customers who enabled Enterprise Bot Management before June 2020 do not have Jav
 
 If you have a Content Security Policy (CSP):
 
+- Depending on how restrictive your CSP policy is, you may need to add `worker-src 'self'`
 - Ensure that anything under `/cdn-cgi/challenge-platform/` is allowed. Your CSP should allow scripts served from your origin domain (`script-src self`).
 - If your CSP uses a `nonce` for script tags, Cloudflare will add these nonces to the scripts it injects by parsing your CSP response header.
 - If your CSP does not use `nonce` for script tags and **JavaScript Detection** is enabled, you may see a console error such as `Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-b123b8a70+4jEj+d6gWI9U6IilUJIrlnRJbRR/uQl2Jc='), or a nonce ('nonce-...') is required to enable inline execution.` We highly discourage the use of `unsafe-inline` and instead recommend the use CSP `nonces` in script tags which we parse and support in our CDN.


### PR DESCRIPTION
Depending on how your restrictive your CSP policy is, worker-src may need to be added to support the bot detection

worker-src 'self' is required for some policy implementations to support Javascript Implementations