### PR TITLE
Update template urls

### DIFF
--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -182,7 +182,7 @@ $ curl https://d1-example.signalnerve.workers.dev/api/posts/hello-world/comments
 
 ## Test with an optional frontend
 
-This application is just an API back end, best served for use with a front-end UI for creating and viewing comments. To test this back-end with a prebuild front-end UI, refer to the example UI in the [example-frontend directory](https://github.com/cloudflare/templates/tree/main/worker-d1-api/example-frontend). Notably, the [`loadComments` and `submitComment` functions](https://github.com/cloudflare/templates/blob/main/worker-d1-api/example-frontend/src/views/PostView.vue#L57-L82) make requests to a deployed version of this site, meaning you can take the frontend and replace the URL with your deployed version of the codebase in this tutorial to use your own data.
+This application is just an API back end, best served for use with a front-end UI for creating and viewing comments. To test this back-end with a prebuild front-end UI, refer to the example UI in the [example-frontend directory](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend). Notably, the [`loadComments` and `submitComment` functions](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend/src/views/PostView.vue#L57-L82) make requests to a deployed version of this site, meaning you can take the frontend and replace the URL with your deployed version of the codebase in this tutorial to use your own data.
 
 Note that interacting with this API from a front end will require enabling specific Cross-Origin Resource Sharing (or *CORS*) headers in your back-end API. Luckily, Hono has a quick way to enable this for your application. Import the `cors` module and add it as middleware to your API in `src/index.js`:
 
@@ -201,4 +201,4 @@ Now, when you make requests to `/api/*`, Hono will automatically generate and ad
 
 ## Conclusion
 
-In this example, you built a comments API for powering a blog. To see the full source for this D1-powered comments API, you can visit [cloudflare/templates/worker-d1-api](https://github.com/cloudflare/templates/tree/main/worker-d1-api).
+In this example, you built a comments API for powering a blog. To see the full source for this D1-powered comments API, you can visit [cloudflare/workers-sdk/tree/main/templates/worker-d1-api](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api).

--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -201,4 +201,4 @@ Now, when you make requests to `/api/*`, Hono will automatically generate and ad
 
 ## Conclusion
 
-In this example, you built a comments API for powering a blog. To see the full source for this D1-powered comments API, you can visit [cloudflare/workers-sdk/tree/main/templates/worker-d1-api](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api).
+In this example, you built a comments API for powering a blog. To see the full source for this D1-powered comments API, you can visit [cloudflare/workers-sdk/templates/worker-d1-api](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api).

--- a/content/pages/tutorials/build-an-api-with-workers/index.md
+++ b/content/pages/tutorials/build-an-api-with-workers/index.md
@@ -29,7 +29,7 @@ You will use the Workers TypeScript template to generate our project. If you do 
 ---
 header: Creating a new Workers project with Wrangler
 ---
-$ git clone https://github.com/cloudflare/worker-typescript-template
+$ git clone https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript
 $ cd worker-typescript-template
 $ npm install
 ```

--- a/content/stream/webrtc-beta.md
+++ b/content/stream/webrtc-beta.md
@@ -55,7 +55,7 @@ Every live input has a unique URL that one creator can be stream to. This URL sh
 
 Copy the URL from the `webRTC` key in the API response (see above), or directly from the [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/stream/inputs).
 
-Paste this URL into the provided [WHIP example code](https://https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/whip.html#L13), which you can [run in your web browser on Stackblitz](https://workers.new/stream/webrtc-whip):
+Paste this URL into the provided [WHIP example code](https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/whip.html#L13), which you can [run in your web browser on Stackblitz](https://workers.new/stream/webrtc-whip):
 
 ```javascript
 ---

--- a/content/stream/webrtc-beta.md
+++ b/content/stream/webrtc-beta.md
@@ -55,7 +55,7 @@ Every live input has a unique URL that one creator can be stream to. This URL sh
 
 Copy the URL from the `webRTC` key in the API response (see above), or directly from the [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/stream/inputs).
 
-Paste this URL into the provided [WHIP example code](https://github.com/cloudflare/templates/blob/main/stream/webrtc/src/whip.html#L13), which you can [run in your web browser on Stackblitz](https://workers.new/stream/webrtc-whip):
+Paste this URL into the provided [WHIP example code](https://https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/whip.html#L13), which you can [run in your web browser on Stackblitz](https://workers.new/stream/webrtc-whip):
 
 ```javascript
 ---
@@ -65,7 +65,7 @@ highlight: [4]
 // Add a <video> element to the HTML page this code runs in:
 // <video id="input-video" autoplay muted></video>
 
-import WHIPClient from "./WHIPClient.js"; // an example WHIP client, see https://github.com/cloudflare/templates/tree/main/stream/webrtc/src/WHIPClient.ts
+import WHIPClient from "./WHIPClient.js"; // an example WHIP client, see https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/WHIPClient.ts
 
 const url = "<WEBRTC_URL_FROM_YOUR_LIVE_INPUT>"; // add the webRTC URL from your live input here
 const videoElement = document.getElementById("input-video");
@@ -80,7 +80,7 @@ You can also use this URL with any client that supports the [WebRTC-HTTP ingesti
 
 Copy the URL from the `webRTCPlayback` key in the API response (see above), or directly from the [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/stream/inputs). There are no limits on the number of concurrent viewers.
 
-Paste this URL into the provided [WHEP example code](https://github.com/cloudflare/templates/blob/main/stream/webrtc/src/whep.html#L13), which you [can run in your browser on Stackblitz](https://workers.new/stream/webrtc-whep).
+Paste this URL into the provided [WHEP example code](https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/whep.html#L13), which you [can run in your browser on Stackblitz](https://workers.new/stream/webrtc-whep).
 
 ```javascript
 ---
@@ -90,7 +90,7 @@ highlight: [4]
 // Add a <video> element to the HTML page this code runs in:
 // <video id="output-video" autoplay muted></video>
 
-import WHEPClient from "./WHEPClient.js"; // an example WHEP client, see https://github.com/cloudflare/templates/tree/main/stream/webrtc/src/WHEPClient.ts
+import WHEPClient from "./WHEPClient.js"; // an example WHEP client, see https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/WHEPClient.ts
 
 const url = "<WEBRTC_URL_FROM_YOUR_LIVE_INPUT>"; // add the webRTCPlayback URL from your live input here
 const videoElement = document.getElementById("output-video");
@@ -113,7 +113,7 @@ If you are building a native app, the example code above can run within a [WkWeb
 
 ## Supported WHIP and WHEP clients
 
-Beyond the [example WHIP client](https://github.com/cloudflare/templates/blob/main/stream/webrtc/src/WHIPClient.ts) and [example WHEP client](https://github.com/cloudflare/templates/blob/main/stream/webrtc/src/WHEPClient.ts) used in the examples above, we have tested and confirmed that the following clients are compatible with Cloudflare Stream:
+Beyond the [example WHIP client](https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/WHIPClient.ts) and [example WHEP client](https://github.com/cloudflare/workers-sdk/blob/main/templates/stream/webrtc/src/WHEPClient.ts) used in the examples above, we have tested and confirmed that the following clients are compatible with Cloudflare Stream:
 
 ### WHIP
 

--- a/content/workers/get-started/quickstarts.md
+++ b/content/workers/get-started/quickstarts.md
@@ -52,11 +52,11 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 {{<worker-starter title="JavaScript Starter" repo="cloudflare/wrangler2/templates/worker" description="A bare-bones Workers starter project, in JavaScript.">}}
 
-{{<worker-starter title="TypeScript Starter" repo="cloudflare/wrangler2/templates/worker-typescript" description="A bare-bones Workers starter project, in TypeScript.">}}
+{{<worker-starter title="TypeScript Starter" repo="cloudflare/workers-sdk/tree/main/templates/worker-typescript" description="A bare-bones Workers starter project, in TypeScript.">}}
 
-{{<worker-starter title="Workers Sites" repo="cloudflare/wrangler2/templates/worker-sites" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
+{{<worker-starter title="Workers Sites" repo="cloudflare/workers-sdk/tree/main/templates/worker-sites" description="Easily deploy a static site or static assets to Cloudflare’s edge network.">}}
 
-{{<worker-starter title="Router" repo="cloudflare/wrangler2/templates/worker-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
+{{<worker-starter title="Router" repo="cloudflare/workers-sdk/tree/main/templates/worker-router" description="Run different logic based on the URL and request method. Use this starter to Build REST APIs or apps that require routing logic.">}}
 
 {{<worker-starter title="Miniflare Example Project" repo="cloudflare/miniflare-typescript-esbuild-jest" description="An example Cloudflare Workers project that uses Miniflare for local development, TypeScript, esbuild for bundling, and Jest for testing, with Miniflare's custom Jest environment.">}}
 
@@ -78,7 +78,7 @@ $ npx wrangler generate <new-project-name> <github-repo-url>
 
 ## Example Projects
 
-{{<worker-starter title="Speedtest" repo="cloudflare/wrangler2/templates/worker-speedtest"
+{{<worker-starter title="Speedtest" repo="cloudflare/workers-sdk/tree/main/templates/worker-speedtest"
 description="Measure download / upload connection speed from the client side, using the Performance Timing API.">}}
 
 {{<worker-starter title="Sentry" repo="bustle/cf-sentry" description="Log exceptions and errors in your Workers application to Sentry.io - an error tracking tool">}}
@@ -89,13 +89,13 @@ description="Measure download / upload connection speed from the client side, us
 
 {{<worker-starter title="BinAST" repo="xtuc/binast-cf-worker-template" description="Serve a JavaScript Binary AST via a Cloudflare Worker.">}}
 
-{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/wrangler2/templates/worker-aws" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
+{{<worker-starter title="AWS DynamoDB SQS" repo="cloudflare/workers-sdk/tree/main/templates/worker-aws" description="Use AWS services such as DynamoDB and SQS from a Cloudflare Worker">}}
 
 {{<worker-starter title="Edge-side rendering - Vitedge" repo="frandiox/vitessedge-template" description="Use Vite to render pages at the edge with great DX. Includes i18n, markdown support and more.">}}
 
 {{<worker-starter title="REST API with Fauna" repo="fauna-labs/fauna-workers" description="Build a fast, globally distributed REST API using Cloudflare Workers and Fauna, the data API for modern applications.">}}
 
-{{<worker-starter title="Analytics Engine Forwarder" repo="cloudflare/templates/worker-analytics-engine-forwarder" description="Use a Worker to capture analytics data with Analytics Engine.">}}
+{{<worker-starter title="Analytics Engine Forwarder" repo="cloudflare/workers-sdk/tree/main/templates/worker-analytics-engine-forwarder" description="Use a Worker to capture analytics data with Analytics Engine.">}}
 
 ---
 
@@ -103,7 +103,7 @@ description="Measure download / upload connection speed from the client side, us
 <!-- Move any templates not in /templates repo into new location cloudflare/wrangler2/templates/  and archive them -->
 Other languages may require you to install additional tools beyond wrangler. See the README.md file in the project.
 
-{{<worker-starter title="Hello World (Rust)" repo="cloudflare/wrangler2/templates/worker-rust" description="A bare-bones starter in Rust.">}}
+{{<worker-starter title="Hello World (Rust)" repo="cloudflare/workers-sdk/tree/main/templates/worker-rust" description="A bare-bones starter in Rust.">}}
 
 {{<worker-starter title="Hello World (Python)" repo="cloudflare/python-worker-hello-world" description="A bare-bones starter in Python.">}}
 
@@ -119,13 +119,13 @@ Other languages may require you to install additional tools beyond wrangler. See
 
 {{<worker-starter title="Hello World (Kotlin)" repo="cloudflare/kotlin-worker-hello-world" description="A bare-bones starter in Kotlin.">}}
 
-{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/wrangler2/templates/worker-cobol" description="A bare-bones starter in COBOL.">}}
+{{<worker-starter title="Hello World (COBOL)" repo="cloudflare/workers-sdk/tree/main/templates/worker-cobol" description="A bare-bones starter in COBOL.">}}
 
 {{<worker-starter title="Hello World (Perl)" repo="cloudflare/perl-worker-hello-world" description="A bare-bones starter in Perl.">}}
 
 {{<worker-starter title="Hello World (PHP)" repo="cloudflare/php-worker-hello-world" description="A bare-bones starter in PHP.">}}
 
-{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/wrangler2/templates/worker-emscripten-template" description="An image resizer in C compiled to Wasm with Emscripten.">}}
+{{<worker-starter title="Emscripten + Wasm Image Resizer" repo="cloudflare/workers-sdk/tree/main/templates/worker-emscripten" description="An image resizer in C compiled to Wasm with Emscripten.">}}
 
 ---
 

--- a/content/workers/platform/languages.md
+++ b/content/workers/platform/languages.md
@@ -18,7 +18,7 @@ The Workers platform fully supports JavaScript. Cloudflare recommends using Java
 | Language   | Template                                                                                          |
 | ---------- | ------------------------------------------------------------------------------------------------- |
 | JavaScript | [cloudflare/worker-template](https://github.com/cloudflare/worker-template)                       |
-| TypeScript | [cloudflare/worker-typescript-template](https://github.com/cloudflare/worker-typescript-template) |
+| TypeScript | [cloudflare/workers-sdk/tree/main/templates/worker-typescript](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript) |
 
 {{</table-wrap>}}
 
@@ -38,7 +38,7 @@ The Workers platform fully supports JavaScript. Cloudflare recommends using Java
 | Language | Template                                                                                          |
 | -------- | ------------------------------------------------------------------------------------------------- |
 | Rust     | [cloudflare/rustwasm-worker-template](https://github.com/cloudflare/rustwasm-worker-template)     |
-| C        | [cloudflare/worker-emscripten-template](https://github.com/cloudflare/worker-emscripten-template) |
+| C        | [cloudflare/workers-sdk/tree/main/templates/worker-emscripten](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-emscripten) |
 | Cobol    | [cloudflare/cobol-worker-template](https://github.com/cloudflare/cobol-worker-template)           |
 
 {{</table-wrap>}}

--- a/content/workers/platform/languages.md
+++ b/content/workers/platform/languages.md
@@ -18,7 +18,7 @@ The Workers platform fully supports JavaScript. Cloudflare recommends using Java
 | Language   | Template                                                                                          |
 | ---------- | ------------------------------------------------------------------------------------------------- |
 | JavaScript | [cloudflare/worker-template](https://github.com/cloudflare/worker-template)                       |
-| TypeScript | [cloudflare/workers-sdk/tree/main/templates/worker-typescript](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript) |
+| TypeScript | [cloudflare/workers-sdk/templates/worker-typescript](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript) |
 
 {{</table-wrap>}}
 
@@ -38,7 +38,7 @@ The Workers platform fully supports JavaScript. Cloudflare recommends using Java
 | Language | Template                                                                                          |
 | -------- | ------------------------------------------------------------------------------------------------- |
 | Rust     | [cloudflare/rustwasm-worker-template](https://github.com/cloudflare/rustwasm-worker-template)     |
-| C        | [cloudflare/workers-sdk/tree/main/templates/worker-emscripten](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-emscripten) |
+| C        | [cloudflare/workers-sdk/templates/worker-emscripten](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-emscripten) |
 | Cobol    | [cloudflare/cobol-worker-template](https://github.com/cloudflare/cobol-worker-template)           |
 
 {{</table-wrap>}}

--- a/content/workers/platform/sites/start-from-scratch.md
+++ b/content/workers/platform/sites/start-from-scratch.md
@@ -20,7 +20,7 @@ This guide shows how to quickly start a new Workers Sites project from scratch.
     The following example creates a project called `my-site`:
 
     ```sh
-    $ git clone --depth=1 --branch=wrangler2 https://github.com/cloudflare/worker-sites-template my-site
+    $ git clone --depth=1 --branch=wrangler2 https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites my-site
     ```
 2.  Run `npm install` to install all dependencies.
 3.  You can preview your site by running the [`wrangler dev`](/workers/wrangler/commands/#dev) command:

--- a/content/workers/platform/sites/start-from-scratch.md
+++ b/content/workers/platform/sites/start-from-scratch.md
@@ -20,7 +20,7 @@ This guide shows how to quickly start a new Workers Sites project from scratch.
     The following example creates a project called `my-site`:
 
     ```sh
-    $ git clone --depth=1 --branch=wrangler2 https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites my-site
+    $ git clone --depth=1 --branch=wrangler2 https://github.com/cloudflare/worker-sites-template my-site
     ```
 2.  Run `npm install` to install all dependencies.
 3.  You can preview your site by running the [`wrangler dev`](/workers/wrangler/commands/#dev) command:

--- a/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
+++ b/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
@@ -91,7 +91,7 @@ Now that we've uploaded the image we'll be using it as a background for our thum
 
 ## Create a Worker to Transform text-to-image
 
-The next phase of this tutorial is to create a worker that will enable you to transform text to image so this can be used as an overlay on the background image we uploaded. We will use the [rustwasm-worker-template](https://github.com/cloudflare/templates/tree/main/worker-rust). Go ahead and clone the repository and run it locally.
+The next phase of this tutorial is to create a worker that will enable you to transform text to image so this can be used as an overlay on the background image we uploaded. We will use the [rustwasm-worker-template](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-rust). Go ahead and clone the repository and run it locally.
 
 ```sh
 $ npx wrangler generate worker-to-text worker-rust

--- a/content/workers/tutorials/localize-a-website/index.md
+++ b/content/workers/tutorials/localize-a-website/index.md
@@ -29,10 +29,10 @@ If you would like to deploy your own version of the site, you can find the sourc
 
 ## Create a project
 
-Create a new project by cloning the [Workers Sites](https://github.com/cloudflare/worker-sites-template) template on GitHub and pass `i18n-example` as the project name.
+Create a new project by cloning the [Workers Sites](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites) template on GitHub and pass `i18n-example` as the project name.
 
 ```sh
-~/ $ git clone https://github.com/cloudflare/worker-sites-template i18n-example
+~/ $ git clone https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites i18n-example
 ~/ $ cd i18n-example
 ~/i18n-example $
 ```

--- a/content/workers/wrangler-legacy/commands.md
+++ b/content/workers/wrangler-legacy/commands.md
@@ -37,7 +37,7 @@ Default values indicated by {{<type>}}=value{{</type>}}.
   - The type of project; one of `webpack`, `javascript`, or `rust`.
 
 - `--site` {{<prop-meta>}}optional{{</prop-meta>}}
-  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/tree/main/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
+  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
 
 {{</definitions>}}
 
@@ -64,7 +64,7 @@ Default values indicated by {{<type>}}=value{{</type>}}.
   - The type of project; one of `webpack`, `javascript`, or `rust`.
 
 - `--site` {{<prop-meta>}}optional{{</prop-meta>}}
-  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/tree/main/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
+  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler-legacy/commands.md
+++ b/content/workers/wrangler-legacy/commands.md
@@ -37,7 +37,7 @@ Default values indicated by {{<type>}}=value{{</type>}}.
   - The type of project; one of `webpack`, `javascript`, or `rust`.
 
 - `--site` {{<prop-meta>}}optional{{</prop-meta>}}
-  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/worker-sites-template`](https://github.com/cloudflare/worker-sites-template). This scaffolds a [Workers Site](/workers/platform/sites/) project.
+  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/tree/main/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
 
 {{</definitions>}}
 
@@ -64,7 +64,7 @@ Default values indicated by {{<type>}}=value{{</type>}}.
   - The type of project; one of `webpack`, `javascript`, or `rust`.
 
 - `--site` {{<prop-meta>}}optional{{</prop-meta>}}
-  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/worker-sites-template`](https://github.com/cloudflare/worker-sites-template). This scaffolds a [Workers Site](/workers/platform/sites/) project.
+  - When defined, the default `$TEMPLATE` value is changed to [`cloudflare/workers-sdk/tree/main/templates/worker-sites`](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites). This scaffolds a [Workers Site](/workers/platform/sites/) project.
 
 {{</definitions>}}
 


### PR DESCRIPTION
This updates template urls following the move of templates into the workers-sdk monorepo (https://github.com/cloudflare/workers-sdk/pull/2498). 

This also fixes url updates made as part of https://github.com/cloudflare/cloudflare-docs/pull/7242.