### PR TITLE
Workers: remove references to service environments. update deployments docs.

### DIFF
--- a/content/workers/learning/using-services/index.md
+++ b/content/workers/learning/using-services/index.md
@@ -35,15 +35,9 @@ There are multiple types of bindings available today:
 
 ## Deployments
 
-Deployments are an audit log of static historical versions of your Worker. They include the bundled code, configuration, and bindings associated with your Worker at a given point in time. A change to any of these will trigger a new deployment on Cloudflare’s network.
+Deployments provide static historical versions of your Worker. They include the bundled code, configuration, and bindings associated with your Worker at a given point in time, and are created when changes to Worker code or configuration is detected.
 
 Read more about [Deployments](/workers/platform/deployments).
-
-## Service environments
-
-We have temporarily disabled the creation of Service Environments while we are improving this feature.
-
-We recommend leveraging [Deployments](/workers/platform/deployments) in place of Environments.
 
 {{<Aside type="note">}}
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -11,73 +11,61 @@ Deployments are currently in Public Beta.
 
 {{</Aside>}}
 
-Deployments are an audit log of static historical versions of your Worker. They include the bundled code, configuration, and bindings associated with your Worker at a given point in time. A change to any of these will trigger a new deployment on Cloudflare’s network.
+Deployments are an audit log of static historical versions of your Worker. They include the bundled code, configuration, and bindings associated with your Worker at a given point in time.
 
 Only one deployment is active at any time. The active deployment is your latest deployment. The active deployment is accessible via any of your configured custom domains, routes, service bindings, schedules, and your `*.workers.dev` subdomain.
 
-You can view a list of your deployments in the Cloudflare dashboard > **Workers** > **your Worker project** > **Deployments**. You can also use the `wrangler deployments` command to list out the most recent deployments.
+## Creating a new Deployment
 
