### PR TITLE
[Support] fix rate limiting table

### DIFF
--- a/content/support/Firewall/Tools/Configuring Cloudflare Rate Limiting.md
+++ b/content/support/Firewall/Tools/Configuring Cloudflare Rate Limiting.md
@@ -62,8 +62,7 @@ rules**.
 
 The number of allowed Rate Limiting rules depends on the domain’s plan:
 
-| Plan | \# Rules | \# Rules matching  
-response headers | Actions | Action Duration | Request Period |
+| Plan | Rules | Rules matching response headers | Actions | Action Duration | Request Period |
 | --- | --- | --- | --- | --- | --- |
 | Free | 1 | 1 | Block | 1 minute or 1 hour | 10 seconds or 1 minute |
 | Pro | 10 | 1 | Block, Interactive Challenge, JS Challenge, Managed Challenge, or Log | 1 minute or 1 hour | 10 seconds or 1 minute |


### PR DESCRIPTION
before: ![](https://up.jross.me/q0rc6evm)

after: ![](https://up.jross.me/7g8x7e5e)

(the table format is still pretty meh, but at least it renders correctly)