### PR TITLE
[Wrangler] Update deployment and rollback docs for new command structure

### DIFF
--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -23,7 +23,7 @@ Associated resources for a worker such as KV, R2, and Durable Objects are not tr
 
 ## Creating a new deployment
 
-New deployments are created whenever an upload, binding change (including environment variables and secrets), usage model change, or [rollback](#rollbacks) is made. Create a new deployment via the Cloudflare dashboard, [Workers API](/api), or wrangler (with [`wrangler publish` command](/workers/wrangler/commands#publish) or [`wrangler rollback` command](/workers/wrangler/commands#rollback)) .
+New deployments are created whenever an upload, binding change (including environment variables and secrets), usage model change, or [rollback](#rollbacks) is made. Create a new deployment via the Cloudflare dashboard, [Workers API](/api), or Wrangler (with [`wrangler publish` command](/workers/wrangler/commands#publish) or [`wrangler rollback` command](/workers/wrangler/commands#rollback)) .
 
 Notably, this does not include changes to bound resources. For example, if two Workers (Worker A and Worker B) are bound via a service binding, changing the code of a Worker B will not trigger a new deployment on Worker A. Changes to the service binding on Worker A will also not trigger a new deployment for Worker B.
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -7,7 +7,7 @@ title: Deployments
 
 {{<Aside type="note">}}
 
-Deployments are currently in Public Beta. Report Deployments bugs to the [Wrangler team](https://github.com/cloudflare/wrangler2/issues/new/choose).
+Deployments are currently in Public Beta. Report deployments bugs to the [Wrangler team](https://github.com/cloudflare/wrangler2/issues/new/choose).
 
 {{</Aside>}}
 
@@ -43,11 +43,11 @@ More details about the `wrangler deployments list` and `wrangler deployments vie
 
 ### via the Cloudflare Dashboard
 
-Access Deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page displays information about the most recently deployed and currently active deployment.
+Access deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page displays information about the most recently deployed and currently active deployment.
 
 ### via the API
 
-Read more about accessing Deployment information via Cloudflare's REST API [here](/api/#worker-deployments-properties).
+Read more about accessing deployment information via Cloudflare's REST API [here](/api/#worker-deployments-properties).
 
 {{<Aside type="note">}}
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -47,7 +47,7 @@ Access deployments by logging into the [Cloudflare dashboard](https://dash.cloud
 
 ### via the API
 
-Read more about accessing deployment information via Cloudflare's REST API [here](/api/#worker-deployments-properties).
+To learn more about accessing deployment information via Cloudflare's REST API, refer to the [API documentation](/api/#worker-deployments-properties).
 
 {{<Aside type="note">}}
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -39,7 +39,7 @@ Changing triggers such as routes, custom domains, or cron triggers will not issu
 
 Wrangler allows you to view the 10 most recent deployments as well as bindings and metadata for a specific deployment.
 
-More details about the `wrangler deployments list` and `wrangler deployments view` commands can be found [here](/workers/wrangler/commands#deployments).
+More details about the `wrangler deployments list` and `wrangler deployments view` commands can be found in the [Wrangler commands documentation](/workers/wrangler/commands#deployments).
 
 ### via the Cloudflare Dashboard
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -37,7 +37,7 @@ Changing triggers such as routes, custom domains, or cron triggers will not issu
 
 ### via Wrangler
 
-Wrangler allows you to view the 10 most recent deployments as well as bindings and metadata information about a specific deployment.
+Wrangler allows you to view the 10 most recent deployments as well as bindings and metadata for a specific deployment.
 
 More details about the `wrangler deployments list` and `wrangler deployments view` commands can be found [here](/workers/wrangler/commands#deployments).
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -13,7 +13,7 @@ Deployments are currently in Public Beta. Report Deployments bugs to the [Wrangl
 
 Deployments are a log of static historical versions of your Worker. They track changes to the bundled code, bindings, compatibility date, and usage model associated with a Worker over time. They also keep metadata associated with the deployment including the user, deploy source, timestamp, and other useful information to understand and audit who or what is making changes to your Worker.
 
-The latest deployment for a Worker is considered the "active deployment". You can view your latest 10 deployments [via the Cloudflare dashboard](#via-the-cloudflare-dashboard) or the [`wrangler deployments` command](#via-wrangler).
+The latest deployment for a Worker is considered the "active deployment". You can view your latest 10 deployments [via the Cloudflare dashboard](#via-the-cloudflare-dashboard) or the [`wrangler deployments list` command](#via-wrangler).
 
 {{<Aside type="note">}}
 
@@ -23,7 +23,7 @@ Associated resources for a worker such as KV, R2, and Durable Objects are not tr
 
 ## Creating a new deployment
 
-New deployments are created whenever an upload, binding change (including environment variables and secrets), usage model change, or [rollback](#rollbacks) is made. These can be done via the Cloudflare dashboard, [Workers API](/api), or [`wrangler publish` command](/workers/wrangler/commands#publish).
+New deployments are created whenever an upload, binding change (including environment variables and secrets), usage model change, or [rollback](#rollbacks) is made. Create a new deployment via the Cloudflare dashboard, [Workers API](/api), or wrangler (with [`wrangler publish` command](/workers/wrangler/commands#publish) or [`wrangler rollback` command](/workers/wrangler/commands#rollback)) .
 
 Notably, this does not include changes to bound resources. For example, if two Workers (Worker A and Worker B) are bound via a service binding, changing the code of a Worker B will not trigger a new deployment on Worker A. Changes to the service binding on Worker A will also not trigger a new deployment for Worker B.
 
@@ -37,13 +37,13 @@ Changing triggers such as routes, custom domains, or cron triggers will not issu
 
 ### via Wrangler
 
-Wrangler allows you to view the 10 most recent deployments as well as source code, bindings and runtime information about a specific deployment.
+Wrangler allows you to view the 10 most recent deployments as well as bindings and metadata information about a specific deployment.
 
-More details about the `wrangler deployments` and `wrangler deployments view` command can be found [here](/workers/wrangler/commands#deployments).
+More details about the `wrangler deployments list` and `wrangler deployments view` commands can be found [here](/workers/wrangler/commands#deployments).
 
 ### via the Cloudflare Dashboard
 
-Access Deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page will now indicate information about the most recently deployed and currently active deployment.
+Access Deployments by logging into the [Cloudflare dashboard](https://dash.cloudflare.com) > **Account Home** > **Workers** > selecting your Worker project > **Deployments**. Deployments includes information about previous deployments, and your Worker’s detail page displays information about the most recently deployed and currently active deployment.
 
 ### via the API
 
@@ -58,13 +58,11 @@ Deployments are in active development. To give feedback, request a [live chat](h
 ## Rollbacks
 Rollbacks are a way to quickly deploy an older deployment to the Cloudflare global network. This could be useful if a breaking change or unintended publish is made to a production Worker.
 
-Perform a rollback via:
-1. [Wrangler](/workers/platform/deployments/#via-wrangler-1).
-2. The [Cloudflare dashboard](/workers/platform/deployments/#via-the-cloudflare-dashboard-1).
+Perform a rollback via [Wrangler](/workers/platform/deployments/#via-wrangler-1) or the [Cloudflare dashboard](/workers/platform/deployments/#via-the-cloudflare-dashboard-1).
 
 ### via Wrangler
 
-To perform a rollback via Wrangler, use the `wrangler deployments rollback` command. Refer to [Wrangler `rollback` command documentation](/workers/wrangler/commands#rollback) for more information.
+To perform a rollback via Wrangler, use the `wrangler rollback` command. Refer to [Wrangler `rollback` command documentation](/workers/wrangler/commands#rollback) for more information. TODO LIZ: THIS IS A BROKEN LINK NEEDS TO BE FIXED
 
 ### via the Cloudflare Dashboard
 

--- a/content/workers/platform/deployments.md
+++ b/content/workers/platform/deployments.md
@@ -62,7 +62,7 @@ Perform a rollback via [Wrangler](/workers/platform/deployments/#via-wrangler-1)
 
 ### via Wrangler
 
-To perform a rollback via Wrangler, use the `wrangler rollback` command. Refer to [Wrangler `rollback` command documentation](/workers/wrangler/commands#rollback) for more information. TODO LIZ: THIS IS A BROKEN LINK NEEDS TO BE FIXED
+To perform a rollback via Wrangler, use the `wrangler rollback` command. Refer to [Wrangler `rollback` command documentation](/workers/wrangler/commands#rollback) for more information.
 
 ### via the Cloudflare Dashboard
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1558,7 +1558,7 @@ $ wrangler deployments list
   - Perform on a specific Worker script rather than inheriting from `wrangler.toml`.
 {{</definitions>}}
 
-Example output
+Example output:
 ```sh
 Deployment ID:  y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
 Created on:     2022-11-11T15:49:08.117218Z

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1545,18 +1545,33 @@ Deployments are currently in Public Beta and subcommands are currently in Beta. 
 
 You can read more about deployments and how they work [here](/workers/platform/deployments).
 
-Retrieve details for the 10 most recent deployments. Details include `Deployment ID`, `Author`, `Source`, `Created on`, and indicates which deployment is `Active`.
+### list
+Retrieve details for the specified deployment. Details include Deployment ID, Author, Source, Created on, and bindings.
+
+Retrieve details for the 10 most recent deployments. Details include `Deployment ID`, `Author`, `Source`, `Created on`, and an indication of which deployment is `Active`. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
 
 ```sh
-$ wrangler deployments
+$ wrangler deployments list
 
 Deployment ID: y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
 Created on: 2022-11-11T15:49:08.117218Z
 Author: example@cloudflare.com
 Source: Dashboard
 
+Deployment ID: 91943f34-4802-4af7-a350-b5894c73ff34
+Created on: 2022-11-11T15:50:08.117218Z
+Author: example@cloudflare.com
+Source: Dashboard
+
+Deployment ID: 31d8f2f0-fba3-4ce9-8427-933f42541b56
+Created on: 2022-11-11T15:51:08.117218Z
+Author: example@cloudflare.com
+Source: Rollback from Wrangler 🤠
+Rollback from: y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
+Message: This is a message submitted on rollback
+
 Deployment ID: e81fe980-7622-6e1d-740b-1457de3e07e2
-Created on: 2022-11-11T15:51:20.79936Z
+Created on: 2022-11-11T15:52:20.79936Z
 Author: example@cloudflare.com
 Source: Wrangler
 🟩 Active
@@ -1571,7 +1586,7 @@ Source: Wrangler
 {{</definitions>}}
 
 ### view <deployment-id>
-Retrieve details for the specified deployment. Details include Deployment ID, Author, Source, Created on, and bindings.
+Retrieve details for the specified deployment, or the latest if no `deployment-id` is provided. Details include Deployment ID, Author, Source, Created on, and bindings. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
 
 ```sh
 wrangler deployments view <DEPLOYMENT_ID>
@@ -1596,32 +1611,9 @@ bucket_name = "testr2"
 [[kv_namespaces]]
 id = "79300c6d17eb4180a07270f450efe53f"
 binding = "MY_KV"
-
----------------------------script---------------------------
-
-// index.js
-var worker_default = {
-  fetch(request) {
-    const base = "https://example.com";
-    const statusCode = 301;
-    const destination = new URL(request.url, base);
-    return Response.redirect(destination.toString(), statusCode);
-  }
-};
-export {
-  worker_default as default
-};
-//# sourceMappingURL=index.js.map
 ```
 
-{{<definitions>}}
-
-- `--content` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - View script content for specified deployment.
-
-{{</definitions>}}
-
-### rollback [deployment-id]
+## rollback
 
 Rollback to a specific deployment by ID. If an ID is not speicified, wrangler will rollback to the previous deployment. There are limitations on what deployments you can rollback to. Refer to [Rollbacks in the Deployments documentation](/workers/platform/deployments#rollbacks) for more information.
 
@@ -1630,15 +1622,23 @@ Rollbacks will immediately replace the current deployment and become the active 
 {{</Aside>}}
 
 ```sh
-wrangler deployments rollback e81fe980-7622-6e1d-740b-1457de3e07e2
+wrangler rollback e81fe980-7622-6e1d-740b-1457de3e07e2
 ```
 
 Output:
 ```sh
 🤖 Using default value in non-interactive context: yes
-🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
-Successfully rolled back to deployment ID: 3mEgaU1T-Intrepid-someThing
+🚧 `wrangler rollback` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
+Successfully rolled back to deployment ID: e81fe980-7622-6e1d-740b-1457de3e07e2
+Current Deployment ID: 04d22369-6e55-49ff-944a-d21e216d9f3e
 ```
+
+{{<definitions>}}
+
+- `--message` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Add message for rollback. Accepts empty string. When specified, interactive prompt is skipped.
+
+{{</definitions>}}
 
 ---
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -27,8 +27,9 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`login`](#login) - Authorize Wrangler with your Cloudflare account using OAuth.
 - [`logout`](#logout) - Remove Wrangler’s authorization for accessing your account.
 - [`whoami`](#whoami) - Retrieve your user information and test your authentication configuration.
+- [`deployments`](#deployments) - Retrieve details for recent deployments.
+- [`rollback`](#rollback) - Rollback to a recent deployment.
 - [`types`](#types) - Generate types from bindings and module rules in configuration.
-- [`deployments`](#deployments) - Retrieve details for the 10 most recent deployments.
 
 {{<Aside type="note">}}
 
@@ -1546,58 +1547,70 @@ Deployments are currently in Public Beta and subcommands are currently in Beta. 
 You can read more about deployments and how they work [here](/workers/platform/deployments).
 
 ### list
-Retrieve details for the specified deployment. Details include Deployment ID, Author, Source, Created on, and bindings.
-
-Retrieve details for the 10 most recent deployments. Details include `Deployment ID`, `Author`, `Source`, `Created on`, and an indication of which deployment is `Active`. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
+Retrieve details for the 10 most recent deployments. Details include `Deployment ID`, `Created on`, `Author`, `Source`, and an indication of which deployment is `Active`. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
 
 ```sh
 $ wrangler deployments list
-
-Deployment ID: y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
-Created on: 2022-11-11T15:49:08.117218Z
-Author: example@cloudflare.com
-Source: Dashboard
-
-Deployment ID: 91943f34-4802-4af7-a350-b5894c73ff34
-Created on: 2022-11-11T15:50:08.117218Z
-Author: example@cloudflare.com
-Source: Dashboard
-
-Deployment ID: 31d8f2f0-fba3-4ce9-8427-933f42541b56
-Created on: 2022-11-11T15:51:08.117218Z
-Author: example@cloudflare.com
-Source: Rollback from Wrangler 🤠
-Rollback from: y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
-Message: This is a message submitted on rollback
-
-Deployment ID: e81fe980-7622-6e1d-740b-1457de3e07e2
-Created on: 2022-11-11T15:52:20.79936Z
-Author: example@cloudflare.com
-Source: Wrangler
-🟩 Active
-
 ```
 
 {{<definitions>}}
-
 - `--name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Perform on a specific Worker script rather than inheriting from `wrangler.toml`.
-
 {{</definitions>}}
 
-### view <deployment-id>
-Retrieve details for the specified deployment, or the latest if no `deployment-id` is provided. Details include Deployment ID, Author, Source, Created on, and bindings. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
-
+Example output
 ```sh
-wrangler deployments view <DEPLOYMENT_ID>
+Deployment ID:  y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
+Created on:     2022-11-11T15:49:08.117218Z
+Author:         example@cloudflare.com
+Source:         Dashboard
+
+Deployment ID:  91943f34-4802-4af7-a350-b5894c73ff34
+Created on:     2022-11-11T15:50:08.117218Z
+Author:         example@cloudflare.com
+Source:         Dashboard
+
+Deployment ID:  31d8f2f0-fba3-4ce9-8427-933f42541b56
+Created on:     2022-11-11T15:51:08.117218Z
+Author:         example@cloudflare.com
+Source:         Rollback from Wrangler 🤠
+Rollback from:  y565f193-a6b9-4c7f-91ae-4b4e6d98ftbf
+Message:        This is a message submitted on rollback
+
+Deployment ID:  7c2761da-5a45-4cb2-9448-a662978e3a59
+Created on:     2022-11-11T15:52:08.117218Z
+Author:         example@cloudflare.com
+Source:         Rollback from Dashboard 🖥️
+Rollback from:  31d8f2f0-fba3-4ce9-8427-933f42541b56
+
+Deployment ID:  e81fe980-7622-6e1d-740b-1457de3e07e2
+Created on:     2022-11-11T15:53:20.79936Z
+Author:         example@cloudflare.com
+Source:         Wrangler
+🟩 Active
 ```
 
-Output:
-```javascript
-Deployment ID: 07d7143d-0284-427e-ba22-2d5e6e91b479
-Created on:    2023-03-02T21:05:15.622446Z
-Author:        example@cloudflare.com
-Source:        Upload from Wrangler 🤠
+### view <deployment-id>
+Retrieve details for the specified deployment, or the latest if no ID is provided. Details include `Deployment ID`, `Author`, `Source`, `Created on`, and bindings. Where applicable, details also include rollback information and a `Message` if one was provided on rollback.
+
+```sh
+$ wrangler deployments view [DEPLOYMENT_ID]
+```
+
+{{<definitions>}}
+- `DEPLOYMENT_ID` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - the ID of the deployment you wish to view.
+- `--name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Perform on a specific Worker script rather than inheriting from `wrangler.toml`.
+{{</definitions>}}
+
+
+Example output:
+```sh
+Deployment ID:      07d7143d-0284-427e-ba22-2d5e6e91b479
+Created on:         2023-03-02T21:05:15.622446Z
+Author:             example@cloudflare.com
+Source:             Upload from Wrangler 🤠
 ------------------------------------------------------------
 Author ID:          e5a3ca86e08fb0940d3a05691310bb42
 Usage Model:        bundled
@@ -1614,31 +1627,35 @@ binding = "MY_KV"
 ```
 
 ## rollback
+Rollback to a specified deployment by ID, or to the previous deployment if no ID is provided. The command will prompt you for confirmation of the rollback. On confirmation, you will be prompted to provide an optional message. 
 
-Rollback to a specific deployment by ID. If an ID is not speicified, wrangler will rollback to the previous deployment. There are limitations on what deployments you can rollback to. Refer to [Rollbacks in the Deployments documentation](/workers/platform/deployments#rollbacks) for more information.
+There are limitations on what deployments you can rollback to. Refer to [Rollbacks in the Deployments documentation](/workers/platform/deployments#rollbacks) for more information.
 
 {{<Aside type="warning">}}
-Rollbacks will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. This change will not affect work in your local development environment.
+A rollback will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. This change will not affect work in your local development environment.
 {{</Aside>}}
 
 ```sh
-wrangler rollback e81fe980-7622-6e1d-740b-1457de3e07e2
-```
-
-Output:
-```sh
-🤖 Using default value in non-interactive context: yes
-🚧 `wrangler rollback` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
-Successfully rolled back to deployment ID: e81fe980-7622-6e1d-740b-1457de3e07e2
-Current Deployment ID: 04d22369-6e55-49ff-944a-d21e216d9f3e
+$ wrangler rollback [DEPLOYMENT_ID]
 ```
 
 {{<definitions>}}
-
+- `DEPLOYMENT_ID` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - the ID of the deployment you wish to view.
 - `--message` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Add message for rollback. Accepts empty string. When specified, interactive prompt is skipped.
-
+  - Add message for rollback. Accepts empty string. When specified, interactive prompts for rollback confirmation and message are skipped.
 {{</definitions>}}
+
+```sh
+$ wrangler rollback e81fe980-7622-6e1d-740b-1457de3e07e2 --message "Example message"
+```
+
+Example output:
+```sh
+🚧 `wrangler rollback` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+Successfully rolled back to deployment ID: e81fe980-7622-6e1d-740b-1457de3e07e2
+Current Deployment ID: 04d22369-6e55-49ff-944a-d21e216d9f3e
+```
 
 ---
 


### PR DESCRIPTION
This PR updates https://github.com/cloudflare/cloudflare-docs/pull/7492 to account for changes to the deployments and rollback commands introduced in https://github.com/cloudflare/workers-sdk/pull/2888