### PR TITLE
Fix Typo `recommend` in smart-placement.md

### DIFF
--- a/content/workers/platform/smart-placement.md
+++ b/content/workers/platform/smart-placement.md
@@ -116,7 +116,7 @@ We may remove the `cf-placement` header before Smart Placement enters general av
 
 ## Best practices
 
-If you are building full-stack applications on Workers, we reccomend splitting up the front-end and back-end logic into different Workers and using [Service Bindings](/workers/runtime-apis/service-bindings/) to connect your front-end logic and back-end logic Workers. 
+If you are building full-stack applications on Workers, we recommend splitting up the front-end and back-end logic into different Workers and using [Service Bindings](/workers/runtime-apis/service-bindings/) to connect your front-end logic and back-end logic Workers. 
 
 ![Smart Placement and Service Bindings](../media/smart-placement-service-bindings.png)
 


### PR DESCRIPTION
It is spelled incorrectly as `reccomend`