### PR TITLE
Add .cloudflareaccess.com firewall requirement

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
@@ -20,6 +20,13 @@ All DNS requests through WARP are sent outside the tunnel via DoH (DNS over HTTP
 
 {{<render file="_doh-ips.md">}}
 
+## Client authentication endpoint
+
+When you [log in to your Zero Trust organization](/cloudflare-one/connections/connect-devices/warp/deployment/manual-deployment/), you will have to complete the authentication steps required by your organization in the browser window that opens. To perform these operations, you must allow `<your-team-name>.cloudflareaccess.com` which will lookup the following IP addresses:.
+
+- IPv4 Endpoints: `104.19.194.29` and `104.19.195.29`
+- IPv6 Endpoints: `2606:4700:300a::6813:c21d` and `2606:4700:300a::6813:c31d`
+
 ## WARP ingress IP
 
 These are the IP addresses that the WARP client will connect to. All traffic from your device to the Cloudflare edge will go through these IP addresses.


### PR DESCRIPTION
When the user log in with team name, the browser will open `https://<your-team-name>.cloudflareaccess.com/warp` to complete the authentication steps.

```
% dig -4 @1.1.1.1 <your-team-name>.cloudflareaccess.com A +short
104.19.195.29
104.19.194.29

% dig -6 @2606:4700:4700::1111 <your-team-name>.cloudflareaccess.com AAAA +short
2606:4700:300a::6813:c21d
2606:4700:300a::6813:c31d
```