### PR TITLE
Make Pages build infra programatic

### DIFF
--- a/content/pages/_partials/_platform-language-support-and-tools/v1.md
+++ b/content/pages/_partials/_platform-language-support-and-tools/v1.md
@@ -1,0 +1,108 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+major_version: 1
+enable_date: "2020-12-17"
+languages:
+  - name: Clojure
+  - name: Elixir
+    default: "1.7"
+    supported: "1.7 only"
+  - name: Emacs
+    default: "25"
+    supported: "25 only"
+  - name: Erlang
+    default: "21"
+    supported: "21 only"
+  - name: Go
+    default: "1.14.4"
+    supported: "Any version"
+    environment_variable: "GO_VERSION"
+  - name: Java
+    default: "8"
+    supported: "8 only"
+  - name: Node.js
+    default: "12.18.0"
+    supported: "Any version"
+    environment_variable: "NODE_VERSION"
+    file:
+      - ".nvmrc"
+      - ".node-version"
+  - name: PHP
+    default: "5.6"
+    supported: "5.6, 7.2, 7.4 only"
+    environment_variable: "PHP_VERSION"
+  - name: Python
+    default: "2.7"
+    supported: "2.7, 3.5, 3.7 only"
+    environment_variable: "PYTHON_VERSION"
+    file:
+      - "runtime.txt"
+      - "Pipfile"
+  - name: Ruby
+    default: "2.7.1"
+    supported: "Any version between 2.6.2 and 2.7.5"
+    environment_variable: "RUBY_VERSION"
+    file:
+      - ".ruby-version"
+  - name: Swift
+    default: "5.2.5"
+    supported: "Any 5.x version"
+    environment_variable: "SWIFT_VERSION"
+    file:
+      - ".swift-version"
+  - name: .NET
+    default: "3.1.302"
+tools:
+  - name: Boot
+    default: "2.5.2"
+    supported: "2.5.2"
+  - name: Bower
+  - name: Cask
+  - name: Composer
+  - name: Doxygen
+    default: "1.8.6"
+  - name: Emacs
+    default: "25"
+  - name: Gutenberg
+    default: "(requires environment variable)"
+    supported: "Any version"
+    environment_variable: "GUTENBERG_VERSION"
+  - name: Hugo
+    default: "0.54.0"
+    supported: "Any version"
+    environment_variable: "HUGO_VERSION"
+  - name: GNU Make
+    default: "3.8.1"
+  - name: ImageMagick
+    default: "6.7.7"
+  - name: jq
+    default: "1.5"
+  - name: Leiningen
+  - name: OptiPNG
+    default: "0.6.4"
+  - name: NPM
+    default: "Corresponds with Node.js version"
+    supported: "Any version"
+    environment_variable: "NPM_VERSION"
+  - name: pip
+    default: "Corresponds with Python version"
+  - name: Pipenv
+    default: "Latest version"
+  - name: sqlite3
+    default: "3.11.0"
+  - name: Yarn
+    default: "1.22.4"
+    supported: "Any version from 0.2.0 to 1.22.19"
+    environment_variable: "YARN_VERSION"
+  - name: Zola
+    default: "(requires environment variable)"
+    supported: "Any version from 0.5.0 and up"
+    environment_variable: "ZOLA_VERSION"
+build_environment:
+  operating_system: "Ubuntu `20.04.5`"
+  architecture: "x86_64"
+---

--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -35,7 +35,7 @@ If you are not using a framework, leave the **Build command** field blank.
 {{<table-wrap>}}
 
 | Framework/tool               | Build command                        | Build directory             |
-|------------------------------|--------------------------------------|-----------------------------|
+| ---------------------------- | ------------------------------------ | --------------------------- |
 | Angular (Angular CLI)        | `ng build`                           | `dist`                      |
 | Astro                        | `npm run build`                      | `dist`                      |
 | Brunch                       | `brunch build --production`          | `public`                    |
