### PR TITLE
[R2] Link from AWS JS SDK v2 -> v3

### DIFF
--- a/content/r2/examples/aws-sdk-js.md
+++ b/content/r2/examples/aws-sdk-js.md
@@ -8,6 +8,8 @@ layout: example
 
 {{<render file="_keys.md">}}
 
+If you are interested in the newer version of the AWS JavaScript SDK visit this [dedicated aws-sdk-js-v3 example page](/r2/examples/aws-sdk-js-v3).
+
 JavaScript or TypeScript users may continue to use the [`aws-sdk`](https://www.npmjs.com/package/aws-sdk) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
 ```ts


### PR DESCRIPTION
Closes https://github.com/cloudflare/cloudflare-docs/issues/7894

Didn't realize that docs for a newer SDK version were available, spent quite a bit of time searching, around and though that this kind of link from v2 -> v3 might be helpful.