### PR TITLE
[Workers] Fix typo in simple.wat example

### DIFF
--- a/content/workers/platform/webassembly/javascript.md
+++ b/content/workers/platform/webassembly/javascript.md
@@ -28,7 +28,7 @@ Review the following example module (`;;` denotes a comment):
   (func $i (import "imports" "imported_func") (param i32))
   ;; Export a function named `exported_func` which takes a
   ;; single i32 argument and returns an i32
-  (func (export "exported_func") (param $input i32) (return i32)
+  (func (export "exported_func") (param $input i32) (result i32)
     ;; Invoke `imported_func` with $input as argument
     local.get $input
     call $i


### PR DESCRIPTION
The current example fails wat2wasm with:
```
Error: parseWat failed:
test.wast:9:61: error: unexpected token i32, expected ).
  (func (export "exported_func") (param $input i32) (return i32)
                                                            ^^^
```
Changing it with "result" fixes that and can be deployed successfully, as used in wat function examples (eg https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format) 