### PR TITLE
[Workers] Overview page revision

### DIFF
--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -3,7 +3,7 @@ title: Overview
 type: overview
 pcx_content_type: overview
 weight: 1
-layout: list
+layout: overview
 meta:
   title: Cloudflare Workers
 ---
@@ -42,7 +42,7 @@ Bindings allow your Workers to interact with resources on the Cloudflare develop
 
 {{<feature header="Playground" href="/workers/learning/playground/">}}
 
-The Playground is a sandbox which gives an instant way to preview and test a Workers script directly in the browser against any site. No setup required.
+The Playground is a sandbox which gives you an instant way to preview and test a Workers script directly in the browser against any site. No setup required.
 
 {{</feature>}}
 

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -36,7 +36,7 @@ The Workers command-line interface, Wrangler, allows you to [create](/workers/wr
 
 {{<feature header="Bindings" href="/workers/platform/bindings/">}}
 
-Bindings allow your Workers to interact with resources on the Cloudflare developer platform, including [R2](/r2/), [KV](/learning/how-kv-works/), [Durable Objects](/workers/learning/using-durable-objects/), and [D1](/d1/).
+Bindings allow your Workers to interact with resources on the Cloudflare developer platform, including [R2](/r2/), [KV](workers/learning/how-kv-works/), [Durable Objects](/workers/learning/using-durable-objects/), and [D1](/d1/).
 
 {{</feature>}}
 

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -5,84 +5,81 @@ pcx_content_type: overview
 weight: 1
 layout: list
 meta:
-  title: Cloudflare Workers documentation
+  title: Cloudflare Workers
 ---
 
 {{<content-column>}}
 
-# Cloudflare Workers documentation
+# Cloudflare Workers
 
-Cloudflare Workers provides a [serverless](https://www.cloudflare.com/learning/serverless/what-is-serverless/) execution environment that allows you to create entirely new applications or augment existing ones without configuring or maintaining infrastructure.
+{{<description>}}
+Build serverless applications and deploy instantly across the globe for exceptional performance, reliability, and scale.
+{{</description>}}
 
-Cloudflare Workers runs on [Cloudflare’s global network](https://www.cloudflare.com/learning/serverless/glossary/what-is-edge-computing/) in over 200 cities around the world, offering both [free and paid plans](/workers/platform/pricing/).
+{{<plan type="all">}}
+ 
+Cloudflare Workers provides a [serverless](https://www.cloudflare.com/learning/serverless/what-is-serverless/) execution environment that allows you to create new applications or augment existing ones without configuring or maintaining infrastructure. 
 
-Learn more about [how Workers works](/workers/learning/how-workers-works/).
+Cloudflare Workers runs on [Cloudflare’s global network](https://www.cloudflare.com/learning/serverless/glossary/what-is-edge-computing/) in over 200 cities around the world, offering both [Free and Paid plans](/workers/platform/pricing/).
+ 
+---
 
-{{<button-group>}}
-{{<button type="primary" href="/workers/get-started/guide">}}Get started{{</button>}}
-{{<button type="secondary" href="/workers/tutorials">}}View the tutorials{{</button>}}
-{{<button type="secondary" href="/workers/platform/betas">}}Explore betas{{</button>}}
-{{<button type="secondary" href="/workers/platform/storage-objects">}}Storage options guide{{</button>}}
-{{</button-group>}}
+## Features
+ 
+{{<feature header="Wrangler" href="/workers/wrangler/install-and-update/">}}
+
+The Workers command-line interface, Wrangler, allows you to [create](/workers/wrangler/commands/#init), [test](/workers/wrangler/commands/#dev), and [deploy](/workers/wrangler/commands/#publish) your Workers projects.
+
+{{</feature>}}
+
+{{<feature header="Bindings" href="/workers/platform/bindings/">}}
+
+Bindings allow your Workers to interact with resources on the Cloudflare developer platform, including [R2](/r2/), [KV](/learning/how-kv-works/), [Durable Objects](/workers/learning/using-durable-objects/), and [D1](/d1/).
+
+{{</feature>}}
+
+{{<feature header="Playground" href="/workers/learning/playground/">}}
+
+The Playground is a sandbox which gives an instant way to preview and test a Workers script directly in the browser against any site. No setup required.
+
+{{</feature>}}
 
 ---
 
-## Installing the Workers CLI
+## Related products
+ 
+{{<related header="R2" href="/r2/" product="r2">}}
 
-To install [`wrangler`](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [`npm` installed](https://docs.npmjs.com/getting-started), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to easily change Node.js versions. Then run:
+Cloudflare R2 Storage allows developers to store large amounts of unstructured data without the costly egress bandwidth fees associated with typical cloud storage services.
 
-```sh
-$ npm install -g wrangler
-```
+{{</related>}}
 
-or install with `yarn`:
+{{<related header="Queues" href="/queues/" product="queues">}}
 
-```sh
-$ yarn global add wrangler
-```
+Cloudflare Queues integrates with Cloudflare Workers to allow developers to send and receive messages with guaranteed delivery, offering at-least once delivery, message batching, and no charge for egress bandwidth.
 
-Read more about [installing Wrangler](/workers/wrangler/install-and-update/).
+{{</related>}}
 
 ---
 
-## Playground
+## More resources
+ 
+{{<resource-group>}}
+ 
+{{<resource header="Plans" href="/workers/platform/pricing/" icon="price">}}Learn about Free and Paid plans.{{</resource>}}
+ 
+{{<resource header="Limits" href="/workers/platform/limits/" icon="documentation-clipboard">}}Learn about plan limits (Free plans get 100,000 requests per day).{{</resource>}}
 
-View this Hello World example in the Workers playground:
+{{<resource header="HTMLRewriter" href="/workers/runtime-apis/html-rewriter/" icon="reference-architecture">}}Parse and transform HTML from inside a Worker.{{</resource>}}
 
-```js
----
-header: Module syntax
----
-export default {
-  async fetch(request) {
-    return new Response("Hello World!");
-  },
-};
-```
+{{<resource header="Storage options" href="/workers/platform/storage-objects/" icon="documentation-clipboard">}}Learn which storage option is best for your project.{{</resource>}}
 
-{{<button-group>}}
-{{<button type="primary" href="https://cloudflareworkers.com/?_gl=1*18yfays*_ga*MTUzMDY1NDM1NS4xNjU5NTMxOTI3*_gid*ODI3NTE3MjI0LjE2NTk1MzE5Mjc.#68813a741e791a07c49fd1aa01359cc6:about:blank">}}Launch playground{{</button>}}
-{{<button type="secondary" href="/workers/learning/playground">}}Learn more{{</button>}}
-{{</button-group>}}
+{{<resource header="Developer Discord" href="https://discord.gg/cloudflaredev" icon="logo-Discord">}}Connect with the Workers community on Discord to ask questions, show what you are building, and discuss the platform with other developers.{{</resource>}}
 
----
+{{<resource header="@CloudflareDev" href="https://twitter.com/cloudflaredev" icon="twitter">}}Follow @CloudflareDev on Twitter to learn about product announcements, and what is new in Cloudflare Workers.{{</resource>}}
 
-## Related resources
-
-- [How Workers works](/workers/learning/how-workers-works/) – Learn how Cloudflare’s global network powers Workers.
-- [Pricing](/workers/platform/pricing/) – Learn about the Free and Bundled plans.
-- [HTMLRewriter](/workers/runtime-apis/html-rewriter/) – Parse and transform HTML from inside a Worker.
-- [Limits](/workers/platform/limits/) – Learn about plan limits (Free plans get 100,000 req/day).
-- [Storage options guide](/workers/platform/storage-objects/) - Learn which storage option is best for your project.
-
----
-
-## Community
-
-[Explore third-party packages](https://workers.cloudflare.com/works) that work on Workers, submitted by Cloudflare users.
-
-[Connect with the Workers community on Discord](https://discord.gg/cloudflaredev) to ask questions, show off what you are building, and discuss the platform with other developers.
-
-[Follow @CloudflareDev on Twitter](https://twitter.com/cloudflaredev) to learn about product announcements, new tutorials, and what is new in Cloudflare Workers.
+{{<resource header="Works on Workers" href="https://workers.cloudflare.com/works" icon="learning-center-book">}}Explore third-party packages that work on Workers, submitted by Cloudflare users.{{</resource>}}
+ 
+{{</resource-group>}}
 
 {{</content-column>}}

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -36,7 +36,7 @@ The Workers command-line interface, Wrangler, allows you to [create](/workers/wr
 
 {{<feature header="Bindings" href="/workers/platform/bindings/">}}
 
-Bindings allow your Workers to interact with resources on the Cloudflare developer platform, including [R2](/r2/), [KV](workers/learning/how-kv-works/), [Durable Objects](/workers/learning/using-durable-objects/), and [D1](/d1/).
+Bindings allow your Workers to interact with resources on the Cloudflare developer platform, including [R2](/r2/), [KV](/workers/learning/how-kv-works/), [Durable Objects](/workers/learning/using-durable-objects/), and [D1](/d1/).
 
 {{</feature>}}
 

--- a/content/workers/_index.md
+++ b/content/workers/_index.md
@@ -21,6 +21,8 @@ Build serverless applications and deploy instantly across the globe for exceptio
 Cloudflare Workers provides a [serverless](https://www.cloudflare.com/learning/serverless/what-is-serverless/) execution environment that allows you to create new applications or augment existing ones without configuring or maintaining infrastructure. 
 
 Cloudflare Workers runs on [Cloudflare’s global network](https://www.cloudflare.com/learning/serverless/glossary/what-is-edge-computing/) in over 200 cities around the world, offering both [Free and Paid plans](/workers/platform/pricing/).
+
+{{<render file="_non-contract-enablement.md" productFolder="fundamentals" >}}
  
 ---
 

--- a/content/workers/get-started/guide.md
+++ b/content/workers/get-started/guide.md
@@ -18,7 +18,7 @@ The quickest way to experiment with Cloudflare Workers is in the [Playground](ht
 
 ## 1. Start a new project with Wrangler (the Workers CLI)
 
-The Workers command-line interface, Wrangler, allows you to [`init`](/workers/wrangler/commands/#init), [`dev`](/workers/wrangler/commands/#dev), and [`publish`](/workers/wrangler/commands/#publish) your Workers projects.
+The Workers command-line interface, Wrangler, allows you to [create](/workers/wrangler/commands/#init), [test](/workers/wrangler/commands/#dev), and [deploy](/workers/wrangler/commands/#publish) your Workers projects.
 
 To use [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [`npm` installed](https://docs.npmjs.com/getting-started), preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to easily change Node.js versions.
 

--- a/content/workers/platform/bindings/_index.md
+++ b/content/workers/platform/bindings/_index.md
@@ -6,7 +6,7 @@ layout: single
 
 # Bindings
 
-Bindings allow your Workers to interact with resources on the Workers platform. 
+Bindings allow your Workers to interact with resources on the Cloudflare developer platform. 
 
 There are multiple types of bindings available today.
 


### PR DESCRIPTION
Conform to style guide's Overview (Landing Page) layout: PCX-6511.

Before:
<img width="314" alt="Screenshot 2023-04-06 at 13 57 19" src="https://user-images.githubusercontent.com/70746074/230385663-f01431bc-edf7-4f7f-aed9-0a7da6c9f246.png">

After:

<img width="430" alt="Screenshot 2023-04-06 at 13 56 12" src="https://user-images.githubusercontent.com/70746074/230385701-93363427-3446-4932-9998-55fbe92bc1c1.png">
<img width="496" alt="Screenshot 2023-04-06 at 13 56 29" src="https://user-images.githubusercontent.com/70746074/230385722-8fa28418-da2b-437b-a43b-7bc8952ce961.png">
