### PR TITLE
Fix incorrect references to KV's old value size limit

### DIFF
--- a/content/workers/wrangler-legacy/commands.md
+++ b/content/workers/wrangler-legacy/commands.md
@@ -990,7 +990,7 @@ The schema below is the full schema for key-value entries uploaded via the bulk 
 
 - `value` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
-  - The UTF-8 encoded string to be stored, up to 10 MB in length.
+  - The UTF-8 encoded string to be stored, up to 25 MB in length.
 
 - `expiration` {{<type>}}int{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
@@ -1064,7 +1064,8 @@ This command takes a JSON file as an argument with a list of key-value pairs to 
   - The key’s name. The name may be at most 512 bytes. All printable, non-whitespace characters are valid.
 
 - `value` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-  - The UTF-8 encoded string to be stored, up to 10 MB in length.
+
+  - This field must be specified for deserialization purposes, but is unused because the provided keys are being deleted, not written.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -912,7 +912,7 @@ Here is the full schema for key-value entries uploaded via the bulk API:
 - `key` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
   - The key’s name. The name may be 512 bytes maximum. All printable, non-whitespace characters are valid.
 - `value` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-  - The UTF-8 encoded string to be stored, up to 10 MB in length.
+  - The UTF-8 encoded string to be stored, up to 25 MB in length.
 - `metadata` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Any arbitrary object (must serialize to JSON) to a maximum of 1024 bytes.
 - `expiration` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}


### PR DESCRIPTION
And clarify the odd presence of a "value" field in wrangler v1's bulk delete command.

The legacy wrangler bulk delete command is awkward in that (judging by the source code) it looks like you actually do have to provide a value field in order to make Rust's serde deserialization happy. I didn't actually test it since I don't have wrangler v1 around anymore, but given that these docs are buried and wrangler v1 is heavily deprecated, it didn't seem worth the time to figure out if or how users could omit the "value" field entirely.

@rts-rob 