### PR TITLE
[Workers] Runtime API: TCP Socket API Docs `connect()`

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -18,6 +18,6 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
-| TCP Workers                   |               |            |     ✅         |[Docs](/workers/runtime-apis/connect)             |
+| TCP Workers                   |               |            |     ✅         |[Docs](/workers/runtime-apis/tcp-sockets)             |
 | Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
 | Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |

--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -18,6 +18,6 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
-| TCP Workers                   |               | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
+| TCP Workers                   |               |            |     ✅         |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
 | Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
 | Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |

--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -18,6 +18,6 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
-| TCP Workers                   |               |            |     ✅         |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
+| TCP Workers                   |               |            |     ✅         |[Docs](/workers/runtime-apis/connect)             |
 | Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
 | Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -242,6 +242,7 @@ While handling a request, each Worker is allowed to have up to six connections o
 - `put()`, `match()`, and `delete()` methods of [Cache objects](/workers/runtime-apis/cache/).
 - `list()`, `get()`, `put()`, `delete()`, and `head()` methods of [R2](/r2/).
 - `send()` and `sendBatch()`, methods of [Queues](/queues/).
+- Opening a TCP socket using the [`connect()`](/workers/runtime-apis/connect/) API.
 
 Once a Worker has six connections open, it can still attempt to open additional connections. However, these attempts are put in a pending queue — the connections will not be initiated until one of the currently open connections has closed. Since earlier connections can delay later ones, if a Worker tries to make many simultaneous subrequests, its later subrequests may appear to take longer to start.
 

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -242,7 +242,7 @@ While handling a request, each Worker is allowed to have up to six connections o
 - `put()`, `match()`, and `delete()` methods of [Cache objects](/workers/runtime-apis/cache/).
 - `list()`, `get()`, `put()`, `delete()`, and `head()` methods of [R2](/r2/).
 - `send()` and `sendBatch()`, methods of [Queues](/queues/).
-- Opening a TCP socket using the [`connect()`](/workers/runtime-apis/connect/) API.
+- Opening a TCP socket using the [`connect()`](/workers/runtime-apis/tcp-sockets/) API.
 
 Once a Worker has six connections open, it can still attempt to open additional connections. However, these attempts are put in a pending queue — the connections will not be initiated until one of the currently open connections has closed. Since earlier connections can delay later ones, if a Worker tries to make many simultaneous subrequests, its later subrequests may appear to take longer to start.
 

--- a/content/workers/platform/protocols.md
+++ b/content/workers/platform/protocols.md
@@ -5,16 +5,13 @@ title: Protocols
 
 # Protocols
 
-Cloudflare Workers support the following protocols and protocol interfaces:
+Cloudflare Workers support the following protocols and interfaces:
 
