### PR TITLE
Make some improvements to codeblocks

### DIFF
--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -45,7 +45,7 @@ const shell = {
   },
 
   command: {
-    pattern: /[$](?:[^\r\n])+/,
+    pattern: /\$([^\n]*\\\n)*[^\n]*/g,
     inside: {
       prompt: {
         pattern: /^[$] /,

--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -32,7 +32,7 @@ import 'prismjs/components/prism-kotlin.min.js';
 import 'prismjs/components/prism-swift.min.js';
 
 // Custom `shell` grammar
-Prism.languages.sh = {
+const shell = {
   comment: {
     pattern: /(^|[^'{\\$])#.*/,
     alias: 'unselectable',
@@ -52,8 +52,11 @@ Prism.languages.sh = {
         alias: 'unselectable',
       },
     },
-  },
+  }
 };
+
+Prism.languages.sh = shell;
+Prism.languages.bash = shell;
 
 // Prism language aliases
 export const langs: Record<string, string> = {

--- a/components/CodeCopy.vue
+++ b/components/CodeCopy.vue
@@ -7,17 +7,13 @@ function copyCode(e: MouseEvent) {
     e.target as HTMLElement
   )?.parentElement?.parentElement?.querySelector("pre code");
   if (highlightedCode) {
-    // the markdown's code blocks adds a class "CodeBlock--token-unselectable", if it is not supposed to be copied.
-    // clone the code node, we do not want to modify the DOM.
-    const code = highlightedCode.cloneNode(true) as HTMLElement;
-
     // We have 2 types of code blocks, ones with commands and one with general outputs
     // For the ones with commands, we only want the commands copied, not their output
     // So let's first try selecting that
-    let lines = code.querySelectorAll("span:where(.CodeBlock--token-command):not(.CodeBlock--token-unselectable)");
+    let lines = highlightedCode.querySelectorAll("span:where(.CodeBlock--token-command):not(.CodeBlock--token-unselectable)");
     // We found no commands so let's instead copy all output
     if (lines.length === 0) {
-      lines = code.querySelectorAll(".CodeBlock--row");
+      lines = highlightedCode.querySelectorAll(".CodeBlock--row");
     }
 
     let textLines: string[] = [];

--- a/components/CodeCopy.vue
+++ b/components/CodeCopy.vue
@@ -10,13 +10,16 @@ function copyCode(e: MouseEvent) {
     // the markdown's code blocks adds a class "CodeBlock--token-unselectable", if it is not supposed to be copied.
     // clone the code node, we do not want to modify the DOM.
     const code = highlightedCode.cloneNode(true) as HTMLElement;
-    const unselectableTokens = code.getElementsByClassName(
-      "CodeBlock--token-unselectable"
-    );
-    for (let i = 0; i < unselectableTokens.length; i++) {
-      unselectableTokens[i].remove();
+
+    // We have 2 types of code blocks, ones with commands and one with general outputs
+    // For the ones with commands, we only want the commands copied, not their output
+    // So let's first try selecting that
+    let lines = code.querySelectorAll("span:where(.CodeBlock--token-command):not(.CodeBlock--token-unselectable)");
+    // We found no commands so let's instead copy all output
+    if (lines.length === 0) {
+      lines = code.querySelectorAll(".CodeBlock--row");
     }
-    const lines = code.querySelectorAll(".CodeBlock--row");
+
     let textLines: string[] = [];
     lines.forEach((line) =>
       textLines.push((line as HTMLElement).innerText.trimEnd())

--- a/content/constellation/get-started/first-constellation-worker.md
+++ b/content/constellation/get-started/first-constellation-worker.md
@@ -110,7 +110,7 @@ The SqueezeNet model was trained on top of the [Imagenet](https://www.image-net.
 ```bash
 $ mkdir src
 $ wget -O src/imagenet.ts \
-  https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
+$  https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
 ```
 
 ## Install modules

--- a/content/constellation/get-started/first-constellation-worker.md
+++ b/content/constellation/get-started/first-constellation-worker.md
@@ -110,7 +110,7 @@ The SqueezeNet model was trained on top of the [Imagenet](https://www.image-net.
 ```bash
 $ mkdir src
 $ wget -O src/imagenet.ts \
-$  https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
+  https://raw.githubusercontent.com/microsoft/onnxjs-demo/master/src/data/imagenet.ts
 ```
 
 ## Install modules

--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -32,10 +32,10 @@ To start a live stream programmatically, make a `POST` request to the `/live_inp
 ---
 header: Request
 ---
-curl -X POST \
--H "Authorization: Bearer <API_TOKEN>" \
--D '{"meta": {"name":"test stream"},"recording": { "mode": "automatic" }}' \
-https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs
+$ curl -X POST \
+  -H "Authorization: Bearer <API_TOKEN>" \
+  -D '{"meta": {"name":"test stream"},"recording": { "mode": "automatic" }}' \
+  https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs
 ```
 
 ```json
@@ -116,7 +116,7 @@ https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs/:i
 ### Recommendations
 
 - Your creators should use an appropriate bitrate for their live streams, typically well under 12Mbps (12000Kbps). High motion, high frame rate content typically should use a higher bitrate, while low motion content like slide presentations should use a lower bitrate.
-- Your creators should use a [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) of between 2 to 10 seconds. The default in most encoding software and hardware, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream. 
+- Your creators should use a [GOP duration](https://en.wikipedia.org/wiki/Group_of_pictures) (keyframe interval) of between 2 to 10 seconds. The default in most encoding software and hardware, including Open Broadcaster Software (OBS), is within this range. Setting a lower GOP duration will reduce latency for viewers, while also reducing encoding efficiency. Setting a higher GOP duration will improve encoding efficiency, while increasing latency for viewers. This is a tradeoff inherent to video encoding, and not a limitation of Cloudflare Stream.
 
 ### Requirements
 

--- a/content/stream/viewing-videos/securing-your-stream.md
+++ b/content/stream/viewing-videos/securing-your-stream.md
@@ -61,9 +61,9 @@ You can call the `/token` endpoint for any video that is marked private to get a
 
 ```bash
 $ curl \
-$   -X POST \
-$   -H "Authorization: Bearer <API_TOKEN>" \
-$   https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/<VIDEO_UID>/token
+  -X POST \
+  -H "Authorization: Bearer <API_TOKEN>" \
+  https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/<VIDEO_UID>/token
 ```
 
 You will see a response similar to this if the request succeeds:

--- a/content/stream/viewing-videos/securing-your-stream.md
+++ b/content/stream/viewing-videos/securing-your-stream.md
@@ -60,10 +60,10 @@ You can program your app to generate token in two ways:
 You can call the `/token` endpoint for any video that is marked private to get a signed url token which expires in one hour:
 
 ```bash
-curl \
--X POST \
--H "Authorization: Bearer <API_TOKEN>" \
-https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/<VIDEO_UID>/token
+$ curl \
+$   -X POST \
+$   -H "Authorization: Bearer <API_TOKEN>" \
+$   https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/<VIDEO_UID>/token
 ```
 
 You will see a response similar to this if the request succeeds:
@@ -104,7 +104,7 @@ async function handleRequest(request) {
 
     var signed_url_restrictions = {
         //limit viewing for the next 12 hours
-        exp: Math.floor(Date.now() / 1000) + (12*60*60) 
+        exp: Math.floor(Date.now() / 1000) + (12*60*60)
     };
 
     const init = {

--- a/static/home.css
+++ b/static/home.css
@@ -2337,42 +2337,53 @@ html {
     color: var(--code-gold)
 }
 
-[language=sh] .CodeBlock--token-directory {
-    color: var(--code-orange)
+[language="sh"] .CodeBlock--token-directory,
+[language="bash"] .CodeBlock--token-directory {
+  color: var(--code-orange);
 }
 
-[language=sh] .CodeBlock--token-prompt {
-    color: var(--code-orange);
-    opacity: .7
+[language="sh"] .CodeBlock--token-prompt,
+[language="bash"] .CodeBlock--token-prompt {
+  color: var(--code-orange);
+  opacity: 0.7;
 }
 
-[language=sh] .CodeBlock--token-value {
-    color: var(--code-cyan)
+[language="sh"] .CodeBlock--token-value,
+[language="bash"] .CodeBlock--token-value {
+  color: var(--code-cyan);
 }
 
-[language=sh] .CodeBlock--token-success {
-    color: var(--code-green)
+[language="sh"] .CodeBlock--token-success,
+[language="bash"] .CodeBlock--token-success {
+  color: var(--code-green);
 }
 
-[language=sh] .CodeBlock--token-plain {
-    color: var(--code-gray)
+[language="sh"] .CodeBlock--token-plain,
+[language="bash"] .CodeBlock--token-plain {
+  color: var(--code-gray);
 }
 
-[language=sh] .CodeBlock--token-plain,
-[language=sh] .CodeBlock--token-unselectable {
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    pointer-events: none;
-    text-decoration: none;
-    transition: opacity .25s ease
+[language="sh"] .CodeBlock--token-plain,
+[language="bash"] .CodeBlock--token-plain,
+[language="sh"] .CodeBlock--token-unselectable,
+[language="bash"] .CodeBlock--token-unselectable {
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  text-decoration: none;
+  transition: opacity 0.25s ease;
 }
 
-[language=sh]:hover .CodeBlock--token-plain,
-[language=sh]:hover .CodeBlock--token-unselectable,
-[language=sh][has-selection-contained-within] .CodeBlock--token-plain,
-[language=sh][has-selection-contained-within] .CodeBlock--token-unselectable {
-    opacity: .25
+[language="sh"]:hover .CodeBlock--token-plain,
+[language="bash"]:hover .CodeBlock--token-plain,
+[language="sh"]:hover .CodeBlock--token-unselectable,
+[language="bash"]:hover .CodeBlock--token-unselectable,
+[language="sh"][has-selection-contained-within] .CodeBlock--token-plain,
+[language="bash"][has-selection-contained-within] .CodeBlock--token-plain,
+[language="sh"][has-selection-contained-within] .CodeBlock--token-unselectable,
+[language="bash"][has-selection-contained-within] .CodeBlock--token-unselectable {
+  opacity: 0.25;
 }
 
 .CodeBlock--row>.CodeBlock--row-indicator:empty+.CodeBlock--row-content>.CodeBlock--token-plain:empty+.CodeBlock--token-doc-comment.CodeBlock--token-comment:empty:after,

--- a/static/style.css
+++ b/static/style.css
@@ -1159,29 +1159,36 @@ html {
   color: var(--code-gold);
 }
 
-[language="sh"] .CodeBlock--token-directory {
+[language="sh"] .CodeBlock--token-directory,
+[language="bash"] .CodeBlock--token-directory {
   color: var(--code-orange);
 }
 
-[language="sh"] .CodeBlock--token-prompt {
+[language="sh"] .CodeBlock--token-prompt,
+[language="bash"] .CodeBlock--token-prompt {
   color: var(--code-orange);
   opacity: 0.7;
 }
 
-[language="sh"] .CodeBlock--token-value {
+[language="sh"] .CodeBlock--token-value,
+[language="bash"] .CodeBlock--token-value {
   color: var(--code-cyan);
 }
 
-[language="sh"] .CodeBlock--token-success {
+[language="sh"] .CodeBlock--token-success,
+[language="bash"] .CodeBlock--token-success {
   color: var(--code-green);
 }
 
-[language="sh"] .CodeBlock--token-plain {
+[language="sh"] .CodeBlock--token-plain,
+[language="bash"] .CodeBlock--token-plain {
   color: var(--code-gray);
 }
 
 [language="sh"] .CodeBlock--token-plain,
-[language="sh"] .CodeBlock--token-unselectable {
+[language="bash"] .CodeBlock--token-plain,
+[language="sh"] .CodeBlock--token-unselectable,
+[language="bash"] .CodeBlock--token-unselectable {
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
@@ -1191,9 +1198,13 @@ html {
 }
 
 [language="sh"]:hover .CodeBlock--token-plain,
+[language="bash"]:hover .CodeBlock--token-plain,
 [language="sh"]:hover .CodeBlock--token-unselectable,
+[language="bash"]:hover .CodeBlock--token-unselectable,
 [language="sh"][has-selection-contained-within] .CodeBlock--token-plain,
-[language="sh"][has-selection-contained-within] .CodeBlock--token-unselectable {
+[language="bash"][has-selection-contained-within] .CodeBlock--token-plain,
+[language="sh"][has-selection-contained-within] .CodeBlock--token-unselectable,
+[language="bash"][has-selection-contained-within] .CodeBlock--token-unselectable {
   opacity: 0.25;
 }
 


### PR DESCRIPTION
Made 3 changes to codeblocks:
* `bash` is now a properly supported language for commands. Which means we no longer need @Erisa to tirelessly go through the whole codebase and change them to `sh` (`bash` also just kinda makes more sense)
* Fixed `$` being copied when you copy from a command codeblock and fixed the command output being copied
* Multi-line commands are now supporteddddddd

Now when you copy from like:
```bash
$ npx command

This is the command output
```

You will only get `npx command` copied :)
Previously you'd get the entire codeblock.

Example page: https://walshy-codeblock-improvement.cloudflare-docs-7ou.pages.dev/constellation/get-started/first-constellation-worker/