### PR TITLE
Add documentation for mTLS certificates in workers

### DIFF
--- a/content/workers/learning/integrations/apis.md
+++ b/content/workers/learning/integrations/apis.md
@@ -45,6 +45,8 @@ const secretValue = env.SECRET_NAME;
 
 Then use the secret value to authenticate with the external service. For example, if the external service requires an API key for authentication, include it in your request headers.
 
+For services that require mTLS authentication, use [mTLS certificates](/workers/runtime-apis/mtls) to present a client certificate.
+
 ## Tips
 
 * Use the Cache API to cache data from the third party API. This allows you to optimize cacheable requests made to the API. Integrating with third party APIs from Cloudflare Workers adds additional functionality and features to your application.

--- a/content/workers/learning/integrations/databases.md
+++ b/content/workers/learning/integrations/databases.md
@@ -44,3 +44,5 @@ const secretValue = env.SECRET_NAME;
 ```
 
 Use the secret value to authenticate with the external service. For example, if the external service requires an API key or database username and password for authentication, include these in using the relevant service's library or API.
+
+For services that require mTLS authentication, use [mTLS certificates](/workers/runtime-apis/mtls) to present a client certificate.

--- a/content/workers/learning/integrations/external-services.md
+++ b/content/workers/learning/integrations/external-services.md
@@ -38,4 +38,6 @@ const secretValue = env.SECRET_NAME;
 
 Then use the secret value to authenticate with the external service. For example, if the external service requires an API key for authentication, include the secret in your library's configuration.
 
+For services that require mTLS authentication, use [mTLS certificates](/workers/runtime-apis/mtls) to present a client certificate.
+
 Use [Custom Domains](/workers/platform/triggers/custom-domains/) when communicating with external APIs, which treat your Worker as your core application.

--- a/content/workers/learning/using-services/index.md
+++ b/content/workers/learning/using-services/index.md
@@ -26,6 +26,7 @@ There are multiple types of bindings available today:
 3. [R2 bucket bindings](/r2/data-access/workers-api/workers-api-reference/#create-a-binding) for communication between a Worker and an R2 bucket.
 4. [Durable Object bindings](/workers/runtime-apis/durable-objects/#accessing-a-durable-object-from-a-worker) for communication between a Worker and a Durable Object.
 5. [Queue bindings](/queues/configuration/) for communication between a Worker and a Queue.
+6. [mTLS certificate bindings](/workers/runtime-apis/mtls) enable communication between a Worker and an origin server secured by mTLS using an uploaded certificate.
 
 {{<Aside type="note">}}
 

--- a/content/workers/platform/bindings/_index.md
+++ b/content/workers/platform/bindings/_index.md
@@ -55,3 +55,10 @@ R2 bucket bindings for communication between a Worker and an R2 bucket.
 Dispatch namespace bindings allow for communication between a dynamic dispatch Worker and a dispatch namespace. Dispatch namespace bindings are used in [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/). Workers for Platforms helps you deploy serverless functions programmatically on behalf of your customers.
 
 * Configure dispatch namespace bindings via your [`wrangler.toml` file](/cloudflare-for-platforms/workers-for-platforms/get-started/configuration/#2-create-a-dynamic-dispatch-worker).
+
+### mTLS certificate bindings
+
+mTLS certificate bindings enable Worker subrequests to present a client certificate when communicating with a service that requires client authentication.
+
+* Learn more about [mTLS certificate bindings](/workers/runtime-apis/mtls/).
+* Configure mTLS certificate bindings via your [`wrangler.toml` file](/workers/wrangler/configuration/#mtls-certificates).

--- a/content/workers/runtime-apis/mTLS.md
+++ b/content/workers/runtime-apis/mTLS.md
@@ -1,0 +1,66 @@
+---
+pcx_content_type: configuration
+title: mTLS
+---
+
+# Client authentication with mTLS
+
+When using [HTTPS](https://www.cloudflare.com/learning/ssl/what-is-https/), a server presents a certificate for the client to authenticate in order to prove their identity. For even tighter security, some services require that the client also present a certificate.
+
+This process - known as [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/) - moves authentication to the protocol of TLS, rather than managing it in application code. Connections from unauthorized clients are rejected during the TLS handshake instead.
+
+To present a client certificate when communicating with a service, you can create and use a [binding](/workers/platform/bindings) to a certificate for use in your Worker project.
+
+First, upload a certificate and its private key to your account using the [`wrangler mtls-certificate`](/workers/wrangler/commands/#mtls-certificate) command:
+
+```sh
+$ wrangler mtls-certificate upload --cert cert.pem --key key.pem --name my-client-cert
+```
+
+Then, update your Worker project's `wrangler.toml` file to create a binding to the certificate:
+
+```toml
+---
+header: wrangler.toml
+---
+mtls_certificates = [
+  { binding = "MY_CERT", certificate_id = "<CERTIFICATE_ID>" } 
+]
+```
+
+{{<Aside type="note">}}
+Certificate IDs are displayed after uploading, and can also be viewed with the command `wrangler mtls-certificate list`.
+{{</Aside>}}
+
+Adding an mTLS certificate binding includes a variable in the Worker's environment on which the `fetch()` method is available. This `fetch()` method uses the standard [Fetch](/workers/runtime-apis/fetch/) API and has the exact same signature as the global `fetch`, but always presents the client certificate when establishing the TLS connection.
+
+{{<Aside type="note">}}
+mTLS certificate bindings present an API similar to [service bindings](/workers/runtime-apis/service-bindings).
+{{</Aside>}}
+
+### Interface
+
+{{<tabs labels="js/esm | ts/esm">}}
+{{<tab label="js/esm" default="true">}}
+```js
+export default {
+    async fetch(request, environment) {
+        return await environment.MY_CERT.fetch("https://a-secured-origin.com")
+    }
+}
+```
+{{</tab>}}
+{{<tab label="ts/esm">}}
+```js
+interface Env {
+  MY_CERT: Fetcher;
+}
+
+export default {
+    async fetch(request: Request, environment: Env) {
+        return await environment.MY_CERT.fetch("https://a-secured-origin.com")
+    }
+}
+```
+{{</tab>}}
+{{</tabs>}}

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -30,7 +30,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`types`](#types) - Generate types from bindings and module rules in configuration.
 - [`deployments`](#deployments) - Retrieve details for the 10 most recent deployments.
 - [`dispatch-namespace`](#dispatch-namespace) - Interact with a [dispatch namespace](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/learning/how-workers-for-platforms-works/#dispatch-namespace).
-
+- [`mtls-certificate`](#mtls-certificate) - Manage certificates used for mTLS connections.
 
 {{<Aside type="note">}}
 
@@ -1633,6 +1633,106 @@ $ wrangler dispatch-namespace get <OLD-NAME> <NEW-NAME>
   - The new name of the dispatch namespace.
 
 ---
+## `mtls-certificate`
+
+Manage client certificates used for mTLS connections in subrequests.
+
+These certificates can be used in [`mtls_certificate` bindings](/workers/runtime-apis/mtls), which allow a Worker to present the certificate when establishing a connection with an origin that requires client authentication (mTLS).
+
+### `upload`
+
+Upload a client certificate.
+
+```sh
+$ wrangler mtls-certificate upload [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `--cert` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+  - A path to the TLS certificate to upload. Certificate chains are supported
+- `--key` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+  - A path the private key to upload.
+- `--name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+{{</definitions>}}
+
+{{<Aside type="note">}}
+Below is an example of using the `upload` command to upload an mTLS certificate.
+
+```sh
+$ wrangler mtls-certificate upload --cert cert.pem --key key.pem --name my-origin-cert
+Uploading mTLS Certificate my-origin-cert...
+Success! Uploaded mTLS Certificate my-origin-cert
+ID: 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d
+Issuer: CN=my-secured-origin.com,OU=my-team,O=my-org,L=San Francisco,ST=California,C=US
+Expires: 1/01/2025
+```
+
+You can then add this certificate as a binding in your `wrangler.toml`:
+```toml
+mtls_certificates = [
+  { binding = "MY_CERT", certificate_id = "99f5fef1-6cc1-46b8-bd79-44a0d5082b8d" }
+]
+```
+{{</Aside>}}
+
+### `list`
+
+List mTLS certificates associated with the current account ID.
+
+```sh
+$ wrangler mtls-certificate list
+```
+
+{{<Aside type="note">}}
+Below is an example of using the `list` command to upload an mTLS certificate.
+
+```sh
+$ wrangler mtls-certificate list
+ID: 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d
+Name: my-origin-cert
+Issuer: CN=my-secured-origin.com,OU=my-team,O=my-org,L=San Francisco,ST=California,C=US
+Created on: 1/01/2023
+Expires: 1/01/2025
+
+ID: c5d004d1-8312-402c-b8ed-6194328d5cbe
+Issuer: CN=another-origin.com,OU=my-team,O=my-org,L=San Francisco,ST=California,C=US
+Created on: 1/01/2023
+Expires: 1/01/2025
+```
+{{</Aside>}}
+
+### `delete`
+
+```sh
+$ wrangler mtls-certificate delete [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `--id` {{<type>}}string{{</type>}}
+  - The ID of the mTLS certificate.
+- `--name` {{<type>}}string{{</type>}}
+  - The name assigned to the mTLS certificate at upload.
+- Note that you must provide either `--id` or `--name` for this command to run successfully.
+
+{{</definitions>}}
+
+{{<Aside type="note">}}
+Below is an example of using the `delete` command to delete an mTLS certificate.
+
+```sh
+$ wrangler mtls-certificate delete --id 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d
+Are you sure you want to delete certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d (my-origin-cert)? [y/n]
+yes
+Deleting certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d...
+Deleted certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d successfully
+```
+{{</Aside>}}
+
+---
+
 ## types
 
 Generate types from bindings and module rules in configuration.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -503,6 +503,38 @@ analytics_engine_datasets = [
 ]
 ```
 
+### mTLS Certificates
+
+To communicate with origins that require client authentication, a Worker can present a certificate for mTLS in subrequests. Wrangler provides the `mtls-certificate` [command](/workers/wrangler/commands#mtls-certificate) to upload and manage these certificates.
+
+To create a [binding](/workers/platform/bindings/) to an mTLS certificate for your Worker, assign an array of objects with the following shape to the `mtls_certificates` key.
+
+{{<definitions>}}
+
+- `binding` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The binding name used to refer to the certificate.
+
+- `certificate_id` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The ID of the certificate. Wrangler displays this via the `mtls-certificate upload` and `mtls-certificate list` commands.
+
+{{</definitions>}}
+
+Example of a `wrangler.toml` configuration that includes an mTLS certificate binding:
+
+```toml
+---
+header: wrangler.toml
+---
+mtls_certificates = [
+    { binding = "<BINDING_NAME>", certificate_id = "<CERTIFICATE_ID>" }
+]
+```
+
+mTLS certificate bindings can then be used at runtime to communicate with secured origins via their [`fetch` method](/workers/runtime-apis/mtls).
+
+
 ## Bundling
 
 You can bundle assets into your Worker using the `rules` key, making these assets available to be imported when your Worker is invoked. The `rules` key will be an array of the below object.


### PR DESCRIPTION
Adds a new page for documenting the runtime API: `/workers/runtime-apis/mtls`
And then references that new page in the `/workers/learning/integrations` pages

Updates the commands and configuration pages for wrangler to document the new mTLS APIs