### PR TITLE
[Workers]: Switch over tabs switcher in Workers Examples to TypeScript/JavaScript tabs 

### DIFF
--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -22,8 +22,8 @@ Currently, `103 Early Hints` are only supported in Chrome 103 or later. To view 
 
 {{</Aside>}}
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 const CSS = "body { color: red; }";
@@ -64,7 +64,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```js
 const CSS = "body { color: red; }";

--- a/content/workers/examples/ab-testing.md
+++ b/content/workers/examples/ab-testing.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 const NAME = "myExampleWorkersABTest";
@@ -53,7 +53,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const NAME = "myExampleWorkersABTest";

--- a/content/workers/examples/accessing-the-cloudflare-object.md
+++ b/content/workers/examples/accessing-the-cloudflare-object.md
@@ -11,8 +11,8 @@ weight: 11
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -32,7 +32,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/aggregate-requests.md
+++ b/content/workers/examples/aggregate-requests.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -62,7 +62,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/alter-headers.md
+++ b/content/workers/examples/alter-headers.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -39,7 +39,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/auth-with-headers.md
+++ b/content/workers/examples/auth-with-headers.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -39,7 +39,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 /**
@@ -153,7 +153,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/block-on-tls.md
+++ b/content/workers/examples/block-on-tls.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -38,7 +38,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/bulk-origin-proxy.md
+++ b/content/workers/examples/bulk-origin-proxy.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -40,7 +40,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/bulk-redirects.md
+++ b/content/workers/examples/bulk-redirects.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -39,7 +39,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cache-api.md
+++ b/content/workers/examples/cache-api.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -53,7 +53,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cache-post-request.md
+++ b/content/workers/examples/cache-post-request.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -60,7 +60,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cache-tags.md
+++ b/content/workers/examples/cache-tags.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -56,7 +56,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cache-using-fetch.md
+++ b/content/workers/examples/cache-using-fetch.md
@@ -12,8 +12,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -42,7 +42,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {
@@ -105,8 +105,8 @@ Normally, Cloudflare computes the cache key for a request based on the request's
 
 {{</content-column>}}
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -128,7 +128,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/conditional-response.md
+++ b/content/workers/examples/conditional-response.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -61,7 +61,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cors-header-proxy.md
+++ b/content/workers/examples/cors-header-proxy.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -167,7 +167,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/country-code-redirect.md
+++ b/content/workers/examples/country-code-redirect.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -39,7 +39,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/cron-trigger.md
+++ b/content/workers/examples/cron-trigger.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -21,7 +21,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/data-loss-prevention.md
+++ b/content/workers/examples/data-loss-prevention.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -86,7 +86,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/debugging-logs.md
+++ b/content/workers/examples/debugging-logs.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -57,7 +57,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/extract-cookie-value.md
+++ b/content/workers/examples/extract-cookie-value.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 import { parse } from "cookie";
@@ -30,7 +30,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/fetch-html.md
+++ b/content/workers/examples/fetch-html.md
@@ -10,8 +10,8 @@ weight: 3
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -56,7 +56,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/fetch-json.md
+++ b/content/workers/examples/fetch-json.md
@@ -10,8 +10,8 @@ weight: 4
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -53,7 +53,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/geolocation-app-weather.md
+++ b/content/workers/examples/geolocation-app-weather.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -64,7 +64,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/geolocation-custom-styling.md
+++ b/content/workers/examples/geolocation-custom-styling.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -182,7 +182,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/geolocation-hello-world.md
+++ b/content/workers/examples/geolocation-hello-world.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -53,7 +53,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/hot-link-protection.md
+++ b/content/workers/examples/hot-link-protection.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -43,7 +43,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/images-workers.md
+++ b/content/workers/examples/images-workers.md
@@ -17,8 +17,8 @@ To serve images from a custom domain:
 3. Select **Create a service**.
 4. In your Workers, select **Quick edit** and paste the following code.
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -37,7 +37,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/logging-headers.md
+++ b/content/workers/examples/logging-headers.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -22,7 +22,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/modify-request-property.md
+++ b/content/workers/examples/modify-request-property.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -72,7 +72,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/modify-response.md
+++ b/content/workers/examples/modify-response.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -63,7 +63,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/multiple-cron-triggers.md
+++ b/content/workers/examples/multiple-cron-triggers.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -37,7 +37,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/post-json.md
+++ b/content/workers/examples/post-json.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -63,7 +63,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/read-post.md
+++ b/content/workers/examples/read-post.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -73,7 +73,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/redirect.md
+++ b/content/workers/examples/redirect.md
@@ -12,8 +12,8 @@ layout: example
 
 ## Redirect all requests to one URL
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -26,7 +26,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {
@@ -45,8 +45,8 @@ export default handler;
 
 ## Redirect requests from one domain to another
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -66,7 +66,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/respond-with-another-site.md
+++ b/content/workers/examples/respond-with-another-site.md
@@ -11,8 +11,8 @@ weight: 12
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -33,7 +33,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/return-html.md
+++ b/content/workers/examples/return-html.md
@@ -10,8 +10,8 @@ weight: 1
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -32,7 +32,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/return-json.md
+++ b/content/workers/examples/return-json.md
@@ -12,8 +12,8 @@ weight: 2
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -34,7 +34,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/rewrite-links.md
+++ b/content/workers/examples/rewrite-links.md
@@ -10,8 +10,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -53,7 +53,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/security-headers.md
+++ b/content/workers/examples/security-headers.md
@@ -12,8 +12,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -102,7 +102,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -11,8 +11,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -95,7 +95,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {
@@ -200,8 +200,8 @@ For request URLs beginning with `/generate/`, replace `/generate/` with `/verify
 
 {{</content-column>}}
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -265,7 +265,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {

--- a/content/workers/examples/turnstile-html-rewriter.md
+++ b/content/workers/examples/turnstile-html-rewriter.md
@@ -9,8 +9,8 @@ weight: 1001
 layout: example
 ---
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 
 ```js
 export default {
@@ -45,7 +45,7 @@ export default {
 ```
 
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 
 ```ts
 const handler: ExportedHandler = {
@@ -89,7 +89,7 @@ This is only half the implementation for Turnstile. The corresponding token that
 {{</Aside>}}
 
 
-{{<tab label="js/esm" default="true">}}
+{{<tab label="js" default="true">}}
 ```js
 async function handlePost(request) {
     const body = await request.formData();

--- a/content/workers/runtime-apis/mTLS.md
+++ b/content/workers/runtime-apis/mTLS.md
@@ -46,8 +46,8 @@ mTLS certificate bindings present an API similar to [service bindings](/workers/
 
 ### Interface
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 ```js
 export default {
     async fetch(request, environment) {
@@ -56,7 +56,7 @@ export default {
 }
 ```
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 ```js
 interface Env {
   MY_CERT: Fetcher;

--- a/content/workers/runtime-apis/service-bindings.md
+++ b/content/workers/runtime-apis/service-bindings.md
@@ -17,8 +17,8 @@ To use Service bindings in your code, you must first create a Service binding fr
 
 ### Interface
 
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm"  default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js"  default="true">}}
 ```js
 export default {
 	async fetch(req, env) {
@@ -27,7 +27,7 @@ export default {
 };
 ```
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 ```ts
 interface Environment {
 	BINDING: Fetcher;

--- a/content/workers/runtime-apis/web-crypto.md
+++ b/content/workers/runtime-apis/web-crypto.md
@@ -50,8 +50,8 @@ The Web Crypto API differs significantly from Node’s Crypto API. If you want t
 
     **Usage:**
 {{</definitions>}}
-{{<tabs labels="js/esm | ts/esm">}}
-{{<tab label="js/esm" default="true">}}
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
 ```js
 export default {
   async fetch(req) {
@@ -78,7 +78,7 @@ export default {
 }
 ```
 {{</tab>}}
-{{<tab label="ts/esm">}}
+{{<tab label="ts">}}
 ```ts
 const handler: ExportedHandler = {
   async fetch(req) {


### PR DESCRIPTION
Switch over tab labels from ESM to use JavaScript/TypeScript labels.