### PR TITLE
[Docs site] Update priority for style.css

### DIFF
--- a/content/_headers
+++ b/content/_headers
@@ -1,2 +1,5 @@
 https://:project.pages.dev/*
  X-Robots-Tag: noindex
+
+/*
+  Link: </styles.css>; rel=preload; as=style

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,8 +3,8 @@
   <head>
     {{- partial "head.meta" (dict "Context" . "Product" .Section) -}}
 
-    <link rel="stylesheet preconnect" href="/style.css" />
-    {{- block "styles" . -}}{{- end -}}
+    <link rel="preload" href="/style.css" as="style" />
+    {{- block "styles" . -}}{{- end -}} 
 
     {{- partial "script" (dict "src" "theme.ts" "inline" true "format" "iife") -}}
     {{- partial "script" (dict "src" "main.ts" "defer" true) -}}


### PR DESCRIPTION
With the upgrades in speed to our baseline site functions, it looks like we actually got too fast for our current style setup (which you can see occasionally in Chrome).

That purple flash + other things are the things hidden by our styles, but it loads behind the page now. Switching to `preload` from `preconnect` seems to help.


https://user-images.githubusercontent.com/26727299/221054388-b96a4471-e28f-4a42-ada2-1562ac2f7098.mov

