### PR TITLE
Updates to reflect new product names and UI elements

### DIFF
--- a/content/cloudflare-one/tutorials/require-swg.md
+++ b/content/cloudflare-one/tutorials/require-swg.md
@@ -1,5 +1,5 @@
 ---
-updated: 2020-12-20
+updated: 2022-01-05
 category: 🔐 Zero Trust
 difficulty: Medium
 pcx_content_type: tutorial
@@ -30,7 +30,7 @@ Cloudflare Gateway operates in two modes:
 - DNS filtering
 - Proxy (HTTP filtering)
 
-The proxy mode in Gateway requires a Gateway Standard or Cloudflare Zero Trust Standard [plan](https://www.cloudflare.com/teams-pricing/).
+The proxy mode in Gateway requires a Gateway Standard or Cloudflare Zero Trust Standard [plan](https://www.cloudflare.com/plans/zero-trust-services/).
 
 To filter all Internet-bound traffic in the proxy mode, devices must install and enroll the Zero Trust WARP client. The WARP client will send all Internet traffic to a Cloudflare data center near the user where it can be filtered and logged before reaching the rest of the Internet.
 
@@ -40,7 +40,7 @@ Building a rule in Access to enforce Gateway connections requires the use of the
 
 Next, build a rule to decide which devices can enroll in your account.
 
-1.  Navigate to **Settings > Devices > Device enrollment**.
+1.  Navigate to **Settings > WARP Client > Device enrollment**.
 
 1.  Click **Manage**.
 
@@ -61,7 +61,7 @@ To inspect traffic, Cloudflare Gateway requires that a [certificate be installed
 To download the Cloudflare certificate:
 
 - Follow the link provided in [these instructions](/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cloudflare-cert/).
-- Find the certificate in the Zero Trust Dashboard, by navigating to **Settings > Devices > Certificates**.
+- Find the certificate in the Zero Trust Dashboard, by navigating to **Settings > Downloads > Certificates**.
 
 ## Enable the Cloudflare proxy
 
@@ -75,7 +75,7 @@ Next, enable TLS decryption. This will tell Cloudflare to begin decrypting traff
 
 1.  Once the client is installed, click the gear icon.
 
-1.  Under the **Account** tab, click **Login with Cloudflare for Teams**.
+1.  Under the **Account** tab, click **Login with Cloudflare Zero Trust**.
 
 1.  Input your [team name](/cloudflare-one/glossary/#team-name). You can find it on the Zero Trust Dashboard under **Settings > General**.
 


### PR DESCRIPTION
Certain UI elements are renamed (For example, the cert is downloaded from the "Downloads" page instead of "Devices") and enrollment policies are defined in the "WARP Client" page. Finally, several names and links were updated to reflect the new branding.