### PR TITLE
Fix function heading

### DIFF
--- a/content/analytics/analytics-engine/sql-reference.md
+++ b/content/analytics/analytics-engine/sql-reference.md
@@ -666,7 +666,7 @@ GROUP BY hour
 ORDER BY hour ASC
 ```
 
-## extract
+### extract
 
 Usage:
 ```SQL


### PR DESCRIPTION
The `extract` function heading was 2nd-level rather than 3rd-level, which made the table of contents look confusing