### PR TITLE
[turnstile] advanced Cloudflare Turnstile example + improved client-side rendering docs

### DIFF
--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -139,7 +139,7 @@ If the invocation is successful, the function returns a `widgetId (string)`. If 
 
 Check out the [demo](https://demo.turnstile.workers.dev/explicit) and its [source code](https://github.com/cloudflare/turnstile-demo-workers/blob/main/src/explicit.html).
 
-Here's an advanced example for dynamically rendering Turnstile widgets using Bootstrap 3 or 4 with modals and responsive widget sizes:
+This is an advanced example for dynamically rendering Turnstile widgets using Bootstrap 3 or 4 with modals and responsive widget sizes:
 
 <div>
 

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -78,7 +78,7 @@ Or:
 
 `https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback`
 
-When using `render=explicit`, HTML elements with the `cf-turnstile` class will not show a challenge. The `turnstile.render` function must be invoked using the following steps.  To combine both options, you would pass a querystring of `?render=explicit&onload=onloadTurnstileCallback`:
+When using `render=explicit`, HTML elements with the `cf-turnstile` class will not show a challenge. The `turnstile.render` function must be invoked using the following steps.  To combine both options, pass a query string of `?render=explicit&onload=onloadTurnstileCallback`:
 
 `https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadTurnstileCallback`
 

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -159,8 +159,6 @@ function handleExplicitTurnstile() {
     sitekey: '<YOUR_SITE_KEY>',
     tabindex: isModal ? -1 : 0,
     action: isModal ? 'modal' : 'page',
-    'expired-callback': (err) => console.error(err),
-    'timeout-callback': (err) => console.error(err),
     'error-callback': (err) => console.error(err)
     // uncomment this if you want to render a smaller size (e.g. 576px = Bootstrap "md" breakpoint)
     // size: window.matchMedia('(min-width: 576px)').matches ? 'normal' : 'compact'

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -164,14 +164,7 @@ function handleExplicitTurnstile() {
     // size: window.matchMedia('(min-width: 576px)').matches ? 'normal' : 'compact'
   });
 
-  if (widgetId) {
-    $(this).data('widgetId', widgetId);
-    return;
-  }
-
-  console.error(new Error('[Cloudflare Turnstile] widgetId missing'));
-  alert('Turnstile render error, please try again or contact us.');
-  window.location.reload();
+  $(this).data('widgetId', widgetId);
 }
 
 // an alternative approach for performance is to use IntersectionObserver API

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -89,7 +89,7 @@ When using `render=explicit`, HTML elements with the `cf-turnstile` class will n
 <div>
 
 ```html
-<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback" async defer></script>
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback" defer></script>
 ```
 </div>
 
