### PR TITLE
Clarify header matching behavior

### DIFF
--- a/content/logs/reference/custom-fields.md
+++ b/content/logs/reference/custom-fields.md
@@ -205,3 +205,4 @@ If you are a Cloudflare Access user, as of March 2022 you have to manually add t
 
 * You can configure up to 40 custom fields across all field types (HTTP request headers, HTTP response headers, and cookies) per zone.
 * The maximum length of custom field data is 8 KB. Any data over this limit will be truncated.
+* For headers which may be included multiple times (eg. the `set-cookie` response header), a custom field will only log the first instance of the header. Subsequent headers of the same type will be ignored.

--- a/content/logs/reference/custom-fields.md
+++ b/content/logs/reference/custom-fields.md
@@ -205,4 +205,4 @@ If you are a Cloudflare Access user, as of March 2022 you have to manually add t
 
 * You can configure up to 40 custom fields across all field types (HTTP request headers, HTTP response headers, and cookies) per zone.
 * The maximum length of custom field data is 8 KB. Any data over this limit will be truncated.
-* For headers which may be included multiple times (eg. the `set-cookie` response header), a custom field will only log the first instance of the header. Subsequent headers of the same type will be ignored.
+* For headers which may be included multiple times (for example, the `set-cookie` response header), a custom field will only log the first instance of the header. Subsequent headers of the same type will be ignored.


### PR DESCRIPTION
Per customer report, currently we only log the first match of a custom field even if the header can be included multiple times eg the set-cookie header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie . This is expected behavior of Custom Fields (i.e. match first, ignore subsequent) but was not previously noted in the documentation as far as I could find.