### PR TITLE
[Workers] Fix KV and Workers Sites modules examples

### DIFF
--- a/content/workers/platform/sites/start-from-existing.md
+++ b/content/workers/platform/sites/start-from-existing.md
@@ -62,14 +62,25 @@ To deploy a pre-existing static site project, start with a pre-generated site. W
 
 ```js
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler';
+import manifestJSON from '__STATIC_CONTENT_MANIFEST';
+const assetManifest = JSON.parse(manifestJSON);
 
 export default {
-  async fetch(request) {
+  async fetch(request, env, ctx) {
     try {
       // Add logic to decide whether to serve an asset or run your original Worker code
-      return await getAssetFromKV(event);
+      return await getAssetFromKV(
+        {
+          request,
+          waitUntil: ctx.waitUntil.bind(ctx),
+        },
+        {
+          ASSET_NAMESPACE: env.__STATIC_CONTENT,
+          ASSET_MANIFEST: assetManifest,
+        }
+      );
     } catch (e) {
-      let pathname = new URL(event.request.url).pathname;
+      let pathname = new URL(request.url).pathname;
       return new Response(`"${pathname}" not found`, {
         status: 404,
         statusText: 'not found',

--- a/content/workers/runtime-apis/kv.md
+++ b/content/workers/runtime-apis/kv.md
@@ -119,8 +119,8 @@ An example of reading a key from within a Worker:
 
 ```js
 export default {
-  async fetch(request) {
-    const value = await NAMESPACE.get("first-key");
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.get("first-key");
 
     if (value === null) {
       return new Response("Value not found",  { status:  404})
@@ -220,8 +220,8 @@ An example:
 
 ```js
 export default {
-  async fetch(request) {
-    const value = await NAMESPACE.list();
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.list();
 
     return new Response(value.keys);
   },
@@ -302,8 +302,8 @@ You can also list all of the keys starting with a particular prefix. For example
 
 ```js
 export default {
-  async fetch(request) {
-    const value = await NAMESPACE.list({ prefix: "user:1:" });
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.list({ prefix: "user:1:" });
     return new Response(value.keys);
   },
 };
@@ -375,10 +375,10 @@ With this, the deployed Worker will have a `TODO` global variable. Any methods o
 
 ```js
 export default {
-  async fetch(request) {
+  async fetch(request, env, ctx) {
     // Get the value for the "to-do:123" key
     // NOTE: Relies on the `TODO` KV binding that maps to the "My Tasks" namespace.
-    let value = await TODO.get("to-do:123");
+    let value = await env.TODO.get("to-do:123");
 
     // Return the value, as is, for the Response
     return new Response(value);


### PR DESCRIPTION
Hey! 👋 This PR is a followup to #7301, fixing some of the syntax in the KV and Workers Sites examples. `event` isn't available when using modules workers, so bindings have to be accessed using the `env` parameter. Additionally, the Workers Sites asset manifest needs to be loaded from the `__STATIC_CONTENT_MANIFEST` synthetic module.