### PR TITLE
Update drand documentation

### DIFF
--- a/content/randomness-beacon/_index.md
+++ b/content/randomness-beacon/_index.md
@@ -10,9 +10,9 @@ meta:
 
 {{<content-column>}}
 
-Drand (pronounced "dee-rand") is a distributed randomness beacon daemon written in Golang. Servers running drand can be linked to each other to produce collective, publicly verifiable, unbiased, unpredictable random values at fixed intervals using bilinear pairings and threshold cryptography.
+drand (pronounced "dee-rand") is a distributed randomness beacon daemon written in Golang. Servers running drand can be linked to each other to produce collective, publicly verifiable, unbiased, unpredictable random values at fixed intervals using bilinear pairings and threshold cryptography.
 
-Drand is meant to be an Internet infrastructure level service that provides randomness to applications, similar to how NTP provides timing information and Certificate Transparency servers provide certificate revocation information.
+drand is meant to be an Internet infrastructure level service that provides randomness to applications, similar to how NTP provides timing information and Certificate Transparency Logs provide certificate issuance information.
 
 For the most up-to-date documentation on drand, please visit [drand.love](https://drand.love).
 

--- a/content/randomness-beacon/about/_index.md
+++ b/content/randomness-beacon/about/_index.md
@@ -8,6 +8,6 @@ weight: 2
 
 The drand project aims to address the current lack of services providing distributed public randomness. Distributed to increase the resilience and trustworthiness, drand provides a standalone randomness-as-a-service network that is application agnostic. This is similar to how NTP networks serve timing information across the globe.
 
-Drand follows the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle). It relies on well-researched cryptographic building blocks and open-source software design principles and libraries, such as protobuf and gRPC, to ensure high performance and interoperability. Drand also attempts to use sane security defaults, such as having TLS enabled by default.
+drand follows the [KISS principle](https://en.wikipedia.org/wiki/KISS_principle). It relies on well-researched cryptographic building blocks and open-source software design principles and libraries, such as protobuf and gRPC, to ensure high performance and interoperability. drand also attempts to use sane security defaults, such as having TLS enabled by default.
 
 Beyond that, drand adds new features important for its practical deployment, such as being able to securely add and remove members of the network through [resharing](https://ieeexplore.ieee.org/document/1183515) while keeping the same shared public key necessary for randomness verification.

--- a/content/randomness-beacon/cryptographic-background/_index.md
+++ b/content/randomness-beacon/cryptographic-background/_index.md
@@ -6,11 +6,11 @@ weight: 3
 
 # Cryptographic Background
 
-Drand is an efficient randomness beacon daemon that utilizes pairing-based cryptography, `𝑡-of-𝑛` distributed key generation, and threshold BLS signatures to generate publicly-verifiable, unbiasable, unpredictable, distributed randomness.
+drand is an efficient randomness beacon daemon that utilizes pairing-based cryptography, `𝑡-of-𝑛` distributed key generation, and threshold BLS signatures to generate publicly-verifiable, unbiasable, unpredictable, distributed randomness.
 
 This is an overview of the cryptographic building blocks drand uses to generate publicly-verifiable, unbiasable, and unpredictable randomness in a distributed manner.
 
-The drand beacon has two phases: a setup phase and a beacon phase. Generally, we assume that there are *n* participants, out of which at most *f\<n* are malicious. Drand relies heavily on threshold cryptography primitives, where (at minimum) a threshold of *t-f+1* nodes work together to successfully execute cryptographic operations.
+The drand beacon has two phases: a setup phase and a beacon phase. Generally, we assume that there are *n* participants, out of which at most *f\<n* are malicious. drand relies heavily on threshold cryptography primitives, where (at minimum) a threshold of *t-f+1* nodes work together to successfully execute cryptographic operations.
 
 Threshold cryptography has many applications as it avoids single points of failure. One application is cryptocurrency multi-sig wallets, where *t-of-n* participants are required to sign a transaction using a threshold signature scheme.
 

--- a/content/randomness-beacon/cryptographic-background/randomness-generation.md
+++ b/content/randomness-beacon/cryptographic-background/randomness-generation.md
@@ -19,7 +19,7 @@ Pairing-based cryptography is based on bilinear groups `(𝔾1,𝔾2,𝔾𝑡)`,
 - **Non-degeneracy:** `𝑒≠1`
 
 - **Computability:** There exists an efficient algorithm to compute `𝑒`.
-  Drand currently uses the Barreto-Naehrig curve BN256.
+  drand currently uses the Barreto-Naehrig curve BN256.
 
 ## BLS Signatures
 
@@ -71,10 +71,22 @@ Thanks to the properties of Lagrange interpolation, the value of `𝜎` is indep
 
 In summary, a threshold BLS signature, `𝜎`, exhibits all properties required for publicly-verifiable, unbiasable, unpredictable, and distributed randomness.
 
+### `𝔾1/𝔾2` swap
+
+In the above, `𝔾1` and `𝔾2` could be swapped. The implication is on the relative size of public key and signatures. The first drand chains are constructed as described above, with signatures on `𝔾2` and public keys on `𝔾1`. Signature size is 96 bytes, and public key size is 48 bytes.
+
+Certain applications prefer smaller signatures at the cost of a larger public key. This is why certain drand beacons have signatures on `𝔾1` and public key on `𝔾2`. Such a change is reffered to as `𝔾1/𝔾2 swap`.
+
 ## Chained Randomness
 
-The drand randomness beacon operates in discrete rounds, `𝑟`. In every round, drand produces a new random value using threshold BLS signatures linked together into a chain of randomness. To extend this chain of randomness, each drand participant, `𝑖`, creates in round `𝑟` the partial BLS signature, `𝜎𝑟𝑖` on the message `𝑚=𝐻(𝑟∥𝜎𝑟−1)` where, `𝜎𝑟−1` denotes the (full) BLS threshold signature from round `𝑟−1` and `𝐻`, a cryptographic hash function.
+The drand randomness beacon operates in discrete rounds, `𝑟`. In every round, drand beacons configured to use chained randomness produce a new random value using threshold BLS signatures linked together into a chain of randomness. To extend this chain of randomness, each drand participant, `𝑖`, creates in round `𝑟` the partial BLS signature, `𝜎𝑟𝑖` on the message `𝑚=𝐻(𝑟∥𝜎𝑟−1)` where, `𝜎𝑟−1` denotes the (full) BLS threshold signature from round `𝑟−1` and `𝐻`, a cryptographic hash function.
 
 Once at least `𝑡` participants have broadcasted their partial signatures, `𝜎𝑟𝑖`, on `𝑚`, anyone can recover the full BLS threshold signature, `𝜎𝑟` that corresponds to the random value of round `𝑟`. After this, drand nodes move to round `𝑟+1` and reiterate the process.
 
 For round `𝑟=0`, drand participants sign a seed fixed during drand setup. This process ensures that every new random value depends on all previously generated signatures. Since the signature is deterministic, there is also no possibility for an adversary forking the chain and presenting two distinct signatures `𝜎𝑟` and `𝜎′𝑟` in a given round `𝑟` to generate inconsistencies in the systems relying on public randomness.
+
+## Unchained Randomness
+
+drand beacons can also be configured to use unchained randomness. To extend this chain of randomness, each drand participant, `𝑖`, creates in round `𝑟` the partial BLS signature, `𝜎𝑟𝑖` on the message `𝑚=𝐻(𝑟)` where `𝐻` a cryptographic hash function.
+
+This process allows for a direct precomputation of message `𝑚` for round `𝑟=i`.

--- a/content/randomness-beacon/cryptographic-background/setup-phase.md
+++ b/content/randomness-beacon/cryptographic-background/setup-phase.md
@@ -34,7 +34,7 @@ Note that you can use any subset of `𝑡-of-𝑛` shares to perform Lagrange in
 
 SSS scheme assumes that the dealer is honest, but this may not always hold in practice. A Verifiable Secret Sharing (VSS) scheme protects against malicious dealers by enabling participants to verify that their shares are consistent with those dealt to other nodes, ensuring that the shared secret can be correctly reconstructed later.
 
-Drand uses Feldman’s VSS scheme, an extension of SSS. Let `𝔾` denote a cyclic group of prime order `𝑝` in which computing discrete logarithms is intractable. A _cyclic group_ means there exists a generator, `𝑔`, so that any element `𝑥∈𝔾` can be written as `𝑥=𝑔𝑎` for some `𝑎∈{0,…,𝑝−1}`.
+drand uses Feldman’s VSS scheme, an extension of SSS. Let `𝔾` denote a cyclic group of prime order `𝑝` in which computing discrete logarithms is intractable. A _cyclic group_ means there exists a generator, `𝑔`, so that any element `𝑥∈𝔾` can be written as `𝑥=𝑔𝑎` for some `𝑎∈{0,…,𝑝−1}`.
 
 ### Share Distribution
 
@@ -46,7 +46,7 @@ The recovery of secret `𝑠` works the same as regular SSS, except that verifie
 
 ## Distributed Key Generation (DKG)
 
-Although VSS schemes protect against a malicious dealer, the dealer still knows the secret. To create a collectively shared secret `𝑠` so no individual node gets any information about it, participants can use a DKG protocol. Drand uses Pedersen’s DKG scheme, which runs `𝑛` instances of Feldman’s VSS in parallel and on top of additional verification steps.
+Although VSS schemes protect against a malicious dealer, the dealer still knows the secret. To create a collectively shared secret `𝑠` so no individual node gets any information about it, participants can use a DKG protocol. drand uses Pedersen’s DKG scheme, which runs `𝑛` instances of Feldman’s VSS in parallel and on top of additional verification steps.
 
 ### Share Distribution
 


### PR DESCRIPTION
* Fix drand capitalisation (all lowercase)
* Fix reference to Certificate Transparency Logs
* Update documentation to mention G1/G2 swap and unchained randomness