### PR TITLE
Update Next.js Edge Runtime link

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -11,7 +11,7 @@ title: Deploy a Next.js site
 
 Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/api-reference/edge-runtime) or any projects which can be [statically exported](https://nextjs.org/docs/advanced-features/static-html-export). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props) and [Middleware](https://nextjs.org/docs/advanced-features/middleware).
 
-For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/advanced-features/react-18/switchable-runtime) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
+For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/app/api-reference/edge) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
 
 {{<render file="_tutorials-before-you-start.md">}}
 

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -9,7 +9,7 @@ title: Deploy a Next.js site
 
 ## Consider if you need the Edge Runtime
 
-Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/api-reference/edge-runtime) or any projects which can be [statically exported](https://nextjs.org/docs/advanced-features/static-html-export). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props) and [Middleware](https://nextjs.org/docs/advanced-features/middleware).
+Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/pages/api-reference/edge) or any projects which can be [statically exported](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/pages/api-reference/functions/get-server-side-props) and [Middleware](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
 For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/app/api-reference/edge) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
 


### PR DESCRIPTION
I have implemented the necessary changes to accommodate the significant restructuring of Next.js documentation site to major support `appDir` starting from Next.js 13.4.
However, ideally, I believe it would be best to add detailed sections specifically dedicated to App and Page Routing information.