### PR TITLE
[Workers] add route uniqueness section. update headings. update structure.

### DIFF
--- a/content/workers/platform/triggers/routes.md
+++ b/content/workers/platform/triggers/routes.md
@@ -9,7 +9,7 @@ title: Routes
 
 Routes allow users to map a URL pattern to a Worker script to enable Workers to run in front of [Custom Domains](/workers/platform/triggers/custom-domains/) or their own external application servers. Customers must manually create DNS records and certificates for Routes to invoke over HTTP(S).
 
-## Customize your routes
+## Customize routes
 
 For zones proxied on Cloudflare, route patterns decide what (if any) script is matched based on the URL of that request. Requests are routed through a Workers script when the URL matches a route pattern assigned to that script. To add a Route, you must have:
 
@@ -38,7 +38,7 @@ Cloudflare Workers accounts come with a `*.workers.dev` subdomain that is config
 
 To claim a `*.workers.dev` subdomain, such as `<YOUR_SUBDOMAIN>.workers.dev`, go to **Account Home** > [**Workers**](https://dash.cloudflare.com/?zone=workers) > **Your subdomain**. The `name` field in your Worker configuration is used as the preview subdomain for the deployed script, (for example, `my-worker.<YOUR_SUBDOMAIN>.workers.dev.`).
 
-### Matching Behavior
+## Route matching behavior
 
 Route patterns look like this:
 
@@ -76,31 +76,23 @@ A route can be specified without being associated with a Worker. This will act t
 
 In this example, all requests destined for example.com and whose paths are prefixed by `/images/` would be routed to `worker-script`, _except_ for `/images/cat.png`, which would bypass Workers completely. Requests with a path of `/images/cat.png?foo=bar` would be routed to `worker-script`, due to the presence of the query string.
 
-## Configure your `wrangler.toml`
+## Route uniqueness
 
-To configure a route in your `wrangler.toml`, add the following to your environment:
+Multiple Workers can not be associated with the same route. In the example above, once the route pattern `example.com/about` has been configured for a Worker, if another Worker tries to associate itself with that route, a duplicate route error will be thrown.
 
-```toml
-routes = [
-    { pattern = "example.com/about", zone_id = "<YOUR_ZONE_ID>" }
-]
-```
-
-If you have specified your zone ID in the environment of your `wrangler.toml`, you will not need to write it again in object form.
-
-### Validity
+## Route validation
 
 The following set of rules govern route pattern validity.
 
-#### Route patterns must include your zone
+### Route patterns must include your zone
 
 If your zone is `example.com`, then the simplest possible route pattern you can have is `example.com`, which would match `http://example.com/` and `https://example.com/`, and nothing else. As with a URL, there is an implied path of `/` if you do not specify one.
 
-#### Route patterns may not contain any query parameters
+### Route patterns may not contain any query parameters
 
 For example, `https://example.com/?anything` is not a valid route pattern.
 
-#### Route patterns may optionally begin with http:// or https://
+### Route patterns may optionally begin with http:// or https://
 
 If you omit a scheme in your route pattern, it will match both `http://` and `https://` URLs. If you include `http://` or `https://`, it will only match HTTP or HTTPS requests, respectively.
 
@@ -108,7 +100,7 @@ If you omit a scheme in your route pattern, it will match both `http://` and `ht
 
 - `*.example.com/` matches both `https://www.example.com/` and `http://www.example.com/`.
 
-#### Hostnames may optionally begin with `*`
+### Hostnames may optionally begin with `*`
 
 If a route pattern hostname begins with `*`, then it matches the host and all subhosts. If a route pattern hostname begins with `*.`, then it only matches all subhosts.
 
@@ -116,7 +108,7 @@ If a route pattern hostname begins with `*`, then it matches the host and all su
 
 - `*.example.com/` matches `https://www.example.com/` but not `https://example.com/`.
 
-#### Paths may optionally end with `*`
+### Paths may optionally end with `*`
 
 If a route pattern path ends with `*`, then it matches all suffixes of that path.
 
@@ -128,7 +120,7 @@ There is a well-known bug associated with path matching concerning wildcards (`*
 
 {{</Aside>}}
 
-#### Subdomains must have a DNS Record
+### Subdomains must have a DNS Record
 
 All subdomains must have a [DNS record](https://support.cloudflare.com/hc/en-us/articles/360019093151#h_60566325041543261564371) to be proxied on Cloudflare and used to invoke a Worker. For example, if you want to put a worker on `myname.example.com`, and you have added `example.com` to Cloudflare but have not added any DNS records for `myname.example.com`, any request to `myname.example.com` will result in the error `ERR_NAME_NOT_RESOLVED`.
 
@@ -137,3 +129,17 @@ All subdomains must have a [DNS record](https://support.cloudflare.com/hc/en-us/
 If you have previously used the Cloudflare dashboard to add an `AAAA` record for `myname` to `example.com`, pointing to `100::` (the [reserved IPv6 discard prefix](https://tools.ietf.org/html/rfc6666)), Cloudflare recommends creating a [Custom Domain](/workers/platform/triggers/custom-domains/) pointing to your Worker instead.
 
 {{</Aside>}}
+
+## Configure routes via `wrangler.toml`
+
+To configure a route in your `wrangler.toml`, add the following to your environment:
+
+```toml
+routes = [
+    { pattern = "example.com/about", zone_id = "<YOUR_ZONE_ID>" }
+]
+```
+
+If you have specified your zone ID in the environment of your `wrangler.toml`, you will not need to write it again in object form.
+
+For more examples of route configuration in `wrangler.toml` refer to [this doc](/workers/wrangler/configuration/#types-of-routes).


### PR DESCRIPTION
This PR:

- adds a new section to mention that routes are unique and multiple Workers can not be associated with the same route.
- updates the structure of the doc to flow better
- adds link to Wrangler route config doc