### PR TITLE
Update Securing user access with two-factor authentication (2FA).md

### DIFF
--- a/content/support/Account Management & Billing/Account Privacy and Security/Securing user access with two-factor authentication (2FA).md
+++ b/content/support/Account Management & Billing/Account Privacy and Security/Securing user access with two-factor authentication (2FA).md
@@ -39,11 +39,13 @@ ___
 
 We recommend that all Cloudflare user account holders enable 2FA to keep their accounts secure. 
 
+2FA can only be enabled successfully on an account with a verified email address. Please ensure to keep the associated email address verified at all times when enforcing 2FA. As it is a prerequisite in 2FA enablement process, **a failure to do so may result in a loss of account access**.
+
 {{<Aside type="warning">}}
 Super Administrators can turn on **2FA Enforcement** to require all
 members to enable 2FA. If you are not a Super Administrator, you will be
 forced to turn on 2FA prior to accepting the invitation to join a
-Cloudflare account as a member.
+Cloudflare account as a member. 
 {{</Aside>}}
 
 To enable two-factor authentication for your Cloudflare login:

--- a/content/support/Account Management & Billing/Account Privacy and Security/Securing user access with two-factor authentication (2FA).md
+++ b/content/support/Account Management & Billing/Account Privacy and Security/Securing user access with two-factor authentication (2FA).md
@@ -39,7 +39,7 @@ ___
 
 We recommend that all Cloudflare user account holders enable 2FA to keep their accounts secure. 
 
-2FA can only be enabled successfully on an account with a verified email address. Please ensure to keep the associated email address verified at all times when enforcing 2FA. As it is a prerequisite in 2FA enablement process, **a failure to do so may result in a loss of account access**.
+2FA can only be enabled successfully on an account with a [verified email address](/fundamentals/account-and-billing/account-setup/verify-email-address/). If you do not verify your email address first, you may lock yourself out of your account.
 
 {{<Aside type="warning">}}
 Super Administrators can turn on **2FA Enforcement** to require all


### PR DESCRIPTION
If a customer enforces 2FA without prior verifying his email, the customer will lock himself out of his account, since the next time the user tries to login he will be asked to setup a second factor of authentication, but it's not possible to do that without the email verified.

Therefore, we would suggest that our 2FA documentation explicitly states that verified email address is necessary to setup 2FA.

You may find examples in the following CUSTESCs:

https://jira.cfdata.org/browse/CUSTESC-25615

https://jira.cfdata.org/browse/CUSTESC-27854