### PR TITLE
Give clearer advice for the SentinelOne application path

### DIFF
--- a/content/cloudflare-one/identity/devices/warp-client-checks/sentinel-one.md
+++ b/content/cloudflare-one/identity/devices/warp-client-checks/sentinel-one.md
@@ -18,16 +18,21 @@ Before you start, make sure SentinelOne is installed on your machine.
 
 1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **WARP Client**.
 
-1. Scroll down to **WARP client checks** and select **Add new**.
+2. Scroll down to **WARP client checks** and select **Add new**.
 
-1. Select **SentinelOne**.
+3. Select **SentinelOne**.
 
-1. You will be prompted for the following information:
+4. You will be prompted for the following information:
 
    1. **Name**: Enter a unique name for this device posture check.
-   1. **Operating system**: Select your operating system. You will need to configure one posture check per operating system (macOS and Windows currently supported).
-   1. **Application Path**: Enter the full path to the SentinelOne process to be checked (for example, `c:\program files\SentinelOne\SentinelOne.exe`).
-   1. **Signing certificate thumbprint (recommended)**: Enter the thumbprint of the publishing certificate used to sign the binary. This proves the binary came from SentinelOne and is the recommended way to validate the process.
-   1. **SHA-256 (optional)**: Enter a SHA-256 value. This is used to validate the SHA256 signature of the binary and ensures the integrity of the binary file on the device. Note: do not fill out this field unless you strictly control updates to SentinelOne, as this will change between versions.
+   2. **Operating system**: Select your operating system. You will need to configure one posture check per operating system (macOS and Windows currently supported).
+   3. **Application Path**: Enter the full path to the SentinelOne process to be checked (for example, `C:\Program Files\SentinelOne\Sentinel Agent 21.7.4.1043\SentinelAgent.exe`).
+  {{<Aside type="note">}}
+  
+- The path of the SentinelOne process may change between updates. Ensure the client check is always changed to match the new path, or use `%PATH%` variables.
+  
+{{</Aside>}}
+   4. **Signing certificate thumbprint (recommended)**: Enter the thumbprint of the publishing certificate used to sign the binary. This proves the binary came from SentinelOne and is the recommended way to validate the process.
+   5. **SHA-256 (optional)**: Enter a SHA-256 value. This is used to validate the SHA256 signature of the binary and ensures the integrity of the binary file on the device. Note: do not fill out this field unless you strictly control updates to SentinelOne, as this will change between versions.
 
 Next, go to **Logs** > **Posture** and [verify](/cloudflare-one/insights/logs/posture-logs) that the SentinelOne check is returning the expected results.


### PR DESCRIPTION
Updated the 'Application Path' section to reflect the fact that the agent may run in a folder with a version number.

Added advice similar to the 'Application check' page to suggest using PATH variables to keep this up-to-date.