### PR TITLE
queues: clarify consumer runtime limit

### DIFF
--- a/content/queues/platform/limits.md
+++ b/content/queues/platform/limits.md
@@ -24,7 +24,7 @@ Many of these limits will increase during Queues' public beta period. [Follow ou
 | Maximum message throughput <sup>3</sup>         | 400 messages per second <sup>4</sup>    |
 | Maximum message retention period <sup>5</sup>   | 4 days (96 hours)                       | 
 | Maximum queue backlog size <sup>6</sup>         | 25GB                                    | 
-| Maximum consumer invocation duration            | 15 minutes (see [Worker limits](/workers/platform/limits/#cpu-runtime))  | 
+| Maximum consumer invocation duration            | 15 minutes (Refer to [Worker limits](/workers/platform/limits/#cpu-runtime).)  | 
 
 
 {{</table-wrap>}}

--- a/content/queues/platform/limits.md
+++ b/content/queues/platform/limits.md
@@ -24,6 +24,7 @@ Many of these limits will increase during Queues' public beta period. [Follow ou
 | Maximum message throughput <sup>3</sup>         | 400 messages per second <sup>4</sup>    |
 | Maximum message retention period <sup>5</sup>   | 4 days (96 hours)                       | 
 | Maximum queue backlog size <sup>6</sup>         | 25GB                                    | 
+| Maximum consumer invocation duration            | 15 minutes (see [Worker limits](/workers/platform/limits/#cpu-runtime))  | 
 
 
 {{</table-wrap>}}

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -186,13 +186,14 @@ Use the [TransformStream API](/workers/runtime-apis/streams/transformstream/) to
 
 ## CPU runtime
 
-Most Workers requests consume less than a millisecond. It is rare to find normally operating Workers that exceed the CPU time limit. CPU time is capped at various limits depending on your plan, usage model, and Worker type.
+Most Workers requests consume less than a millisecond of CPU time. It is rare to find normally operating Workers that exceed the CPU time limit. CPU time is capped at various limits depending on your plan, usage model, and Worker type.
 
 * A Worker may consume up to **10 milliseconds** on the Free plan.
-* A Worker or [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may consume up to **50 milliseconds** with the Bundled usage model on the Paid Plan.
-* A Worker may consume up to **30 seconds** with the Unbound usage model on the Paid Plan.
-* A [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may consume up to **30 seconds** with the Unbound usage model on the Paid Plan, when the schedule interval is less than 1 hour.
-* A [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may consume up to **15 minutes** with the Unbound usage model on the Paid Plan, when the schedule interval is greater than 1 hour.
+* A Worker or [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may consume up to **50 milliseconds** of CPU time with the Bundled usage model on the Paid Plan.
+* A Worker may run for up to **30 seconds** with the Unbound usage model on the Paid Plan.
+* A [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may run for up to **30 seconds** with the Unbound usage model on the Paid Plan, when the schedule interval is less than 1 hour.
+* A [Scheduled Worker](/workers/platform/triggers/cron-triggers/) may run for up to **15 minutes** with the Unbound usage model on the Paid Plan, when the schedule interval is greater than 1 hour.
+* A [Queue consumer Worker](/queues/platform/javascript-apis/#consumer) may run for up to **15 minutes** with the Unbound usage model on the Paid Plan, per invocation.
 
 There is no limit on the real runtime for a Worker. As long as the client that sent the request remains connected, the Worker can continue processing, making subrequests, and setting timeouts on behalf of that request. When the client disconnects, all tasks associated with that client request are canceled. You can use [`event.waitUntil()`](/workers/runtime-apis/fetch-event/) to delay cancellation for another 30 seconds or until the promise passed to `waitUntil()` completes.
 


### PR DESCRIPTION
Clarify the maximum wall-clock time a queue() handler can run for.