### PR TITLE
[Ruleset Engine] Update ip.geoip.* to ip.src.* in Fields reference

### DIFF
--- a/content/firewall/recipes/update-rules-customers-partners.md
+++ b/content/firewall/recipes/update-rules-customers-partners.md
@@ -26,7 +26,7 @@ If a customer or partner is large enough, you could set up a firewall rule based
 
 This example uses:
 
-- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#field-ip-geoip-asnum) field to specify the general region
+- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#field-ip-src-asnum) field to specify the general region
 - The [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/#field-cf-bot_management-score) dynamic field to ensure partner traffic does not come from bots
 
 <table style="table-layout:fixed; width:100%">
@@ -58,7 +58,7 @@ Access to [Bot Management](/bots/plans/bm-subscription/) requires a Cloudflare E
 
 This example uses:
 
-- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#field-ip-geoip-asnum) field to specify the general region.
+- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#field-ip-src-asnum) field to specify the general region.
 - The [`cf.threat_score`](/ruleset-engine/rules-language/fields/#field-cf-threat_score) dynamic field to ensure requests are not high-risk traffic.
 
 If a request meets these criteria, your firewall bypasses normal `User Agent Block` rules.

--- a/content/rules/transform/managed-transforms/reference.md
+++ b/content/rules/transform/managed-transforms/reference.md
@@ -64,7 +64,7 @@ layout: list
         <ul>
           <li><code>cf-ipcity</code>: The visitor's city (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-city"><code>ip.src.city</code></a> field).</li>
           <li><code>cf-ipcountry</code>: The visitor's country (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-country"><code>ip.src.country</code></a> field).</li>
-          <li><code>cf-ipcontinent</code>: The visitor's continent (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-geoip-continent"><code>ip.geoip.continent</code></a> field).</li>
+          <li><code>cf-ipcontinent</code>: The visitor's continent (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-continent"><code>ip.src.continent</code></a> field).</li>
           <li><code>cf-iplongitude</code>: The visitor's longitude (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-lon"><code>ip.src.lon</code></a> field).</li>
           <li><code>cf-iplatitude</code>: The visitor's latitude (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-lat"><code>ip.src.lat</code></a> field).</li>
           <li><code>cf-region-code</code>: The code of the visitor's <a href="https://en.wikipedia.org/wiki/ISO_3166-2">ISO 3166-2</a> first-level region (value from the <a href="/ruleset-engine/rules-language/fields/#field-ip-src-region_code"><code>ip.src.region_code</code></a> field).</li>

--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -31,7 +31,7 @@ Most standard fields use the same naming conventions as [Wireshark display field
 
 {{<Aside type="note" header="Availability notes">}}
 
-- Access to `ip.geoip.is_in_european_union`, `ip.geoip.subdivision_1_iso_code`, and `ip.geoip.subdivision_2_iso_code` fields requires a Cloudflare Business or Enterprise plan.
+- Access to `ip.src.is_in_european_union`, `ip.src.subdivision_1_iso_code`, and `ip.src.subdivision_2_iso_code` fields requires a Cloudflare Business or Enterprise plan.
 
 - Access to `http.request.cookies` field requires a Cloudflare Pro, Business, or Enterprise plan.
 
@@ -283,17 +283,18 @@ The Cloudflare Rules language supports these standard fields:
          <p>This field is only available in rewrite expressions of <a href="/rules/transform/">Transform Rules</a>.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-asnum">
-      <td valign="top"><code>ip.geoip.asnum</code><br />{{<type>}}Number{{</type>}}</td>
+   <tr id="field-ip-src-asnum">
+      <td valign="top"><code>ip.src.asnum</code><br />{{<type>}}Number{{</type>}}</td>
       <td>
          <p>Represents the 16- or 32-bit integer representing the Autonomous System (AS) number associated with client IP address.
          </p>
+         <p>This field has the same value as the <code>ip.geoip.asnum</code> field, which is still available.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-continent">
-      <td valign="top"><code>ip.geoip.continent</code><br />{{<type>}}String{{</type>}}</td>
+   <tr id="field-ip-src-continent">
+      <td valign="top"><code>ip.src.continent</code><br />{{<type>}}String{{</type>}}</td>
       <td>
-         Represents the continent code associated with client IP address:
+         <p>Represents the continent code associated with client IP address:
           <ul>
               <li>AF &#8211; Africa</li>
               <li>AN &#8211; Antarctica</li>
@@ -304,10 +305,12 @@ The Cloudflare Rules language supports these standard fields:
               <li>SA &#8211; South America</li>
               <li>T1 &#8211; Tor network</li>
           </ul>
+        </p>
+        <p>This field has the same value as the <code>ip.geoip.continent</code> field, which is still available.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-country">
-      <td valign="top"><code>ip.geoip.country</code><br />{{<type>}}String{{</type>}}</td>
+   <tr id="field-ip-src-country">
+      <td valign="top"><code>ip.src.country</code><br />{{<type>}}String{{</type>}}</td>
       <td>
          <p>Represents the 2-letter country code in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.
          </p>
@@ -315,20 +318,22 @@ The Cloudflare Rules language supports these standard fields:
          <br /><code class="InlineCode">GB</code>
          </p>
          <p>For more information on the ISO 3166-1 Alpha 2 format, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
+         <p>This field has the same value as the <code>ip.geoip.country</code> field, which is still available.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-subdivision-1-iso-code">
-      <td valign="top"><code>ip.geoip.subdivision_1_iso_code</code><br />{{<type>}}String{{</type>}}</td>
+   <tr id="field-ip-src-subdivision-1-iso-code">
+      <td valign="top"><code>ip.src.subdivision_1_iso_code</code><br />{{<type>}}String{{</type>}}</td>
       <td>
          <p>Represents the ISO 3166-2 code for the first level region associated with the IP address. When the actual value is not available, this field contains an empty string.</p>
          <p>Example value:
          <br />
          <code class="InlineCode">GB-ENG</code></p>
          <p>For more information on the ISO 3166-2 standard and the available regions, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-2">ISO 3166-2</a> on Wikipedia.</p>
+         <p>This field has the same value as the <code>ip.geoip.subdivision_1_iso_code</code> field, which is still available.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-subdivision-2-iso-code">
-      <td valign="top"><code>ip.geoip.subdivision_2_iso_code</code><br />{{<type>}}String{{</type>}}</td>
+   <tr id="field-ip-src-subdivision-2-iso-code">
+      <td valign="top"><code>ip.src.subdivision_2_iso_code</code><br />{{<type>}}String{{</type>}}</td>
       <td>
          <p>Represents the ISO 3166-2 code for the second level region associated with the IP address. When the actual value is not available, this field contains an empty string.
          </p>
@@ -337,13 +342,15 @@ The Cloudflare Rules language supports these standard fields:
          <code class="InlineCode">GB-SWK</code>
          </p>
          <p>For more information on the ISO 3166-2 standard and the available regions, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-2">ISO 3166-2</a> on Wikipedia.</p>
+         <p>This field has the same value as the <code>ip.geoip.subdivision_2_iso_code</code> field, which is still available.</p>
       </td>
    </tr>
-   <tr id="field-ip-geoip-is-in-european-union">
-      <td valign="top"><code>ip.geoip.is_in_european_union</code><br />{{<type>}}Boolean{{</type>}}</td>
+   <tr id="field-ip-src-is-in-european-union">
+      <td valign="top"><code>ip.src.is_in_european_union</code><br />{{<type>}}Boolean{{</type>}}</td>
       <td>
          <p>Returns <code class="InlineCode">true</code> when the request originates from a country in the European Union.
          </p>
+         <p>This field has the same value as the <code>ip.geoip.is_in_european_union</code> field, which is still available.</p>
       </td>
   </tr>
   <tr id="field-raw-http-request-full-uri">
@@ -795,14 +802,16 @@ The Cloudflare Rules language supports these dynamic fields:
          <p>For more information on the ISO 3166-1 Alpha 2 format, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
         </td>
     </tr>
-    <tr id="field-ip-geoip-country">
-        <td><p><code>ip.geoip.country</code><br />{{<type>}}String{{</type>}}</p>
+    <tr id="field-ip-src-country">
+        <td><p><code>ip.src.country</code><br />{{<type>}}String{{</type>}}</p>
         </td>
         <td>
-         Represents the 2-letter country code associated with the client IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
-         Example value:
-         <code class="InlineCode">GB</code>
+         <p>Represents the 2-letter country code associated with the client IP address in <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Alpha 2</a> format.<br />
+            Example value:<br />
+            <code>GB</code>
+         </p>
          <p>For more information on the ISO 3166-1 Alpha 2 format, refer to <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 Alpha 2</a> on Wikipedia.</p>
+         <p>This field has the same value as the <code>ip.geoip.country</code> field, which is still available.</p>
         </td>
     </tr>
     <tr id="field-ip-hdr_len">


### PR DESCRIPTION
Addresses PCX-6792.

- Also updates links pointing to the old fields. 
- We still mention the old field names in the descriptions, for findability purposes.
- We're not updating examples in different documentation areas for now.