### PR TITLE
Update common-policies.md

### DIFF
--- a/content/cloudflare-one/policies/filtering/dns-policies/common-policies.md
+++ b/content/cloudflare-one/policies/filtering/dns-policies/common-policies.md
@@ -39,7 +39,7 @@ Block sites with a specific top-level domain (TLD).
 
 | Selector | Operator      | Value     | Action |
 | -------- | ------------- | --------- | ------ |
-| Domain   | matches regex | `[.]fail` | Block  |
+| Domain   | matches regex | `[.]fail$` | Block  |
 
 ## Control IP version
 


### PR DESCRIPTION
Added an end of line regex symbol `$` to the TLD example in order to block:

```
domain.fail
```

but avoid unintended blocks like:

```
domain.fail.com
```