### PR TITLE
[Pages] [_headers] mention that :placeholder includes hyphens

### DIFF
--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -87,7 +87,7 @@ The matched value can be referenced within the header value as the `:splat` plac
 
 #### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the name that follows must be composed of alphanumeric characters and underscores (`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the name that follows must be composed of alphanumeric characters, underscores, and hyphens (`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
 
 Similarly, the matched value can be used in the header values with `:placeholder_name`.
 

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -87,7 +87,7 @@ The matched value can be referenced within the header value as the `:splat` plac
 
 #### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores(`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
 
 Similarly, the matched value can be used in the header values with `:placeholder_name`.
 

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -87,7 +87,7 @@ The matched value can be referenced within the header value as the `:splat` plac
 
 #### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the name that follows must be composed of alphanumeric characters, underscores, and hyphens (`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores(`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
 
 Similarly, the matched value can be used in the header values with `:placeholder_name`.
 


### PR DESCRIPTION
The doc says `:placeholder` includes "alphanumeric characters and underscores" but it actually also includes hyphens. I discovered it while testing this:

```
/*.:extension
  Cache-Control: public, max-age=31536000, immutable
```