### PR TITLE
Fix kv_namespaces anchor

### DIFF
--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -83,7 +83,7 @@ filename: wrangler.toml
 
 ### Adding KV namespaces via wrangler
 
-KV namespaces are defined via the [`kv_namespaces`](/workers/wrangler/configuration/#kv_namespaces) configuration in your `wrangler.toml` and are always provided as [KV runtime instances](/workers/runtime-apis/kv/).
+KV namespaces are defined via the [`kv_namespaces`](/workers/wrangler/configuration/#kv-namespaces) configuration in your `wrangler.toml` and are always provided as [KV runtime instances](/workers/runtime-apis/kv/).
 
 ```toml
 ---


### PR DESCRIPTION
While the config is `kv_namespaces`, the HTML anchor is `kv-namespaces`.