### PR TITLE
[Turnstile] Add idempotency key documentation for Turnstile

### DIFF
--- a/content/turnstile/changelog.md
+++ b/content/turnstile/changelog.md
@@ -7,6 +7,10 @@ rss: file
 
 # Changelog
 
+## 2023-05-25
+
+- Added idempotency support for `POST /siteverify` requests via the `idempotency_key` parameter.
+
 ## 2023-04-17
 
 - Added references to Turnstile Public API.

--- a/content/workers/examples/turnstile-html-rewriter.md
+++ b/content/workers/examples/turnstile-html-rewriter.md
@@ -100,12 +100,12 @@ async function handlePost(request) {
     // Validate the token by calling the `/siteverify` API.
     let formData = new FormData();
 
-		// `secret_key` here is set using Wrangler secrets
+    // `secret_key` here is set using Wrangler secrets
     formData.append('secret', secret_key);
     formData.append('response', token);
     formData.append('remoteip', ip);
 
-	const url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    const url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
     const result = await fetch(url, {
         body: formData,
         method: 'POST',
@@ -116,9 +116,9 @@ async function handlePost(request) {
     if (!outcome.success) {
         return new Response('The provided Turnstile token was not valid!', { status: 401 });
     }
-		// The Turnstile token was successfuly validated. Proceed with your application logic.
+    // The Turnstile token was successfuly validated. Proceed with your application logic.
     // Validate login, redirect user, etc.
-	return await fetch(request)
+    return await fetch(request)
 }
 
 export default {


### PR DESCRIPTION
We have recently introduced a support for idempotent POST requests for Turnstile's Siteverify. This PR adds documentation which would inform customers how to make use of this functionality.