### PR TITLE
[Docs site] Added RSS feeds where appropriate

### DIFF
--- a/content/analytics/web-analytics/changelog.md
+++ b/content/analytics/web-analytics/changelog.md
@@ -4,6 +4,7 @@ pcx_content_type: changelog
 weight: 6
 meta:
   title: Changelog for beacon.min.js
+rss: file
 ---
 
 # Changelog for `beacon.min.js`

--- a/content/ddos-protection/change-log/_index.md
+++ b/content/ddos-protection/change-log/_index.md
@@ -5,6 +5,7 @@ weight: 20
 layout: single
 meta:
   title: Changelog for managed rulesets
+rss: folder
 ---
 
 # Changelog for managed rulesets

--- a/content/queues/changelog.md
+++ b/content/queues/changelog.md
@@ -2,6 +2,7 @@
 pcx_content_type: changelog
 title: Changelog
 weight: 11
+rss: file
 ---
 
 # Changelog

--- a/content/r2/platform/changelog.md
+++ b/content/r2/platform/changelog.md
@@ -2,6 +2,7 @@
 pcx_content_type: changelog
 title: Changelog
 weight: 3
+rss: file
 ---
 
 # Changelog

--- a/content/turnstile/changelog.md
+++ b/content/turnstile/changelog.md
@@ -2,6 +2,7 @@
 pcx_content_type: changelog
 title: Changelog
 weight: 10
+rss: file
 ---
 
 # Changelog

--- a/content/waf/change-log/scheduled-changes.md
+++ b/content/waf/change-log/scheduled-changes.md
@@ -4,6 +4,7 @@ pcx_content_type: changelog
 title: Scheduled changes
 weight: 2
 layout: list
+rss: file
 ---
 
 # Scheduled changes

--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -2,6 +2,7 @@
 pcx_content_type: concept
 title: Compatibility dates
 layout: compatibility-dates
+rss: file
 outputs:
   - html
   - json


### PR DESCRIPTION
Following up on #7053 and #7217, adding RSS feed links to the other changelog pages in our docs.

@GregBrimble, also think the compatibility dates page makes sense, but let me know if you think otherwise.