### PR TITLE
[Workers] Fix Tail Worker example

### DIFF
--- a/content/workers/platform/tail-workers.md
+++ b/content/workers/platform/tail-workers.md
@@ -25,7 +25,7 @@ To configure a Tail Worker:
 filename: index.js
 ---
 export default {
-  async tail(events) => {
+  async tail(events) {
     fetch("https://example.com/endpoint", {
       method: "POST",
       body: JSON.stringify(events),

--- a/content/workers/runtime-apis/tail-event.md
+++ b/content/workers/runtime-apis/tail-event.md
@@ -18,7 +18,7 @@ Written using the Module Worker syntax, handle `TailEvent` in Workers functions 
 filename: index.js
 ---
 export default {
-  async tail(events, env, ctx) => {
+  async tail(events, env, ctx) {
     fetch("<YOUR_ENDPOINT>", {
       method: "POST",
       body: JSON.stringify(events),


### PR DESCRIPTION
The `=>` is throwing 

```
Uncaught SyntaxError: Unexpected token '=>' at worker.js:2:21 (Code: 10021) 
```

Looks to be a holdover from service worker syntax