### PR TITLE
[WIP] Generate changelogs within Functions

### DIFF
--- a/functions/changelog/[product].ts
+++ b/functions/changelog/[product].ts
@@ -1,0 +1,94 @@
+interface Change {
+  date?: string;
+  text?: string;
+  items?: string[];
+
+  // string still in progress of being written
+  wip?: string;
+}
+type Changes = Change[];
+
+export const onRequestGet: PagesFunction<{}, 'product'> = async ({ env, request, params }) => {
+  // Attempt to get the changelog, it's usually at the root of the product or under platform
+  // TODO: This is pretty gross but is there a better way to handle than requiring to update this file?
+  let changelog = await env.ASSETS.fetch(`https://docs/${params.product}/changelog/`);
+  if (changelog.status === 404) {
+    changelog = await env.ASSETS.fetch(`https://docs/${params.product}/platform/changelog/`);
+    if (changelog.status === 404) {
+      return env.ASSETS.fetch('https://docs/404/');
+    }
+  }
+
+  const changes: Changes = [];
+  const res = new HTMLRewriter()
+    .on('h1, h2, li', new ChangelogParser(changes))
+    .transform(changelog);
+
+  // Trigger HTMLRewriter to stream through
+  await res.text();
+
+  return Response.json(changes);
+}
+
+class ChangelogParser {
+
+  #changes: Changes;
+  #entry: Change = null;
+  #heading = false;
+  #listItem = false;
+
+  constructor(changes: Changes) {
+    this.#changes = changes;
+  }
+
+  element(elem: Element) {
+    // TOOD: Clean this up
+    if (elem.tagName === 'h2') {
+      this.#heading = true;
+      this.#listItem = false;
+
+      // If we have an entry in the works, submit it and reset for the next one
+      if (this.#entry !== null) {
+        this.#changes.push(this.#entry);
+      }
+      this.#entry = null;
+    } else if (elem.tagName === 'li' && this.#entry) {
+      this.#heading = false;
+      this.#listItem = true;
+
+      elem.onEndTag(() => {
+        this.#listItem = false;
+        if (!this.#entry.items) {
+          this.#entry.items = [];
+        }
+        if (this.#entry.wip) {
+          // Write out WIP string
+          this.#entry.items.push(this.#entry.wip);
+          delete this.#entry.wip;
+        }
+      });
+    } else {
+      this.#heading = false;
+    }
+  }
+
+  text(chunk: Text) {
+    // Ignore juml
+    if (chunk.text.trim() === '') return;
+
+    // If this is a heading of a new entry
+    if (this.#heading && /\d{4}-\d{2}-\d{2}/.test(chunk.text)) {
+      this.#entry = {
+        date: chunk.text,
+      };
+
+    // If there's an entry in progress we append to it
+    } else if (this.#entry !== null) {
+      if (this.#listItem) {
+        this.#entry.wip = (this.#entry.wip ?? '') + chunk.text;
+      } else {
+        this.#entry.text = (this.#entry.text ?? '') + chunk.text;
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "repository": "cloudflare/cloudflare-docs",
   "description": "Cloudflare Developer Docs",
   "scripts": {
-    "dev": "hugo serve -D",
+    "dev": "concurrently npm:dev:*",
+    "dev:hugo": "hugo --watch",
+    "dev:wrangler": "wrangler pages dev public",
     "lint": "tsm bin/format.ts --check",
     "crawl": "tsm bin/crawl.ts",
     "prebuild": "tsm bin/highlight.ts replace",
@@ -21,10 +23,12 @@
     "@types/node": "16.11.12",
     "@types/prettier": "2.4.3",
     "@types/prismjs": "^1.26.0",
+    "concurrently": "^7.6.0",
     "node-html-parser": "5.2.0",
     "prettier": "2.5.1",
     "prismjs": "^1.29.0",
-    "tsm": "2.2.2"
+    "tsm": "2.2.2",
+    "wrangler": "^2.8.1"
   },
   "volta": {
     "node": "18.10.0"


### PR DESCRIPTION
Note: Currently WIP and is super messy

Changelogs now have RSS feeds added to them, these RSS feeds are the commits made to the file. They're helpful to know the file was updated but not very helpful to know _what_ was added/changed.
This PR aims to address that with the power of Functions

Instead of just relying on GitHub commits, we will take the changelog that exists and parse it into a JSON (and soon RSS feed). This means anyone can subscribe to the RSS feed, and write their own Worker or app to check this :)

(WIP) Example here: https://walshy-generate-changelog-fe.cloudflare-docs-7ou.pages.dev/changelog/pages

Few things still to fix:
* Inner bullet points are sent in the same item (not sure how to handle these yet)
* External link stuff is being added ("External link iconOpen external link")

Branched off #7449