### PR TITLE
[Workers] Fix broken worker pricing link in kv.md

### DIFF
--- a/content/workers/runtime-apis/kv.md
+++ b/content/workers/runtime-apis/kv.md
@@ -435,4 +435,4 @@ export class DurableObject {
 
 - [Use KV with Wrangler](/workers/wrangler/workers-kv/)
 - [Limits](/workers/platform/limits/#kv-limits)
-- [Pricing](/workers/platform/pricing/#kv)
+- [Pricing](/workers/platform/pricing/#workers-kv)


### PR DESCRIPTION
- Fixes a broken pricing link at the bottom of the Worker KV

Current link is `https://developers.cloudflare.com/workers/platform/pricing/#kv` when it should be `https://developers.cloudflare.com/workers/platform/pricing/#workers-kv`.