### PR TITLE
Link to zero trust dashboard was incorrect

### DIFF
--- a/content/cloudflare-one/applications/non-http/_index.md
+++ b/content/cloudflare-one/applications/non-http/_index.md
@@ -27,7 +27,7 @@ Cloudflare can render certain non-web applications in your browser without the n
 
 To enable browser rendering:
 
-1. In the [Zero Trust dashboard](jttps://dash.teams.cloudflare.com), go to **Access** > **Applications**.
+1. In the [Zero Trust dashboard](https://dash.teams.cloudflare.com), go to **Access** > **Applications**.
 2. Locate the SSH or VNC application you created when [connecting the server to Cloudflare](/cloudflare-one/connections/connect-apps/use_cases/ssh/). Select **Configure**.
 3. In the **Policies** tab, ensure that only **Allow** or **Block** policies are present. **Bypass** and **Service Auth** are not supported for browser-rendered applications.
 4. In the **Settings** tab, scroll down to **Browser rendering**.


### PR DESCRIPTION
It sent you to jttps://dash.teams.cloudflare.com instead of https://dash.teams.cloudflare.com (there was a j instead of a h at the start of the link)