### PR TITLE
[Page Shield, Other docs] Update API links

### DIFF
--- a/content/dns/additional-options/custom-nameservers.md
+++ b/content/dns/additional-options/custom-nameservers.md
@@ -20,10 +20,10 @@ Cloudflare domains on Business or Enterprise plans can set Custom Nameservers at
 
 - Enterprise plans:
   - Create account-level nameservers via the [API](/api/operations/account-level-custom-nameservers-list-account-custom-nameservers)
-  - Create zone-level nameservers via the dashboard or [API](/api/operations/zone-edit-zone)
+  - Create zone-level nameservers via the dashboard or [API](/api/operations/zones-0-patch)
 - Business plans:
   - Create account-level nameservers via the [API](/api/operations/account-level-custom-nameservers-add-account-custom-nameserver) (after [contacting Cloudflare Support](https://support.cloudflare.com/hc/articles/200172476))
-  - Create zone-level nameservers via the dashboard or [API](/api/operations/zone-edit-zone)
+  - Create zone-level nameservers via the dashboard or [API](/api/operations/zones-0-patch)
 
 ## Restrictions
 
@@ -93,7 +93,7 @@ To add custom nameservers to a specific zone:
 
 1.  Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account and domain.
 2.  Go to **DNS** > **Records**.
-3.  On **Custom Nameservers**, click **Add Custom Nameservers** and enter the subdomains used for the nameserver hostnames (like ns1, ns2, ns3).
+3.  On **Custom Nameservers**, select **Add Custom Nameservers** and enter the subdomains used for the nameserver hostnames (like ns1, ns2, ns3).
 4.  Cloudflare will assign an IPv4 and IPv6 address to each custom nameserver hostname and automatically create the associated `A` or `AAAA` records (visible after you refresh the page).
 5.  The next step depends on whether you are using [Cloudflare Registrar](/registrar/) for your domain:
     - If you are using Cloudflare Registrar for your domain, no further action is required. Glue records will be added automatically on your behalf.
@@ -101,7 +101,7 @@ To add custom nameservers to a specific zone:
 
 #### Using the API
 
-To add zone-level custom nameservers via the API, use a [PATCH request](/api/operations/zone-edit-zone) and specify the custom nameservers in the payload:
+To add zone-level custom nameservers via the API, use a [PATCH request](/api/operations/zones-0-patch) and specify the custom nameservers in the payload:
 
 ```txt
 "vanity_name_servers": ["ns1.example.com","ns2.example.com"]
@@ -115,12 +115,12 @@ To remove zone-level nameservers (and their associated, read-only DNS records) u
 
 1.  Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account and domain.
 2.  Go to **DNS** > **Records**.
-3.  On **Custom Nameservers**, click **Remove Custom Nameservers**.
+3.  On **Custom Nameservers**, select **Remove Custom Nameservers**.
 4.  Cloudflare will remove your nameservers and their associated read-only `A` or `AAAA` records.
 
 #### Using the API
 
-To remove zone-level custom nameservers (and their associated, read-only DNS records) via the API, use a [PATCH request](/api/operations/zone-edit-zone) and include an empty array in the payload:
+To remove zone-level custom nameservers (and their associated, read-only DNS records) via the API, use a [PATCH request](/api/operations/zones-0-patch) and include an empty array in the payload:
 
 ```txt
 "vanity_name_servers": []

--- a/content/firewall/api/cf-filters/endpoints.md
+++ b/content/firewall/api/cf-filters/endpoints.md
@@ -23,7 +23,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](/f
 
 The Filters API endpoints require a value for `<ZONE_ID>`.
 
-To retrieve a list of zones associated with your account, use the [List Zones](/api/operations/zone-list-zones) operation and note the Zone ID associated with the domain for which you want to manage filters.
+To retrieve a list of zones associated with your account, use the [List Zones](/api/operations/zones-get) operation and note the Zone ID associated with the domain for which you want to manage filters.
 
 {{</Aside>}}
 

--- a/content/firewall/api/cf-firewall-rules/endpoints.md
+++ b/content/firewall/api/cf-firewall-rules/endpoints.md
@@ -23,7 +23,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](/f
 
 The Firewall Rules API endpoints require a value for `<ZONE_ID>`.
 
-To retrieve a list of zones associated with your account, use the [List Zones](/api/operations/zone-list-zones) operation and note the zone ID associated with the domain whose firewall rules you want to manage.
+To retrieve a list of zones associated with your account, use the [List Zones](/api/operations/zones-get) operation and note the zone ID associated with the domain whose firewall rules you want to manage.
 
 {{</Aside>}}
 

--- a/content/fundamentals/api/how-to/create-via-api.md
+++ b/content/fundamentals/api/how-to/create-via-api.md
@@ -75,8 +75,8 @@ Each token can contain multiple policies.
 API token policies support three resource types: `User`, `Account`, and `Zone`.
 
 {{<Aside type="note">}}
- 
-Fetch each object's ID by calling the appropriate `GET <object>` API. Refer to [User](/api/operations/user-user-details), [Account](/api/operations/accounts-list-accounts), and [Zone](/api/operations/zone-list-zones) documentation for more details.
+
+Fetch each object's ID by calling the appropriate `GET <object>` API. Refer to [User](/api/operations/user-user-details), [Account](/api/operations/accounts-list-accounts), and [Zone](/api/operations/zones-get) documentation for more details.
   {{</Aside>}}
 
 ##### Account
@@ -132,7 +132,7 @@ Each parameter in the `in` and `not_in` objects must be in CIDR notation. For ex
 Combine the previous information to create a token as in the following example:
 
 ```json
-$ curl -X POST 
+$ curl -X POST
 "https://api.cloudflare.com/client/v4/user/tokens" \
      -H "Authorization: Bearer <api token secret>" \
      -H "Content-Type: application/json" \

--- a/content/load-balancing/_partials/_load-balancer-create-api.md
+++ b/content/load-balancing/_partials/_load-balancer-create-api.md
@@ -9,7 +9,7 @@ For a full list of properties, refer to [Create Load Balancer](/api/operations/l
 
 {{<Aside type="note">}}
 
-Since load balancers only exist on a zone — and not an account — you may need to get the zone `id` with the [List Zones](/api/operations/zone-list-zones) command.
+Since load balancers only exist on a zone — and not an account — you may need to get the zone `id` with the [List Zones](/api/operations/zones-get) command.
 
 {{</Aside>}}
 

--- a/content/page-shield/reference/page-shield-api.md
+++ b/content/page-shield/reference/page-shield-api.md
@@ -6,7 +6,7 @@ weight: 5
 
 # Page Shield API
 
-You can change the Page Shield status and fetch information about the currently monitored scripts and connections using the [Page Shield API](/api/operations/page-shield-get-page-shield-settings).
+You can enable and disable Page Shield, configure its settings, and fetch information about detected scripts and connections using the [Page Shield API](/api/operations/page-shield-get-page-shield-settings).
 
 For authentication instructions, refer to [Getting Started: Requests](/fundamentals/api/) in the Cloudflare API documentation.
 
@@ -16,42 +16,45 @@ Refer to [API deprecations](/fundamentals/api/reference/deprecations/#page-shiel
 
 ## Endpoints
 
-You can obtain the complete endpoint by appending the [Page Shield API](/api/operations/page-shield-get-page-shield-settings) endpoints listed below to the Cloudflare API base URL.
-
-The Cloudflare API base URL is:
+You can obtain the complete endpoint by appending the [Page Shield API](/api/operations/page-shield-get-page-shield-settings) endpoints to the Cloudflare API base URL:
 
 ```txt
 https://api.cloudflare.com/client/v4
 ```
 
-The `<ZONE_ID>` argument is the zone ID (a hexadecimal string). You can find this value in the Cloudflare dashboard or using the Cloudflare API's [`/zones` endpoint](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
+The `{zone_id}` argument is the zone ID (a hexadecimal string). You can find this value in the Cloudflare dashboard or using the Cloudflare API's [`/zones` endpoint](/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
 
-The `<SCRIPT_ID>` argument is the script ID (a hexadecimal string). This value is included in the response of the [List Page Shield scripts](/api/operations/page-shield-list-page-shield-scripts) operation for every monitored script.
+The `{script_id}` argument is the script ID (a hexadecimal string). This value is included in the response of the [List Page Shield scripts](/api/operations/page-shield-list-page-shield-scripts) operation for every detected script.
 
-The `<CONNECTION_ID>` argument is the connection ID (a hexadecimal string). This value is included in the response of the List Page Shield connections API operation for every monitored connection.
+The `{connection_id}` argument is the connection ID (a hexadecimal string). This value is included in the response of the List Page Shield connections API operation for every detected connection.
 
 The following table summarizes the available operations:
 
-| Operation                         | Method + URL stub                                      | Notes                                                    |
-| --------------------------------- | ------------------------------------------------------ | -------------------------------------------------------- |
-| [Get Page Shield status][1]       | `GET zones/<ZONE_ID>/page_shield`                      | Fetch the current Page Shield status (enabled/disabled). |
-| [Update Page Shield status][2]    | `PUT zones/<ZONE_ID>/page_shield`                      | Update the Page Shield status (enabled/disabled).        |
-| [List Page Shield scripts][3]     | `GET zones/<ZONE_ID>/page_shield/scripts`              | Fetch a list of currently monitored scripts.             |
-| [Get a Page Shield script][4]     | `GET zones/<ZONE_ID>/page_shield/scripts/<SCRIPT_ID>`  | Fetch the details of a currently monitored script.       |
-| [List Page Shield connections][5] | `GET zones/<ZONE_ID>/page_shield/connections`          | Fetch a list of currently monitored connections.         |
-| [Get a Page Shield connection][6] | `GET zones/<ZONE_ID>/page_shield/connections/<CONNECTION_ID>` | Fetch the details of a connection.                |
-| List policies                     | `GET zones/<ZONE_ID>/page_shield/policies`             | Fetch a list of all configured CSP policies.             |
-| Get a policy                      | `GET zones/<ZONE_ID>/page_shield/policies/<POLICY_ID>` | Fetch the details of a CSP policy.                       |
-| Create a policy                   | `POST zones/<ZONE_ID>/page_shield/policies`            | Creates a CSP policy with the provided configuration.    |
-| Update a policy                   | `PUT zones/<ZONE_ID>/page_shield/policies/<POLICY_ID>` | Updates an existing CSP policy.                          |
-| Delete a policy                   | `DELETE zones/<ZONE_ID>/page_shield/policies/<POLICY_ID>` | Deletes an existing CSP policy.                       |
+| Operation                         | Method + URL stub                                      | Notes                                                 |
+| --------------------------------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| [Get Page Shield settings][1]     | `GET zones/{zone_id}/page_shield`                      | Fetch Page Shield settings (including the status).    |
+| [Update Page Shield settings][2]  | `PUT zones/{zone_id}/page_shield`                      | Update Page Shield settings.                          |
+| [List Page Shield scripts][3]     | `GET zones/{zone_id}/page_shield/scripts`              | Fetch a list of detected scripts.                     |
+| [Get a Page Shield script][4]     | `GET zones/{zone_id}/page_shield/scripts/{script_id}`  | Fetch the details of a script.                        |
+| [List Page Shield connections][5] | `GET zones/{zone_id}/page_shield/connections`          | Fetch a list of detected connections.                 |
+| [Get a Page Shield connection][6] | `GET zones/{zone_id}/page_shield/connections/{connection_id}` | Fetch the details of a connection.             |
+| [List Page Shield policies][7]    | `GET zones/{zone_id}/page_shield/policies`             | Fetch a list of all configured CSP policies.          |
+| [Get a Page Shield policy][8]     | `GET zones/{zone_id}/page_shield/policies/{policy_id}` | Fetch the details of a CSP policy.                    |
+| [Create a Page Shield policy][9]  | `POST zones/{zone_id}/page_shield/policies`            | Creates a CSP policy with the provided configuration. |
+| [Update a Page Shield policy][10] | `PUT zones/{zone_id}/page_shield/policies/{policy_id}` | Updates an existing CSP policy.                       |
+| [Delete a Page Shield policy][11] | `DELETE zones/{zone_id}/page_shield/policies/{policy_id}` | Deletes an existing CSP policy.                    |
 
-[1]: https://developers.cloudflare.com/api/operations/page-shield-get-page-shield-status
-[2]: https://developers.cloudflare.com/api/operations/page-shield-update-page-shield-status
-[3]: https://developers.cloudflare.com/api/operations/page-shield-list-page-shield-scripts
-[4]: https://developers.cloudflare.com/api/operations/page-shield-get-a-page-shield-script
-[5]: https://developers.cloudflare.com/api/operations/page-shield-list-page-shield-connections
-[6]: https://developers.cloudflare.com/api/operations/page-shield-get-a-page-shield-connection
+[1]: /api/operations/page-shield-get-page-shield-settings
+[2]: /api/operations/page-shield-update-page-shield-settings
+[3]: /api/operations/page-shield-list-page-shield-scripts
+[4]: /api/operations/page-shield-get-a-page-shield-script
+[5]: /api/operations/page-shield-list-page-shield-connections
+[6]: /api/operations/page-shield-get-a-page-shield-connection
+[7]: /api/operations/page-shield-list-page-shield-policies
+[8]: /api/operations/page-shield-get-a-page-shield-policy
+[9]: /api/operations/page-shield-create-a-page-shield-policy
+[10]: /api/operations/page-shield-update-a-page-shield-policy
+[11]: /api/operations/page-shield-delete-a-page-shield-policy
 
 ## API notes
 
@@ -61,16 +64,16 @@ The following table summarizes the available operations:
 
 ## Common API calls
 
-### Get Page Shield status
+### Get Page Shield settings
 
-This example obtains the current status of Page Shield (enabled/disabled).
+This example obtains the current settings of Page Shield, including the status (enabled/disabled).
 
 ```bash
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/page_shield" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/page_shield \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -80,7 +83,9 @@ header: Response
 {
   "result": {
     "enabled": true,
-    "updated_at": "2021-11-14T11:47:55.677555Z"
+    "updated_at": "2023-05-14T11:47:55.677555Z",
+    "use_cloudflare_reporting_endpoint": true,
+    "use_connection_url_path": false
   },
   "success": true,
   "errors": [],
@@ -96,11 +101,11 @@ This example enables Page Shield in the specified zone.
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/page_shield" \
--H "Authorization: Bearer <API_TOKEN>" \
--H "Content-Type: application/json" \
--d '{ "enabled": true }'
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/page_shield \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{ "enabled": true }'
 ```
 
 ```json
@@ -110,7 +115,7 @@ header: Response
 {
   "result": {
     "enabled": true,
-    "updated_at": "2021-11-14T11:50:41.756996Z"
+    "updated_at": "2023-05-14T11:50:41.756996Z"
   },
   "success": true,
   "errors": [],
@@ -118,9 +123,9 @@ header: Response
 }
 ```
 
-### Fetch list of monitored scripts
+### Fetch list of detected scripts
 
-This example fetches a list of scripts monitored by Page Shield on hostname `example.net`, requesting the first page with 15 items per page. The URL query string includes filtering and paging parameters.
+This example fetches a list of scripts detected by Page Shield on hostname `example.net`, requesting the first page with 15 items per page. The URL query string includes filtering and paging parameters.
 
 By default, the response will only include scripts with `active` status when you do not specify a `status` filter parameter in the URL query string.
 
@@ -128,8 +133,8 @@ By default, the response will only include scripts with `active` status when you
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/scripts?hosts=example.net&page=1&per_page=15" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/scripts?hosts=example.net&page=1&per_page=15 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -141,9 +146,9 @@ header: Response
     {
       "id": "8337233faec2357ff84465a919534e4d",
       "url": "https://malicious.example.com/badscript.js",
-      "added_at": "2021-11-18T10:51:10.09615Z",
-      "first_seen_at": "2021-11-18T10:51:08Z",
-      "last_seen_at": "2021-11-22T09:57:54Z",
+      "added_at": "2023-05-18T10:51:10.09615Z",
+      "first_seen_at": "2023-05-18T10:51:08Z",
+      "last_seen_at": "2023-05-22T09:57:54Z",
       "host": "example.net",
       "domain_reported_malicious": false,
       "url_reported_malicious": true,
@@ -155,7 +160,7 @@ header: Response
       "js_integrity_score": 10,
       "obfuscation_score": 10,
       "dataflow_score": 8,
-      "fetched_at": "2021-11-21T16:58:07Z"
+      "fetched_at": "2023-05-21T16:58:07Z"
     },
     // (...)
   ],
@@ -184,8 +189,8 @@ This example fetches a list of infrequently reported scripts on hostname `exampl
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/scripts?status=infrequent&hosts=example.net&page=1&per_page=15" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/scripts?status=infrequent&hosts=example.net&page=1&per_page=15 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -197,9 +202,9 @@ header: Response
     {
       "id": "83c8da2267394ce8465b74c299658fea",
       "url": "https://scripts.example.com/anotherbadscript.js",
-      "added_at": "2021-11-17T13:16:03.419619Z",
-      "first_seen_at": "2021-11-17T13:15:23Z",
-      "last_seen_at": "2021-11-18T09:05:20Z",
+      "added_at": "2023-05-17T13:16:03.419619Z",
+      "first_seen_at": "2023-05-17T13:15:23Z",
+      "last_seen_at": "2023-05-18T09:05:20Z",
       "host": "example.net",
       "domain_reported_malicious": false,
       "url_reported_malicious": false,
@@ -210,7 +215,7 @@ header: Response
       "js_integrity_score": 48,
       "obfuscation_score": 49,
       "dataflow_score": 45,
-      "fetched_at": "2021-11-18T03:58:07Z"
+      "fetched_at": "2023-05-18T03:58:07Z"
     },
     // (...)
   ],
@@ -231,16 +236,16 @@ Some fields displayed in the example response may not be available, depending on
 
 For details on the available filtering, paging, and sorting parameters, refer to the [API reference](/api/operations/page-shield-list-page-shield-scripts).
 
-### Get details of a monitored script
+### Get details of a detected script
 
-This example obtains the details of a script monitored by Page Shield with script ID `8337233faec2357ff84465a919534e4d`.
+This example obtains the details of a script detected by Page Shield with script ID `8337233faec2357ff84465a919534e4d`.
 
 ```bash
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/scripts/8337233faec2357ff84465a919534e4d" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/scripts/8337233faec2357ff84465a919534e4d \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -251,9 +256,9 @@ header: Response
   "result": {
     "id": "8337233faec2357ff84465a919534e4d",
     "url": "https://malicious.example.com/badscript.js",
-    "added_at": "2021-11-18T10:51:10.09615Z",
-    "first_seen_at": "2021-11-18T10:51:08Z",
-    "last_seen_at": "2021-11-22T09:57:54Z",
+    "added_at": "2023-05-18T10:51:10.09615Z",
+    "first_seen_at": "2023-05-18T10:51:08Z",
+    "last_seen_at": "2023-05-22T09:57:54Z",
     "host": "example.net",
     "domain_reported_malicious": false,
     "url_reported_malicious": true,
@@ -265,7 +270,7 @@ header: Response
     "js_integrity_score": 48,
     "obfuscation_score": 49,
     "dataflow_score": 45,
-    "fetched_at": "2021-11-21T16:58:07Z",
+    "fetched_at": "2023-05-21T16:58:07Z",
     "page_urls": [
       "http://malicious.example.com/page_two.html",
       "http://malicious.example.com/page_three.html",
@@ -275,7 +280,7 @@ header: Response
       {
         "hash": "9245aad577e846dd9b990b1b32425a3fae4aad8b8a28441a8b80084b6bb75a45",
         "js_integrity_score": 50,
-        "fetched_at": "2021-11-21T16:58:07Z"
+        "fetched_at": "2023-05-21T16:58:07Z"
       }
     ]
   },
@@ -287,9 +292,9 @@ header: Response
 
 Some fields displayed in the example response may not be available, depending on your Cloudflare plan.
 
-### Fetch list of monitored connections
+### Fetch list of detected connections
 
-This example fetches a list of connections monitored by Page Shield, requesting the first page with 15 items per page.
+This example fetches a list of connections detected by Page Shield, requesting the first page with 15 items per page.
 
 By default, the response will only include connections with `active` status when you do not specify a `status` filter parameter in the URL query string.
 
@@ -297,8 +302,8 @@ By default, the response will only include connections with `active` status when
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/connections?page=1&per_page=15" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/connections?page=1&per_page=15 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -339,16 +344,16 @@ header: Response
 
 For details on the available filtering, paging, and sorting parameters, refer to the [API reference](/api/operations/page-shield-list-page-shield-scripts).
 
-### Get details of a monitored connection
+### Get details of a detected connection
 
-This example obtains the details of a connection monitored by Page Shield with connection ID `0a7bb628776f4e50a50d8594c4a01740`.
+This example obtains the details of a connection detected by Page Shield with connection ID `0a7bb628776f4e50a50d8594c4a01740`.
 
 ```bash
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/connections/0a7bb628776f4e50a50d8594c4a01740" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/connections/0a7bb628776f4e50a50d8594c4a01740 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -402,9 +407,10 @@ Currently, you can only create Page Shield policies containing `script-src` dire
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/api/v4/zones/<ZONE_ID>/page_shield/policies" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl https://api.cloudflare.com/api/v4/zones/{zone_id}/page_shield/policies \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "description": "My first policy in log mode",
   "action": "log",
   "expression": "http.host eq myapp.example.com",

--- a/content/ruleset-engine/rulesets-api/endpoints.md
+++ b/content/ruleset-engine/rulesets-api/endpoints.md
@@ -36,7 +36,7 @@ The Rulesets API endpoints require a value for `<ACCOUNT_ID>` or `<ZONE_ID>`.
 
 To retrieve a list of accounts you have access to, use the [List Accounts](/api/operations/accounts-list-accounts) operation. Note the IDs of the accounts you want to manage.
 
-To retrieve a list of zones you have access to, use the [List Zones](/api/operations/zone-list-zones) operation. Note the IDs of the zones you want to manage.
+To retrieve a list of zones you have access to, use the [List Zones](/api/operations/zones-get) operation. Note the IDs of the zones you want to manage.
 
 {{</Aside>}}
 

--- a/content/tenant/get-started/index.md
+++ b/content/tenant/get-started/index.md
@@ -28,14 +28,14 @@ For more details on using the Cloudflare API, refer to our [API overview](/funda
 
 {{<tabs labels="Dashboard | API">}}
 {{<tab label="dashboard" no-code="true">}}
- 
+
 {{<render file="_create-account-dash.md">}}
- 
+
 {{</tab>}}
 {{<tab label="api" no-code="true">}}
- 
+
 {{<render file="_create-account-api.md">}}
- 
+
 {{</tab>}}
 {{</tabs>}}
 
@@ -65,9 +65,9 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CUSTOMER_ACCOUNT_ID
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
 -H 'x-auth-key: <API_KEY>' \
--d '{ 
-    "email": "<customer-email>", 
-    "roles": ["<user-role>"] 
+-d '{
+    "email": "<customer-email>",
+    "roles": ["<user-role>"]
     }'
 ```
 
@@ -97,8 +97,8 @@ curl -X POST 'https://api.cloudflare.com/client/v4/users' \
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
 -H 'x-auth-key: <API_KEY>' \
--d '{ 
-    "email": "<ID@youremaildomain.com>" 
+-d '{
+    "email": "<ID@youremaildomain.com>"
     }'
 ```
 
@@ -133,7 +133,7 @@ header: Response
 
 Now that you have a customer account and customer users (or service users), you need to create a zone.
 
-To do this, send a [`POST`](/api/operations/zone-create-zone) request to the `/zones` endpoint (including the customer account ID you received in [Step 1](#step-1---create-an-account)).
+To do this, send a [`POST`](/api/operations/zones-post) request to the `/zones` endpoint (including the customer account ID you received in [Step 1](#step-1---create-an-account)).
 
 ```bash
 ---

--- a/content/terraform/_partials/_find-ids-managed-rulesets.md
+++ b/content/terraform/_partials/_find-ids-managed-rulesets.md
@@ -8,6 +8,6 @@ _build:
 The Terraform configurations provided in this page need the zone ID (or account ID) of the zone/account where you will deploy the managed rulesets.
 
 * To retrieve the list of accounts you have access to, including their IDs, use the [List accounts](/api/operations/accounts-list-accounts) API operation.
-* To retrieve the list of zones you have access to, including their IDs, use the [List zones](/api/operations/zone-list-zones) API operation.
+* To retrieve the list of zones you have access to, including their IDs, use the [List zones](/api/operations/zones-get) API operation.
 
 The deployment of managed rulesets via Terraform requires that you use the ruleset IDs. To find the IDs of managed rulesets, use the [List account rulesets](/api/operations/listAccountRulesets) API operation. The response will include the description and IDs of existing managed rulesets.

--- a/content/terraform/_partials/_find-ids.md
+++ b/content/terraform/_partials/_find-ids.md
@@ -8,4 +8,4 @@ _build:
 The Terraform configurations provided in this page need the zone ID (or account ID) of the zone/account where you will deploy rulesets.
 
 * To retrieve the list of accounts you have access to, including their IDs, use the [List accounts](/api/operations/accounts-list-accounts) API operation.
-* To retrieve the list of zones you have access to, including their IDs, use the [List zones](/api/operations/zone-list-zones) API operation.
+* To retrieve the list of zones you have access to, including their IDs, use the [List zones](/api/operations/zones-get) API operation.


### PR DESCRIPTION
Partially addresses #9218.

Updates API links for:
* Page Shield operations
* Zone operations

Fixes the following broken links:
* https://developers.cloudflare.com/api/operations/zone-edit-zone
* https://developers.cloudflare.com/api/operations/zone-list-zones
* https://developers.cloudflare.com/api/operations/zone-create-zone
* https://developers.cloudflare.com/api/operations/page-shield-get-page-shield-status
* https://developers.cloudflare.com/api/operations/page-shield-update-page-shield-status