### PR TITLE
bindings per environment guidance w/ example toml

### DIFF
--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -228,6 +228,30 @@ Published my-worker
   https://my-worker.<your-subdomain>.workers.dev
 ```
 
+### Bindings and Environments
+
+Bindings are defined per environment and are not shared between environments.  Below is an example of a service binding for a dev and production environment:
+
+```toml
+---
+filename: wrangler.toml
+---
+name = "my-worker-dev"
+
+[[ services ]]
+binding = "SERVICE_WORKER"
+service = "service-worker"
+environment = "dev"
+
+[env.production]
+name = "my-worker"
+
+[[ env.production.services ]]
+binding = "SERVICE_WORKER"
+service = "service-worker"
+environment = "production"
+```
+
 {{<Aside type="note">}}
 
 When you create a Service or Environment, Cloudflare automatically registers an SSL certification for it. SSL certifications are discoverable and a matter of public record. Be careful when naming your Services and Environments that they do not contain sensitive information i.e `migrating-service-from-company1-to-company2` or `company1-acquisition-load-test`.

--- a/content/workers/platform/environments.md
+++ b/content/workers/platform/environments.md
@@ -228,9 +228,11 @@ Published my-worker
   https://my-worker.<your-subdomain>.workers.dev
 ```
 
-### Bindings and Environments
+### Non-inheritable keys and environments
 
-Bindings are defined per environment and are not shared between environments.  Below is an example of a service binding for a dev and production environment:
+[Non-inheritable keys](/workers/wrangler/configuration/#non-inheritable-keys) cannot be inherited by environments and must be specified for each environment.
+
+Below is an example of a service binding for the default target and production environment:
 
 ```toml
 ---
@@ -241,15 +243,13 @@ name = "my-worker-dev"
 [[ services ]]
 binding = "SERVICE_WORKER"
 service = "service-worker"
-environment = "dev"
 
 [env.production]
 name = "my-worker"
 
 [[ env.production.services ]]
 binding = "SERVICE_WORKER"
-service = "service-worker"
-environment = "production"
+service = "service-worker-production"
 ```
 
 {{<Aside type="note">}}


### PR DESCRIPTION
Added a simple example for bindings per environment.  Couldn't find any docs on this and it caused a minor issue in our project.

Problem: Some bindings are not inherited by environments.  `wrangler` prints an error message about this but there is no mention of it in the docs.

Solution:  Added section to `environment.md` with guidance and example toml