### PR TITLE
Update reports.md

### DIFF
--- a/content/ddos-protection/reference/reports.md
+++ b/content/ddos-protection/reference/reports.md
@@ -12,10 +12,6 @@ To download an ad-hoc DDoS report, generate a PDF report file by selecting **Pri
 
 Additionally, if you are a Magic Transit or Spectrum BYOIP customer, you will receive weekly DDoS reports by email with a snapshot of the DDoS attacks that Cloudflare detected and mitigated in the previous week.
 
-{{<Aside type="note">}}
-Currently, Magic Transit customers with leased IPs will not receive weekly DDoS reports.
-{{</Aside>}}
-
 ## Weekly DDoS reports
 
 Cloudflare sends DDoS reports via email from `no-reply@notify.cloudflare.com` to users with the Super Administrator role on accounts with prefixes advertised by Cloudflare.


### PR DESCRIPTION
removed the note about customers with Leased IPs not getting reports. Since we migrated the reports to use NAv2 data, then customers with Leased IPs should also be receiving these reports.