### PR TITLE
workers: link out to native integrations

### DIFF
--- a/content/workers/databases/native-integrations.md
+++ b/content/workers/databases/native-integrations.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Native Integrations
+weight: 9
+
+external_link: /workers/learning/integrations/databases/#native-database-integrations-beta
+_build:
+  publishResources: false
+  render: never
+---


### PR DESCRIPTION
Make it easier to find Native Integrations for databases in the nav.

Future work will refactor this and likely bring https://developers.cloudflare.com/workers/learning/integrations/databases/#native-database-integrations-beta up underneath /databases as we expand these. 