### PR TITLE
Updated list of compatible plugins

### DIFF
--- a/content/automatic-platform-optimization/about/plugin-compatibility.md
+++ b/content/automatic-platform-optimization/about/plugin-compatibility.md
@@ -40,7 +40,8 @@ The Cloudflare APO Wordpress plugin does not support multisite WordPress install
 - [wiziApp](https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app)
 - [WPML](https://wpml.org/)
 - [Hummingbird](https://wordpress.org/plugins/hummingbird-performance/)
+- [Imunify360](https://docs.imunify360.com/features/#webshield)
 
 ## Plugins and services that may cause issues
 
-- [Imunify360](https://docs.imunify360.com/features/#webshield)
+- 


### PR DESCRIPTION
The Imunify360 and APO incompatibility issue was fixed in Imunify360 v5.4.2 (DEF-14652) on Nov 12, 2020. The current stable version is 6.9.2.
* https://blog.imunify360.com/release-notes-imunify360-v.5.4-2
* https://www.imunify360.com/getting-started-recaptcha/