### PR TITLE
[Notifications] Update conditions required for using webhooks

### DIFF
--- a/content/fundamentals/notifications/create-notifications/configure-webhooks.md
+++ b/content/fundamentals/notifications/create-notifications/configure-webhooks.md
@@ -8,7 +8,7 @@ weight: 2
 
 {{<Aside type="note">}}
 
-This feature is only available if your account has at least one paid feature. For more information, see our [plans page] (https://www.cloudflare.com/plans/).
+This feature is only available if your account has at least one paid feature. For more information, see our [plans page](https://www.cloudflare.com/plans/).
 
 {{</Aside>}}
 

--- a/content/fundamentals/notifications/create-notifications/configure-webhooks.md
+++ b/content/fundamentals/notifications/create-notifications/configure-webhooks.md
@@ -8,7 +8,7 @@ weight: 2
 
 {{<Aside type="note">}}
 
-This feature is only available if your account has at least one zone on a Professional or higher plan. For more information, see our [plans page](https://www.cloudflare.com/plans/).
+This feature is only available if your account has at least one paid feature. For more information, see our [plans page] (https://www.cloudflare.com/plans/).
 
 {{</Aside>}}
 


### PR DESCRIPTION
Previously webhooks required you to have a zone at pro level or above. Now they require you to be signed up for any paid-for feature so that more customers can access and use webhooks.