### PR TITLE
[DOCS] fix typo in vary_for_images.md

### DIFF
--- a/content/cache/about/vary-for-images.md
+++ b/content/cache/about/vary-for-images.md
@@ -46,5 +46,5 @@ To begin using Vary for Images, refer to [Enable Vary for Images](/cache/how-to/
 
 ## Limitations
 
-* For Vary for images to work, your image URLs must include the file extension in the path and not the query string. For example the URL `https://example.com/image.jpg` is compatible but `https://example.com?index.php?file=image.jpg` is not compatible.
+* For Vary for images to work, your image URLs must include the file extension in the path and not the query string. For example the URL `https://example.com/image.jpg` is compatible but `https://example.com/index.php?file=image.jpg` is not compatible.
 * Your origin must return an image type matching the file extension in the URL when a HTTP client sends no `Accept` header, or an `Accept: */*` header. Otherwise, you will see `CF-Cache-Status: BYPASS` in the HTTP response headers.


### PR DESCRIPTION
Fix typo in URL on image variants page.