### PR TITLE
Cipher Suite Updates

### DIFF
--- a/content/ssl/origin-configuration/cipher-suites.md
+++ b/content/ssl/origin-configuration/cipher-suites.md
@@ -14,7 +14,7 @@ Note that the cipher suites below are ordered based on how they appear in the Cl
 
 ## Supported cipher suites by protocol
 
-| OpenSSL Name                        | TLS 1.0 | TLS 1.1 | TLS 1.2 | TLS 1.3 |
+| Cipher name                        | TLS 1.0 | TLS 1.1 | TLS 1.2 | TLS 1.3 |
 | ----------------------------------- | ------- | ------- | ------- | ------- |
 | AEAD-AES128-GCM-SHA256 [^1]        | ❌      | ❌      | ❌      | ✅      |
 | AEAD-AES256-GCM-SHA384 [^1]        | ❌      | ❌      | ❌      | ✅      |

--- a/content/ssl/reference/cipher-suites/supported-cipher-suites.md
+++ b/content/ssl/reference/cipher-suites/supported-cipher-suites.md
@@ -33,8 +33,8 @@ Cloudflare supports the following cipher suites by default. If needed, you can [
 | AES256-SHA256                       | TLS 1.2 | Legacy | [0x3d] | TLS_RSA_WITH_AES_256_CBC_SHA256 |
 | AES256-SHA                          | TLS 1.0 | Legacy | [0x35] | TLS_RSA_WITH_AES_256_CBC_SHA |
 | DES-CBC3-SHA                        | TLS 1.0 | Legacy | [0x0701c0] | SSL_CK_DES_192_EDE3_CBC_WITH_SHA |
-| AEAD-AES128-GCM-SHA256[^1]        | TLS 1.3 | Modern | {0x13,0x01} | TLS_AES_128_GCM_SHA256 |
-| AEAD-AES256-GCM-SHA384[^1]        | TLS 1.3 | Modern | {0x13,0x02} | TLS_AES_256_GCM_SHA384 |
-| AEAD-CHACHA20-POLY1305-SHA256[^1]  | TLS 1.3 | Modern | {0x13,0x03} | TLS_CHACHA20_POLY1305_SHA256 |
+| AEAD-AES128-GCM-SHA256 [^1]        | TLS 1.3 | Modern | {0x13,0x01} | TLS_AES_128_GCM_SHA256 |
+| AEAD-AES256-GCM-SHA384 [^1]        | TLS 1.3 | Modern | {0x13,0x02} | TLS_AES_256_GCM_SHA384 |
+| AEAD-CHACHA20-POLY1305-SHA256 [^1]  | TLS 1.3 | Modern | {0x13,0x03} | TLS_CHACHA20_POLY1305_SHA256 |
 
 [^1]: Automatically supported by your zone if you [enable TLS 1.3](/ssl/edge-certificates/additional-options/tls-13/#enable-tls-13). TLS 1.3 uses the same cipher suite space as previous versions of TLS, but defines these cipher suites differently. TLS 1.3 only specifies the symmetric ciphers and cannot be used for TLS 1.2. Similarly, TLS 1.2 and lower cipher suites cannot be used with TLS 1.3 (IETF TLS 1.3 draft 21). BoringSSL also hard-codes cipher preferences in this order for TLS 1.3.

--- a/content/ssl/reference/cipher-suites/supported-cipher-suites.md
+++ b/content/ssl/reference/cipher-suites/supported-cipher-suites.md
@@ -11,7 +11,7 @@ meta:
 
 Cloudflare supports the following cipher suites by default. If needed, you can [restrict your application](/ssl/reference/cipher-suites/customize-cipher-suites/) to only use specific cipher suites.
 
-| OpenSSL Name | Minimum protocol | [Security recommendation](/ssl/reference/cipher-suites/recommendations/) | Cipher suite | IANA name |
+| Cipher name | Minimum protocol | [Security recommendation](/ssl/reference/cipher-suites/recommendations/) | Cipher suite | IANA name |
 | ----------------------------------- | ------- | ------- | ------- | ------- |
 | ECDHE-ECDSA-AES128-GCM-SHA256       | TLS 1.2 | Modern | [0xc02b] | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 |
 | ECDHE-ECDSA-CHACHA20-POLY1305       | TLS 1.2 | Modern | [0xcca9] | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 |
@@ -33,8 +33,8 @@ Cloudflare supports the following cipher suites by default. If needed, you can [
 | AES256-SHA256                       | TLS 1.2 | Legacy | [0x3d] | TLS_RSA_WITH_AES_256_CBC_SHA256 |
 | AES256-SHA                          | TLS 1.0 | Legacy | [0x35] | TLS_RSA_WITH_AES_256_CBC_SHA |
 | DES-CBC3-SHA                        | TLS 1.0 | Legacy | [0x0701c0] | SSL_CK_DES_192_EDE3_CBC_WITH_SHA |
-| TLS_AES_128_GCM_SHA256[^1]        | TLS 1.3 | Modern | {0x13,0x01} | TLS_AES_128_GCM_SHA256 |
-| TLS_AES_256_GCM_SHA384[^1]        | TLS 1.3 | Modern | {0x13,0x02} | TLS_AES_256_GCM_SHA384 |
-| TLS_CHACHA20_POLY1305_SHA256[^1]  | TLS 1.3 | Modern | {0x13,0x03} | TLS_CHACHA20_POLY1305_SHA256 |
+| AEAD-AES128-GCM-SHA256[^1]        | TLS 1.3 | Modern | {0x13,0x01} | TLS_AES_128_GCM_SHA256 |
+| AEAD-AES256-GCM-SHA384[^1]        | TLS 1.3 | Modern | {0x13,0x02} | TLS_AES_256_GCM_SHA384 |
+| AEAD-CHACHA20-POLY1305-SHA256[^1]  | TLS 1.3 | Modern | {0x13,0x03} | TLS_CHACHA20_POLY1305_SHA256 |
 
 [^1]: Automatically supported by your zone if you [enable TLS 1.3](/ssl/edge-certificates/additional-options/tls-13/#enable-tls-13). TLS 1.3 uses the same cipher suite space as previous versions of TLS, but defines these cipher suites differently. TLS 1.3 only specifies the symmetric ciphers and cannot be used for TLS 1.2. Similarly, TLS 1.2 and lower cipher suites cannot be used with TLS 1.3 (IETF TLS 1.3 draft 21). BoringSSL also hard-codes cipher preferences in this order for TLS 1.3.


### PR DESCRIPTION
Since Cloudflare uses BoringSSL:
1. Rename "OpenSSL Name" column to "Cipher name"
2. Update the last 3 rows of TLS 1.3 ciphers to match the TLS 1.3 cipher name actually returned