### PR TITLE
[Search] Treat support docs like other docs

### DIFF
--- a/assets/search.redirect.ts
+++ b/assets/search.redirect.ts
@@ -2,11 +2,7 @@
   let $ = document.querySelector.bind(document);
   let element = $('#DocsSearch--input') || $('#SiteSearch--input');
   let productGroup = $('meta[name="pcx_content_group"]')
-  let canonical = $('link[rel="canonical"]')
   let searchTab = '&t=Docs'
-  if (canonical.href.includes('https://developers.cloudflare.com/support/')) {
-    searchTab = '&t=Other'
-  }
 
   addEventListener('keydown', ev => {
     let key = ev.which;
@@ -24,7 +20,6 @@
         if (productGroup) {
           redirect += '&product_group=' + encodeURIComponent(productGroup.content);
         }
-        // redirect += '&f:source=[Developer%20docs]';
       }
 
       return location.assign(redirect);

--- a/content/search.html
+++ b/content/search.html
@@ -38,9 +38,9 @@ layout: home
       <div class="CoveoBreadcrumb"></div>
       <div class="CoveoDidYouMean"></div>
       <div class="coveo-tab-section">
-        <a class="CoveoTab" data-id="Docs" data-caption="Product docs" data-expression="NOT @dev_docs_product==&quot;/support/&quot; AND @customer_facing_source==(&quot;Product documentation&quot;)"></a>
+        <a class="CoveoTab" data-id="Docs" data-caption="Product docs" data-expression="@customer_facing_source==(&quot;Product documentation&quot;)"></a>
         <a class="CoveoTab" data-id="API Docs" data-caption="API docs" data-expression="@customer_facing_source==(&quot;API documentation&quot;)"></a>
-        <a class="CoveoTab" data-id="Other" data-caption="Other resources" data-expression="@dev_docs_product==&quot;/support/&quot; OR NOT @customer_facing_source==(&quot;Product documentation&quot;, &quot;API documentation&quot;)"></a>
+        <a class="CoveoTab" data-id="Other" data-caption="Other resources" data-expression="NOT @customer_facing_source==(&quot;Product documentation&quot;, &quot;API documentation&quot;)"></a>
       </div>
       <div class="coveo-results-header">
         <div class="coveo-summary-section">


### PR DESCRIPTION
Based on internal feedback, there's a lot of confusion around nuancing the search to remove /support/ docs from regular product docs.