-Deployments are triggered by:
+New Deployments will be created whenever you change code, configuration, or bindings. This includes:
 
 * Changes to a Worker’s bindings, code, or configuration in the Cloudflare dashboard.
 * Changes to a Worker’s bindings, code, or configuration in the REST API.
 * Changes to a Worker’s bindings, code, or configuration in the CLI via [wrangler publish](/workers/wrangler/commands#publish).
 
-## Interacting with Deployments
+When you deploy changes to your Worker, Cloudflare will track the user, token, or interface from which your code was last deployed. This is useful to understand and audit who or what is making changes to your applications.
 
-### wrangler publish
+{{<Aside type="note">}}
 
-The [`wrangler publish`](/workers/wrangler/commands#publish) command will publish your Worker, and additionally output the identifier of the newly generated deployment.
+Changing routes, custom domains, or cron triggers will not issue a new deployment.
 
-### wrangler deployments
+{{ </Aside>}}
 
-The [`wrangler deployments`](/workers/wrangler/commands#deployments) command will output detailed information about the most recent deployments, including source, timestamp, identifier, and author.
+### Updating Code
 
-### Deployments in the dashboard
+Any changes to code will trigger a new deployment. This can be as small as a simple whitespace change.
 
-The Deployments tab of your Cloudflare dashboard will include information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
+### Updating Bindings
 
-<!-- ### Metadata binding
+Updates to bindings include a change to the value or variable name of a binding, or any CRUD operation on an individual binding. 
 
-Deployment information is optionally available directly within your Worker code. This information is presented as a Metadata binding, and can be configured at any custom variable name. To configure in dashboard, head to your Worker > Settings > Variables > Metadata binding, and click ‘Add binding’. Optionally configure a variable name (e.g. CF_METADATA).
+Notably, this does not include changes to the target resource itself. For example, changing the code of a Worker B that is connected via a service binding from Worker A will not trigger a new deployment on Worker A. Only changes to the service binding between Worker A and Worker B will trigger a new deployment.
 
-Once configured, your Worker will be able to access metadata on the specified variable name. For example:
+### Updating Configuration
 
-```
-export default {
-	fetch(req, env, ctx) {
-		return new Response(JSON.stringify(env.CF_METADATA.deployment.id))
-	}
-}
-```
-
-The Metadata binding object definition is as follows:
-
-```
-{
-	name: string,
-	deployment: {
-		id: string,
-		timestamp: datetime
-	}
-}
-```  -->
-
-## Creating a new Deployment
-
-New Deployments will be created whenever you change code, configuration, or bindings.
-
-Updates to code can be as small as a simple whitespace change. Any changes to code will trigger a new deployment.
-
-Updates to bindings include a change to the value or variable name of a binding, or any CRUD operation on an individual binding. Notably, this does not include changes to the target resource itself. For example, changing the code of a Worker B that is connected via a service binding from Worker A will not trigger a new deployment on Worker A. Only changes to the service binding between Worker A and Worker B will trigger a new deployment. Similarly, changing routes, custom domains, or cron triggers will not issue a new deployment.
-
-Changes to configuration include:
+Updates to configuration include:
 
 * Changing a Worker’s usage model.
 * Changing a Worker’s secret or environment variable names and values.
 
-## Author and source
+## Interacting with Deployments
 
-When you deploy changes to your Worker, Cloudflare will track the user, token, or interface from which your code was last deployed. This is useful to understand and audit who or what is making changes to your applications.
+Deployment information can be obtained via Wrangler, the Cloudflare Dashboard, or Cloudflare's REST API.
 
-The author of a deployment is available in the Cloudflare dashboard, visible via [`wrangler deployments`](/workers/wrangler/commands#deployments) command, and accessible in [Cloudflare’s REST API](https://api.cloudflare.com/).
+### via Wrangler
+
+The [`wrangler deployments`](/workers/wrangler/commands#deployments) command will output detailed information about the most recent deployments, including source, timestamp, identifier, and author.
+
+### via the Cloudflare Dashboard
+
+The Deployments tab of your Cloudflare dashboard includes information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
+
+## via the API
+
+Read more about accessing Deployment information via Cloudflare's REST API [here](https://api.cloudflare.com/#worker-deployments-properties).
+
+{{<Aside type="note">}}
+
+Deployments are in active development. If you'd like to give feedback, please [request a chat](https://www.cloudflare.com/lp/developer-week-deployments).
+
+{{</Aside>}}

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -66,6 +66,6 @@ Read more about accessing Deployment information via Cloudflare's REST API [here
 
 {{<Aside type="note">}}
 
-Deployments are in active development. If you'd like to give feedback, please [request a chat](https://www.cloudflare.com/lp/developer-week-deployments).
+Deployments are in active development. To give feedback, request a [live chat](https://www.cloudflare.com/lp/developer-week-deployments).
 
 {{</Aside>}}

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -60,7 +60,7 @@ The [`wrangler deployments`](/workers/wrangler/commands#deployments) command wil
 
 Access Deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
 
-## via the API
+## Via the API
 
 Read more about accessing Deployment information via Cloudflare's REST API [here](https://api.cloudflare.com/#worker-deployments-properties).
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -58,7 +58,7 @@ The [`wrangler deployments`](/workers/wrangler/commands#deployments) command wil
 
 ### via the Cloudflare Dashboard
 
-The Deployments tab of your Cloudflare dashboard includes information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
+Access Deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
 
 ## via the API
 

--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -349,12 +349,3 @@ Error: ⚠️  Your environment should only include `workers_dev` or `route`. If
 ~/my-worker $ wrangler publish --env staging
 Error: ⚠️  Your environment should only include `workers_dev` or `route`. If you are trying to publish to workers.dev, remove `route` from your wrangler.toml, if you are trying to publish to your own domain, remove `workers_dev`.
 ```
-
-
-{{<Aside type="note">}}
-
-We recommend using [Deployments](/workers/platform/deployments) in place of Environments. Deployments give you a powerful audit log of changes to your application, and will soon include integrated rollbacks and automated deployment.
-
-We have temporarily disabled the creation of [Service Environments](/workers/learning/using-services/#service-environments) while we are improving this feature. Environments made using Wrangler, as described below, are still supported.
-
-{{</Aside>}}

--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -5,14 +5,6 @@ title: Environments
 
 # Environments
 
-{{<Aside type="note">}}
-
-We recommend using [Deployments](/workers/platform/deployments) in place of Environments. Deployments give you a powerful audit log of changes to your application, and will soon include integrated rollbacks and automated deployment.
-
-We have temporarily disabled the creation of [Service Environments](/workers/learning/using-services/#service-environments) while we are improving this feature. Environments made using Wrangler, as described below, are still supported.
-
-{{</Aside>}}
-
 ## Background
 
 Environments are different contexts that your code runs in. The Workers platform allows you to create and manage different environments. Through environments, you can deploy the same project to multiple places under multiple names.

--- a/content/workers/wrangler/compare-v1-v2.md
+++ b/content/workers/wrangler/compare-v1-v2.md
@@ -12,7 +12,6 @@ Wrangler 2 introduces a number of new features for developing and deploying a Wo
 - `dev` and `publish` accept CLI arguments.
 - `tail` can be run on arbitrary Worker names.
 - `init` creates a project boilerplate.
-- Service environments.
 - JSON bindings for `vars`.
 - Local mode for `wrangler dev`.
 - Module system (for both modules and service worker format Workers).

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -319,7 +319,7 @@ To bind Durable Objects to your Worker, assign an array of the below object to t
 
 - `environment` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The service environment of the `script_name` to bind to.
+  - The environment of the `script_name` to bind to.
 
 {{</definitions>}}
 
@@ -455,7 +455,7 @@ To bind other Workers to your Worker, assign an array of the below object to the
 
 - `environment` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  -  The environment of the service (for example, `production`, `staging`, etc). Refer to [Service Environments](/workers/platform/environments/).
+  -  The environment of the service (for example, `production`, `staging`, etc). Refer to [Environments](/workers/platform/environments/).
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/environments.md
+++ b/content/workers/wrangler/environments.md
@@ -6,10 +6,4 @@ weight: 7
 
 # Environments
 
-{{<Aside type="note">}}
-
-We have temporarily disabled the creation of Service Environments while we are improving this feature.
-
-{{</Aside>}}
-
-Wrangler 2 supports [environments](/workers/platform/environments/) from Wrangler 1. We are currently working on support for [Service Environments](/workers/learning/using-services/).  Refer to the [Wrangler 1 environments](/workers/platform/environments/) for more information.
+Wrangler 2 supports [environments](/workers/platform/environments/) from Wrangler 1.  Refer to the [Wrangler 1 environments](/workers/platform/environments/) for more information.


### PR DESCRIPTION
This PR aims to:

- clear up documentation around Deployments and remove references to them as replacements for Service Environments
- remove references to Service Environments since they do not work as of Wrangler v2 and the messaging can be confusing

Closes #7187 