### PR TITLE
Adding missing parameter in example

### DIFF
--- a/content/rules/url-forwarding/bulk-redirects/use-cases.md
+++ b/content/rules/url-forwarding/bulk-redirects/use-cases.md
@@ -38,6 +38,7 @@ In this example, an old website was discontinued and replaced by a new one in a 
 
     - **Source URL**: `example.com/`
     - **Target URL**: `https://example.net/`
+    - **Subpath matching**: Enabled
     - **Include subdomains**: Enabled
 
 2.  Create a Bulk Redirect Rule that enables this list.


### PR DESCRIPTION
Subpath matching needs to be enabled in the "Redirect all requests for a domain to the root page of different domain" example
SPM-1228
