### PR TITLE
[Pages] Add "Module Support in Functions" docs

### DIFF
--- a/content/pages/platform/functions/advanced-mode.md
+++ b/content/pages/platform/functions/advanced-mode.md
@@ -10,7 +10,7 @@ Advanced mode allows you to develop your Pages Functions with a `_workers.js` fi
 
 In some cases, Pages Functions' built-in file path based routing and middleware system is not desirable for existing applications. You may have a Worker that is complex and difficult to splice up into Pages' file-based routing system. For these cases, Pages offers the ability to define a `_worker.js` file in the output directory of your Pages project.
 
-When using a `_worker.js` file, the entire `/functions` directory is ignored, including its routing and middleware characteristics. Instead, the `_worker.js` file is deployed as is and must be written using the [Module Worker syntax](/workers/runtime-apis/fetch-event/#syntax-module-worker). If you have never used Module syntax, refer to the [JavaScript modules blog post](https://blog.cloudflare.com/workers-javascript-modules/) to learn more. Using Module syntax enables JavaScript frameworks to generate a Worker as part of the Pages output directory contents.
+When using a `_worker.js` file, the entire `/functions` directory is ignored, including its routing and middleware characteristics. Instead, the `_worker.js` file is deployed and must be written using the [Module Worker syntax](/workers/runtime-apis/fetch-event/#syntax-module-worker). If you have never used Module syntax, refer to the [JavaScript modules blog post](https://blog.cloudflare.com/workers-javascript-modules/) to learn more. Using Module syntax enables JavaScript frameworks to generate a Worker as part of the Pages output directory contents.
 
 ## Set up a Function
 

--- a/content/pages/platform/functions/module-support.md
+++ b/content/pages/platform/functions/module-support.md
@@ -1,0 +1,116 @@
+---
+pcx-content-type: how-to
+title: Module support
+weight: 13
+---
+
+## Module support
+
+Pages Functions provide support for several module types, much like [Workers](https://blog.cloudflare.com/workers-javascript-modules/). This means that you can import and use external modules such as WebAssembly (Wasm), `text` and `binary` files inside your Functions code.
+
+This guide will instruct you on how to use these different module types inside your Pages Functions.
+
+### ECMAScript Modules
+
+ECMAScript modules (or in short ES Modules) is the official, [standardized](https://tc39.es/ecma262/#sec-modules) module system for JavaScript. It is the recommended mechanism for writing modular and reusable JavaScript code. 
+
+[ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) are defined by the use of `import` and `export` statements. Below is an example of a script written in ES Modules format, and a Pages Function that imports that module:
+
+```js
+---
+filename: src/greeting.ts
+---
+export function greeting(name: string): string {
+  return `Hello ${name}!`;
+}
+```
+
+```js
+---
+filename: functions/hello.ts
+---
+import { greeting } from "../src/greeting.ts";
+
+export async function onRequest(context) {
+    return new Response(`${greeting("Pages Functions")}`);
+}
+```
+
+### WebAssembly Modules
+
+[WebAssembly](https://webassembly.org/) (or Wasm) is a low-level language that provides programming languages such as C++ or Rust with a compilation target so that they can run on the web. The distributable, loadable, and executable unit of code in WebAssembly is called a [module](https://webassembly.github.io/spec/core/syntax/modules.html).
+
+Below is a basic example of how you can import Wasm Modules inside your Pages Functions code:
+
+```js
+---
+filename: functions/meaning-of-life.ts
+---
+import addModule from "add.wasm";
+
+export async function onRequest() {
+	const addInstance = await WebAssembly.instantiate(addModule);
+	return new Response(
+		`The meaning of life is ${addInstance.exports.add(20, 1)}`
+	);
+}
+```
+
+### Text Modules
+
+Text Modules are a non-standardized means of importing resources such as HTML files as a `String`.
+
+To import the below HTML file into your Pages Functions code:
+
+```html
+---
+filename: index.html
+---
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Hello Pages Functions!</h1>
+  </body>
+</html>
+```
+
+Use the following script:
+
+```js
+---
+filename: functions/hey.ts
+---
+import html from "../index.html";
+
+export async function onRequest() {
+	return new Response(
+		html,
+    {
+      headers: { "Content-Type": "text/html" }
+    }
+	);
+}
+```
+
+
+### Binary Modules
+
+Binary Modules are a non-standardized way of importing binary data such as images as an `ArrayBuffer`.
+
+Below is a basic example of how you can import the data from a binary file inside your Pages Functions code:
+
+```js
+---
+filename: functions/data.ts
+---
+import data from "../my-data.bin";
+
+export async function onRequest() {
+	return new Response(
+		data,
+    {
+      headers: { "Content-Type": "application/octet-stream" }
+    }
+	);
+}
+```


### PR DESCRIPTION
This PR adds a new section for Pages Functions that details the different types of modules Functions have support for: ES Modules, WebAssembly modules, text and binary modules