### PR TITLE
Add WAE forwarder template to quickstarts

### DIFF
--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -95,6 +95,8 @@ description="Measure download / upload connection speed from the client side, us
 
 {{<worker-starter title="REST API with Fauna" repo="fauna-labs/fauna-workers" description="Build a fast, globally distributed REST API using Cloudflare Workers and Fauna, the data API for modern applications.">}}
 
+{{<worker-starter title="Analytics Engine Forwarder" repo="cloudflare/templates/worker-analytics-engine-forwarder" description="Use a Worker to capture analytics data with Analytics Engine.">}}
+
 ---
 
 ## Other languages

--- a/layouts/shortcodes/worker-starter.html
+++ b/layouts/shortcodes/worker-starter.html
@@ -3,11 +3,13 @@
 {{- $descr := .Get "description" -}}
 
 {{- $remote := printf "https://github.com/%s" $repo -}}
-{{- $command := printf "npx wrangler generate my-app %s" $remote -}}
+{{- $template := cond (hasPrefix $repo "cloudflare/templates/") (path.Base $repo) $repo -}}
+{{- $command := printf "npx wrangler generate my-app %s" $template -}}
+{{- $link := cond (hasPrefix $repo "cloudflare/templates/") (printf "https://github.com/cloudflare/templates/tree/main/%s" $template) $remote}}
 
 <div class="WorkerStarter">
   <div class="WorkerStarter--title">
-    {{- $text := printf "[%s](%s)" $title $remote -}}
+    {{- $text := printf "[%s](%s)" $title $link -}}
     {{- .Page.RenderString $text -}}
   </div>
 


### PR DESCRIPTION
Add the Analytics Engine template to the quickstarts page.
The shortcode used on that page didn't support templates from the cloudflare/templates repo so I added that support too.