### PR TITLE
[Wrangler] Template URL Updates

### DIFF
--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -50,13 +50,13 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 ## Templates
 
-{{<worker-starter title="JavaScript Starter" repo="cloudflare/worker-template" description="A bare-bones Workers starter project, in JavaScript.">}}
+{{<worker-starter title="JavaScript Starter" repo="cloudflare/wrangler2/packages/templates/worker" description="A bare-bones Workers starter project, in JavaScript.">}}
 
-{{<worker-starter title="TypeScript Starter" repo="cloudflare/worker-typescript-template" description="A bare-bones Workers starter project, in TypeScript.">}}
+{{<worker-starter title="TypeScript Starter" repo="cloudflare/wrangler2/packages/templates/worker-typescript" description="A bare-bones Workers starter project, in TypeScript.">}}
 
-{{<worker-starter title="Workers Sites" repo="cloudflare/worker-sites-template" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
+{{<worker-starter title="Workers Sites" repo="cloudflare/wrangler2/packages/templates/worker-sites" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
 
-{{<worker-starter title="Router" repo="cloudflare/worker-template-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
+{{<worker-starter title="Router" repo="cloudflare/wrangler2/packages/templates/worker-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
 
 {{<worker-starter title="Miniflare Example Project" repo="mrbbot/miniflare-typescript-esbuild-jest" description="An example Cloudflare Workers project that uses Miniflare for local development, TypeScript, esbuild for bundling, and Jest for testing, with Miniflare's custom Jest environment.">}}
 
@@ -78,7 +78,7 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 ## Example Projects
 
-{{<worker-starter title="Speedtest" repo="cloudflare/worker-speedtest-template"
+{{<worker-starter title="Speedtest" repo="cloudflare/wrangler2/packages/templates/worker-speedtest"
 description="Measure download / upload connection speed from the client side, using the Performance Timing API.">}}
 
 {{<worker-starter title="Sentry" repo="bustle/cf-sentry" description="Log exceptions and errors in your Workers application to Sentry.io - an error tracking tool">}}
@@ -89,7 +89,7 @@ description="Measure download / upload connection speed from the client side, us
 
 {{<worker-starter title="BinAST" repo="xtuc/binast-cf-worker-template" description="Serve a JavaScript Binary AST via a Cloudflare Worker.">}}
 
-{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/workers-aws-template" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
+{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/wrangler2/packages/templates/worker-aws" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
 
 {{<worker-starter title="Edge-side rendering - Vitedge" repo="frandiox/vitessedge-template" description="Use Vite to render pages at the edge with great DX. Includes i18n, markdown support and more.">}}
 
@@ -98,10 +98,10 @@ description="Measure download / upload connection speed from the client side, us
 ---
 
 ## Other languages
-
+<!-- Move any templates not in /templates repo into new location cloudflare/wrangler2/packages/templates/  and archive them -->
 Other languages may require you to install additional tools beyond wrangler. See the README.md file in the project.
 
-{{<worker-starter title="Hello World (Rust)" repo="cloudflare/rustwasm-worker-template" description="A bare-bones starter in Rust.">}}
+{{<worker-starter title="Hello World (Rust)" repo="cloudflare/wrangler2/packages/templates/worker-rust" description="A bare-bones starter in Rust.">}}
 
 {{<worker-starter title="Hello World (Python)" repo="cloudflare/python-worker-hello-world" description="A bare-bones starter in Python.">}}
 
@@ -117,13 +117,13 @@ Other languages may require you to install additional tools beyond wrangler. See
 
 {{<worker-starter title="Hello World (Kotlin)" repo="cloudflare/kotlin-worker-hello-world" description="A bare-bones starter in Kotlin.">}}
 
-{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/cobol-worker-template" description="A bare-bones starter in COBOL.">}}
+{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/wrangler2/packages/templates/worker-cobol" description="A bare-bones starter in COBOL.">}}
 
 {{<worker-starter title="Hello World (Perl)" repo="cloudflare/perl-worker-hello-world" description="A bare-bones starter in Perl.">}}
 
 {{<worker-starter title="Hello World (PHP)" repo="cloudflare/php-worker-hello-world" description="A bare-bones starter in PHP.">}}
 
-{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/worker-emscripten-template" description="An image resizer in C compiled to Wasm with Emscripten.">}}
+{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/wrangler2/packages/templates/worker-emscripten-template" description="An image resizer in C compiled to Wasm with Emscripten.">}}
 
 ---
 

--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -50,13 +50,13 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 ## Templates
 
-{{<worker-starter title="JavaScript Starter" repo="cloudflare/wrangler2/packages/templates/worker" description="A bare-bones Workers starter project, in JavaScript.">}}
+{{<worker-starter title="JavaScript Starter" repo="cloudflare/wrangler2/templates/worker" description="A bare-bones Workers starter project, in JavaScript.">}}
 
-{{<worker-starter title="TypeScript Starter" repo="cloudflare/wrangler2/packages/templates/worker-typescript" description="A bare-bones Workers starter project, in TypeScript.">}}
+{{<worker-starter title="TypeScript Starter" repo="cloudflare/wrangler2/templates/worker-typescript" description="A bare-bones Workers starter project, in TypeScript.">}}
 
-{{<worker-starter title="Workers Sites" repo="cloudflare/wrangler2/packages/templates/worker-sites" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
+{{<worker-starter title="Workers Sites" repo="cloudflare/wrangler2/templates/worker-sites" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
 
-{{<worker-starter title="Router" repo="cloudflare/wrangler2/packages/templates/worker-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
+{{<worker-starter title="Router" repo="cloudflare/wrangler2/templates/worker-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
 
 {{<worker-starter title="Miniflare Example Project" repo="mrbbot/miniflare-typescript-esbuild-jest" description="An example Cloudflare Workers project that uses Miniflare for local development, TypeScript, esbuild for bundling, and Jest for testing, with Miniflare's custom Jest environment.">}}
 
@@ -78,7 +78,7 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 ## Example Projects
 
-{{<worker-starter title="Speedtest" repo="cloudflare/wrangler2/packages/templates/worker-speedtest"
+{{<worker-starter title="Speedtest" repo="cloudflare/wrangler2/templates/worker-speedtest"
 description="Measure download / upload connection speed from the client side, using the Performance Timing API.">}}
 
 {{<worker-starter title="Sentry" repo="bustle/cf-sentry" description="Log exceptions and errors in your Workers application to Sentry.io - an error tracking tool">}}
@@ -89,7 +89,7 @@ description="Measure download / upload connection speed from the client side, us
 
 {{<worker-starter title="BinAST" repo="xtuc/binast-cf-worker-template" description="Serve a JavaScript Binary AST via a Cloudflare Worker.">}}
 
-{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/wrangler2/packages/templates/worker-aws" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
+{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/wrangler2/templates/worker-aws" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
 
 {{<worker-starter title="Edge-side rendering - Vitedge" repo="frandiox/vitessedge-template" description="Use Vite to render pages at the edge with great DX. Includes i18n, markdown support and more.">}}
 
@@ -98,10 +98,10 @@ description="Measure download / upload connection speed from the client side, us
 ---
 
 ## Other languages
-<!-- Move any templates not in /templates repo into new location cloudflare/wrangler2/packages/templates/  and archive them -->
+<!-- Move any templates not in /templates repo into new location cloudflare/wrangler2/templates/  and archive them -->
 Other languages may require you to install additional tools beyond wrangler. See the README.md file in the project.
 
-{{<worker-starter title="Hello World (Rust)" repo="cloudflare/wrangler2/packages/templates/worker-rust" description="A bare-bones starter in Rust.">}}
+{{<worker-starter title="Hello World (Rust)" repo="cloudflare/wrangler2/templates/worker-rust" description="A bare-bones starter in Rust.">}}
 
 {{<worker-starter title="Hello World (Python)" repo="cloudflare/python-worker-hello-world" description="A bare-bones starter in Python.">}}
 
@@ -117,13 +117,13 @@ Other languages may require you to install additional tools beyond wrangler. See
 
 {{<worker-starter title="Hello World (Kotlin)" repo="cloudflare/kotlin-worker-hello-world" description="A bare-bones starter in Kotlin.">}}
 
-{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/wrangler2/packages/templates/worker-cobol" description="A bare-bones starter in COBOL.">}}
+{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/wrangler2/templates/worker-cobol" description="A bare-bones starter in COBOL.">}}
 
 {{<worker-starter title="Hello World (Perl)" repo="cloudflare/perl-worker-hello-world" description="A bare-bones starter in Perl.">}}
 
 {{<worker-starter title="Hello World (PHP)" repo="cloudflare/php-worker-hello-world" description="A bare-bones starter in PHP.">}}
 
-{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/wrangler2/packages/templates/worker-emscripten-template" description="An image resizer in C compiled to Wasm with Emscripten.">}}
+{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/wrangler2/templates/worker-emscripten-template" description="An image resizer in C compiled to Wasm with Emscripten.">}}
 
 ---
 


### PR DESCRIPTION
Moving the templates repo under Wrangler2 monorepo. Further work will include moving all other templates into the Wrangler2 templates package.

Discovered there are still a lot of templates that were not moved into the templates repo, next efforts should be to move any templates not in `/templates` repo into new location `cloudflare/wrangler2/packages/templates/`  and archive them too.
Cc: @lauragift21 

Goes in with PR https://github.com/cloudflare/wrangler2/pull/2498