### PR TITLE
[Docs site] If no page meta description specified, use the first 150 characters of the text

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ languageCode = "en"
 DefaultContentLanguage = "en"
 disableHugoGeneratorInject = true
 enableRobotsTXT = false
-
+summaryLength = 30
 disableAliases = true
 disableKinds = ["taxonomy", "taxonomyTerm"]
 

--- a/content/dns/manage-dns-records/reference/proxied-dns-records.md
+++ b/content/dns/manage-dns-records/reference/proxied-dns-records.md
@@ -6,9 +6,9 @@ weight: 1
 
 # Proxy status
 
-The **Proxy status** of a DNS record affects how Cloudflare treats incoming traffic to that record. Cloudlare recommends enabling our proxy for all `A`, `AAAA`, and `CNAME` records.
-
 ![Proxy status affects how Cloudflare treats traffic intended for specific DNS records](/dns/static/proxy-status-screenshot.png)
+
+The **Proxy status** of a DNS record affects how Cloudflare treats incoming traffic to that record. Cloudlare recommends enabling our proxy for all `A`, `AAAA`, and `CNAME` records.
 
 ---
 

--- a/content/dns/manage-dns-records/reference/proxied-dns-records.md
+++ b/content/dns/manage-dns-records/reference/proxied-dns-records.md
@@ -6,9 +6,7 @@ weight: 1
 
 # Proxy status
 
-The **Proxy status** of a DNS record affects how Cloudflare treats incoming traffic to that record.
-
-Cloudlare recommends enabling our proxy for all `A`, `AAAA`, and `CNAME` records.
+The **Proxy status** of a DNS record affects how Cloudflare treats incoming traffic to that record. Cloudlare recommends enabling our proxy for all `A`, `AAAA`, and `CNAME` records.
 
 ![Proxy status affects how Cloudflare treats traffic intended for specific DNS records](/dns/static/proxy-status-screenshot.png)
 

--- a/content/dns/manage-dns-records/reference/proxied-dns-records.md
+++ b/content/dns/manage-dns-records/reference/proxied-dns-records.md
@@ -6,9 +6,9 @@ weight: 1
 
 # Proxy status
 
-![Proxy status affects how Cloudflare treats traffic intended for specific DNS records](/dns/static/proxy-status-screenshot.png)
-
 The **Proxy status** of a DNS record affects how Cloudflare treats incoming traffic to that record. Cloudlare recommends enabling our proxy for all `A`, `AAAA`, and `CNAME` records.
+
+![Proxy status affects how Cloudflare treats traffic intended for specific DNS records](/dns/static/proxy-status-screenshot.png)
 
 ---
 

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -5,8 +5,8 @@
 {{- $pt := default .Context.Title .Context.Params.meta.title -}}
 {{- $title := printf "%s · %s" $pt $DATA.meta.title -}}
 {{ $raw_summary := index (split (index (split .Context.Content "</p>") 0) "<p>") 1 | plainify | htmlUnescape | chomp }}
-{{ $summary_no_external_links := replace $raw_summary "External link icon Open external link " "" }}
-{{- $description:= default $summary_no_external_links .Context.Params.meta.description -}}
+{{ $summary := truncate 160 (replace $raw_summary "External link icon Open external link " "") }}
+{{- $description:= default $summary .Context.Params.meta.description -}}
 
 <meta charset="utf-8">
 <title>{{ $title }}</title>
@@ -22,16 +22,16 @@
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="theme-color" content="#f38020"/>
 
-<meta name="description" content="{{ $description }}" />
+<meta name="description" content="{{ default $META.description $description }}" />
 
 <meta property="og:image" content="{{ $META.image | absURL }}"/>
 <meta property="og:title" content="{{ $title }}"/>
-<meta property="og:description" content="{{ $description }}"/>
+<meta property="og:description" content="{{ default $META.description $description }}"/>
 <meta property="og:type" content="website"/>
 
 <meta name="twitter:title" content="{{ $title }}"/>
 <meta name="twitter:image" content="{{ $META.image | absURL }}"/>
-<meta name="twitter:description" content="{{ $description }}"/>
+<meta name="twitter:description" content="{{ default $META.description $description }}"/>
 <meta name="twitter:creator" content="{{ $META.author }}"/>
 <meta name="twitter:card" content="summary_large_image"/>
 

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -4,6 +4,7 @@
 
 {{- $pt := default .Context.Title .Context.Params.meta.title -}}
 {{- $title := printf "%s · %s" $pt $DATA.meta.title -}}
