### PR TITLE
[Queues] Codeblock cleanup

### DIFF
--- a/content/queues/examples/send-errors-to-r2.md
+++ b/content/queues/examples/send-errors-to-r2.md
@@ -34,26 +34,26 @@ name = "my-worker"
 ---
 filename: worker.ts
 ---
-type Environment = {
+  type Environment = {
   readonly ERROR_QUEUE: Queue;
-  readonly ERROR_BUCKET: R2Bucket;
+readonly ERROR_BUCKET: R2Bucket;
 };
 
 export default {
-  async fetch(request: Request, env: Environment): Promise<Response> {
+  async fetch(req: Request, env: Environment): Promise<Response> {
     try {
-      return doRequest(request);
+      return doRequest(req);
     } catch (error) {
       await env.ERROR_QUEUE.send(error);
       return new Response(error.message, { status: 500 });
     }
   },
   async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
-    let file = "";
+    let file = '';
     for (const message of batch.messages) {
       const error = message.body;
       file += error.stack || error.message || String(error);
-      file += "\r\n";
+      file += '\r\n';
     }
     await env.ERROR_BUCKET.put(`errors/${Date.now()}.log`, file);
   },
@@ -61,8 +61,8 @@ export default {
 
 function doRequest(request: Request): Promise<Response> {
   if (Math.random() > 0.5) {
-    return new Response("Success!");
+    return new Response('Success!');
   }
-  throw new Error("Failed!");
+  throw new Error('Failed!');
 }
 ```

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -53,7 +53,7 @@ $ yarn global add wrangler
 Queues requires Wrangler version `2.2.1` or higher. Run `wrangler version` to check your version:
 
 ```sh
-wrangler --version
+$ wrangler --version
 2.2.1
 ```
 
@@ -66,7 +66,7 @@ To use queues, you need to create at least one queue to publish messages to and 
 To create a queue, run:
 
 ```sh
-wrangler queues create <MY_FIRST_QUEUE>
+$ wrangler queues create <MY_FIRST_QUEUE>
 ```
 
 Choose a name that is descriptive and relates to the types of messages you intend to use this queue for. Descriptive queue names look like: `debug-logs`, `user-clickstream-data`, or `password-reset-prod`. 
@@ -111,18 +111,23 @@ You will now configure your producer Worker to create messages to publish to you
 
 In your Worker project directory, open the `src` folder and add the following to your `index.ts` file:
 
-```toml
+```ts
 ---
 filename: src/index.ts
-highlight: [4]
+highlight: [8]
 ---
 export default {
- async fetch(request: Request, env: Environment): Promise<Response> {
-   let log = await request.json();
-   await env.<MY_QUEUE>.send(log);
-   return new Response("Success!");
- }
- ```
+  async fetch(req: Request, env: Environment): Promise<Response> {
+    let log = {
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers),
+    };
+    await env.<MY_QUEUE>.send(log);
+    return new Response('Success!');
+  },
+};
+```
 
 Replace `MY_QUEUE` with the name you have set for your binding from your `wrangler.toml`.
 
@@ -158,22 +163,26 @@ In this guide, you will create a consumer Worker and use it to log and inspect t
 
 To create a consumer Worker, open your `index.ts` file and add the following `queue` handler to your existing `fetch` handler:
 
-```sh
+```ts
 ---
 filename: src/index.ts
-highlight: [4]
+highlight: [11]
 ---
 export default {
- async fetch(request: Request, env: Environment): Promise<Response> {
-   let log = await request.json();
-   await env.<MY_QUEUE>.send(log);
-   return new Response("Success!");
- }
- async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
-   let messages = JSON.stringify(batch.messages)
-   console.log(`consumed from our queue: ${messages}`)
- }
-}
+  async fetch(req: Request, env: Environment): Promise<Response> {
+    let log = {
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers),
+    };
+    await env.<MY_QUEUE>.send(log);
+    return new Response('Success!');
+  },
+  async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
+    let messages = JSON.stringify(batch.messages);
+    console.log(`consumed from our queue: ${messages}`);
+  },
+};
 ```
 
 Replace `MY_QUEUE` with the name you have set for your binding from your `wrangler.toml`.

--- a/content/queues/javascript-apis.md
+++ b/content/queues/javascript-apis.md
@@ -26,13 +26,13 @@ type Environment = {
 };
 
 export default {
-  async fetch(request: Request, env: Environment) {
+  async fetch(req: Request, env: Environment): Promise<Response> {
     await env.MY_QUEUE.send({
-      url: request.url,
-      method: request.method,
-      headers: Object.fromEntries(request.headers),
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers),
     });
-    return new Response("Sent!");
+    return new Response('Sent!');
   },
 };
 ```
@@ -42,10 +42,10 @@ The Queues API also supports writing multiple messages at once:
 ```ts
 const sendResultsToQueue = async (results: Array<any>, env: Environment) => {
   const batch: MessageSendRequest[] = results.map((value) => ({
-    body: JSON.stringify(value)
+    body: JSON.stringify(value),
   }));
   await env.queue.sendBatch(batch);
-}
+};
 ```
 
 ### `Queue`
@@ -79,8 +79,8 @@ A wrapper type used for sending message batches.
 
 ```ts
 type MessageSendRequest<Body = any> = {
-  body: Body
-}
+  body: Body;
+};
 ```
 
 {{<definitions>}}
@@ -108,9 +108,13 @@ If the `queue` function throws, or the promise returned by it or any of the prom
 
 ```ts
 export default {
-  async queue(batch: MessageBatch, env: Environment, ctx: ExecutionContext) {
+  async queue(
+    batch: MessageBatch,
+    env: Environment,
+    ctx: ExecutionContext
+  ): Promise<void> {
     for (const message of batch.messages) {
-      console.log("Received", message);
+      console.log('Received', message);
     }
   },
 };
@@ -121,8 +125,8 @@ The `env` and `ctx` fields are as [documented in the Workers docs](/workers/lear
 Or alternatively, a queue consumer can be written using service worker syntax:
 
 ```js
-addEventListener("queue", (event) => {
-  event.waitUntil(handleMessages(event));
+addEventListener('queue', (event) => {
+	event.waitUntil(handleMessages(event));
 });
 ```
 

--- a/content/queues/learning/how-queues-works.md
+++ b/content/queues/learning/how-queues-works.md
@@ -36,11 +36,19 @@ A producer is the term for a client that is publishing or producing messages on 
 For example, if we bound a queue named `my-first-queue` to a binding of `MY_FIRST_QUEUE`, messages can be written to the queue by calling `.send()` on the binding:
 
 ```ts
+type Environment = {
+  readonly MY_FIRST_QUEUE: Queue;
+};
+
 export default {
-    async fetch(req: Request, env: Environment): Promise<Response> {
-        let message = request.json()
-        await env.MY_FIRST_QUEUE.send(message) // This will throw an exception if the send fails for any reason
-    }
+  async fetch(req: Request, env: Environment): Promise<Response> {
+    let message = {
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers),
+    };
+    await env.MY_FIRST_QUEUE.send(message); // This will throw an exception if the send fails for any reason
+  },
 };
 ```
 
@@ -54,11 +62,11 @@ A consumer is the term for a client that is subscribing to or _consuming_ messag
 
 ```ts
 export default {
-    async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
-        // Do something with messages in the batch
-        // i.e. write to R2 storage, D1 database, or POST to an external API 
-        // You can also iterate over each message in the batch by looping over batch.messages
-    }
+  async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
+    // Do something with messages in the batch
+    // i.e. write to R2 storage, D1 database, or POST to an external API
+    // You can also iterate over each message in the batch by looping over batch.messages
+  },
 };
 ```
 
@@ -91,22 +99,22 @@ For example, a consumer configured to consume messages from multiple queues woul
 
 ```ts
 export default {
-    async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
-        // MessageBatch has a `queue` property we can switch on
-        switch (batch.queue) {
-            case "log-queue":
-                // Write the batch to R2
-                break;
-            case "debug-queue":
-                // Write the message to the console or to another queue
-                break;
-            case "email-reset":
-                // Trigger a password reset email via an external API
-                break;
-            default:
-                // Handle messages we haven't mentioned explicitly (write a log, push to a DLQ)
-        }
+  async queue(batch: MessageBatch<Error>, env: Environment): Promise<void> {
+    // MessageBatch has a `queue` property we can switch on
+    switch (batch.queue) {
+      case 'log-queue':
+        // Write the batch to R2
+        break;
+      case 'debug-queue':
+        // Write the message to the console or to another queue
+        break;
+      case 'email-reset':
+        // Trigger a password reset email via an external API
+        break;
+      default:
+      // Handle messages we haven't mentioned explicitly (write a log, push to a DLQ)
     }
+  },
 };
 ```
 


### PR DESCRIPTION
There was some scope creep - originally I just added `$` to some codeblocks and decided to try bring all of the code examples in-line with each other.

Some specified return types, some said `req` vs `request`, etc - generally ran them all through Prettier in line with how I've done other Workers in the docs.