### PR TITLE
[Terraform] Fix examples

### DIFF
--- a/content/terraform/advanced-topics/import-cloudflare-resources.md
+++ b/content/terraform/advanced-topics/import-cloudflare-resources.md
@@ -229,8 +229,8 @@ You would run each command individually in the terminal:
 $ terraform import cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31 1109d899a5ff5fd74bc01e581693685b/3c0b456bc2aa443089c5f40f45f51b31
 cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Importing from ID "1109d899a5ff5fd74bc01e581693685b/3c0b456bc2aa443089c5f40f45f51b31"...
 cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Import complete!
-  Imported cloudflare_record (ID: 3c0b456bc2aa443089c5f40f45f51b31)
-cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Refreshing state... (ID: 3c0b456bc2aa443089c5f40f45f51b31)
+  Imported cloudflare_record [id=3c0b456bc2aa443089c5f40f45f51b31]
+cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Refreshing state... [id=3c0b456bc2aa443089c5f40f45f51b31]
 
 Import successful!
 
@@ -240,8 +240,8 @@ your Terraform state and will henceforth be managed by Terraform.
 $ terraform import cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354 1109d899a5ff5fd74bc01e581693685b/d09d916d059aa9fc8cb54bdd49deea5f
 cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354: Importing from ID "1109d899a5ff5fd74bc01e581693685b/d09d916d059aa9fc8cb54bdd49deea5f"...
 cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354: Import complete!
-  Imported cloudflare_record (ID: d09d916d059aa9fc8cb54bdd49deea5f)
-cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354: Refreshing state... (ID: d09d916d059aa9fc8cb54bdd49deea5f)
+  Imported cloudflare_record [id=d09d916d059aa9fc8cb54bdd49deea5f]
+cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354: Refreshing state... [id=d09d916d059aa9fc8cb54bdd49deea5f]
 
 Import successful!
 
@@ -251,8 +251,8 @@ your Terraform state and will henceforth be managed by Terraform.
 $ terraform import cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248 1109d899a5ff5fd74bc01e581693685b/8d6ec0d02c5b22212ff673782c816ef8
 cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248: Importing from ID "1109d899a5ff5fd74bc01e581693685b/8d6ec0d02c5b22212ff673782c816ef8"...
 cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248: Import complete!
-  Imported cloudflare_record (ID: 8d6ec0d02c5b22212ff673782c816ef8)
-cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248: Refreshing state... (ID: 8d6ec0d02c5b22212ff673782c816ef8)
+  Imported cloudflare_record [id=8d6ec0d02c5b22212ff673782c816ef8]
+cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248: Refreshing state... [id=8d6ec0d02c5b22212ff673782c816ef8]
 
 Import successful!
 
@@ -262,8 +262,8 @@ your Terraform state and will henceforth be managed by Terraform.
 $ terraform import cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2 1109d899a5ff5fd74bc01e581693685b/3766b952a2dda4c47e71952aeef33c77
 cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2: Importing from ID "1109d899a5ff5fd74bc01e581693685b/3766b952a2dda4c47e71952aeef33c77"...
 cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2: Import complete!
-  Imported cloudflare_record (ID: 3766b952a2dda4c47e71952aeef33c77)
-cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2: Refreshing state... (ID: 3766b952a2dda4c47e71952aeef33c77)
+  Imported cloudflare_record [id=3766b952a2dda4c47e71952aeef33c77]
+cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2: Refreshing state... [id=3766b952a2dda4c47e71952aeef33c77]
 
 Import successful!
 

--- a/content/terraform/advanced-topics/import-cloudflare-resources.md
+++ b/content/terraform/advanced-topics/import-cloudflare-resources.md
@@ -116,84 +116,86 @@ Calling `terraform plan` at this point will try to create these resources as if 
 ```sh
 $ terraform plan
 
-Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
   + create
 
 Terraform will perform the following actions:
 
   # cloudflare_record.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31 will be created
   + resource "cloudflare_record" "terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31" {
-      + id:          <computed>
-      + created_on:  <computed>
-      + domain:      "mitigateddos.net"
-      + hostname:    <computed>
-      + metadata.%:  <computed>
-      + modified_on: <computed>
-      + name:        "mitigateddos.net"
-      + proxiable:   <computed>
-      + proxied:     true
-      + ttl:         1
-      + type:        "A"
-      + value:       "192.0.2.1"
-      + zone_id:     "1109d899a5ff5fd74bc01e581693685b"
+      + id          = (known after apply)>
+      + created_on  = (known after apply)
+      + domain      = "mitigateddos.net"
+      + hostname    = (known after apply)
+      + metadata    = (known after apply)
+      + modified_on = (known after apply)
+      + name        = "mitigateddos.net"
+      + proxiable   = (known after apply)
+      + proxied     = true
+      + ttl         = 1
+      + type        = "A"
+      + value       = "192.0.2.1"
+      + zone_id     = "1109d899a5ff5fd74bc01e581693685b"
     }
 
   # cloudflare_record.terraform_managed_resource_5e10399a590a45279f09aa8fb1163354 will be created
   + resource "cloudflare_record" "terraform_managed_resource_5e10399a590a45279f09aa8fb1163354" {
-      + id:          <computed>
-      + created_on:  <computed>
-      + domain:      "mitigateddos.net"
-      + hostname:    <computed>
-      + metadata.%:  <computed>
-      + modified_on: <computed>
-      + name:        "www.mitigateddos.net"
-      + proxiable:   <computed>
-      + proxied:     true
-      + ttl:         1
-      + type:        "CNAME"
-      + value:       "mitigateddos.net"
-      + zone_id:     "1109d899a5ff5fd74bc01e581693685b"
+      + id          = (known after apply)
+      + created_on  = (known after apply)
+      + domain      = "mitigateddos.net"
+      + hostname    = (known after apply)
+      + metadata    = (known after apply)
+      + modified_on = (known after apply)
+      + name        = "www.mitigateddos.net"
+      + proxiable   = (known after apply)
+      + proxied     = true
+      + ttl         = 1
+      + type        = "CNAME"
+      + value       = "mitigateddos.net"
+      + zone_id     = "1109d899a5ff5fd74bc01e581693685b"
     }
 
   # cloudflare_record.terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248 will be created
   + resource "cloudflare_record" "terraform_managed_resource_de1cb74bae184b569bb7f83fefe72248" {
-      + id:          <computed>
-      + created_on:  <computed>
-      + domain:      "mitigateddos.net"
-      + hostname:    <computed>
-      + metadata.%:  <computed>
-      + modified_on: <computed>
-      + name:        "a123.mitigateddos.net"
-      + proxiable:   <computed>
-      + proxied:     false
-      + ttl:         300
-      + type:        "NS"
-      + value:       "rafe.ns.cloudflare.com"
-      + zone_id:     "1109d899a5ff5fd74bc01e581693685b"
+      + id          = (known after apply)
+      + created_on  = (known after apply)
+      + domain      = "mitigateddos.net"
+      + hostname    = (known after apply)
+      + metadata    = (known after apply)
+      + modified_on = (known after apply)
+      + name        = "a123.mitigateddos.net"
+      + proxiable   = (known after apply)
+      + proxied     = false
+      + ttl         = 300
+      + type        = "NS"
+      + value       = "rafe.ns.cloudflare.com"
+      + zone_id     = "1109d899a5ff5fd74bc01e581693685b"
     }
 
   # cloudflare_record.terraform_managed_resource_5799bb01054843eea726758f935d2aa2 will be created
   + resource "cloudflare_record" "terraform_managed_resource_5799bb01054843eea726758f935d2aa2" {
-      + id:          <computed>
-      + created_on:  <computed>
-      + domain:      "mitigateddos.net"
-      + hostname:    <computed>
-      + metadata.%:  <computed>
-      + modified_on: <computed>
-      + name:        "a123.mitigateddos.net"
-      + proxiable:   <computed>
-      + proxied:     false
-      + ttl:         300
-      + type:        "NS"
-      + value:       "terin.ns.cloudflare.com"
-      + zone_id:     "1109d899a5ff5fd74bc01e581693685b"
+      + id          = (known after apply)
+      + created_on  = (known after apply)
+      + domain      = "mitigateddos.net"
+      + hostname    = (known after apply)
+      + metadata    = (known after apply)
+      + modified_on = (known after apply)
+      + name        = "a123.mitigateddos.net"
+      + proxiable   = (known after apply)
+      + proxied     = false
+      + ttl         = 300
+      + type        = "NS"
+      + value       = "terin.ns.cloudflare.com"
+      + zone_id     = "1109d899a5ff5fd74bc01e581693685b"
     }
 
 Plan: 4 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 ```
 
 To fix this, you must import the real state of those resources from Cloudflare into the Terraform state file (`.tfstate`).

