### PR TITLE
Add integration-guide content type

### DIFF
--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -56,7 +56,7 @@
         "body": [
             "---",
             "title: ${1:title}",
-            "pcx_content_type: ${2|overview,concept,how-to,configuration,reference,navigation,best-practices,faq,tutorial,glossary|}",
+            "pcx_content_type: ${2|overview,concept,how-to,tutorial,integration-guide,configuration,reference,navigation,best-practices,faq,glossary|}",
             "weight: TODO",
             "---",
             "",


### PR DESCRIPTION
Placing `how-to`, `tutorial`, and `integration-guide` content types next to each other because there's a nuanced choice between them.