### PR TITLE
[Workers] Add deflate-raw to supported algorithms in Compression Streams API

### DIFF
--- a/content/workers/runtime-apis/web-standards.md
+++ b/content/workers/runtime-apis/web-standards.md
@@ -123,7 +123,7 @@ A new spec-compliant implementation of the URL class can be enabled using the `u
 
 ## Compression Streams
 
-The `CompressionStream` and `DecompressionStream` classes support gzip and deflate compression methods.
+The `CompressionStream` and `DecompressionStream` classes support the deflate, deflate-raw and gzip compression methods.
 
 [Refer to the MDN documentation for more information](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API)
 


### PR DESCRIPTION
This has been implemented in https://github.com/cloudflare/workerd/pull/398 and since been [released](https://community.cloudflare.com/t/2023-3-3-workers-runtime-release-notes/480077) in Workers Runtime.