### PR TITLE
[Docs site] Specifying site name properties to try and get rid of "CloudFlare"

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,6 +23,10 @@
     <noscript><link rel="stylesheet" href="https://feedback.developers.cloudflare.com/sdk.css"/></noscript>
   </head>
   <body>
+    <div itemscope itemtype="https://schema.org/WebSite">
+      <meta itemprop="url" content="https://developers.cloudflare.com/"/>
+      <meta itemprop="name" content="Cloudflare Docs"/>
+    </div>
     {{- with $.Page.Params.structured_data -}}{{- if or (eq $.Page.Params.pcx_content_type "how-to") (eq $.Page.Params.pcx_content_type "tutorial") -}}<div itemscope itemtype="https://schema.org/HowTo">{{- end -}}{{- end -}}
     {{- block "main" . -}}{{- end -}}
     {{- with $.Page.Params.structured_data -}}{{- if or (eq $.Page.Params.pcx_content_type "how-to") (eq $.Page.Params.pcx_content_type "tutorial") -}}</div>{{- end -}}{{- end -}}

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -11,6 +11,10 @@
 
   </head>
   <body>
+    <div itemscope itemtype="https://schema.org/WebSite">
+      <meta itemprop="url" content="https://developers.cloudflare.com/"/>
+      <meta itemprop="name" content="Cloudflare Docs"/>
+    </div>
     <div class="DocsPage">
       <div class="SiteHeader">
         <div class="SiteHeader--container">

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -66,6 +66,7 @@
 
 <meta property="og:image" content="{{ $imagePlaceholder }}"/>
 <meta property="og:title" content="{{ $title }}"/>
+<meta property="og:site_name" content="Cloudflare Docs"/>
 <meta property="og:description" content="{{ $description }}"/>
 <meta property="og:type" content="website"/>
 


### PR DESCRIPTION
Confirmed working in:
- https://validator.schema.org/#url=https%3A%2F%2Fspecify-site-title.cloudflare-docs-7ou.pages.dev%2F
- https://validator.schema.org/#url=https%3A%2F%2Fspecify-site-title.cloudflare-docs-7ou.pages.dev%2Ffundamentals%2Faccount-and-billing%2F