### PR TITLE
d1: mention --persist

### DIFF
--- a/content/pages/platform/functions/bindings.md
+++ b/content/pages/platform/functions/bindings.md
@@ -198,7 +198,7 @@ While developing locally, interact with a D1 database by adding `--d1=<BINDING_N
 {{<Aside type="note">}}
 By default, data in local development is not persisted. This means if you create a schema and/or insert data into a D1 table, the next time you start local dev, it will no longer exist.
   
-You can enable persistence with the --persist flag.
+You can enable persistence with the `--persist` flag.
 {{</Aside>}}
   
 Specifically:

--- a/content/pages/platform/functions/bindings.md
+++ b/content/pages/platform/functions/bindings.md
@@ -196,14 +196,14 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 While developing locally, interact with a D1 database by adding `--d1=<BINDING_NAME>` to your run command.
   
 {{<Aside type="note">}}
-By default, data in local development is not persisted. This means if you create a schema and/or insert data into a D1 table, the next time you start local dev, it will no longer exist.
+By default, data in local development is not persisted. This means if you create a schema and/or insert data into a D1 table, the next time you start local development, it will no longer exist.
   
 You can enable persistence with the `--persist` flag.
 {{</Aside>}}
   
 Specifically:
   
-* If your database is bound to `NORTHWIND_DB`, access this database in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --d1=NORTHWIND_DB`.
+* If your database is bound to `NORTHWIND_DB`, access this database in local development by running `npx wrangler pages dev <OUTPUT_DIR> --d1=NORTHWIND_DB`.
 * Interact with this binding by using `context.env` - for example, `context.env.NORTHWIND_DB`
 
 Refer to the [D1 client API documentation](/d1/platform/client-api/) for the API methods available on your D1 binding.

--- a/content/pages/platform/functions/bindings.md
+++ b/content/pages/platform/functions/bindings.md
@@ -193,7 +193,20 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 ### Interact with your D1 databases locally
 
-While developing locally, interact with a D1 database by adding `--d1=<BINDING_NAME>` to your run command. For example, if your database is bound to `NORTHWIND_DB`, access this database in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --d1=NORTHWIND_DB`. Interact with this binding by `using context.env` (for example, `context.env.NORTHWIND_DB`).
+While developing locally, interact with a D1 database by adding `--d1=<BINDING_NAME>` to your run command.
+  
+{{<Aside type="note">}}
+By default, data in local development is not persisted. This means if you create a schema and/or insert data into a D1 table, the next time you start local dev, it will no longer exist.
+  
+You can enable persistence with the --persist flag.
+{{</Aside>}}
+  
+Specifically:
+  
+* If your database is bound to `NORTHWIND_DB`, access this database in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --d1=NORTHWIND_DB`.
+* Interact with this binding by using `context.env` - for example, `context.env.NORTHWIND_DB`
+
+Refer to the [D1 client API documentation](/d1/platform/client-api/) for the API methods available on your D1 binding.
 
 ## Service bindings
 


### PR DESCRIPTION
Make it clearer that `--persist` is needed to, well, persist data in local dev.

The note at the top of the page is easily missed and we’ve seen users run into this multiple times.