### PR TITLE
[PubSub] Clean up shell codeblocks in PubSub docs

### DIFF
--- a/content/pub-sub/get-started/guide.md
+++ b/content/pub-sub/get-started/guide.md
@@ -54,8 +54,8 @@ $ yarn global add wrangler
 
 Validate that you have a version of `wrangler` that supports Pub/Sub:
 
-```
-wrangler --version
+```sh
+$ wrangler --version
 2.0.16 # should show 2.0.16 or greater - e.g. 2.0.17 or 2.1.0
 ```
 

--- a/content/pub-sub/learning/command-line-wrangler.md
+++ b/content/pub-sub/learning/command-line-wrangler.md
@@ -71,7 +71,7 @@ Commands:
 
 The available `wrangler pubsub broker` sub-commands include:
 
-```bash
+```sh
 $ wrangler pubsub broker --help
 
 Interact with your Pub/Sub Brokers

--- a/content/pub-sub/learning/integrate-workers.md
+++ b/content/pub-sub/learning/integrate-workers.md
@@ -54,7 +54,7 @@ You should be familiar with setting up a [Worker](/workers/get-started/guide/) b
 
 To ensure your Worker can validate incoming requests, you must make the public keys available to your Worker via an [environmental variable](/workers/platform/environment-variables/). To do so, we can fetch the public keys from our Broker:
 
-```bash
+```sh
 $ wrangler pubsub broker public-keys YOUR_BROKER --namespace=NAMESPACE_NAME
 ```
 


### PR DESCRIPTION
Make them all use the correct sh with $ format