### PR TITLE
Add a note about workersInvocationsAdaptive

### DIFF
--- a/content/analytics/graphql-api/features/data-sets/index.md
+++ b/content/analytics/graphql-api/features/data-sets/index.md
@@ -22,7 +22,9 @@ identifies the type of data they return:
 * **Aggregated data** - Nodes that represent aggregated data include the
   `Groups` suffix. For example, the `loadBalancingRequestsAdaptiveGroups` node
   represents aggregated data for Load Balancing requests. Aggregated data is
-  returned in an array of `...Group` objects.
+  returned in an array of `...Group` objects. Please note: we have a node that
+  currently excluded from that naming convention - `workersInvocationsAdaptive`
+  (beta).
 
 * **Raw data** - Raw data nodes, such as `loadBalancingRequestsAdaptive`, are
   not aggregated and so do not incorporate the `Groups` suffix. Raw data is


### PR DESCRIPTION
We have a node that does not follow the naming convention: `workersInvocationsAdaptive` (should be named with `Groups` suffix). It's a beta node, and we are looking to replace it with `workersInvocationsAdaptiveGroups` following the deprecation policy.

This commit supposed to address confusion caused by name mismatch (see #7756).