### PR TITLE
[Analytics] Update NAv1 deprecation date

### DIFF
--- a/content/analytics/graphql-api/migration-guides/network-analytics-v2/_index.md
+++ b/content/analytics/graphql-api/migration-guides/network-analytics-v2/_index.md
@@ -8,7 +8,7 @@ layout: single
 
 # Network Analytics v1 to Network Analytics v2
 
-In early 2020, Cloudflare released the first version of the Network Analytics dashboard and its corresponding API. The second version was made available on September 13th, 2021. Users should only use the newer version, Network Analytics v2 (NAv2). Network Analytics v1 (NAv1) is planned to be deprecated on August 1st, 2023.
+In early 2020, Cloudflare released the first version of the Network Analytics dashboard and its corresponding API. The second version was made available on 2021-09-13. Users should only use the newer version, Network Analytics v2 (NAv2). Network Analytics v1 (NAv1) is planned to be deprecated on 2023-08-01.
 
 ## Before you start
 

--- a/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
+++ b/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
@@ -17,7 +17,7 @@ which contains minutely aggregates of Network Analytics attack activity.
 {{<Aside type="warning" header="Warning">}}
 
 This tutorial uses Network Analytics v1 (NAv1) nodes. These nodes are planned to
-be deprecated on March 31, 2022. For more information on migrating from Network
+be deprecated on August 1st, 2023. For more information on migrating from Network
 Analytics v1 to Network Analytics v2, refer to the [migration guide][5].
 
 [5]: /analytics/graphql-api/migration-guides/network-analytics-v2/

--- a/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
+++ b/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
@@ -17,7 +17,7 @@ which contains minutely aggregates of Network Analytics attack activity.
 {{<Aside type="warning" header="Warning">}}
 
 This tutorial uses Network Analytics v1 (NAv1) nodes. These nodes are planned to
-be deprecated on August 1st, 2023. For more information on migrating from Network
+be deprecated on 2023-08-01. For more information on migrating from Network
 Analytics v1 to Network Analytics v2, refer to the [migration guide][5].
 
 [5]: /analytics/graphql-api/migration-guides/network-analytics-v2/


### PR DESCRIPTION
We should have the same date as the one stated in the migration page: https://developers.cloudflare.com/analytics/graphql-api/migration-guides/network-analytics-v2/