### PR TITLE
docs: add feathers-kysely to community-project.md

### DIFF
--- a/content/d1/platform/community-projects.md
+++ b/content/d1/platform/community-projects.md
@@ -41,7 +41,7 @@ Kysely is a type-safe and autocompletion-friendly typescript SQL query builder. 
 
 ### feathers-kysely
 
-The `feathers-kysely` database adapter follows the FeathersJS Query Syntax standard and works with any framework. It is built on the D1 adapter for Kysely and supports passing queries directly from client applications. Since the FeathersJS query syntax is a subset of MongoDB's, this is a great tool for MongoDB users to use Cloudflare D1 without previous SQL experience.
+The `feathers-kysely` database adapter follows the FeathersJS Query Syntax standard and works with any framework. It is built on the D1 adapter for Kysely and supports passing queries directly from client applications. Since the FeathersJS query syntax is a subset of MongoDB's syntax, this is a great tool for MongoDB users to use Cloudflare D1 without previous SQL experience.
 
 * [feathers-kysely on npm](https://www.npmjs.com/package/feathers-kysely)
 * [feathers-kysely on GitHub](https://github.com/marshallswain/feathers-kysely)

--- a/content/d1/platform/community-projects.md
+++ b/content/d1/platform/community-projects.md
@@ -39,6 +39,13 @@ Kysely is a type-safe and autocompletion-friendly typescript SQL query builder. 
 * [Kysely GitHub](https://github.com/koskimas/kysely)
 * [D1 adapter](https://github.com/aidenwallis/kysely-d1)
 
+### feathers-kysely
+
+The `feathers-kysely` database adapter follows the FeathersJS Query Syntax standard and works with any framework. It is built on the D1 adapter for Kysely and supports passing queries directly from client applications. Since the FeathersJS query syntax is a subset of MongoDB's, this is a great tool for MongoDB users to use Cloudflare D1 without previous SQL experience.
+
+* [feathers-kysely on npm](https://www.npmjs.com/package/feathers-kysely)
+* [feathers-kysely on GitHub](https://github.com/marshallswain/feathers-kysely)
+
 ### Drizzle ORM
 
 Drizzle ORM is a TypeScript ORM for SQL databases designed with maximum type safety in mind. It also comes with an automatic migrations generation tool. Drizzle automatically generates your D1 schema based on types you define in TypeScript, and exposes an API that allows you to query your database directly.


### PR DESCRIPTION
This PR adds feathers-kysely to the `community-projects.md` page.  I've grouped it under the Kysely Adapter for D1 since it builds on top of Kysely.