### PR TITLE
Clarify that no logs are stored on Cloudflare with v2

### DIFF
--- a/content/logs/about/index.md
+++ b/content/logs/about/index.md
@@ -10,7 +10,7 @@ Logpush delivers logs in less than one minute with batches of no more than 100,0
 
 Prior to mid-2020, Logpush sent logs once every five minutes (referred to as Logpush v1). The change to more frequent log pushing allows Cloudflare to deliver information to you as close to real time as possible in smaller files. You may receive log files that contain fewer lines - that is expected. If you have legacy Logpush jobs configured to the old settings, use the Logpush API to upgrade your job to Logpush v2. All new jobs will use Logpush v2 by default.
 
-Please note that with the Logpush v2 no logs are stored on the Cloudflare side.
+Logpush v2 does not store logs; we attempt to send logs as quickly as they arrive. In the event of an error or loss of connection, logs may be buffered for up to a few hours before being dropped. Please note that Logpush itself does not provide a way to store or search logs. 
 
 ## Availability
 

--- a/content/logs/about/index.md
+++ b/content/logs/about/index.md
@@ -10,6 +10,8 @@ Logpush delivers logs in less than one minute with batches of no more than 100,0
 
 Prior to mid-2020, Logpush sent logs once every five minutes (referred to as Logpush v1). The change to more frequent log pushing allows Cloudflare to deliver information to you as close to real time as possible in smaller files. You may receive log files that contain fewer lines - that is expected. If you have legacy Logpush jobs configured to the old settings, use the Logpush API to upgrade your job to Logpush v2. All new jobs will use Logpush v2 by default.
 
+Please note that with the Logpush v2 no logs are stored on the Cloudflare side.
+
 ## Availability
 
 {{<feature-table id="analytics.logpush">}}


### PR DESCRIPTION
Clarify that no logs are stored on Cloudflare with v2, following an email thread with JPL