### PR TITLE
Need to set JEKYLL_ENV=production

### DIFF
--- a/content/pages/migrations/migrating-jekyll-from-github-pages.md
+++ b/content/pages/migrations/migrating-jekyll-from-github-pages.md
@@ -125,6 +125,16 @@ Deploy your site to Pages by logging in to the [Cloudflare dashboard](https://da
 
 </div>
 
+In the **Environment Variables** section, add the following variables for the **Production** environment:
+
+</div>
+
+| Variable name | Value      |
+| ------------- | -----------|
+| JEKYLL_ENV    | production |
+
+</div>
+
 After you have configured your site, you can begin your first deploy. You should see Cloudflare Pages installing `jekyll`, your project dependencies, and building your site, before deploying it.
 
 {{<Aside type="note">}}


### PR DESCRIPTION
Some plugins, such as Disqus comments, require the `JEKYLL_ENV=production` environment variable to be defined when building the site to work.