### PR TITLE
[Internet section] Added redirect

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1048,6 +1048,7 @@
 /distributed-web/* /web3/:splat 301
 /docs-engine/* https://github.com/cloudflare/cloudflare-docs/blob/production/README.md 301
 /fundamentals/internet/* /fundamentals/the-internet/ 301
+/internet/* https://www.cloudflare.com/learning/ 301
 /fundamentals/get-started/basic-tasks/account-maintenance/* /fundamentals/account-and-billing/account-maintenance/:splat 301
 /fundamentals/get-started/setup/troubleshooting/* /fundamentals/get-started/setup/add-site/ 301
 /fundamentals/get-started/basic-tasks/account-security/* /fundamentals/account-and-billing/account-security/:splat 301


### PR DESCRIPTION
For some reason, the [Internet section](https://developers.cloudflare.com/internet/) is still around. Clearing it out with a redirect.