### PR TITLE
Correct link title for "Selectable CA"

### DIFF
--- a/data/plans.json
+++ b/data/plans.json
@@ -2050,7 +2050,7 @@
           "ent": "Yes"
         },
         "selectable_ca": {
-          "title": "[Custom analytics](/ssl/reference/certificate-authorities/)",
+          "title": "[Selectable CA](/ssl/reference/certificate-authorities/)",
           "free": "No",
           "pro": "No",
           "biz": "No",


### PR DESCRIPTION
This link title is duplicated from Custom Hostnames 

https://community.cloudflare.com/t/cloudflare-docs-small-confusion/447493