### PR TITLE
[Cache] Fixed markdown typo in default-cache-behavior.md

### DIFF
--- a/content/cache/about/default-cache-behavior.md
+++ b/content/cache/about/default-cache-behavior.md
@@ -61,7 +61,7 @@ Cloudflare cacheable file limits:
 
 ## Cloudflare cache responses
 
-The output of the `CF-Cache-Status header` shows whether or not a resource is cached. To investigate cache responses returned by the `CF-Cache-Status` header, use services like [Redbot](https://redbot.org/), [webpagetest.org](http://www.webpagetest.org/), or a visual tool like [Chrome’s Dr. Flare plugin](https://community.cloudflare.com/t/community-tip-dr-flare-debug-tool-for-cloudflare-chrome-extension/110166).
+The output of the `CF-Cache-Status` header shows whether or not a resource is cached. To investigate cache responses returned by the `CF-Cache-Status` header, use services like [Redbot](https://redbot.org/), [webpagetest.org](http://www.webpagetest.org/), or a visual tool like [Chrome’s Dr. Flare plugin](https://community.cloudflare.com/t/community-tip-dr-flare-debug-tool-for-cloudflare-chrome-extension/110166).
 
 {{<table-wrap>}}
 <table>


### PR DESCRIPTION
- Fixed a typo in the markdown of default-cache-behavior.md

The word "header" was included in the code block with the name of the actual header. This might cause confusion for people, and considering that a bit further in the text the word "header" isn't in the code block, I assume that this was a typo.