### PR TITLE
[Workers] Update deploy button action YAML example to 2.0

### DIFF
--- a/content/workers/platform/deploy-button.md
+++ b/content/workers/platform/deploy-button.md
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish
-        uses: cloudflare/wrangler-action@1.3.0
+        uses: cloudflare/wrangler-action@2.0.0
 ```
 
 2.  Add support for `CF_API_TOKEN` and `CF_ACCOUNT_ID` in your workflow:
@@ -43,11 +43,10 @@ jobs:
 ```yaml
 # Update "Publish" step from last code snippet
 - name: Publish
-  uses: cloudflare/wrangler-action@1.3.0
+  uses: cloudflare/wrangler-action@2.0.0
   with:
     apiToken: ${{ secrets.CF_API_TOKEN }}
-  env:
-    CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+    accountId: ${{ secrets.CF_ACCOUNT_ID }}
 ```
 
 3.  Add the Markdown code for your button to your project's README, replacing the example `url` parameter with your repository URL.


### PR DESCRIPTION
## Changes

- Update `cloudflare/wrangler-action` to 2.0
- Fix passing `accountId`

Tested on my own worker template.

![image](https://user-images.githubusercontent.com/563819/225107318-407496bd-5f7e-44b9-bdd0-19f0f5883140.png)

## Questions

1. Does it make sense to have `pull_request` action? For example, if someone opens a PR you don't necessarily want to deploy a new worker 🤔 It's not like Pages with deploy previews, right?