### PR TITLE
Add missing codeblock in article

### DIFF
--- a/content/support/More Dashboard Apps/Cloudflare Scrape Shield/What does Server Side Excludes (SSE) do.md
+++ b/content/support/More Dashboard Apps/Cloudflare Scrape Shield/What does Server Side Excludes (SSE) do.md
@@ -19,10 +19,12 @@ To enable SSE:
 3.  For **Server-side Excludes**, change the toggle to be **Enabled**.
 
 To exclude content from suspicious visitors, wrap the content in the following SSE tags:
-```html
-<!--sse--><!--/sse-->```
 
-For example: <!--sse--> Bad visitors won't see my phone number, 555-555-5555 <!--/sse-->
+```
+<!--sse--><!--/sse-->
+```
+
+For example: `<!--sse-->` Bad visitors won't see my phone number, 555-555-5555 `<!--/sse-->`
 
 {{<Aside type="note">}}
 SSE only will work with HTML. If you have HTML minification enabled, you

--- a/content/support/More Dashboard Apps/Cloudflare Scrape Shield/What does Server Side Excludes (SSE) do.md
+++ b/content/support/More Dashboard Apps/Cloudflare Scrape Shield/What does Server Side Excludes (SSE) do.md
@@ -18,7 +18,9 @@ To enable SSE:
 2.  Go to **Scrape Shield**.
 3.  For **Server-side Excludes**, change the toggle to be **Enabled**.
 
-To exclude content from suspicious visitors, wrap the content in the following SSE tags: <!--sse--><!--/sse-->
+To exclude content from suspicious visitors, wrap the content in the following SSE tags:
+```html
+<!--sse--><!--/sse-->```
 
 For example: <!--sse--> Bad visitors won't see my phone number, 555-555-5555 <!--/sse-->
 


### PR DESCRIPTION
I added the missing codeblock to [What does Server Side Excludes (SSE) do?](https://developers.cloudflare.com/support/more-dashboard-apps/cloudflare-scrape-shield/what-does-server-side-excludes-sse-do/) in the usage example (currently it's just html tag).