### PR TITLE
Add link to Cloudflare Pages Functions from WebAssembly docs

### DIFF
--- a/content/pages/platform/functions/module-support.md
+++ b/content/pages/platform/functions/module-support.md
@@ -38,7 +38,9 @@ export async function onRequest(context) {
 
 ### WebAssembly Modules
 
-[WebAssembly](https://webassembly.org/) (or Wasm) is a low-level language that provides programming languages such as C++ or Rust with a compilation target so that they can run on the web. The distributable, loadable, and executable unit of code in WebAssembly is called a [module](https://webassembly.github.io/spec/core/syntax/modules.html).
+[WebAssembly](/workers/platform/web-assembly/) (abbreviated Wasm) allows you to compile languages like Rust, Go, or C to a binary format that can run in a wide variety of environments, including web browsers, Cloudflare Workers, Cloudflare Pages Functions, and other WebAssembly runtimes.
+
+The distributable, loadable, and executable unit of code in WebAssembly is called a [module](https://webassembly.github.io/spec/core/syntax/modules.html).
 
 Below is a basic example of how you can import Wasm Modules inside your Pages Functions code:
 

--- a/content/workers/platform/web-assembly/_index.md
+++ b/content/workers/platform/web-assembly/_index.md
@@ -8,7 +8,7 @@ layout: single
 
 [WebAssembly](https://webassembly.org/) (abbreviated Wasm) allows you to compile languages like Rust, Go, or C to a binary format that can run in a wide variety of environments, including [web browsers](https://developer.mozilla.org/en-US/docs/WebAssembly#browser_compatibility), Cloudflare Workers, and other WebAssembly runtimes.
 
-On Workers, you can use WebAssembly to:
+On Workers and in [Cloudflare Pages Functions](https://blog.cloudflare.com/pages-functions-with-webassembly/), you can use WebAssembly to:
 - Execute code written in a language other than JavaScript, via `WebAssembly.instantiate()`.
 - Write an entire Cloudflare Worker in Rust, using bindings that make Workers' JavaScript APIs available directly from your Rust code.
 


### PR DESCRIPTION
- Links to Pages Functions <> Wasm blog post from WebAssembly docs, to clarify that Pages Functions supports WebAssembly.
- Adds link from Pages Functions docs back to Workers WebAssembly docs.