### PR TITLE
Fix API docs schema behavior

### DIFF
--- a/functions/schema.js
+++ b/functions/schema.js
@@ -15,14 +15,13 @@ export async function onRequestGet() {
 
       Object.keys(schema.paths).forEach(key => {
         const path = schema.paths[key]
-        const endpoint = Object.values(path)[0]
-        if (endpoint) {
+        const tag = Object.values(path).find(endpoint => {
           const tags = endpoint.tags
-          const tag = tags && tags.length ? tags[0] : null
-          if (tag) {
-            if (!pathsByTag[tag]) pathsByTag[tag] = []
-            pathsByTag[tag].push({ path, key })
-          }
+          return tags && tags.length && tags[0]
+        })
+        if (tag) {
+          if (!pathsByTag[tag]) pathsByTag[tag] = []
+          pathsByTag[tag].push({ path, key })
         }
       })
 


### PR DESCRIPTION
This PR fixes an issue with the /schema function not correctly loading tags for specific endpoints. The previous functionality checked the first method for a given endpoint and tried to pull the tags out of it.

For instance, given `/users`, we would try and pull the tags from the `get` method defined underneath that `/users` endpoint.

This works until a team defines an endpoint and uses a ref to a component as the first "method" in an array of methods for an endpoint.

To fix this behavior, the function now iterates through each method in an endpoint, looking for tags. When one is found, it now updates the tag references correctly.

For reference, this is the identified endpoint that was susceptible to this bug, which should be viewable now in the deploy preview for this PR: https://kristian-api-schema-function.cloudflare-docs-7ou.pages.dev/api/operations/accounts-turnstile-widget-rotate-secret