### PR TITLE
docs(d1): :memo: add persist flag usage instruction for v3

### DIFF
--- a/content/d1/get-started.md
+++ b/content/d1/get-started.md
@@ -158,7 +158,7 @@ While in your project directory, test your database locally by running:
 $ wrangler dev --local --persist
 ```
 
-> Starting from Wrangler 3 you don't need to pass the `--persist` flag.
+> Starting from Wrangler 3 you don't need to pass the `--persist` flag. By default it'll be cached in the `.wrangler` folder and used upon reloads.
 
 When you run `wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you visit the URL Wrangler provides, you will see this message: `Call /api/beverages to see everyone who works at Bs Beverages`.
 

--- a/content/d1/get-started.md
+++ b/content/d1/get-started.md
@@ -155,8 +155,10 @@ After configuring your Worker, test your project locally.
 While in your project directory, test your database locally by running:
 
 ```sh
-$ wrangler dev --local
+$ wrangler dev --local --persist
 ```
+
+> Starting from Wrangler 3 you don't need to pass the `--persist` flag.
 
 When you run `wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you visit the URL Wrangler provides, you will see this message: `Call /api/beverages to see everyone who works at Bs Beverages`.
 

--- a/content/d1/get-started.md
+++ b/content/d1/get-started.md
@@ -155,7 +155,7 @@ After configuring your Worker, test your project locally.
 While in your project directory, test your database locally by running:
 
 ```sh
-$ wrangler dev --local --persist
+$ wrangler dev --local
 ```
 
 When you run `wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you visit the URL Wrangler provides, you will see this message: `Call /api/beverages to see everyone who works at Bs Beverages`.


### PR DESCRIPTION
Remove `--persist` flag from the dev local run command. Since it's a default behavior now.

Here is the response I got from the Discord server.

> Wrangler will now persist local KV, R2, D1, Cache and Durable Object data
in the .wrangler folder, by default, between reloads. This persistence
directory can be customised with the --persist-to flag. The --persist flag
has been removed, as this is now the default behaviour.