### PR TITLE
[Workers] Remove duplicate `body` property in data-loss-prevention.md

### DIFF
--- a/content/workers/examples/data-loss-prevention.md
+++ b/content/workers/examples/data-loss-prevention.md
@@ -25,7 +25,6 @@ export default {
     async function postDataBreach(request) {
       return await fetch(SOME_HOOK_SERVER, {
         method: "POST",
-        body: JSON.stringify(body),
         headers: {
           "content-type": "application/json;charset=UTF-8",
         },
@@ -100,7 +99,6 @@ const handler: ExportedHandler = {
     async function postDataBreach(request) {
       return await fetch(SOME_HOOK_SERVER, {
         method: "POST",
-        body: JSON.stringify(body),
         headers: {
           "content-type": "application/json;charset=UTF-8",
         },


### PR DESCRIPTION
There's duplicate `body` property in fetch request that is unnecessary in example code. This fixes it.