### PR TITLE
Update "Domain Group Manager" location

### DIFF
--- a/content/fundamentals/account-and-billing/members/scope.md
+++ b/content/fundamentals/account-and-billing/members/scope.md
@@ -59,7 +59,7 @@ If you want a member with access to a group of specific domains, you can also cr
 To create a domain group: 
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account (you must be logged in as a **Super Administrator** and have a [verified email address](/fundamentals/account-and-billing/account-setup/verify-email-address/)).
-2. Go to **Manage Account** > **Configurations**.
+2. Go to **Manage Account** > **Configurations** > **Lists**.
 3. For **Domain Group Manager**, select **Create**.
 4. Create your domain group:
 


### PR DESCRIPTION
Corrected "Domain Group Manager" location, it is under _**Manage Account** > **Configurations** > **Lists**_
Rather than just: _**Manage Account** > **Configurations**_