### PR TITLE
[turnstile] add hCaptcha migration

### DIFF
--- a/content/turnstile/migration/_index.md
+++ b/content/turnstile/migration/_index.md
@@ -1,0 +1,18 @@
+---
+title: Migration
+pcx_content_type: migration
+weight: 2
+layout: single
+---
+
+# Migrating from alternatives
+
+Customers using alternate services can switch to Cloudflare Turnstile.
+Step-by-step guides for select services are available below to assist with the upgrade process.
+
+If there is no guide available yet, it's recommended to start from [scratch](/turnstile/get-started/).
+
+## Guides
+
+- [reCAPTCHA](/turnstile/migration/migrating-from-recaptcha/)
+- [hCAPTCHA](/turnstile/migration/migrating-from-hcaptcha/)

--- a/content/turnstile/migration/migrating-from-hcaptcha.md
+++ b/content/turnstile/migration/migrating-from-hcaptcha.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from hCaptcha
 pcx_content_type: migration
-weight: 3
+weight: 4
 layout: single
 ---
 

--- a/content/turnstile/migration/migrating-from-hcaptcha.md
+++ b/content/turnstile/migration/migrating-from-hcaptcha.md
@@ -50,10 +50,12 @@ Turnstile supports:
 
 ## Server-side integration
 
-Update the server-side integration by replacing the siteverify URL. Replace:
+1. Update the server-side integration by replacing the siteverify URL. Replace:
 
 `https://hcaptcha.com/siteverify`
 
 With:
 
 `https://challenges.cloudflare.com/turnstile/v0/siteverify`
+
+2. Replace the `h-captcha-response` input name with `cf-turnstile-response`.

--- a/content/turnstile/migration/migrating-from-hcaptcha.md
+++ b/content/turnstile/migration/migrating-from-hcaptcha.md
@@ -1,0 +1,59 @@
+---
+title: Migrating from hCaptcha
+pcx_content_type: migration
+weight: 3
+layout: single
+---
+
+# Migrating from hCaptcha
+
+Customers using hCaptcha today can switch seamlessly to Cloudflare Turnstile. Follow the step-by-step guide below to assist with the upgrade process. 
+
+To complete the migration, you must obtain the [sitekey and secret key](/turnstile/get-started/#sitekey-and-secret-key).
+
+## Client-side integration 
+
+1. Update the client-side integration by inserting the Turnstile script snippet in your HTML's `<head>` element:
+
+<div>
+
+```html
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+```
+
+</div>
+
+2. Locate the `hcaptcha.render()` calls and replace the sitekey with your Turnstile sitekey and the api.
+
+<div>
+
+```js
+// before
+hcaptcha.render(element, {
+    sitekey: "00000000-0000-0000-0000-000000000000"
+})
+// after
+turnstile.render(element, {
+    sitekey: "1x00000000000000000000AA"
+})
+```
+
+</div>
+
+{{<Aside type= "Note">}}
+
+Turnstile supports:
+* the `render()` call 
+* hCaptcha invisible mode with the `execute()` call
+
+{{</Aside>}}
+
+## Server-side integration
+
+Update the server-side integration by replacing the siteverify URL. Replace:
+
+`https://hcaptcha.com/siteverify`
+
+With:
+
+`https://challenges.cloudflare.com/turnstile/v0/siteverify`

--- a/content/turnstile/migration/migrating-from-recaptcha.md
+++ b/content/turnstile/migration/migrating-from-recaptcha.md
@@ -26,7 +26,7 @@ To complete the migration, you must obtain the [sitekey and secret key](/turnsti
 Adding `?compat=recaptcha` runs Turnstile in compatibility mode, which
 enables the following features:
 * implicit rendering for reCAPTCHA
-* extra `g-recaptcha-response` input name for forms
+* `g-recaptcha-response` input name for forms
 * register the Turnstile API as `grecaptcha`
 
 {{</Aside>}}

--- a/content/turnstile/migration/migrating-from-recaptcha.md
+++ b/content/turnstile/migration/migrating-from-recaptcha.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from reCAPTCHA
-pcx_content_type: get-started
+pcx_content_type: migration
 weight: 3
 layout: single
 ---
@@ -13,7 +13,7 @@ To complete the migration, you must obtain the [sitekey and secret key](/turnsti
 
 ## Client-side integration 
 
-1. Update the client-side integration inserting the Turnstile script snippet in your HTML's `<head>` element:
+1. Update the client-side integration by inserting the Turnstile script snippet in your HTML's `<head>` element:
 
 <div>
 
@@ -21,10 +21,27 @@ To complete the migration, you must obtain the [sitekey and secret key](/turnsti
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?compat=recaptcha" async defer></script>
 ```
 
+{{<Aside type= "Note">}}
+
+Adding `?compat=recaptcha` runs Turnstile in compatibility mode, which
+enables the following features:
+* implicit rendering for reCAPTCHA
+* extra `g-recaptcha-response` input name for forms
+* register the Turnstile API as `grecaptcha`
+
+{{</Aside>}}
+
 </div>
 
 2. Locate the `grecaptcha.render()` calls and replace the sitekey with your Turnstile sitekey.
 
+{{<Aside type= "Note">}}
+
+Turnstile supports:
+* the `render()` call 
+* reCAPTCHA v2 invisible mode with the `execute()` call
+
+{{</Aside>}}
 
 ## Server-side integration
 
@@ -43,13 +60,5 @@ reCAPTCHA supports `GET` requests using query parameters, i.e: `GET /siteverify?
 Turnstile's siteverify endpoint does **not** support this and only accepts `POST` requests with a FormData or JSON body.
 
 Refer to [server-side validation](/turnstile/get-started/server-side-validation/) for more information.
-
-{{</Aside>}}
-
-{{<Aside type= "Note">}}
-
-Turnstile supports:
-* the `render()` call 
-* reCAPTCHA v2 invisible mode with the `execute()` call
 
 {{</Aside>}}


### PR DESCRIPTION
This PR:
* adds a very basic hCaptcha migration guide, based on the reCaptcha one
* adds infobox for `?compat=recaptcha` and moves the other infobox to a more fitting place
* moves migrating into its own category
  * preparing for #7755 (extra page for it possibly?)
  * preparing for other providers (geetest, funcaptcha, mtcaptcha, ...)

Might make sense to wait for `?compat=hcaptcha` which aliases `hcaptcha` to turnstile and input names, but this is better than nothing. 🤷 