### PR TITLE
[Logpush] Remove beta notice from R2 destination

### DIFF
--- a/content/logs/get-started/enable-destinations/r2/index.md
+++ b/content/logs/get-started/enable-destinations/r2/index.md
@@ -9,9 +9,7 @@ layout: single
 
 Cloudflare Logpush supports pushing logs directly to R2 via the Cloudflare dashboard or via API. 
 
-We are offering Enterprise customers interested in storing their logs on Cloudflare access to R2 for evaluation and testing. Note that at this time we are not offering an SLA for R2. It should not be used for production use cases where logs are mission-critical. 
-
-During this phase, we will not be charging for R2 usage. We will be providing 30 days notice ahead of any charges. At that time, your account team will reach out to discuss interest in signing a contract for R2 usage. We expect to start charging for R2 in Q4 2022.
+For more information about R2, refer to the [Cloudflare R2](/r2/) documentation.
 
 Before getting started:
 


### PR DESCRIPTION
Removes the outdated notice about R2 being early access/beta with no SLA or pricing.