### PR TITLE
Update http-request-headers.md

### DIFF
--- a/content/fundamentals/get-started/reference/http-request-headers.md
+++ b/content/fundamentals/get-started/reference/http-request-headers.md
@@ -14,7 +14,7 @@ This header will only be sent on the traffic from Cloudflare's edge to your orig
 
 For guidance on logging your visitor’s original IP address, refer to [Restoring original visitor IPs](https://support.cloudflare.com/hc/articles/200170786).
 
-Alternatively, if you do not wish to receive the `CF-Connecting-IP` header or any HTTP header that may contain the visitor's IP address, [enable the **Remove visitor IP headers** Managed Transform](/rules/transform/managed-transforms/configure/).
+Alternatively, if you do not wish to receive the `CF-Connecting-IP` header, [enable the **Remove visitor IP headers** Managed Transform](/rules/transform/managed-transforms/reference/).
 
 ## CF-Connecting-IPv6
 

--- a/content/fundamentals/get-started/reference/http-request-headers.md
+++ b/content/fundamentals/get-started/reference/http-request-headers.md
@@ -14,7 +14,7 @@ This header will only be sent on the traffic from Cloudflare's edge to your orig
 
 For guidance on logging your visitor’s original IP address, refer to [Restoring original visitor IPs](https://support.cloudflare.com/hc/articles/200170786).
 
-Alternatively, if you do not wish to receive the `CF-Connecting-IP` header, [enable the **Remove visitor IP headers** Managed Transform](/rules/transform/managed-transforms/reference/).
+Alternatively, if you do not wish to receive the `CF-Connecting-IP` header, enable the [**Remove visitor IP headers** Managed Transform](/rules/transform/managed-transforms/reference/).
 
 ## CF-Connecting-IPv6
 


### PR DESCRIPTION
x-forwarded-for can't be removed and may contain the visitor IP. On the updated link notes are provided how it works.