### PR TITLE
[TryCloudflare] Updated the "oldest version" in trycloudflare.md

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare.md
+++ b/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare.md
@@ -10,7 +10,7 @@ Developers can use the TryCloudflare tool to experiment with Cloudflare Tunnel w
 
 ## Using TryCloudflare
 
-1.  Follow [these instructions](/cloudflare-one/connections/connect-apps/install-and-setup/installation/) to install `cloudflared`. If you have an older copy, update to 2019.4.0 or later.
+1.  Follow [these instructions](/cloudflare-one/connections/connect-apps/install-and-setup/installation/) to install `cloudflared`. If you have an older copy, update to 2020.5.1 or later.
 1.  Launch a web server that is available over localhost to `cloudflared`.
 1.  Run the following terminal command to start a free tunnel.
 


### PR DESCRIPTION
As per [/cloudflare-one/connections/connect-apps/install-and-setup/installation.md]( https://github.com/cloudflare/cloudflare-docs/blob/production/content/cloudflare-one/connections/connect-apps/install-and-setup/installation.md), 2020.5.1 is the oldest _current_ supported version and not 2019.4.0 