### PR TITLE
[D1] Improve API tutorial to remove friction when following along

### DIFF
--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -18,16 +18,21 @@ First, use [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packag
 $ npx wrangler init d1-example
 ```
 
-> **Note**
-> During the initialization process, Wrangler will ask you "What type of application do you want to create?". Pick "Hello World" script for this tutorial.
-
+{{<Aside type="note">}}
+> During the initialization process, Wrangler will ask you "What type of application do you want to create?". Choose "Hello World" script for this tutorial.
+{{</Aside>}}
+## Install Hono
 In this example, you will use [Hono](https://github.com/honojs/hono), an Express.js-style framework, to build your API. To use Hono in this project, install it using npm:
 
 ```sh
 $ npm install hono
 ```
 
-Next, in `src/worker.js`, initialize a new Hono app, and define the following endpoints - `GET /API/posts/:slug/comments`, and `POST /get/api/:slug/comments`:
+## Initialize your Hono application
+
+In `src/worker.js`, initialize a new Hono application, and define the following endpoints:
+- `GET /API/posts/:slug/comments`.
+- `POST /get/api/:slug/comments`.
 
 ```js
 import { Hono } from 'hono'
@@ -125,7 +130,7 @@ In this function, you accept a `slug` URL query parameter and set up a new SQL s
 
 ## Insert data
 
-By completing the previous step, you have built read-only access to your data. Next, you will define another endpoint function in `src/worker.js` that allows creating new comments, by inserting data into the database:
+The previous steps grant read-only access to your data. To create new comments by inserting data into the database, define another endpoint in `src/worker.js`:
 
 ```js
 app.post('/api/posts/:slug/comments', async c => {
@@ -187,7 +192,7 @@ $ curl https://d1-example.signalnerve.workers.dev/api/posts/hello-world/comments
 
 This application is just an API back end, best served for use with a front-end UI for creating and viewing comments. To test this back-end with a prebuild front-end UI, refer to the example UI in the [example-frontend directory](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend). Notably, the [`loadComments` and `submitComment` functions](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend/src/views/PostView.vue#L57-L82) make requests to a deployed version of this site, meaning you can take the frontend and replace the URL with your deployed version of the codebase in this tutorial to use your own data.
 
-Note that interacting with this API from a front end will require enabling specific Cross-Origin Resource Sharing (or *CORS*) headers in your back-end API. Luckily, Hono has a quick way to enable this for your application. Import the `cors` module and add it as middleware to your API in `src/worker.js`:
+Interacting with this API from a front-end will require enabling specific Cross-Origin Resource Sharing (or *CORS*) headers in your back-end API. Hono allows you to easily enable Cross-Origin Resource Sharing for your application. Import the `cors` module and add it as middleware to your API in `src/worker.js`:
 
 ```typescript
 ---

--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -18,13 +18,16 @@ First, use [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packag
 $ npx wrangler init d1-example
 ```
 
+> **Note**
+> During the initialization process, Wrangler will ask you "What type of application do you want to create?". Pick "Hello World" script for this tutorial.
+
 In this example, you will use [Hono](https://github.com/honojs/hono), an Express.js-style framework, to build your API. To use Hono in this project, install it using npm:
 
 ```sh
 $ npm install hono
 ```
 
-Next, in `src/index.js`, initialize a new Hono app, and define the following endpoints - `GET /API/posts/:slug/comments`, and `POST /get/api/:slug/comments`:
+Next, in `src/worker.js`, initialize a new Hono app, and define the following endpoints - `GET /API/posts/:slug/comments`, and `POST /get/api/:slug/comments`:
 
 ```js
 import { Hono } from 'hono'
@@ -72,11 +75,11 @@ $ wrangler d1 execute d1-example --command "SELECT name FROM sqlite_schema WHERE
 
 Executing on d1-example:
 
-┌─────────────────┐
-│ name            │
-├─────────────────┤
-│ sqlite_sequence │
-└─────────────────┘
+┌───────┐
+│ name  │
+├───────┤
+│ d1_kv │
+└───────┘
 ```
 
 You can also pass a SQL file - perfect for initial data seeding in a single command. Create `schemas/schema.sql`, which will create a new `comments` table for your project:
@@ -122,7 +125,7 @@ In this function, you accept a `slug` URL query parameter and set up a new SQL s
 
 ## Insert data
 
-By completing the previous step, you have built read-only access to your data. Next, you will define another endpoint function in `src/index.js` that allows creating new comments, by inserting data into the database:
+By completing the previous step, you have built read-only access to your data. Next, you will define another endpoint function in `src/worker.js` that allows creating new comments, by inserting data into the database:
 
 ```js
 app.post('/api/posts/:slug/comments', async c => {
@@ -156,7 +159,7 @@ After you have logged in, confirm that your `wrangler.toml` file is configured s
 
 ```toml
 name = "d1-example"
-main = "src/index.js"
+main = "src/worker.js"
 compatibility_date = "2022-07-15"
 
 [[ d1_databases ]]
@@ -184,7 +187,7 @@ $ curl https://d1-example.signalnerve.workers.dev/api/posts/hello-world/comments
 
 This application is just an API back end, best served for use with a front-end UI for creating and viewing comments. To test this back-end with a prebuild front-end UI, refer to the example UI in the [example-frontend directory](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend). Notably, the [`loadComments` and `submitComment` functions](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api/example-frontend/src/views/PostView.vue#L57-L82) make requests to a deployed version of this site, meaning you can take the frontend and replace the URL with your deployed version of the codebase in this tutorial to use your own data.
 
-Note that interacting with this API from a front end will require enabling specific Cross-Origin Resource Sharing (or *CORS*) headers in your back-end API. Luckily, Hono has a quick way to enable this for your application. Import the `cors` module and add it as middleware to your API in `src/index.js`:
+Note that interacting with this API from a front end will require enabling specific Cross-Origin Resource Sharing (or *CORS*) headers in your back-end API. Luckily, Hono has a quick way to enable this for your application. Import the `cors` module and add it as middleware to your API in `src/worker.js`:
 
 ```typescript
 ---


### PR DESCRIPTION
When following the D1 comment API tutorial, I encountered a bit of friction here and there because of differences between the docs and what I saw in my terminal.

`npx wrangler init ...` provides 4 options on what type of application to create:
- Website or web app
- "Hello World" script
- Common Worker functions
- ChatGPT plugin (Typescript)

I ran this command 3 times to see which one best fit the remaining tutorial.  "Hello World" script seemed like the best option, but the output of the `src/index.js` file was actually named `src/worker.js`. Other application types either created typescript files or large javascript projects that didn't fit the tutorial.

I added a note so developers know which application to create, and updated all references of `src/index.js` to `src/worker.js` to align with Wrangler's output. Would love feedback if the `**Note**` MD syntax is best way to convey this message.

Last small update was to the output of 
```sh
$ wrangler d1 execute d1-example --command "SELECT name FROM sqlite_schema WHERE type ='table'"
``` 
because the default output now for all new d1 clusters I've tested is 
```
┌───────┐
│ name  │
├───────┤
│ d1_kv │
└───────┘
```

Thanks!