### PR TITLE
Fix Svelte prerender option in svelte.config.js

### DIFF
--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -196,8 +196,8 @@ const config = {
 +     }
 +   ),
 +   prerender: {
-+     // This can be false if you're using a fallback (i.e. SPA mode)
-+     default: true
++     // Default option shown. This can be [] if you're using SPA mode.
++     entries: ['*']
 +   }
   }
 };

--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -196,7 +196,7 @@ const config = {
 +     }
 +   ),
 +   prerender: {
-+     // Default option shown. This can be [] if you're using SPA mode.
++     // Default option shown. This can be [] if you are using SPA mode.
 +     entries: ['*']
 +   }
   }


### PR DESCRIPTION
The docs for using SvelteKit's static adapter were based on an outdated value for the `prerender` option in svelte.config.js. Using `default: true` doesn't work any more. It resulted in a build error when I tried it.