--- a/content/terraform/tutorial/add-page-rules.md
+++ b/content/terraform/tutorial/add-page-rules.md
@@ -8,7 +8,7 @@ meta:
 
 # Add exceptions with Page Rules
 
-In the [Configure HTTPS settings](/terraform/tutorial/configure-https-settings/) tutorial, you configured zone settings that apply to all of `example.com`. In this tutorial, you will add an exception to these settings using [Page Rules](https://support.cloudflare.com/hc/articles/218411427).
+In the [Configure HTTPS settings](/terraform/tutorial/configure-https-settings/) tutorial, you configured zone settings that apply to all incoming requests for `example.com`. In this tutorial, you will add an exception to these settings using [Page Rules](https://support.cloudflare.com/hc/articles/218411427).
 
 Specifically, you will increase the security level for a URL known to be expensive to render and cannot be cached: `https://www.example.com/expensive-db-call`. Additionally, you will add a redirect from the previous URL used to host this page.
 

--- a/content/terraform/tutorial/add-page-rules.md
+++ b/content/terraform/tutorial/add-page-rules.md
@@ -17,8 +17,8 @@ Specifically, you will increase the security level for a URL known to be expensi
 Create a new branch and append the configuration.
 
 ```bash
-$ git checkout -b step6-pagerule
-Switched to a new branch 'step6-pagerule'
+$ git checkout -b step5-pagerule
+Switched to a new branch 'step5-pagerule'
 
 $ cat >> cloudflare.tf <<'EOF'
 resource "cloudflare_page_rule" "increase-security-on-expensive-page" {
@@ -116,14 +116,14 @@ guarantee to take exactly these actions if you run "terraform apply" now.
 
 $ git add cloudflare.tf
 
-$ git commit -m "Step 6 - Add two Page Rules."
-[step6-pagerule d4fec16] Step 6 - Add two Page Rules.
+$ git commit -m "Step 5 - Add two Page Rules."
+[step5-pagerule d4fec16] Step 5 - Add two Page Rules.
  1 file changed, 23 insertions(+)
 
 $ git checkout master
 Switched to branch 'master'
 
-$ git merge step6-pagerule
+$ git merge step5-pagerule
 Updating 7a2ac34..d4fec16
 Fast-forward
  cloudflare.tf | 23 +++++++++++++++++++++++

--- a/content/terraform/tutorial/add-page-rules.md
+++ b/content/terraform/tutorial/add-page-rules.md
@@ -52,64 +52,67 @@ Preview the changes Terraform will make and then merge them into the `master` br
 
 ```sh
 $ terraform plan
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+cloudflare_load_balancer_monitor.get-root-https: Refreshing state... [id=4238142473fcd48e89ef1964be72e3e0]
+cloudflare_load_balancer_pool.www-servers: Refreshing state... [id=906d2a7521634783f4a96c062eeecc6d]
+cloudflare_load_balancer.www-lb: Refreshing state... [id=cb94f53f150e5c1a65a07e43c5d4cac4]
 
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-cloudflare_load_balancer_monitor.get-root-https: Refreshing state... (ID: 4238142473fcd48e89ef1964be72e3e0)
-cloudflare_load_balancer_pool.www-servers: Refreshing state... (ID: 906d2a7521634783f4a96c062eeecc6d)
-cloudflare_load_balancer.www-lb: Refreshing state... (ID: cb94f53f150e5c1a65a07e43c5d4cac4)
-
-------------------------------------------------------------------------
-
-An execution plan has been generated and is shown below.
+Terraform used the selected providers to generate the following execution plan.
 Resource actions are indicated with the following symbols:
   + create
 
 Terraform will perform the following actions:
 
-  + cloudflare_page_rule.increase-security-on-expensive-page
-      id:                                     <computed>
-      actions.#:                              "1"
-      actions.0.always_use_https:             "false"
-      actions.0.disable_apps:                 "false"
-      actions.0.disable_performance:          "false"
-      actions.0.disable_security:             "false"
-      actions.0.security_level:               "under_attack"
-      priority:                               "1"
-      status:                                 "active"
-      target:                                 "www.example.com/expensive-db-call"
-      zone:                                   "example.com"
-      zone_id:                                <computed>
+  # cloudflare_page_rule.increase-security-on-expensive-page will be created
+  + resource "cloudflare_page_rule" "increase-security-on-expensive-page" {
+      + id       = (known after apply)
+      + priority = 1
+      + status   = "active"
+      + target   = "www.example.com/expensive-db-call"
+      + zone_id  = "e2e6491340be87a3726f91fc4148b126"
 
-  + cloudflare_page_rule.redirect-to-new-db-page
-      id:                                     <computed>
-      actions.#:                              "1"
-      actions.0.always_use_https:             "false"
-      actions.0.disable_apps:                 "false"
-      actions.0.disable_performance:          "false"
-      actions.0.disable_security:             "false"
-      actions.0.forwarding_url.#:             "1"
-      actions.0.forwarding_url.0.status_code: "301"
-      actions.0.forwarding_url.0.url:         "https://www.example.com/expensive-db-call"
-      priority:                               "2"
-      status:                                 "active"
-      target:                                 "www.example.com/old-location.php"
-      zone:                                   "example.com"
-      zone_id:                                <computed>
+      + actions {
+          + always_use_https    = false
+          + disable_apps        = false
+          + disable_performance = false
+          + disable_railgun     = false
+          + disable_security    = false
+          + disable_zaraz       = false
+          + security_level      = "under_attack"
+        }
+    }
 
+  # cloudflare_page_rule.redirect-to-new-db-page will be created
+  + resource "cloudflare_page_rule" "redirect-to-new-db-page" {
+      + id       = (known after apply)
+      + priority = 2
+      + status   = "active"
+      + target   = "www.example.com/old-location.php"
+      + zone_id  = "e2e6491340be87a3726f91fc4148b126"
+
+      + actions {
+          + always_use_https    = false
+          + disable_apps        = false
+          + disable_performance = false
+          + disable_railgun     = false
+          + disable_security    = false
+          + disable_zaraz       = false
+
+          + forwarding_url {
+              + status_code = 301
+              + url         = "https://www.example.com/expensive-db-call"
+            }
+        }
+    }
 
 Plan: 2 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
-can't guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
-
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 
 $ git add cloudflare.tf
 
@@ -140,40 +143,65 @@ As expected, the location cannot be found. Apply the Page Rules, including the r
 
 ```sh
 $ terraform apply --auto-approve
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
-cloudflare_load_balancer_monitor.get-root-https: Refreshing state... (ID: 4238142473fcd48e89ef1964be72e3e0)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_load_balancer_pool.www-servers: Refreshing state... (ID: 906d2a7521634783f4a96c062eeecc6d)
-cloudflare_load_balancer.www-lb: Refreshing state... (ID: cb94f53f150e5c1a65a07e43c5d4cac4)
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+cloudflare_load_balancer_monitor.get-root-https: Refreshing state... [id=4238142473fcd48e89ef1964be72e3e0]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_load_balancer_pool.www-servers: Refreshing state... [id=906d2a7521634783f4a96c062eeecc6d]
+cloudflare_load_balancer.www-lb: Refreshing state... [id=cb94f53f150e5c1a65a07e43c5d4cac4]
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # cloudflare_page_rule.increase-security-on-expensive-page will be created
+  + resource "cloudflare_page_rule" "increase-security-on-expensive-page" {
+      + id       = (known after apply)
+      + priority = 1
+      + status   = "active"
+      + target   = "www.example.com/expensive-db-call"
+      + zone_id  = "e2e6491340be87a3726f91fc4148b126"
+
+      + actions {
+          + always_use_https    = false
+          + disable_apps        = false
+          + disable_performance = false
+          + disable_railgun     = false
+          + disable_security    = false
+          + disable_zaraz       = false
+          + security_level      = "under_attack"
+        }
+    }
+
+  # cloudflare_page_rule.redirect-to-new-db-page will be created
+  + resource "cloudflare_page_rule" "redirect-to-new-db-page" {
+      + id       = (known after apply)
+      + priority = 2
+      + status   = "active"
+      + target   = "www.example.com/old-location.php"
+      + zone_id  = "e2e6491340be87a3726f91fc4148b126"
+
+      + actions {
+          + always_use_https    = false
+          + disable_apps        = false
+          + disable_performance = false
+          + disable_railgun     = false
+          + disable_security    = false
+          + disable_zaraz       = false
+
+          + forwarding_url {
+              + status_code = 301
+              + url         = "https://www.example.com/expensive-db-call"
+            }
+        }
+    }
+
 cloudflare_page_rule.redirect-to-new-db-page: Creating...
-  actions.#:                              "0" => "1"
-  actions.0.always_use_https:             "" => "false"
-  actions.0.disable_apps:                 "" => "false"
-  actions.0.disable_performance:          "" => "false"
-  actions.0.disable_security:             "" => "false"
-  actions.0.forwarding_url.#:             "0" => "1"
-  actions.0.forwarding_url.0.status_code: "" => "301"
-  actions.0.forwarding_url.0.url:         "" => "https://www.example.com/expensive-db-call"
-  priority:                               "" => "2"
-  status:                                 "" => "active"
-  target:                                 "" => "www.example.com/old-location.php"
-  zone:                                   "" => "example.com"
-  zone_id:                                "" => "<computed>"
 cloudflare_page_rule.increase-security-on-expensive-page: Creating...
-  actions.#:                     "0" => "1"
-  actions.0.always_use_https:    "" => "false"
-  actions.0.disable_apps:        "" => "false"
-  actions.0.disable_performance: "" => "false"
-  actions.0.disable_security:    "" => "false"
-  actions.0.security_level:      "" => "under_attack"
-  priority:                      "" => "1"
-  status:                        "" => "active"
-  target:                        "" => "www.example.com/expensive-db-call"
-  zone:                          "" => "example.com"
-  zone_id:                       "" => "<computed>"
-cloudflare_page_rule.redirect-to-new-db-page: Creation complete after 3s (ID: c5c40ff2dc12416b5fe4d0541980c591)
-cloudflare_page_rule.increase-security-on-expensive-page: Creation complete after 6s (ID: 1c13fdb84710c4cc8b11daf7ffcca449)
+cloudflare_page_rule.redirect-to-new-db-page: Creation complete after 3s [id=c5c40ff2dc12416b5fe4d0541980c591]
+cloudflare_page_rule.increase-security-on-expensive-page: Creation complete after 6s [id=1c13fdb84710c4cc8b11daf7ffcca449]
 
 Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
 ```

--- a/content/terraform/tutorial/add-page-rules.md
+++ b/content/terraform/tutorial/add-page-rules.md
@@ -27,7 +27,7 @@ resource "cloudflare_page_rule" "increase-security-on-expensive-page" {
   priority = 1
 
   actions {
-    security_level = "under_attack",
+    security_level = "under_attack"
   }
 }
 

--- a/content/terraform/tutorial/configure-https-settings.md
+++ b/content/terraform/tutorial/configure-https-settings.md
@@ -45,7 +45,7 @@ EOF
 Review what Terraform is proposing before applying changes. The example output below is being filtered to ignore computed values — in this case, settings that will keep their default values.
 
 ```sh
-$ terraform plan | grep -v "<computed>"
+$ terraform plan | grep -v "(known after apply)"
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
 persisted to local or remote state storage.

--- a/content/terraform/tutorial/configure-https-settings.md
+++ b/content/terraform/tutorial/configure-https-settings.md
@@ -29,7 +29,7 @@ Switched to a new branch 'step3-https'
 $ cat >> cloudflare.tf <<'EOF'
 
 resource "cloudflare_zone_settings_override" "example-com-settings" {
-  name = var.zone_id
+  zone_id = var.zone_id
 
   settings {
     tls_1_3                  = "on"

--- a/content/terraform/tutorial/configure-https-settings.md
+++ b/content/terraform/tutorial/configure-https-settings.md
@@ -50,7 +50,7 @@ Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
 persisted to local or remote state storage.
 
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8668)
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8668]
 
 ------------------------------------------------------------------------
 
@@ -60,21 +60,25 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-  + cloudflare_zone_settings_override.example-com-settings
-      name:                                   "example.com"
-      settings.#:                             "1"
-      settings.0.automatic_https_rewrites:    "on"
-      settings.0.ssl:                         "strict"
-      settings.0.tls_1_3:                     "on"
+  # cloudflare_zone_settings_override.example-com-settings will be created
+  + resource "cloudflare_zone_settings_override" "example-com-settings" {
+      + zone_id                  = "<ZONE_ID>"
 
+      + settings {
+        + automatic_https_rewrites    = "on"
+        + ssl                         = "strict"
+        + tls_1_3                     = "on"
+
+        # (...)
+      }
+  }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
-can't guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 ```
 
 The proposed changes look good, so you can merge them into the `master` branch and then apply them with `terraform apply`. When working on a team, you may want to require pull requests and use this opportunity to peer review any proposed configuration changes.
@@ -119,58 +123,103 @@ As shown above, you should receive an error because TLS 1.3 is not yet enabled o
 
 ```sh
 $ terraform apply --auto-approve
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8668)
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # cloudflare_zone_settings_override.example-com-settings will be created
+  + resource "cloudflare_zone_settings_override" "example-com-settings" {
+      + id                       = (known after apply)
+      + initial_settings         = (known after apply)
+      + initial_settings_read_at = (known after apply)
+      + readonly_settings        = (known after apply)
+      + zone_id                  = "e2e6491340be87a3726f91fc4148b126"
+      + zone_status              = (known after apply)
+      + zone_type                = (known after apply)
+
+      + settings {
+          + always_online               = (known after apply)
+          + always_use_https            = (known after apply)
+          + automatic_https_rewrites    = "on"
+          + binary_ast                  = (known after apply)
+          + brotli                      = (known after apply)
+          + browser_cache_ttl           = (known after apply)
+          + browser_check               = (known after apply)
+          + cache_level                 = (known after apply)
+          + challenge_ttl               = (known after apply)
+          + ciphers                     = (known after apply)
+          + cname_flattening            = (known after apply)
+          + development_mode            = (known after apply)
+          + early_hints                 = (known after apply)
+          + email_obfuscation           = (known after apply)
+          + filter_logs_to_cloudflare   = (known after apply)
+          + h2_prioritization           = (known after apply)
+          + hotlink_protection          = (known after apply)
+          + http2                       = (known after apply)
+          + http3                       = (known after apply)
+          + image_resizing              = (known after apply)
+          + ip_geolocation              = (known after apply)
+          + ipv6                        = (known after apply)
+          + log_to_cloudflare           = (known after apply)
+          + max_upload                  = (known after apply)
+          + min_tls_version             = (known after apply)
+          + mirage                      = (known after apply)
+          + opportunistic_encryption    = (known after apply)
+          + opportunistic_onion         = (known after apply)
+          + orange_to_orange            = (known after apply)
+          + origin_error_page_pass_thru = (known after apply)
+          + origin_max_http_version     = (known after apply)
+          + polish                      = (known after apply)
+          + prefetch_preload            = (known after apply)
+          + privacy_pass                = (known after apply)
+          + proxy_read_timeout          = (known after apply)
+          + pseudo_ipv4                 = (known after apply)
+          + response_buffering          = (known after apply)
+          + rocket_loader               = (known after apply)
+          + security_level              = (known after apply)
+          + server_side_exclude         = (known after apply)
+          + sort_query_string_for_cache = (known after apply)
+          + ssl                         = "strict"
+          + tls_1_2_only                = (known after apply)
+          + tls_1_3                     = "on"
+          + tls_client_auth             = (known after apply)
+          + true_client_ip_header       = (known after apply)
+          + universal_ssl               = (known after apply)
+          + visitor_ip                  = (known after apply)
+          + waf                         = (known after apply)
+          + webp                        = (known after apply)
+          + websockets                  = (known after apply)
+          + zero_rtt                    = (known after apply)
+
+          + minify {
+              + css  = (known after apply)
+              + html = (known after apply)
+              + js   = (known after apply)
+            }
+
+          + mobile_redirect {
+              + mobile_subdomain = (known after apply)
+              + status           = (known after apply)
+              + strip_uri        = (known after apply)
+            }
+
+          + security_header {
+              + enabled            = (known after apply)
+              + include_subdomains = (known after apply)
+              + max_age            = (known after apply)
+              + nosniff            = (known after apply)
+              + preload            = (known after apply)
+            }
+        }
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
 cloudflare_zone_settings_override.example-com-settings: Creating...
-  initial_settings.#:                     "" => "<computed>"
-  initial_settings_read_at:               "" => "<computed>"
-  name:                                   "" => "example.com"
-  readonly_settings.#:                    "" => "<computed>"
-  settings.#:                             "" => "1"
-  settings.0.advanced_ddos:               "" => "<computed>"
-  settings.0.always_online:               "" => "<computed>"
-  settings.0.always_use_https:            "" => "<computed>"
-  settings.0.automatic_https_rewrites:    "" => "on"
-  settings.0.brotli:                      "" => "<computed>"
-  settings.0.browser_cache_ttl:           "" => "<computed>"
-  settings.0.browser_check:               "" => "<computed>"
-  settings.0.cache_level:                 "" => "<computed>"
-  settings.0.challenge_ttl:               "" => "<computed>"
-  settings.0.cname_flattening:            "" => "<computed>"
-  settings.0.development_mode:            "" => "<computed>"
-  settings.0.edge_cache_ttl:              "" => "<computed>"
-  settings.0.email_obfuscation:           "" => "<computed>"
-  settings.0.hotlink_protection:          "" => "<computed>"
-  settings.0.http2:                       "" => "<computed>"
-  settings.0.ip_geolocation:              "" => "<computed>"
-  settings.0.ipv6:                        "" => "<computed>"
-  settings.0.max_upload:                  "" => "<computed>"
-  settings.0.minify.#:                    "" => "<computed>"
-  settings.0.mirage:                      "" => "<computed>"
-  settings.0.mobile_redirect.#:           "" => "<computed>"
-  settings.0.opportunistic_encryption:    "" => "<computed>"
-  settings.0.origin_error_page_pass_thru: "" => "<computed>"
-  settings.0.polish:                      "" => "<computed>"
-  settings.0.prefetch_preload:            "" => "<computed>"
-  settings.0.privacy_pass:                "" => "<computed>"
-  settings.0.pseudo_ipv4:                 "" => "<computed>"
-  settings.0.response_buffering:          "" => "<computed>"
-  settings.0.rocket_loader:               "" => "<computed>"
-  settings.0.security_header.#:           "" => "<computed>"
-  settings.0.security_level:              "" => "<computed>"
-  settings.0.server_side_exclude:         "" => "<computed>"
-  settings.0.sha1_support:                "" => "<computed>"
-  settings.0.sort_query_string_for_cache: "" => "<computed>"
-  settings.0.ssl:                         "" => "strict"
-  settings.0.tls_1_2_only:                "" => "<computed>"
-  settings.0.tls_1_3:                     "" => "on"
-  settings.0.tls_client_auth:             "" => "<computed>"
-  settings.0.true_client_ip_header:       "" => "<computed>"
-  settings.0.waf:                         "" => "<computed>"
-  settings.0.webp:                        "" => "<computed>"
-  settings.0.websockets:                  "" => "<computed>"
-  zone_status:                            "" => "<computed>"
-  zone_type:                              "" => "<computed>"
-cloudflare_zone_settings_override.example-com-settings: Creation complete after 2s (ID: e2e6491340be87a3726f91fc4148b125)
+cloudflare_zone_settings_override.example-com-settings: Still creating... [10s elapsed]
+cloudflare_zone_settings_override.example-com-settings: Creation complete after 14s [id=e2e6491340be87a3726f91fc4148b126]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ```

--- a/content/terraform/tutorial/initialize-terraform.md
+++ b/content/terraform/tutorial/initialize-terraform.md
@@ -104,45 +104,39 @@ After installing the Cloudflare provider, review the proposed changes to your Cl
 
 ```sh
 $ terraform plan
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
 
-
-------------------------------------------------------------------------
-
-An execution plan has been generated and is shown below.
+Terraform used the selected providers to generate the following execution plan.
 Resource actions are indicated with the following symbols:
   + create
 
 Terraform will perform the following actions:
 
-  + cloudflare_record.www
-      id:          <computed>
-      created_on:  <computed>
-      domain:      <computed>
-      hostname:    <computed>
-      metadata.%:  <computed>
-      modified_on: <computed>
-      name:        "www"
-      proxiable:   <computed>
-      proxied:     "true"
-      ttl:         <computed>
-      type:        "A"
-      value:       "203.0.113.10"
-      zone_id:     "e097e1136dc79bc1149e32a8a6bde5ef"
-
+  # cloudflare_record.www will be created
+  + resource "cloudflare_record" "www" {
+      + allow_overwrite = false
+      + created_on      = (known after apply)
+      + hostname        = (known after apply)
+      + id              = (known after apply)
+      + metadata        = (known after apply)
+      + modified_on     = (known after apply)
+      + name            = "www"
+      + proxiable       = (known after apply)
+      + proxied         = true
+      + ttl             = (known after apply)
+      + type            = "A"
+      + value           = "203.0.113.10"
+      + zone_id         = "e2e6491340be87a3726f91fc4148b126"
+    }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn’t specify an "-out" parameter to save this plan, so Terraform
-can’t guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 ```
 
-As displayed in the execution plan, Terraform will create a new DNS record. The output shows the values that you explicitly specified, such as the value of the `A` record (`203.0.113.10`). Values shown as `<computed>` are derived based on other API calls (for example, looking up the `metadata`), or the values are returned after the object is created.
+As displayed in the execution plan, Terraform will create a new DNS record. The output shows the values that you explicitly specified, such as the value of the `A` record (`203.0.113.10`). Values shown as `(known after apply)` are derived based on other API calls (for example, looking up the `metadata`), or the values are returned after the object is created.
 
 ## 4. Apply your changes
 
@@ -152,50 +146,67 @@ You can use `--auto-approve` on the command line for a briefer output. Without t
 
 ```sh
 $ terraform apply --auto-approve
-cloudflare_record.www: Creating...
-  created_on:  "" => "<computed>"
-  domain:      "" => "example.com"
-  hostname:    "" => "<computed>"
-  metadata.%:  "" => "<computed>"
-  modified_on: "" => "<computed>"
-  name:        "" => "www"
-  proxiable:   "" => "<computed>"
-  proxied:     "" => "true"
-  ttl:         "" => "<computed>"
-  type:        "" => "A"
-  value:       "" => "203.0.113.10"
-  zone_id:     "" => "<computed>"
-cloudflare_record.www: Creation complete after 1s (ID: c38d3103767284e7cd14d5dad3ab8668)
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # cloudflare_record.www will be created
+  + resource "cloudflare_record" "www" {
+      + allow_overwrite = false
+      + created_on      = (known after apply)
+      + hostname        = (known after apply)
+      + id              = (known after apply)
+      + metadata        = (known after apply)
+      + modified_on     = (known after apply)
+      + name            = "www"
+      + proxiable       = (known after apply)
+      + proxied         = true
+      + ttl             = (known after apply)
+      + type            = "A"
+      + value           = "203.0.113.10"
+      + zone_id         = "e2e6491340be87a3726f91fc4148b126"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+cloudflare_record.www: Creation complete after 1s [id=c38d3103767284e7cd14d5dad3ab8668]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ```
 
 ## 5. Verify the results
 
-Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and navigate to **DNS** > **Records**. The record created by Terraform appears in the records list.
+Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and go to **DNS** > **Records**. The record created by Terraform appears in the records list.
 
 To see the full results returned from the API call, including the default values that you did not specify but let Terraform compute, run `terraform show`.
 
 ```sh
 $ terraform show
-cloudflare_record.www:
-  id = c38d3103767284e7cd14d5dad3ab8668
-  created_on = 2018-04-08T00:37:33.76321Z
-  data.% = 0
-  domain = example.com
-  hostname = www.example.com
-  metadata.% = 2
-  metadata.auto_added = false
-  metadata.managed_by_apps = false
-  modified_on = 2018-04-08T00:37:33.76321Z
-  name = www
-  priority = 0
-  proxiable = true
-  proxied = true
-  ttl = 1
-  type = A
-  value = 203.0.113.10
-  zone_id = e097e1136dc79bc1149e32a8a6bde5ef
+# cloudflare_record.www:
+resource "cloudflare_record" "www" {
+    id          = "c38d3103767284e7cd14d5dad3ab8668"
+    created_on  = "2023-04-08T00:37:33.76321Z"
+    data        = []
+    domain      = "example.com"
+    hostname    = "www.example.com"
+    metadata    = [
+        {
+            auto_added      = false
+            managed_by_apps = false
+        }
+    ]
+    modified_on = "2023-04-08T00:37:33.76321Z"
+    name        = "www"
+    priority    = 0
+    proxiable   = true
+    proxied     = true
+    ttl         = 1
+    type        = "A"
+    value       = "203.0.113.10"
+    zone_id     = "e2e6491340be87a3726f91fc4148b126"
+}
 ```
 
 ```sh

--- a/content/terraform/tutorial/initialize-terraform.md
+++ b/content/terraform/tutorial/initialize-terraform.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have [installed Terraform](/terraform/installing/).
 
 ## 1. Define your first Terraform config file
 
-Create an initial Terraform config file, filling in your own values for the [API token](/fundamentals/api/get-started/create-token/), [zone ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/), and [domain](/fundamentals/get-started/setup/add-site/).
+Create an initial Terraform config file, filling in your own values for the [API token](/fundamentals/api/get-started/create-token/), [zone ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/), [account ID](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/), and [domain](/fundamentals/get-started/setup/add-site/).
 
 Terraform will process any files with a `.tf` extension. As the configuration becomes more complex, you will want to split the config into separate files and modules. For now, proceed with a single file.
 
@@ -39,6 +39,10 @@ provider "cloudflare" {
 
 variable "zone_id" {
   default = "<YOUR_ZONE_ID>"
+}
+
+variable "account_id" {
+  default = "<YOUR_ACCOUNT_ID>"
 }
 
 variable "domain" {

--- a/content/terraform/tutorial/revert-configuration.md
+++ b/content/terraform/tutorial/revert-configuration.md
@@ -127,31 +127,34 @@ index b92cb6f..195b646 100644
  }
 +
 +resource "cloudflare_load_balancer_monitor" "get-root-https" {
-+  expected_body = "alive"
++  account_id     = var.account_id
++  expected_body  = "alive"
 +  expected_codes = "200"
-+  method = "GET"
-+  timeout = 5
-+  path = "/"
-+  interval = 60
-+  retries = 2
-+  description = "GET / over HTTPS - expect 200"
++  method         = "GET"
++  timeout        = 5
++  path           = "/"
++  interval       = 60
++  retries        = 2
++  description    = "GET / over HTTPS - expect 200"
 +}
++
 +resource "cloudflare_load_balancer_pool" "www-servers" {
-+  name = "www-servers"
-+  monitor = cloudflare_load_balancer_monitor.get-root-https.id
-+  check_regions = ["WNAM", "ENAM", "WEU", "EEU", "SEAS", "NEAS"]
++  account_id = var.account_id
++  name       = "www-servers"
++  monitor    = cloudflare_load_balancer_monitor.get-root-https.id
 +  origins {
-+    name = "www-us"
++    name    = "www-us"
 +    address = "203.0.113.10"
 +  }
 +  origins {
-+    name = "www-asia"
++    name    = "www-asia"
 +    address = "198.51.100.15"
 +  }
-+  description = "www origins"
-+  enabled = true
-+  minimum_origins = 1
++  description        = "www origins"
++  enabled            = true
++  minimum_origins    = 1
 +  notification_email = "you@example.com"
++  check_regions      = ["WNAM", "ENAM", "WEU", "EEU", "SEAS", "NEAS"]
 +}
 +resource "cloudflare_load_balancer" "www-lb" {
 +  zone_id = var.zone_id
@@ -227,14 +230,14 @@ Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
 persisted to local or remote state storage.
 
-cloudflare_page_rule.increase-security-on-expensive-page: Refreshing state... (ID: 1c13fdb84710c4cc8b11daf7ffcca449)
-cloudflare_page_rule.redirect-to-new-db-page: Refreshing state... (ID: c5c40ff2dc12416b5fe4d0541980c591)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_load_balancer_monitor.get-root-https: Refreshing state... (ID: 4238142473fcd48e89ef1964be72e3e0)
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
-cloudflare_load_balancer_pool.www-servers: Refreshing state... (ID: 906d2a7521634783f4a96c062eeecc6d)
-cloudflare_load_balancer.www-lb: Refreshing state... (ID: cb94f53f150e5c1a65a07e43c5d4cac4)
+cloudflare_page_rule.increase-security-on-expensive-page: Refreshing state... [id=1c13fdb84710c4cc8b11daf7ffcca449]
+cloudflare_page_rule.redirect-to-new-db-page: Refreshing state... [id=c5c40ff2dc12416b5fe4d0541980c591]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_load_balancer_monitor.get-root-https: Refreshing state... [id=4238142473fcd48e89ef1964be72e3e0]
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+cloudflare_load_balancer_pool.www-servers: Refreshing state... [id=906d2a7521634783f4a96c062eeecc6d]
+cloudflare_load_balancer.www-lb: Refreshing state... [id=cb94f53f150e5c1a65a07e43c5d4cac4]
 
 ------------------------------------------------------------------------
 
@@ -266,16 +269,16 @@ The changes look good. Terraform reverts the Cloudflare configuration when you a
 
 ```sh
 $ terraform apply --auto-approve
-cloudflare_page_rule.redirect-to-new-db-page: Refreshing state... (ID: c5c40ff2dc12416b5fe4d0541980c591)
-cloudflare_page_rule.increase-security-on-expensive-page: Refreshing state... (ID: 1c13fdb84710c4cc8b11daf7ffcca449)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-cloudflare_load_balancer_monitor.get-root-https: Refreshing state... (ID: 4238142473fcd48e89ef1964be72e3e0)
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
-cloudflare_load_balancer_pool.www-servers: Refreshing state... (ID: 906d2a7521634783f4a96c062eeecc6d)
-cloudflare_load_balancer.www-lb: Refreshing state... (ID: cb94f53f150e5c1a65a07e43c5d4cac4)
-cloudflare_page_rule.redirect-to-new-db-page: Destroying... (ID: c5c40ff2dc12416b5fe4d0541980c591)
-cloudflare_page_rule.increase-security-on-expensive-page: Destroying... (ID: 1c13fdb84710c4cc8b11daf7ffcca449)
+cloudflare_page_rule.redirect-to-new-db-page: Refreshing state... [id=c5c40ff2dc12416b5fe4d0541980c591]
+cloudflare_page_rule.increase-security-on-expensive-page: Refreshing state... [id=1c13fdb84710c4cc8b11daf7ffcca449]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+cloudflare_load_balancer_monitor.get-root-https: Refreshing state... [id=4238142473fcd48e89ef1964be72e3e0]
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+cloudflare_load_balancer_pool.www-servers: Refreshing state... [id=906d2a7521634783f4a96c062eeecc6d]
+cloudflare_load_balancer.www-lb: Refreshing state... [id=cb94f53f150e5c1a65a07e43c5d4cac4]
+cloudflare_page_rule.redirect-to-new-db-page: Destroying... [id=c5c40ff2dc12416b5fe4d0541980c591]
+cloudflare_page_rule.increase-security-on-expensive-page: Destroying... [id=1c13fdb84710c4cc8b11daf7ffcca449]
 cloudflare_page_rule.increase-security-on-expensive-page: Destruction complete after 0s
 cloudflare_page_rule.redirect-to-new-db-page: Destruction complete after 1s
 

--- a/content/terraform/tutorial/track-history.md
+++ b/content/terraform/tutorial/track-history.md
@@ -40,11 +40,7 @@ After running the commands above, ensure that you can still authenticate to Clou
 
 ```sh
 $ terraform plan
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-cloudflare_record.www: Refreshing state... (ID: c38d3102767284e7ca14d5dad3ab8b69)
+cloudflare_record.www: Refreshing state... [id=c38d3102767284e7ca14d5dad3ab8b69]
 
 ------------------------------------------------------------------------
 

--- a/content/terraform/tutorial/use-load-balancing.md
+++ b/content/terraform/tutorial/use-load-balancing.md
@@ -15,8 +15,8 @@ In this tutorial, you will add a second origin for some basic round robining, an
 To get started, add a DNS record for a second web server, located in Asia. The IP address for this server is `198.51.100.15`.
 
 ```bash
-$ git checkout -b step5-loadbalance
-Switched to a new branch 'step5-loadbalance'
+$ git checkout -b step4-loadbalance
+Switched to a new branch 'step4-loadbalance'
 
 $ cat >> cloudflare.tf <<'EOF'
 resource "cloudflare_record" "www-asia" {
@@ -70,14 +70,14 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 
 $ git add cloudflare.tf
-$ git commit -m "Step 5 - Add additional 'www' DNS record for Asia data center."
-[step5-loadbalance 6761a4f] Step 5 - Add additional 'www' DNS record for Asia data center.
+$ git commit -m "Step 4 - Add additional 'www' DNS record for Asia data center."
+[step4-loadbalance 6761a4f] Step 4 - Add additional 'www' DNS record for Asia data center.
  1 file changed, 7 insertions(+)
 
 $ git checkout master
 Switched to branch 'master'
 
-$ git merge step5-loadbalance
+$ git merge step4-loadbalance
 Updating e1c38cf..6761a4f
 Fast-forward
  cloudflare.tf | 7 +++++++
@@ -158,8 +158,8 @@ As described in the [Load Balancing tutorial](/learning-paths/load-balancing/), 
 To monitor the origins, create a basic health check that makes a `GET` request to each origin on the URL `https://www.example.com`. If the origin returns the `200` status code (`OK`) within five seconds, it is considered healthy. If it fails to do so three times in a row, it is considered unhealthy. This health check will be run once per minute from several regions and send an email notification to `you@example.com` if any failures are detected.
 
 ```bash
-$ git checkout step5-loadbalance
-Switched to branch 'step5-loadbalance'
+$ git checkout step4-loadbalance
+Switched to branch 'step4-loadbalance'
 
 $ cat >> cloudflare.tf <<'EOF'
 
@@ -339,8 +339,8 @@ The plan looks good. Merge the plan and apply it.
 
 ```sh
 $ git add cloudflare.tf
-$ git commit -m "Step 5 - Create load balancer (LB) monitor, LB pool, and LB."
-[step5-loadbalance bc9aa9a] Step 5 - Create load balancer (LB) monitor, LB pool, and LB.
+$ git commit -m "Step 4 - Create load balancer (LB) monitor, LB pool, and LB."
+[step4-loadbalance bc9aa9a] Step 4 - Create load balancer (LB) monitor, LB pool, and LB.
  1 file changed, 35 insertions(+)
 
 $ terraform apply --auto-approve

--- a/content/terraform/tutorial/use-load-balancing.md
+++ b/content/terraform/tutorial/use-load-balancing.md
@@ -155,7 +155,7 @@ As described in the [Load Balancing tutorial](/learning-paths/load-balancing/), 
 
 ### i. Define and create the health check ("monitor")
 
-To monitor the origins, create a basic health check that makes a `GET` request to each origin on the URL `https://www.example.com`. If the origin returns the `200` status code (`OK`) within five seconds, it is considered healthy. If it fails to do so three times in a row, it is considered unhealthy. This health check will be run once per minute from several regions and send an email notification to `you@example.com` if any failures are detected.
+To monitor the origins, create a basic health check that makes a `GET` request to each origin on the URL `https://www.example.com`. If the origin returns the `200` status code (`OK`) within five seconds, it is considered healthy. If it fails to do so three times in a row, it is considered unhealthy. This health check will be run once per minute from several regions and send an email notification to your email address (configured as `<YOUR_EMAIL>`) if any failures are detected.
 
 ```bash
 $ git checkout step4-loadbalance
@@ -206,7 +206,7 @@ resource "cloudflare_load_balancer_pool" "www-servers" {
   description        = "www origins"
   enabled            = true
   minimum_origins    = 1
-  notification_email = "you@example.com"
+  notification_email = "<YOUR_EMAIL>"
   check_regions      = ["WNAM", "ENAM", "WEU", "EEU", "SEAS", "NEAS"]
 }
 EOF
@@ -314,7 +314,7 @@ Terraform will perform the following actions:
       + modified_on        = (known after apply)
       + monitor            = (known after apply)
       + name               = "www-servers"
-      + notification_email = "you@example.com"
+      + notification_email = "<YOUR_EMAIL>"
 
       + origins {
           + address = "198.51.100.15"
@@ -425,7 +425,7 @@ Terraform will perform the following actions:
       + modified_on        = (known after apply)
       + monitor            = (known after apply)
       + name               = "www-servers"
-      + notification_email = "you@example.com"
+      + notification_email = "<YOUR_EMAIL>"
 
       + origins {
           + address = "198.51.100.15"

--- a/content/terraform/tutorial/use-load-balancing.md
+++ b/content/terraform/tutorial/use-load-balancing.md
@@ -36,7 +36,7 @@ Note that while the name of the `resource` is different because Terraform resour
 Check the `terraform plan` and then merge and apply the changes.
 
 ```sh
-$ terraform plan | grep -v "<computed>"
+$ terraform plan | grep -v "(known after apply)"
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
 persisted to local or remote state storage.

--- a/content/terraform/tutorial/use-load-balancing.md
+++ b/content/terraform/tutorial/use-load-balancing.md
@@ -164,6 +164,7 @@ Switched to branch 'step4-loadbalance'
 $ cat >> cloudflare.tf <<'EOF'
 
 resource "cloudflare_load_balancer_monitor" "get-root-https" {
+  account_id     = var.account_id
   expected_body  = "alive"
   expected_codes = "200"
   method         = "GET"
@@ -191,8 +192,9 @@ Note the reference to the monitor that you added in the last step. When applying
 $ cat >> cloudflare.tf <<'EOF'
 
 resource "cloudflare_load_balancer_pool" "www-servers" {
-  name    = "www-servers"
-  monitor = cloudflare_load_balancer_monitor.get-root-https.id
+  account_id = var.account_id
+  name       = "www-servers"
+  monitor    = cloudflare_load_balancer_monitor.get-root-https.id
   origins {
     name    = "www-us"
     address = "203.0.113.10"
@@ -204,7 +206,8 @@ resource "cloudflare_load_balancer_pool" "www-servers" {
   description        = "www origins"
   enabled            = true
   minimum_origins    = 1
-  check_regions  = ["WNAM", "ENAM", "WEU", "EEU", "SEAS", "NEAS"]
+  notification_email = "you@example.com"
+  check_regions      = ["WNAM", "ENAM", "WEU", "EEU", "SEAS", "NEAS"]
 }
 EOF
 ```

--- a/content/terraform/tutorial/use-load-balancing.md
+++ b/content/terraform/tutorial/use-load-balancing.md
@@ -41,8 +41,8 @@ Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be
 persisted to local or remote state storage.
 
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
 
 ------------------------------------------------------------------------
 
@@ -52,21 +52,22 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-  + cloudflare_record.www-asia
-      zone_id:     "e097e1136dc79bc1149e32a8a6bde5ef"
-      name:        "www"
-      proxied:     "true"
-      type:        "A"
-      value:       "198.51.100.15"
-
+  # cloudflare_record.www-asia will be created
+  + resource "cloudflare_record" "www-asia" {
+      + allow_overwrite = false
+      + name            = "www"
+      + proxied         = true
+      + type            = "A"
+      + value           = "198.51.100.15"
+      + zone_id         = "e2e6491340be87a3726f91fc4148b126"
+    }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
-can't guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 
 $ git add cloudflare.tf
 $ git commit -m "Step 5 - Add additional 'www' DNS record for Asia data center."
@@ -89,22 +90,35 @@ Add the second DNS record for www.example.com.
 
 ```sh
 $ terraform apply --auto-approve
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8668)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8668]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # cloudflare_record.www-asia will be created
+  + resource "cloudflare_record" "www-asia" {
+      + allow_overwrite = false
+      + created_on      = (known after apply)
+      + hostname        = (known after apply)
+      + id              = (known after apply)
+      + metadata        = (known after apply)
+      + modified_on     = (known after apply)
+      + name            = "www"
+      + proxiable       = (known after apply)
+      + proxied         = true
+      + ttl             = (known after apply)
+      + type            = "A"
+      + value           = "198.51.100.15"
+      + zone_id         = "e2e6491340be87a3726f91fc4148b126"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
 cloudflare_record.www-asia: Creating...
-  created_on:  "" => "<computed>"
-  domain:      "" => "example.com"
-  hostname:    "" => "<computed>"
-  metadata.%:  "" => "<computed>"
-  modified_on: "" => "<computed>"
-  name:        "" => "www"
-  proxiable:   "" => "<computed>"
-  proxied:     "" => "true"
-  ttl:         "" => "<computed>"
-  type:        "" => "A"
-  value:       "" => "198.51.100.15"
-  zone_id:     "" => "<computed>"
-cloudflare_record.www-asia: Creation complete after 1s (ID: fda39d8c9bf909132e82a36bab992864)
+cloudflare_record.www-asia: Creation complete after 1s [id=fda39d8c9bf909132e82a36bab992864]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ```
@@ -166,7 +180,7 @@ EOF
 
 In this example, the pool will be called `www-servers` with two origins added to it:
 
-* `www-us` (`203.0.113.10`) 
+* `www-us` (`203.0.113.10`)
 * `www-asia` (`198.51.100.15`)
 
 For now, skip any sort of [geo routing](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/).
@@ -184,8 +198,8 @@ resource "cloudflare_load_balancer_pool" "www-servers" {
     address = "203.0.113.10"
   }
   origins {
-    address = "198.51.100.15"
     name    = "www-asia"
+    address = "198.51.100.15"
   }
   description        = "www origins"
   enabled            = true
@@ -219,84 +233,106 @@ As usual, review the proposed plan before applying any changes.
 
 ```sh
 $ terraform plan
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
 
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-
-------------------------------------------------------------------------
-
-An execution plan has been generated and is shown below.
+Terraform used the selected providers to generate the following execution plan.
 Resource actions are indicated with the following symbols:
   + create
 
 Terraform will perform the following actions:
 
-  + cloudflare_load_balancer.www-lb
-      id:                         <computed>
-      created_on:                 <computed>
-      default_pool_ids.#:         <computed>
-      description:                "example load balancer"
-      fallback_pool_id:           <computed>
-      modified_on:                <computed>
-      name:                       "www-lb"
-      pop_pools.#:                <computed>
-      proxied:                    "true"
-      region_pools.#:             <computed>
-      ttl:                        <computed>
-      zone:                       "example.com"
-      zone_id:                    <computed>
+  # cloudflare_load_balancer.www-lb will be created
+  + resource "cloudflare_load_balancer" "www-lb" {
+      + created_on       = (known after apply)
+      + default_pool_ids = (known after apply)
+      + description      = "example load balancer"
+      + enabled          = true
+      + fallback_pool_id = (known after apply)
+      + id               = (known after apply)
+      + modified_on      = (known after apply)
+      + name             = "www-lb"
+      + proxied          = true
+      + session_affinity = "none"
+      + steering_policy  = (known after apply)
+      + ttl              = (known after apply)
+      + zone_id          = "e2e6491340be87a3726f91fc4148b126"
 
-  + cloudflare_load_balancer_monitor.get-root-https
-      id:                         <computed>
-      created_on:                 <computed>
-      description:                "GET / over HTTPS - expect 200"
-      expected_body:              "alive"
-      expected_codes:             "200"
-      interval:                   "60"
-      method:                     "GET"
-      modified_on:                <computed>
-      path:                       "/"
-      retries:                    "2"
-      timeout:                    "5"
-      type:                       "http"
+      + country_pools {
+          + country  = (known after apply)
+          + pool_ids = (known after apply)
+        }
 
-  + cloudflare_load_balancer_pool.www-servers
-      id:                         <computed>
-      check_regions.#:            "6"
-      check_regions.1151265357:   "SEAS"
-      check_regions.1997072153:   "WEU"
-      check_regions.2367191053:   "EEU"
-      check_regions.2826842289:   "ENAM"
-      check_regions.2992567379:   "WNAM"
-      check_regions.3706632574:   "NEAS"
-      created_on:                 <computed>
-      description:                "www origins"
-      enabled:                    "true"
-      minimum_origins:            "1"
-      modified_on:                <computed>
-      monitor:                    <computed>
-      name:                       "www-servers"
-      notification_email:         "you@example.com"
-      origins.#:                  "2"
-      origins.3039426352.address: "198.51.100.15"
-      origins.3039426352.enabled: "true"
-      origins.3039426352.name:    "www-asia"
-      origins.4241861547.address: "203.0.113.10"
-      origins.4241861547.enabled: "true"
-      origins.4241861547.name:    "www-us"
+      + pop_pools {
+          + pool_ids = (known after apply)
+          + pop      = (known after apply)
+        }
 
+      + region_pools {
+          + pool_ids = (known after apply)
+          + region   = (known after apply)
+        }
+    }
+
+  # cloudflare_load_balancer_monitor.get-root-https will be created
+  + resource "cloudflare_load_balancer_monitor" "get-root-https" {
+      + account_id     = "8baedd8d98bf4b0c9bc650acc307b441"
+      + created_on     = (known after apply)
+      + description    = "GET / over HTTPS - expect 200"
+      + expected_body  = "alive"
+      + expected_codes = "200"
+      + id             = (known after apply)
+      + interval       = 60
+      + method         = "GET"
+      + modified_on    = (known after apply)
+      + path           = "/"
+      + retries        = 2
+      + timeout        = 5
+      + type           = "http"
+    }
+
+  # cloudflare_load_balancer_pool.www-servers will be created
+  + resource "cloudflare_load_balancer_pool" "www-servers" {
+      + account_id    = "8baedd8d98bf4b0c9bc650acc307b441"
+      + check_regions = [
+          + "EEU",
+          + "ENAM",
+          + "NEAS",
+          + "SEAS",
+          + "WEU",
+          + "WNAM",
+        ]
+      + created_on         = (known after apply)
+      + description        = "www origins"
+      + enabled            = true
+      + id                 = (known after apply)
+      + minimum_origins    = 1
+      + modified_on        = (known after apply)
+      + monitor            = (known after apply)
+      + name               = "www-servers"
+      + notification_email = "you@example.com"
+
+      + origins {
+          + address = "198.51.100.15"
+          + enabled = true
+          + name    = "www-asia"
+          + weight  = 1
+        }
+      + origins {
+          + address = "203.0.113.10"
+          + enabled = true
+          + name    = "www-us"
+          + weight  = 1
+        }
+    }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
-can't guarantee that exactly these actions will be performed if
-"terraform apply" is subsequently run.
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
 ```
 
 The plan looks good. Merge the plan and apply it.
@@ -307,62 +343,107 @@ $ git commit -m "Step 5 - Create load balancer (LB) monitor, LB pool, and LB."
 [step5-loadbalance bc9aa9a] Step 5 - Create load balancer (LB) monitor, LB pool, and LB.
  1 file changed, 35 insertions(+)
 
-e$ terraform apply --auto-approve
-cloudflare_zone_settings_override.example-com-settings: Refreshing state... (ID: e2e6491340be87a3726f91fc4148b126)
-cloudflare_record.www: Refreshing state... (ID: c38d3103767284e7cd14d5dad3ab8669)
-cloudflare_record.www-asia: Refreshing state... (ID: fda39d8c9bf909132e82a36bab992864)
+$ terraform apply --auto-approve
+cloudflare_zone_settings_override.example-com-settings: Refreshing state... [id=e2e6491340be87a3726f91fc4148b126]
+cloudflare_record.www: Refreshing state... [id=c38d3103767284e7cd14d5dad3ab8669]
+cloudflare_record.www-asia: Refreshing state... [id=fda39d8c9bf909132e82a36bab992864]
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # cloudflare_load_balancer.www-lb will be created
+  + resource "cloudflare_load_balancer" "www-lb" {
+      + created_on       = (known after apply)
+      + default_pool_ids = (known after apply)
+      + description      = "example load balancer"
+      + enabled          = true
+      + fallback_pool_id = (known after apply)
+      + id               = (known after apply)
+      + modified_on      = (known after apply)
+      + name             = "www-lb"
+      + proxied          = true
+      + session_affinity = "none"
+      + steering_policy  = (known after apply)
+      + ttl              = (known after apply)
+      + zone_id          = "e2e6491340be87a3726f91fc4148b126"
+
+      + country_pools {
+          + country  = (known after apply)
+          + pool_ids = (known after apply)
+        }
+
+      + pop_pools {
+          + pool_ids = (known after apply)
+          + pop      = (known after apply)
+        }
+
+      + region_pools {
+          + pool_ids = (known after apply)
+          + region   = (known after apply)
+        }
+    }
+
+  # cloudflare_load_balancer_monitor.get-root-https will be created
+  + resource "cloudflare_load_balancer_monitor" "get-root-https" {
+      + account_id     = "8baedd8d98bf4b0c9bc650acc307b441"
+      + created_on     = (known after apply)
+      + description    = "GET / over HTTPS - expect 200"
+      + expected_body  = "alive"
+      + expected_codes = "200"
+      + id             = (known after apply)
+      + interval       = 60
+      + method         = "GET"
+      + modified_on    = (known after apply)
+      + path           = "/"
+      + retries        = 2
+      + timeout        = 5
+      + type           = "http"
+    }
+
+  # cloudflare_load_balancer_pool.www-servers will be created
+  + resource "cloudflare_load_balancer_pool" "www-servers" {
+      + account_id      = "8baedd8d98bf4b0c9bc650acc307b441"
+      + check_regions   = [
+          + "EEU",
+          + "ENAM",
+          + "NEAS",
+          + "SEAS",
+          + "WEU",
+          + "WNAM",
+        ]
+      + created_on         = (known after apply)
+      + description        = "www origins"
+      + enabled            = true
+      + id                 = (known after apply)
+      + minimum_origins    = 1
+      + modified_on        = (known after apply)
+      + monitor            = (known after apply)
+      + name               = "www-servers"
+      + notification_email = "you@example.com"
+
+      + origins {
+          + address = "198.51.100.15"
+          + enabled = true
+          + name    = "www-asia"
+          + weight  = 1
+        }
+      + origins {
+          + address = "203.0.113.10"
+          + enabled = true
+          + name    = "www-us"
+          + weight  = 1
+        }
+    }
+
 cloudflare_load_balancer_monitor.get-root-https: Creating...
-  created_on:     "" => "<computed>"
-  description:    "" => "GET / over HTTPS - expect 200"
-  expected_body:  "" => "alive"
-  expected_codes: "" => "200"
-  interval:       "" => "60"
-  method:         "" => "GET"
-  modified_on:    "" => "<computed>"
-  path:           "" => "/"
-  retries:        "" => "2"
-  timeout:        "" => "5"
-  type:           "" => "http"
-cloudflare_load_balancer_monitor.get-root-https: Creation complete after 1s (ID: 4238142473fcd48e89ef1964be72e3e0)
+cloudflare_load_balancer_monitor.get-root-https: Creation complete after 1s [id=4238142473fcd48e89ef1964be72e3e0]
 cloudflare_load_balancer_pool.www-servers: Creating...
-  check_regions.#:            "" => "6"
-  check_regions.1151265357:   "" => "SEAS"
-  check_regions.1997072153:   "" => "WEU"
-  check_regions.2367191053:   "" => "EEU"
-  check_regions.2826842289:   "" => "ENAM"
-  check_regions.2992567379:   "" => "WNAM"
-  check_regions.3706632574:   "" => "NEAS"
-  created_on:                 "" => "<computed>"
-  description:                "" => "www origins"
-  enabled:                    "" => "true"
-  minimum_origins:            "" => "1"
-  modified_on:                "" => "<computed>"
-  monitor:                    "" => "4238142473fcd48e89ef1964be72e3e0"
-  name:                       "" => "www-servers"
-  notification_email:         "" => "you@example.com"
-  origins.#:                  "" => "2"
-  origins.3039426352.address: "" => "198.51.100.15"
-  origins.3039426352.enabled: "" => "true"
-  origins.3039426352.name:    "" => "www-asia"
-  origins.4241861547.address: "" => "203.0.113.10"
-  origins.4241861547.enabled: "" => "true"
-  origins.4241861547.name:    "" => "www-us"
-cloudflare_load_balancer_pool.www-servers: Creation complete after 0s (ID: 906d2a7521634783f4a96c062eeecc6d)
+cloudflare_load_balancer_pool.www-servers: Creation complete after 0s [id=906d2a7521634783f4a96c062eeecc6d]
 cloudflare_load_balancer.www-lb: Creating...
-  created_on:         "" => "<computed>"
-  default_pool_ids.#: "" => "1"
-  default_pool_ids.0: "" => "906d2a7521634783f4a96c062eeecc6d"
-  description:        "" => "example load balancer"
-  fallback_pool_id:   "" => "906d2a7521634783f4a96c062eeecc6d"
-  modified_on:        "" => "<computed>"
-  name:               "" => "www-lb"
-  pop_pools.#:        "" => "<computed>"
-  proxied:            "" => "true"
-  region_pools.#:     "" => "<computed>"
-  ttl:                "" => "<computed>"
-  zone:               "" => "example.com"
-  zone_id:            "" => "<computed>"
-cloudflare_load_balancer.www-lb: Creation complete after 1s (ID: cb94f53f150e5c1a65a07e43c5d4cac4)
+cloudflare_load_balancer.www-lb: Creation complete after 1s [id=cb94f53f150e5c1a65a07e43c5d4cac4]
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 ```


### PR DESCRIPTION
Closes #8878.

* Fixes param `name` to `zone_id`.
* `grep` commands now search for (inverse of) `"(known after apply)"` instead of `"<computed>"`.
* Adds required `account_id` to a couple of load balancing resources (and as a config var), as well a `notification_email` that was only half present.
* Updates most output from the Terraform tool.
* Includes a few additional small fixes (such as step numbers).
