### PR TITLE
beta: Socket Workers

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -18,6 +18,7 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
+| Socket Workers                |               | ✅           |              |[Blog](https://blog.cloudflare.com/introducing-socket-workers/)             |
 | TCP Workers                   |               |            |     ✅         |[Docs](/workers/runtime-apis/tcp-sockets)             |
 | Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
 | Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |


### PR DESCRIPTION
Socket Workers (private beta) are different to TCP Workers (which are now in public beta).