### PR TITLE
d1: local dev + debugging

### DIFF
--- a/content/d1/learning/debug-d1.md
+++ b/content/d1/learning/debug-d1.md
@@ -6,13 +6,13 @@ pcx_content_type: concept
 
 # Debug
 
-Debugging issues is a critical part of development. D1 allows you to both capture exceptions and log errors returned when querying a database using the same tools available when [debugging Workers](/workers/learning/debugging-workers/).
+D1 allows you to capture exceptions and log errors returned when querying a database. To debug D1, you will use the same tools available when [debugging Workers](/workers/learning/debugging-workers/).
 
-## Handling errors
+## Handle errors
 
 The D1 [client API](/d1/platform/client-api/) returns detailed error messages on the [`cause` property](/d1/platform/client-api/#errors) within an `Error` object. 
 
-To ensure you're capturing the full error message, make sure to log or return `e.cause.message`, as follows:
+To ensure you are capturing the full error message, make sure to log or return `e.cause.message`, as follows:
 
 ```ts
 try {
@@ -31,11 +31,11 @@ try {
 */
 ```
 
-## Viewing logs
+## View logs
 
-You can view a stream of live logs from your Worker by using [`wrangler tail`](/workers/learning/logging-workers/#view-logs-using-wrangler-tail) or via the [Cloudflare dashboard](/workers/learning/logging-workers/#view-logs-from-the-dashboard).
+View a stream of live logs from your Worker by using [`wrangler tail`](/workers/learning/logging-workers/#view-logs-using-wrangler-tail) or via the [Cloudflare dashboard](/workers/learning/logging-workers/#view-logs-from-the-dashboard).
 
-## Reporting issues
+## Report issues
 
 {{<Aside type="note" header="Reporting bugs during the open alpha">}}
 
@@ -55,8 +55,8 @@ You should include as much of the following in any bug report:
 * The Worker code that makes the query, including any calls to `.bind()` using the [client API](/d1/platform/client-api/).
 * The full error text, including the content of [`error.cause.message`](#handling-errors).
 
-## Next steps
+## Related resources
 
-* Learn [how to debug Workers](/workers/learning/debugging-workers/)
-* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1
+* Learn [how to debug Workers](/workers/learning/debugging-workers/).
+* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1.
 * Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and D1 locally and debug issues before deploying.

--- a/content/d1/learning/debug-d1.md
+++ b/content/d1/learning/debug-d1.md
@@ -43,10 +43,9 @@ D1 is in open alpha and we welcome any bug reports or issues.
 
 {{</Aside>}}
 
-To report a bug or issue with D1:
-
-* For `wrangler` issues, open an [issue on GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose)
-* For issues with D1 queries or databases, join the Cloudflare [Developer Discord](https://discord.cloudflare.com/) to engage with other developers building on Workers and the engineering team behind D1.
+* To report bugs or request features, go to the [Cloudflare Community Forums](https://community.cloudflare.com/c/developers/d1/85).
+* To give feedback, go to the [D1 Discord channel](https://discord.com/invite/cloudflaredev).
+* If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose)."
 
 You should include as much of the following in any bug report:
 

--- a/content/d1/learning/debug-d1.md
+++ b/content/d1/learning/debug-d1.md
@@ -1,10 +1,10 @@
 ---
-title: Debugging D1
+title: Debug D1
 weight: 5
 pcx_content_type: concept
 ---
 
-# Debugging
+# Debug
 
 Debugging issues is a critical part of development. D1 allows you to both capture exceptions and log errors returned when querying a database using the same tools available when [debugging Workers](/workers/learning/debugging-workers/).
 

--- a/content/d1/learning/debugging-d1.md
+++ b/content/d1/learning/debugging-d1.md
@@ -1,0 +1,62 @@
+---
+title: Debugging D1
+weight: 5
+pcx_content_type: concept
+---
+
+# Debugging
+
+Debugging issues is a critical part of development. D1 allows you to both capture exceptions and log errors returned when querying a database using the same tools available when [debugging Workers](/workers/learning/debugging-workers/).
+
+## Handling errors
+
+The D1 [client API](/d1/platform/client-api/) returns detailed error messages on the [`cause` property](/d1/platform/client-api/#errors) within an `Error` object. 
+
+To ensure you're capturing the full error message, make sure to log or return `e.cause.message`, as follows:
+
+```ts
+try {
+    await db.exec("INSERTZ INTO my_table (name, employees) VALUES ()");
+} catch (e: any) {
+    console.log({
+        message: e.message,
+        cause: e.cause.message,
+    });
+}
+/*
+{
+  "message": "D1_EXEC_ERROR",
+  "cause": "Error in line 1: INSERTZ INTO my_table (name, employees) VALUES (): sql error: near \"INSERTZ\": syntax error in INSERTZ INTO my_table (name, employees) VALUES () at offset 0"
+}
+*/
+```
+
+## Viewing logs
+
+You can view a stream of live logs from your Worker by using [`wrangler tail`](/workers/learning/logging-workers/#view-logs-using-wrangler-tail) or via the [Cloudflare dashboard](/workers/learning/logging-workers/#view-logs-from-the-dashboard).
+
+## Reporting issues
+
+{{<Aside type="note" header="Reporting bugs during the open alpha">}}
+
+D1 is in open alpha and we welcome any bug reports or issues.
+
+{{</Aside>}}
+
+To report a bug or issue with D1:
+
+* For `wrangler` issues, open an [issue on GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose)
+* For issues with D1 queries or databases, join the Cloudflare [Developer Discord](https://discord.cloudflare.com/) to engage with other developers building on Workers and the engineering team behind D1.
+
+You should include as much of the following in any bug report:
+
+* The ID of your database: use `wrangler d1 list` to match a database name to its ID.
+* The query, or queries, that you ran when you encountered an issue. Ensure you redact any personally identifying information (PII).
+* The Worker code that makes the query, including any calls to `.bind()` using the [client API](/d1/platform/client-api/).
+* The full error text, including the content of [`error.cause.message`](#handling-errors).
+
+## Next steps
+
+* Learn [how to debug Workers](/workers/learning/debugging-workers/)
+* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1
+* Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and D1 locally and debug issues before deploying.

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -6,13 +6,13 @@ pcx_content_type: concept
 
 # Develop locally
 
-D1 has fully-featured support for local development, running the same version of D1 as Cloudflare runs globally. Local development uses [wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
+D1 has fully-featured support for local development, running the same version of D1 as Cloudflare runs globally. Local development uses [Wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
 
-## Starting a local development session
+## Start a local development session
 
 {{<Aside type="note">}}
 
-This guide assumes you are using [wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
+This guide assumes you are using [Wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
 
 Users new to D1 and/or Cloudflare Workers should visit the [D1 tutorial](/d1/get-started/) to install `wrangler` and deploy their first database.
 
@@ -45,7 +45,7 @@ Your worker has access to the following bindings:
 [b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                 │
 ```
 
-In this example, we can see that our Worker has access to local-only D1 database. The corresponding binding in our `wrangler.toml` configuration file would resemble the following:
+In this example, the Worker has access to local-only D1 database. The corresponding D1 binding in your `wrangler.toml` configuration file would resemble the following:
 
 ```toml
 ---
@@ -54,14 +54,14 @@ header: wrangler.toml
 [[d1_databases]]
 binding = "DB"
 database_name = "test-db"
-database_id = "c020574a-5623-407b-be0c-cd192bab9545"V
+database_id = "c020574a-5623-407b-be0c-cd192bab9545"
 ```
 
 Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) database, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
 
-Visit the [documentation for `wrangler dev`](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
+Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
 
-## Persisting data
+## Persist data
 
 **By default, in wrangler `3.0.0` and above, data is persisted across each run of `wrangler dev`**. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
 
@@ -69,8 +69,8 @@ Use `wrangler dev --persist-to=/path/to/file` to persist data to a specific loca
 
 Users of wrangler `2.x` must use the `--persist` flag: previous versions of wrangler did not persist data by default.
 
-## Next steps
+## Related resources
 
 * Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and D1 locally and debug issues before deploying.
-* Learn [how to debug D1](/d1/learning/debug-d1/)
-* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1
+* Learn [how to debug D1](/d1/learning/debug-d1/).
+* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1.

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -6,7 +6,7 @@ pcx_content_type: concept
 
 # Develop locally
 
-D1 has fully-featured support for local development, running the same version of D1 as we run globally. Local development uses [wrangler](/workers/wrangler/install-and-update/), our command-line interface, for managing local development sessions and state.
+D1 has fully-featured support for local development, running the same version of D1 as Cloudflare runs globally. Local development uses [wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
 
 ## Starting a local development session
 
@@ -63,7 +63,7 @@ Visit the [documentation for `wrangler dev`](/workers/wrangler/commands/#dev) to
 
 ## Persisting data
 
-**By default, in wrangler `3.0.0` and above, data is persisted cross each run of `wrangler dev`.**. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
+**By default, in wrangler `3.0.0` and above, data is persisted across each run of `wrangler dev`**. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
 
 Use `wrangler dev --persist-to=/path/to/file` to persist data to a specific location. This can be useful when working in a team (allowing you to share) the same copy, when deploying via CI/CD (to ensure the same starting state), or as a way to keep data when migrating across machines.
 

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -14,7 +14,7 @@ D1 has fully-featured support for local development, running the same version of
 
 This guide assumes you are using [wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
 
-If you're new to D1 and/or Cloudflare Workers, visit the [D1 tutorial](/d1/get-started/) to install `wrangler` and deploy your first database.
+Users new to D1 and/or Cloudflare Workers should visit the [D1 tutorial](/d1/get-started/) to install `wrangler` and deploy their first database.
 
 {{</Aside>}}
 
@@ -63,12 +63,11 @@ Visit the [documentation for `wrangler dev`](/workers/wrangler/commands/#dev) to
 
 ## Persisting data
 
-By default, each run of `wrangler dev` starts from a clean slate, and **does not retain any database state between invocations**. If your local development and testing requires a populated database, you will need to `INSERT` data first.
+**By default, in wrangler `3.0.0` and above, data is persisted cross each run of `wrangler dev`.**. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
 
-To persist data across local development sessions:
+Use `wrangler dev --persist-to=/path/to/file` to persist data to a specific location. This can be useful when working in a team (allowing you to share) the same copy, when deploying via CI/CD (to ensure the same starting state), or as a way to keep data when migrating across machines.
 
-* Use `wrangler dev --persist` to persist a local version of your D1 database.
-* Use `wrangler dev --persist-to=/path/to/file` to persist to a specific location. This can be useful when working in a team (allowing you to share) the same copy, when deploying via CI/CD (to ensure the same starting state), or as a way to keep data across machines.
+Users of wrangler `2.x` must use the `--persist` flag: previous versions of wrangler did not persist data by default.
 
 ## Next steps
 

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -4,7 +4,7 @@ weight: 6
 pcx_content_type: concept
 ---
 
-# Developing locally
+# Develop locally
 
 D1 has fully-featured support for local development, running the same version of D1 as we run globally. Local development uses [wrangler](/workers/wrangler/install-and-update/), our command-line interface, for managing local development sessions and state.
 
@@ -73,5 +73,5 @@ To persist data across local development sessions:
 ## Next steps
 
 * Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and D1 locally and debug issues before deploying.
-* Learn [how to debug D1](/d1/debugging-d1/)
+* Learn [how to debug D1](/d1/learning/debug-d1/)
 * Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -10,7 +10,7 @@ D1 has fully-featured support for local development, running the same version of
 
 ## Starting a local development session
 
-{{<Aside type="note"}}
+{{<Aside type="note">}}
 
 This guide assumes you are using [wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
 

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -1,0 +1,77 @@
+---
+title: Local development
+weight: 6
+pcx_content_type: concept
+---
+
+# Developing locally
+
+D1 has fully-featured support for local development, running the same version of D1 as we run globally. Local development uses [wrangler](/workers/wrangler/install-and-update/), our command-line interface, for managing local development sessions and state.
+
+## Starting a local development session
+
+{{<Aside type="note"}}
+
+This guide assumes you are using [wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
+
+If you're new to D1 and/or Cloudflare Workers, visit the [D1 tutorial](/d1/get-started/) to install `wrangler` and deploy your first database.
+
+{{</Aside>}}
+
+Local development sessions create a standalone, local-only environment that mirrors the production environment D1 runs in so that you can test your Worker and D1 _before_ you deploy to production.
+
+An existing [D1 binding](/workers/wrangler/configuration/#d1-database) of `DB` would be available to your Worker when running locally.
+
+To start a local development session:
+
+```sh
+# Confirm we are using wrangler v3.0+
+$ wrangler --version
+⛅️ wrangler 3.0.0
+
+# Start a local dev session:
+$ wrangler dev
+
+# Outputs:
+------------------
+wrangler dev now uses local mode by default, powered by 🔥 Miniflare and 👷 workerd.
+To run an edge preview session for your Worker, use wrangler dev --remote
+Your worker has access to the following bindings:
+- D1 Databases:
+  - DB: test-db (c020574a-5623-407b-be0c-cd192bab9545)
+⎔ Starting local server...
+
+[mf:inf] Ready on http://127.0.0.1:8787/
+[b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                 │
+```
+
+In this example, we can see that our Worker has access to local-only D1 database. The corresponding binding in our `wrangler.toml` configuration file would resemble the following:
+
+```toml
+---
+header: wrangler.toml
+---
+[[d1_databases]]
+binding = "DB"
+database_name = "test-db"
+database_id = "c020574a-5623-407b-be0c-cd192bab9545"V
+```
+
+Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) database, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
+
+Visit the [documentation for `wrangler dev`](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
+
+## Persisting data
+
+By default, each run of `wrangler dev` starts from a clean slate, and **does not retain any database state between invocations**. If your local development and testing requires a populated database, you will need to `INSERT` data first.
+
+To persist data across local development sessions:
+
+* Use `wrangler dev --persist` to persist a local version of your D1 database.
+* Use `wrangler dev --persist-to=/path/to/file` to persist to a specific location. This can be useful when working in a team (allowing you to share) the same copy, when deploying via CI/CD (to ensure the same starting state), or as a way to keep data across machines.
+
+## Next steps
+
+* Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and D1 locally and debug issues before deploying.
+* Learn [how to debug D1](/d1/debugging-d1/)
+* Understand how to [access logs](/workers/learning/logging-workers/) generated from your Worker and D1

--- a/content/workers/platform/bindings/_index.md
+++ b/content/workers/platform/bindings/_index.md
@@ -54,8 +54,8 @@ R2 bucket bindings for communication between a Worker and an R2 bucket.
 
 [D1](/d1) bindings allow you to query a D1 database from your Worker.
 
-* [Configure a D1 binding](/d1/get-started/#4-bind-your-worker-to-your-d1-database)
-* Learn more about how to query a D1 database using the [client API](/d1/platform/client-api/)
+* [Configure a D1 binding](/d1/get-started/#4-bind-your-worker-to-your-d1-database).
+* Learn more about how to query a D1 database using the [client API](/d1/platform/client-api/).
 
 ### Dispatch namespace bindings (Workers for Platforms)
 

--- a/content/workers/platform/bindings/_index.md
+++ b/content/workers/platform/bindings/_index.md
@@ -50,6 +50,13 @@ R2 bucket bindings for communication between a Worker and an R2 bucket.
 
 * Configure Queue bindings via your [`wrangler.toml` file](/queues/platform/configuration/).
 
+### D1 database bindings
+
+[D1](/d1) bindings allow you to query a D1 database from your Worker.
+
+* [Configure a D1 binding](/d1/get-started/#4-bind-your-worker-to-your-d1-database)
+* Learn more about how to query a D1 database using the [client API](/d1/platform/client-api/)
+
 ### Dispatch namespace bindings (Workers for Platforms)
 
 Dispatch namespace bindings allow for communication between a dynamic dispatch Worker and a dispatch namespace. Dispatch namespace bindings are used in [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/). Workers for Platforms helps you deploy serverless functions programmatically on behalf of your customers.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -303,7 +303,7 @@ watch_dir = "build_watch_dir"
 
 ### D1 databases
 
-[D1](/d1/) is Cloudflare's serverless SQL database. A Worker can query a D1 database (or databases) by creating a binding to each database for D1's [client API](/d1/platform/client-api/).
+[D1](/d1/) is Cloudflare's serverless SQL database. A Worker can query a D1 database (or databases) by creating a [binding](/workers/platform/bindings/) to each database for D1's [client API](/d1/platform/client-api/).
 
 To bind D1 databases to your Worker, assign an array of the below object to the `[[d1_databases]]` key.
 

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -301,6 +301,40 @@ watch_dir = "build_watch_dir"
 
 ## Bindings
 
+### D1 databases
+
+[D1](/d1/) is Cloudflare's serverless SQL database. A Worker can query a D1 database (or databases) by creating a binding to each database for D1's [client API](/d1/platform/client-api/).
+
+To bind D1 databases to your Worker, assign an array of the below object to the `[[d1_databases]]` key.
+
+{{<definitions>}}
+
+- `binding` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The binding name used to refer to the D1 database. The value (string) you set will be used to reference this database in your Worker. The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "MY_DB"` or `binding = "productionDB"` would both be valid names for the binding.
+
+- `name` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The name of the database. This a human-readable name that allows you to distinguish between different databases, and is set when you first create the database.
+
+- `id` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
+
+{{</definitions>}}
+
+Example:
+
+```toml
+---
+header: wrangler.toml
+---
+[[d1_databases]]
+binding = "<BINDING_NAME>"
+database_name = "<DATABASE_NAME>"
+database_id = "<UUID>"
+```
+
 ### Durable Objects
 
 [Durable Objects](/workers/learning/using-durable-objects/) provide low-latency coordination and consistent storage for the Workers platform.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -330,9 +330,9 @@ Example:
 header: wrangler.toml
 ---
 [[d1_databases]]
-binding = "<BINDING_NAME>"
-database_name = "<DATABASE_NAME>"
-database_id = "<UUID>"
+binding = "PROD_DB"
+database_name = "test-db"
+database_id = "c020574a-5623-407b-be0c-cd192bab9545"V
 ```
 
 ### Durable Objects


### PR DESCRIPTION
This PR adds:

- [x] D1 to the wrangler bindings page - https://developers.cloudflare.com/workers/wrangler/configuration/
- [x] D1 to the binding overview: https://developers.cloudflare.com/workers/platform/bindings/
- [x] A new `/d1/learning/debugging-d1/` page with an overview of how to log errors and report bugs
- [x] A new `/d1/learning/local-development/` page that pulls together `wrangler dev` with D1 specific steps. 