### PR TITLE
[ZT] Formatting fixes in application-check.md

### DIFF
--- a/content/cloudflare-one/identity/devices/warp-client-checks/application-check.md
+++ b/content/cloudflare-one/identity/devices/warp-client-checks/application-check.md
@@ -19,10 +19,9 @@ The Application Check device posture attribute checks that a specific applicatio
 3.  Select **Application Check**.
 
 4.  You will be prompted for the following information:
-
-        1. **Name**: Enter a unique name for this device posture check.
-        2. **Operating system**: Select your operating system.
-        3. **Application path**: Enter the file path for the executable that will be running (for example, `c:\my folder\myfile.exe`).
+    1. **Name**: Enter a unique name for this device posture check.
+    2. **Operating system**: Select your operating system.
+    3. **Application path**: Enter the file path for the executable that will be running (for example, `c:\my folder\myfile.exe`).
 
     {{<Aside type="note">}}
 
@@ -60,7 +59,8 @@ When setting up new device posture checks, we recommend first testing them witho
 2. Run the following command to extract certificates for the WARP application:
 
    ```sh
-   ~/Desktop/tmp $ codesign -d --extract-certificates "/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP" Executable=/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP
+   ~/Desktop/tmp $ codesign -d --extract-certificates "/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP"
+   Executable=/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP
    ```
 
 3. Next, run the following command to extract the SHA1 thumbprint:

--- a/content/cloudflare-one/identity/devices/warp-client-checks/application-check.md
+++ b/content/cloudflare-one/identity/devices/warp-client-checks/application-check.md
@@ -28,7 +28,8 @@ The Application Check device posture attribute checks that a specific applicatio
 - Be sure to enter the binary file path, not the application launch path. When checking for an application on macOS, a common mistake is to enter `/Applications/ApplicationName.app`. This will not work as `ApplicationName.app` is a folder. The executable file that will be running is located within the folder, for example `ApplicationName.app/Contents/MacOS/ApplicationName`.
 - Some applications change their file path after an update. Ensure that the application is always in a stable location or use `%PATH%` variables when possible.
 
-{{</Aside>}} 4. **Signing certificate thumbprint (recommended)**: Enter the [thumbprint of the publishing certificate](#determine-the-signing-thumbprint) used to sign the binary. Adding this information will enable the check to ensure that the application was signed by the expected software developer.
+{{</Aside>}}
+    4. **Signing certificate thumbprint (recommended)**: Enter the [thumbprint of the publishing certificate](#determine-the-signing-thumbprint) used to sign the binary. Adding this information will enable the check to ensure that the application was signed by the expected software developer.
 
     5. **SHA-256 (optional)**: Enter the [SHA-256 value](#determine-the-sha-256-value) of the binary. This is used to ensure the integrity of the binary file on the device.
 


### PR DESCRIPTION
* Updated the `codesign` command example to include a line break. The current way it displays looks as if the `stdout` data is part of command itself.
* Fixed nested list so that it doesn't display as a codeblock - it currently shows 1, 2 and 3 in a codeblock, then `4.` as text, and 5 as `e`.