### PR TITLE
fix: HTMLRewriter example

### DIFF
--- a/content/workers/runtime-apis/html-rewriter.md
+++ b/content/workers/runtime-apis/html-rewriter.md
@@ -110,7 +110,8 @@ class UserElementHandler {
 async function handleRequest(req) {
   const res = await fetch(req);
 
-  return new HTMLRewriter().on('div:user_info', new UserElementHandler()).transform(res);
+  // run the user element handler via HTMLRewriter on a div with ID `user_info`
+  return new HTMLRewriter().on('div#user_info', new UserElementHandler()).transform(res);
 }
 ```
 


### PR DESCRIPTION
`div:user_info` isn't valid syntax as `user_info` isn't a pseudo-element. `div#user_info` or `div.user_info` would be valid, for an ID and class respectively .