### PR TITLE
Update Wrangler version check instructions

### DIFF
--- a/content/workers/wrangler/install-and-update.md
+++ b/content/workers/wrangler/install-and-update.md
@@ -57,7 +57,7 @@ $ yarn global add wrangler
 To check your Wrangler version, run:
 
 ```sh
-$ wrangler version
+$ wrangler --version
 ```
 
 ### Update Wrangler locally

--- a/content/workers/wrangler/install-and-update.md
+++ b/content/workers/wrangler/install-and-update.md
@@ -58,6 +58,8 @@ To check your Wrangler version, run:
 
 ```sh
 $ wrangler --version
+// or run:
+$ wrangler version
 ```
 
 ### Update Wrangler locally


### PR DESCRIPTION
The instructions incorrectly stated that `wrangler version` displays the version but it's a flag not a command