### PR TITLE
changed "signedUrl" to "signedUrl.url"

### DIFF
--- a/content/r2/data-access/s3-api/presigned-urls.md
+++ b/content/r2/data-access/s3-api/presigned-urls.md
@@ -108,7 +108,7 @@ export default <ExportedHandler>{
 			);
 
 			// Caller can now use this URL to upload to that object.
-			return new Response(signedUrl, { status: 200 });
+			return new Response(signedUrl.url, { status: 200 });
 		}
 
 		// ... handle other kinds of requests


### PR DESCRIPTION
signedUrl is a request object, using it directly in a response will cause it to be [object Object]. Even JSON.stringify doesn't make it normal. Thanks :)