@@ -158,6 +158,9 @@ function handleExplicitTurnstile() {
   widgetId = window.turnstile.render(this, {
     sitekey: '<YOUR_SITE_KEY>',
     tabindex: isModal ? -1 : 0,
+    action: isModal ? 'modal' : 'page',
+    'expired-callback': (err) => console.error(err),
+    'timeout-callback': (err) => console.error(err),
     'error-callback': (err) => console.error(err)
     // uncomment this if you want to render a smaller size (e.g. 576px = Bootstrap "md" breakpoint)
     // size: window.matchMedia('(min-width: 576px)').matches ? 'normal' : 'compact'
@@ -187,7 +190,7 @@ window.onloadTurnstileCallback = function () {
     .each(handleExplicitTurnstile);
 
   // handle modals
-  $('body').on('show.bs.modal hide.bs.modal', '.modal', function () {
+  $('body').on('show.bs.modal', '.modal', function () {
     $(this).find('.cf-explicit-turnstile').each(handleExplicitTurnstile);
   });
 };

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -139,7 +139,7 @@ If the invocation is successful, the function returns a `widgetId (string)`. If 
 
 Check out the [demo](https://demo.turnstile.workers.dev/explicit) and its [source code](https://github.com/cloudflare/turnstile-demo-workers/blob/main/src/explicit.html).
 
-This is an advanced example for dynamically rendering Turnstile widgets using Bootstrap 3 or 4 with modals and responsive widget sizes:
+This is an advanced example for dynamically rendering Turnstile widgets using [Bootstrap](https://getbootstrap.com/) 3 or 4 with modals and responsive widget sizes:
 
 <div>
 

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -84,7 +84,7 @@ When using `render=explicit`, HTML elements with the `cf-turnstile` class will n
 
 ## Explicitly render the Turnstile widget
 
-1. Insert the JavaScript tag and related code below (and be sure to replace `<YOUR_SITE_KEY>` with your site key).  **Also ensure that you have renamed the class name of `.cf-turnstile` to `#example-container` (if and only if you do not set the `render=explicit` querystring option as shown above, because it will _still_ render otherwise).**  Once the script is embedded, you will have access to a global function with multiple callback options you can customize. For the following function to work properly, the page must contain an HTML element with ID `example-container`.<br>The challenge can be invoked explicitly with the following JavaScript snippet:
+1. Insert the JavaScript tag and the related code below. Ensure that you have renamed the class name of `.cf-turnstile` to `#example-container` (if you do not set the `render=explicit` query string option as shown above, it will still render otherwise). Once the script is embedded, you will have access to a global function with multiple callback options you can customize. For the following function to work properly, the page must contain an HTML element with ID `example-container`.
 
 <div>
 

--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -139,7 +139,7 @@ If the invocation is successful, the function returns a `widgetId (string)`. If 
 
 Check out the [demo](https://demo.turnstile.workers.dev/explicit) and its [source code](https://github.com/cloudflare/turnstile-demo-workers/blob/main/src/explicit.html).
 
-Here's an advanced example for rendering Turnstile widgets using Bootstrap 3 or 4 with modals and responsive widget sizes:
+Here's an advanced example for dynamically rendering Turnstile widgets using Bootstrap 3 or 4 with modals and responsive widget sizes:
 
 <div>
 


### PR DESCRIPTION
We switched from [hCaptcha](https://www.hcaptcha.com/) to Cloudflare Turnstile in this commit <https://github.com/forwardemail/forwardemail.net/commit/d94ff44d755948e44d624a97f45df198726d09b8> for our service [Forward Email](https://forwardemail.net).

This PR is to share our research and development &ndash; and also to share our thanks for building Cloudflare Turnstile (and making it free!).  Hopefully this effort we made in this PR gives back a little. 🙏 👏  🎉 

Our front-end code for jQuery, Bootstrap, and Pug is at https://github.com/forwardemail/forwardemail.net (search for "turnstile" in the repo) &ndash;  and our back-end code for Node.js Koa server-side validation is at <https://github.com/ladjs/policies/blob/60e48c42ebafd7198a5540bf7dd254cd819a5001/index.js#L294-L368>.

Additionally, we mentioned in this PR a `<noscript>` concept, which is this in our [Pug views](https://github.com/forwardemail/forwardemail.net/tree/master/app/views):

```pug
if config.turnstileEnabled
  noscript
    .alert.alert-danger.font-weight-bold.text-center.border-top-0.border-left-0.border-right-0.rounded-0.small!= t("Please enable JavaScript to use our website.")
  .cf-explicit-turnstile
```

This would be similar to writing something like the following.  You might want to add this to the docs - since users currently aren't suggested to add a `<noscript>` tag in the Turnstile docs:

```html
<noscript>Please enable JavaScript to use our website.</noscript>
```

**Feel free to edit this PR as needed.  We tried to match your existing styling and indentation.**

Lastly, here are some examples screenshots and notes from our website before vs. after Cloudflare Turnstile integration.

## Before

<img width="541" alt="Screen Shot 2023-03-02 at 11 34 13 PM" src="https://user-images.githubusercontent.com/101466223/222640272-9b54cd7a-5107-4e5c-847b-3d649ba376b0.png">

<img width="569" alt="Screen Shot 2023-03-02 at 11 34 16 PM" src="https://user-images.githubusercontent.com/101466223/222640281-30688b69-20a1-4b9b-9416-e37fcf7b0299.png">

<img width="548" alt="Screen Shot 2023-03-02 at 11 34 35 PM" src="https://user-images.githubusercontent.com/101466223/222640292-3ce45352-5388-4564-ac88-e35ef8b01979.png">

The last screenshot above demonstrates modals not rendering captchas properly when they are opened and closed.  This is an incredibly common issue for hCaptcha, reCAPTCHA, and others &ndash; as it requires logic (which we baked into our PR and in the commit referenced above).

Also, hCaptcha does not automatically switch between color themes (dark vs. light) &ndash; this might be something you want to advertise in the docs too (since nobody else does this awesome feature!).

## After

![signal-2023-03-03-000918](https://user-images.githubusercontent.com/101466223/222644639-fa092329-dc08-449d-9310-8b6aba191400.png)

<img width="541" alt="Screen Shot 2023-03-03 at 12 08 17 AM" src="https://user-images.githubusercontent.com/101466223/222644667-8b67cde1-4eb0-4f2f-9fb5-fe2801927b08.png">

<img width="531" alt="Screen Shot 2023-03-03 at 12 08 30 AM" src="https://user-images.githubusercontent.com/101466223/222644682-40f3bddf-483a-4324-97d8-542075e942e7.png">

---

P.S. The docs have trailing and without trailing slash support at https://developers.cloudflare.com/turnstile/ and https://developers.cloudflare.com/turnstile (both "/" and without "/" work; this is not SEO best practice as search engines see this as duplicate content).