### PR TITLE
[Durable Objects] pricing: clarify WebSockets pricing outside of DO

### DIFF
--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -29,7 +29,7 @@ All [Pages Functions](/pages/platform/functions/) are billed as Workers. All pri
 
 {{</table-wrap>}}
 
-1.  Requests inbound to your Worker from the Internet are charged on a unit basis for paid plans. [Subrequests](/workers/platform/limits/#subrequests) to external services are not billed on a unit basis, but network time incurred may slightly increase any duration-based billing. For WebSockets, each incoming message is billed as a separate request.
+1.  Requests inbound to your Worker from the Internet are charged on a unit basis for paid plans. [Subrequests](/workers/platform/limits/#subrequests) to external services are not billed on a unit basis, but network time incurred may slightly increase any duration-based billing. WebSockets messages are unmetered and not billed.
 
 2.  Cloudflare will bill for duration charges based on the higher of your wall time or CPU time, with a multiple of 8 applied to the CPU time to account for the processing power allotted to your Worker. Cloudflare will not bill for wall time duration charges beyond the execution [limit](/workers/platform/limits/#worker-limits) given.
 

--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -29,7 +29,7 @@ All [Pages Functions](/pages/platform/functions/) are billed as Workers. All pri
 
 {{</table-wrap>}}
 
-1.  Requests inbound to your Worker from the Internet are charged on a unit basis for paid plans. [Subrequests](/workers/platform/limits/#subrequests) to external services are not billed on a unit basis, but network time incurred may slightly increase any duration-based billing.
+1.  Requests inbound to your Worker from the Internet are charged on a unit basis for paid plans. [Subrequests](/workers/platform/limits/#subrequests) to external services are not billed on a unit basis, but network time incurred may slightly increase any duration-based billing. For WebSockets, each incoming message is billed as a separate request.
 
 2.  Cloudflare will bill for duration charges based on the higher of your wall time or CPU time, with a multiple of 8 applied to the CPU time to account for the processing power allotted to your Worker. Cloudflare will not bill for wall time duration charges beyond the execution [limit](/workers/platform/limits/#worker-limits) given.
 


### PR DESCRIPTION
The docs only mention websockets pricing in the context of Durable Objects. For raw Workers themselves, each incoming message is billed as if it was a separate request.

This was mentioned by one of the cf support folks (green cloud) in the `developer-week-2023-chat` discord channel ([link](https://discord.com/channels/595317990191398933/1106627441616756788/1108486541694742560)) just today but there's no documentation on it.

---

Note: I'm not sure if outgoing websocket messages are also billed. 