### PR TITLE
Remove airtable in workers docs

### DIFF
--- a/content/workers/learning/integrations/external-services.md
+++ b/content/workers/learning/integrations/external-services.md
@@ -7,21 +7,6 @@ title: External Services
 
 Many external services provide libraries and SDKs to interact with their APIs. While many Node-compatible libraries work on Workers right out of the box, some, which implement `fs`, `http/net`, or access the browser `window` do not directly translate to the Workers runtime, which is v8-based. 
 
-For a list of working packages, refer to [Works on Workers](https://workers.cloudflare.com/works).
-
-<iframe 
-    class="airtable-embed" 
-    src="https://airtable.com/embed/shrTR0QCusxZoCgiJ?backgroundColor=yellow&viewControls=on" 
-    frameborder="0" 
-    width="100%" 
-    height="800" 
-    style="background:transparent;border:1px solid #ccc"
-    allowFullScreen></iframe>
-
-{{<Aside type="note">}}
-If you do not see an integration listed or have an integration to add, complete and submit the [Cloudflare Developer Platform Integration form](https://forms.gle/iaUqLWE8aezSEhgd6) or [submit a package directly through Airtable](https://airtable.com/shrtvoM4QfEr48ZoQ).
-{{</Aside>}}
-
 ## Authentication
 
 If your service requires authentication, use Wrangler secrets to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:


### PR DESCRIPTION
Removes the airtable table in our external integrations page, as we've deprecated that form/embed and no longer use it on the Workers marketing site either