### PR TITLE
Fix broken link to #supported-back-end-services on smart-placement.md

### DIFF
--- a/content/workers/platform/smart-placement.md
+++ b/content/workers/platform/smart-placement.md
@@ -91,7 +91,7 @@ $ curl -X GET https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/workers
 Possible placement states include:
 - _(not present)_: The Worker has not been analyzed for Smart Placement yet.
 - `INSUFFICIENT_INVOCATIONS`: Not enough requests for Smart Placement to make a placement decision.
-- `NO_VALID_HOSTS`: The Worker does not send subrequests to [back-end services supported by Smart Placement](/workers/platform/smart-placement/#supported-backend-services).
+- `NO_VALID_HOSTS`: The Worker does not send subrequests to [back-end services supported by Smart Placement](/workers/platform/smart-placement/#supported-back-end-services).
 - `INSUFFICIENT_SUBREQUESTS`: The Worker does not send enough subrequests to valid back-end services.
 - `SUCCESS`: The Worker has been successfully analyzed and will be optimized by Smart Placement.
 


### PR DESCRIPTION
The link was `#supported-backend-services` but that isn't the correct link to that section, which is `#supported-back-end-services`