### PR TITLE
Add `dev:wrangler` to `dev` command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:hugo": "hugo -D -w",
     "dev:wrangler": "wrangler pages dev -- vite",
     "dev:vite": "vite",
-    "dev": "concurrently --kill-others \"npm run dev:hugo\" \"npm run dev:vite\"",
+    "dev": "concurrently --kill-others \"npm run dev:hugo\" \"npm run dev:vite\" \"npm run dev:wrangler\"",
     "lint": "tsm bin/format.ts --check",
     "crawl": "tsm bin/crawl.ts",
     "build:hugo": "hugo",


### PR DESCRIPTION
If we use `http://localhost:8788` for previewing, I believe we need to add `dev:wrangler` to the `dev` command. However, it's better to use the Vite server at `http://localhost:5173/`. This PR is unnecessary and we need to update the README.

PS:

I'm currently a Cloudflare employee, but I haven't yet gained access to the Cloudflare GitHub organization; I'm still in the applying process. Therefore, this PR was sent from my personal repository.