### PR TITLE
R2 documentation - trivial typo at title - content/r2/objects/download-objects.md

### DIFF
--- a/content/r2/objects/download-objects.md
+++ b/content/r2/objects/download-objects.md
@@ -4,7 +4,7 @@ pcx_content_type: how to
 weight: 2
 ---
 
-# Upload objects
+# Download objects
 
 You can download objects from your bucket from the Cloudflare dashboard or using the Wrangler.
 
@@ -12,7 +12,7 @@ You can download objects from your bucket from the Cloudflare dashboard or using
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select **R2**.
 2. From the **R2** page in the dashboard, locate and select your bucket.
-3. From your bucket's page, locate the object you want to download. 
+3. From your bucket's page, locate the object you want to download.
 4. At the end of the object's row, select the menu button and click **Download**.
 
 ## Download objects via Wrangler


### PR DESCRIPTION
Resolves: https://github.com/cloudflare/cloudflare-docs/issues/8952

And by the way, my editor has removed trailing space.