### PR TITLE
nodejs_compat docs

### DIFF
--- a/content/workers/_partials/_nodejs-compat-howto.md
+++ b/content/workers/_partials/_nodejs-compat-howto.md
@@ -1,0 +1,10 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="note">}}
+To use node.js APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`.
+{{</Aside>}}

--- a/content/workers/_partials/_nodejs-compat-howto.md
+++ b/content/workers/_partials/_nodejs-compat-howto.md
@@ -6,5 +6,5 @@ _build:
 ---
 
 {{<Aside type="note">}}
-To use node.js APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`.
+To use Node.js APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`.
 {{</Aside>}}

--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -47,9 +47,9 @@ This example enabled the specific flag `formdata_parser_supports_files`, which i
 
 Most developers will not need to use `compatibility_flags`; instead, Cloudflare recommends only specifying `compatibility_date`. `compatibility_flags` can be useful if you want to help the Workers team test upcoming changes that are not yet enabled by default, or if you need to hold back a change that your code depends on but still want to apply other compatibility changes.
 
-### Node.js Compatibility Flag
+### Node.js compatibility flag
 
-A [growing subset](/workers/runtime-apis/nodejs/) of node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:
+A [growing subset](/workers/runtime-apis/nodejs/) of Node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:
 
 ```toml
 ---
@@ -58,7 +58,7 @@ header: wrangler.toml
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
-As additional node.js APIs are added, they will be made available under this same compatibility flag. Unlike most other compatibility flags, we do not expect the `nodejs_compat` to become active by default at a future date.
+As additional Node.js APIs are added, they will be made available under the `nodejs_compat` compatibility flag. Unlike most other compatibility flags, we do not expect the `nodejs_compat` to become active by default at a future date.
 
 ## Change history
 

--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -47,6 +47,19 @@ This example enabled the specific flag `formdata_parser_supports_files`, which i
 
 Most developers will not need to use `compatibility_flags`; instead, Cloudflare recommends only specifying `compatibility_date`. `compatibility_flags` can be useful if you want to help the Workers team test upcoming changes that are not yet enabled by default, or if you need to hold back a change that your code depends on but still want to apply other compatibility changes.
 
+### Node.js Compatibility Flag
+
+A [growing subset](/workers/runtime-apis/nodejs/) of node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:
+
+```toml
+---
+header: wrangler.toml
+---
+compatibility_flags = [ "nodejs_compat" ]
+```
+
+As additional node.js APIs are added, they will be made available under this same compatibility flag. Unlike most other compatibility flags, we do not expect the `nodejs_compat` to become active by default at a future date.
+
 ## Change history
 
 Newest changes are listed first.

--- a/content/workers/runtime-apis/nodejs/EventEmitter.md
+++ b/content/workers/runtime-apis/nodejs/EventEmitter.md
@@ -7,7 +7,7 @@ title: EventEmitter
 
 {{<render file="nodejs-compat-howto.md">}}
 
-An EventEmitter is an object that emits named events that cause listeners to be called.
+An `EventEmitter` is an object that emits named events that cause listeners to be called.
 
 ```js
 import { EventEmitter } from 'node:events';
@@ -20,7 +20,7 @@ emitter.on('hello', (...args) => {
 emitter.emit('hello', 1, 2, 3);
 ```
 
-The implementation in the Workers runtime fully supports the entire Node.js EventEmitter API, including the `captureRejections` option that allows improved handling of async functions as event handlers:
+The implementation in the Workers runtime fully supports the entire Node.js `EventEmitter` API. This includes the `captureRejections` option that allows improved handling of async functions as event handlers:
 
 ```js
 const emitter = new EventEmitter({ captureRejections: true });
@@ -32,4 +32,4 @@ emitter.on('error', (err) => {
 });
 ```
 