@@ -53,7 +53,7 @@ If you are not using a framework, leave the **Build command** field blank.
 | Mkdocs                       | `mkdocs build`                       | `site`                      |
 | Next.js (Static HTML Export) | `next build && next export`          | `out`                       |
 | Nuxt 2                       | `nuxt generate`                      | `dist`                      |
-| Nuxt 3+                      | `nuxt build`                         | `dist`                      |  
+| Nuxt 3+                      | `nuxt build`                         | `dist`                      |
 | Pelican                      | `pelican content [-s settings.py]`   | `output`                    |
 | Quasar                       | `quasar build`                       | `dist/spa`                  |
 | React (create-react-app)     | `npm run build`                      | `build`                     |
@@ -74,65 +74,8 @@ If your project makes use of environment variables to build your site, you can p
 The following system environment variables are injected by default (but can be overridden):
 
 | Environment Variable  | Injected value                        | Example use-case                                                                        |
-|-----------------------|---------------------------------------|-----------------------------------------------------------------------------------------|
+| --------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- |
 | `CF_PAGES`            | `1`                                   | Changing build behaviour when run on Pages versus locally                               |
 | `CF_PAGES_COMMIT_SHA` | `<sha1-hash-of-current-commit>`       | Passing current commit ID to error reporting, for example, Sentry                       |
 | `CF_PAGES_BRANCH`     | `<branch-name-of-current-deployment>` | Customizing build based on branch, for example, disabling debug logging on `production` |
 | `CF_PAGES_URL`        | `<url-of-current-deployment>`         | Allowing build tools to know the URL the page will be deployed at                       |
