### PR TITLE
[Browser Rendering] Tabbed Browser Worker code to support JS & TS

### DIFF
--- a/content/browser-rendering/platform/puppeteer.md
+++ b/content/browser-rendering/platform/puppeteer.md
@@ -22,20 +22,44 @@ npm install @cloudflare/puppeteer --save-dev
 
 Once the [browser binding](/browser-rendering/platform/wrangler/#bindings) is configured and the `@cloudflare/puppeteer` library is installed, Puppeteer can be used in a Worker:
 
-```javascript
+{{<tabs labels="js | ts">}}
+{{<tab label="js" default="true">}}
+```js
 import puppeteer from "@cloudflare/puppeteer";
 
 export default {
-    async fetch(request: Request, env: Env): Promise<Response> {
-        const browser = await puppeteer.launch(env.MYBROWSER);
-        const page = await browser.newPage();
-        await page.goto("https://example.com");
-        const metrics = await page.metrics();
-        await browser.close();
-        return new Response(JSON.stringify(metrics));
-    },
+	async fetch(request, env) {
+		const browser = await puppeteer.launch(env.MYBROWSER);
+		const page = await browser.newPage();
+		await page.goto("https://example.com");
+		const metrics = await page.metrics();
+		await browser.close();
+		return Response.json(metrics);
+	},
 };
 ```
+{{</tab>}}
+{{<tab label="ts">}}
+```ts
+import puppeteer from "@cloudflare/puppeteer";
+
+interface Env {
+	MYBROWSER: Fetcher;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const browser = await puppeteer.launch(env.MYBROWSER);
+		const page = await browser.newPage();
+		await page.goto("https://example.com");
+		const metrics = await page.metrics();
+		await browser.close();
+		return Response.json(metrics);
+	},
+};
+```
+{{</tab>}}
+{{</tabs>}}
 
 This script [launches](https://pptr.dev/api/puppeteer.puppeteernode.launch) the `env.MYBROWSER` browser, opens a [new page](https://pptr.dev/api/puppeteer.browser.newpage), [goes to](https://pptr.dev/api/puppeteer.page.goto) https://example.com/, gets the page load [metrics](https://pptr.dev/api/puppeteer.page.metrics), [closes](https://pptr.dev/api/puppeteer.browser.close) the browser and prints metrics in JSON.
 

--- a/content/browser-rendering/platform/wrangler.md
+++ b/content/browser-rendering/platform/wrangler.md
@@ -35,7 +35,7 @@ main = "src/index.ts"
 node_compat = true
 workers_dev = true
 
-browser = { binding = "MYBROWSER", type = "browser" }
+browser = { binding = "MYBROWSER" }
 ```
 
 After the binding is declared, access the DevTools endpoint using `env.MYBROWSER` in your Worker code:


### PR DESCRIPTION
Changes:
* Support switching both JS & TS
  * Following existing conventions, JS is default
* Code is now tabbed
* Remove redundant `type` from binding (https://github.com/cloudflare/workers-sdk/blob/4082cfcbdf08740d4a608d3d87df22e51ad0ce4a/packages/wrangler/src/worker.ts#L111C1-L113)