### PR TITLE
Fix schema function

### DIFF
--- a/functions/schema.js
+++ b/functions/schema.js
@@ -6,35 +6,47 @@ export async function onRequestGet() {
   const cache = caches.default
   let response = await cache.match(req)
 
-  if (!response) {
-    response = await fetch(req)
-    let schema = await response.json()
+  try {
+    if (!response) {
+      response = await fetch(req)
+      let schema = await response.json()
 
-    const pathsByTag = {}
+      const pathsByTag = {}
 
-    Object.keys(schema.paths).forEach(key => {
-      const path = schema.paths[key]
-      const tag = Object.values(path)[0].tags[0]
-      if (!pathsByTag[tag]) pathsByTag[tag] = []
-      pathsByTag[tag].push({ path, key })
-    })
-
-    const sortedPaths = {}
-    const sortedTags = Object.keys(pathsByTag).sort()
-    sortedTags.forEach(tag => {
-      const tagArray = pathsByTag[tag]
-      tagArray.forEach(({ key, path }) => {
-        if (sortedPaths[key]) console.log('key already exists')
-        sortedPaths[key] = path
+      Object.keys(schema.paths).forEach(key => {
+        const path = schema.paths[key]
+        const endpoint = Object.values(path)[0]
+        if (endpoint) {
+          const tags = endpoint.tags
+          const tag = tags && tags.length ? tags[0] : null
+          if (tag) {
+            if (!pathsByTag[tag]) pathsByTag[tag] = []
+            pathsByTag[tag].push({ path, key })
+          }
+        }
       })
-    })
 
-    let sortedSchema = Object.assign({}, schema, { paths: sortedPaths })
+      const sortedPaths = {}
+      const sortedTags = Object.keys(pathsByTag).sort()
+      sortedTags.forEach(tag => {
+        const tagArray = pathsByTag[tag]
+        tagArray.forEach(({ key, path }) => {
+          if (sortedPaths[key]) console.log('key already exists')
+          sortedPaths[key] = path
+        })
+      })
 
-    response = new Response(JSON.stringify(sortedSchema), {
-      headers: { 'Content-type': 'application/json' }
-    })
+      let sortedSchema = Object.assign({}, schema, { paths: sortedPaths })
+
+      response = new Response(JSON.stringify(sortedSchema), {
+        headers: { 'Content-type': 'application/json' }
+      })
+    }
+
+    return response
+  } catch (err) {
+    console.log(err)
+    return fetch(req)
   }
 
-  return response
 }


### PR DESCRIPTION
This PR fixes two things in the /schema Pages function

1) Corrects an issue where the function was throwing an exception when
   trying to parse tags for an OpenAPI schema endpoint
2) When an error occurs, fall back to the raw GitHub JSON data to not
   cause any downtime on the API Docs frontend

Follow-up work will be to notify the team (Sentry or something else) in the catch portion of the block so that if an exception is occurring in this function, it can be resolved without downtime to the API Docs frontend