-
-## Language support and tools
-
-Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, PHP, and Go.
-
-If you need to use a specific version of a language, (for example, Node.js or Ruby) you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code.
-
-Here are the pinned versions for tools included in the Cloudflare Pages build environment, and how to override them as relevant:
-
-{{<table-wrap>}}
-
-| Language | Default version | Supported versions                  | Environment variable | File                      |
-|----------|-----------------|-------------------------------------|----------------------|---------------------------|
-| Clojure  |                 |                                     |                      |                           |
-| Elixir   | 1.7             | 1.7 only                            |                      |                           |
-| Emacs    | 25              | 25 only                             |                      |                           |
-| Erlang   | 21              | 21 only                             |                      |                           |
-| Go       | 1.14.4          | Any version                         | `GO_VERSION`         |                           |
-| Java     | 8               | 8 only                              |                      |                           |
-| Node.js  | 12.18.0         | Any version                         | `NODE_VERSION`       | `.nvmrc`, `.node-version` |
-| PHP      | 5.6             | 5.6, 7.2, 7.4 only                  | `PHP_VERSION`        |                           |
-| Python   | 2.7             | 2.7, 3.5, 3.7 only                  | `PYTHON_VERSION`     | `runtime.txt`, `Pipfile`  |
-| Ruby     | 2.7.1           | Any version between 2.6.2 and 2.7.5 | `RUBY_VERSION`       | `.ruby-version`           |
-| Swift    | 5.2.5           | Any 5.x version                     | `SWIFT_VERSION`      | `.swift-version`          |
-| .NET     | 3.1.302         |                                     |                      |                           |
-
-{{</table-wrap>}}
-
-Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
-
-| Tools       | Default version                           | Supported versions                | Environment variable |
-|-------------|-------------------------------------------|-----------------------------------|----------------------|
-| Boot        | 2.5.2                                     | 2.5.2                             |                      |
-| Bower       |                                           |                                   |                      |
-| Cask        |                                           |                                   |                      |
-| Composer    |                                           |                                   |                      |
-| Doxygen     | Version 1.8.6                             |                                   |                      |
-| Emacs       | Version 25                                |                                   |                      |
-| Gutenberg   | (requires environment variable)           | Any version                       | `GUTENBERG_VERSION`  |
-| Hugo        | Version 0.54.0                            | Any version                       | `HUGO_VERSION`       |
-| GNU Make    | Version 3.8.1                             |                                   |                      |
-| ImageMagick | Version 6.7.7                             |                                   |                      |
-| jq          | Version 1.5                               |                                   |                      |
-| Leiningen   |                                           |                                   |                      |
-| OptiPNG     | Version 0.6.4                             |                                   |                      |
-| NPM         | Corresponds with Node.js version          | Any version                       | `NPM_VERSION`        |
-| pip         | Version corresponding with Python version |                                   |                      |
-| Pipenv      | Latest version                            |                                   |                      |
-| sqlite3     | Version 3.11.0                            |                                   |                      |
-| Yarn        | Version 1.22.4                            | Any version from 0.2.0 to 1.22.19 | `YARN_VERSION`       |
-| Zola        | (requires environment variable)           | Any version from 0.5.0 and up     | `ZOLA_VERSION`       |
-
-If you want to set a specific version of a framework your Cloudflare Pages project is using, note that Pages will respect your package manager of choice during your build process. For example, if you use Gatsby.js, your `package.json` should indicate a version of the `gatsby` npm package, which will be installed using `npm install` as your project builds on Cloudflare Pages.
-
-## Build environment
-
-Cloudflare Pages builds are run in a [gVisor](https://gvisor.dev/docs/) container. The operating system is Ubuntu `20.04.5`. The architecture is `x86_64`.

--- a/content/pages/platform/language-support-and-tools.md
+++ b/content/pages/platform/language-support-and-tools.md
@@ -14,11 +14,11 @@ Cloudflare Pages' build environment has broad support for a variety of languages
 
 If you need to use a specific version of a language, (for example, Node.js or Ruby) you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code.
 
-Here are the pinned versions for tools included in the Cloudflare Pages build environment, and how to override them as relevant:
+In the following table, review the preinstalled versions for tools included in the Cloudflare Pages build environment, and how to override them as relevant:
 
 {{<languages />}}
 
-Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
+Many common tools have been preinstalled in the Cloudflare Pages build environment. The environment variable available for overriding the preinstalled version is specified in the following table, as available:
 
 {{<tools />}}
 

--- a/content/pages/platform/language-support-and-tools.md
+++ b/content/pages/platform/language-support-and-tools.md
@@ -1,0 +1,31 @@
+---
+pcx_content_type: concept
+title: Language support and tools
+layout: language-support-and-tools
+rss: https://github.com/cloudflare/cloudflare-docs/commits/production/content/pages/_partials/_platform-language-support-and-tools.atom
+outputs:
+  - html
+  - json
+---
+
+# Language support and tools
+
+Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, PHP, and Go.
+
+If you need to use a specific version of a language, (for example, Node.js or Ruby) you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code.
+
+Here are the pinned versions for tools included in the Cloudflare Pages build environment, and how to override them as relevant:
+
+{{<languages />}}
+
+Many common tools have been pre-installed as well. The environment variable available for overriding the pinned version is specified, as available:
+
+{{<tools />}}
+
+If you want to set a specific version of a framework your Cloudflare Pages project is using, note that Pages will respect your package manager of choice during your build process. For example, if you use Gatsby, your `package.json` should indicate a version of the `gatsby` npm package, which will be installed using `npm install` as your project builds on Cloudflare Pages.
+
+## Build environment
+
+Cloudflare Pages builds are run in a [gVisor](https://gvisor.dev/docs/) container.
+
+{{<build-environment />}}

--- a/functions/pages/platform/language-support-and-tools.json.ts
+++ b/functions/pages/platform/language-support-and-tools.json.ts
@@ -1,0 +1,5 @@
+// Will replace this with rewrites/proxying when eventually supported
+
+export const onRequest = ({ request, next }) => {
+  return next("/pages/platform/language-support-and-tools/index.json", request);
+};

--- a/layouts/_default/language-support-and-tools.json.json
+++ b/layouts/_default/language-support-and-tools.json.json
@@ -1,0 +1,10 @@
+{{- $files := slice -}}
+{{- range os.ReadDir "content/pages/_partials/_platform-language-support-and-tools" -}}
+  {{- with $.Site.GetPage (path.Join "pages/_partials/_platform-language-support-and-tools/" .Name) -}}
+    {{- $files = $files | append (dict "major_version" .Params.major_version "enable_date" (time .Params.enable_date) "languages" .Params.languages "tools" .Params.tools "build_environment" .Params.build_environment) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $files = sort $files "enable_date" "asc" -}}
+
+{{- $files | jsonify -}}

--- a/layouts/shortcodes/build-environment.html
+++ b/layouts/shortcodes/build-environment.html
@@ -1,0 +1,54 @@
+{{- $files := slice -}}
+{{- range os.ReadDir "content/pages/_partials/_platform-language-support-and-tools" -}}
+  {{- with $.Site.GetPage (path.Join "pages/_partials/_platform-language-support-and-tools/" .Name) -}}
+    {{- $files = $files | append (dict "name" (printf "v%d" .Params.major_version) "enable_date" (time .Params.enable_date) "build_environment" .Params.build_environment) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $files = sort $files "enable_date" "asc" -}}
+
+{{- $defaultEnableDate := time "1970-01-01" -}}
+{{- range $files -}}
+  {{- if and (gt .enable_date $defaultEnableDate) (lt .enable_date now) -}}
+    {{ $defaultEnableDate = .enable_date }}
+  {{- end -}}
+{{- end -}}
+
+{{ $unique_id := substr (md5 .Inner) 0 16 }}
+
+<div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
+  <nav role="navigation" class="tabs">
+    <ul class="tab-active" block-id="{{ $unique_id }}">
+      {{ range $idx, $file := $files }}
+      <li class="tab-label-wrapper">
+        <a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{ $file.name }}"
+           data-id="{{ lower $unique_id }}">
+          {{ $file.name }}
+        </a>
+      </li>
+      {{ end }}
+    </ul>
+  </nav>
+
+  {{- range $files -}}
+    <div class="tab noCodeTab {{ if eq .enable_date $defaultEnableDate }}tab-default{{ end }}" id="tab-{{ .name }}-{{ $unique_id }}">
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <strong>Operating system</strong>
+            </td>
+            <td>{{ .build_environment.operating_system | markdownify }}</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Architecture</strong>
+            </td>
+            <td><code>{{ .build_environment.architecture }}</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  {{- end -}}
+
+</div>

--- a/layouts/shortcodes/languages.html
+++ b/layouts/shortcodes/languages.html
@@ -1,0 +1,60 @@
+{{- $files := slice -}}
+{{- range os.ReadDir "content/pages/_partials/_platform-language-support-and-tools" -}}
+  {{- with $.Site.GetPage (path.Join "pages/_partials/_platform-language-support-and-tools/" .Name) -}}
+    {{- $files = $files | append (dict "name" (printf "v%d" .Params.major_version) "enable_date" (time .Params.enable_date) "languages" .Params.languages) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $files = sort $files "enable_date" "asc" -}}
+
+{{- $defaultEnableDate := time "1970-01-01" -}}
+{{- range $files -}}
+  {{- if and (gt .enable_date $defaultEnableDate) (lt .enable_date now) -}}
+    {{ $defaultEnableDate = .enable_date }}
+  {{- end -}}
+{{- end -}}
+
+{{ $unique_id := substr (md5 .Inner) 0 16 }}
+
+<div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
+  <nav role="navigation" class="tabs">
+    <ul class="tab-active" block-id="{{ $unique_id }}">
+      {{ range $idx, $file := $files }}
+      <li class="tab-label-wrapper">
+        <a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{ $file.name }}"
+           data-id="{{ lower $unique_id }}">
+          {{ $file.name }}
+        </a>
+      </li>
+      {{ end }}
+    </ul>
+  </nav>
+
+  {{- range $files -}}
+    <div class="tab noCodeTab {{ if eq .enable_date $defaultEnableDate }}tab-default{{ end }}" id="tab-{{ .name }}-{{ $unique_id }}">
+      <table>
+        <thead>
+          <th>Language</th>
+          <th>Default version</th>
+          <th>Supported versions</th>
+          <th>Environment variable</th>
+          <th>File</th>
+        </thead>
+        <tbody>
+          {{- range .languages -}}
+          <tr>
+            <td>
+              <strong>{{ .name }}</strong>
+            </td>
+            <td>{{ .default }}</td>
+            <td>{{ .supported }}</td>
+            <td>{{ if .environment_variable }}<code>{{ .environment_variable }}</code>{{ end }}</td>
+            <td>{{ if .file }}<code>{{ delimit .file "</code>, <code>" }}</code>{{ end }}</td>
+          </tr>
+          {{- end -}}
+        </tbody>
+      </table>
+    </div>
+  {{- end -}}
+
+</div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -2,10 +2,4 @@
 {{- $default := .Get "default" -}}
 {{- $noCode := .Get "no-code" -}}
 
