### PR TITLE
[Docs site] Testing fouc fix

### DIFF
--- a/assets/learning-path-navigation.ts
+++ b/assets/learning-path-navigation.ts
@@ -44,7 +44,6 @@ import { learning_paths as paths } from "./json-collector";
       }
     }
 
-
     // Update final next link to point to the next module
     const nextModuleLink = document.getElementById("nextModuleLink");
     if (nextModuleLink && currentPathData) {

--- a/assets/learning-path-navigation.ts
+++ b/assets/learning-path-navigation.ts
@@ -27,6 +27,24 @@ import { learning_paths as paths } from "./json-collector";
       );
     }
 
+    // Update the link and title of the path in side navigation
+    const titleNavText = document.getElementsByClassName("DocsSidebar--docs-title-text-scaler")
+    const titleLength = currentPathData["title"].length
+    if (titleNavText) {
+      for (const item of titleNavText) {
+        item.setAttribute("style", `--length:${titleLength}`)
+        item.innerHTML = currentPathData["title"]
+      }
+    }
+    
+    const titleNavLinks = document.getElementsByClassName("DocsSidebar--docs-title-logo-link");
+    if (titleNavLinks) {
+      for (const item of titleNavLinks) {
+        item.setAttribute("href", currentPathData["path"])
+      }
+    }
+
+
     // Update final next link to point to the next module
     const nextModuleLink = document.getElementById("nextModuleLink");
     if (nextModuleLink && currentPathData) {

--- a/content/learning-paths/modules/performance/load-balancing-concepts/routing.md
+++ b/content/learning-paths/modules/performance/load-balancing-concepts/routing.md
@@ -1,5 +1,5 @@
 ---
-title: Routing
+title: Routing traffic
 pcx_content_type: learning-unit
 weight: 4
 layout: learning-unit
@@ -31,7 +31,7 @@ Routing decisions can be based on proximity, pool performance, geography, and mo
 
 Once the request reaches a pool, that pool's [origin steering policy](/load-balancing/understand-basics/traffic-steering/origin-level-steering/) control how each pool distributes requests to the servers in the pool.
 
-These decisions can be based on default percentages of traffic sent to individual servers (also known as the **Weight**), where previous requests from the same IP address went, or both.
+These decisions can be based on default percentages of traffic sent to individual servers (also known as the **Weight**), aspects of the request (such as source IP address), or both.
 
 ### Server health
 

--- a/data/learning-paths.yml
+++ b/data/learning-paths.yml
@@ -11,3 +11,7 @@ meta:
   description: Learning paths guide you through modules and projects so you can get started with Cloudflare as quickly as possible.
   author: '@cloudflare'
   image: /core-services-preview.png
+
+externals:
+  - title: All learning paths
+    url: /learning-paths/

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
     {{- partial "onetrust" -}}
+    <style>html{visibility: hidden;opacity:0;}</style>
     {{- partial "head.meta" (dict "Context" . "Product" .Section) -}}
 
     {{- if hugo.IsProduction -}}

--- a/layouts/shortcodes/learning-path.html
+++ b/layouts/shortcodes/learning-path.html
@@ -88,21 +88,15 @@
   </span>
 </p>
 
-  {{- if eq $index 0 -}}
   <details class="pathDetails" open>
-  {{- else -}}
-  <details class="pathDetails">
-  {{- end -}}
-
     <summary>Contains {{ len (index $moduleData "units") }} units</summary>
     <div>
         <ul>
         {{- range index $moduleData "units" -}}  
           <li><a href="{{- print .RelPermalink "?learning_path=" $pathUID -}}">{{- .Title -}}</a>
             <p class="readingTime">{{- .ReadingTime -}}&nbsp;min</p>
+          </li>
         {{- end -}}
-        
-        </li>
         </ul>
     </div>
     </details>

--- a/static/home.css
+++ b/static/home.css
@@ -5840,3 +5840,10 @@ html #ot-sdk-btn.ot-sdk-show-settings {
 html #ot-sdk-btn.ot-sdk-show-settings:hover {
     color: inherit;
 }
+
+/* Should be last to avoid flashes of unstyled content */
+
+html {
+    visibility: visible;
+    opacity: 1;
+  }

--- a/static/style.css
+++ b/static/style.css
@@ -5420,3 +5420,10 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
 [theme="dark"] #ot-sdk-btn.ot-sdk-show-settings:hover {
   color: var(--code-orange);
 }
+
+/* Should be last to avoid flashes of unstyled content */
+
+html {
+  visibility: visible;
+  opacity: 1;
+}


### PR DESCRIPTION
We're having Flashes of unstyled content or [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) on our pages.

This temporary fix is based on the CSS implementation suggested by [stack overflow](https://stackoverflow.com/questions/3221561/eliminate-flash-of-unstyled-content).

Based on some [preliminary digging](https://dev.to/lyqht/what-the-fouc-is-happening-flash-of-unstyled-content-413j), it seems like it might require some edits to the _vite.config.ts_, specifically the `rewrite` function.