### PR TITLE
d1: add backups + importing docs

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -175,11 +175,12 @@
 /cloudflare-for-platforms/workers-for-platforms/platform/analytics/ /cloudflare-for-platforms/workers-for-platforms/platform/observability/ 301
 
 # d1
-/d1/wrangler-commands/ /d1/platform/wrangler-commands/ 301
-/d1/platform/wrangler-commands/ /workers/wrangler/commands/#d1 301
 /d1/client-api/ /d1/platform/client-api/ 301
-/d1/migrations/ /d1/platform/migrations/ 301
 /d1/community-projects/ /d1/platform/community-projects/ 301
+/d1/learning/using-d1-from-pages /pages/platform/functions/bindings/#d1-databases 301
+/d1/migrations/ /d1/platform/migrations/ 301
+/d1/platform/wrangler-commands/ /workers/wrangler/commands/#d1 301
+/d1/wrangler-commands/ /d1/platform/wrangler-commands/ 301
 
 # ddos-protection
 /ddos-protection/managed-rulesets/tcp-protection/ /ddos-protection/tcp-protection/ 301

--- a/content/d1/learning/_index.md
+++ b/content/d1/learning/_index.md
@@ -1,0 +1,9 @@
+---
+title: Learning
+pcx_content_type: navigation
+weight: 2
+---
+
+# Learning
+
+{{<directory-listing>}}

--- a/content/d1/learning/backups.md
+++ b/content/d1/learning/backups.md
@@ -8,7 +8,7 @@ pcx_content_type: concept
 
 D1 has built-in support for creating and restoring backups of your databases, including support for scheduled automatic backups and manual backup management.
 
-## Automatic Backups
+## Automatic backups
 
 D1 automatically backs up your databases every hour on your behalf. Backups will block access to the DB while they are running. In most cases this should only be a second or two, and any requests that arrive during the backup will be queued.
 
@@ -32,16 +32,16 @@ For example, to list all of the backups of a D1 database named `existing-db`:
 
 The `id` of each backup allows you to download or restore a specific backup.
 
