### PR TITLE
Only Super Admin can see Payload Logging option

### DIFF
--- a/content/waf/managed-rules/payload-logging/configure.md
+++ b/content/waf/managed-rules/payload-logging/configure.md
@@ -8,6 +8,10 @@ meta:
 
 # Configure payload logging for a managed ruleset in the dashboard
 
+{{<Aside type="note">}}
+Only the **Super Administrator** can see the option to configure Payload Logging. The decryption of logs is available to everyone as long as they have access to the private key.
+{{</Aside>}}
+
 Configure payload logging for a ruleset in the ruleset configuration page.
 
 1.  Open **Security** > **WAF** > **Managed rules**.

--- a/content/waf/managed-rules/payload-logging/configure.md
+++ b/content/waf/managed-rules/payload-logging/configure.md
@@ -8,11 +8,13 @@ meta:
 
 # Configure payload logging for a managed ruleset in the dashboard
 
+Configure payload logging for a ruleset in the ruleset configuration page.
+
 {{<Aside type="note">}}
-Only the **Super Administrator** can see the option to configure Payload Logging. The decryption of logs is available to everyone as long as they have access to the private key.
+Only users with the [Super Administrator role](/fundamentals/account-and-billing/members/roles/) can configure payload logging and decrypt payloads in the Cloudflare dashboard. Other users can decrypt payloads if they have access to the logs and to the private key.
 {{</Aside>}}
 
-Configure payload logging for a ruleset in the ruleset configuration page.
+Do the following:
 
 1.  Open **Security** > **WAF** > **Managed rules**.
 


### PR DESCRIPTION
{{<Aside type="note">}}
Only the **Super Administrator** can see the option to configure Payload Logging. The decryption of logs is available to everyone as long as they have access to the private key. {{</Aside>}}