### PR TITLE
[R2] Add HEAD to supported methods

### DIFF
--- a/content/r2/api/s3/presigned-urls.md
+++ b/content/r2/api/s3/presigned-urls.md
@@ -46,6 +46,7 @@ Another potential use case for presigned URLs is debugging. For example, if you 
 R2 currently supports the following methods when generating a presigned URL:
 
 - `GET`: allows a user to fetch an object from a bucket
+- `HEAD`: allows a user to fetch an object's metadata from a bucket
 - `PUT`: allows a user to upload an object to a bucket
 - `DELETE`: allows a user to delete an object from a bucket
 


### PR DESCRIPTION
Personally I would clarify and have it like [fetch an object's metadata](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html) as a link to the HeadObject operation but that would entail doing it for the rest so I'll leave it up to the reviewer.