### PR TITLE
Match limit to the pricing page for builds per month

### DIFF
--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -15,7 +15,7 @@ You can request adjustments to limits that conflict with your project goals by c
 
 ## Builds
 
-Each time you push new code to your Git repository, Pages will build and deploy your site. You can deploy up to 500 times per month on the Free plan. Refer to the Pro and Business plans in [Pricing](https://pages.cloudflare.com/#pricing) if you need to deploy more frequently.
+Each time you push new code to your Git repository, Pages will build and deploy your site. You can build up to 500 times per month on the Free plan. Refer to the Pro and Business plans in [Pricing](https://pages.cloudflare.com/#pricing) if you need to deploy more frequently.
 
 Builds will timeout after 20 minutes.
 

--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -15,7 +15,7 @@ You can request adjustments to limits that conflict with your project goals by c
 
 ## Builds
 
-Each time you push new code to your Git repository, Pages will build and deploy your site. You can build up to 500 times per month on the Free plan. Refer to the Pro and Business plans in [Pricing](https://pages.cloudflare.com/#pricing) if you need to deploy more frequently.
+Each time you push new code to your Git repository, Pages will build and deploy your site. You can build up to 500 times per month on the Free plan. Refer to the Pro and Business plans in [Pricing](https://pages.cloudflare.com/#pricing) if you need more builds.
 
 Builds will timeout after 20 minutes.
 


### PR DESCRIPTION
The pricing page says the free plan includes 500 "builds" per month whereas the limits docs said 500 "deploys" per month. This PR changes the docs to say 500 "builds" per month to match the pricing page.

https://pages.cloudflare.com/#pricing