### PR TITLE
remove extra tab default in nextjs guide

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -52,7 +52,7 @@ export default async function (req) {
 ```
 
 {{</tab>}}
-{{<tab label="ts" default="true">}}
+{{<tab label="ts">}}
 
 ```ts
 ---


### PR DESCRIPTION
in the Next.js guide for the api/hello.(js|ts) file we have two
tabs (for the js and ts version) both are set as default,
this causes both tabs to be displayed when accessing the page,
remove the default from the ts tab so that only the js one is
shown initially

___

This is the issue this PR is fixing:
![Screenshot 2023-01-16 at 16 31 18](https://user-images.githubusercontent.com/61631103/212730856-f6b50aa3-9ba2-4d88-ae0f-3e3df546cf69.png)
