### PR TITLE
[Workers] Removed unclear wording about environment variables

### DIFF
--- a/content/workers/platform/environment-variables.md
+++ b/content/workers/platform/environment-variables.md
@@ -5,7 +5,7 @@ title: Environment variables
 
 # Environment variables
 
-In the Workers platform, environment variables, secrets, and KV namespaces are known as bindings. Regardless of type, bindings are always available as global variables within your Worker script.
+In the Workers platform, environment variables, secrets, and KV namespaces are known as bindings.
 
 ## Environment variables with module Workers
 


### PR DESCRIPTION
- Before this change, on the Workers -> Platform -> Environment Variables page, there was a sentence `Regardless of type, bindings are always available as global variables within your Worker script`
- A user on the Discord was confused about this wording, mostly because this is only valid for the Service Workers format and the paragraph below it (about Module Workers) directly contradicts it.
- I removed the whole sentence, since it seemed unnecessary. It could also just be reworded, it just seemed out of place and a bit confusing if you're skimming the top paragraph. 