### PR TITLE
[API] Handle Redirects via Functions

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -131,26 +131,7 @@
 /argo-tunnel/trycloudflare/ /cloudflare-one/connections/connect-apps/install-and-setup/ 301
 
 # api
-/api/v4docs/ /fundamentals/api/how-to/make-api-calls/ 301
-/api/tokens/ /fundamentals/api/get-started/ 301
-/api/tokens/create/ /fundamentals/api/get-started/create-token/ 301
-/api/tokens/create/template/ /fundamentals/api/reference/template/ 301
-/api/tokens/create/permissions/ /fundamentals/api/reference/permissions/ 301
-/api/tokens/advanced/ /fundamentals/api/how-to/ 301
-/api/tokens/advanced/restrictions/ /fundamentals/api/how-to/restrict-tokens/ 301
-/api/tokens/advanced/api/ /fundamentals/api/how-to/create-via-api/ 301
-/api/keys/ /fundamentals/api/get-started/keys/ 301
-/api/limits/ /fundamentals/api/reference/limits/ 301
-/api/how-to/make-api-calls/ /fundamentals/api/how-to/make-api-calls/ 301
-/api/get-started/ /fundamentals/api/get-started/ 301
-/api/get-started/create-token/ /fundamentals/api/get-started/create-token/ 301
-/api/reference/template/ /fundamentals/api/reference/template/ 301
-/api/reference/permissions/ /fundamentals/api/reference/permissions/ 301
-/api/how-to/ /fundamentals/api/how-to/ 301
-/api/how-to/restrict-tokens/ /fundamentals/api/how-to/restrict-tokens/ 301
-/api/how-to/create-via-api/ /fundamentals/api/how-to/create-via-api/ 301
-/api/get-started/keys/ /fundamentals/api/get-started/keys/ 301
-/api/reference/limits/ /fundamentals/api/reference/limits 301
+# moved to functions/api/redirects.ts
 
 # api-shield
 /api-shield/security/sequential-abuse-detection/ /api-shield/security/sequence-analytics/ 301

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -1,3 +1,5 @@
+import redirects from "./redirects"
+
 const apiBase = "https://cloudflare-api-docs-frontend.pages.dev"
 
 const rewriteStaticAssets = {
@@ -25,7 +27,15 @@ export const onRequestGet: PagesFunction<{}> = async ({ request }) => {
 
   const url = new URL(request.url)
 
-  const subpath = url.pathname.replace(apiPath, "")
+  let subpath = url.pathname.replace(apiPath, "")
+  // Local Pages dev server doesn't appear to force trailing slash, this is a workaround
+  if(subpath.slice(-1) !== "/") {
+    subpath = `${subpath}/`
+  }
+  if(subpath in redirects) {
+    url.pathname = redirects[subpath]
+    return Response.redirect(url.toString(), 301)
+  }
   const proxyUrl = `${apiBase}/${subpath}`
   const proxyResponse = await fetch(proxyUrl)
 

--- a/functions/api/redirects.ts
+++ b/functions/api/redirects.ts
@@ -1,0 +1,22 @@
+export default {
+  "/v4docs/": "/fundamentals/api/how-to/make-api-calls/",
+  "/tokens/": "/fundamentals/api/get-started/",
+  "/tokens/create/": "/fundamentals/api/get-started/create-token/",
+  "/tokens/create/template/": "/fundamentals/api/reference/template/",
+  "/tokens/create/permissions/": "/fundamentals/api/reference/permissions/",
+  "/tokens/advanced/": "/fundamentals/api/how-to/",
+  "/tokens/advanced/restrictions/": "/fundamentals/api/how-to/restrict-tokens/",
+  "/tokens/advanced/api/": "/fundamentals/api/how-to/create-via-api/",
+  "/keys/": "/fundamentals/api/get-started/keys/",
+  "/limits/": "/fundamentals/api/reference/limits/",
+  "/how-to/make-api-calls/": "/fundamentals/api/how-to/make-api-calls/",
+  "/get-started/": "/fundamentals/api/get-started/",
+  "/get-started/create-token/": "/fundamentals/api/get-started/create-token/",
+  "/reference/template/": "/fundamentals/api/reference/template/",
+  "/reference/permissions/": "/fundamentals/api/reference/permissions/",
+  "/how-to/": "/fundamentals/api/how-to/",
+  "/how-to/restrict-tokens/": "/fundamentals/api/how-to/restrict-tokens/",
+  "/how-to/create-via-api/": "/fundamentals/api/how-to/create-via-api/",
+  "/get-started/keys/": "/fundamentals/api/get-started/keys/",
+  "/reference/limits/": "/fundamentals/api/reference/limits"
+}


### PR DESCRIPTION
Functions take precedence over `_redirects`. This PR patches redirects for `/api` to be handled via the `/api` Function, so they are functional.

Closes #8161