### PR TITLE
add missing shortcode closing tags

### DIFF
--- a/content/r2/data-access/workers-api/workers-api-reference.md
+++ b/content/r2/data-access/workers-api/workers-api-reference.md
@@ -150,6 +150,7 @@ export default {
 
   -  Retrieves the `httpMetadata` from the `R2Object` and applies their corresponding HTTP headers to the `Headers` input object. Refer to [HTTP Metadata](#http-metadata).
 
+{{</definitions>}}
 ## `R2ObjectBody` definition
 
 `R2ObjectBody` represents an object's metadata combined with its body. It is returned when you `GET` an object from an R2 bucket. The full list of keys for `R2ObjectBody` includes the list below and all keys inherited from [`R2Object`](#r2object-definition).

--- a/content/r2/data-access/workers-api/workers-api-reference.md
+++ b/content/r2/data-access/workers-api/workers-api-reference.md
@@ -151,6 +151,7 @@ export default {
   -  Retrieves the `httpMetadata` from the `R2Object` and applies their corresponding HTTP headers to the `Headers` input object. Refer to [HTTP Metadata](#http-metadata).
 
 {{</definitions>}}
+
 ## `R2ObjectBody` definition
 
 `R2ObjectBody` represents an object's metadata combined with its body. It is returned when you `GET` an object from an R2 bucket. The full list of keys for `R2ObjectBody` includes the list below and all keys inherited from [`R2Object`](#r2object-definition).

--- a/content/stream/_index.md
+++ b/content/stream/_index.md
@@ -63,3 +63,5 @@ Understand and analyze which videos and live streams are viewed most and break d
 {{<resource header="Billing" href="https://support.cloudflare.com/hc/en-us/articles/360016450871-Billing-for-Cloudflare-Stream" icon="price">}} Understand billing for Cloudflare Stream{{</resource>}}
 
 {{<resource header="Discord" href="https://discord.com/channels/595317990191398933/893253103695065128" icon="logo-Discord">}} Join the Stream developer community {{</resource>}}
+
+{{</resource-group>}}

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1585,6 +1585,8 @@ $ wrangler dispatch-namespace get <NAME>
 
   - The name of the dispatch namespace to get details about.
 
+{{</definitions>}}
+
 ### create
 
 Create a dispatch namespace.
@@ -1598,6 +1600,8 @@ $ wrangler dispatch-namespace create <NAME>
 - `NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
   - The name of the dispatch namespace to create.
+
+{{</definitions>}}
 
 ### delete
 
@@ -1616,6 +1620,8 @@ You must delete all user Workers in the dispatch namespace before it can be dele
 
   - The name of the dispatch namespace to delete.
 
+{{</definitions>}}
+
 ### rename
 
 Rename a dispatch namespace.
@@ -1633,6 +1639,8 @@ $ wrangler dispatch-namespace get <OLD-NAME> <NEW-NAME>
 - `NEW NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
   - The new name of the dispatch namespace.
+
+{{</definitions>}}
 
 ---
 ## `mtls-certificate`


### PR DESCRIPTION
some shortcodes wrongly do not have closing tags, this can produce build errors as the following:
```
   failed to extract shortcode: unclosed shortcode "resource-group"
```

fix the above by providing the missing shortcode closing tags