### PR TITLE
[Cache] reword note about `no-cache` directive in cache-control.md

### DIFF
--- a/content/cache/about/cache-control.md
+++ b/content/cache/about/cache-control.md
@@ -45,7 +45,9 @@ Expiration refers to how long a resource should remain in the cache, and the dir
 
 Cloudflare respects whichever value is higher: the [Browser Cache TTL](/cache/about/edge-browser-cache-ttl/) in Cloudflare or the `max-age` header. You can also simultaneously specify a Cloudflare Edge Cache TTL different than a Browser’s Cache TTL respectively via the `s-maxage` and `max-age` Cache-Control headers.
 
-When using Origin Cache-Control and setting `max-age=0`, Cloudflare prefers to cache and revalidate. With Origin Cache-Control off and `max-age=0`, Cloudflare settings bypass cache. Setting `no-cache` bypasses cache regardless of the Origin Cache-Control setting.
+When using Origin Cache-Control and setting `max-age=0`, Cloudflare prefers to cache and revalidate. With Origin Cache-Control off and `max-age=0`, Cloudflare will bypass cache. Setting `no-cache` bypasses cache regardless of the Origin Cache-Control setting.
+
+When setting `no-cache` with Origin Cache-Control off, Cloudflare does not cache. When setting `no-cache` with Origin Cache-Control on, Cloudflare caches and revalidates. 
 
 {{</Aside>}}
 

--- a/content/cache/about/cache-control.md
+++ b/content/cache/about/cache-control.md
@@ -45,7 +45,7 @@ Expiration refers to how long a resource should remain in the cache, and the dir
 
 Cloudflare respects whichever value is higher: the [Browser Cache TTL](/cache/about/edge-browser-cache-ttl/) in Cloudflare or the `max-age` header. You can also simultaneously specify a Cloudflare Edge Cache TTL different than a Browser’s Cache TTL respectively via the `s-maxage` and `max-age` Cache-Control headers.
 
-When using Origin Cache-Control and setting `max-age=0`, Cloudflare prefers to cache and revalidate. With Origin Cache-Control off and `max-age=0`, Cloudflare settings bypass cache. Setting `no-cache` also bypasses cache.
+When using Origin Cache-Control and setting `max-age=0`, Cloudflare prefers to cache and revalidate. With Origin Cache-Control off and `max-age=0`, Cloudflare settings bypass cache. Setting `no-cache` bypasses cache regardless of the Origin Cache-Control setting.
 
 {{</Aside>}}
 


### PR DESCRIPTION
- Update wording to explicitly state the outcome from using `no-cache` and ANY Origin Cache-Control (on or off)
- This removes the possibility of someone interpreting the note initially as "Origin Cache-Control OFF and `no-cache` bypasses cache". This is how I initially interpreted it, and it seems this interpretation is ~~wrong~~ _not what the meaning of the note was meant to be._ I believe the intended meaning is that using `no-cache` ALWAYS bypasses CloudFlare cache.