### PR TITLE
Update Linux install instructions

### DIFF
--- a/content/terraform/installing.md
+++ b/content/terraform/installing.md
@@ -30,19 +30,25 @@ Terraform v0.11.6
 
 ## Linux
 
-On Linux, download and place the binary in your `PATH`.
+The `terraform` binary can be installed via your distribution's package manager, eg:
 
 ```sh
-$ wget -q https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_linux_amd64.zip
+$ sudo apt install terraform
+```
 
-$ unzip terraform_0.11.6_linux_amd64.zip
-Archive:  terraform_0.11.6_linux_amd64.zip
+You can also fetch a specific version directly and place the binary in your `PATH`:
+
+```sh
+$ wget -q https://releases.hashicorp.com/terraform/1.4.5/terraform_1.4.5_linux_amd64.zip
+
+$ unzip terraform_1.4.5_linux_amd64.zip
+Archive:  terraform_1.4.5_linux_amd64.zip
   inflating: terraform
 
 $ sudo mv terraform /usr/local/bin/terraform
 
 $ terraform version
-Terraform v0.11.6
+Terraform v1.4.5
 ```
 
 ## Windows

--- a/content/terraform/installing.md
+++ b/content/terraform/installing.md
@@ -30,13 +30,13 @@ Terraform v0.11.6
 
 ## Linux
 
-The `terraform` binary can be installed via your distribution's package manager, eg:
+You can install the `terraform` binary via your distribution's package manager. For example:
 
 ```sh
 $ sudo apt install terraform
 ```
 
-You can also fetch a specific version directly and place the binary in your `PATH`:
+Alternatively, you can fetch a specific version directly and place the binary in your `PATH`:
 
 ```sh
 $ wget -q https://releases.hashicorp.com/terraform/1.4.5/terraform_1.4.5_linux_amd64.zip


### PR DESCRIPTION
Current Linux install instructions recommended explicitly installing outdated terraform version 0.11.6. Updated to add mention of package-manager-based installation as well as updating the reference to the most recent stable release version 1.4.5 (as of 2023-04-14).