### PR TITLE
[Stream] Added more info about video statuses

### DIFF
--- a/content/stream/manage-video-library/using-webhooks.md
+++ b/content/stream/manage-video-library/using-webhooks.md
@@ -60,7 +60,9 @@ header: Example POST request body sent in response to successful encoding
   }
 ```
 
-When a video is done processing, the `state` field returns a `ready` state. Videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not 100, which means higher quality renditions are still processing. When `pctComplete` reaches 100, all quality resolutions are available for the video.
+When a video is done processing, the `state` field returns a `ready` state, which means all quality levels are encoded. The `ready` state can be useful if picture quality is important to you, and you only want to enable video playback when the highest quality levels are available. The `readyToStream` value returns `true` when at least one quality level is encoded and ready to be streamed.
+
+Videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not 100, which means higher quality renditions are still processing. When `pctComplete` reaches 100, all quality resolutions are available for the video.
 
 ## Error codes
 

--- a/content/stream/manage-video-library/using-webhooks.md
+++ b/content/stream/manage-video-library/using-webhooks.md
@@ -62,7 +62,7 @@ header: Example POST request body sent in response to successful encoding
 
 When a video is done processing and all quality levels are encoded, the `state` field returns a `ready` state. The `ready` state can be useful if picture quality is important to you, and you only want to enable video playback when the highest quality levels are available. 
 
-If higher quality renditions are still processing, videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not 100. When `pctComplete` reaches 100, all quality resolutions are available for the video.
+If higher quality renditions are still processing, videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not `100`. When `pctComplete` reaches `100`, all quality resolutions are available for the video.
 
 When at least one quality level is encoded and ready to be streamed, the `readyToStream` value returns `true`.
 

--- a/content/stream/manage-video-library/using-webhooks.md
+++ b/content/stream/manage-video-library/using-webhooks.md
@@ -60,9 +60,11 @@ header: Example POST request body sent in response to successful encoding
   }
 ```
 
-When a video is done processing, the `state` field returns a `ready` state, which means all quality levels are encoded. The `ready` state can be useful if picture quality is important to you, and you only want to enable video playback when the highest quality levels are available. The `readyToStream` value returns `true` when at least one quality level is encoded and ready to be streamed.
+When a video is done processing and all quality levels are encoded, the `state` field returns a `ready` state. The `ready` state can be useful if picture quality is important to you, and you only want to enable video playback when the highest quality levels are available. 
 
-Videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not 100, which means higher quality renditions are still processing. When `pctComplete` reaches 100, all quality resolutions are available for the video.
+If higher quality renditions are still processing, videos may sometimes return the `state` field as `ready` and an additional `pctComplete` state that is not 100. When `pctComplete` reaches 100, all quality resolutions are available for the video.
+
+When at least one quality level is encoded and ready to be streamed, the `readyToStream` value returns `true`.
 
 ## Error codes
 


### PR DESCRIPTION
Updated docs to include the differences between `state: ready` and `readyToStream: true` to address PCX-4363.