### PR TITLE
[Wrangler] Simplify "update locally" instructions

### DIFF
--- a/content/workers/wrangler/install-and-update.md
+++ b/content/workers/wrangler/install-and-update.md
@@ -65,13 +65,7 @@ $ wrangler version
 To update Wrangler only in your current directory containing a `package.json`, run:
 
 ```sh
-$ npm upgrade wrangler --save
-```
-
-or
-
-```sh
-$ npm update wrangler --save
+$ npm install wrangler
 ```
 
 ### Update Wrangler globally


### PR DESCRIPTION
`npm update/upgrade` doesn't always work, `npm install` does, and `--save` is no longer necessary