-{{ if eq $default "true"}}
-<div class="tab tab-default" id="tab-{{$label}}-UNIQUE_ID">{{ $.Inner | .Page.RenderString }}</div>
-{{ else if eq $noCode "true" }}
-<div class="tab noCodeTab" id="tab-{{$label}}-UNIQUE_ID">{{ $.Inner | .Page.RenderString }}</div>
-{{ else }}
-<div class="tab" id="tab-{{$label}}-UNIQUE_ID">{{ $.Inner | .Page.RenderString }}</div>
-{{ end }}
+<div class="tab {{ if eq $default "true" }}tab-default{{ end }} {{ if eq $noCode "true" }}noCodeTab{{ end }}" id="tab-{{ $label }}-UNIQUE_ID">{{ $.Inner | .Page.RenderString }}</div>

--- a/layouts/shortcodes/tools.html
+++ b/layouts/shortcodes/tools.html
@@ -1,0 +1,58 @@
+{{- $files := slice -}}
+{{- range os.ReadDir "content/pages/_partials/_platform-language-support-and-tools" -}}
+  {{- with $.Site.GetPage (path.Join "pages/_partials/_platform-language-support-and-tools/" .Name) -}}
+    {{- $files = $files | append (dict "name" (printf "v%d" .Params.major_version) "enable_date" (time .Params.enable_date) "tools" .Params.tools) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $files = sort $files "enable_date" "asc" -}}
+
+{{- $defaultEnableDate := time "1970-01-01" -}}
+{{- range $files -}}
+  {{- if and (gt .enable_date $defaultEnableDate) (lt .enable_date now) -}}
+    {{ $defaultEnableDate = .enable_date }}
+  {{- end -}}
+{{- end -}}
+
+{{ $unique_id := substr (md5 .Inner) 0 16 }}
+
+<div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
+  <nav role="navigation" class="tabs">
+    <ul class="tab-active" block-id="{{ $unique_id }}">
+      {{ range $idx, $file := $files }}
+      <li class="tab-label-wrapper">
+        <a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{ lower $file.name }}"
+           data-id="{{ lower $unique_id }}">
+          {{ $file.name }}
+        </a>
+      </li>
+      {{ end }}
+    </ul>
+  </nav>
+
+  {{- range $files -}}
+    <div class="tab noCodeTab {{ if eq .enable_date $defaultEnableDate }}tab-default{{ end }}" id="tab-{{ .name }}-{{ $unique_id }}">
+      <table>
+        <thead>
+          <th>Tool</th>
+          <th>Default version</th>
+          <th>Supported versions</th>
+          <th>Environment variable</th>
+        </thead>
+        <tbody>
+          {{- range .tools -}}
+          <tr>
+            <td>
+              <strong>{{ .name }}</strong>
+            </td>
+            <td>{{ .default }}</td>
+            <td>{{ .supported }}</td>
+            <td>{{ if .environment_variable }}<code>{{ .environment_variable }}</code>{{ end }}</td>
+          </tr>
+          {{- end -}}
+        </tbody>
+      </table>
+    </div>
+  {{- end -}}
+
+</div>


### PR DESCRIPTION
The only content changes I made were:
- changing "Gatsby.js" -> "Gatsby"
- removing the redundant word "version" in each row of the tools table
- making NPM and pip's phrasing consistent for their default versions

https://programattic-pages-build-ima.cloudflare-docs-7ou.pages.dev/pages/platform/language-support-and-tools/

cc. @jrf0110 @WalshyDev 