### PR TITLE
[Workers] Add Notes about Type Expections about Worker's Socket API

### DIFF
--- a/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
+++ b/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
@@ -72,7 +72,7 @@ await someResponse.body.pipeTo(writable);
 - {{<code>}}write(chunk{{<param-type>}}any{{</param-type>}}){{</code>}} : {{<type>}}Promise\<void>{{</type>}}
 
   - Writes a chunk of data to the writer and returns a promise that resolves if the operation succeeds.
-  - The underlaying stream may accept fewer kinds of type than `any`, it will throw an exception when encountering an unexpected type.
+  - The underlying stream may accept fewer kinds of type than `any`, it will throw an exception when encountering an unexpected type.
 
 {{</definitions>}}
 

--- a/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
+++ b/content/workers/runtime-apis/streams/writablestreamdefaultwriter.md
@@ -72,6 +72,7 @@ await someResponse.body.pipeTo(writable);
 - {{<code>}}write(chunk{{<param-type>}}any{{</param-type>}}){{</code>}} : {{<type>}}Promise\<void>{{</type>}}
 
   - Writes a chunk of data to the writer and returns a promise that resolves if the operation succeeds.
+  - The underlaying stream may accept fewer kinds of type than `any`, it will throw an exception when encountering an unexpected type.
 
 {{</definitions>}}
 

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -82,7 +82,7 @@ export default {
 
 - {{<code>}}writable{{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writablestream/">}}WritableStream{{</type-link>}}
   - Returns the writable side of the TCP socket.
-  - The `WriteableStream` returned only accept chunks of `Uint8Array` or its views.
+  - The `WriteableStream` returned only accepts chunks of `Uint8Array` or its views.
 
 - `closed` {{<type>}}`Promise<void>`{{</type>}}
   - This promise is resolved when the socket is closed and is rejected if the socket encounters an error.

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -82,6 +82,7 @@ export default {
 
 - {{<code>}}writable{{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writablestream/">}}WritableStream{{</type-link>}}
   - Returns the writable side of the TCP socket.
+  - The `WriteableStream` returned only accept chunks of `Uint8Array` or its views.
 
 - `closed` {{<type>}}`Promise<void>`{{</type>}}
   - This promise is resolved when the socket is closed and is rejected if the socket encounters an error.

--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -82,7 +82,7 @@ export default {
 
 - {{<code>}}writable{{</code>}} : {{<type-link href="/workers/runtime-apis/streams/writablestream/">}}WritableStream{{</type-link>}}
   - Returns the writable side of the TCP socket.
-  - The `WriteableStream` returned only accepts chunks of `Uint8Array` or its views.
+  - The `WritableStream` returned only accepts chunks of `Uint8Array` or its views.
 
 - `closed` {{<type>}}`Promise<void>`{{</type>}}
   - This promise is resolved when the socket is closed and is rejected if the socket encounters an error.


### PR DESCRIPTION
Currently, the documentation about Worker's Stream API do not mention that the `write()` may accept fewer kinds of type than `any` and however, it will throw an exception if the type is unexpected. This exception is more likely to be ignored in websocket's event handler since it is not an asynchronize function.

(See also: https://github.com/cloudflare/workerd/issues/688)
