### PR TITLE
Fixes CSS bugs on home with product icons/names

### DIFF
--- a/static/home.css
+++ b/static/home.css
@@ -831,9 +831,13 @@ html[is-site-page] .DocsContent {
 
 .TriBlock li {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     gap: 10px;
     padding: 6px 0;
+}
+
+.TriBlock li p {
+    margin-bottom: initial;
 }
 
 .TriBlock img {
@@ -850,6 +854,7 @@ html[is-site-page] .DocsContent {
 
 .DocsMarkdown .TriBlock ul {
     padding-left: 0;
+    margin-bottom: 1em;
 }
 
 .DocsMarkdown .TriBlockHeader p {


### PR DESCRIPTION
This PR fixes CSS bugs related to the product names and icons on the [Cloudflare Docs Homepage](https://developers.cloudflare.com/). The changes make it so that the TriBlock li styles align the product icons and names together rather than being pushed apart. See screenshots:

Old:
![image](https://user-images.githubusercontent.com/53151058/236574691-03cbac38-aaa7-4617-8439-bf3445e4f4dd.png)

With changes:
![image](https://user-images.githubusercontent.com/53151058/236574740-5967e0e0-1726-465c-83c5-e566b7e69131.png)

Closes #8759 