### PR TITLE
Fix invalid JSON payload in creating clips curl example

### DIFF
--- a/content/stream/edit-videos/video-clipping.md
+++ b/content/stream/edit-videos/video-clipping.md
@@ -50,7 +50,7 @@ curl --location --request POST 'https://api.cloudflare.com/client/v4/accounts/<Y
 --data-raw '{
     "clippedFromVideoUID": "0ea62994907491cf9ebefb0a34c1e2c6",
     "startTimeSeconds": 10,
-    "endTimeSeconds": 15,
+    "endTimeSeconds": 15
     }'
 ```
 


### PR DESCRIPTION
In the curl example for creating clips, the trailing period after ` "endTimeSeconds": 15` in the JSON payload will actually cause the API to throw a really confusing error:

```
{
  "result": null,
  "success": false,
  "errors": [
    {
      "code": 10004,
      "message": "Decoding Error"
    }
  ],
  "messages": null
}
```

I almost gave up on using Cloudflare Stream as a reliable way to create video clips. I opened a support ticket 9 days ago but didn't hear back. I was about to close my account until I noticed the extra comma and realized that "Decoding Error" may be referring to JSON decoding, not video decoding. :) Hope this helps others.

Also, the other documentation site (developers.cloudflare.com/api/...) also has incorrect documentation for video clipping, here: https://developers.cloudflare.com/api/operations/stream-video-clipping-clip-videos-given-a-start-and-end-time . You can see the URL, section title, and POST endpoint is about video clipping, but the example body payload is for video watermarking, not video clipping.