### PR TITLE
Clarifying that a replica can be added using dashboard commands

### DIFF
--- a/content/cloudflare-one/connections/connect-apps/install-and-setup/deploy-cloudflared-replicas.md
+++ b/content/cloudflare-one/connections/connect-apps/install-and-setup/deploy-cloudflared-replicas.md
@@ -22,6 +22,11 @@ By design, replicas do not offer any level of traffic steering (random, hash, or
 - To update the configuration of a tunnel without downtime.
 
 ### Deploy `cloudflared` replicas
+{{<Aside type="note" header="If your tunnel was created in the dashboard">}}
+
+To install another replica connector for a tunnel created from the instructions via the dashboard, simply re-run the same command in the Overview section of the tunnel in the dashboard on each host. This will create a replica for that tunnel.
+  
+{{</Aside>}}
 
 To deploy multiple instances of `cloudflared`, you can create and configure one tunnel and run it as multiple different processes.
 

--- a/content/cloudflare-one/identity/users/short-lived-certificates.md
+++ b/content/cloudflare-one/identity/users/short-lived-certificates.md
@@ -26,7 +26,7 @@ Cloudflare Access will take the identity from a token and, using short-lived cer
 
 ## 3. Generate a short-lived certificate public key
 
-1. In Zero Trust, navigate to **Access > Service Auth**.
+1. In Zero Trust, navigate to **Access > Service Auth** and select the SSH tab.
 
 2. In the dropdown, choose the application that represents the resource you secured in Step 1.
 


### PR DESCRIPTION
It's not obvious from the documentation that you can also install another connector for a tunnel by just running the same command again from the dashboard Overview page for the tunnel. This change adds clarification.