### PR TITLE
result instead of return in exported_func

### DIFF
--- a/content/workers/platform/web-assembly/javascript.md
+++ b/content/workers/platform/web-assembly/javascript.md
@@ -28,7 +28,7 @@ Review the following example module (`;;` denotes a comment):
   (func $i (import "imports" "imported_func") (param i32))
   ;; Export a function named `exported_func` which takes a
   ;; single i32 argument and returns an i32
-  (func (export "exported_func") (param $input i32) (return i32)
+  (func (export "exported_func") (param $input i32) (result i32)
     ;; Invoke `imported_func` with $input as argument
     local.get $input
     call $i


### PR DESCRIPTION
`(func (export "exported_func") (param $input i32) (result i32)` will get this error:

```
$ wat2wasm src/simple.wat -o src/simple.wasm
src/simple.wat:9:61: error: unexpected token i32, expected ).
  (func (export "exported_func") (param $input i32) (return i32)
```