### PR TITLE
Add link to cache using fetch() example

### DIFF
--- a/content/workers/runtime-apis/cache.md
+++ b/content/workers/runtime-apis/cache.md
@@ -227,5 +227,6 @@ The `cache.delete` method only purges content of the cache in the data center th
 
 - [How the Cache works](/workers/learning/how-the-cache-works/)
 - [Configure your CDN](/workers/tutorials/configure-your-cdn/)
+- [Example: Cache using `fetch()`](/workers/examples/cache-using-fetch/)
 - [Example: using the Cache API](/workers/examples/cache-api/)
 - [Example: caching POST requests](/workers/examples/cache-post-request/)


### PR DESCRIPTION
Found in reviewing https://github.com/cloudflare/cloudflare-docs/pull/7765 that we don't link to this example from the Cache API page