### PR TITLE
[Queues] billing wrangler updates

### DIFF
--- a/content/queues/learning/consumer-concurrency.md
+++ b/content/queues/learning/consumer-concurrency.md
@@ -55,10 +55,6 @@ Note that if you are writing messages to a queue faster than you can process the
 
 ### Set concurrency settings via `wrangler.toml`
 
-{{<Aside type="note">}}
-
-Ensure you are using the latest version of [wrangler](/workers/wrangler/install-and-update/). Support for configuring the maximum concurrency of a queue consumer is currently only supported in `wrangler@beta` (`wrangler@0.0.0-ace46939` or greater). 
-
 {{</Aside>}}
 
 To set a fixed maximum number of concurrent consumer invocations for a given queue, configure a `max_concurrency` in your `wrangler.toml` file:
@@ -95,5 +91,9 @@ When multiple consumer Workers are invoked, each Worker invocation incurs [durat
 
 * If you intend to process all messages written to a queue, _the effective overall cost is the same_, even with concurrency enabled.
 * Enabling concurrency simply brings those costs forward, and can help prevent messages from reaching the [message retention limit](/queues/platform/limits/).
+
+Billing for consumers follows the [Workers unbound usage model](/workers/platform/pricing/#usage-models) meaning a developer is billed for the request and the duration of the request. 
+
+### Example
 
 A consumer Worker that takes 2 seconds ([256 GB-seconds](/workers/platform/pricing/#workers-unbound-billing-examples)) to process a batch of messages will incur the same overall costs to process 50 million (50,000,000) messages, whether it does so concurrently (faster) or individually (slower).

--- a/content/queues/learning/consumer-concurrency.md
+++ b/content/queues/learning/consumer-concurrency.md
@@ -55,8 +55,6 @@ Note that if you are writing messages to a queue faster than you can process the
 
 ### Set concurrency settings via `wrangler.toml`
 
-{{</Aside>}}
-
 To set a fixed maximum number of concurrent consumer invocations for a given queue, configure a `max_concurrency` in your `wrangler.toml` file:
 
 ```toml

--- a/content/queues/learning/how-queues-works.md
+++ b/content/queues/learning/how-queues-works.md
@@ -58,6 +58,8 @@ Additionally, multiple queues can be bound to a single Worker. That single Worke
 
 ## Consumers
 
+### Creating a consumer
+
 A consumer is the term for a client that is subscribing to or _consuming_ messages from a queue. In its most basic form, a consumer is defined by creating a `queue` handler in a Worker:
 
 ```ts
@@ -117,6 +119,9 @@ export default {
   },
 };
 ```
+### Removing a consumer
+
+To remove a queue from your project, run `wrangler queues consumer remove <queue-name> <script-name>` and then remove the desired queue below the `[[queues.consumers]]` in `wrangler.toml` file.
 
 ## Messages
 

--- a/content/queues/learning/how-queues-works.md
+++ b/content/queues/learning/how-queues-works.md
@@ -58,7 +58,7 @@ Additionally, multiple queues can be bound to a single Worker. That single Worke
 
 ## Consumers
 
-### Creating a consumer
+### Create a consumer
 
 A consumer is the term for a client that is subscribing to or _consuming_ messages from a queue. In its most basic form, a consumer is defined by creating a `queue` handler in a Worker:
 

--- a/content/queues/learning/how-queues-works.md
+++ b/content/queues/learning/how-queues-works.md
@@ -119,7 +119,7 @@ export default {
   },
 };
 ```
-### Removing a consumer
+### Remove a consumer
 
 To remove a queue from your project, run `wrangler queues consumer remove <queue-name> <script-name>` and then remove the desired queue below the `[[queues.consumers]]` in `wrangler.toml` file.
 

--- a/content/queues/platform/configuration.md
+++ b/content/queues/platform/configuration.md
@@ -83,6 +83,6 @@ Refer to [Limits](/queues/platform/limits) to review the maximum values for each
 
 - {{<code>}}max_concurrency{{<param-type>}}number{{</param-type>}}{{</code>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The maximum number of concurrent consumers allowed to run at once. Leaving this unset, will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
+  - The maximum number of concurrent consumers allowed to run at once. Leaving this unset will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
 
 {{</definitions>}}

--- a/content/queues/platform/configuration.md
+++ b/content/queues/platform/configuration.md
@@ -83,6 +83,6 @@ Refer to [Limits](/queues/platform/limits) to review the maximum values for each
 
 - {{<code>}}max_concurrency{{<param-type>}}number{{</param-type>}}{{</code>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The maximum number of concurrent consumers allowed to run at once. Leaving this unset, or setting it to `null`, will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
+  - The maximum number of concurrent consumers allowed to run at once. Leaving this unset, will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
 
 {{</definitions>}}


### PR DESCRIPTION
A few things here:

- removed a block suggesting that the feature is only in wrangler beta, its in GA version now
- added text explaining how to remove a queue from a project via Wrangler
- removed text incorrectly instructing users to set consumers to "null" which does not work
- Clarified that Consumer Queues are billed as unbound in the billing section