### PR TITLE
[W4P] Cleanup Dynamic Dispatch Worker

### DIFF
--- a/content/cloudflare-for-platforms/workers-for-platforms/get-started/dynamic-dispatch.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/get-started/dynamic-dispatch.md
@@ -13,29 +13,30 @@ Use any method of routing to a namespaced Worker (reading the subdomain, request
 
 In the following example, routing to user Workers is done through reading the subdomain `<USER_WORKER_NAME>.example.com/*`. For example, `my-customer.example.com` will run the script uploaded to `PUT accounts/<ACCOUNT_ID>/workers/dispatch/namespaces/my-dispatch-namespace/scripts/my-customer`.
 
-`src/index.ts`
-
 ```js
+---
+filename: src/index.js
+---
 export default {
-  async fetch(request, env) {
-    try {
-        // parse the URL, read the subdomain
-        let workerName = new URL(request.url).host.split('.')[0]
-        let userWorker = env.dispatcher.get(workerName)
-        return await userWorker.fetch(request) 
-    } catch (e) {
-        if (e.message.startsWith('Worker not found')) {
-            // we tried to get a worker that doesn't exist in our dispatch namespace
-            return new Response('', {status: 404})
-        }
+	async fetch(request, env) {
+		try {
+			// parse the URL, read the subdomain
+			let workerName = new URL(request.url).host.split('.')[0];
+			let userWorker = env.dispatcher.get(workerName);
+			return await userWorker.fetch(request);
+		} catch (e) {
+			if (e.message.startsWith('Worker not found')) {
+				// we tried to get a worker that doesn't exist in our dispatch namespace
+				return new Response('', { status: 404 });
+			}
 
-        // this could be any other exception from `fetch()` *or* an exception
-        // thrown by the called worker (e.g. if the dispatched worker has 
-        // `throw MyException()`, you could check for that here).
-        return new Response(e.message, {status: 500})
-    }
-  }
-}
+			// this could be any other exception from `fetch()` *or* an exception
+			// thrown by the called worker (e.g. if the dispatched worker has
+			// `throw MyException()`, you could check for that here).
+			return new Response(e.message, { status: 500 });
+		}
+	},
+};
 ```
 
 ### Dispatch Namespace API reference


### PR DESCRIPTION
Since there's no types for the Dispatch Namespace binding, moved the example to be `.js` rather than `.ts` (it was already JavaScript code rather than TypeScript anyhow).

Ran the existing Worker through Prettier.