### PR TITLE
fix: remove Pages serving infinite redirect

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -445,7 +445,6 @@
 /pages/platform/github-integration/ /pages/platform/git-integration/ 301
 /pages/platform/direct-uploads/ /pages/platform/direct-upload/ 301
 /platform/functions/billing/ /platform/functions/pricing/ 301
-/pages/platform/serving-pages/#single-page-app-spa-rendering /pages/platform/serving-pages/#single-page-application-spa-rendering 301
 
 # partners
 /partners/ /learning-paths/technology-partner-integrations/ 301


### PR DESCRIPTION
The server doesn't get the fragment part of this URL, so it just ends up infinite redirecting `https://developers.cloudflare.com/pages/platform/serving-pages` to `https://developers.cloudflare.com/pages/platform/serving-pages`.