### PR TITLE
[1.1.1.1] Change link to 1.1.1.1 debug page to dual-stack website in check.md

### DIFF
--- a/content/1.1.1.1/setup/check.md
+++ b/content/1.1.1.1/setup/check.md
@@ -9,6 +9,6 @@ title: Verify 1.1.1.1 connection
 After setting up 1.1.1.1, you can check if you are correctly connected to Cloudflare's resolver.
 
 1. Open a web browser on a configured device (smartphone or computer) or on a device connected to your configured router.
-2. Enter [https://1.1.1.1/help](https://1.1.1.1/help) on the browser address bar.
+2. Enter [https://1.1.1.1/help](https://one.one.one.one/help) on the browser address bar.
 
 Wait for the page to load and run its tests. The page will present you a summary of the type of connection you have to 1.1.1.1, as well as the Cloudflare data center you are connected to.


### PR DESCRIPTION
- Changed hyperlink destination from `https://1.1.1.1/help` to `https://one.one.one.one/help`

Using the IPv4 address 1.1.1.1 in the hyperlink makes the debug page unreachable for anyone who doesn't have access to IPv4. Using the domain one.one.one.one will allow both IPv4-only and IPv6-only users, and in my opinion should be used instead. Similar to #5821.