### PR TITLE
[Pages] Astro 2.0 drops support for node 14

### DIFF
--- a/content/pages/framework-guides/astro.md
+++ b/content/pages/framework-guides/astro.md
@@ -101,12 +101,12 @@ Select the new GitHub repository that you created and, in the **Set up builds an
 
 <div>
 
-| Configuration option  | Value              |
-| --------------------- | ------------------ |
-| Production branch     | `main`             |
-| Build command         | `npm run build`    |
-| Build directory       | `dist`             |
-| Environment Variables | `NODE_VERSION: 14` |
+| Configuration option  | Value                   |
+| --------------------- | ----------------------- |
+| Production branch     | `main`                  |
+| Build command         | `npm run build`         |
+| Build directory       | `dist`                  |
+| Environment Variables | `NODE_VERSION: 16.12.0` |
 
 </div>
 
@@ -114,7 +114,7 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 
 {{<Aside type="warning" header="Important">}}
 
-Astro requires Node.js version `14` or later to build successfully. When creating your Pages project, you must expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `14` or greater.
+Astro requires Node.js version `16.12.0` or later to build successfully. When creating your Pages project, you must expand the **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16.12.0` or greater.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Astro 2.0 now only supports Node versions 16.12.0 or later.  [^1] [^2]

[^1]: https://docs.astro.build/en/guides/upgrade-to/v2/#removed-support-for-node-14
[^2]: https://github.com/withastro/astro/commit/1f92d64ea35c03fec43aff64eaf704dc5a9eb30a