### PR TITLE
queues: update limits notice

### DIFF
--- a/content/queues/changelog.md
+++ b/content/queues/changelog.md
@@ -11,7 +11,7 @@ rss: file
 
 ### Higher per-queue throughput
 
-The per-queue throughput limit has now been [raised to 400 messages per second](/queues/platform/limits/). Happy queueing!
+The per-queue throughput limit has now been [raised to 400 messages per second](/queues/platform/limits/).
 
 ## 2022-12-12
 

--- a/content/queues/changelog.md
+++ b/content/queues/changelog.md
@@ -7,6 +7,12 @@ rss: file
 
 # Changelog
 
+## 2023-03-01
+
+### Higher per-queue throughput
+
+The per-queue throughput limit has now been [raised to 400 messages per second](/queues/platform/limits/). Happy queueing!
+
 ## 2022-12-12
 
 ### Increased per-account limits

--- a/content/queues/platform/limits.md
+++ b/content/queues/platform/limits.md
@@ -8,7 +8,7 @@ weight: 9
 
 {{<Aside type="note">}}
 
-Many of these limits will increase during Queues' public beta period. If you have questions about a certain limit, [contact the Queues team](mailto:queues@cloudflare.com).
+Many of these limits will increase during Queues' public beta period. [Follow our changelog](https://developers.cloudflare.com/queues/changelog/) or join the [`#queues-beta`](https://discord.gg/rrZXVVcKQF) channel in our Developer Discord to keep up-to-date with changes.
 
 {{</Aside>}}
 

--- a/content/queues/platform/limits.md
+++ b/content/queues/platform/limits.md
@@ -14,22 +14,22 @@ Many of these limits will increase during Queues' public beta period. [Follow ou
 
 {{<table-wrap>}}
 
-| Feature                                         | Limit                             |
-| ----------------------------------------------- | --------------------------------- |
-| Queues                                          | 100 per account <sup>1</sup>      |
-| Maximum message size                            | 128 KB                            |
-| Maximum message retries                         | 100                               |
-| Maximum batch size                              | 100 messages                      |
-| Maximum batch wait time                         | 30 seconds                        |
-| Maximum message throughput <sup>2</sup>         | 100 messages per second           |
-| Maximum message retention period <sup>3</sup>   | 4 days (96 hours)                 |
+| Feature                                         | Limit                                   |
+| ----------------------------------------------- | --------------------------------------- |
+| Queues                                          | 100 per account <sup>1</sup>            |
+| Maximum message size                            | 128 KB <sup>2</sup>                     |
+| Maximum message retries                         | 100                                     |
+| Maximum batch size                              | 100 messages                            |
+| Maximum batch wait time                         | 30 seconds                              |
+| Maximum message throughput <sup>3</sup>         | 400 messages per second <sup>4</sup>    |
+| Maximum message retention period <sup>5</sup>   | 4 days (96 hours)                       | 
 
 {{</table-wrap>}}
 
-* <sup>1</sup> Request adjustments to limits that conflict with your project goals by contacting Cloudflare. To increase a limit, complete the [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform).
-* <sup>2</sup> This is a limit that we will increase, and aspire to effectively eliminate in the future.
-* <sup>3</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit.
-
 Notes:
 
-* 1 KB is measured as 1000 bytes. Messages can include up to ~100 bytes of internal metadata that counts towards total message limits.
+* <sup>1</sup> Request adjustments to limits that conflict with your project goals by contacting Cloudflare. To increase a limit, complete the [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform).
+* <sup>2</sup> 1 KB is measured as 1000 bytes. Messages can include up to ~100 bytes of internal metadata that counts towards total message limits.
+* <sup>3</sup> The maximum message throughput per queue will continue to increase during the beta period.
+* <sup>4</sup> Exceeding the maximum message throughput will cause the `.send` and `.sendBatch` methods to throw an exception with a `Too Many Requests` error until your producer falls below the limit.
+* <sup>5</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit.


### PR DESCRIPTION
- [x] Update beta notice to more clearly steer users to feedback channels
- [x] Update "Maximum message throughput" limit from 100 -> 400
- [x] Update /changelog with the same
