### PR TITLE
Mention intune supported token variables

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/partners/intune.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/partners/intune.md
@@ -36,7 +36,7 @@ Refer to the [generic instructions for macOS](/cloudflare-one/connections/connec
 
 Refer to the [generic instructions for iOS](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/#ios).
 
-If you would like to use variables within a property list of an app configuration policy in Intune, Refer to [the available token types with example values](https://learn.microsoft.com/en-us/mem/intune/apps/app-configuration-policies-use-ios#tokens-used-in-the-property-list). For example, you can use `{{deviceid}}` as [`unique_client_id` key](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#unique_client_id) for large-scale [Device UUID](/cloudflare-one/identity/devices/warp-client-checks/device-uuid.md) posture check deployment.
+Intune allows you to insert [predefined variables](https://learn.microsoft.com/en-us/mem/intune/apps/app-configuration-policies-use-ios#tokens-used-in-the-property-list) into the XML configuration file. For example, you can set the [`unique_client_id`](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#unique_client_id) key to `{{deviceid}}` for a [device UUID posture check](/cloudflare-one/identity/devices/warp-client-checks/device-uuid/) deployment.
 
 ## Android
 

--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/partners/intune.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/partners/intune.md
@@ -36,6 +36,8 @@ Refer to the [generic instructions for macOS](/cloudflare-one/connections/connec
 
 Refer to the [generic instructions for iOS](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/#ios).
 
+If you would like to use variables within a property list of an app configuration policy in Intune, Refer to [the available token types with example values](https://learn.microsoft.com/en-us/mem/intune/apps/app-configuration-policies-use-ios#tokens-used-in-the-property-list). For example, you can use `{{deviceid}}` as [`unique_client_id` key](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#unique_client_id) for large-scale [Device UUID](/cloudflare-one/identity/devices/warp-client-checks/device-uuid.md) posture check deployment.
+
 ## Android
 
 Refer to the [generic instructions for Android](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/#android).


### PR DESCRIPTION
Tokens used in the property list - Add app configuration policies for managed iOS/iPadOS devices - Microsoft Intune | Microsoft Learn https://learn.microsoft.com/en-us/mem/intune/apps/app-configuration-policies-use-ios#tokens-used-in-the-property-list