### PR TITLE
fix: remove unsupported `cloudflared tunnel` bare option

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare.md
+++ b/content/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare.md
@@ -15,13 +15,7 @@ Developers can use the TryCloudflare tool to experiment with Cloudflare Tunnel w
 1.  Run the following terminal command to start a free tunnel.
 
 ```sh
-$ cloudflared tunnel
-```
-
-The command above will default to port 8080; you can specify an alternate port with the --url flag.
-
-```sh
-$ cloudflared tunnel --url http://localhost:7000
+$ cloudflared tunnel --url http://localhost:8080
 ```
 
 `cloudflared` will generate a random subdomain when connecting to the Cloudflare network and print it in the terminal for you to use and share. The output will serve traffic from the server on your local machine to the public internet, using Cloudflare's Argo Smart Routing, at a public URL.


### PR DESCRIPTION
Running `cloudflared tunnel` alone no longer works - a url is required.

```
❯ cloudflared tunnel
You did not specify any valid additional argument to the cloudflared tunnel command.

If you are trying to run a Quick Tunnel then you need to explicitly pass the --url flag.
Eg. cloudflared tunnel --url localhost:8080/.

Please note that Quick Tunnels are meant to be ephemeral and should only be used for testing purposes.
For production usage, we recommend creating Named Tunnels. (https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/)
```