### PR TITLE
[algolia/search] Fix facet typo

### DIFF
--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -130,7 +130,7 @@
 
   {{- if $DATA.algolia -}}
   <script>window.algoliaConfig = {{ $DATA.algolia }}</script>
-  <meta name="algolia:product" content="{{ $DATA.algolia.product }}" />
+  <meta name="docsearch:product" content="{{ $DATA.algolia.product }}" />
   {{- end -}}
 
   {{- $coveo := index $.Context.Site.Params "coveo" -}}


### PR DESCRIPTION
fix bug in meta tag - should be docsearch, not algolia - eg `meta name="docsearch:product"`

per docs here: https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags