### PR TITLE
[Docs site] Added temp css fix for FOUC

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
     {{- partial "onetrust" -}}
+    <style>html{visibility: hidden;opacity:0;}</style>
     {{- partial "head.meta" (dict "Context" . "Product" .Section) -}}
 
     {{- if hugo.IsProduction -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
     {{- partial "onetrust" -}}
-    <style>html{visibility: hidden;opacity:0;}</style>
     {{- partial "head.meta" (dict "Context" . "Product" .Section) -}}
 
     {{- if hugo.IsProduction -}}

--- a/static/home.css
+++ b/static/home.css
@@ -5840,3 +5840,10 @@ html #ot-sdk-btn.ot-sdk-show-settings {
 html #ot-sdk-btn.ot-sdk-show-settings:hover {
     color: inherit;
 }
+
+/* Should be last to avoid flashes of unstyled content */
+
+html {
+    visibility: visible;
+    opacity: 1;
+  }

--- a/static/home.css
+++ b/static/home.css
@@ -5840,10 +5840,3 @@ html #ot-sdk-btn.ot-sdk-show-settings {
 html #ot-sdk-btn.ot-sdk-show-settings:hover {
     color: inherit;
 }
-
-/* Should be last to avoid flashes of unstyled content */
-
-html {
-    visibility: visible;
-    opacity: 1;
-  }

--- a/static/style.css
+++ b/static/style.css
@@ -5420,3 +5420,10 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
 [theme="dark"] #ot-sdk-btn.ot-sdk-show-settings:hover {
   color: var(--code-orange);
 }
+
+/* Should be last to avoid flashes of unstyled content */
+
+html {
+  visibility: visible;
+  opacity: 1;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -5420,10 +5420,3 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
 [theme="dark"] #ot-sdk-btn.ot-sdk-show-settings:hover {
   color: var(--code-orange);
 }
-
-/* Should be last to avoid flashes of unstyled content */
-
-html {
-  visibility: visible;
-  opacity: 1;
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,5 +106,6 @@ export default defineConfig({
     rollupOptions: {
       input: glob.sync("public/**/*.html"),
     },
+    cssCodeSplit: false
   },
 });


### PR DESCRIPTION
Believe this was introduced in #7580...

We're having Flashes of unstyled content or [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) on our pages.

This temporary fix is based on the CSS implementation suggested by [stack overflow](https://stackoverflow.com/questions/3221561/eliminate-flash-of-unstyled-content).

Based on some [preliminary digging](https://dev.to/lyqht/what-the-fouc-is-happening-flash-of-unstyled-content-413j), it seems like it might require some edits to the _vite.config.ts_, specifically the `rewrite` function.

cc: @penalosa 