### PR TITLE
[framework-guides/deploy-a-nextjs-site.md] Fix code snippet: current code throws an error when you build it

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -46,8 +46,8 @@ export const config = {
   runtime: 'edge',
 }
 
-export default async function (req) {
-  return Response.json({ name: 'John Doe' })
+export default async function handler(req) {
+  return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 ```
 
@@ -66,8 +66,8 @@ export const config = {
   runtime: 'edge',
 }
 
-export default async function (req: NextRequest) {
-  return Response.json({ name: 'John Doe' })
+export default async function handler(req: NextRequest) {
+  return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 ```
 


### PR DESCRIPTION
Although `Response.json()` works when you run `npm run dev`, when you build it it throws following error:

>Type error: Property 'json' does not exist on type '{ new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response; prototype: Response; error(): Response; redirect(url: string | URL, status?: number | undefined): Response; }'.

As far as I read [Next.js docs](https://nextjs.org/docs/api-routes/edge-api-routes), you should change it to:

```javascript
new Response(JSON.stringify())
```

Also, as function should be named in Next.js, I named the function as `handler`.
