### PR TITLE
workers/storage: link to /storage-options/ guide

### DIFF
--- a/content/d1/platform/storage-options.md
+++ b/content/d1/platform/storage-options.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Storage Options guide
+
+external_link: /workers/platform/storage-options/
+weight: 1
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/queues/platform/storage-options.md
+++ b/content/queues/platform/storage-options.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Storage Options guide
+
+external_link: /workers/platform/storage-options/
+weight: 1
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/r2/reference/storage-options.md
+++ b/content/r2/reference/storage-options.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Storage Options guide
+
+external_link: /workers/platform/storage-options/
+weight: 1
+_build:
+  publishResources: false
+  render: never
+---


### PR DESCRIPTION
Adds a link to the Storage Options guide from other storage-related products.

e.g.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/18544/233088273-b0cfd884-a056-4ba1-83db-91899a998017.png">
<img width="278" alt="image" src="https://user-images.githubusercontent.com/18544/233088399-4b741736-511c-44a1-a3c5-dc33d80f6355.png">
<img width="279" alt="image" src="https://user-images.githubusercontent.com/18544/233088433-0f592d87-4bb4-4e1b-8f19-8d4682dfe2b6.png">
