### PR TITLE
r2: add consistency & security docs

### DIFF
--- a/content/r2/learning/consistency.md
+++ b/content/r2/learning/consistency.md
@@ -1,0 +1,58 @@
+---
+title: Consistency Model
+weight: 1
+pcx_content_type: concept
+---
+
+# Consistency Model
+
+This page details R2's consistency model, including where R2 is strongly, globally consistent and which operations this applies to.
+
+R2 can be described as "strongly consistent", especially in comparison to other distriubted object storage systems. This strong consistency ensures that operations against R2 see the latest (accurate) state: clients should be able to observe the effects of any write, update and/or delete operation immediately, globally. 
+
+## Terminology
+
+In the context of R2, _strong_ consistency and _eventual_ consistency have the following meanings: 
+
+* **Strongly consistent** - the effect of an operation will be observed globally, immediately, by all clients. Clients will not observe 'stale' (inconsistent) state.
+* **Eventually consistent** - clients may not see the effect of an operation immediately: state may take a some time (typically seconds to a minute) to propagate globally.
+
+## Operations and Consistency
+
+Operations against R2 buckets and objects adhere to the following consistency guarantees:
+
+{{<table-wrap>}}
+
+| Action                                            | Consistency                           |
+| ------------------------------------------------- | ------------------------------------- |
+| Read-after-write: Write (upload) an object, then read it   | Strongly consistent: readers will immediately see the latest object globally          |
+| Metadata: Update an object's metadata             | Strongly consistent: readers will immediately see the updated metadata globally
+| Deletion: Delete an object                        | Strongly consistent: reads to that object will immediately return a "does not exist" error
+| Object listing: List the objects in a bucket      | Strongly consistent: the list operation will list all objects at that point in time                    |
+| IAM: Adding/removing R2 Storage permissions       | Eventually consistent: A [new or updated API key](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) may take up to a minute to have permissions reflected globally
+
+{{</table-wrap>}}
+
+Additional notes:
+
+* In the event two clients are writing (`PUT` or `DELETE`) to the same key, the last writer to complete "wins".
+* When performing a multipart upload, read-after-write consistency continues to apply once all parts have been successfully uploaded. In the case the same part is uploaded (in error) from multple writers, the last write will win
+* Copying an object within the same bucket also follows the same read-after-write consistency that writing a new object would. The "copied" object is immediately readable by all clients once the copy operation completes.
+
+## Caching
+
+{{<Aside type="note">}}
+
+By default, Cloudflare's cache will cache common, cacheable status codes automatically [per our cache documentation](https://developers.cloudflare.com/cache/how-to/configure-cache-status-code/#edge-ttl).
+
+{{</Aside>}}
+
+When connecting a [custom domain](https://developers.cloudflare.com/r2/data-access/public-buckets/#custom-domains) to an R2 bucket and enabling caching for objects served from that bucket, the consistency model is necessarily relaxed when accessing content via a domain with caching enabled.
+
+Specifically, you should expect:
+
+* An object you delete from R2, but that is still cached, will still be available. You should [purge the cache](https://developers.cloudflare.com/cache/how-to/purge-cache/) after deleting an object/objects if you need that delete to be reflected 
+* Cloudflare's cache to [cache HTTP 404 (Not Found) responses](https://developers.cloudflare.com/cache/how-to/configure-cache-status-code/#edge-ttl) automatically. If you upload an object to that same path, the cache may continue to return HTTP 404s until the cache TTL (Time to Live) expires and the new object is fetched from R2, or the [cache is purged](https://developers.cloudflare.com/cache/how-to/purge-cache/).
+* An object for a given key is overwritten with a new object: the old (previous) object will continue to be served to clients until the cache TTL expires (or the object is evicted), or the cache is purged.
+
+The cache does not affect access via [Worker API bindings](https://developers.cloudflare.com/r2/data-access/workers-api/) or the [S3 API](https://developers.cloudflare.com/r2/data-access/s3-api/), as these operations are made directly against the bucket and do not transit through the cache.

--- a/content/r2/learning/consistency.md
+++ b/content/r2/learning/consistency.md
@@ -14,8 +14,8 @@ R2 can be described as "strongly consistent", especially in comparison to other 
 
 In the context of R2, _strong_ consistency and _eventual_ consistency have the following meanings: 
 
-* **Strongly consistent** - the effect of an operation will be observed globally, immediately, by all clients. Clients will not observe 'stale' (inconsistent) state.
-* **Eventually consistent** - clients may not see the effect of an operation immediately: state may take a some time (typically seconds to a minute) to propagate globally.
+* **Strongly consistent** - The effect of an operation will be observed globally, immediately, by all clients. Clients will not observe 'stale' (inconsistent) state.
+* **Eventually consistent** - Clients may not see the effect of an operation immediately. The state may take a some time (typically seconds to a minute) to propagate globally.
 
 ## Operations and Consistency
 
@@ -36,7 +36,7 @@ Operations against R2 buckets and objects adhere to the following consistency gu
 Additional notes:
 
 * In the event two clients are writing (`PUT` or `DELETE`) to the same key, the last writer to complete "wins".
-* When performing a multipart upload, read-after-write consistency continues to apply once all parts have been successfully uploaded. In the case the same part is uploaded (in error) from multple writers, the last write will win
+* When performing a multipart upload, read-after-write consistency continues to apply once all parts have been successfully uploaded. In the case the same part is uploaded (in error) from multiple writers, the last write will win.
 * Copying an object within the same bucket also follows the same read-after-write consistency that writing a new object would. The "copied" object is immediately readable by all clients once the copy operation completes.
 
 ## Caching
@@ -51,8 +51,8 @@ When connecting a [custom domain](https://developers.cloudflare.com/r2/data-acce
 
 Specifically, you should expect:
 
-* An object you delete from R2, but that is still cached, will still be available. You should [purge the cache](https://developers.cloudflare.com/cache/how-to/purge-cache/) after deleting an object/objects if you need that delete to be reflected 
-* Cloudflare's cache to [cache HTTP 404 (Not Found) responses](https://developers.cloudflare.com/cache/how-to/configure-cache-status-code/#edge-ttl) automatically. If you upload an object to that same path, the cache may continue to return HTTP 404s until the cache TTL (Time to Live) expires and the new object is fetched from R2, or the [cache is purged](https://developers.cloudflare.com/cache/how-to/purge-cache/).
-* An object for a given key is overwritten with a new object: the old (previous) object will continue to be served to clients until the cache TTL expires (or the object is evicted), or the cache is purged.
+* An object you delete from R2, but that is still cached, will still be available. You should [purge the cache](https://developers.cloudflare.com/cache/how-to/purge-cache/) after deleting objects if you need that delete to be reflected.
+* Cloudflare's cache to [cache HTTP 404 (Not Found) responses](https://developers.cloudflare.com/cache/how-to/configure-cache-status-code/#edge-ttl) automatically. If you upload an object to that same path, the cache may continue to return HTTP 404s until the cache TTL (Time to Live) expires and the new object is fetched from R2 or the [cache is purged](https://developers.cloudflare.com/cache/how-to/purge-cache/).
+* An object for a given key is overwritten with a new object: the old (previous) object will continue to be served to clients until the cache TTL expires (or the object is evicted) or the cache is purged.
 
 The cache does not affect access via [Worker API bindings](https://developers.cloudflare.com/r2/data-access/workers-api/) or the [S3 API](https://developers.cloudflare.com/r2/data-access/s3-api/), as these operations are made directly against the bucket and do not transit through the cache.

--- a/content/r2/learning/data-security.md
+++ b/content/r2/learning/data-security.md
@@ -1,0 +1,27 @@
+---
+title: Data Security
+weight: 2
+pcx_content_type: concept
+---
+
+# Data Security
+
+This page details the data security properties of R2, including encryption-at-rest (EAR), encryption-in-transit (EIT), and Cloudflare's compliance certifications.
+
+## Encryption at Rest 
+
+All objects stored in R2, including their metadata, are encrypted at rest. Encryption and decryption are automatic, do not require user configuration to enable, and do not impact the effective performance of R2.
+
+Encryption keys are managed by Cloudflare and securely stored in the same key management systems we use for managing encrypted data across Cloudflare internally.
+
+Objects are encrypted using [AES-256](https://www.cloudflare.com/learning/ssl/what-is-encryption/), a widely tested, highly performant and industry-standard encryption algorithm. R2 uses GCM (Galois/Counter Mode) as its preferred mode.
+
+## Encryption in Transit
+
+Data transfer between a client and R2 is secured using the same [Transport Layer Security](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) (TLS/SSL) supported on all Cloudflare domains.
+
+Access over plaintext HTTP (without TLS/SSL) can be disabled by connecting a [custom domain](https://developers.cloudflare.com/r2/data-access/public-buckets/#custom-domains) to your R2 bucket and enabling [Always Use HTTPS](https://developers.cloudflare.com/ssl/edge-certificates/additional-options/always-use-https/).
+
+## Compliance
+
+To learn more about Cloudflare's adherence to industry-standard security compliance certifications, visit the Cloudflare [Trust Hub](https://www.cloudflare.com/trust-hub/compliance-resources/).

--- a/content/r2/learning/unicode-interoperability.md
+++ b/content/r2/learning/unicode-interoperability.md
@@ -1,5 +1,6 @@
 ---
 title: Filename encoding and interoperability problems
+weight: 3
 pcx_content_type: concept
 ---
 


### PR DESCRIPTION
Fixes #7091 

- A new "Data Security" page that covers how we encrypt data at rest, in-transit, and a link out to Cloudflare's security compliance certifications
- A new "Consistency Model" page that demonstrates R2's strong consistency on a per-operation basis

cc/ @dcpena

@codymgriffin @jonesphillip have co-reviewed internally.