### PR TITLE
[search] Add icon styling fix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4486,7 +4486,7 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   margin: 0 auto;
 }
 
-[theme="dark"] .DocSearch-Logo svg > * {
+[theme="dark"] .DocSearch-Logo svg>* {
   fill: white;
 }
 
@@ -4495,6 +4495,13 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   #algolia {
     display: none;
   }
+}
+
+.DocSearch-Search-Icon,
+.DocSearch-Container svg,
+.DocSearch-Logo svg {
+  height: auto;
+  width: auto;
 }
 
 /* dark */


### PR DESCRIPTION
people don't appear to like my new abstract art that I released in the docsearch UI, so this PR fixes the styling to resemble something more like a close icon

**before:**

<img width="595" alt="Screenshot 2023-06-02 at 12 32 42 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/922353/86bd44d9-5ee6-43cd-ac5e-8f9898b331ef">

**after:**

<img width="602" alt="Screenshot 2023-06-02 at 12 31 42 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/922353/4e9481e1-b7f9-4a24-8c57-fdac0e20dc97">