-For more, refer to the [Node.js documentation for EventEmitter](https://nodejs.org/api/events.html#class-eventemitter)].
+Refer to the [Node.js documentation for `EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter) for more information.

--- a/content/workers/runtime-apis/nodejs/EventEmitter.md
+++ b/content/workers/runtime-apis/nodejs/EventEmitter.md
@@ -5,6 +5,8 @@ title: EventEmitter
 
 # EventEmitter
 
+{{<render file="nodejs-compat-howto.md">}}
+
 An EventEmitter is an object that emits named events that cause listeners to be called.
 
 ```js

--- a/content/workers/runtime-apis/nodejs/EventEmitter.md
+++ b/content/workers/runtime-apis/nodejs/EventEmitter.md
@@ -1,0 +1,33 @@
+---
+pcx_content_type: configuration
+title: EventEmitter
+---
+
+# EventEmitter
+
+An EventEmitter is an object that emits named events that cause listeners to be called.
+
+```js
+import { EventEmitter } from 'node:events';
+
+const emitter = new EventEmitter();
+emitter.on('hello', (...args) => {
+  console.log(...args);
+});
+
+emitter.emit('hello', 1, 2, 3);
+```
+
+The implementation in the Workers runtime fully supports the entire Node.js EventEmitter API, including the `captureRejections` option that allows improved handling of async functions as event handlers:
+
+```js
+const emitter = new EventEmitter({ captureRejections: true });
+emitter.on('hello', async (...args) => {
+  throw new Error('boom');
+});
+emitter.on('error', (err) => {
+  // the async promise rejection is emitted here!
+});
+```
+
+For more, refer to the [Node.js documentation for EventEmitter](https://nodejs.org/api/events.html#class-eventemitter)].

--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -1,0 +1,17 @@
+---
+pcx_content_type: navigation
+title: Node.js Compatibility
+---
+
+# Node.js Compatibility
+
+The following APIs from node.js are available directly in the Workers runtime. To enable these APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
+
+```toml
+---
+header: wrangler.toml
+---
+compatibility_flags = [ "nodejs_compat" ]
+```
+
+{{<directory-listing>}}

--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -5,7 +5,7 @@ title: Node.js Compatibility
 
 # Node.js Compatibility
 
-The following APIs from node.js are available directly in the Workers runtime. To enable these APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
+The following APIs from Node.js are available directly in the Workers runtime. To enable these APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
 
 ```toml
 ---

--- a/content/workers/runtime-apis/nodejs/assert.md
+++ b/content/workers/runtime-apis/nodejs/assert.md
@@ -1,0 +1,35 @@
+---
+pcx_content_type: configuration
+title: assert
+---
+
+# assert
+
+The assert module in Node.js provides a number of useful assertions that are useful when building tests.
+
+```js
+import {
+  strictEqual,
+  deepStrictEqual,
+  ok,
+  doesNotReject,
+} from 'node:assert';
+
+strictEqual(1, 1); // ok!
+strictEqual(1, "1"); // fails! throws AssertionError
+
+deepStrictEqual({ a: { b: 1 }}, { a: { b: 1 }});// ok!
+deepStrictEqual({ a: { b: 1 }}, { a: { b: 2 }});// fails! throws AssertionError
+
+ok(true); // ok!
+ok(false); // fails! throws AssertionError
+
+await doesNotReject(async () => {}); // ok!
+await doesNotReject(async () => { throw new Error('boom') }); // fails! throws AssertionError
+```
+
+{{<Aside type="note">}}
+In the Workers implementation of assert, all assertions run in what Node.js calls the "strict assertion mode", which means that non-strict methods behave like their corresponding strict methods. For example, `deepEqual()` will behave like `deepStrictEqual()`.
+{{</Aside>}}
+
+For more, refer to the [Node.js documentation for assert](https://nodejs.org/dist/latest-v19.x/docs/api/assert.html)].

--- a/content/workers/runtime-apis/nodejs/assert.md
+++ b/content/workers/runtime-apis/nodejs/assert.md
@@ -7,7 +7,7 @@ title: assert
 
 {{<render file="nodejs-compat-howto.md">}}
 
-The assert module in Node.js provides a number of useful assertions that are useful when building tests.
+The `assert` module in Node.js provides a number of useful assertions that are useful when building tests.
 
 ```js
 import {
@@ -31,7 +31,7 @@ await doesNotReject(async () => { throw new Error('boom') }); // fails! throws A
 ```
 
 {{<Aside type="note">}}
-In the Workers implementation of assert, all assertions run in what Node.js calls the "strict assertion mode", which means that non-strict methods behave like their corresponding strict methods. For example, `deepEqual()` will behave like `deepStrictEqual()`.
+In the Workers implementation of `assert`, all assertions run in, what Node.js calls, the strict assertion mode. In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example, `deepEqual()` will behave like `deepStrictEqual()`.
 {{</Aside>}}
 
-For more, refer to the [Node.js documentation for assert](https://nodejs.org/dist/latest-v19.x/docs/api/assert.html)].
+Refer to the [Node.js documentation for `assert`](https://nodejs.org/dist/latest-v19.x/docs/api/assert.html) for more information.

--- a/content/workers/runtime-apis/nodejs/assert.md
+++ b/content/workers/runtime-apis/nodejs/assert.md
@@ -5,6 +5,8 @@ title: assert
 
 # assert
 
+{{<render file="nodejs-compat-howto.md">}}
+
 The assert module in Node.js provides a number of useful assertions that are useful when building tests.
 
 ```js

--- a/content/workers/runtime-apis/nodejs/buffer.md
+++ b/content/workers/runtime-apis/nodejs/buffer.md
@@ -5,4 +5,31 @@ title: Buffer
 
 # Buffer
 
-## Background
+The Buffer API in Node.js is one of the most commonly used Node.js APIs for manipulating binary data. Every Buffer instance extends from the standard [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class, but adds a range of unique capabilities such as built-in base64 and hex encoding/decoding, byte-order manipulation, and encoding-aware substring searching.
+
+```js
+import { Buffer } from 'node:buffer';
+
+const buf = Buffer.from('hello world', 'utf8');
+
+console.log(buf.toString('hex'));
+// Prints: 68656c6c6f20776f726c64
+console.log(buf.toString('base64'));
+// Prints: aGVsbG8gd29ybGQ=
+```
+
+Because a Buffer extends from Uint8Array, it can be used in any workers API that currently accepts Uint8Array, such as creating a new Response:
+
+```js
+const response = new Response(Buffer.from("hello world"));
+```
+
+You can also use the Buffer API when interacting with streams:
+
+```js
+const writable = getWritableStreamSomehow();
+const writer = writable.getWriter();
+writer.write(Buffer.from("hello world"));
+```
+
+For more, refer to the [Node.js documentation for Buffer](https://nodejs.org/dist/latest-v19.x/docs/api/buffer.html)].

--- a/content/workers/runtime-apis/nodejs/buffer.md
+++ b/content/workers/runtime-apis/nodejs/buffer.md
@@ -1,0 +1,8 @@
+---
+pcx_content_type: configuration
+title: Buffer
+---
+
+# Buffer
+
+## Background

--- a/content/workers/runtime-apis/nodejs/buffer.md
+++ b/content/workers/runtime-apis/nodejs/buffer.md
@@ -7,7 +7,7 @@ title: Buffer
 
 {{<render file="nodejs-compat-howto.md">}}
 
-The Buffer API in Node.js is one of the most commonly used Node.js APIs for manipulating binary data. Every Buffer instance extends from the standard [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class, but adds a range of unique capabilities such as built-in base64 and hex encoding/decoding, byte-order manipulation, and encoding-aware substring searching.
+The `Buffer` API in Node.js is one of the most commonly used Node.js APIs for manipulating binary data. Every `Buffer` instance extends from the standard [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class, but adds a range of unique capabilities such as built-in base64 and hex encoding/decoding, byte-order manipulation, and encoding-aware substring searching.
 
 ```js
 import { Buffer } from 'node:buffer';
@@ -20,13 +20,13 @@ console.log(buf.toString('base64'));
 // Prints: aGVsbG8gd29ybGQ=
 ```
 
-Because a Buffer extends from Uint8Array, it can be used in any workers API that currently accepts Uint8Array, such as creating a new Response:
+A Buffer extends from `Uint8Array`. Therefore, it can be used in any Workers API that currently accepts `Uint8Array`, such as creating a new Response:
 
 ```js
 const response = new Response(Buffer.from("hello world"));
 ```
 
-You can also use the Buffer API when interacting with streams:
+You can also use the `Buffer` API when interacting with streams:
 
 ```js
 const writable = getWritableStreamSomehow();
@@ -34,4 +34,4 @@ const writer = writable.getWriter();
 writer.write(Buffer.from("hello world"));
 ```
 
-For more, refer to the [Node.js documentation for Buffer](https://nodejs.org/dist/latest-v19.x/docs/api/buffer.html)].
+Refer to the [Node.js documentation for `Buffer`](https://nodejs.org/dist/latest-v19.x/docs/api/buffer.html) for more information.

--- a/content/workers/runtime-apis/nodejs/buffer.md
+++ b/content/workers/runtime-apis/nodejs/buffer.md
@@ -5,6 +5,8 @@ title: Buffer
 
 # Buffer
 
+{{<render file="nodejs-compat-howto.md">}}
+
 The Buffer API in Node.js is one of the most commonly used Node.js APIs for manipulating binary data. Every Buffer instance extends from the standard [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class, but adds a range of unique capabilities such as built-in base64 and hex encoding/decoding, byte-order manipulation, and encoding-aware substring searching.
 
 ```js

--- a/content/workers/runtime-apis/nodejs/util.md
+++ b/content/workers/runtime-apis/nodejs/util.md
@@ -7,11 +7,11 @@ title: util
 
 {{<render file="nodejs-compat-howto.md">}}
 
-## Promisify/Callbackify
+## promisify/callbackify
 
-The promisify and callbackify APIs in Node.js provide a means of bridging between a Promise-based programming model and a callback-based model.
+The `promisify` and `callbackify` APIs in Node.js provide a means of bridging between a Promise-based programming model and a callback-based model.
 
-The promisify method allows taking a Node.js-style callback function and converting it into a Promise-returning async function:
+The `promisify` method allows taking a Node.js-style callback function and converting it into a Promise-returning async function:
 
 ```js
 import { promisify } from 'node:util';
@@ -29,7 +29,7 @@ const promisifiedFoo = promisify(foo);
 await promisifiedFoo(args);
 ```
 
-Similarly, callbackify converts a Promise-returning async function into a Node.js-style callback function:
+Similarly to `promisify`, `callbackify` converts a Promise-returning async function into a Node.js-style callback function:
 
 ```js
 import { callbackify } from 'node:util';
@@ -45,13 +45,13 @@ callbackifiedFoo(args, (err, value) => {
 });
 ```
 
-Together these utilities make it easy to properly handle all of the the challenges that come with with properly bridging between callbacks and promises.
+`callbackify` and `promisify` make it easy to handle all of the the challenges that come with bridging between callbacks and promises.
 
-For more, refer to the Node.js documentation for [callbackify](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilcallbackifyoriginal) and [promisify](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilpromisifyoriginal).
+Refer to the [Node.js documentation for `callbackify`](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilcallbackifyoriginal) and [Node.js documentation for `promisify`](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilpromisifyoriginal) for more information.
 
 ## util.types
 
-The util.types API provides a reliable and generally more efficient way of checking that values are instances of various built-in types.
+The `util.types` API provides a reliable and efficient way of checking that values are instances of various built-in types.
 
 ```js
 import { types } from 'node:util';
@@ -73,4 +73,4 @@ types.isAsyncFunction(async function foo() {});  // Returns true
 The Workers implementation currently does not provide implementations of the `util.types.isExternal()`, `util.types.isProxy()`, `util.types.isKeyObject()`, or `util.type.isWebAssemblyCompiledModule()` APIs.
 {{</Aside>}}
 
-For more about `util.types`, refer to the [Node.js documentation for util](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utiltypes)].
+For more about `util.types`, refer to the [Node.js documentation for util](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utiltypes).

--- a/content/workers/runtime-apis/nodejs/util.md
+++ b/content/workers/runtime-apis/nodejs/util.md
@@ -5,6 +5,8 @@ title: util
 
 # util
 
+{{<render file="nodejs-compat-howto.md">}}
+
 ## Promisify/Callbackify
 
 The promisify and callbackify APIs in Node.js provide a means of bridging between a Promise-based programming model and a callback-based model.
@@ -67,7 +69,7 @@ types.isAsyncFunction(function foo() {});  // Returns false
 types.isAsyncFunction(async function foo() {});  // Returns true
 // .. and so on
 ```
-{{<Aside type="note">}}
+{{<Aside type="warning">}}
 The Workers implementation currently does not provide implementations of the `util.types.isExternal()`, `util.types.isProxy()`, `util.types.isKeyObject()`, or `util.type.isWebAssemblyCompiledModule()` APIs.
 {{</Aside>}}
 

--- a/content/workers/runtime-apis/nodejs/util.md
+++ b/content/workers/runtime-apis/nodejs/util.md
@@ -1,0 +1,74 @@
+---
+pcx_content_type: configuration
+title: util
+---
+
+# util
+
+## Promisify/Callbackify
+
+The promisify and callbackify APIs in Node.js provide a means of bridging between a Promise-based programming model and a callback-based model.
+
+The promisify method allows taking a Node.js-style callback function and converting it into a Promise-returning async function:
+
+```js
+import { promisify } from 'node:util';
+
+function foo(args, callback) {
+  try {
+    callback(null, 1);
+  } catch (err) {
+    // Errors are emitted to the callback via the first argument.
+    callback(err);
+  }
+}
+
+const promisifiedFoo = promisify(foo);
+await promisifiedFoo(args);
+```
+
+Similarly, callbackify converts a Promise-returning async function into a Node.js-style callback function:
+
+```js
+import { callbackify } from 'node:util';
+
+async function foo(args) {
+  throw new Error('boom');
+}
+
+const callbackifiedFoo = callbackify(foo);
+
+callbackifiedFoo(args, (err, value) => {
+  If (err) throw err;
+});
+```
+
+Together these utilities make it easy to properly handle all of the the challenges that come with with properly bridging between callbacks and promises.
+
+For more, refer to the Node.js documentation for [callbackify](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilcallbackifyoriginal) and [promisify](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utilpromisifyoriginal).
+
+## util.types
+
+The util.types API provides a reliable and generally more efficient way of checking that values are instances of various built-in types.
+
+```js
+import { types } from 'node:util';
+
+types.isAnyArrayBuffer(new ArrayBuffer());  // Returns true
+types.isAnyArrayBuffer(new SharedArrayBuffer());  // Returns true
+types.isArrayBufferView(new Int8Array());  // true
+types.isArrayBufferView(Buffer.from('hello world')); // true
+types.isArrayBufferView(new DataView(new ArrayBuffer(16)));  // true
+types.isArrayBufferView(new ArrayBuffer());  // false
+function foo() {
+  types.isArgumentsObject(arguments);  // Returns true
+}
+types.isAsyncFunction(function foo() {});  // Returns false
+types.isAsyncFunction(async function foo() {});  // Returns true
+// .. and so on
+```
+{{<Aside type="note">}}
+The Workers implementation currently does not provide implementations of the `util.types.isExternal()`, `util.types.isProxy()`, `util.types.isKeyObject()`, or `util.type.isWebAssemblyCompiledModule()` APIs.
+{{</Aside>}}
+
+For more about `util.types`, refer to the [Node.js documentation for util](https://nodejs.org/dist/latest-v19.x/docs/api/util.html#utiltypes)].

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -639,11 +639,11 @@ SECRET_KEY=value
 
 ## Node compatibility
 
-If you depend on node.js APIs, either directly in your own code or via a library you depend on, you can either use a subset of node.js APIs available directly in the Workers runtime, or add polyfills for a subset of node.js APIs to your own code.
+If you depend on Node.js APIs, either directly in your own code or via a library you depend on, you can either use a subset of Node.js APIs available directly in the Workers runtime, or add polyfills for a subset of node.js APIs to your own code.
 
 ### Use runtime APIs directly
 
-A [growing subset of node.js APIs](/workers/runtime-apis/nodejs/) are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` ](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
+A [growing subset of Node.js APIs](/workers/runtime-apis/nodejs/) are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` ](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
 
 ```toml
 ---
@@ -652,9 +652,9 @@ header: wrangler.toml
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
-### Add polyfills using wrangler
+### Add polyfills using Wrangler
 
-You can add polyfills for subset of node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
+Add polyfills for subset of Node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
 
 ```toml
 ---
@@ -663,7 +663,7 @@ header: wrangler.toml
 node_compat = true
 ```
 
-It is not possible to polyfill all Node APIs or behaviours, but it is possible to polyfill some of them.
+It is not possible to polyfill all Node APIs or behaviors, but it is possible to polyfill some of them.
 
 This is currently powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -643,7 +643,7 @@ If you depend on node.js APIs, either directly in your own code or via a library
 
 ### Use runtime APIs directly
 
-A [growing subset](/workers/runtime-apis/nodejs) of node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` compatibility flag](/workers/platform/compatibility-dates/#nodejs-compat) to your `wrangler.toml`:
+A [growing subset of node.js APIs](/workers/runtime-apis/nodejs/) are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` ](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
 
 ```toml
 ---

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -639,9 +639,31 @@ SECRET_KEY=value
 
 ## Node compatibility
 
-You can add experimental Node compatibility to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
+If you depend on node.js APIs, either directly in your own code or via a library you depend on, you can either use a subset of node.js APIs available directly in the Workers runtime, or add polyfills for a subset of node.js APIs to your own code.
 
-It is not possible to polyfill all Node APIs or behaviours, but it is possible to polyfill some of them. APIs such as `fs` cannot be replicated as Workers has no concept of a filesystem.
+### Use runtime APIs directly
+
+A [growing subset](/workers/runtime-apis/nodejs) of node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` compatibility flag](/workers/platform/compatibility-dates/#nodejs-compat) to your `wrangler.toml`:
+
+```toml
+---
+header: wrangler.toml
+---
+compatibility_flags = [ "nodejs_compat" ]
+```
+
+### Add polyfills using wrangler
+
+You can add polyfills for subset of node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
+
+```toml
+---
+header: wrangler.toml
+---
+node_compat = true
+```
+
+It is not possible to polyfill all Node APIs or behaviours, but it is possible to polyfill some of them.
 
 This is currently powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 


### PR DESCRIPTION
Merge this, then the AsyncLocalstorage docs https://github.com/cloudflare/cloudflare-docs/pull/7180

Documents how to use node.js _Runtime_ APIs with a Worker, documents available APIs.

**Adds docs on how to use the `nodejs_compat` compatibility flag to the following places**

- `/workers/wrangler/configuration/` (breaks existing `node_compat` section into two, to clarify difference between the `node_compat` _wrangler_ flag and the `nodejs_compat` compatibility flag)
- `/workers/platform/compatibility-dates/#nodejs-compatibility-flag` (adds a special section, distinct from other compatibility flags, for the `nodejs_compat` flag, since this flag is different from others, in that we never expect it to become the default, and we always want to highlight it above other flags, since it will be used much more often than most other flags)
- `/workers/runtime-apis/nodejs` (Reiterates how to opt-in to these APIs at the top of this page, as well as at the top of each API page)

...cross linking between them to help people understand concepts (compatibility flags, runtime APIs, and wrangler configuration)

**Documents the following APIs:**

- `Buffer`
- `EventEmitter`
- `util`
- `assert`