### PR TITLE
Update Deprecated Variables

### DIFF
--- a/content/workers/platform/deploy-button.md
+++ b/content/workers/platform/deploy-button.md
@@ -38,16 +38,16 @@ jobs:
         uses: cloudflare/wrangler-action@1.3.0
 ```
 
-2.  Add support for `CF_API_TOKEN` and `CF_ACCOUNT_ID` in your workflow:
+2.  Add support for `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in your workflow:
 
 ```yaml
 # Update "Publish" step from last code snippet
 - name: Publish
   uses: cloudflare/wrangler-action@1.3.0
   with:
-    apiToken: ${{ secrets.CF_API_TOKEN }}
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   env:
-    CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 ```
 
 3.  Add the Markdown code for your button to your project's README, replacing the example `url` parameter with your repository URL.

--- a/content/workers/wrangler/cli-wrangler/authentication.md
+++ b/content/workers/wrangler/cli-wrangler/authentication.md
@@ -30,16 +30,16 @@ To set up Wrangler to work with your Cloudflare user, use the following commands
 
 You can also configure your global user with environment variables. This is the preferred method for using Wrangler in CI (continuous integration) environments.
 
-To customize the authentication tokens that Wrangler uses, you may provide the `CF_ACCOUNT_ID` and `CF_API_TOKEN` environment variables when running any Wrangler command. The account ID may be obtained from the Cloudflare dashboard in **Overview** and you may [create or reuse an existing API token](#generate-tokens).
+To customize the authentication tokens that Wrangler uses, you may provide the `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` environment variables when running any Wrangler command. The account ID may be obtained from the Cloudflare dashboard in **Overview** and you may [create or reuse an existing API token](#generate-tokens).
 
 ```sh
-$ CF_ACCOUNT_ID=accountID CF_API_TOKEN=veryLongAPIToken wrangler publish
+$ CLOUDFLARE_ACCOUNT_ID=accountID CLOUDFLARE_API_TOKEN=veryLongAPIToken wrangler publish
 ```
 
-Alternatively, you may use the `CF_EMAIL` and `CF_API_KEY` environment variable combination instead:
+Alternatively, you may use the `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` environment variable combination instead:
 
 ```sh
-$ CF_EMAIL=cloudflareEmail CF_API_KEY=veryLongAPI wrangler publish
+$ CLOUDFLARE_EMAIL=cloudflareEmail CLOUDFLARE_API_KEY=veryLongAPI wrangler publish
 ```
 
 You can also specify or override the target Zone ID by defining the `CF_ZONE_ID` environment variable.

--- a/content/workers/wrangler/cli-wrangler/commands.md
+++ b/content/workers/wrangler/cli-wrangler/commands.md
@@ -1088,7 +1088,7 @@ y
 
 Wrangler supports any `wrangler.toml` keys passed in as environment variables. This works by passing in `CF_` + any uppercased TOML key. For example:
 
-`CF_NAME=my-worker CF_ACCOUNT_ID=1234 wrangler dev`
+`CF_NAME=my-worker CLOUDFLARE_ACCOUNT_ID=1234 wrangler dev`
 
 ---
 

--- a/content/workers/wrangler/cli-wrangler/configuration.md
+++ b/content/workers/wrangler/cli-wrangler/configuration.md
@@ -124,7 +124,7 @@ Cloudflare will continue to support `rust` and `webpack` project types, but reco
 
 - `account_id` {{<type>}}inherited{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
-  - This is the ID of the account associated with your zone. You might have more than one account, so make sure to use the ID of the account associated with the `zone_id` you provide, if you provide one. It can also be specified through the `CF_ACCOUNT_ID` environment variable.
+  - This is the ID of the account associated with your zone. You might have more than one account, so make sure to use the ID of the account associated with the `zone_id` you provide, if you provide one. It can also be specified through the `CLOUDFLARE_ACCOUNT_ID` environment variable.
 
 - `zone_id` {{<type>}}inherited{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 


### PR DESCRIPTION
Updating examples using CF_ACCOUNT_ID etc., replacing them with CLOUDFLARE_ACCOUNT_ID. Removes warnings in wrangler