### PR TITLE
Add OBS as supported WHIP client (w/note)

### DIFF
--- a/content/stream/webrtc-beta.md
+++ b/content/stream/webrtc-beta.md
@@ -120,6 +120,7 @@ Beyond the [example WHIP client](https://github.com/cloudflare/templates/blob/ma
 - [@eyevinn/whip-web-client](https://www.npmjs.com/package/@eyevinn/whip-web-client) (Typescript)
 - [whip-go](https://github.com/ggarber/whip-go) (Go)
 - [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) (Gstreamer plugins, written in Rust)
+- [OBS](https://github.com/obsproject/obs-studio/pull/7926) (in active development, coming soon)
 
 ### WHEP
 


### PR DESCRIPTION
Adds OBS as a compatible WHIP client, linking to the PR where this support is being worked on, with a note that this is being worked on and coming soon.