### PR TITLE
Fix typo in Errors section of `/d1/platform/client-api`

### DIFF
--- a/content/d1/platform/client-api.md
+++ b/content/d1/platform/client-api.md
@@ -382,7 +382,7 @@ new Error("D1_ERROR", { cause: new Error("Error detail") })
 To capture exceptions:
 ```js
 try {
-    await db.exec("INSERTZ INTO my_table (name, employees) VALUES ()");
+    await db.exec("INSERT INTO my_table (name, employees) VALUES ()");
 } catch (e: any) {
     console.log({
         message: e.message,


### PR DESCRIPTION
Fixes a *very* small typo in the SQL code at https://developers.cloudflare.com/d1/platform/client-api/#errors.