+{{- $description:= default .Context.Summary .Context.Params.meta.description | safeHTML -}}
 
 <meta charset="utf-8">
 <title>{{ $title }}</title>
@@ -19,16 +20,16 @@
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="theme-color" content="#f38020"/>
 
-<meta name="description" content="{{ $META.description }}" />
+<meta name="description" content="{{ $description | safeHTML }}" />
 
 <meta property="og:image" content="{{ $META.image | absURL }}"/>
 <meta property="og:title" content="{{ $title }}"/>
-<meta property="og:description" content="{{ $META.description }}"/>
+<meta property="og:description" content="{{ $description | safeHTML }}"/>
 <meta property="og:type" content="website"/>
 
 <meta name="twitter:title" content="{{ $title }}"/>
 <meta name="twitter:image" content="{{ $META.image | absURL }}"/>
-<meta name="twitter:description" content="{{ $META.description }}"/>
+<meta name="twitter:description" content="{{ $description | safeHTML }}"/>
 <meta name="twitter:creator" content="{{ $META.author }}"/>
 <meta name="twitter:card" content="summary_large_image"/>
 

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -4,7 +4,9 @@
 
 {{- $pt := default .Context.Title .Context.Params.meta.title -}}
 {{- $title := printf "%s · %s" $pt $DATA.meta.title -}}
-{{- $description:= default .Context.Summary .Context.Params.meta.description | safeHTML -}}
+{{ $raw_summary := index (split (index (split .Context.Content "</p>") 0) "<p>") 1 | plainify | htmlUnescape | chomp }}
+{{ $summary_no_external_links := replace $raw_summary "External link icon Open external link " "" }}
+{{- $description:= default $summary_no_external_links .Context.Params.meta.description -}}
 
 <meta charset="utf-8">
 <title>{{ $title }}</title>
@@ -20,16 +22,16 @@
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="theme-color" content="#f38020"/>
 
-<meta name="description" content="{{ $description | safeHTML }}" />
+<meta name="description" content="{{ $description }}" />
 
 <meta property="og:image" content="{{ $META.image | absURL }}"/>
 <meta property="og:title" content="{{ $title }}"/>
-<meta property="og:description" content="{{ $description | safeHTML }}"/>
+<meta property="og:description" content="{{ $description }}"/>
 <meta property="og:type" content="website"/>
 
 <meta name="twitter:title" content="{{ $title }}"/>
 <meta name="twitter:image" content="{{ $META.image | absURL }}"/>
-<meta name="twitter:description" content="{{ $description | safeHTML }}"/>
+<meta name="twitter:description" content="{{ $description }}"/>
 <meta name="twitter:creator" content="{{ $META.author }}"/>
 <meta name="twitter:card" content="summary_large_image"/>
 

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -5,8 +5,8 @@
 {{- $pt := default .Context.Title .Context.Params.meta.title -}}
 {{- $title := printf "%s · %s" $pt $DATA.meta.title -}}
 {{ $raw_summary := index (split (index (split .Context.Content "</p>") 0) "<p>") 1 | plainify | htmlUnescape | chomp }}
-{{ $summary := truncate 160 (replace $raw_summary "External link icon Open external link " "") }}
-{{- $description:= default $summary .Context.Params.meta.description -}}
+{{ $summary := replace $raw_summary "External link icon Open external link " "" }}
+{{- $description:= truncate 160 (default $META.description (default $summary .Context.Params.meta.description)) -}}
 
 <meta charset="utf-8">
 <title>{{ $title }}</title>
@@ -22,16 +22,16 @@
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="theme-color" content="#f38020"/>
 
-<meta name="description" content="{{ default $META.description $description }}" />
+<meta name="description" content="{{ $description }}" />
 
 <meta property="og:image" content="{{ $META.image | absURL }}"/>
 <meta property="og:title" content="{{ $title }}"/>
-<meta property="og:description" content="{{ default $META.description $description }}"/>
+<meta property="og:description" content="{{ $description }}"/>
 <meta property="og:type" content="website"/>
 
 <meta name="twitter:title" content="{{ $title }}"/>
 <meta name="twitter:image" content="{{ $META.image | absURL }}"/>
-<meta name="twitter:description" content="{{ default $META.description $description }}"/>
+<meta name="twitter:description" content="{{ $description }}"/>
 <meta name="twitter:creator" content="{{ $META.author }}"/>
 <meta name="twitter:card" content="summary_large_image"/>
 


### PR DESCRIPTION
Known issues:
- Leaves in footnote numbers (seems like a minor concern)