### PR TITLE
[Docs site] Small updates to footnote styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5329,7 +5329,12 @@ pre {
   max-width: 3em;
 }
 
-[theme="dark"] .littlefoot-footnote__content {
+.littlefoot__content p {
+  font-size: 1.05em;
+  font-weight: 120;
+}
+
+[theme="dark"] .littlefoot__content {
   background: #242628;
 }
 


### PR DESCRIPTION
Recent changes to the structure led dark mode styles not being triggered.