### PR TITLE
[Docs site] Added structured metadata for breadcrumbs

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -24,7 +24,7 @@
       {{- end -}}
       &nbsp;&nbsp;>&nbsp;&nbsp;
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-          <a href="{{- $rellink -}}" itemprop="item" {{- if eq $title "..." -}}aria-label="{{- $page.Title -}}" title="{{- $page.Title -}}"{{- end -}}class="DocsMarkdown--link">
+          <a href="{{- print $rellink "/" -}}" itemprop="item" {{- if eq $title "..." -}}aria-label="{{- $page.Title -}}" title="{{- $page.Title -}}"{{- end -}}class="DocsMarkdown--link">
             <span class="DocsMarkdown--link-content" {{- if ne $title "..." -}}itemprop="name"{{- end -}}>{{- $title -}}</span></a>
             {{- if eq $title "..." -}}
             <meta itemprop="name" content="{{$page.Title}}" />

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -3,8 +3,8 @@
 
 <ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
     <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-    <a href="/products/" class="DocsMarkdown--link" itemprop="item">
-      <span itemprop="name" class="DocsMarkdown--link-content">Products</span></a>
+      <a href="/products/" class="DocsMarkdown--link" itemprop="item">
+        <span itemprop="name" class="DocsMarkdown--link-content">Products</span></a>
       <meta itemprop="position" content="1" />
     </li>
       
@@ -26,11 +26,11 @@
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
           <a href="{{- print $rellink "/" -}}" itemprop="item" {{- if eq $title "..." -}}aria-label="{{- $page.Title -}}" title="{{- $page.Title -}}"{{- end -}}class="DocsMarkdown--link">
             <span class="DocsMarkdown--link-content" {{- if ne $title "..." -}}itemprop="name"{{- end -}}>{{- $title -}}</span></a>
-            {{- if eq $title "..." -}}
-            <meta itemprop="name" content="{{$page.Title}}" />
-            {{- end -}}
-            <meta itemprop="position" content="{{add $index 1}}" />
-          </li>
+          {{- if eq $title "..." -}}
+          <meta itemprop="name" content="{{$page.Title}}" />
+          {{- end -}}
+          <meta itemprop="position" content="{{add $index 1}}" />
+        </li>
       {{- end -}}
     {{- end -}}
   </ol>

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,8 +1,13 @@
 {{ $DATA := (index $.Site.Data .Section) }}
 {{ $productName := $DATA.product.title }}
 
-<ol class="breadcrumb">
-    <li><a href="/products/" class="DocsMarkdown--link"><span class="DocsMarkdown--link-content">Products</span></a></li>
+<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+    <a href="/products/" class="DocsMarkdown--link" itemprop="item">
+      <span itemprop="name" class="DocsMarkdown--link-content">Products</span></a>
+      <meta itemprop="position" content="1" />
+    </li>
+      
     {{- $rellink := "" -}}
     {{- $title := "" -}}
     {{- $length :=  sub (len (split .RelPermalink "/")) 1 -}}
@@ -17,7 +22,15 @@
       {{- else -}}
         {{- $title = $page.Title -}}
       {{- end -}}
-        <li><a href="{{- $rellink -}}" {{- if eq $title "..." -}}aria-label="{{- $page.Title -}}" title="{{- $page.Title -}}"{{- end -}}class="DocsMarkdown--link"><span class="DocsMarkdown--link-content">{{- $title -}}</span></a></li>
+      &nbsp;&nbsp;>&nbsp;&nbsp;
+        <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+          <a href="{{- $rellink -}}" itemprop="item" {{- if eq $title "..." -}}aria-label="{{- $page.Title -}}" title="{{- $page.Title -}}"{{- end -}}class="DocsMarkdown--link">
+            <span class="DocsMarkdown--link-content" {{- if ne $title "..." -}}itemprop="name"{{- end -}}>{{- $title -}}</span></a>
+            {{- if eq $title "..." -}}
+            <meta itemprop="name" content="{{$page.Title}}" />
+            {{- end -}}
+            <meta itemprop="position" content="{{add $index 1}}" />
+          </li>
       {{- end -}}
     {{- end -}}
   </ol>

--- a/static/style.css
+++ b/static/style.css
@@ -5432,8 +5432,3 @@ pre {
   display: inline;
   white-space: nowrap;
 }
-
-.breadcrumb li + li:before {
-  content: ">";
-  padding: 0.3rem;
-}


### PR DESCRIPTION
PCX-5760
(https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)

Also works around the hidden `...` by adding a meta property for the microdata to pick up (per recommendations from [Schema.org](https://schema.org/docs/gs.html#advanced_missing))

Validated in:
- https://search.google.com/test/rich-results/result/r%2Fbreadcrumbs?id=lw2QrvQk6DX_aXBpQ_hHBw
- https://validator.schema.org/#url=https%3A%2F%2Fmicrodata-breadcrumb-tagging.cloudflare-docs-7ou.pages.dev%2Fworkers%2Fplatform%2Fsites%2Fstart-from-existing%2F

Also added in a trailing slash for our links so they're pointing to the canonical version of the page.