### PR TITLE
[Docs site] Broadened RSS feeds to take direct input

### DIFF
--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -2,7 +2,7 @@
 pcx_content_type: concept
 title: Compatibility dates
 layout: compatibility-dates
-rss: file
+rss: https://github.com/cloudflare/cloudflare-docs/commits/production/content/workers/_partials/_platform-compatibility-dates.atom
 outputs:
   - html
   - json

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -57,9 +57,16 @@
 
   {{ if or (eq . "folder") (eq . "file") }}
 
- {{ $rssFeed = printf "%s%s%s" $rssPath $contentPath $folderPlaceholder }}
- {{ printf `<link rel="alternate" type="application/rss+xml" href="%s" title="%s - RSS Feed" />` $rssFeed $pt | safeHTML }}
-{{ end }}
+  {{ $rssFeed = printf "%s%s%s" $rssPath $contentPath $folderPlaceholder }}
+  {{ printf `<link rel="alternate" type="application/rss+xml" href="%s" title="%s - RSS Feed" />` $rssFeed $pt | safeHTML }}
+  
+  {{ else }}
+
+  {{ printf `<link rel="alternate" type="application/rss+xml" href="%s" title="%s - RSS Feed" />` . $pt | safeHTML }}
+
+  {{ end }}
+
+
 {{ end }}
 <link rel="icon" href="/favicon-32x32.png"/>
 <link rel="canonical" href="{{ .Context.Permalink }}"/>

--- a/layouts/partials/topbar.tools.html
+++ b/layouts/partials/topbar.tools.html
@@ -30,6 +30,12 @@
 
   {{ $rssFeed = printf "%s%s%s" $rssPath $contentPath $folderPlaceholder }}
 
+  {{ else }}
+
+  {{ $rssFeed = . }}
+
+  {{ end }}
+
   <div class="DocsToolbar--tools-spacer"></div>
 
   <div class="DocsToolbar--tools-icon-item">
@@ -48,8 +54,6 @@
       </span>
     </div>
   </div>
-
-  {{ end }}
 
   {{ end }}
 


### PR DESCRIPTION
In the case of something like the [Compatibility Dates](https://developers.cloudflare.com/workers/platform/compatibility-dates/) page, actually watching [the page's RSS feed](https://github.com/cloudflare/cloudflare-docs/commits/production/content/workers/platform/compatibility-dates.md.atom) isn't helpful. 

Instead, you'd want to watch the RSS feed for the [_partials folder](https://github.com/cloudflare/cloudflare-docs/commits/production/content/workers/_partials/_platform-compatibility-dates.atom).

Broadening our components to allow a bit more flexibility.

cc: @GregBrimble 