### PR TITLE
SNI is not a supported Selector for SSH Audit

### DIFF
--- a/content/cloudflare-one/policies/filtering/network-policies/ssh-logging.md
+++ b/content/cloudflare-one/policies/filtering/network-policies/ssh-logging.md
@@ -69,7 +69,7 @@ $ cat /etc/ssh/sshd_config
 
 2. In the **Network** tab, create a new network policy.
 
-3. Name the policy and specify the [Destination IP](/cloudflare-one/policies/filtering/network-policies/#destination-ip) or [hostname](/cloudflare-one/policies/filtering/network-policies/#sni) for your origin server.
+3. Name the policy and specify the [Destination IP](/cloudflare-one/policies/filtering/network-policies/#destination-ip) for your origin server.
 
 4. Add any other conditions to your policy. If a user does not meet the criteria, they will be blocked by default.
 


### PR DESCRIPTION
SNI is not a supported selector for the Audit SSH Action.  In fact its not even possible to do this in the GUI. 

To recreate: 
1. Create a Network Firewall Policy
2. For selector, select `SNI`
3. See that under action no Audit SSH exists

As opposed to when using the Selector Domain, you will see Audit SSH (as that is supported)