### PR TITLE
Update wrangler docs for mtls file structure

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1764,7 +1764,7 @@ $ wrangler mtls-certificate upload [OPTIONS]
 - `--cert` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
   - A path to the TLS certificate to upload. Certificate chains are supported
 - `--key` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-  - A path the private key to upload.
+  - A path to the private key to upload.
 - `--name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
 {{</definitions>}}
@@ -1787,6 +1787,8 @@ mtls_certificates = [
   { binding = "MY_CERT", certificate_id = "99f5fef1-6cc1-46b8-bd79-44a0d5082b8d" }
 ]
 ```
+
+Note that the certificate and private key must be in separate (typically `.pem`) files when uploading
 {{</Aside>}}
 
 ### `list`

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1788,7 +1788,7 @@ mtls_certificates = [
 ]
 ```
 
-Note that the certificate and private key must be in separate (typically `.pem`) files when uploading
+Note that the certificate and private keys must be in separate (typically `.pem`) files when uploading.
 {{</Aside>}}
 
 ### `list`


### PR DESCRIPTION
While .pem files can contain multiple entities of different types (certificates and private keys) due to the lack of a standard for the format, Wrangler currently only accepts a .pem file with certificates in it for `--cert` and a .pem file with a private key in it for `--key` when using the `mtls-certificate upload` command.

This updates the documentation for the command to reflect that.

Also fixes a type in the definitions for the command

Resolves #8114