### PR TITLE
[algolia] add facet filters

### DIFF
--- a/assets/search.ts
+++ b/assets/search.ts
@@ -20,9 +20,9 @@
       appId: '8MU1G3QO9P',
       apiKey,
       container: '#algolia',
-      // searchParameters: {
-      //   facetFilters
-      // },
+      searchParameters: {
+        facetFilters
+      },
       transformItems: items => {
         return items.filter(item => {
           const url = new URL(item.url)

--- a/assets/search.ts
+++ b/assets/search.ts
@@ -21,7 +21,7 @@
       apiKey,
       container: '#algolia',
       searchParameters: {
-        facetFilters
+        optionalFilters: facetFilters
       },
       transformItems: items => {
         return items.filter(item => {


### PR DESCRIPTION
following #8599, this PR enables the facetfilters config now that they've been indexed into our algolia index

i've made the decision to implement this using the `optionalFilters` parameter - the difference between this and the `facetFilters` parameter that is generally recommended by Algolia is that optionalFilters weighs in favor of the parameters passed in, but will still show other results. this means that in an instance where we have matching product results (eg workers-related content while in the workers docs), they will appear first, but other products/docs will appear, just with a lower weight/priority. 

to see this in action, visit this page: https://integrate-facet.cloudflare-docs-7ou.pages.dev/cloudflare-for-platforms/

search for "kv" - the first result is https://integrate-facet.cloudflare-docs-7ou.pages.dev/cloudflare-for-platforms/workers-for-platforms/platform/limits/, which contains the text "KV", whereas the second and third results correctly send the user over to the workers kv docs.