### PR TITLE
[Rules] Cannot remove `x-forwarded-for` header

### DIFF
--- a/content/rules/transform/request-header-modification/_index.md
+++ b/content/rules/transform/request-header-modification/_index.md
@@ -23,7 +23,7 @@ To modify HTTP headers in the **response**, refer to [HTTP Response Header Modif
 
 *   You cannot modify or remove HTTP request headers whose name starts with `x-cf-` or `cf-` except for the `cf-connecting-ip` HTTP request header, which you can remove.
 
-*   You cannot modify the value of any header commonly used to identify the website visitor's IP address, such as `x-forwarded-for`, `true-client-ip`, or `x-real-ip`.
+*   You cannot modify the value of any header commonly used to identify the website visitor's IP address, such as `x-forwarded-for`, `true-client-ip`, or `x-real-ip`. Additionally, you cannot remove the `x-forwarded-for` header.
 
 *   If you modify the value of an existing HTTP request header using an expression that evaluates to an empty string (`""`) or an undefined value, the HTTP request header is **removed**.
 


### PR DESCRIPTION
Closes #4741.
