### PR TITLE
[Cache] Clarify meaning of Edge Cache TTL

### DIFF
--- a/content/cache/about/edge-browser-cache-ttl.md
+++ b/content/cache/about/edge-browser-cache-ttl.md
@@ -7,7 +7,7 @@ pcx_content_type: concept
 
 ## Edge Cache TTL
 
-Edge Cache TTL (Time to Live) specifies how long to cache a resource in the Cloudflare edge network. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
+Edge Cache TTL (Time to Live) specifies the maximimum time to cache a resource in the Cloudflare edge network. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
 
 {{<feature-table id="cache.edge_cache_ttl">}}
 


### PR DESCRIPTION
Many customers believe that setting a high Edge Cache TTL of e.g. 1 year will make Cloudflare always cache their site content for a full year and raise queries to support and community when this is not the case.

My small wording tweak is a suggestion, I believe we should be clearer that the TTL is a maximum and not a guarantee. 

It may also be beneficial to direct users who need better guarantees to Cache Reserve, which will fulfil the 1 year TTL as long as there is 1 request every 30 days: https://developers.cloudflare.com/cache/about/cache-reserve/