### PR TITLE
fix: search product docs

### DIFF
--- a/assets/search.redirect.ts
+++ b/assets/search.redirect.ts
@@ -24,7 +24,7 @@
         if (productGroup) {
           redirect += '&product_group=' + encodeURIComponent(productGroup.content);
         }
-        // redirect += '&f:source=[Developer%20docs]';
+        redirect += '&f:source=[Product%20documentation]';
       }
 
       return location.assign(redirect);


### PR DESCRIPTION
This tweaks the search to only search product documentation and produce much more useful results.

For example, searching "Workers":
before: ![](https://up.jross.me/jp73drgc)
API references intermingled with results, which is not helpful especially for new users

after: ![](https://up.jross.me/ltf4qfyq)
only actual Workers documentation.