### PR TITLE
Dropping OS versions no longer supported

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/download-warp.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/download-warp.md
@@ -18,7 +18,7 @@ Alternatively, download the client from one of the following links after checkin
       <td>
         <strong>OS Ver</strong>
       </td>
-      <td>Windows 8.1, Windows 10, Windows 11</td>
+      <td>Windows 10, Windows 11</td>
     </tr>
     <tr>
       <td>
@@ -65,7 +65,7 @@ Alternatively, download the client from one of the following links after checkin
       <td>
         <strong>OS Ver</strong>
       </td>
-      <td>Mojave, Catalina, Big Sur, Monterey, Ventura</td>
+      <td>Catalina, Big Sur, Monterey, Ventura</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
Dropping Mojave and Windows 8 as they are no longer supported by the vendor (and so no longer supported by us)