### PR TITLE
[Queues] fix omissions in get-started.md

### DIFF
--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -197,7 +197,7 @@ To connect your queue to your consumer Worker, open your `wrangler.toml` file an
 
 ```toml
 [[queues.consumers]]
- queue = "YOUR_QUEUE_NAME"
+ queue = "<YOUR_QUEUE_NAME>"
  # Required: this should match the name of the queue you created in step 3.
  # If you misspell the name, you will receive an error when attempting to publish your Worker.
  max_batch_size = 10 # optional: defaults to 10

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -151,7 +151,7 @@ Published <YOUR-WORKER-NAME> (0.29 sec)
   https://<YOUR-WORKER-NAME>.<YOUR-ACCOUNT>.workers.dev
 ```
 
-Now make a POST request to your worker using cURL:
+Now make a POST request to your producer Worker using cURL:
 
 ```sh
 $ curl --request POST --url https://<YOUR-WORKER-NAME>.<YOUR-ACCOUNT>.workers.dev/ --header 'content-type: application/json' --data '{"message": "Hello World!"}'

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -151,7 +151,7 @@ Published <YOUR-WORKER-NAME> (0.29 sec)
   https://<YOUR-WORKER-NAME>.<YOUR-ACCOUNT>.workers.dev
 ```
 
-Now make a POST request to your producer Worker using cURL:
+After you have updated your `index.ts` file, make a POST request to your producer Worker using cURL:
 
 ```sh
 $ curl --request POST --url https://<YOUR-WORKER-NAME>.<YOUR-ACCOUNT>.workers.dev/ --header 'content-type: application/json' --data '{"message": "Hello World!"}'


### PR DESCRIPTION
The guide now:
- Uses POST requests to trigger the producer Worker. 
- Uses the worker file structure and types that wrangler generates when `wrangler init` is used.

This fixes issue: #7482 