### PR TITLE
[Pages] Update Next.js guide for `@cloudflare/next-on-pages` v1

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -16,6 +16,7 @@ For more information about the Edge Runtime, refer to [the official Next.js docu
 {{<render file="_tutorials-before-you-start.md">}}
 
 ## Using the Edge Runtime
+
 ### 1. Select your Next.js app
 
 If you already have a Next.js project that you wish to deploy, change to its directory and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
@@ -32,10 +33,10 @@ $ cd my-app
 
 ### 2. Configure the application to use the Edge Runtime
 
-The default template uses traditional Node.js-powered routes that are not supported on Cloudflare Pages. To run your application, you need to opt into the Edge Runtime for any routes that have server-side functionality (e.g. API routes or pages that use `getServerSideProps`). To do this, you need to export a `runtime` [route segment config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) option from each route's file. 
+The default template uses traditional Node.js-powered routes that are not supported on Cloudflare Pages. To run your application, you need to opt into the Edge Runtime for any routes that have server-side functionality (e.g. API routes or pages that use `getServerSideProps`). To do this, you need to export a `runtime` [route segment config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) option from each route's file.
 
 ```js
-export const runtime = 'edge';
+export const runtime = "edge";
 ```
 
 As an example, an [Edge Route Handler](https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes) might look like this:
@@ -89,7 +90,6 @@ export async function GET(request: Request) {
 
 For more examples of this and for Next.js versions prior to v13.3.1, take a look at the `@cloudflare/next-on-pages` [examples document](https://github.com/cloudflare/next-on-pages/blob/main/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md).
 
-
 {{<render file="_create-github-repository_no_init.md">}}
 
 ### 3. Deploy your application to Cloudflare Pages
@@ -108,11 +108,11 @@ Deploy your site to Pages:
 
    {{<table-wrap>}}
 
-   | Configuration option | Value                                                 |
-   | -------------------- | ----------------------------------------------------- |
-   | Production branch    | `main`                                                |
-   | Build command        | `npx @cloudflare/next-on-pages@v1`                    |
-   | Build directory      | `.vercel/output/static`                               |
+   | Configuration option | Value                              |
+   | -------------------- | ---------------------------------- |
+   | Production branch    | `main`                             |
+   | Build command        | `npx @cloudflare/next-on-pages@v1` |
+   | Build directory      | `.vercel/output/static`            |
 
    {{</table-wrap>}}
 
@@ -127,6 +127,7 @@ The `@cloudflare/next-on-pages` CLI transforms the Edge Runtime components of yo
 {{</Aside>}}
 
 ## Using a Static Export
+
 ### 1. Select your Next.js app
 
 If you already have a Next.js project that you wish to deploy, ensure that it is [configured for static exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports), change to its directory, and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
@@ -153,11 +154,11 @@ Deploy your site to Pages:
 
    {{<table-wrap>}}
 
-   | Configuration option | Value            |
-   | -------------------- | ---------------- |
-   | Production branch    | `main`           |
-   | Build command        | `npm run build`  |
-   | Build directory      | `out`            |
+   | Configuration option | Value           |
+   | -------------------- | --------------- |
+   | Production branch    | `main`          |
+   | Build command        | `npm run build` |
+   | Build directory      | `out`           |
 
    {{</table-wrap>}}
 

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -7,25 +7,30 @@ title: Deploy a Next.js site
 
 [Next.js](https://nextjs.org) is an open-source React framework for creating websites and apps. In this guide, you will create a new Next.js application and deploy it using Cloudflare Pages.
 
+This guide will instruct you how to deploy:
+
+* Full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge). 
+* Next.js projects which can be [statically exported](https://nextjs.org/docs/app/building-your-application/deploying/static-exports).
+
 ## Consider if you need the Edge Runtime
 
-Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge), or any projects which can be [statically exported](https://nextjs.org/docs/app/building-your-application/deploying/static-exports). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/pages/api-reference/functions/get-server-side-props), [Server Components](https://nextjs.org/docs/getting-started/react-essentials#server-components), and [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware).
+The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/pages/api-reference/functions/get-server-side-props), [Server Components](https://nextjs.org/docs/getting-started/react-essentials#server-components), and [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware).
 
 For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
 
 {{<render file="_tutorials-before-you-start.md">}}
 
-## Using the Edge Runtime
+## Use the Edge Runtime
 
-### 1. Select your Next.js app
+### 1. Select your Next.js project
 
-If you already have a Next.js project that you wish to deploy, change to its directory and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
+If you already have a Next.js project that you wish to deploy, change to its directory and proceed to the next step. Otherwise, use `create-next-app` to create a new Next.js project:
 
 ```sh
 $ npx create-next-app my-app
 ```
 
-After creating your project, a new `my-app` directory will be generated using the official default template. Switch to this directory to continue.
+After creating your project, a new `my-app` directory will be generated using the official default template. Change to this directory to continue.
 
 ```sh
 $ cd my-app
@@ -117,26 +122,28 @@ Deploy your site to Pages:
    {{</table-wrap>}}
 
 4. Next.js requires Node.js v16 or later to build successfully. To set your Node version, go to **Settings** in your Pages project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16` or greater.
-5. Click on **Save and Deploy** to start the deployment (this first deployment won't be fully functional as the next step is also necessary).
-6. Go to the **Pages project settings** page (_Settings_ > _Functions_ > _Compatibility Flags_), **add the `nodejs_compat` flag** for both production and preview, and make sure that the **Compatibility Date** for both production and preview is set to at least `2022-11-30`.
+5. Click on **Save and Deploy** to start the deployment. This first deployment will not be fully functional as the next step is also necessary.
+6. In your Pages project, go to **Settings** > **Functions** > **Compatibility Flags**.
+7. Configure a `nodejs_compat` flag for both production and preview .
+8. Above **Compability Flags**, go to **Compatibility Date**  and configure a compatibility date that is at least `2022-11-30` for both production and preview.
 
 {{<Aside type="note" header="Note">}}
 
-The `@cloudflare/next-on-pages` CLI transforms the Edge Runtime components of your project into a `_worker.js` file which is deployed with [Pages Functions](/pages/platform/functions/advanced-mode/). The library attempts to deduplicate code that would otherwise result in your project quickly hitting the [script size limit](/workers/platform/limits/#worker-size). If you notice any bugs, please let us know by filing a [GitHub issue](https://github.com/cloudflare/next-on-pages/issues/).
+The `@cloudflare/next-on-pages` CLI transforms the Edge Runtime components of your project into a `_worker.js` file which is deployed with [Pages Functions](/pages/platform/functions/advanced-mode/). The library attempts to deduplicate code that would otherwise result in your project quickly hitting the [script size limit](/workers/platform/limits/#worker-size). If you notice any bugs, let us know by filing a [GitHub issue](https://github.com/cloudflare/next-on-pages/issues/).
 
 {{</Aside>}}
 
-## Using a Static Export
+## Use a static export
 
-### 1. Select your Next.js app
+### 1. Select your Next.js project
 
-If you already have a Next.js project that you wish to deploy, ensure that it is [configured for static exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports), change to its directory, and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
+If you already have a Next.js project that you wish to deploy, ensure that it is [configured for static exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports), change to its directory, and proceed to the next step. Otherwise, use `create-next-app` to create a new Next.js project.
 
 ```sh
 $ npx create-next-app --example with-static-export my-app
 ```
 
-After creating your project, a new `my-app` directory will be generated using the official [`with-static-export`](https://github.com/vercel/next.js/tree/canary/examples/with-static-export) example as a template. Switch to this directory to continue.
+After creating your project, a new `my-app` directory will be generated using the official [`with-static-export`](https://github.com/vercel/next.js/tree/canary/examples/with-static-export) example as a template. Change to this directory to continue.
 
 ```sh
 $ cd my-app
@@ -162,7 +169,7 @@ Deploy your site to Pages:
 
    {{</table-wrap>}}
 
-4. Next.js requires Node.js v16 or later to build successfully. To set your Node version, go to **Settings** in your Pages project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16` or greater.
+4. Next.js requires a specific Node.js version to build successfully. Refer to [System Requirements in Next.js Installation guide](https://nextjs.org/docs/getting-started/installation) to review the required Node.js version. To set your Node.js version, go to your Pages project > **Settings** > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of the required version. For example, if the required Node.js version on Next.js's Installation guide is Node.js `16.8` or later, your environment variable value must be set to `16` or greater.
 
 After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `next`, your project dependencies, and building your site before deploying it.
 

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -97,7 +97,7 @@ For more examples of this and for Next.js versions prior to v13.3.1, take a look
 To deploy your application to Cloudflare Pages, you need to install the `@cloudflare/next-on-pages` package. This library builds your Next.js project in a format that can be deployed to Pages, and handles the runtime logic for your application.
 
 ```sh
-$ npm install @cloudflare/next-on-pages --save-dev
+$ npm install --save-dev @cloudflare/next-on-pages
 ```
 
 Deploy your site to Pages:

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -116,7 +116,7 @@ Deploy your site to Pages:
    | Configuration option | Value                              |
    | -------------------- | ---------------------------------- |
    | Production branch    | `main`                             |
-   | Build command        | `npx @cloudflare/next-on-pages@1` |
+   | Build command        | `npx @cloudflare/next-on-pages@1`  |
    | Build directory      | `.vercel/output/static`            |
 
    {{</table-wrap>}}

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -5,49 +5,60 @@ title: Deploy a Next.js site
 
 # Deploy a Next.js site
 
-[Next.js](https://nextjs.org/) is an open-source React framework for creating websites and apps. In this guide, you will create a new Next.js application and deploy it using Cloudflare Pages.
+[Next.js](https://nextjs.org) is an open-source React framework for creating websites and apps. In this guide, you will create a new Next.js application and deploy it using Cloudflare Pages.
 
 ## Consider if you need the Edge Runtime
 
-Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/api-reference/edge-runtime) or any projects which can be [statically exported](https://nextjs.org/docs/advanced-features/static-html-export). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props) and [Middleware](https://nextjs.org/docs/advanced-features/middleware).
+Cloudflare Pages supports full-stack Next.js projects which use the [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge), or any projects which can be [statically exported](https://nextjs.org/docs/app/building-your-application/deploying/static-exports). The Edge Runtime allows applications to use server-side features such as [Edge API Routes](https://nextjs.org/docs/api-routes/edge-api-routes), server-side rendering (SSR) pages with [`getServerSideProps()`](https://nextjs.org/docs/pages/api-reference/functions/get-server-side-props), [Server Components](https://nextjs.org/docs/getting-started/react-essentials#server-components), and [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware).
 
-For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/advanced-features/react-18/switchable-runtime) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
+For more information about the Edge Runtime, refer to [the official Next.js documentation](https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes) which explains the differences between the Edge Runtime and traditional Node.js servers, or [read the Cloudflare announcement blog post](https://blog.cloudflare.com/next-on-pages).
 
 {{<render file="_tutorials-before-you-start.md">}}
 
-## Create a new project using the Edge Runtime
+## Using the Edge Runtime
+### 1. Select your Next.js app
 
-Create a new project using `npx` or `yarn` by running either of the following commands in your terminal:
+If you already have a Next.js project that you wish to deploy, change to its directory and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
 
 ```sh
 $ npx create-next-app my-app
-# or
-$ yarn create next-app my-app
 ```
 
-After creating your project, a new `my-app` directory will be generated using the official default template.
+After creating your project, a new `my-app` directory will be generated using the official default template. Switch to this directory to continue.
 
-### Configure the project to use the Edge Runtime
+```sh
+$ cd my-app
+```
 
-The default template includes a traditional Node.js-powered API route (`pages/api/hello.js`). Delete this file. It is incompatible with the Edge Runtime. To use API routes, refer to Next.js' [Edge API Routes documentation](https://nextjs.org/docs/api-routes/edge-api-routes), which offers a standards-based equivalent.
+### 2. Configure the application to use the Edge Runtime
 
-As an example, the existing `pages/api/hello.js` file re-written as an Edge API Route would look like this:
+The default template uses traditional Node.js-powered routes that are not supported on Cloudflare Pages. To run your application, you need to opt into the Edge Runtime for any routes that have server-side functionality (e.g. API routes or pages that use `getServerSideProps`). To do this, you need to export a `runtime` [route segment config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) option from each route's file. 
+
+```js
+export const runtime = 'edge';
+```
+
+As an example, an [Edge Route Handler](https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes) might look like this:
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
 
 ```js
 ---
-filename: pages/api/hello.js
+filename: app/api/hello/route.js
 ---
-// Next.js Edge API Routes: https://nextjs.org/docs/api-routes/edge-api-routes
+import { cookies } from 'next/headers';
 
-export const config = {
-  runtime: 'edge',
-}
+export const runtime = 'edge';
 
-export default async function handler(req) {
-  return new Response(JSON.stringify({ name: 'John Doe' }))
+export async function GET(request) {
+	const cookieStore = cookies();
+	const token = cookieStore.get('token');
+
+	return new Response('Hello, Next.js!', {
+		status: 200,
+		headers: { 'Set-Cookie': `token=${token}` },
+	});
 }
 ```
 
@@ -56,56 +67,38 @@ export default async function handler(req) {
 
 ```ts
 ---
-filename: pages/api/hello.ts
+filename: app/api/hello/route.ts
 ---
-// Next.js Edge API Routes: https://nextjs.org/docs/api-routes/edge-api-routes
+import { cookies } from 'next/headers';
 
-import type { NextRequest } from 'next/server'
+export const runtime = 'edge';
 
-export const config = {
-  runtime: 'edge',
-}
+export async function GET(request: Request) {
+	const cookieStore = cookies();
+	const token = cookieStore.get('token');
 
-export default async function handler(req: NextRequest) {
-  return new Response(JSON.stringify({ name: 'John Doe' }))
+	return new Response('Hello, Next.js!', {
+		status: 200,
+		headers: { 'Set-Cookie': `token=${token}` },
+	});
 }
 ```
 
 {{</tab>}}
 {{</tabs>}}
 
-Next, you must configure the rest of the project to use the Edge Runtime.
+For more examples of this and for Next.js versions prior to v13.3.1, take a look at the `@cloudflare/next-on-pages` [examples document](https://github.com/cloudflare/next-on-pages/blob/main/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md).
 
-You can opt in on individual pages by exporting the following from each page:
-
-```js
-export const config = {
-  runtime: "edge",
-};
-```
-
-Or configure the whole application to use the Edge Runtime by setting the runtime globally:
-
-```js
----
-filename: next.config.js
----
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  experimental: {
-    runtime: 'edge',
-  }
-}
-
-module.exports = nextConfig
-```
-
-Refer to [Next.js' documentation about the Edge Runtime](https://nextjs.org/docs/advanced-features/react-18/switchable-runtime) for more information.
 
 {{<render file="_create-github-repository_no_init.md">}}
 
-### Deploy with Cloudflare Pages
+### 3. Deploy your application to Cloudflare Pages
+
+To deploy your application to Cloudflare Pages, you need to install the `@cloudflare/next-on-pages` package. This library builds your Next.js project in a format that can be deployed to Pages, and handles the runtime logic for your application.
+
+```sh
+$ npm install @cloudflare/next-on-pages --save-dev
+```
 
 Deploy your site to Pages:
 
@@ -118,36 +111,39 @@ Deploy your site to Pages:
    | Configuration option | Value                                                 |
    | -------------------- | ----------------------------------------------------- |
    | Production branch    | `main`                                                |
-   | Build command        | `npx @cloudflare/next-on-pages --experimental-minify` |
+   | Build command        | `npx @cloudflare/next-on-pages@v1`                    |
    | Build directory      | `.vercel/output/static`                               |
 
    {{</table-wrap>}}
 
 4. Next.js requires Node.js v16 or later to build successfully. To set your Node version, go to **Settings** in your Pages project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16` or greater.
+5. Click on **Save and Deploy** to start the deployment (this first deployment won't be fully functional as the next step is also necessary).
+6. Go to the **Pages project settings** page (_Settings_ > _Functions_ > _Compatibility Flags_), **add the `nodejs_compat` flag** for both production and preview, and make sure that the **Compatibility Date** for both production and preview is set to at least `2022-11-30`.
 
 {{<Aside type="note" header="Note">}}
 
-The `@cloudflare/next-on-pages` CLI transforms the Edge Runtime components of your project into a `_worker.js` file which is deployed with [Pages Functions](/pages/platform/functions/advanced-mode/). The `--experimental-minify` argument attempts to deduplicate code that would otherwise result in your project quickly hitting the [script size limit](/workers/platform/limits/#worker-size). If you notice any bugs in this feature, please let us know by filing a [GitHub issue](https://github.com/cloudflare/next-on-pages/issues/).
+The `@cloudflare/next-on-pages` CLI transforms the Edge Runtime components of your project into a `_worker.js` file which is deployed with [Pages Functions](/pages/platform/functions/advanced-mode/). The library attempts to deduplicate code that would otherwise result in your project quickly hitting the [script size limit](/workers/platform/limits/#worker-size). If you notice any bugs, please let us know by filing a [GitHub issue](https://github.com/cloudflare/next-on-pages/issues/).
 
 {{</Aside>}}
 
-After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `@cloudflare/next-on-pages`, your project dependencies, and building your site before deploying it.
+## Using a Static Export
+### 1. Select your Next.js app
 
-## Create a new static project
-
-Create a new project using `npx` or `yarn` by running either of the following commands in your terminal:
+If you already have a Next.js project that you wish to deploy, ensure that it is [configured for static exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports), change to its directory, and proceed to the next step. Otherwise, you can use `create-next-app` to start a new one.
 
 ```sh
 $ npx create-next-app --example with-static-export my-app
-# or
-$ yarn create next-app --example with-static-export my-app
 ```
 
-After creating your project, a new `my-app` directory will be generated using the official [`with-static-export`](https://github.com/vercel/next.js/tree/canary/examples/with-static-export) example as a template.
+After creating your project, a new `my-app` directory will be generated using the official [`with-static-export`](https://github.com/vercel/next.js/tree/canary/examples/with-static-export) example as a template. Switch to this directory to continue.
+
+```sh
+$ cd my-app
+```
 
 {{<render file="_create-github-repository_no_init.md">}}
 
-### Deploy with Cloudflare Pages
+### 2. Deploy your application to Cloudflare Pages
 
 Deploy your site to Pages:
 
@@ -160,12 +156,12 @@ Deploy your site to Pages:
    | Configuration option | Value            |
    | -------------------- | ---------------- |
    | Production branch    | `main`           |
-   | Build command        | `npm run export` |
+   | Build command        | `npm run build`  |
    | Build directory      | `out`            |
 
    {{</table-wrap>}}
 
-4. Next.js requires Node.js v12.22.0 or later to build successfully. To set your Node version, go to **Settings** in your Workers project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `12.22.0` or greater.
+4. Next.js requires Node.js v16 or later to build successfully. To set your Node version, go to **Settings** in your Pages project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16` or greater.
 
 After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `next`, your project dependencies, and building your site before deploying it.
 
@@ -180,24 +176,24 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 
 A [binding](/pages/platform/functions/bindings/) allows your application to interact with Cloudflare developer products, such as [KV](/workers/learning/how-kv-works/), [Durable Object](/workers/learning/using-durable-objects/), [R2](/r2/), and [D1](https://blog.cloudflare.com/introducing-d1/).
 
-In Next.js, add server-side code via [API Routes](https://nextjs.org/docs/api-routes/introduction) and [getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Then access bindings set for your application by accessing them in your code via `process.env`.
+In Next.js, add server-side code via [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes), [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/router-handlers), and [getServerSideProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props). Then, access bindings set for your application by accessing them in your code via `process.env`.
 
 The following code block shows an example of accessing a KV namespace in Next.js.
 
 ```typescript
 ---
-filename: src/index.tsx
+filename: app/api/hello/route.js
 highlight: [4, 5]
 ---
 // ...
 
-export async function getServerSideProps({ req }: GetServerSidePropsContext) => {
+export async function GET(request: Request) {
   // the type `KVNamespace` comes from the @cloudflare/workers-types package
   const { MY_KV } = (process.env as { MY_KV: KVNamespace }));
 
-  return {
+  return new Response(
     // ...
-  };
+	);
 };
 ```
 

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -124,7 +124,7 @@ Deploy your site to Pages:
 4. Next.js requires Node.js v16 or later to build successfully. To set your Node version, go to **Settings** in your Pages project > **Environment Variables (advanced)** section and add a `NODE_VERSION` variable with a value of `16` or greater.
 5. Click on **Save and Deploy** to start the deployment. This first deployment will not be fully functional as the next step is also necessary.
 6. In your Pages project, go to **Settings** > **Functions** > **Compatibility Flags**.
-7. Configure a `nodejs_compat` flag for both production and preview .
+7. Configure a `nodejs_compat` flag for both production and preview.
 8. Above **Compability Flags**, go to **Compatibility Date**  and configure a compatibility date that is at least `2022-11-30` for both production and preview.
 
 {{<Aside type="note" header="Note">}}

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -36,7 +36,7 @@ $ cd my-app
 The default template uses traditional Node.js-powered routes that are not supported on Cloudflare Pages. To run your application, you need to opt into the Edge Runtime for any routes that have server-side functionality (e.g. API routes or pages that use `getServerSideProps`). To do this, you need to export a `runtime` [route segment config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) option from each route's file.
 
 ```js
-export const runtime = "edge";
+export const runtime = 'edge';
 ```
 
 As an example, an [Edge Route Handler](https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes) might look like this:
@@ -111,7 +111,7 @@ Deploy your site to Pages:
    | Configuration option | Value                              |
    | -------------------- | ---------------------------------- |
    | Production branch    | `main`                             |
-   | Build command        | `npx @cloudflare/next-on-pages@v1` |
+   | Build command        | `npx @cloudflare/next-on-pages@1` |
    | Build directory      | `.vercel/output/static`            |
 
    {{</table-wrap>}}


### PR DESCRIPTION
This PR does the following:
- Updates the Edge Runtime section to reflect the next-on-pages v1 release.
- Updates the examples to reflect the code samples from the recommended Next.js app directory (which is now stable).
- Updates the static export section as `next export` has been deprecated.

These changes are intended to bring the Next.js guide up to date with the v1 release of `@cloudflare/next-on-pages`, and the documentation we have over there.

https://github.com/cloudflare/next-on-pages