### PR TITLE
Removed non-standard ports for RDP

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/use_cases/rdp.md
+++ b/content/cloudflare-one/connections/connect-apps/use_cases/rdp.md
@@ -90,7 +90,7 @@ You now have secure, remote access to the RDP server.
 
 2. In the **Public Hostnames** tab, choose a domain from the drop-down menu and specify any subdomain (for example, `rdp.example.com`).
 
-3. For **Service**,  select _RDP_ and enter the [RDP listening port](https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/change-listening-port) of your server (for example, `localhost:3389`). It will likely be port `80`, `443`, or `3389`.
+3. For **Service**,  select _RDP_ and enter the [RDP listening port](https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/change-listening-port) of your server (for example, `localhost:3389`). It will likely be port `3389`.
 
 4. Select **Save hostname**.
 


### PR DESCRIPTION
RDP _usually_ uses port `3389`. Ports `80` and `443` are seldom used for RDP, but they are used for RDS which is a different technology that should get its own article.