### PR TITLE
Update managed-networks.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -87,7 +87,7 @@ SHA256 Fingerprint=DD4F4806C57A5BBAF1AA5B080F0541DA75DB468D0A1FE731310149500CCD8
 
 5. In **TLS Cert SHA-256**, enter the [SHA-256 fingerprint](#2-extract-the-sha-256-fingerprint) of the TLS certificate.
 
-WARP will automatically exclude the TLS endpoint from all [Split Tunnel](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) configurations by IP address. This prevents remote users from accessing the endpoint through the WARP tunnel on any port. 
+WARP will automatically exclude the IP address of the TLS endpoint from all [Split Tunnel](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) configurations. This prevents remote users from accessing the endpoint through the WARP tunnel on any port. 
 
 ## 4. Configure device profile
 

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -87,7 +87,7 @@ SHA256 Fingerprint=DD4F4806C57A5BBAF1AA5B080F0541DA75DB468D0A1FE731310149500CCD8
 
 5. In **TLS Cert SHA-256**, enter the [SHA-256 fingerprint](#2-extract-the-sha-256-fingerprint) of the TLS certificate.
 
-WARP will automatically exclude the TLS endpoint from all [Split Tunnel](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) configurations. This prevents remote users from accessing the endpoint through the WARP tunnel.
+WARP will automatically exclude the TLS endpoint from all [Split Tunnel](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) configurations by IP address. This prevents remote users from accessing the endpoint through the WARP tunnel on any port. 
 
 ## 4. Configure device profile
 


### PR DESCRIPTION
Correction raised by customer.  We exclude all of the IP address, so even if the TLS endpoint is listening on 443, users will be unable to access it over WARP -> Tunnel on any port (ie. 22, 80, ...)