### PR TITLE
Update edge-browser-cache-ttl.md

### DIFF
--- a/content/cache/about/edge-browser-cache-ttl.md
+++ b/content/cache/about/edge-browser-cache-ttl.md
@@ -7,7 +7,7 @@ pcx_content_type: concept
 
 ## Edge Cache TTL
 
-Edge Cache TTL (Time to Live) specifies the maximimum time to cache a resource in the Cloudflare edge network. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
+Edge Cache TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare edge network. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
 
 {{<feature-table id="cache.edge_cache_ttl">}}
 


### PR DESCRIPTION
From maximimum To maximum.

"Edge Cache TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare edge network."