### PR TITLE
[Docs] Update RSS icon

### DIFF
--- a/layouts/partials/topbar.tools.html
+++ b/layouts/partials/topbar.tools.html
@@ -41,8 +41,8 @@
   <div class="DocsToolbar--tools-icon-item">
     <div class="Tooltip---root">
       <div class="DocsToolbar--tools-icon-item-content">
-        <a class="Link Link-without-underline RSS" href="{{$rssFeed}}" target="_blank">
-          <svg viewBox="0 0 485 560" role="img" aria-labelledby="title-1234" xmlns="http://www.w3.org/2000/svg">
+        <a class="Link Link-without-underline" href="{{$rssFeed}}" target="_blank">
+          <svg viewBox="0 0 485 560" fill="currentColor" role="img" aria-labelledby="title-1234" xmlns="http://www.w3.org/2000/svg">
             <title id="title-1234">RSS icon</title>
             <path
               d="M0 64C0 46.3 14.3 32 32 32c229.8 0 416 186.2 416 416c0 17.7-14.3 32-32 32s-32-14.3-32-32C384 253.6 226.4 96 32 96C14.3 96 0 81.7 0 64zM128 416c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM32 160c159.1 0 288 128.9 288 288c0 17.7-14.3 32-32 32s-32-14.3-32-32c0-123.7-100.3-224-224-224c-17.7 0-32-14.3-32-32s14.3-32 32-32z">


### PR DESCRIPTION
The RSS topbar icon had a hardcoded CSS class that would keep it from changing color on hover. This 
adds currentColor to the SVG so that it inherits the current icon color and shows the accent color on 
hover (like the GitHub icon).
