### PR TITLE
[Constellation] Clarify wrangler commands, fix bash codeblocks

### DIFF
--- a/content/constellation/get-started/first-constellation-worker.md
+++ b/content/constellation/get-started/first-constellation-worker.md
@@ -296,6 +296,17 @@ $ npx wrangler dev --remote
 ⬣ Listening at http://0.0.0.0:8787
 ```
 
+{{<Aside type="note">}}
+
+If you're still using Wrangler v2 then run:
+
+```sh
+$ npx wrangler dev
+⬣ Listening at http://0.0.0.0:8787
+```
+
+{{</Aside>}}
+
 To classify some test images, run the following commands in your `image-classifier-worker` Worker:
 
 ```sh

--- a/content/constellation/get-started/first-constellation-worker.md
+++ b/content/constellation/get-started/first-constellation-worker.md
@@ -35,7 +35,7 @@ $ npx wrangler constellation project list
 
 Create a new [Worker](/workers/) named `image-classifier-worker`. You will install [Wrangler, the developer platform CLI, for Constellation](/constellation/platform/wrangler/#installation).
 
-```bash
+```sh
 $ mkdir image-classifier-worker
 $ cd image-classifier-worker
 $ npm init -f

--- a/content/constellation/get-started/first-constellation-worker.md
+++ b/content/constellation/get-started/first-constellation-worker.md
@@ -20,7 +20,7 @@ Before continuing, make sure you have:
 
 Generate a new Constellation project named `image-classifier` by running the [`create`](/constellation/platform/wrangler/#manage-projects) command. Then run `list` to review the details of your newly created project:
 
-```bash
+```sh
 $ npx wrangler constellation project create "image-classifier" ONNX
 $ npx wrangler constellation project list
 
@@ -33,13 +33,13 @@ $ npx wrangler constellation project list
 
 ## Create a new Worker
 
-Create a new [Worker](/workers/) named `image-classifier-worker`. You will install [Wrangler, the developer platform CLI, for Constellation](/constellation/platform/wrangler/#installation) which is still in beta.
+Create a new [Worker](/workers/) named `image-classifier-worker`. You will install [Wrangler, the developer platform CLI, for Constellation](/constellation/platform/wrangler/#installation).
 
 ```bash
 $ mkdir image-classifier-worker
 $ cd image-classifier-worker
 $ npm init -f
-$ npm install wrangler@beta --save-dev
+$ npm install wrangler --save-dev
 $ npx wrangler init
 ```
 
@@ -81,7 +81,7 @@ constellation = [
 
 In your `image-classifier-worker` Worker, install the [client API](/constellation/platform/client-api/) library:
 
-```bash
+```sh
 $ npm install @cloudflare/constellation --save-dev
 ```
 
@@ -89,7 +89,7 @@ $ npm install @cloudflare/constellation --save-dev
 
 Upload the pre-trained [SqueezeNet 1.1](https://github.com/onnx/models/blob/main/vision/classification/squeezenet/README.md) ONNX model to your `image-classifier` Constellation project:
 
-```bash
+```sh
 $ wget https://github.com/microsoft/onnxjs-demo/raw/master/docs/squeezenet1_1.onnx
 $ npx wrangler constellation model upload "image-classifier" "squeezenet11" squeezenet1_1.onnx
 $ npx wrangler constellation model list "image-classifier"
@@ -107,17 +107,16 @@ Take note of the `id` field as this will be the model ID.
 
 The SqueezeNet model was trained on top of the [Imagenet](https://www.image-net.org/) dataset. Make a new `src` folder in your `image-classifier-worker` project directory. Then download the the list of 1,000 image classes that SqueezeNet was trained for:
 
-```bash
+```sh
 $ mkdir src
-$ wget -O src/imagenet.ts \
-  https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
+$ wget -O src/imagenet.ts https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
 ```
 
 ## Install modules
 
 In your `image-classifier-worker` Worker, install [pngjs](https://github.com/pngjs/pngjs), a PNG decoder, and [string-to-stream](https://github.com/feross/string-to-stream):
 
-```bash
+```sh
 $ npm install string-to-stream --save-dev
 $ npm install pngjs --save-dev
 ```
@@ -282,7 +281,7 @@ export interface Env {
 
 In your `image-classifier-worker` Worker, download some test `224`x`244` PNG images you can use for tests.
 
-```bash
+```sh
 $ wget https://imagedelivery.net/WPOeHKUnTTahhk4F5twuvg/8b78a6fb-44ac-4a97-121b-fb8f47f1e000/public -O cat.png
 $ wget https://imagedelivery.net/WPOeHKUnTTahhk4F5twuvg/05c265ae-d3c0-4114-208b-a2d7709cc100/public -O house.png
 $ wget https://imagedelivery.net/WPOeHKUnTTahhk4F5twuvg/4152ee23-f9af-4b21-a636-600e33883400/public -O mountain.png
@@ -292,14 +291,14 @@ $ wget https://imagedelivery.net/WPOeHKUnTTahhk4F5twuvg/4152ee23-f9af-4b21-a636-
 
 Start a local server to test your `image-classifier-worker` Worker by running [`wrangler dev`](/workers/wrangler/commands/#dev):
 
-```bash
-$ npx wrangler dev
+```sh
+$ npx wrangler dev --remote
 ⬣ Listening at http://0.0.0.0:8787
 ```
 
 To classify some test images, run the following commands in your `image-classifier-worker` Worker:
 
-```bash
+```sh
 $ curl http://0.0.0.0:8787 -F file=@cat.png
 {"id":"n02124075","index":285,"name":"Egyptian cat","probability":0.5356272459030151}
 
@@ -316,7 +315,7 @@ Your image classifier is ready. Run it through other `224`x`244` PNG images of y
 
 When you are ready, deploy your Worker:
 
-```bash
+```sh
 $ npx wrangler publish
 ```
 

--- a/content/constellation/platform/runtimes.md
+++ b/content/constellation/platform/runtimes.md
@@ -16,7 +16,7 @@ Our vision is to support multiple runtimes. Currently, we only support the ONNX 
 
 Use Wrangler to list the models Cloudflare supports:
 
-```bash
+```sh
 $ npx wrangler constellation runtime list
 
 ┌──────┐

--- a/content/constellation/platform/wrangler.md
+++ b/content/constellation/platform/wrangler.md
@@ -12,13 +12,13 @@ weight: 30
 
 Wrangler for Constellation is still in Beta. To install Wrangler for Constellation, run:
 
-```bash
+```sh
 $ npm install wrangler@beta --save-dev
 ```
 
 Test Wrangler with [npx](https://github.com/npm/npx):
 
-```bash
+```sh
 $ npx wrangler constellation
 wrangler constellation
 
@@ -43,7 +43,7 @@ Flags:
 
 Use Wrangler to list, create or delete your [projects](/constellation/platform/data-model/#projects).
 
-```bash
+```sh
 $ npx wrangler constellation project --help
 wrangler constellation project
 
@@ -59,7 +59,7 @@ Commands:
 
 Create a Constellation project.
 
-```bash
+```sh
 $ npx wrangler constellation project create "<YOUR_PROJECT_NAME>" ONNX
 ```
 
@@ -67,7 +67,7 @@ $ npx wrangler constellation project create "<YOUR_PROJECT_NAME>" ONNX
 
 List your Constellation project.
 
-```bash
+```sh
 $ npx wrangler constellation project list
 ```
 
@@ -75,7 +75,7 @@ $ npx wrangler constellation project list
 
 Delete a Constellation project.
 
-```bash
+```sh
 $ npx wrangler constellation project delete "<YOUR_PROJECT_NAME"
 ```
 
@@ -83,7 +83,7 @@ $ npx wrangler constellation project delete "<YOUR_PROJECT_NAME"
 
 You can use Wrangler to list, create or delete your [models](/constellation/platform/data-model/#models).
 
-```bash
+```sh
 $ npx wrangler constellation model --help
 wrangler constellation model
 
@@ -99,7 +99,7 @@ Commands:
 
 To upload the [SqueezeNet1.1 CNN model](https://github.com/onnx/models/tree/main/vision/classification/squeezenet#model) to your project, run:
 
-```bash
+```sh
 $ npx wrangler constellation model upload "<YOUR_PROJECT_NAME>" "squeezenet11" squeezenet1.1.onnx
 ```
 
@@ -107,7 +107,7 @@ $ npx wrangler constellation model upload "<YOUR_PROJECT_NAME>" "squeezenet11" s
 
 List the models in your Constellation project.
 
-```bash
+```sh
 $ npx wrangler constellation model list "<YOUR_PROJECT_NAME>"
 ```
 
@@ -115,7 +115,7 @@ $ npx wrangler constellation model list "<YOUR_PROJECT_NAME>"
 
 Delete a model in your Constellation project.
 
-```bash
+```sh
 $ npx wrangler constellation model delete  "<YOUR_PROJECT_NAME>" "squeezenet11"
 ```
 
@@ -127,7 +127,7 @@ The [catalog](/constellation/platform/data-model/#catalog) has ready-to-use pre-
 
 List the models in the catalog.
 
-```bash
+```sh
 $ npx wrangler constellation catalog list
 ```
 

--- a/content/constellation/platform/wrangler.md
+++ b/content/constellation/platform/wrangler.md
@@ -10,10 +10,10 @@ weight: 30
 
 ## Installation
 
-Wrangler for Constellation is still in Beta. To install Wrangler for Constellation, run:
+To install Wrangler for Constellation, run:
 
 ```sh
-$ npm install wrangler@beta --save-dev
+$ npm install wrangler --save-dev
 ```
 
 Test Wrangler with [npx](https://github.com/npm/npx):


### PR DESCRIPTION
- Beta version of wrangler is no longer needed
- `--remote` is needed on wrangler dev
- Replace bash codeblocks with sh so they display and copy optimally