### PR TITLE
d1: fix missing trailing slash in _redirects

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -177,7 +177,7 @@
 # d1
 /d1/client-api/ /d1/platform/client-api/ 301
 /d1/community-projects/ /d1/platform/community-projects/ 301
-/d1/learning/using-d1-from-pages /pages/platform/functions/bindings/#d1-databases 301
+/d1/learning/using-d1-from-pages/ /pages/platform/functions/bindings/#d1-databases 301
 /d1/migrations/ /d1/platform/migrations/ 301
 /d1/platform/wrangler-commands/ /workers/wrangler/commands/#d1 301
 /d1/wrangler-commands/ /d1/platform/wrangler-commands/ 301


### PR DESCRIPTION
Redirect doesn’t match without the trailing slash.