### PR TITLE
Add note about --experimental-local and nodejs_compat interaction

### DIFF
--- a/content/workers/_partials/_nodejs-compat-local-dev.md
+++ b/content/workers/_partials/_nodejs-compat-local-dev.md
@@ -1,0 +1,10 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="warning">}}
+When using the `nodejs_compat` compatibility flag in local development, you must use [`wrangler dev --experimental-local`](https://developers.cloudflare.com/workers/wrangler/commands/#dev) instead of `wrangler dev --local`. [`--experimental-local` will soon become the default](https://blog.cloudflare.com/miniflare-and-workerd/) for local development in Wrangler.
+{{</Aside>}}

--- a/content/workers/_partials/_nodejs-compat-local-dev.md
+++ b/content/workers/_partials/_nodejs-compat-local-dev.md
@@ -6,5 +6,5 @@ _build:
 ---
 
 {{<Aside type="warning">}}
-When using the `nodejs_compat` compatibility flag in local development, you must use [`wrangler dev --experimental-local`](https://developers.cloudflare.com/workers/wrangler/commands/#dev) instead of `wrangler dev --local`. [`--experimental-local` will soon become the default](https://blog.cloudflare.com/miniflare-and-workerd/) for local development in Wrangler.
+When using the `nodejs_compat` compatibility flag in local development, you must use [`wrangler dev --experimental-local`](https://developers.cloudflare.com/workers/wrangler/commands/#dev) instead of `wrangler dev --local`. `--experimental-local` [will soon become the default](https://blog.cloudflare.com/miniflare-and-workerd/) for local development in Wrangler.
 {{</Aside>}}

--- a/content/workers/platform/compatibility-dates.md
+++ b/content/workers/platform/compatibility-dates.md
@@ -58,6 +58,8 @@ header: wrangler.toml
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
+{{<render file="_nodejs-compat-local-dev.md">}}
+
 As additional Node.js APIs are added, they will be made available under the `nodejs_compat` compatibility flag. Unlike most other compatibility flags, we do not expect the `nodejs_compat` to become active by default at a future date.
 
 ## Change history

--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -18,6 +18,8 @@ header: wrangler.toml
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
+{{<render file="_nodejs-compat-local-dev.md">}}
+
 ## Pages Functions
 
 If you are using [Pages Functions](/pages/platform/functions/), set compatibility flags using the [Pages-specific CLI commands](/workers/wrangler/commands/#dev-1). To set Pages compatibility flags in the Cloudflare dashboard:

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -670,6 +670,8 @@ header: wrangler.toml
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
+{{<render file="_nodejs-compat-local-dev.md">}}
+
 ### Add polyfills using Wrangler
 
 Add polyfills for subset of Node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.


### PR DESCRIPTION
Explains that `--experimental-local` must be used instead of `--local` when `nodejs_compat` is enabled.

supercedes https://github.com/cloudflare/cloudflare-docs/pull/8276
refs https://github.com/cloudflare/workers-sdk/issues/1074#issuecomment-1488840350