-## Manually Back Up a Database
+## Manually back up a database
 
 Creating a manual backup of your database before making large schema changes, manually inserting or deleting data, or otherwise modifying a database you are actively using is a good practice to get into. D1 allows you to make a backup of a database at any time, and stores the backup on your behalf. You should also consider [using migrations](https://developers.cloudflare.com/d1/platform/migrations/) to simplify changes to an existing database.
 
-In order to back up a D1 database, you need to:
+To back up a D1 database, you must have:
 
-1. Have the Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
-2. Have an existing D1 database you want to back up
+1. The Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+2. An existing D1 database you want to back up.
 
-For example, to create a manual backup of a D1 database named `example-db`, we can call `d1 backup create`.
+For example, to create a manual backup of a D1 database named `example-db`, call `d1 backup create`.
 
 ```sh
 ➜  wrangler d1 backup create example-db
@@ -55,9 +55,9 @@ For example, to create a manual backup of a D1 database named `example-db`, we c
 
 Larger databases, especially those that are several megabytes (MB) in size with many tables, may take a few seconds to backup. The `state` column in the output will let you know when the backup is done.
 
-## Downloading a Backup Locally
+## Downloading a backup locally
 
-To download a backup locally, call `wrangler d1 backup <DATABASE_NAME> <BACKUP_ID>`. You can use `wrangler d1 backup list <DATABASE_NAME>` to list the available backups, including their IDs, for a given D1 database.
+To download a backup locally, call `wrangler d1 backup <DATABASE_NAME> <BACKUP_ID>`. Use `wrangler d1 backup list <DATABASE_NAME>` to list the available backups, including their IDs, for a given D1 database.
 
 For example, to download a specific backup for a database named `example-db`:
 
@@ -71,7 +71,7 @@ For example, to download a specific backup for a database named `example-db`:
 
 The database backup will be download to the current working directory in native SQLite3 format. To import a local database, read [the documentation on importing data](https://developers.cloudflare.com//learning/importing-data/) to D1.
 
-## Restoring a Backup
+## Restoring a backup
 
 {{<Aside type="warning">}}
 
@@ -79,7 +79,7 @@ Restoring a backup will overwrite the existing version of your D1 database in-pl
 
 {{</Aside>}}
 
-Restoring a backup will overwrite the current running version of a database with the backup. Database tables (and their data) that don't exist in the backup will no longer exist in the current version of the database, and queries that rely on them will fail.
+Restoring a backup will overwrite the current running version of a database with the backup. Database tables (and their data) that do not exist in the backup will no longer exist in the current version of the database, and queries that rely on them will fail.
 
 To restore a previous backup of a D1 database named `existing-db`, pass the ID of that backup to `d1 backup restore`:
 

--- a/content/d1/learning/backups.md
+++ b/content/d1/learning/backups.md
@@ -1,0 +1,93 @@
+---
+title: Backups
+weight: 2
+pcx_content_type: concept
+---
+
+# Backups
+
+D1 has built-in support for creating and restoring backups of your databases, including support for scheduled automatic backups and manual backup management.
+
+## Automatic Backups
+
+D1 automatically backs up your databases every hour on your behalf. Backups will block access to the DB while they are running. In most cases this should only be a second or two, and any requests that arrive during the backup will be queued.
+
+To view and manage these backups, including any manual backups you have made, you can use the `d1 backup list <DATABASE_NAME>` command to list each backup.
+
+For example, to list all of the backups of a D1 database named `existing-db`:
+
+```sh
+➜  wrangler d1 backup list existing-db
+
+┌──────────────┬──────────────────────────────────────┬────────────┬─────────┐
+│ created_at   │ id                                   │ num_tables │ size    │
+├──────────────┼──────────────────────────────────────┼────────────┼─────────┤
+│ 1 hour ago   │ 54a23309-db00-4c5c-92b1-c977633b937c │ 1          │ 95.3 kB │
+├──────────────┼──────────────────────────────────────┼────────────┼─────────┤
+│ <...>        │ <...>                                │ <...>      │ <...>   │
+├──────────────┼──────────────────────────────────────┼────────────┼─────────┤
+│ 2 months ago │ 8433a91e-86d0-41a3-b1a3-333b080bca16 │ 1          │ 65.5 kB │
+└──────────────┴──────────────────────────────────────┴────────────┴─────────┘%
+```
+
+The `id` of each backup allows you to download or restore a specific backup.
+
+## Manually Back Up a Database
+
+Creating a manual backup of your database before making large schema changes, manually inserting or deleting data, or otherwise modifying a database you are actively using is a good practice to get into. D1 allows you to make a backup of a database at any time, and stores the backup on your behalf. You should also consider [using migrations](https://developers.cloudflare.com/d1/platform/migrations/) to simplify changes to an existing database.
+
+In order to back up a D1 database, you need to:
+
+1. Have the Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+2. Have an existing D1 database you want to back up
+
+For example, to create a manual backup of a D1 database named `example-db`, we can call `d1 backup create`.
+
+```sh
+➜  wrangler d1 backup create example-db
+
+┌─────────────────────────────┬──────────────────────────────────────┬────────────┬─────────┬───────┐
+│ created_at                  │ id                                   │ num_tables │ size    │ state │
+├─────────────────────────────┼──────────────────────────────────────┼────────────┼─────────┼───────┤
+│ 2023-02-04T15:49:36.113753Z │ 123a81a2-ab91-4c2e-8ebc-64d69633faf1 │ 1          │ 65.5 kB │ done  │
+└─────────────────────────────┴──────────────────────────────────────┴────────────┴─────────┴───────┘
+```
+
+Larger databases, especially those that are several megabytes (MB) in size with many tables, may take a few seconds to backup. The `state` column in the output will let you know when the backup is done.
+
+## Downloading a Backup Locally
+
+To download a backup locally, call `d1 backup <DATABASE_NAME> <BACKUP_ID>`.
+
+For example, to download a specific backup for a database named `example-db`:
+
+```sh
+➜  wrangler d1 backup download example-db 123a81a2-ab91-4c2e-8ebc-64d69633faf1
+
+🌀 Downloading backup 123a81a2-ab91-4c2e-8ebc-64d69633faf1 from 'example-db'
+🌀 Saving to /Users/you/projects/example-db.123a81a2.sqlite3
+🌀 Done!
+```
+
+The database backup will be download to the current working directory in native SQLite3 format. To import a local database, read [the documentation on importing data](https://developers.cloudflare.com//learning/importing-data/) to D1.
+
+## Restoring a Backup
+
+{{<Aside type="warning">}}
+
+Restoring a backup will overwrite the existing version of your D1 database in-place. We recommend you make a manual backup before you restore a database, so that you have a backup to revert to if you accidentally restore the wrong backup or break your application.
+
+{{</Aside>}}
+
+Restoring a backup will overwrite the current running version of a database with the backup. Database tables (and their data) that don't exist in the backup will no longer exist in the current version of the database, and queries that rely on them will fail.
+
+To restore a previous backup of a D1 database named `existing-db`, pass the ID of that backup to `d1 backup restore`:
+
+```sh
+➜  wrangler d1 backup restore existing-db  6cceaf8c-ceab-4351-ac85-7f9e606973e3
+
+Restoring existing-db from backup 6cceaf8c-ceab-4351-ac85-7f9e606973e3....
+Done!
+```
+
+Any queries against the database will immediately query the current (restored) version once the restore has completed.

--- a/content/d1/learning/backups.md
+++ b/content/d1/learning/backups.md
@@ -57,7 +57,7 @@ Larger databases, especially those that are several megabytes (MB) in size with 
 
 ## Downloading a Backup Locally
 
-To download a backup locally, call `d1 backup <DATABASE_NAME> <BACKUP_ID>`.
+To download a backup locally, call `wrangler d1 backup <DATABASE_NAME> <BACKUP_ID>`. You can use `wrangler d1 backup list <DATABASE_NAME>` to list the available backups, including their IDs, for a given D1 database.
 
 For example, to download a specific backup for a database named `example-db`:
 

--- a/content/d1/learning/importing-data.md
+++ b/content/d1/learning/importing-data.md
@@ -1,28 +1,28 @@
 ---
-title: Importing Data
+title: Importing data
 weight: 1
 pcx_content_type: concept
 ---
 
-# Importing Data
+# Importing data
 
-D1 allows you to import existing SQLite tables & their data directly, enabling you to migrate existing data into D1 quickly and easily. This can be useful when migrating applications to use Workers + D1, or when you want to prototype a schema locally before importing it to your D1 database(s).
+D1 allows you to import existing SQLite tables and their data directly, enabling you to migrate existing data into D1 quickly and easily. This can be useful when migrating applications to use Workers and D1, or when you want to prototype a schema locally before importing it to your D1 database(s).
 
-## Import an Existing Database
+## Import an existing database
 
-To import an existing SQLite database into D1, you need to:
+To import an existing SQLite database into D1, you must have:
 
-1. Have the Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
-2. Create a database to use as the target
-3. Have an existing SQLite (version 3.0+) database file to import
+1. The Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/).
+2. A database to use as the target
+3. An existing SQLite (version 3.0+) database file to import.
 
 {{<Aside type="note">}}
 
-You cannot import a raw SQLite database (`.sqlite3` files) directly. See [how to convert an existing SQLite file](#converting-sqlite-database-files) first.
+You cannot import a raw SQLite database (`.sqlite3` files) directly. Refer to [how to convert an existing SQLite file](#converting-sqlite-database-files) first.
 
 {{</Aside>}}
 
-For example, consider the following `users_export.sql` schema & values, which includes a `CREATE TABLE IF NOT EXISTS` statement
+For example, consider the following `users_export.sql` schema & values, which includes a `CREATE TABLE IF NOT EXISTS` statement:
 
 ```sql
 CREATE TABLE IF NOT EXISTS users (
@@ -37,7 +37,7 @@ insert into users (id, full_name, created_on) values ('01GREFXCNDGQNBQAJG1AP0TYX
 insert into users (id, full_name, created_on) values ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
 ```
 
-With our `users_export.sql` file in the current working directory, we can pass the `--file=users_export.sql` flag to `d1 execute` to execute (import) our table schema & values:
+With your `users_export.sql` file in the current working directory, you can pass the `--file=users_export.sql` flag to `d1 execute` to execute (import) our table schema and values:
 
 ```sh
 ➜  wrangler d1 execute example-db --file=users_export.sql
@@ -48,7 +48,7 @@ With our `users_export.sql` file in the current working directory, we can pass t
 🚣 Executed 1 command in 61.64555000513792ms
 ```
 
-To confirm our table was imported correctly and is queryable, we can execute a simple `SELECT` statement against our `users` table directly:
+To confirm your table was imported correctly and is queryable, execute a `SELECT` statement against your `users` table directly:
 
 ```sh
 ➜  wrangler d1 execute example-db --command "SELECT * FROM users LIMIT 100;"
@@ -72,11 +72,11 @@ To confirm our table was imported correctly and is queryable, we can execute a s
 └────────────────────────────┴──────────────────┴─────────────────────┘
 ```
 
-Note that we apply a `LIMIT 100` clause here as a precaution: if we were importing a larger database with hundreds or thousands of rows, we may not want to output every row to the terminal.
+Note that we apply a `LIMIT 100` clause here as a precaution: if you were importing a larger database with hundreds or thousands of rows, you may not want to output every row to the terminal.
 
-From here, we can now query our new table from our Worker [using the D1 client API](https://developers.cloudflare.com/d1/platform/client-api/).
+From here, you can now query our new table from our Worker [using the D1 client API](https://developers.cloudflare.com/d1/platform/client-api/).
 
-## Converting SQLite Database Files
+## Converting SQLite database files
 
 {{<Aside type="note">}}
 

--- a/content/d1/learning/importing-data.md
+++ b/content/d1/learning/importing-data.md
@@ -18,7 +18,7 @@ To import an existing SQLite database into D1, you need to:
 
 {{<Aside type="note">}}
 
-You cannot import SQLite database (`.sqlite3`) directly. Use the `sqlite3` [command line tool](https://sqlite.org/cli.html) to convert the database dump: `sqlite3 db_dump.sqlite3 .dump > db.sql`.
+You cannot import a raw SQLite database (`.sqlite3` files) directly. See [how to convert an existing SQLite file](#converting-sqlite-database-files) first.
 
 {{</Aside>}}
 
@@ -76,12 +76,30 @@ Note that we apply a `LIMIT 100` clause here as a precaution: if we were importi
 
 From here, we can now query our new table from our Worker [using the D1 client API](https://developers.cloudflare.com/d1/platform/client-api/).
 
+## Converting SQLite Database Files
+
+{{<Aside type="note">}}
+
+In order to convert a raw SQLite3 database dump (a `.sqlite3` file) you will need the [sqlite command-line tool](https://sqlite.org/cli.html) installed on your system.
+
+{{</Aside>}}
+
+If you have an existing SQLite database from another system, you can import its tables into a D1 database. Using the `sqlite` command-line tool, you can convert an `.sqlite3` file into a series of SQL statements that can be imported (executed) against a D1 database.
+
+For example, if you have a raw SQLite dump called `db_dump.sqlite3`, run the following `sqlite` command to convert it:
+
+```sh
+$ sqlite3 db_dump.sqlite3 .dump > db.sql`.
+```
+
+You can then follow the steps to [import an existing database](#import-an-existing-database) into D1 by using the `.sql` file you generated from the database dump as the input to `wrangler d1 execute`.
+
 ## Troubleshooting
 
 If you receive an error when trying to import an existing schema and/or dataaset into D1:
 
-* Ensure you are importing data in SQL format (typically with a `.sql`) file extension. You cannot import SQLite database (`.sqlite3`) directly. Use the `sqlite3` [command line tool](https://sqlite.org/cli.html) to convert the database dump: `sqlite3 db_dump.sqlite3 .dump > db.sql`.
-* Make sure the schema is [SQLite 3](https://www.sqlite.org/docs.html) compatible. You cannot import data from a MySQL or PostgreSQL database into D1, as the types and SQL syntax are not directly compatible.
+* Ensure you are importing data in SQL format (typically with a `.sql`) file extension. See [how to convert SQLite files](#converting-sqlite-database-files) if you have a `.sqlite3` database dump.
+* Make sure the schema is [SQLite3](https://www.sqlite.org/docs.html) compatible. You cannot import data from a MySQL or PostgreSQL database into D1, as the types and SQL syntax are not directly compatible.
 * If you have foreign key relationships between tables, ensure you are importing the tables in the right order. You can't refer to a table that doesn't yet exist.
 
 ## Next Steps

--- a/content/d1/learning/importing-data.md
+++ b/content/d1/learning/importing-data.md
@@ -1,0 +1,91 @@
+---
+title: Importing Data
+weight: 1
+pcx_content_type: concept
+---
+
+# Importing Data
+
+D1 allows you to import existing SQLite tables & their data directly, enabling you to migrate existing data into D1 quickly and easily. This can be useful when migrating applications to use Workers + D1, or when you want to prototype a schema locally before importing it to your D1 database(s).
+
+## Import an Existing Database
+
+To import an existing SQLite database into D1, you need to:
+
+1. Have the Cloudflare [Wrangler CLI installed](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+2. Create a database to use as the target
+3. Have an existing SQLite (version 3.0+) database file to import
+
+{{<Aside type="note">}}
+
+You cannot import SQLite database (`.sqlite3`) directly. Use the `sqlite3` [command line tool](https://sqlite.org/cli.html) to convert the database dump: `sqlite3 db_dump.sqlite3 .dump > db.sql`.
+
+{{</Aside>}}
+
+For example, consider the following `users_export.sql` schema & values, which includes a `CREATE TABLE IF NOT EXISTS` statement
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+	id VARCHAR(50),
+	full_name VARCHAR(50),
+	created_on DATE
+);
+insert into users (id, full_name, created_on) values ('01GREFXCN9519NRVXWTPG0V0BF', 'Catlaina Harbar', '2022-08-20 05:39:52');
+insert into users (id, full_name, created_on) values ('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13');
+insert into users (id, full_name, created_on) values ('01GREFXCNCWAJWRQWC2863MYW4', 'Christin Moss', '2022-07-28 04:13:37');
+insert into users (id, full_name, created_on) values ('01GREFXCNDGQNBQAJG1AP0TYXZ', 'Vlad Koche', '2022-11-29 17:40:57');
+insert into users (id, full_name, created_on) values ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
+```
+
+With our `users_export.sql` file in the current working directory, we can pass the `--file=users_export.sql` flag to `d1 execute` to execute (import) our table schema & values:
+
+```sh
+➜  wrangler d1 execute example-db --file=users_export.sql
+
+🌀 Mapping SQL input into an array of statements
+🌀 Parsing 1 statements
+🌀 Executing on example-db (c7fe3a2a-9973-4231-85ff-edd63d7a4e6d):
+🚣 Executed 1 command in 61.64555000513792ms
+```
+
+To confirm our table was imported correctly and is queryable, we can execute a simple `SELECT` statement against our `users` table directly:
+
+```sh
+➜  wrangler d1 execute example-db --command "SELECT * FROM users LIMIT 100;"
+
+🌀 Mapping SQL input into an array of statements
+🌀 Parsing 1 statements
+🌀 Executing on example-db (63571930-b2f1-4bdb-bffa-a7db6ee04c5d):
+🚣 Executed 1 command in 102.00563299655914ms
+┌────────────────────────────┬──────────────────┬─────────────────────┐
+│ id                         │ full_name        │ created_on          │
+├────────────────────────────┼──────────────────┼─────────────────────┤
+│ 01GREFXCN9519NRVXWTPG0V0BF │ Catlaina Harbar  │ 2022-08-20 05:39:52 │
+├────────────────────────────┼──────────────────┼─────────────────────┤
+│ 01GREFXCNBYBGX2GC6ZGY9FMP4 │ Hube Bilverstone │ 2022-12-15 21:56:13 │
+├────────────────────────────┼──────────────────┼─────────────────────┤
+│ 01GREFXCNCWAJWRQWC2863MYW4 │ Christin Moss    │ 2022-07-28 04:13:37 │
+├────────────────────────────┼──────────────────┼─────────────────────┤
+│ 01GREFXCNDGQNBQAJG1AP0TYXZ │ Vlad Koche       │ 2022-11-29 17:40:57 │
+├────────────────────────────┼──────────────────┼─────────────────────┤
+│ 01GREFXCNF67KV7FPPSEJVJMEW │ Riane Zamora     │ 2022-12-24 06:49:04 │
+└────────────────────────────┴──────────────────┴─────────────────────┘
+```
+
+Note that we apply a `LIMIT 100` clause here as a precaution: if we were importing a larger database with hundreds or thousands of rows, we may not want to output every row to the terminal.
+
+From here, we can now query our new table from our Worker [using the D1 client API](https://developers.cloudflare.com/d1/platform/client-api/).
+
+## Troubleshooting
+
+If you receive an error when trying to import an existing schema and/or dataaset into D1:
+
+* Ensure you are importing data in SQL format (typically with a `.sql`) file extension. You cannot import SQLite database (`.sqlite3`) directly. Use the `sqlite3` [command line tool](https://sqlite.org/cli.html) to convert the database dump: `sqlite3 db_dump.sqlite3 .dump > db.sql`.
+* Make sure the schema is [SQLite 3](https://www.sqlite.org/docs.html) compatible. You cannot import data from a MySQL or PostgreSQL database into D1, as the types and SQL syntax are not directly compatible.
+* If you have foreign key relationships between tables, ensure you are importing the tables in the right order. You can't refer to a table that doesn't yet exist.
+
+## Next Steps
+
+* Read the SQLite [`CREATE TABLE`](https://www.sqlite.org/lang_createtable.html) documentation
+* Learn how to [use the D1 client API](https://developers.cloudflare.com/d1/platform/client-api/) from within a Worker
+* Understand how [database migrations work](https://developers.cloudflare.com/d1/platform/migrations/) with D1

--- a/content/d1/learning/using-d1-from-pages.md
+++ b/content/d1/learning/using-d1-from-pages.md
@@ -1,0 +1,17 @@
+---
+title: Using D1 from Pages
+weight: 3
+pcx_content_type: concept
+---
+
+<!--
+
+Do not write on this page. It's kept here to display "Using D1 from Pages" in the D1 menu.
+
+Users will get 301'd to https://developers.cloudflare.com/pages/platform/functions/bindings/#d1-databases
+
+Make edits only to the /pages/platform/functions/bindings.md doc
+
+!-->
+
+This page redirects to https://developers.cloudflare.com/pages/platform/functions/bindings/#d1-databases

--- a/content/d1/platform/_index.md
+++ b/content/d1/platform/_index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: Platform
-weight: 2
+weight: 3
 ---
 
 # Platform

--- a/content/d1/tutorials/_index.md
+++ b/content/d1/tutorials/_index.md
@@ -1,6 +1,5 @@
 ---
 type: overview
-hideChildren: true
 pcx_content_type: navigation
 title: Tutorials
 weight: 4


### PR DESCRIPTION
This PR adds:

* A new `/learning/importing-data` guide to help users understand how to import existing table definitions & data into a D1 database, as well as how to convert an SQLite3 database dump locally.
* A new `/learning/backups` guide that explains how automatic backups work, as well as how to manually create backups and restore them.
* A deep-link into https://developers.cloudflare.com/pages/platform/functions/bindings/#d1-databases so that users can find the Pages Functions specific binding docs
* Expanding the _Tutorials_ sidebar to list the tutorials, just as we do with Pages docs: https://developers.cloudflare.com/pages/

What the sidebar will look like:

<img width="386" alt="image" src="https://user-images.githubusercontent.com/18544/217549959-e76eba44-1254-4021-baac-fae827b1f967.png">

cc/ @nevikashah @geelen 