### PR TITLE
[Stream] fix example date filter in fetching-bulk-analytics.md

### DIFF
--- a/content/stream/getting-analytics/fetching-bulk-analytics.md
+++ b/content/stream/getting-analytics/fetching-bulk-analytics.md
@@ -54,8 +54,8 @@ query {
     }) {
       streamMinutesViewedAdaptiveGroups(
         filter: {
-          date_geq: "2022-03-01"
-          date_lt: "2022-02-01"
+          date_geq: "2022-02-01"
+          date_lt: "2022-03-01"
         }
         orderBy:[sum_minutesViewed_DESC]
         limit: 100


### PR DESCRIPTION
This example `streamMinutesViewedAdaptiveGroups` query would return zero results because the date range filters were the wrong way around. This fixes it to make the example easier to understand and use.