### PR TITLE
add mdBook to the list of build configurations

### DIFF
--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -49,6 +49,7 @@ If you are not using a framework, leave the **Build command** field blank.
 | Hugo                         | `hugo`                               | `public`                    |
 | Jekyll                       | `jekyll build`                       | `_site`                     |
 | Jigsaw                       | `vendor/bin/jigsaw build production` | `build_production`          |
+| mdBook                       | `mdbook build`                       | `book`                      |
 | Mkdocs                       | `mkdocs build`                       | `site`                      |
 | Next.js (Static HTML Export) | `next build && next export`          | `out`                       |
 | Nuxt.js                      | `nuxt generate`                      | `dist`                      |


### PR DESCRIPTION
Since Zola -- a Rust-based tool -- is supported, it would be nice to have mdBook supported as well since it too is Rust-based

More info here: https://rust-lang.github.io/mdBook/continuous-integration.html