### PR TITLE
Update send-email-workers.md

### DIFF
--- a/content/email-routing/email-workers/send-email-workers.md
+++ b/content/email-routing/email-workers/send-email-workers.md
@@ -40,10 +40,10 @@ export default {
    msg.setSender({ name: "GPT-4", addr: "<SENDER>@example.com" });
    msg.setRecipient("<RECIPIENT>@example2.com");
    msg.setSubject("An email generated in a worker");
-   msg.setMessage(
-     "text/plain",
-     `Congratulations, you just sent an email from a worker.`
-   );
+   msg.addMessage({
+       contentType: 'text/plain',
+       data: `Congratulations, you just sent an email from a worker.`
+   });
 
    var message = new EmailMessage(
      "<SENDER>@example.com",


### PR DESCRIPTION
Fix tutorial example. Based on [documentation for `mimetext`](https://www.npmjs.com/package/mimetext#use), the message should be configured using `addMessage` function now.

The API is changed in `mimetext` 3.0.0 release: https://github.com/muratgozel/MIMEText/releases/tag/v3.0.0

Quote from the mimetext documentation:
```javascript
// cjs
const {createMimeMessage} = require('mimetext')
// es
import {createMimeMessage} from 'mimetext'

// create a simple plain text email
const msg = createMimeMessage()
msg.setSender({name: 'Lorem Ipsum', addr: 'lorem@ipsum.com'})
msg.setRecipient('foobor@test.com')
msg.setSubject('🚀 Issue 49!')
msg.addMessage({
    contentType: 'text/plain',
    data: `Hi,
I'm a simple text.`
})
const raw = msg.asRaw()
/*
Date: Sun, 24 Oct 2021 04:50:32 +0000
From: "Lorem Ipsum" <lorem@ipsum.com>
To: <foobor@test.com>
Message-ID: <is6jcakaj6p-1635051032602@ipsum.com>
Subject: =?utf-8?B?8J+agCBJc3N1ZSA0OSE=?=
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8

Hi,
I'm a simple text.
*/
```