### PR TITLE
[Workers] Clarify `WRANGLER_LOG` variable behaviour

### DIFF
--- a/content/workers/wrangler/system-environment-variables.md
+++ b/content/workers/wrangler/system-environment-variables.md
@@ -46,7 +46,7 @@ Wrangler supports the following environment variables:
 
 - `WRANGLER_LOG` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`.
+  - Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`. Levels are case-insensitive and default to `"log"`. If an invalid level is specified, Wrangler will fallback to the default.
 
 {{</definitions>}}
 


### PR DESCRIPTION
Hey! 👋 This is the corresponding docs PR for https://github.com/cloudflare/workers-sdk/pull/2840. It clarifies that the `WRANGLER_LOG` environment variable is now case-insensitive, and defaults to `"log"` if an invalid value is specified.