### PR TITLE
Fix code example in Tail Workers docs

### DIFF
--- a/content/workers/platform/tail-workers.md
+++ b/content/workers/platform/tail-workers.md
@@ -25,7 +25,7 @@ To configure a Tail Worker:
 filename: index.js
 ---
 export default {
-  async tail(events) => {
+  async tail(events) {
     fetch("https://example.com/endpoint", {
       method: "POST",
       body: JSON.stringify(events),


### PR DESCRIPTION
Don't need `=>` when defining a method