### PR TITLE
Add deprecation for ChaCha20 ciphers

### DIFF
--- a/content/fundamentals/api/reference/deprecations.md
+++ b/content/fundamentals/api/reference/deprecations.md
@@ -11,13 +11,13 @@ Cloudflare occasionally makes updates to our APIs that result in behavior change
 ## ChaCha20 TLS Cipher Removal
 **End of life Date: July 1st, 2023**
 
-Back in 2016 Cloudflare introduced support for ChaCha20-Poly1305 cipher suites for TLS 1.2 (see https://blog.cloudflare.com/it-takes-two-to-chacha-poly/ for more details).
+Back in 2016 Cloudflare [introduced support](https://blog.cloudflare.com/it-takes-two-to-chacha-poly/) for `ChaCha20-Poly1305` cipher suites for TLS 1.2.
 
 At the time, we introduced two variants of these new suites, the "standard" suites as defined by the IETF RFC 7905, and "draft" suites that followed an earlier draft of said specification.
 
-The draft suites were added for compatibility with some older Android devices that at the time did not yet support the proper ChaCha20-Poly1305 standard versions.
+The draft suites were added for compatibility with some older Android devices that at the time did not yet support the proper `ChaCha20-Poly1305` standard versions.
 
-This was in 2016, and in the meantime the standard ChaCha20-Poly1305 cipher suites have gained much wider adotpion, to the point were traffic using the old suites has dropped significantly.
+This was in 2016, and in the meantime the standard `ChaCha20-Poly1305` cipher suites have gained much wider adoption, to the point were traffic using the old suites has dropped significantly.
 
 Due to the current low usage and the non-standard nature of these cipher suites, we are now deprecating their support on the Cloudflare network.
 
@@ -25,7 +25,7 @@ This should not affect customer zones in any way, as clients that might currentl
 
 In addition, unlike the standard variants, these legacy cipher suites are not exposed directly through our API (e.g. through the TLS cipher suites preferences endpoint), and their deprecation will not affect customer configurations in any way.
 
-The ChaCha20-Poly1305 ciphers will be removed from Cloudflare on July 1st, 2023. If you have clients that use these ciphers you are advised to upgrade them to newer ciphers.
+The `ChaCha20-Poly1305` ciphers will be removed from Cloudflare on July 1st, 2023. If you have clients that use these ciphers you are advised to upgrade them to newer ciphers.
 
 ## Argo Tunnel
 **End of life Date: February 4, 2024**

--- a/content/fundamentals/api/reference/deprecations.md
+++ b/content/fundamentals/api/reference/deprecations.md
@@ -8,6 +8,25 @@ weight: 22
 
 Cloudflare occasionally makes updates to our APIs that result in behavior changes or deprecations. When this happens, we will communicate when the API will no longer be available and whether there will be a replacement.
 
+## ChaCha20 TLS Cipher Removal
+**End of life Date: July 1st, 2023**
+
+Back in 2016 Cloudflare introduced support for ChaCha20-Poly1305 cipher suites for TLS 1.2 (see https://blog.cloudflare.com/it-takes-two-to-chacha-poly/ for more details).
+
+At the time, we introduced two variants of these new suites, the "standard" suites as defined by the IETF RFC 7905, and "draft" suites that followed an earlier draft of said specification.
+
+The draft suites were added for compatibility with some older Android devices that at the time did not yet support the proper ChaCha20-Poly1305 standard versions.
+
+This was in 2016, and in the meantime the standard ChaCha20-Poly1305 cipher suites have gained much wider adotpion, to the point were traffic using the old suites has dropped significantly.
+
+Due to the current low usage and the non-standard nature of these cipher suites, we are now deprecating their support on the Cloudflare network.
+
+This should not affect customer zones in any way, as clients that might currently use these cipher suites will be able to fallback to different ones.
+
+In addition, unlike the standard variants, these legacy cipher suites are not exposed directly through our API (e.g. through the TLS cipher suites preferences endpoint), and their deprecation will not affect customer configurations in any way.
+
+The ChaCha20-Poly1305 ciphers will be removed from Cloudflare on July 1st, 2023. If you have clients that use these ciphers you are advised to upgrade them to newer ciphers.
+
 ## Argo Tunnel
 **End of life Date: February 4, 2024**
 
@@ -46,11 +65,11 @@ This field is deprecated and has been moved to [Cloudflare centralized notificat
 `notification_email` is the email address to send health status notifications to. This can be an individual mailbox or a mailing list. Multiple emails can be supplied as a comma delimited list.
 
 ## Transfer-Encoding and Content-Length headers 
-**End of life date: March 31, 2023**
+**End of life date: July 1st, 2023**
 
 Previously, RFC 2616 allowed the use of `Transfer-Encoding` and `Content-Length` HTTP headers in the same request. RFC 7230 supersedes RFC 2616 and prohibits the use of `Transfer-Encoding` and `Content-Length` headers in the same request because they can cause HTTP request smuggling vulnerabilities.
 
-Starting on March 31, 2023, Cloudflare will decline requests with both `Transfer-Encoding` and `Content-Length` HTTP headers.
+Starting on July 1st, 2023, Cloudflare will decline requests with both `Transfer-Encoding` and `Content-Length` HTTP headers.
 
 ## Access Bookmark applications
 **End of life date: March 19, 2023**


### PR DESCRIPTION
Setting content-encoding deprecation to July 1st so we can notify customers through newsletter.