### PR TITLE
[Docs site] Fix broken GitHub URLs on Windows (local dev server)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -43,7 +43,7 @@
       <span class="DocsFooter--edit-on-gh-link-wrapper">
         {{- with .File -}} {{- $url := (printf
         "https://github.com/cloudflare/cloudflare-docs/blob/production/content/%s"
-        .Path) -}} {{- partial "external.link" (dict "text" "Edit on GitHub"
+        (replace .Path "\\" "/")) -}} {{- partial "external.link" (dict "text" "Edit on GitHub"
         "url" $url) }} {{- end -}}
       </span>
 


### PR DESCRIPTION
The documentation, when previewed using Hugo's local development server, had incorrect "Edit on GitHub" links on Windows machines due to the path separator (`\` instead of `/`).
This change should have no impact on other platforms or production builds.