### PR TITLE
remove "wiziApp"

### DIFF
--- a/content/automatic-platform-optimization/about/plugin-compatibility.md
+++ b/content/automatic-platform-optimization/about/plugin-compatibility.md
@@ -37,7 +37,6 @@ The Cloudflare APO Wordpress plugin does not support multisite WordPress install
 - [Any Mobile Theme Switcher](https://wordpress.org/plugins/any-mobile-theme-switcher/)
 - [Easy Social Share Buttons](https://codecanyon.net/item/easy-social-share-buttons-for-wordpress/6394476)
 - [Jetpack (Mobile Theme)](https://wordpress.org/plugins/jetpack/)
-- [wiziApp](https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app)
 - [WPML](https://wpml.org/)
 - [Hummingbird](https://wordpress.org/plugins/hummingbird-performance/)
 - [Imunify360](https://docs.imunify360.com/features/#webshield)

--- a/content/automatic-platform-optimization/reference/cache-device-type.md
+++ b/content/automatic-platform-optimization/reference/cache-device-type.md
@@ -26,7 +26,6 @@ The Cloudflare for WordPress plugin automatically purges all cache variations fo
 
 - [WP Touch (Free Version)](https://wordpress.org/plugins/wptouch/)
 - [Wp Mobile Detect](https://wordpress.org/plugins/wp-mobile-detect/)
-- [wiziApp](https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app)
 - [WordPress Mobile Pack](https://wordpress.org/plugins/wordpress-mobile-pack/)
 - [WP-Mobilizer](https://wordpress.org/plugins/wp-mobilizer/)
 - [WP Mobile Edition](https://wordpress.org/plugins/wp-mobile-edition/)


### PR DESCRIPTION
> "This plugin has been closed as of March 17, 2019 and is not available for download. This closure is permanent. Reason: Author Request."
--- https://wordpress.org/plugins/wiziapp-create-your-own-native-iphone-app/