### PR TITLE
workers: separate out integrations and databases

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -663,8 +663,8 @@
 /workers/cli-wrangler/webpack/ /workers/wrangler-legacy/migration/eject-webpack/ 301
 /workers/wrangler/compare-v1-v2/ /workers/wrangler-legacy/compare-v1-v2/ 301
 /workers/wrangler-legacy/migration/migrating-from-wrangler-1/ /workers/wrangler-legacy/migration/ 301
-/workers/deploying-workers/serverless/ /workers/learning/integrations/ 301
-/workers/deploying-workers/terraform/ /workers/learning/integrations/ 301
+/workers/deploying-workers/serverless/ /workers/integrations/overview 301
+/workers/deploying-workers/terraform/ /workers/integrations/overview 301
 /workers/examples/rustwasm/ /workers/tutorials/hello-world-rust/ 301
 /workers/examples/signed-request/ /workers/examples/signing-requests/ 301
 /workers/faq/ /workers/ 301
@@ -750,8 +750,8 @@
 /workers/tooling/api/bindings/ /workers/platform/bindings/ 301
 /workers/tooling/api/scripts/ /api/operations/worker-script-list-workers 301
 /workers/tooling/playground/ /workers/learning/playground/ 301
-/workers/tooling/serverless/ /workers/learning/integrations/ 301
-/workers/tooling/terraform/ /workers/learning/integrations/ 301
+/workers/tooling/serverless/ /workers/integrations/ 301
+/workers/tooling/terraform/ /workers/integrations/ 301
 /workers/tooling/wrangler/ /workers/wrangler/ 301
 /workers/tooling/wrangler/commands/ /workers/wrangler/commands/ 301
 /workers/tooling/wrangler/configuration/ /workers/wrangler/configuration/ 301
@@ -788,6 +788,8 @@
 /workers/wrangler/get-started/ /workers/wrangler/install-and-update/ 301
 /workers/runtime-apis/headers/ /workers/platform/headers/ 301
 /workers/platform/storage-objects/ /workers/platform/storage-options/ 301
+/workers/learning/integrations/databases/ /workers/databases/connecting-to-databases/ 301
+/workers/learning/integrations/* /workers/integrations/:splat 301
 
 # zaraz
 

--- a/content/workers/databases/_index.md
+++ b/content/workers/databases/_index.md
@@ -1,9 +1,11 @@
 ---
 pcx_content_type: navigation
-title: Runtime APIs
-weight: 9
+title: Databases
+weight: 8
 ---
 
-# Runtime APIs
+# Databases
 
 {{<directory-listing>}}
+
+

--- a/content/workers/databases/connecting-to-databases.md
+++ b/content/workers/databases/connecting-to-databases.md
@@ -1,11 +1,16 @@
 ---
 pcx_content_type: concept
-title: Databases
+title: Connecting to Databases
+weight: 1
 ---
 
-# Databases
+# Connecting to Databases
 
-Use Cloudflare Workers to connect your application to external databases, such as Postgres, MySQL, FaunaDB, Supabase, MongoDB Atlas, PlanetScale, Prisma, and more. To use these Cloudflare Workers integrations, you need to install the relevant packages for the databases you want to use.
+Cloudflare Workers can connect to and query external databases, including Postgres, MySQL, FaunaDB, Supabase, MongoDB Atlas, PlanetScale, and Prisma, allowing you to build full-stack applications directly on Cloudflare.
+
+## Database Drivers
+
+The following table lists databases and their currently supported connection methods:
 
 {{<table-wrap>}}
 
@@ -31,7 +36,7 @@ Once you have installed the necessary packages, use the APIs provided by these p
 
 ## Authentication
 
-If your database requires authentication, use Wrangler secrets to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:
+If your database requires authentication, use [Secrets](/workers/platform/environment-variables/#add-secrets-to-your-project) to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:
 
 ```sh
 wrangler secret put SECRET_NAME
@@ -45,4 +50,4 @@ const secretValue = env.SECRET_NAME;
 
 Use the secret value to authenticate with the external service. For example, if the external service requires an API key or database username and password for authentication, include these in using the relevant service's library or API.
 
-For services that require mTLS authentication, use [mTLS certificates](/workers/runtime-apis/mtls) to present a client certificate.
+For services that require Mutual TLS (mTLS) authentication, use Worker's support for [mTLS certificates](/workers/runtime-apis/mtls) to present a client certificate to the upstream server.

--- a/content/workers/databases/d1.md
+++ b/content/workers/databases/d1.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Cloudflare D1
+
+external_link: /d1/
+weight: 10
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/workers/integrations/_index.md
+++ b/content/workers/integrations/_index.md
@@ -1,9 +1,11 @@
 ---
 pcx_content_type: navigation
-title: Runtime APIs
-weight: 9
+title: Integrations
+weight: 7
 ---
 
-# Runtime APIs
+# Integrations
 
 {{<directory-listing>}}
+
+

--- a/content/workers/integrations/apis.md
+++ b/content/workers/integrations/apis.md
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: concept
 title: APIs
+weight: 2
 ---
 
 # APIs

--- a/content/workers/integrations/external-services.md
+++ b/content/workers/integrations/external-services.md
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: concept
 title: External Services
+weight: 4
 ---
 
 # External Services

--- a/content/workers/integrations/overview.md
+++ b/content/workers/integrations/overview.md
@@ -1,9 +1,8 @@
 ---
 pcx_content_type: concept
-title: Integrations
-weight: 6
+title: Overview
+weight: 1
 ---
-
 
 # Integrations
 
@@ -15,9 +14,9 @@ One of the key features of Cloudflare Workers is the ability to easily integrate
 
 Cloudflare Workers offers several types of integrations, including:
 
-* [Databases](/workers/learning/integrations/databases/): Cloudflare Workers can be integrated with a variety of databases, including SQL and NoSQL databases. This allows you to store and retrieve data from your databases directly from your Cloudflare Workers code.
-* [APIs](/workers/learning/integrations/apis/): Cloudflare Workers can be used to integrate with external APIs, allowing you to access and use the data and functionality exposed by those APIs in your own code.
-* [Third-party services](/workers/learning/integrations/external-services/): Cloudflare Workers can be used to integrate with a wide range of third-party services, such as payment gateways, authentication providers, and more. This makes it possible to use these services in your Cloudflare Workers code.
+* [Databases](/workers/databases/): Cloudflare Workers can be integrated with a variety of databases, including SQL and NoSQL databases. This allows you to store and retrieve data from your databases directly from your Cloudflare Workers code.
+* [APIs](/workers/integrations/apis/): Cloudflare Workers can be used to integrate with external APIs, allowing you to access and use the data and functionality exposed by those APIs in your own code.
+* [Third-party services](/workers/integrations/external-services/): Cloudflare Workers can be used to integrate with a wide range of third-party services, such as payment gateways, authentication providers, and more. This makes it possible to use these services in your Cloudflare Workers code.
 
 
 ## How to use integrations

--- a/content/workers/wrangler/_index.md
+++ b/content/workers/wrangler/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Wrangler
 pcx_content_type: navigation
-weight: 8
+weight: 10
 meta:
   title: Wrangler (command line)
 ---


### PR DESCRIPTION
WIP / draft.

This PR separates out Integrations and Databases into their own top-level navigation items, so that they are more easily discovered by developers. These are both "critical path" items that we get a number of questions about.

![image](https://user-images.githubusercontent.com/18544/233653983-ade1b662-e54a-453f-bbbf-8449a0c69568.png)
