### PR TITLE
[ZT] Add Block file types partial to DLP policies

### DIFF
--- a/content/cloudflare-one/_partials/gateway/_block-file-types.md
+++ b/content/cloudflare-one/_partials/gateway/_block-file-types.md
@@ -1,0 +1,15 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+## Block file types
+
+Block the upload or download of files based on their type.
+
+| Selector           | Operator | Value                                 | Logic | Action |
+| ------------------ | -------- | ------------------------------------- | ----- | ------ |
+| Upload File Type   | in       | Microsoft Office Word Document (docx) | And   | Block  |
+| Download File Type | in       | PDF (pdf)                             |       |        |

--- a/content/cloudflare-one/policies/data-loss-prevention/dlp-policies/common-policies.md
+++ b/content/cloudflare-one/policies/data-loss-prevention/dlp-policies/common-policies.md
@@ -26,6 +26,8 @@ The **Allow** action functions as an implicit logger, providing visibility into 
 |------|
 |Allow |
 
+{{<render file="gateway/_block-file-types.md">}}
+
 ## Block uploads/downloads for specific users
 
 You can configure access on a per-user or group basis by adding [identity-based conditions](/cloudflare-one/policies/filtering/identity-selectors/) to your policies. The following example blocks only contractors from uploading/downloading Financial Information to file sharing apps.

--- a/content/cloudflare-one/policies/filtering/http-policies/common-policies.md
+++ b/content/cloudflare-one/policies/filtering/http-policies/common-policies.md
@@ -72,14 +72,7 @@ When accessing origin servers with certificates not signed by a public certifica
 | -------- | -------- | ------------------- | -------------- |
 | Domain   | in       | `internal.site.com` | Do Not Inspect |
 
-## Block file types
-
-Block the upload or download of files based on their type.
-
-| Selector           | Operator | Value                                 | Logic | Action |
-| ------------------ | -------- | ------------------------------------- | ----- | ------ |
-| Upload File Type   | in       | Microsoft Office Word Document (docx) | And   | Block  |
-| Download File Type | in       | PDF (pdf)                             |       |        |
+{{<render file="gateway/_block-file-types.md">}}
 
 ## Block Google services
 


### PR DESCRIPTION
Turn 'Block file types' from common HTTP policies into partial and add to 
common DLP policies.
