### PR TITLE
workers: update storage options guide

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -5,15 +5,19 @@ title: Betas
 
 # Beta Status
 
-These are the betas relevant to Cloudflare Workers.
+These are the current alphas & betas relevant to the Cloudflare Workers platform.
 
-| Product                       | Private Beta | Public Beta | More Info                                                                  |
-|:---                           |    :----:    |    :----:   | -----------                                                                |
-| Email Workers                 | ✅           |              |[Blog](https://blog.cloudflare.com/announcing-route-to-workers/)            |
-| D1 Database                   | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-d1/)                         |
-| Green Compute                 |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
-| Pub/Sub                       | ✅           |              |[Docs](/pub-sub)                                                            |
-| Queues                        |              |  ✅          |[Docs](/queues)                                                             |
-| TCP Workers                   | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
-| Workers Analytics Engine      |             | ✅            |[Docs](/analytics/analytics-engine/)               |
-| Workers Deployments           |             | ✅            |[Docs](/workers/platform/deployments)               |
+* *Public* alphas and betas are openly available, but may have limitations and caveats due to their early stage of development.
+* *Private* alphas and betas require explicit access to be granted. Visit the documentation for that product to join the relevant waitlist.
+
+
+| Product                       | Public Alpha  | Private Beta | Public Beta | More Info                                                                  |
+|:---                           |    :----:     |    :----:    |    :----:   | -----------                                                                |
+| Email Workers                 |               | ✅           |              |[Blog](https://blog.cloudflare.com/announcing-route-to-workers/)            |
+| D1 Database                   | ✅            |             |              |[Blog](https://blog.cloudflare.com/introducing-d1/)                         |
+| Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
+| Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
+| Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
+| TCP Workers                   |               | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
+| Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
+| Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |

--- a/content/workers/platform/storage-objects.md
+++ b/content/workers/platform/storage-objects.md
@@ -10,6 +10,14 @@ meta:
 
 The Cloudflare Workers platform provides multiple storage options. This guide will inform you on which storage option is appropriate based on your project's use case.
 
+* [KV](#kv) for key-value storage 
+* [R2](#r2) for S3-compatible object storage use-cases
+* [Durable Objects](#durable-objects) for transactional, co-ordinated use-cases
+* [D1](#d1) for relational, SQL-based database use-cases
+* [Queues](#queues) for job queueing, batching and inter-service communication
+
+Applications built on the Workers platform may combine one or more storage components as they grow, scale or as requirements demand.
+
 ## KV
 
 Workers KV is an eventually consistent key-value data store that caches on the edge.
@@ -18,7 +26,7 @@ It is ideal for projects that require:
 
 * High volumes of reads and/or repeated reads to the same keys.
 * Per-object time-to-live (TTL).
-* Asset storage for websites.
+* Distributed configuaration
 
 To get started with KV:
 
@@ -34,8 +42,9 @@ R2 is S3-compatible blob storage that allows developers to store large amounts o
 It is ideal for projects that require:
 
 * Storage for files which are infrequently accessed.
-* Large object storage.
+* Large object storage (e.g. gigabytes or more per object)
 * Strong consistency per object.
+* Asset storage for websites (see the [caching guide](https://developers.cloudflare.com/r2/data-access/public-buckets/#caching))
 
 To get started with R2:
 
@@ -65,7 +74,54 @@ To get started with Durable Objects:
 * Review the [Durable Objects Runtime API](/workers/runtime-apis/durable-objects/).
 * Learn about Durable Objects [Limits](/workers/platform/limits/#durable-objects-limits/).
 
+## D1
+
+{{<Aside type="note">}}
+
+D1 is currently in [public (open) alpha](https://developers.cloudflare.com/workers/platform/betas/).
+
+{{</Aside>}}
+
+Built on SQLite, D1 is Cloudflare’s first [queryable relational database at the edge](https://blog.cloudflare.com/introducing-d1/). Create an entire database in a few quick steps by importing data or defining your tables and writing your queries within a Worker or through our API.
+
+D1 is ideal for:
+
+* Persistent, relational storage for user data, account data, and other structured datasets
+* Use-cases that require querying across your data ad-hoc (using SQL)
+* Workloads with a high ratio of reads to writes (most web applications)
+
+To get started with D1:
+
+* Read [the documentation](https://developers.cloudflare.com/d1)
+* Follow the [getting started guide](https://developers.cloudflare.com/d1/get-started/) to provision your first D1 database
+* Learn the [D1 client API](https://developers.cloudflare.com/d1/platform/client-api/)
+
+## Queues
+
+{{<Aside type="note">}}
+
+Queues is currently in [public (open) beta](https://developers.cloudflare.com/workers/platform/betas/).
+
+{{</Aside>}}
+
+Cloudflare Queues allows developers to send and receive messages with guaranteed delivery. It integrates with [Cloudflare Workers](/workers) and offers at-least once delivery, message batching, and does not charge for egress bandwidth.
+
+Queues is ideal for:
+
+* Offloading work from a request to schedule later 
+* Send data from Worker to Worker (inter-service communication)
+* Buffering or batching data before writing to upstream systems, including third-party APIs or [Cloudflare R2](https://developers.cloudflare.com/queues/examples/send-errors-to-r2/)
+
+To get started with Queues:
+
+* Visit [the documentation](https://developers.cloudflare.com/queues/)
+* [Set up your first queue](https://developers.cloudflare.com/queues/get-started/)
+* Learn more [about how Queues works](https://developers.cloudflare.com/queues/learning/how-queues-works/)
+
+
 ## Comparison
+
+The following table highlights the primary differences and behaviours of KV, R2 and DO as primary storage mechanisms:
 
 {{<table-wrap>}}
 


### PR DESCRIPTION
This updates the:

* Storage Options guide to highlight D1 and Queues: https://developers.cloudflare.com/workers/platform/storage-objects/
* An adjacent change to the Betas page to indicate that D1 is public (open) alpha: https://developers.cloudflare.com/workers/platform/betas/

cc @dcpena @deadlypants1973 
