### PR TITLE
[Docs Site] specify a requirement on extended hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You must have [Hugo](https://gohugo.io) installed on your system and available in your `$PATH` as a global binary. Most operating systems are supported – follow the relevant [Install Hugo](https://gohugo.io/getting-started/installing) instructions for your operating system guides to get started.
 
-> **Important:** This project is built with version `0.92.2+extended` but `0.92.x` is the minimum required version. You may (probably) use a newer version of Hugo, but will be subject to any Hugo changes.
+> **Important:** This project is built with version `0.92.2+extended` and is the minimum required version. You may (probably) use a newer version of Hugo, but will be subject to any Hugo changes.
 
 You must also have a recent version of Node.js (14+) installed. You may use [Volta](https://github.com/volta-cli/volta), a Node version manager, to install the latest version of Node and `npm`, which is a package manager that is included with `node`'s installation.
 


### PR DESCRIPTION
Since the introduction of image resizing, this is now required - base 0.92, 0.98, etc. do not work - you _have_ to use the extended version. (ref: https://discourse.gohugo.io/t/resize-image-this-feature-is-not-available-in-your-current-hugo-version/34682/4)

Running without the extended version results in errors like this:
```
[0] Error: Error building site: "E:\GitHub\cloudflare-docs\layouts\_default\_markup\render-image.html:8:19": execute of template failed: template: _default/_markup/render-image.html:8:19: executing "_default/_markup/render-image.html" at <$img.Resize>: error calling Resize: image "E:\\GitHub\\cloudflare-docs\\assets\\images\\railgun\\cnn.webp": this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information
```