### PR TITLE
fix SQL in /d1/tutorials/build-a-comments-api/index.md

### DIFF
--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -93,7 +93,7 @@ CREATE INDEX idx_comments_post_slug ON comments (post_slug);
 
 -- Optionally, uncomment the below query to create data
 
--- INSERT INTO COMMENTS (author, body, post_slug) VALUES ("Kristian", "Great post!", "hello-world");
+-- INSERT INTO COMMENTS (author, body, post_slug) VALUES ('Kristian', 'Great post!', 'hello-world');
 ```
 
 With the file created, execute the schema file against the D1 database by passing it with the flag `--file`:


### PR DESCRIPTION
In sql, single quote is valid, not double quote.