### PR TITLE
Change order of where list of APIs appears on Node.js compat page

### DIFF
--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -5,7 +5,11 @@ title: Node.js compatibility
 
 # Node.js compatibility
 
-The following APIs from Node.js are available directly in the Workers runtime. To enable these APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
+The following APIs from Node.js are available directly in the Workers runtime.
+
+{{<directory-listing>}}
+
+To enable these APIs in your Worker, add the [`nodejs_compat`](/workers/platform/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
 
 ```toml
 ---
@@ -22,5 +26,3 @@ If you are using [Pages Functions](/pages/platform/functions/), set compatibilit
 2. Select **Pages** and select your Pages project.
 3. Select **Settings** > **Functions** > **Compatibility Flags**.
 4. Configure your Production and Preview compatiblity flags as needed.
-
-{{<directory-listing>}}


### PR DESCRIPTION
Ordering of content on this page got squirrely.

**Before**

<img width="1101" alt="Screenshot 2023-03-31 at 4 55 18 PM" src="https://user-images.githubusercontent.com/1221592/229251955-0d9a0f8f-50f8-4102-8be2-5d16baad3913.png">


**After:**

<img width="1097" alt="Screenshot 2023-03-31 at 4 54 50 PM" src="https://user-images.githubusercontent.com/1221592/229251930-6da81d91-8926-4f35-8247-6e36444c57a8.png">
