### PR TITLE
[Email routing] Correct example for Sender Rewriting Scheme in postmaster

### DIFF
--- a/content/email-routing/postmaster.md
+++ b/content/email-routing/postmaster.md
@@ -131,7 +131,7 @@ $ dig TXT 2022._domainkey.email.cloudflare.net +short
 
 Email Routing rewrites the SMTP envelope sender (`MAIL FROM`) to the forwarding domain to avoid issues with SPF. Email Routing uses a scheme similar to the [Sender Rewriting Scheme](https://en.wikipedia.org/wiki/Sender_Rewriting_Scheme).
 
-For example, when receiving an email at `mycfdomain.com` with a sender address of `me@example.com`, Email Routing will rewrite the `MAIL FROM` to `me=example.com@mycfdomain.com`. The rewriting happens during the SMTP session to the destination upstream.
+For example, when receiving an email at `mycfdomain.com` with a sender address of `me@example.com`, Email Routing will rewrite the `MAIL FROM` to `example.com=me@mycfdomain.com`. The rewriting happens during the SMTP session to the destination upstream.
 
 This has no effect to the end user's experience, though. The message headers will still report the original sender's `From:` address.
 


### PR DESCRIPTION
Fetched correct format from https://en.wikipedia.org/wiki/Sender_Rewriting_Scheme and validated with actual CF behavior in production. 

The element rewritten by CF seems to be be `RETURN-PATH` instead of `MAIL FROM`, it may be worth adding it to the documentation. 