### PR TITLE
[Pages] Update `local-development.md`

### DIFF
--- a/content/pages/platform/functions/local-development.md
+++ b/content/pages/platform/functions/local-development.md
@@ -22,13 +22,21 @@ With your folder of static assets set up, run the following command to start loc
 $ npx wrangler pages dev <DIRECTORY-OF-ASSETS>
 ```
 
-This will then start serving your Pages project. You can press `B` to open the browser on your local site.
+This will then start serving your Pages project. You can press `b` to open the browser on your local site.
 
 If you are using a framework, you can pass through the framework-provided dev command (such as, `npm run dev`) to run development. This enables you to benefit from the framework hot-reloading and any special build process around it. To run a framework-provided dev command:
 
 ```sh
 $ npx wrangler pages dev -- <COMMAND>
 ```
+
+This will start a local Wrangler development server that serves your Pages project. It will also spawn a new process, running the provided `<COMMAND>`. This provided command is expected to start its own local server, which serves static assets. Wrangler will proxy requests for assets to this underlying server. You can press `b` to open the browser on your local site, (available, by default, on [http://localhost:8788](http://localhost:8788)).
+
+{{<Aside type="note">}}
+
+`npx wrangler pages dev -- <COMMAND>` does not have support for Pages specific metafiles, such as `_headers`, `_redirects` or `_routes.json`. When running in this proxy mode, the local development server will ignore any of these files and the respective rules they declare. If your project uses these metafiles, use the `npx wrangler pages dev <DIRECTORY-OF-ASSETS>` command instead.
+
+{{</Aside>}}
 
 ### HTTPS support
 


### PR DESCRIPTION
This commit adds some extra clarifications regarding how the `wrangler pages dev -- <COMMAND>` command works.

It also adds a note section detailing available support for Pages specific metafiles, such as `_headers`, `_redirects` and `_routes.json`.

Fixes #7240