### PR TITLE
Update discord link to discord developer main invite

### DIFF
--- a/content/stream/_index.md
+++ b/content/stream/_index.md
@@ -62,6 +62,6 @@ Understand and analyze which videos and live streams are viewed most and break d
 
 {{<resource-group>}}
 
-{{<resource header="Discord" href="https://discord.com/channels/595317990191398933/893253103695065128" icon="logo-Discord">}} Join the Stream developer community {{</resource>}}
+{{<resource header="Discord" href="https://discord.gg/cloudflaredev" icon="logo-Discord">}} Join the Stream developer community {{</resource>}}
 
 {{</resource-group>}}


### PR DESCRIPTION
I was reading docs and noticed the "Join the Stream developer community" link linked to a channel directly instead of a proper discord invite. I found the invite via a friend, so I updated it.

The link previously only worked if you were on the discord already
![image](https://github.com/cloudflare/cloudflare-docs/assets/385946/6fc66a2c-24d5-4205-b34b-b288d815e360)
