### PR TITLE
[Docs Site] feat: add highlight ranges

### DIFF
--- a/content/pages/framework-guides/deploy-a-remix-site.md
+++ b/content/pages/framework-guides/deploy-a-remix-site.md
@@ -85,7 +85,7 @@ The following code block shows an example of accessing a KV namespace in Remix.
 ```typescript
 ---
 filename: app/routes/products/$productId.tsx
-highlight: [9,10,11,12,13,17,24]
+highlight: 9-13,17,24
 ---
 import type { LoaderArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";

--- a/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
+++ b/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
@@ -46,7 +46,7 @@ const abTest = async ({request, next, env}) => {
   /*
   Todo: 
   1. Conditional statements to check for the cookie
-  2. Assign cookies based on percentage, then sever 
+  2. Assign cookies based on percentage, then serve 
   */
 }
 
@@ -89,7 +89,7 @@ const newHomepagePathName = "/test"
 const abTest = async ({request, next, env}) => {
   /*
   Todo: 
-  1. Assign cookies based on randomly genrated percentage, then serve
+  1. Assign cookies based on randomly generated percentage, then serve
   */
 
   const url = new URL(request.url)
@@ -125,7 +125,7 @@ A Function is a Worker that executes on your Pages project to add dynamic functi
 ```js
 ---
 filename: /functions/_middleware.js
-highlight: [20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36]
+highlight: 20-36
 ---
 const cookieName = "ab-test-cookie"
 const newHomepagePathName = "/test"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "concurrently": "^7.6.0",
     "glob": "^8.1.0",
     "html-rewriter-wasm": "^0.4.1",
+    "parse-numeric-range": "^1.3.0",
     "prettier": "2.5.1",
     "prismjs": "^1.29.0",
     "tsm": "2.2.2",


### PR DESCRIPTION
This adds support for highlight ranges, so instead of doing:
```yaml
highlight: [15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
```

You can now just do:

```yaml
highlight: ["15-31"]
```

No breaking changes or anything here - the more verbose syntax will continue to work without issue.

Closes #8765 