### PR TITLE
[R2] Use sh codeblock and $ for curl in CORS guide

### DIFF
--- a/content/r2/learning/cors.md
+++ b/content/r2/learning/cors.md
@@ -69,8 +69,8 @@ console.log(url);
 
 Test the presigned URL by uploading an object using cURL. The example below would upload the `123` text to R2 with a `Content-Type` of `text/plain`.
 
-```json
-curl -X PUT <URL> -H "Content-Type: text/plain" -d "123"
+```sh
+$ curl -X PUT <URL> -H "Content-Type: text/plain" -d "123"
 ```
 
 ## Add CORS policies from the dashboard


### PR DESCRIPTION
Makes the codeblock for curl in the CORS guide use an `sh` codeblock and $ styling, like other shell codeblocks