### PR TITLE
queues: remove concurrency warning

### DIFF
--- a/content/queues/changelog.md
+++ b/content/queues/changelog.md
@@ -7,6 +7,12 @@ rss: file
 
 # Changelog
 
+## 2023-03-28
+
+### Consumer concurrency (enabled)
+
+Queue consumers will now [automatically scale up](/queues/learning/consumer-concurrency/) based on the number of messages being written to the queue. To control or limit concurrency, you can explicitly define a [`max_concurrency`](/queues/platform/configuration/#consumer) for your consumer.
+
 ## 2023-03-15
 
 ### Consumer concurrency (upcoming)

--- a/content/queues/learning/consumer-concurrency.md
+++ b/content/queues/learning/consumer-concurrency.md
@@ -14,16 +14,6 @@ Note that queue producers are always scalable, up to the [maximum supported mess
 
 ## Enable concurrency
 
-{{<Aside type="warning">}}
-
-Queue consumers will soon automatically scale up concurrently as a queues' backlog grows in order to keep overall message processing latency down. Concurrency will be enabled on all existing queues by 2023-03-28.
-
-**To opt-out, or to configure a fixed maximum concurrency**, set `max_concurrency = 1` in your `wrangler.toml` file or via [the queues dashboard](https://dash.cloudflare.com/?to=/:account/queues).
-
-**To opt-in to concurrency, you do not need to take any action**: your consumer will begin to scale out as needed to keep up with your message backlog. It will scale back down as the backlog shrinks, and/or if a consumer starts to generate a higher rate of errors. To learn more about how consumers scale, refer to the [consumer concurrency](/queues/learning/consumer-concurrency/) documentation.
-
-{{</Aside>}}
-
 By default, all queues have concurrency enabled. Queue consumers will automatically scale up [to the maximum concurrent invocations](/queues/platform/limits/) as needed to manage a queue's backlog and/or error rates. 
 
 ## How concurrency works 


### PR DESCRIPTION
Concurrency is now live for all! 🥳 