-| Protocol  | Inbound | Outbound |
+| Protocol       | Inbound | Outbound |
 |---|---|---|
 | **HTTP / HTTPS**  | Handle incoming HTTP requests using the [`fetch()` handler](workers/runtime-apis/fetch-event/#syntax-module-worker/)  | Make HTTP subrequests using the [`fetch()` API](/workers/runtime-apis/fetch/)  |
 | **Direct TCP sockets**  | Support for handling inbound TCP connections is [coming soon](https://blog.cloudflare.com/introducing-socket-workers/)  | Create outbound TCP connections using the [`connect()` API](/workers/runtime-apis/tcp-sockets/) |
 | **WebSockets**  | Accept incoming WebSocket connections using the [`WebSocket` API](/workers/runtime-apis/websockets/), or with [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/)  | [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/) |
 | **MQTT** | Handle incoming messages to an MQTT broker with [Pub Sub](/pub-sub/learning/integrate-workers/) | Support for publishing MQTT messages to an MQTT topic is [coming soon](/pub-sub/learning/integrate-workers/) |
-
-
-### Using Workers to process and forward emails
-
-Instead of interacting directly via SMTP email servers, you can use [Email Workers](/email-routing/email-workers/), which provides a simple set of APIs to process and forward email.
+| **HTTP/3 (QUIC)** | Accept inbound requests over [HTTP/3](https://www.cloudflare.com/learning/performance/what-is-http3/) by enabling it on your [zone](/fundamentals/get-started/concepts/accounts-and-zones/#zones) in the network tab of the [Cloudflare dashboard](https://dash.cloudflare.com/). | |
+| **SMTP** | Use [Email Workers](/email-routing/email-workers/) to process and forward email, without having to manage TCP connections to SMTP email servers | [Email Workers](/email-routing/email-workers/) |

--- a/content/workers/platform/protocols.md
+++ b/content/workers/platform/protocols.md
@@ -1,0 +1,20 @@
+---
+pcx_content_type: concept
+title: Protocols
+---
+
+# Protocols
+
+Cloudflare Workers support the following protocols and protocol interfaces:
+
+| Protocol  | Inbound | Outbound |
+|---|---|---|
+| **HTTP / HTTPS**  | Handle incoming HTTP requests using the [`fetch()` handler](workers/runtime-apis/fetch-event/#syntax-module-worker/)  | Make HTTP subrequests using the [`fetch()` API](/workers/runtime-apis/fetch/)  |
+| **Direct TCP sockets**  | Support for handling inbound TCP connections is [coming soon](https://blog.cloudflare.com/introducing-socket-workers/)  | Create outbound TCP connections using the [`connect()` API](/workers/runtime-apis/tcp-sockets/) |
+| **WebSockets**  | Accept incoming WebSocket connections using the [`WebSocket` API](/workers/runtime-apis/websockets/), or with [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/)  | [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/) |
+| **MQTT** | Handle incoming messages to an MQTT broker with [Pub Sub](/pub-sub/learning/integrate-workers/) | Support for publishing MQTT messages to an MQTT topic is [coming soon](/pub-sub/learning/integrate-workers/) |
+
+
+### Using Workers to process and forward emails
+
+Instead of interacting directly via SMTP email servers, you can use [Email Workers](/email-routing/email-workers/), which provides a simple set of APIs to process and forward email.

--- a/content/workers/platform/protocols.md
+++ b/content/workers/platform/protocols.md
@@ -9,7 +9,7 @@ Cloudflare Workers support the following protocols and interfaces:
 
 | Protocol       | Inbound | Outbound |
 |---|---|---|
-| **HTTP / HTTPS**  | Handle incoming HTTP requests using the [`fetch()` handler](workers/runtime-apis/fetch-event/#syntax-module-worker/)  | Make HTTP subrequests using the [`fetch()` API](/workers/runtime-apis/fetch/)  |
+| **HTTP / HTTPS**  | Handle incoming HTTP requests using the [`fetch()` handler](/workers/runtime-apis/fetch-event/#syntax-module-worker/)  | Make HTTP subrequests using the [`fetch()` API](/workers/runtime-apis/fetch/)  |
 | **Direct TCP sockets**  | Support for handling inbound TCP connections is [coming soon](https://blog.cloudflare.com/introducing-socket-workers/)  | Create outbound TCP connections using the [`connect()` API](/workers/runtime-apis/tcp-sockets/) |
 | **WebSockets**  | Accept incoming WebSocket connections using the [`WebSocket` API](/workers/runtime-apis/websockets/), or with [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/)  | [MQTT over WebSockets (Pub/Sub)](/pub-sub/learning/websockets-browsers/) |
 | **MQTT** | Handle incoming messages to an MQTT broker with [Pub Sub](/pub-sub/learning/integrate-workers/) | Support for publishing MQTT messages to an MQTT topic is [coming soon](/pub-sub/learning/integrate-workers/) |

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -118,6 +118,31 @@ const socket = connect(address, { secureTransport: "starttls" });
 const secureSocket = socket.startTls();
 ```
 
+## Error handling
+
+- TODO - show what happens when the server closes the connection, and how to handle it gracefully.
+
+```typescript
+import { connect } from "cloudflare:sockets"
+
+const connectionUrl = "<URL>";
+
+export default {
+  async fetch(req, env) {
+
+    try {
+      const socket = connect(connectionUrl);
+
+      //...
+
+      return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
+    } catch (error) {
+      return new Response("Socket connection failed: " + error, { status: 500 });
+    }
+  }
+};
+```
+
 Note the following:
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -175,3 +175,4 @@ Note the following:
 
 - When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, in order to use `connect()`.
 - TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 
+- Each open TCP socket counts towards the maximum number of [open connections](/workers/platform/limits/#simultaneous-open-connections) that can be simultaneously open.

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -108,6 +108,11 @@ const socket = connect(address, { secureTransport: "starttls" });
 const secureSocket = socket.startTls();
 ```
 
+#### Note the following:
+
+- `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
+- Once `startTls()` is called, the initial socket is closed and no longer usable. In the example above, one would would use the newly created `secureSocket`.
+
 ## Error handling
 
 import { connect } from 'cloudflare:sockets';
@@ -164,12 +169,6 @@ socket.close();
 // After close() is called, you can no longer read from the readable side of the socket
 const reader = socket.readable.getReader(); // This fails
 ```
-
-
-Note the following:
-
-- `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
-- Once `startTls()` is called, the initial socket is closed and no longer usable. In the example above, one would would use the newly created `secureSocket`.
 
 ### Considerations
 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -111,7 +111,8 @@ const secureSocket = socket.startTls();
 #### Note the following:
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
-- Once `startTls()` is called, the initial socket is closed and no longer usable. In the example above, one would would use the newly created `secureSocket`.
+- Once `startTls()` is called, the initial socket is closed and can no longer be read from or written to. In the example above, anytime after `startTls()` is called, you would use the newly created `secureSocket`. Any existing readers and writers based off the original socket will no longer work — you must create new readers and writers from the newly created `secureSocket`.
+- `startTls()` should only be called once on an existing socket.
 
 ## Error handling
 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -115,6 +115,8 @@ const secureSocket = socket.startTls();
 
 ## Error handling
 
+To handle errors when creating a new TCP socket, reading from a socket, or writing to a socket, wrap these calls inside `try..catch` blocks. This example opens a connection to Google.com, initiates a HTTP request, and returns the response. If any of this fails and throws an exception, it returns a 500:
+
 ```typescript
 import { connect } from 'cloudflare:sockets';
 const connectionUrl = "google.com:80";
@@ -130,13 +132,13 @@ export default {
       
       return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
     } catch (error) {
-      return new Response("Socket connection failed: " + error, { status: 500 });
+      return new Response(`Socket connection failed: ${error}`, { status: 500 });
     }
   }
 };
 ```
 
-### Closing TCP connections
+## Closing TCP connections
 
 You can close a TCP connection by calling `close()` on the socket. This will close both the readable and writeable sides of the socket.
 
@@ -151,7 +153,7 @@ socket.close();
 const reader = socket.readable.getReader(); // This fails
 ```
 
-### Considerations
+## Considerations
 
 - When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, in order to use `connect()`.
 - TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -115,38 +115,19 @@ const secureSocket = socket.startTls();
 
 ## Error handling
 
+```typescript
 import { connect } from 'cloudflare:sockets';
-
-const connectionUrl = "nonexistinghostname.invalid:1234";
-
+const connectionUrl = "google.com:80";
 export interface Env { }
-
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     try {
       const socket = connect(connectionUrl);
-
-      // This will throw because the `closed` promise is rejected with an exception.
-      await socket.closed;
-    } catch (error) {
-      return new Response("Socket connection failed: " + error, { status: 500 });
-    }
-  }
-};
-
-```typescript
-import { connect } from "cloudflare:sockets"
-
-const connectionUrl = "<URL>";
-
-export default {
-  async fetch(req, env) {
-
-    try {
-      const socket = connect(connectionUrl);
-
-      //...
-
+      const writer = socket.writable.getWriter();
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode("GET / HTTP/1.0\r\n\r\n");
+      await writer.write(encoded);
+      
       return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
     } catch (error) {
       return new Response("Socket connection failed: " + error, { status: 500 });

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -88,17 +88,8 @@ export default {
 - `close()` {{<type>}}`Promise<void>`{{</type>}}
   - Closes the TCP socket. Both the readable and writable streams are forcibly closed.
 
-- {{<code>}}startTls(options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/connect/#tlsoptions">}}TlsOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}Socket{{</type-link>}}
+- {{<code>}}startTls(){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}Socket{{</type-link>}}
   - Upgrades an insecure socket to a secure one that uses TLS, returning a new [Socket](/workers/runtime-apis/connect#socket). Note that in order to call `startTls()`, you must set [`secureTransport`](/workers/runtime-apis/connect/#socketoptions) to `starttls` when initially calling `connect()` to create the socket.
-
-{{</definitions>}}
-
-### `TlsOptions`
-
-{{<definitions>}}
-
-- `expectedServerHostname` {{<type>}}string{{</type>}}
-  - TODO
 
 {{</definitions>}}
 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -143,6 +143,34 @@ export default {
 };
 ```
 
+### Closing TCP connections
+
+You can close a TCP connection by calling `close()` on the socket. By default, unless the `allowHalfOpen` is explicitly set to `true`, this will close both the readable and writeable sides of the socket
+
+```typescript
+import { connect } from "cloudflare:sockets"
+
+const socket = connect("my-url.com:70");
+const reader = socket.readable.getReader();
+socket.close();
+
+// After close() is called, you can no longer read from the readable side of the socket
+const reader = socket.readable.getReader(); // This fails
+```
+
+If you need to create a socket that is compatible with existing code that assumes the pattern from Node.js, where the readable side of a socket remains open after `socket.end()` is called, you can set the `allowHalfOpen` option when creating a socket.
+
+```typescript
+import { connect } from "cloudflare:sockets"
+
+const socket = connect("my-url.com:70", { allowHalfOpen: true });
+const reader = socket.readable.getReader();
+socket.close();
+
+// After close() is called, you can continue to read from the readable side of the socket
+const reader = socket.readable.getReader(); // This works
+```
+
 Note the following:
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -122,3 +122,7 @@ Note the following:
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
 - Once `startTls()` is called, the initial socket is closed and no longer usable. In the example above, one would would use the newly created `secureSocket`.
+
+### Considerations
+
+- TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -79,7 +79,7 @@ export default {
 - {{<code>}}readable(){{</code>}} : {{<type-link href="/workers/runtime-apis/streams/readablestream/">}}ReadableStream{{</type-link>}}
   - Returns the readable side of the TCP socket.
 
-- {{<code>}}writeable(){{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writeable/">}}WriteableStream{{</type-link>}}
+- {{<code>}}writeable(){{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writablestream/">}}WriteableStream{{</type-link>}}
   - Returns the writable side of the TCP socket.
 
 - `closed()` {{<type>}}`Promise<void>`{{</type>}}

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -1,0 +1,124 @@
+---
+pcx_content_type: configuration
+title: Connect (TCP Socket API)
+weight: 4
+---
+
+# connect()
+
+The `connect()` API provides a programming interface for creating an outbound [TCP connection](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from a Cloudflare Worker. It returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
+
+Many application-layer protocols are built on top of TCP, and require an underlying TCP socket API in order to work, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB and more. `connect()` is the lower-level API that allows these protocols to work on Cloudflare Workers.
+
+`connect()` is provided as a [Runtime API](/workers/runtime-apis/), and is accessed by importing the `connect` function from `cloudflare:sockets`, akin to how one imports built-in modules in Node.js. A simple example of creating a TCP socket, writing to it, and returning the readable side of the socket as a response, is shown below:
+
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+const connectionUrl = "<URL>";
+
+export default {
+  async fetch(req, env) {
+
+    try {
+      const socket = connect(connectionUrl);
+
+      const writer = socket.writable.getWriter()
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode(url.pathname + "\r\n");
+      await writer.write(encoded);
+
+      return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
+    } catch (error) {
+      return new Response("Socket connection failed: " + error, { status: 500 });
+    }
+  }
+};
+```
+
+## Syntax and Types
+
+{{<definitions>}}
+
+- {{<code>}}connect(address: {{<type-link href="/workers/runtime-apis/connect/#socketaddress">}}SocketAddress{{</type-link>}} | string, options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/connect/#socketoptions">}}SocketOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}`Socket`{{</type-link>}}
+  - `connect()` accepts either a URL string or [`SocketAddress`](/workers/runtime-apis/connect/#socketaddress) to define the hostname and port number to connect to, and an optional configuration object, [`SocketOptions`](/workers/runtime-apis/connect/#socketoptions). It returns an instance of a [`Socket`](/workers/runtime-apis/connect/#socket).
+{{</definitions>}}
+
+### `SocketAddress`
+
+{{<definitions>}}
+
+- `hostname` {{<type>}}string{{</type>}}
+  - The hostname to connect to. Ex: `cloudflare.com`.
+
+- `port` {{<type>}}number{{</type>}}
+  - The port number to connect to. Ex: `5432`.
+
+{{</definitions>}}
+
+### `SocketOptions`
+
+{{<definitions>}}
+
+- `secureTransport` {{<type>}}"off" | "on" | "starttls"{{</type>}} — Defaults to `off`
+  - Specifies whether or not to use [TLS](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) when creating the TCP socket.
+  - `off` — do not use TLS.
+  - `on` — use TLS.
+  - `starttls` — do not use TLS initially, but allow the socket to be upgraded to use TLS by calling [`startTls()`](/workers/runtime-apis/connect/#how-to-implement-the-starttls-pattern).
+
+- `allowHalfOpen` {{<type>}}boolean{{</type>}} — Defaults to `false`
+  - Defines whether the writable side of the TCP socket will automatically close on EOF. When set to `false`, the writable side of the TCP socket will automatically close on EOF. When set to `true`, the writable side of the TCP socket will remain open on EOF.
+  - This option allows for interoperability with TCP socket implementations in Node.js and Deno, which currently behave differently.
+
+{{</definitions>}}
+
+### `Socket`
+
+{{<definitions>}}
+
+- {{<code>}}readable(){{</code>}} : {{<type-link href="/workers/runtime-apis/streams/readablestream/">}}ReadableStream{{</type-link>}}
+  - Returns the readable side of the TCP socket.
+
+- {{<code>}}writeable(){{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writeable/">}}WriteableStream{{</type-link>}}
+  - Returns the writable side of the TCP socket.
+
+- `closed()` {{<type>}}`Promise<void>`{{</type>}}
+  - TODO
+
+- `close()` {{<type>}}`Promise<void>`{{</type>}}
+  - Closes the TCP socket. If [`allowHalfOpen`](/workers/runtime-apis/connect/#socketoptions) is set to `true`, only the writeable side of the socket will be closed, and the readable side of the socket will remain readable.
+
+- {{<code>}}startTls(options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/connect/#tlsoptions">}}TlsOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}Socket{{</type-link>}}
+  - Upgrades an insecure socket to a secure one that uses TLS, returning a new [Socket](/workers/runtime-apis/connect#socket). Note that in order to call `startTls()`, you must set [`secureTransport`](/workers/runtime-apis/connect/#socketoptions) to `starttls` when initially calling `connect()` to create the socket.
+
+{{</definitions>}}
+
+### `TlsOptions`
+
+{{<definitions>}}
+
+- `expectedServerHostname` {{<type>}}string{{</type>}}
+  - TODO
+
+{{</definitions>}}
+
+## How to implement the startTLS pattern
+
+Many TCP-based systems, including databases and email servers, require that clients use a pattern called StartTLS when connecting. In this pattern, the client first creates an insecure TCP socket, without TLS, and then "upgrades" it to a secure TCP socket, that uses TLS. The `connect()` API simplifies this by providing a method, `startTls()`, which returns a new `Socket` instance that uses TLS:
+
+```typescript
+import { connect } from "cloudflare:sockets"
+
+const address = {
+  hostname: "example-postgres-db.com",
+  port: 5432
+};
+const socket = connect(address, { secureTransport: "starttls" });
+const secureSocket = socket.startTls();
+```
+
+Note the following:
+
+- `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
+- Once `startTls()` is called, the initial socket is closed and no longer usable. In the example above, one would would use the newly created `secureSocket`.

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -12,17 +12,16 @@ Many application-layer protocols are built on top of TCP, and require an underly
 
 `connect()` is provided as a [Runtime API](/workers/runtime-apis/), and is accessed by importing the `connect` function from `cloudflare:sockets`, akin to how one imports built-in modules in Node.js. A simple example of creating a TCP socket, writing to it, and returning the readable side of the socket as a response, is shown below:
 
-
 ```typescript
 import { connect } from 'cloudflare:sockets';
 
-const connectionUrl = "<URL>";
-
 export default {
-  async fetch(req, env) {
+  async fetch(req: Request) {
+    const gopherAddr = "gopher.floodgap.com:70";
+    const url = new URL(req.url);
 
     try {
-      const socket = connect(connectionUrl);
+      const socket = connect(gopherAddr);
 
       const writer = socket.writable.getWriter()
       const encoder = new TextEncoder();
@@ -178,4 +177,5 @@ Note the following:
 
 ### Considerations
 
+- When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, in order to use `connect()`.
 - TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 

--- a/content/workers/runtime-apis/connect.md
+++ b/content/workers/runtime-apis/connect.md
@@ -6,7 +6,7 @@ weight: 4
 
 # connect()
 
-The `connect()` API provides a programming interface for creating an outbound [TCP connection](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from a Cloudflare Worker. It returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
+The Workers runtime provides an API, `connect()`, for creating a outbound [TCP connections](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from Workers. It returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
 
 Many application-layer protocols are built on top of TCP, and require an underlying TCP socket API in order to work, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB and more. `connect()` is the lower-level API that allows these protocols to work on Cloudflare Workers.
 
@@ -86,7 +86,7 @@ export default {
   - This promise is resolved when the socket is closed and is rejected if the socket encounters an error.
 
 - `close()` {{<type>}}`Promise<void>`{{</type>}}
-  - Closes the TCP socket. If [`allowHalfOpen`](/workers/runtime-apis/connect/#socketoptions) is set to `true`, only the writeable side of the socket will be closed, and the readable side of the socket will remain readable.
+  - Closes the TCP socket. Both the readable and writable streams are forcibly closed.
 
 - {{<code>}}startTls(options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/connect/#tlsoptions">}}TlsOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}Socket{{</type-link>}}
   - Upgrades an insecure socket to a secure one that uses TLS, returning a new [Socket](/workers/runtime-apis/connect#socket). Note that in order to call `startTls()`, you must set [`secureTransport`](/workers/runtime-apis/connect/#socketoptions) to `starttls` when initially calling `connect()` to create the socket.
@@ -161,7 +161,7 @@ export default {
 
 ### Closing TCP connections
 
-You can close a TCP connection by calling `close()` on the socket. By default, unless the `allowHalfOpen` is explicitly set to `true`, this will close both the readable and writeable sides of the socket
+You can close a TCP connection by calling `close()` on the socket. This will close both the readable and writeable sides of the socket.
 
 ```typescript
 import { connect } from "cloudflare:sockets"
@@ -174,18 +174,6 @@ socket.close();
 const reader = socket.readable.getReader(); // This fails
 ```
 
-If you need to create a socket that is compatible with existing code that assumes the pattern from Node.js, where the readable side of a socket remains open after `socket.end()` is called, you can set the `allowHalfOpen` option when creating a socket.
-
-```typescript
-import { connect } from "cloudflare:sockets"
-
-const socket = connect("my-url.com:70", { allowHalfOpen: true });
-const reader = socket.readable.getReader();
-socket.close();
-
-// After close() is called, you can continue to read from the readable side of the socket
-const reader = socket.readable.getReader(); // This works
-```
 
 Note the following:
 

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -159,3 +159,4 @@ const reader = socket.readable.getReader(); // This fails
 - When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, in order to use `connect()`.
 - TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 
 - Each open TCP socket counts towards the maximum number of [open connections](/workers/platform/limits/#simultaneous-open-connections) that can be simultaneously open.
+- By default, Workers cannot create outbound TCP connections on port 25 to send email to SMTP mail servers. [Cloudflare Email Workers](/email-routing/email-workers/) provides APIs to process and forward email.

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -1,14 +1,18 @@
 ---
 pcx_content_type: configuration
-title: Connect (TCP Socket API)
+title: TCP Sockets
 weight: 4
 ---
 
-# connect()
+# TCP Sockets
 
-The Workers runtime provides an API, `connect()`, for creating a outbound [TCP connections](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from Workers. It returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
+The Workers runtime provides the `connect()` API for creating a outbound [TCP connections](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from Workers.
 
-Many application-layer protocols are built on top of TCP, and require an underlying TCP socket API in order to work, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB and more. `connect()` is the lower-level API that allows these protocols to work on Cloudflare Workers.
+Many application-layer protocols are built on top of TCP, and require an underlying TCP socket API in order to work, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB and more.
+
+## `connect()`
+
+The `connect()` function returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
 
 `connect()` is provided as a [Runtime API](/workers/runtime-apis/), and is accessed by importing the `connect` function from `cloudflare:sockets`, akin to how one imports built-in modules in Node.js. A simple example of creating a TCP socket, writing to it, and returning the readable side of the socket as a response, is shown below:
 
@@ -35,8 +39,6 @@ export default {
   }
 };
 ```
-
-## Syntax and Types
 
 {{<definitions>}}
 
@@ -93,7 +95,7 @@ export default {
 
 {{</definitions>}}
 
-## How to implement Opportunistic TLS (StartTLS)
+## Opportunistic TLS (StartTLS)
 
 Many TCP-based systems, including databases and email servers, require that clients use opportunistic TLS (otherwise known as [StartTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS)) when connecting. In this pattern, the client first creates an insecure TCP socket, without TLS, and then "upgrades" it to a secure TCP socket, that uses TLS. The `connect()` API simplifies this by providing a method, `startTls()`, which returns a new `Socket` instance that uses TLS:
 
@@ -107,8 +109,6 @@ const address = {
 const socket = connect(address, { secureTransport: "starttls" });
 const secureSocket = socket.startTls();
 ```
-
-#### Note the following:
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
 - Once `startTls()` is called, the initial socket is closed and can no longer be read from or written to. In the example above, anytime after `startTls()` is called, you would use the newly created `secureSocket`. Any existing readers and writers based off the original socket will no longer work — you must create new readers and writers from the newly created `secureSocket`.

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -1,27 +1,26 @@
 ---
 pcx_content_type: configuration
-title: TCP Sockets
-weight: 4
+title: TCP sockets
 ---
 
-# TCP Sockets
+# TCP sockets
 
-The Workers runtime provides the `connect()` API for creating a outbound [TCP connections](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from Workers.
+The Workers runtime provides the `connect()` API for creating outbound [TCP connections](https://www.cloudflare.com/learning/ddos/glossary/tcp-ip/) from Workers.
 
-Many application-layer protocols are built on top of TCP, and require an underlying TCP socket API in order to work, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB and more.
+Many application-layer protocols are built on top of the Transmission Control Protocol (TCP). These application-layer protocols, including SSH, MQTT, SMTP, FTP, IRC, and most database wire protocols including MySQL, PostgreSQL, MongoDB, require an underlying TCP socket API in order to work.
 
 ## `connect()`
 
-The `connect()` function returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data, allowing you to read and write data on an ongoing basis, as long as the connection remains open.
+The `connect()` function returns a TCP socket, with both a [readable](/workers/runtime-apis/streams/readablestream/) and [writable](/workers/runtime-apis/streams/writablestream/) stream of data. This allows you to read and write data on an ongoing basis, as long as the connection remains open.
 
-`connect()` is provided as a [Runtime API](/workers/runtime-apis/), and is accessed by importing the `connect` function from `cloudflare:sockets`, akin to how one imports built-in modules in Node.js. A simple example of creating a TCP socket, writing to it, and returning the readable side of the socket as a response, is shown below:
+`connect()` is provided as a [Runtime API](/workers/runtime-apis/), and is accessed by importing the `connect` function from `cloudflare:sockets`. This process is similar to how one imports built-in modules in Node.js. Refer to the following codeblock for an example of creating a TCP socket, writing to it, and returning the readable side of the socket as a response:
 
 ```typescript
 import { connect } from 'cloudflare:sockets';
 
 export default {
   async fetch(req: Request) {
-    const gopherAddr = "gopher.floodgap.com:70";
+    const gopherAddr = { hostname: "gopher.floodgap.com", port: 70 };
     const url = new URL(req.url);
 
     try {
@@ -51,10 +50,10 @@ export default {
 {{<definitions>}}
 
 - `hostname` {{<type>}}string{{</type>}}
-  - The hostname to connect to. Ex: `cloudflare.com`.
+  - The hostname to connect to. Example: `cloudflare.com`.
 
 - `port` {{<type>}}number{{</type>}}
-  - The port number to connect to. Ex: `5432`.
+  - The port number to connect to. Example: `5432`.
 
 {{</definitions>}}
 
@@ -64,13 +63,13 @@ export default {
 
 - `secureTransport` {{<type>}}"off" | "on" | "starttls"{{</type>}} — Defaults to `off`
   - Specifies whether or not to use [TLS](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) when creating the TCP socket.
-  - `off` — do not use TLS.
-  - `on` — use TLS.
-  - `starttls` — do not use TLS initially, but allow the socket to be upgraded to use TLS by calling [`startTls()`](/workers/runtime-apis/tcp-sockets/#how-to-implement-the-starttls-pattern).
+  - `off` — Do not use TLS.
+  - `on` — Use TLS.
+  - `starttls` — Do not use TLS initially, but allow the socket to be upgraded to use TLS by calling [`startTls()`](/workers/runtime-apis/tcp-sockets/#how-to-implement-the-starttls-pattern).
 
 - `allowHalfOpen` {{<type>}}boolean{{</type>}} — Defaults to `false`
-  - Defines whether the writable side of the TCP socket will automatically close on EOF. When set to `false`, the writable side of the TCP socket will automatically close on EOF. When set to `true`, the writable side of the TCP socket will remain open on EOF.
-  - This option is similar to that offered by the Node.js [`net` module](https://nodejs.org/api/net.html) and allows interoperability with code which utilises it.
+  - Defines whether the writable side of the TCP socket will automatically close on end-of-file (EOF). When set to `false`, the writable side of the TCP socket will automatically close on EOF. When set to `true`, the writable side of the TCP socket will remain open on EOF.
+  - This option is similar to that offered by the Node.js [`net` module](https://nodejs.org/api/net.html) and allows interoperability with code which utilizes it.
 
 {{</definitions>}}
 
@@ -97,7 +96,7 @@ export default {
 
 ## Opportunistic TLS (StartTLS)
 
-Many TCP-based systems, including databases and email servers, require that clients use opportunistic TLS (otherwise known as [StartTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS)) when connecting. In this pattern, the client first creates an insecure TCP socket, without TLS, and then "upgrades" it to a secure TCP socket, that uses TLS. The `connect()` API simplifies this by providing a method, `startTls()`, which returns a new `Socket` instance that uses TLS:
+Many TCP-based systems, including databases and email servers, require that clients use opportunistic TLS (otherwise known as [StartTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS)) when connecting. In this pattern, the client first creates an insecure TCP socket, without TLS, and then upgrades it to a secure TCP socket, that uses TLS. The `connect()` API simplifies this by providing a method, `startTls()`, which returns a new `Socket` instance that uses TLS:
 
 ```typescript
 import { connect } from "cloudflare:sockets"
@@ -111,16 +110,16 @@ const secureSocket = socket.startTls();
 ```
 
 - `startTls()` can only be called if `secureTransport` is set to `starttls` when creating the initial TCP socket.
-- Once `startTls()` is called, the initial socket is closed and can no longer be read from or written to. In the example above, anytime after `startTls()` is called, you would use the newly created `secureSocket`. Any existing readers and writers based off the original socket will no longer work — you must create new readers and writers from the newly created `secureSocket`.
+- Once `startTls()` is called, the initial socket is closed and can no longer be read from or written to. In the example above, anytime after `startTls()` is called, you would use the newly created `secureSocket`. Any existing readers and writers based off the original socket will no longer work. You must create new readers and writers from the newly created `secureSocket`.
 - `startTls()` should only be called once on an existing socket.
 
-## Error handling
+## Handle errors
 
-To handle errors when creating a new TCP socket, reading from a socket, or writing to a socket, wrap these calls inside `try..catch` blocks. This example opens a connection to Google.com, initiates a HTTP request, and returns the response. If any of this fails and throws an exception, it returns a 500:
+To handle errors when creating a new TCP socket, reading from a socket, or writing to a socket, wrap these calls inside `try..catch` blocks. The following example opens a connection to Google.com, initiates a HTTP request, and returns the response. If any of this fails and throws an exception, it returns a `500` response:
 
 ```typescript
 import { connect } from 'cloudflare:sockets';
-const connectionUrl = "google.com:80";
+const connectionUrl = { hostname: "google.com", port: 80 };
 export interface Env { }
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -139,14 +138,14 @@ export default {
 };
 ```
 
-## Closing TCP connections
+## Close TCP connections
 
 You can close a TCP connection by calling `close()` on the socket. This will close both the readable and writeable sides of the socket.
 
 ```typescript
 import { connect } from "cloudflare:sockets"
 
-const socket = connect("my-url.com:70");
+const socket = connect({ hostname: "my-url.com", port: 70 });
 const reader = socket.readable.getReader();
 socket.close();
 
@@ -156,7 +155,7 @@ const reader = socket.readable.getReader(); // This fails
 
 ## Considerations
 
-- When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, in order to use `connect()`.
+- When developing locally with [Wrangler](/workers/wrangler/), you must pass the [`--experimental-local`](/workers/wrangler/commands/#dev) flag, instead of the `--local` flag, to use `connect()`.
 - TCP sockets must be created within the [`fetch()` handler](/workers/get-started/guide/#3-write-code) of a Worker. TCP sockets cannot be created in global scope and shared across requests. 
 - Each open TCP socket counts towards the maximum number of [open connections](/workers/platform/limits/#simultaneous-open-connections) that can be simultaneously open.
-- By default, Workers cannot create outbound TCP connections on port 25 to send email to SMTP mail servers. [Cloudflare Email Workers](/email-routing/email-workers/) provides APIs to process and forward email.
+- By default, Workers cannot create outbound TCP connections on port `25` to send email to SMTP mail servers. [Cloudflare Email Workers](/email-routing/email-workers/) provides APIs to process and forward email.

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -42,8 +42,8 @@ export default {
 
 {{<definitions>}}
 
-- {{<code>}}connect(address: {{<type-link href="/workers/runtime-apis/connect/#socketaddress">}}SocketAddress{{</type-link>}} | string, options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/connect/#socketoptions">}}SocketOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}`Socket`{{</type-link>}}
-  - `connect()` accepts either a URL string or [`SocketAddress`](/workers/runtime-apis/connect/#socketaddress) to define the hostname and port number to connect to, and an optional configuration object, [`SocketOptions`](/workers/runtime-apis/connect/#socketoptions). It returns an instance of a [`Socket`](/workers/runtime-apis/connect/#socket).
+- {{<code>}}connect(address: {{<type-link href="/workers/runtime-apis/tcp-sockets/#socketaddress">}}SocketAddress{{</type-link>}} | string, options?: {{<prop-meta>}}optional{{</prop-meta>}} {{<type-link href="/workers/runtime-apis/tcp-sockets/#socketoptions">}}SocketOptions{{</type-link>}}){{</code>}} : {{<type-link href="/workers/runtime-apis/tcp-sockets/#socket">}}`Socket`{{</type-link>}}
+  - `connect()` accepts either a URL string or [`SocketAddress`](/workers/runtime-apis/tcp-sockets/#socketaddress) to define the hostname and port number to connect to, and an optional configuration object, [`SocketOptions`](/workers/runtime-apis/tcp-sockets/#socketoptions). It returns an instance of a [`Socket`](/workers/runtime-apis/tcp-sockets/#socket).
 {{</definitions>}}
 
 ### `SocketAddress`
@@ -66,7 +66,7 @@ export default {
   - Specifies whether or not to use [TLS](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) when creating the TCP socket.
   - `off` — do not use TLS.
   - `on` — use TLS.
-  - `starttls` — do not use TLS initially, but allow the socket to be upgraded to use TLS by calling [`startTls()`](/workers/runtime-apis/connect/#how-to-implement-the-starttls-pattern).
+  - `starttls` — do not use TLS initially, but allow the socket to be upgraded to use TLS by calling [`startTls()`](/workers/runtime-apis/tcp-sockets/#how-to-implement-the-starttls-pattern).
 
 - `allowHalfOpen` {{<type>}}boolean{{</type>}} — Defaults to `false`
   - Defines whether the writable side of the TCP socket will automatically close on EOF. When set to `false`, the writable side of the TCP socket will automatically close on EOF. When set to `true`, the writable side of the TCP socket will remain open on EOF.
@@ -90,8 +90,8 @@ export default {
 - `close()` {{<type>}}`Promise<void>`{{</type>}}
   - Closes the TCP socket. Both the readable and writable streams are forcibly closed.
 
-- {{<code>}}startTls(){{</code>}} : {{<type-link href="/workers/runtime-apis/connect/#socket">}}Socket{{</type-link>}}
-  - Upgrades an insecure socket to a secure one that uses TLS, returning a new [Socket](/workers/runtime-apis/connect#socket). Note that in order to call `startTls()`, you must set [`secureTransport`](/workers/runtime-apis/connect/#socketoptions) to `starttls` when initially calling `connect()` to create the socket.
+- {{<code>}}startTls(){{</code>}} : {{<type-link href="/workers/runtime-apis/tcp-sockets/#socket">}}Socket{{</type-link>}}
+  - Upgrades an insecure socket to a secure one that uses TLS, returning a new [Socket](/workers/runtime-apis/tcp-sockets#socket). Note that in order to call `startTls()`, you must set [`secureTransport`](/workers/runtime-apis/tcp-sockets/#socketoptions) to `starttls` when initially calling `connect()` to create the socket.
 
 {{</definitions>}}
 


### PR DESCRIPTION
**Do not merge yet**

- [x] `/runtime-apis/connect`
- [x] `/platform/protocols` (Think this is worth adding — _"What protocols can I use with Cloudflare Workers?"._ Will cover HTTP, WebSockets, Outbound TCP, reference [Socket Workers blog post](https://blog.cloudflare.com/introducing-socket-workers/))
- [x] Address TODO comments
- [x] How do TCP connections count towards subrequest limits?
- [x] Example showing closing sockets, `allowHalfOpen` differences (https://github.com/cloudflare/cloudflare-docs/pull/8795/commits/fe93dd3a494f0c5cad1169a5d648d4dd924151f9)
- [x] Example showing error handling (https://github.com/cloudflare/cloudflare-docs/pull/8795/files#r1188052039)
- [x] Clarify that connections should not / cannot be created globally (https://github.com/cloudflare/cloudflare-docs/pull/8795/commits/a4f04859ac7f780e8e67cdf4ee4dec13adc73eba)
- [x] Add link to original blog post at top of `/platform/protocols` section, and cross-link to that from the `/runtime-apis/connect` docs page
- [x] Clarify local dev (`--experimental-local`)

### After 05/17/23

- [ ] Remove `--experimental-local` caveat