### PR TITLE
docs(turnstile): remove missing sitekey notice

### DIFF
--- a/content/turnstile/reference/testing.md
+++ b/content/turnstile/reference/testing.md
@@ -19,12 +19,6 @@ The following sitekeys and secret keys are available for testing.
 | `2x00000000000000000000BB` | Always blocks | invisible |
 | `3x00000000000000000000FF` | Forces an interactive challenge | visible |
 
-{{<Aside type="note">}}
-
-There are currently no sitekeys for testing invisible mode.
-
-{{</Aside>}}
-
 | Secret key | Description |
 | --- | --- |
 | `1x0000000000000000000000000000000AA` | Always passes |


### PR DESCRIPTION
4530b48279460125a52e5f7d9715b180e95bf03f added testing invisible sitekey documentation but seemed to have missed removing the now seemingly outdated notice.