### PR TITLE
[R2] Document multipart upload part size considerations in rclone example

### DIFF
--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -67,17 +67,30 @@ $ rclone tree r2demo:my-bucket-name
 ## Upload and retrieve objects
 
 The [rclone copy](https://rclone.org/commands/rclone_copy/) command can be used to upload objects to an R2 bucket and vice versa - this allows you to upload files up to the 5 TB maximum object size that R2 supports.
-  
+
 ```sh
 # Upload dog.txt to the user-uploads bucket
-$ rclone copy dog.txt r2demo:user-uploads/dog.txt
+$ rclone copy dog.txt r2demo:user-uploads/
 $ rclone tree r2demo:user-uploads
 # /
 # ├── foobar.png
 # └── dog.txt
 
 # Download dog.txt from the user-uploads bucket
-$ rclone copy r2demo:user-uploads/dog.txt dog.txt
+$ rclone copy r2demo:user-uploads/dog.txt .
+```
+
+### A note about multipart upload part sizes
+
+For multipart uploads, part sizes can significantly affect the number of Class A operations that are used, which can alter how much you end up being charged.
+Every part upload counts as a separate operation, so larger part sizes will use fewer operations, but might be costly to retry if the upload fails. Also consider that a multipart upload is always going to consume at least 3 times as many operations as a single `PutObject`, because it will include at least one `CreateMultipartUpload`, `UploadPart` & `CompleteMultipartUpload` operations.
+
+Balancing part size depends heavily on your use-case, but these factors can help you minimize your bill, so they are worth thinking about.
+
+You can configure rclone's multipart upload part size using the `--s3-chunk-size` CLI argument. Note that you might also have to adjust the `--s3-upload-cutoff` argument to ensure that rclone is using multipart uploads. Both of these can be set in your configuration file as well. Generally, `--s3-upload-cutoff` will be no less than `--s3-chunk-size`.
+
+```sh
+$ rclone copy long-video.mp4 r2demo:user-uploads/ --s3-upload-cutoff=100M --s3-chunk-size=100M
 ```
 
 ## Generate presigned URLs

--- a/content/r2/platform/limits.md
+++ b/content/r2/platform/limits.md
@@ -29,6 +29,7 @@ Managed public bucket access through an `r2.dev` subdomain is not intended for p
 | Object metadata size            | 2,048 bytes                           |
 | Object size                     | 5 TB per object<sup>1</sup>           |
 | Maximum upload size<sup>3</sup> | 5 GB<sup>2</sup>                      |
+| Maximum upload parts            | 10,000                                |
 
 {{</table-wrap>}}
 


### PR DESCRIPTION
plus Max number of parts allowed in a multipart upload