### PR TITLE
[WAF, Ruleset Engine] Update API examples to add rules

### DIFF
--- a/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
@@ -14,10 +14,10 @@ To deploy a managed ruleset to a phase, use the [Rulesets API](/ruleset-engine/r
 
 Use the following workflow to deploy a managed ruleset to a phase at the account level.
 
-1. Get your account ID.
-2. Get the ID of the managed ruleset you wish to deploy. Refer to [List existing rulesets](/ruleset-engine/rulesets-api/view/#list-existing-rulesets) for details.
-3. Identify the phase where you want to deploy the managed ruleset. Ensure that the managed ruleset belongs to the same phase where you want to deploy it. To learn more about the available phases supported by each Cloudflare product, check the specific documentation for that product.
-4. Add a rule to the account-level phase entry point ruleset that executes the managed ruleset. Regarding the rule expression, you must use parentheses to enclose any custom conditions and end your expression with `and cf.zone.plan eq "ENT"` so that it only applies to zones on an Enterprise plan.
+1. Get your [account ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
+2. Invoke the [List account rulesets](/api/operations/listAccountRulesets) API operation to obtain the available rulesets. Find the ruleset ID of the managed ruleset you wish to deploy.
+3. Identify the [phase](/ruleset-engine/about/phases/) where you want to deploy the managed ruleset. Ensure that the managed ruleset belongs to the same phase where you want to deploy it. To learn more about the available phases supported by each Cloudflare product, refer to the specific documentation for that product, or the [Phases list](/ruleset-engine/reference/phases-list/).
+4. Add a rule to the account-level phase entry point ruleset that executes the managed ruleset. Use parentheses to enclose any custom conditions in the rule expression and end your expression with `and cf.zone.plan eq "ENT"` so that it only applies to zones on an Enterprise plan.
 
 ### Example
 
@@ -88,9 +88,9 @@ header: Response
 
 Use the following workflow to deploy a managed ruleset to a phase at the zone level.
 
-1.  Get your zone ID.
-2.  Get the ID of the managed ruleset you wish to deploy. Refer to [List existing rulesets](/ruleset-engine/rulesets-api/view/#list-existing-rulesets) for details.
-3.  Identify the phase where you want to deploy the managed ruleset. Ensure that the managed ruleset belongs to the same phase where you want to deploy it. To learn more about the available phases supported by each Cloudflare product, check the specific documentation for that product.
+1.  Get your [zone ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
+2.  Invoke the [List account rulesets](/api/operations/listAccountRulesets) API operation to obtain the available rulesets. Managed rulesets exist at the account level, but you can deploy them to a zone. Find the ruleset ID of the managed ruleset you wish to deploy.
+3.  Identify the [phase](/ruleset-engine/about/phases/) where you want to deploy the managed ruleset. Ensure that the managed ruleset belongs to the same phase where you want to deploy it. To learn more about the available phases supported by each Cloudflare product, refer to the specific documentation for that product, or the [Phases list](/ruleset-engine/reference/phases-list/).
 4.  Add a rule to the zone-level phase entry point ruleset that executes the managed ruleset.
 
 ### Example

--- a/content/ruleset-engine/rulesets-api/update-rule.md
+++ b/content/ruleset-engine/rulesets-api/update-rule.md
@@ -181,7 +181,7 @@ curl -X PATCH \
   "position": {
     "index": 3
   }
-}
+}'
 ```
 
 In this case, the new rule order would be:

--- a/content/waf/_partials/_api-add-rule-to-ruleset.md
+++ b/content/waf/_partials/_api-add-rule-to-ruleset.md
@@ -1,8 +1,0 @@
----
-_build:
-  publishResources: false
-  render: never
-  list: never
----
-
-To add a rule to a ruleset keeping existing rules, refer to [Add rule to ruleset](/ruleset-engine/rulesets-api/add-rule/) in the Ruleset Engine documentation.

--- a/content/waf/_partials/_api-create-ruleset-with-rule.md
+++ b/content/waf/_partials/_api-create-ruleset-with-rule.md
@@ -1,0 +1,8 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+For instructions on creating an entry point ruleset and defining its rules using a single API call, refer to [Add rules to phase entry point rulesets](/ruleset-engine/basic-operations/add-rule-phase-rulesets/) in the Ruleset Engine documentation.

--- a/content/waf/_partials/_api-create-ruleset-with-rule.md
+++ b/content/waf/_partials/_api-create-ruleset-with-rule.md
@@ -5,4 +5,6 @@ _build:
   list: never
 ---
 
-For instructions on creating an entry point ruleset and defining its rules using a single API call, refer to [Add rules to phase entry point rulesets](/ruleset-engine/basic-operations/add-rule-phase-rulesets/) in the Ruleset Engine documentation.
+To define a specific position for the new rule, include a `position` object in the request body according to the guidelines in [Change the order of a rule in a ruleset](/ruleset-engine/rulesets-api/update-rule/#change-the-order-of-a-rule-in-a-ruleset).
+
+For instructions on creating an entry point ruleset and defining its rules using a single API call, refer to [Add rules to phase entry point rulesets](/ruleset-engine/basic-operations/add-rule-phase-rulesets/).

--- a/content/waf/_partials/_api-generic-create-rule-procedure.md
+++ b/content/waf/_partials/_api-generic-create-rule-procedure.md
@@ -1,0 +1,17 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+inputParameters: ruleName;;extraObject;;phase
+---
+
+To create a $1 for a zone, add a rule $2 to the `$3` phase entry point ruleset.
+
+1. Invoke the [List zone rulesets](/api/operations/listZoneRulesets) method to obtain the list of rulesets in your zone. You will need the [zone ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/) for this operation.
+
+2. Search for an entry point ruleset for the `$3` phase in the response. Such a ruleset would have the following properties: `"kind": "zone"` and `"phase": "$3"`. If you find the ruleset, take note of its ID for the next step.
+
+3. If the entry point ruleset already exists, invoke the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a $1 to the existing ruleset. By default, the rule will be added at the end of the list of rules already in the ruleset. Refer to the examples below for details.
+
+    If the entry point ruleset does not exist, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) API operation to create the entry point ruleset with the new $1. Refer to [Create ruleset](/ruleset-engine/rulesets-api/create/#example---create-a-zone-level-phase-entry-point-ruleset) for an example.

--- a/content/waf/custom-rules/create-api.md
+++ b/content/waf/custom-rules/create-api.md
@@ -18,7 +18,9 @@ You must deploy custom rules to the `http_request_firewall_custom` [phase entry 
 
 ### Example A
 
-This example request, which covers step 3 in the rule creation procedure, adds a rule to the `http_request_firewall_custom` phase entry point ruleset for the zone with ID `{zone_id}`. The entry point ruleset already exists, with ID `{ruleset_id}`. The new rule, which will be the last rule in the ruleset, will challenge requests from the United Kingdom or France with a threat score greater than `10`:
+This example request, which covers step 3 in the rule creation procedure, adds a rule to the `http_request_firewall_custom` phase entry point ruleset for the zone with ID `{zone_id}`. The entry point ruleset already exists, with ID `{ruleset_id}`.
+
+The new rule, which will be the last rule in the ruleset, will challenge requests from the United Kingdom or France with a threat score greater than `10`:
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules" \
@@ -35,7 +37,9 @@ curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}
 
 ### Example B
 
-This example request, which covers step 3 in the rule creation procedure, adds a rule to the `http_request_firewall_custom` phase entry point ruleset for the zone with ID `{zone_id}`. The entry point ruleset already exists, with ID `{ruleset_id}`. The new rule, which will be the last rule in the ruleset, includes the definition of a [custom response](/waf/custom-rules/create-dashboard/#configuring-a-custom-response-for-blocked-requests) for blocked requests:
+This example request, which covers step 3 in the rule creation procedure, adds a rule to the `http_request_firewall_custom` phase entry point ruleset for the zone with ID `{zone_id}`. The entry point ruleset already exists, with ID `{ruleset_id}`.
+
+The new rule, which will be the last rule in the ruleset, includes the definition of a [custom response](/waf/custom-rules/create-dashboard/#configuring-a-custom-response-for-blocked-requests) for blocked requests:
 
 ```bash
 ---

--- a/content/waf/custom-rules/create-api.md
+++ b/content/waf/custom-rules/create-api.md
@@ -23,7 +23,7 @@ This example request, which covers step 3 in the rule creation procedure, adds a
 The new rule, which will be the last rule in the ruleset, will challenge requests from the United Kingdom or France with a threat score greater than `10`:
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules" \
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{
@@ -45,7 +45,7 @@ The new rule, which will be the last rule in the ruleset, includes the definitio
 ---
 highlight: 8-12
 ---
-curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules" \
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{

--- a/content/waf/custom-rules/create-api.md
+++ b/content/waf/custom-rules/create-api.md
@@ -14,15 +14,7 @@ You must deploy custom rules to the `http_request_firewall_custom` [phase entry 
 
 ## Create a custom rule
 
-To create a custom rule for a zone, add a rule to the `http_request_firewall_custom` phase entry point ruleset:
-
-1. Invoke the [List zone rulesets](/api/operations/listZoneRulesets) method to obtain the list of rulesets in your zone. You will need the [zone ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/) for this operation.
-
-2. Search for an entry point ruleset for the `http_request_firewall_custom` phase in the response. Such a ruleset would have the following properties: `"kind": "zone"` and `"phase": "http_request_firewall_custom"`. If you find the ruleset, take note of its ID for the next step.
-
-3. If the entry point ruleset already exists, invoke the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule to the existing ruleset. By default, the rule will be added at the end of the list of rules already in the ruleset. Refer to the examples below for details.
-
-    If the entry point ruleset does not exist, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) API operation to create the entry point ruleset with the new custom rule.
+{{<render file="_api-generic-create-rule-procedure.md" withParameters="custom rule;;;;http_request_firewall_custom">}}
 
 ### Example A
 

--- a/content/waf/custom-rules/skip/api-examples.md
+++ b/content/waf/custom-rules/skip/api-examples.md
@@ -72,8 +72,6 @@ This example invokes the [Create a zone ruleset rule](/api/operations/createZone
 * Skips the `http_ratelimit` phase
 * Disables event logging for the current rule
 
-For requests matching the rule expression.
-
 ```bash
 curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \

--- a/content/waf/custom-rules/skip/api-examples.md
+++ b/content/waf/custom-rules/skip/api-examples.md
@@ -16,107 +16,40 @@ The following sections provide examples for the different skip rule scenarios av
 
 Take the following into account regarding the provided examples:
 
-*   The `<ZONE_ID>` value is the ID of the zone where you want to add the rule. To retrieve a list of zones you have access to, use the [List Zones](/api/operations/zone-list-zones) operation.
+* The `{zone_id}` value is the [ID of the zone](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/) where you want to add the rule.
 
-*   The `<RULESET_ID>` value is the ID of the entry point ruleset of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). If you do not have such a ruleset yet, you can use the [Update a zone entry point ruleset](/api/operations/updateZoneEntrypointRuleset) API operation to create the entry point ruleset with a skip rule in a single operation.
+* The `{ruleset_id}` value is the ID of the [entry point ruleset](/ruleset-engine/about/phases/#phase-entry-point-ruleset) of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). The API examples in this page add a skip rule to an existing ruleset using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) operation.
 
-*   Although each example only includes one action parameter, you can use several skip options in the same rule by specifying the `ruleset`, `phases`, and `products` action parameters simultaneously.
+    However, the entry point ruleset may not exist yet. In this case, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) API operation to create the entry point ruleset with a skip rule.
+
+* Although each example only includes one action parameter, you can use several skip options in the same rule by specifying the `ruleset`, `phases`, and `products` action parameters simultaneously.
 
 ## Skip the remaining rules in the current ruleset
 
-This example uses the [Update a zone entry point ruleset](/api/operations/updateZoneEntrypointRuleset) API operation to set all the rules in the entry point ruleset of the `http_request_firewall_custom` phase. The first rule, configured with the `skip` action, will skip all remaining rules in the current ruleset based on the request URI path:
+This example invokes the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a skip rule to the existing `http_request_firewall_custom` phase entry point ruleset with ID `{ruleset_id}`. The rule will skip all remaining rules in the current ruleset for requests matching the rule expression:
 
-```json
----
-header: Example request
-highlight: [7,8,9,10]
----
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_custom/entrypoint" \
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
-  "rules": [
-    {
-      "action": "skip",
-      "action_parameters": {
-        "ruleset": "current"
-      },
-      "expression": "http.request.uri.path contains \"/skip-current-ruleset/\"",
-      "description": ""
-    },
-    {
-      "action": "managed_challenge",
-      "expression": "ip.geoip.country eq \"GB\" and cf.threat_score > 40",
-      "description": "Challenge UK requests with threat score over 40",
-    }
-  ]
+  "action": "skip",
+  "action_parameters": {
+    "ruleset": "current"
+  },
+  "expression": "http.request.uri.path contains \"/skip-current-ruleset/\"",
+  "description": ""
 }'
 ```
 
-<details>
-<summary>Example response</summary>
-<div>
-
-```json
-{
-  "result": {
-    "id": "<RULESET_ID>",
-    "name": "default",
-    "description": "",
-    "kind": "zone",
-    "version": "4",
-    "rules": [
-      {
-        "id": "<RULE_1_ID>",
-        "version": "1",
-        "action": "skip",
-        "action_parameters": {
-          "ruleset": "current"
-        },
-        "expression": "http.request.uri.path contains \"/skip-current-ruleset/\"",
-        "description": "",
-        "last_updated": "2022-05-08T08:48:50.171838Z",
-        "ref": "<RULE_1_REF>",
-        "enabled": true,
-        "logging": {
-          "enabled": true
-        }
-      },
-      {
-        "id": "<RULE_2_ID>",
-        "version": "1",
-        "action": "managed_challenge",
-        "expression": "ip.geoip.country eq \"GB\" and cf.threat_score > 40",
-        "description": "Challenge UK requests with threat score over 40",
-        "last_updated": "2022-05-08T08:48:50.171838Z",
-        "ref": "<RULE_2_REF>",
-        "enabled": true
-      }
-    ],
-    "last_updated": "2022-05-08T08:48:50.171838Z",
-    "phase": "http_request_firewall_custom"
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
-}
-```
-
-</div>
-</details>
-
 ## Skip a phase
 
-This example uses the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule that skips the `http_ratelimit` phase:
+This example invokes the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule to the existing `http_request_firewall_custom` phase entry point ruleset with ID `{ruleset_id}`. The rule will skip the `http_ratelimit` phase for requests matching the rule expression:
 
-```json
----
-header: Example request
-highlight: [5,6,7,8,9,10]
----
-curl -X POST \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "action": "skip",
   "action_parameters": {
@@ -134,19 +67,17 @@ Refer to [Available skip options](/waf/custom-rules/skip/options/) for the list 
 
 ## Skip a phase and do not log matching requests
 
-This example uses the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule that:
+This example invokes the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule that:
 
 * Skips the `http_ratelimit` phase
-* Disables logging for requests matching this rule
+* Disables event logging for the current rule
 
-```json
----
-header: Example request
-highlight: [5,6,7,8,9,10,11,12,13]
----
-curl -X POST \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
+For requests matching the rule expression.
+
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "action": "skip",
   "action_parameters": {
@@ -166,16 +97,12 @@ Refer to [Available skip options: Logging](/waf/custom-rules/skip/options/#loggi
 
 ## Skip security products
 
-This example uses the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule that skips the Zone Lockdown and User Agent Blocking products:
+This example uses the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation to add a rule that skips the [Zone Lockdown](/waf/tools/zone-lockdown/) and [User Agent Blocking](/waf/tools/user-agent-blocking/) products for requests matching the rule expression:
 
-```json
----
-header: Example request
-highlight: [5,6,7,8,9,10,11]
----
-curl -X POST \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
+-H "Content-Type: application/json" \
 -d '{
   "action": "skip",
   "action_parameters": {

--- a/content/waf/custom-rules/skip/api-examples.md
+++ b/content/waf/custom-rules/skip/api-examples.md
@@ -12,15 +12,15 @@ Use the [Rulesets API](/ruleset-engine/rulesets-api/) to configure custom rules 
 
 The `skip` action supports different [skip options](/waf/custom-rules/skip/options/), according to the security features or products that you wish to skip.
 
-The following sections provide examples for the different skip rule scenarios available for custom rules.
+## Before you continue
 
-Take the following into account regarding the provided examples:
+This page contains examples of different skip rule scenarios for custom rules. Take the following into account:
 
 * The `{zone_id}` value is the [ID of the zone](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/) where you want to add the rule.
 
 * The `{ruleset_id}` value is the ID of the [entry point ruleset](/ruleset-engine/about/phases/#phase-entry-point-ruleset) of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). The API examples in this page add a skip rule to an existing ruleset using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) operation.
 
-    However, the entry point ruleset may not exist yet. In this case, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) API operation to create the entry point ruleset with a skip rule.
+    However, the entry point ruleset may not exist yet. In this case, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) API operation to create the entry point ruleset with a skip rule. Refer to [Create ruleset](/ruleset-engine/rulesets-api/create/#example---create-a-zone-level-phase-entry-point-ruleset) for an example.
 
 * Although each example only includes one action parameter, you can use several skip options in the same rule by specifying the `ruleset`, `phases`, and `products` action parameters simultaneously.
 

--- a/content/waf/rate-limiting-rules/create-api.md
+++ b/content/waf/rate-limiting-rules/create-api.md
@@ -17,9 +17,7 @@ You must deploy rate limiting rules to the `http_ratelimit` phase.
 
 ## Create a rate limiting rule
 
-To create a rate limiting rule, add a rule with a `ratelimit` field to the `http_ratelimit` phase entry point ruleset by issuing a `PUT` request (refer to the examples below).
-
-Add any existing rules in the ruleset to the request by including their rule ID in the `rules` field of the request body. Rate limiting rules must appear at the end of the rules list.
+{{<render file="_api-generic-create-rule-procedure.md" withParameters="rate limiting rule;;with a `ratelimit` object;;http_ratelimit">}}
 
 ### Example A - Rate limiting based on request properties
 

--- a/content/waf/rate-limiting-rules/create-api.md
+++ b/content/waf/rate-limiting-rules/create-api.md
@@ -13,7 +13,9 @@ Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a rate limiting 
 
 A rate limiting rule is similar to a regular rule handled by the Ruleset Engine, but contains an additional `ratelimit` object with the rate limiting configuration. Refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/) for more information on this field and its parameters.
 
-You must deploy rate limiting rules to the `http_ratelimit` phase.
+You must deploy rate limiting rules to the `http_ratelimit` [phase entry point ruleset](/ruleset-engine/about/phases/#phase-entry-point-ruleset).
+
+Rate limiting rules must appear at the end of the rules list.
 
 ## Create a rate limiting rule
 
@@ -21,34 +23,26 @@ You must deploy rate limiting rules to the `http_ratelimit` phase.
 
 ### Example A - Rate limiting based on request properties
 
-This example **replaces all rate limiting rules** in zone `<ZONE_ID>`, defining a rate limiting rule based on three characteristics applied to URL paths starting with `/api/` and with action `block`.
+This example adds a rate limiting rule to the `http_ratelimit` phase entry point ruleset for the zone with ID `{zone_id}`. The phase entry point ruleset already exists, with ID `{ruleset_id}`.
 
-```json
----
-header: Request
----
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_ratelimit/entrypoint" \
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{
-  "rules": [
-    {
-      "description": "My rate limiting rule",
-      "expression": "(http.request.uri.path matches \"^/api/\")",
-      "action": "block",
-      "ratelimit": {
-        "characteristics": [
-          "cf.colo.id",
-          "ip.src",
-          "http.request.headers[\"x-api-key\"]"
-        ],
-        "period": 60,
-        "requests_per_period": 100,
-        "mitigation_timeout": 600
-      }
-    }
-  ]
+  "description": "My rate limiting rule",
+  "expression": "(http.request.uri.path matches \"^/api/\")",
+  "action": "block",
+  "ratelimit": {
+    "characteristics": [
+      "cf.colo.id",
+      "ip.src",
+      "http.request.headers[\"x-api-key\"]"
+    ],
+    "period": 60,
+    "requests_per_period": 100,
+    "mitigation_timeout": 600
+  }
 }'
 ```
 
@@ -56,42 +50,38 @@ curl -X PUT \
 
 ### Example B - Rate limiting with a custom response
 
-This example request **replaces all rate limiting rules** in zone `<ZONE_ID>`, defining a single rate limiting rule with a [custom response](/waf/rate-limiting-rules/create-zone-dashboard/#configuring-a-custom-response-for-blocked-requests) for requests blocked due to rate limiting.
+This example adds a rate limiting rule to the `http_ratelimit` phase entry point ruleset for the zone with ID `{zone_id}`. The phase entry point ruleset already exists, with ID `{ruleset_id}`.
 
-```json
+The new rule defines a [custom response](/waf/rate-limiting-rules/create-zone-dashboard/#configuring-a-custom-response-for-blocked-requests) for requests blocked due to rate limiting.
+
+```bash
 ---
-header: Request
-highlight: [12,13,14,15,16]
+highlight: 9-13
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_ratelimit/entrypoint" \
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{
-  "rules": [
-    {
-      "description": "My rate limiting rule",
-      "expression": "(http.request.uri.path matches \"^/api/\")",
-      "action": "block",
-      "action_parameters": {
-        "response": {
-          "status_code": 403,
-          "content": "You have been rate limited.",
-          "content_type": "text/plain"
-        }
-      },
-      "ratelimit": {
-        "characteristics": [
-          "cf.colo.id",
-          "ip.src",
-          "http.request.headers[\"x-api-key\"]"
-        ],
-        "period": 60,
-        "requests_per_period": 100,
-        "mitigation_timeout": 600
-      }
+  "description": "My rate limiting rule",
+  "expression": "(http.request.uri.path matches \"^/api/\")",
+  "action": "block",
+  "action_parameters": {
+    "response": {
+      "status_code": 403,
+      "content": "You have been rate limited.",
+      "content_type": "text/plain"
     }
-  ]
+  },
+  "ratelimit": {
+    "characteristics": [
+      "cf.colo.id",
+      "ip.src",
+      "http.request.headers[\"x-api-key\"]"
+    ],
+    "period": 60,
+    "requests_per_period": 100,
+    "mitigation_timeout": 600
+  }
 }'
 ```
 
@@ -99,36 +89,32 @@ curl -X PUT \
 
 ### Example C - Rate limiting ignoring cached assets
 
-This example request **replaces all limiting rules** in zone `<ZONE_ID>`, defining a single rate limiting rule that does not consider requests for cached assets when calculating the rate.
+This example adds a rate limiting rule to the `http_ratelimit` phase entry point ruleset for the zone with ID `{zone_id}`. The phase entry point ruleset already exists, with ID `{ruleset_id}`.
 
-```json
+The new rule does not consider requests for cached assets when calculating the rate.
+
+```bash
 ---
-header: Request
-highlight: [20]
+highlight: 17
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_ratelimit/entrypoint" \
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{
-  "rules": [
-    {
-      "description": "My rate limiting rule",
-      "expression": "(http.request.uri.path matches \"^/api/\")",
-      "action": "block",
-      "ratelimit": {
-        "characteristics": [
-          "cf.colo.id",
-          "ip.src",
-          "http.request.headers[\"x-api-key\"]"
-        ],
-        "period": 60,
-        "requests_per_period": 100,
-        "mitigation_timeout": 600,
-        "requests_to_origin": true
-      }
-    }
-  ]
+  "description": "My rate limiting rule",
+  "expression": "(http.request.uri.path matches \"^/api/\")",
+  "action": "block",
+  "ratelimit": {
+    "characteristics": [
+      "cf.colo.id",
+      "ip.src",
+      "http.request.headers[\"x-api-key\"]"
+    ],
+    "period": 60,
+    "requests_per_period": 100,
+    "mitigation_timeout": 600,
+    "requests_to_origin": true
+  }
 }'
 ```
 
@@ -140,36 +126,33 @@ curl -X PUT \
 [Complexity-based rate limiting](/waf/rate-limiting-rules/request-rate/#complexity-based-rate-limiting) is available in beta and can only be configured via API.
 {{</Aside>}}
 
-This example **replaces all rate limiting rules** in zone `<ZONE_ID>`, configuring a complexity-based rate limiting rule that takes the `my-score` HTTP response header into account to calculate a total complexity score for the client. The counter with the total score is updated when there is a match for the rate limiting rule's counting expression (in this case, the same as the rule expression). When this total score becomes larger than `400` during a 60-second period, any later client requests will be blocked for a period of 600 seconds (10 minutes).
 
-```json
+This example adds a rate limiting rule to the `http_ratelimit` phase entry point ruleset for the zone with ID `{zone_id}`. The phase entry point ruleset already exists, with ID `{ruleset_id}`.
+
+The new rule is a complexity-based rate limiting rule that takes the `my-score` HTTP response header into account to calculate a total complexity score for the client. The counter with the total score is updated when there is a match for the rate limiting rule's counting expression (in this case, the same as the rule expression). When this total score becomes larger than `400` during a 60-second period, any later client requests will be blocked for a period of 600 seconds (10 minutes).
+
+```bash
 ---
-header: Request
-highlight: [17,18]
+highlight: 14-15
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_ratelimit/entrypoint" \
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
 -H "Authorization: Bearer <API_TOKEN>" \
 -H "Content-Type: application/json" \
 -d '{
-  "rules": [
-    {
-      "description": "My complexity-based rate limiting rule",
-      "expression": "http.request.uri.path matches \"^/graphql/\"",
-      "action": "block",
-      "ratelimit": {
-        "characteristics": [
-          "cf.colo.id",
-          "http.request.headers[\"x-api-key\"]"
-        ],
-        "period": 60,
-        "score_per_period": 400,
-        "score_response_header_name": "my-score",
-        "mitigation_timeout": 600,
-        "counting_expression": ""
-      }
-    }
-  ]
+  "description": "My complexity-based rate limiting rule",
+  "expression": "http.request.uri.path matches \"^/graphql/\"",
+  "action": "block",
+  "ratelimit": {
+    "characteristics": [
+      "cf.colo.id",
+      "http.request.headers[\"x-api-key\"]"
+    ],
+    "period": 60,
+    "score_per_period": 400,
+    "score_response_header_name": "my-score",
+    "mitigation_timeout": 600,
+    "counting_expression": ""
+  }
 }'
 ```
 

--- a/content/waf/rate-limiting-rules/create-api.md
+++ b/content/waf/rate-limiting-rules/create-api.md
@@ -54,7 +54,7 @@ curl -X PUT \
 }'
 ```
 
-{{<render file="_api-add-rule-to-ruleset.md">}}
+{{<render file="_api-create-ruleset-with-rule.md">}}
 
 ### Example B - Rate limiting with a custom response
 
@@ -97,7 +97,7 @@ curl -X PUT \
 }'
 ```
 
-{{<render file="_api-add-rule-to-ruleset.md">}}
+{{<render file="_api-create-ruleset-with-rule.md">}}
 
 ### Example C - Rate limiting ignoring cached assets
 
@@ -134,7 +134,7 @@ curl -X PUT \
 }'
 ```
 
-{{<render file="_api-add-rule-to-ruleset.md">}}
+{{<render file="_api-create-ruleset-with-rule.md">}}
 
 ### Example D - Complexity-based rate limiting rule
 
@@ -175,4 +175,4 @@ curl -X PUT \
 }'
 ```
 
-{{<render file="_api-add-rule-to-ruleset.md">}}
+{{<render file="_api-create-ruleset-with-rule.md">}}


### PR DESCRIPTION
Switches API examples to a safer rule creation method:
* The previous examples used a single API operation, but would replace any existing rules in the ruleset.
* The new approach involves finding the ruleset ID first and then adding the rule, but we reduce the possibility of losing existing rules.