### PR TITLE
[Ruleset Engine] Specify the rule position when creating a new rule

### DIFF
--- a/content/ruleset-engine/rulesets-api/add-rule.md
+++ b/content/ruleset-engine/rulesets-api/add-rule.md
@@ -20,9 +20,11 @@ Use one of the following API endpoints:
 [ar-account]: https://developers.cloudflare.com/api/operations/account-rulesets-create-an-account-ruleset-rule
 [ar-zone]: https://developers.cloudflare.com/api/operations/zone-rulesets-create-a-zone-ruleset-rule
 
-Invoking this method creates a new version of the ruleset.
+Include the rule definition in the request body.
 
-Include the rule definition in the request body. The rule will be added to the end of the existing list of rules in the ruleset.
+By default, the rule will be added to the end of the existing list of rules in the ruleset. To define a specific position for the rule, include a `position` object in the request body according to the guidelines in [Change the order of a rule in a ruleset](/ruleset-engine/rulesets-api/update-rule/#change-the-order-of-a-rule-in-a-ruleset).
+
+Invoking this method creates a new version of the ruleset.
 
 ## Example
 

--- a/content/ruleset-engine/rulesets-api/update-rule.md
+++ b/content/ruleset-engine/rulesets-api/update-rule.md
@@ -93,7 +93,7 @@ The response includes the complete ruleset after updating the rule.
 
 ## Change the order of a rule in a ruleset
 
-To reorder a rule in a list of ruleset rules, include a `position` field in the request, containing one of the following arguments:
+To reorder a rule in a list of ruleset rules, include a `position` object in the request, containing one of the following:
 
 *   `"before": "<RULE_ID>"` — Places the rule before rule `<RULE_ID>`. Use this argument with an empty rule ID value (`""`) to set the rule as the first rule in the ruleset.
 
@@ -103,11 +103,11 @@ To reorder a rule in a list of ruleset rules, include a `position` field in the 
 
 {{<Aside type="warning" header="Important">}}
 
-You can only use one of the arguments `before`, `after`, and `index` at a time.
+You can only use one of the `before`, `after`, and `index` fields at a time.
 
 {{</Aside>}}
 
-Reorder a rule without changing its definition by including only the `position` field in the `PATCH` request body. You can also update a rule definition and reorder it in the same `PATCH` request by including both the `rule` field and the `position` field.
+Reorder a rule without changing its definition by including only the `position` object in the `PATCH` request body. You can also update a rule definition and reorder it in the same `PATCH` request by including both the `rule` object and the `position` object.
 
 The following examples build upon the following (abbreviated) ruleset:
 
@@ -124,7 +124,7 @@ The following examples build upon the following (abbreviated) ruleset:
 
 ### Example #1
 
-The following request with the `position` field places rule `<RULE_ID_2>` as the first rule:
+The following request with the `position` object places rule `<RULE_ID_2>` as the first rule:
 
 ```json
 ---
@@ -146,7 +146,7 @@ In this case, the new rule order would be:
 
 ### Example #2
 
-The following request with the `position` field places rule `<RULE_ID_2>` after rule 3:
+The following request with the `position` object places rule `<RULE_ID_2>` after rule 3:
 
 ```json
 ---
@@ -168,7 +168,7 @@ In this case, the new rule order would be:
 
 ### Example #3
 
-The following request with the `position` field places rule `<RULE_ID_1>` in position 3, becoming the third rule in the ruleset:
+The following request with the `position` object places rule `<RULE_ID_1>` in position 3, becoming the third rule in the ruleset:
 
 ```json
 ---


### PR DESCRIPTION
Users can also define the rule position when creating the rule, not only when updating it.

Related to ERE-585 (reported in the same chat thread).