### PR TITLE
remove "wp-mobile-edition" 

### DIFF
--- a/content/automatic-platform-optimization/about/plugin-compatibility.md
+++ b/content/automatic-platform-optimization/about/plugin-compatibility.md
@@ -33,7 +33,6 @@ The Cloudflare APO Wordpress plugin does not support multisite WordPress install
 - [Mobile Detect](https://wordpress.org/plugins/tinywp-mobile-detect/)
 - [WordPress Mobile Pack](https://wordpress.org/plugins/wordpress-mobile-pack/)
 - [WP-Mobilizer](https://wordpress.org/plugins/wp-mobilizer/)
-- [WP Mobile Edition](https://wordpress.org/plugins/wp-mobile-edition/)
 - [Any Mobile Theme Switcher](https://wordpress.org/plugins/any-mobile-theme-switcher/)
 - [Easy Social Share Buttons](https://codecanyon.net/item/easy-social-share-buttons-for-wordpress/6394476)
 - [Jetpack (Mobile Theme)](https://wordpress.org/plugins/jetpack/)

--- a/content/automatic-platform-optimization/reference/cache-device-type.md
+++ b/content/automatic-platform-optimization/reference/cache-device-type.md
@@ -29,7 +29,6 @@ The Cloudflare for WordPress plugin automatically purges all cache variations fo
 - [wiziApp](https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app)
 - [WordPress Mobile Pack](https://wordpress.org/plugins/wordpress-mobile-pack/)
 - [WP-Mobilizer](https://wordpress.org/plugins/wp-mobilizer/)
-- [WP Mobile Edition](https://wordpress.org/plugins/wp-mobile-edition/)
 - [Device Theme Switcher](https://wordpress.org/plugins/device-theme-switcher/)
 - [Easy Social Share Buttons for WordPress](https://codecanyon.net/item/easy-social-share-buttons-for-wordpress/6394476)
 - [Jetpack (when mobile theme is activated)](https://jetpack.com/support/mobile-theme/)


### PR DESCRIPTION
> "This plugin has been closed as of April 9, 2021 and is not available for download. This closure is permanent. Reason: Author Request."
 --- https://wordpress.org/plugins/wp-mobile-edition/