### PR TITLE
Fix example Cron Trigger typo

### DIFF
--- a/content/workers/platform/triggers/cron-triggers/index.md
+++ b/content/workers/platform/triggers/cron-triggers/index.md
@@ -72,7 +72,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
   - 6PM on the last Friday of the month
 
-- `23 59 LW * *`
+- `59 23 LW * *`
   - 11:59PM on the last weekday of the month
 
 {{</definitions>}}


### PR DESCRIPTION
Looks like this example was invalid (the 23rd minute of the 59th hour)? I presume this should be `59 23 * * *`?