### PR TITLE
[Zaraz] Ecommerce - Add Shipping Info Entered and payment_type

### DIFF
--- a/content/zaraz/web-api/ecommerce.md
+++ b/content/zaraz/web-api/ecommerce.md
@@ -107,7 +107,7 @@ Parameter | Type | Description |
 `creative`               | String | Label for creative asset of promotion being tracked.
 `query`                  | String | Product search term.
 `step`                   | Number | The Number of the checkout step in the checkout process.
-`payment_type`           | String | The type of payment used. Maps to `payment_method` in GA4.
+`payment_type`           | String | The type of payment used.
 
 {{</table-wrap>}}
 

--- a/content/zaraz/web-api/ecommerce.md
+++ b/content/zaraz/web-api/ecommerce.md
@@ -64,6 +64,7 @@ To create a complete tracking event, you need to add an event and one or more pa
 - `Order Cancelled`
 - `Clicked Promotion`
 - `Viewed Promotion`
+- `Shipping Info Entered`
 
 ## List of supported parameters:
 
@@ -106,6 +107,7 @@ Parameter | Type | Description |
 `creative`               | String | Label for creative asset of promotion being tracked.
 `query`                  | String | Product search term.
 `step`                   | Number | The Number of the checkout step in the checkout process.
+`payment_type`           | String | The type of payment used. Maps to `payment_method` in GA4.
 
 {{</table-wrap>}}
 


### PR DESCRIPTION
Adds a new 'Shipping Info Entered' event and 'payment_type' API parameter in the Zaraz Ecommerce docs