### PR TITLE
[1.1.1.1] Fix mistake in "DNS in Google Sheets" causing it to fail for people in some regions

### DIFF
--- a/content/1.1.1.1/other-ways-to-use-1.1.1.1/dns-in-google-sheets.md
+++ b/content/1.1.1.1/other-ways-to-use-1.1.1.1/dns-in-google-sheets.md
@@ -100,6 +100,11 @@ For example, typing:
 ```txt
 NSLookup(B1, B2)
 ```
+or
+```txt
+NSLookup(B1; B2)
+```
+depending on your regional settings
 
 <div class="medium-img">
 

--- a/content/1.1.1.1/other-ways-to-use-1.1.1.1/dns-in-google-sheets.md
+++ b/content/1.1.1.1/other-ways-to-use-1.1.1.1/dns-in-google-sheets.md
@@ -100,11 +100,12 @@ For example, typing:
 ```txt
 NSLookup(B1, B2)
 ```
-or
+
+Or - depending on your regional settings - you may have to use this formula:
+
 ```txt
 NSLookup(B1; B2)
 ```
-depending on your regional settings
 
 <div class="medium-img">
 


### PR DESCRIPTION
In Sweden the cell will fail with a message saying "Error in formula parsing" translated to English if you use a comma.
![image](https://user-images.githubusercontent.com/58081413/218314280-e351a03e-eaa4-406c-b652-3436ecb537d1.png)
Replacing it with a semicolon fixes this.
![image](https://user-images.githubusercontent.com/58081413/218314320-a72fce5b-47af-45d7-bfbc-11770780307a.png)
Reproducable if you change the region to Swedish and uncheck the "Always use english function names" box in the Google Sheet settings.
![image](https://user-images.githubusercontent.com/58081413/218314369-69b84507-0a26-4645-aa29-443c14cd13a7.png)
