### PR TITLE
[turnstile] add community resources

### DIFF
--- a/content/turnstile/community-resources.md
+++ b/content/turnstile/community-resources.md
@@ -1,0 +1,57 @@
+---
+title: Community Resources
+pcx_content_type: reference
+weight: 13
+layout: list
+structured_data: true
+---
+
+# Community Resources
+
+Community Resources for our customers to help them integrate Turnstile.
+
+{{<Aside type="warning">}}
+
+These resources are made by the **community** and not maintained directly
+by Cloudflare.
+As such, Cloudflare is not liable for any damages arising from using them.
+
+{{</Aside>}}
+
+{{<Aside type="note">}}
+
+Did we miss your library? [Contribute to our list][1].
+
+[1]: https://github.com/cloudflare/cloudflare-docs/blob/production/CONTRIBUTING.md#pull-requests
+
+{{</Aside>}}
+
+## Client-side rendering libraries
+
+Libraries that only support the client-side rendering of Turnstile:
+
+- [React](https://www.npmjs.com/package/react-turnstile)
+- [Vue](https://www.npmjs.com/package/cfturnstile-vue3)
+- [Angular](https://www.npmjs.com/package/ngx-turnstile)
+- [Svelte](https://www.npmjs.com/package/svelte-turnstile)
+
+## Server-side validation libraries
+
+Libraries that only support the server-side validation of Turnstile:
+
+- N/A
+
+## Fullstack libraries
+
+Libraries that both support the both client-side rendering and server-side validation of Turnstile:
+
+- [Nuxt](https://www.npmjs.com/package/@nuxtjs/turnstile)
+- [Laravel](https://github.com/romanzipp/Laravel-Turnstile)
+
+## Integrations
+
+Turnstile integrations for popular content managment systems:
+
+- [Wordpress](https://wordpress.org/plugins/simple-cloudflare-turnstile/)
+- [Statamic](https://statamic.com/addons/aryeh-raber/captcha)
+- [SilverStripe](https://github.com/webbuilders-group/silverstripe-turnstile)

--- a/content/turnstile/community-resources.md
+++ b/content/turnstile/community-resources.md
@@ -55,3 +55,7 @@ Turnstile integrations for popular content managment systems:
 - [Wordpress](https://wordpress.org/plugins/simple-cloudflare-turnstile/)
 - [Statamic](https://statamic.com/addons/aryeh-raber/captcha)
 - [SilverStripe](https://github.com/webbuilders-group/silverstripe-turnstile)
+
+## Other
+
+- [TypeScript definitions](https://www.npmjs.com/package/turnstile-types)

--- a/content/turnstile/community-resources.md
+++ b/content/turnstile/community-resources.md
@@ -58,4 +58,6 @@ Turnstile integrations for popular content managment systems:
 
 ## Other
 
+Other resources related to integrating Turnstile:
+
 - [TypeScript definitions](https://www.npmjs.com/package/turnstile-types)


### PR DESCRIPTION
Adds some community libraries for Turnstile.
The current list is sourced from [#turnstile in the Cloudflare Developers Discord](https://discord.gg/cloudflaredev).

I am not a lawyer, so the disclaimer probably needs improvement (hence draft).