### PR TITLE
[Support] Removed breadcrumb from tile entirely

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,8 +1,7 @@
 {{ $DATA := (index $.Site.Data .Section) }}
 {{ $productName := $DATA.product.title }}
-{{- $currentLocation := .RelPermalink -}}
 
-{{- if not (in $currentLocation "/support/other-languages") -}}
+{{- if ne $productName "Support" -}}
 
 <ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
     <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">


### PR DESCRIPTION
Still seeing weird bugs where the title isn't being pulled correctly, so just removing entirely.