### PR TITLE
Fix TOML section in D1 docs

### DIFF
--- a/content/d1/get-started.md
+++ b/content/d1/get-started.md
@@ -67,7 +67,7 @@ You must create a binding for your Worker to connect to your D1 database. [Bindi
 To bind your D1 database to your Worker, add the following to your `wrangler.toml` file:
 
 ```toml
-[[ d1_databases ]]
+[[d1_databases]]
 binding = "<BINDING_NAME>"
 database_name = "<DATABASE_NAME>"
 database_id = "<UUID>"


### PR DESCRIPTION
```toml
[[ d1_databases ]]
    binding = "DB"  
```
should be this
```toml
[[d1_databases]]
    binding = "DB"  
```

Otherwise this happens
![image](https://user-images.githubusercontent.com/33439542/230156187-d6e4ea23-7669-4833-8888-6056ff5d6ee0.png)
