### PR TITLE
[Send emails from Workers] replacing setMessage with addMessage in send-email-workers.md

### DIFF
--- a/content/email-routing/email-workers/send-email-workers.md
+++ b/content/email-routing/email-workers/send-email-workers.md
@@ -40,9 +40,9 @@ export default {
    msg.setSender({ name: "GPT-4", addr: "<SENDER>@example.com" });
    msg.setRecipient("<RECIPIENT>@example2.com");
    msg.setSubject("An email generated in a worker");
-   msg.setMessage(
-     "text/plain",
-     `Congratulations, you just sent an email from a worker.`
+   msg.addMessage({
+     contentType: "text/plain",
+     data: `Congratulations, you just sent an email from a worker.`
    );
 
    var message = new EmailMessage(


### PR DESCRIPTION
* I had to change the code according to the [official docs](https://github.com/muratgozel/MIMEText#use) in order for the example to work.
* setMessage => addMessage
* Object with contentType and data