### PR TITLE
Bug fix in Querying Access login events with GraphQL index.md

### DIFF
--- a/content/analytics/graphql-api/tutorials/querying-access-login-events/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-access-login-events/index.md
@@ -59,7 +59,7 @@ echo '{ "query":
   -H "X-Auth-key: <API_KEY>" \
   -s \
   -d @- \
-  https://api.cloudflare.com/client/v4/graphql/ | jq.
+  https://api.cloudflare.com/client/v4/graphql/ | jq .
 ```
 
 {{<Aside type="note">}}


### PR DESCRIPTION
A space is required between `jq` and `.`