### PR TITLE
Add search.ts to ignored gg checks

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,4 +1,5 @@
 version: 2
 secret:
   ignored-paths:
+    - 'assets/search.ts'
     - 'data/*.yml'


### PR DESCRIPTION
Fixes an issue with Gitguardian where it was returning an error with the appId being hardcoded in `search.ts`. This is a public-facing value so it's okay to have in the file.

Feel free to merge on +1 and review