### PR TITLE
[Durable Objects - Workers] Add Hibernation API to changelog; add note

### DIFF
--- a/content/workers/platform/changelog.md
+++ b/content/workers/platform/changelog.md
@@ -8,6 +8,10 @@ rss: file
 
 # Changelog
 
+## 2023-05-26
+
+- A new [Hibernation API](/workers/runtime-apis/durable-objects/#websockets-hibernation-api) (beta) has been added to [Durable Objects](/workers/learning/using-durable-objects/). The Hibernation API allows a Durable Object that is not currently running an event handler (for example: processing a WebSocket message or alarm) to be removed from memory while keeping its WebSockets connected (“hibernation”). A Durable Object that hibernates will not incur billable Duration (GB-sec) charges. 
+
 ## 2023-05-16
 
 - The [new `connect()` method](/workers/runtime-apis/tcp-sockets/) allows you to connect to any TCP-speaking services directly from your Workers. To learn more about other protocols supported on the Workers platform, visit the [new Protocols documentation](/workers/platform/protocols/).

--- a/content/workers/platform/changelog.md
+++ b/content/workers/platform/changelog.md
@@ -10,7 +10,7 @@ rss: file
 
 ## 2023-05-26
 
-- A new [Hibernation API](/workers/runtime-apis/durable-objects/#websockets-hibernation-api) (beta) has been added to [Durable Objects](/workers/learning/using-durable-objects/). The Hibernation API allows a Durable Object that is not currently running an event handler (for example: processing a WebSocket message or alarm) to be removed from memory while keeping its WebSockets connected (“hibernation”). A Durable Object that hibernates will not incur billable Duration (GB-sec) charges. 
+- A new [Hibernation API](/workers/runtime-apis/durable-objects/#websockets-hibernation-api) (beta) has been added to [Durable Objects](/workers/learning/using-durable-objects/). The Hibernation API allows a Durable Object that is not currently running an event handler (for example, processing a WebSocket message or alarm) to be removed from memory while keeping its WebSockets connected (“hibernation”). A Durable Object that hibernates will not incur billable Duration (GB-sec) charges. 
 
 ## 2023-05-16
 

--- a/content/workers/runtime-apis/durable-objects.md
+++ b/content/workers/runtime-apis/durable-objects.md
@@ -363,7 +363,7 @@ If the method fails with an uncaught exception, the exception will be thrown int
 
 Durable Objects WebSockets support includes Cloudflare-specific extensions to the standard WebSocket interface, related methods on the `state` object, and handler methods that a Durable Object can implement for processing WebSocket events.
 
-The Hibernation APIs allow a Durable Object that is not currently running an event handler, such as handling a WebSocket message, HTTP request, or [alarm](/workers/learning/using-durable-objects/#alarms-in-durable-objects), to be removed from memory while keeping its WebSockets connected ("hibernation").
+The Hibernation API allows a Durable Object that is not currently running an event handler, such as handling a WebSocket message, HTTP request, or [alarm](/workers/learning/using-durable-objects/#alarms-in-durable-objects), to be removed from memory while keeping its WebSockets connected ("hibernation").
 
 {{ <Aside type="note"> }}
 
@@ -390,7 +390,7 @@ If an event occurs for a hibernated Durable Object's corresponding handler metho
 
 - {{<code>}}state.acceptWebSocket(ws{{<param-type>}}WebSocket{{</param-type>}}, tags{{<param-type>}}Array\<string>{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}){{</code>}} : {{<type>}}void{{</type>}}
 
-  - Adds a WebSocket to the set attached to this object. `ws.accept()` must NOT have been called separately. Once called, any incoming messages will be delivered by calling the Durable Object's `webSocketMessage()` handler, and `webSocketClose()` will be invoked upon disconnect. After calling this, the WebSocket is accepted, so its `send()` and `close()` methods can be used to send messages, but its `addEventListener()` method won't ever receive any events as they'll be delivered to the Durable Object instead. `tags` are optional string tags which can be used to look up the WebSocket with `getWebSockets()`. Each tag is limited to 256 characters, and each WebSocket is limited to 10 tags associated with it.
+  - Adds a WebSocket to the set attached to this object. `ws.accept()` must NOT have been called separately. Once called, any incoming messages will be delivered by calling the Durable Object's `webSocketMessage()` handler, and `webSocketClose()` will be invoked upon disconnect. After calling this, the WebSocket is accepted, so its `send()` and `close()` methods can be used to send messages. Its `addEventListener()` method won't ever receive any events as they'll be delivered to the Durable Object instead. `tags` are optional string tags which can be used to look up the WebSocket with `getWebSockets()`. Each tag is limited to 256 characters, and each WebSocket is limited to 10 tags associated with it.
   - This API has a maximum of 32,768 WebSockets connected per Durable Object instance, but the CPU and memory usage of a given workload may further limit the practical number of simultaneous connections. 
 
 - {{<code>}}state.getWebSockets(tag{{<param-type>}}string{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}){{</code>}} : {{<type>}}Array\<WebSocket>{{</type>}}

--- a/content/workers/runtime-apis/durable-objects.md
+++ b/content/workers/runtime-apis/durable-objects.md
@@ -359,9 +359,17 @@ The method takes a [`Request`](/workers/runtime-apis/request/) as the parameter 
 
 If the method fails with an uncaught exception, the exception will be thrown into the calling Worker that made the `fetch()` request.
 
-### WebSockets Hibernation API (beta)
+### {{<beta>}} WebSockets Hibernation API {{</beta>}}
 
-Durable Objects WebSockets support includes Cloudflare-specific extensions to the standard WebSocket interface, related methods on the `state` object, and handler methods that a Durable Object can implement for processing WebSocket events. These APIs allow a Durable Object that is not currently running an event handler to be removed from memory while keeping its WebSockets connected ("hibernation").
+Durable Objects WebSockets support includes Cloudflare-specific extensions to the standard WebSocket interface, related methods on the `state` object, and handler methods that a Durable Object can implement for processing WebSocket events.
+
+The Hibernation APIs allow a Durable Object that is not currently running an event handler, such as handling a WebSocket message, HTTP request, or [alarm](/workers/learning/using-durable-objects/#alarms-in-durable-objects), to be removed from memory while keeping its WebSockets connected ("hibernation").
+
+{{ <Aside type="note"> }}
+
+A Durable Object that hibernates will not incur billable [Duration (GB-sec) charges](/workers/platform/pricing/#durable-objects). For applications with many long-lived Durable Objects and periodic WebSocket messages or events, using the Hibernation APIs can measurably reduce billable duration.
+
+{{ </Aside> }}
 
 If an event occurs for a hibernated Durable Object's corresponding handler method, it will return to memory. This will call the Durable Object's constructor, so it is best to minimize work in the constructor when using WebSocket hibernation.
 
@@ -371,7 +379,8 @@ If an event occurs for a hibernated Durable Object's corresponding handler metho
 
 - {{<code>}}webSocket.serializeAttachment(value{{<param-type>}}any{{</param-type>}}){{</code>}} : {{<type>}}void{{</type>}}
 
-  - Keeps a copy of `value` in memory (not on disk) such that it will survive hibernation. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. If you modify `value` after calling this method, those changes will not be retained unless you call this method again. The serialized size of `value` is limited to 2048 bytes, otherwise this method will throw an error. If you need larger values to survive hibernation, use the [storage api](/workers/runtime-apis/durable-objects/#transactional-storage-api) and pass the corresponding key to this method so it can be retrieved later.
+  - Keeps a copy of `value` in memory (not on disk) such that it will survive hibernation. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types.
+  - If you modify `value` after calling this method, those changes will not be retained unless you call this method again. The serialized size of `value` is limited to 2048 bytes, otherwise this method will throw an error. If you need larger values to survive hibernation, use the [storage api](/workers/runtime-apis/durable-objects/#transactional-storage-api) and pass the corresponding key to this method so it can be retrieved later.
 
 - {{<code>}}webSocket.deserializeAttachment(){{</code>}} : {{<type>}}any{{</type>}}
 
@@ -381,7 +390,8 @@ If an event occurs for a hibernated Durable Object's corresponding handler metho
 
 - {{<code>}}state.acceptWebSocket(ws{{<param-type>}}WebSocket{{</param-type>}}, tags{{<param-type>}}Array\<string>{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}){{</code>}} : {{<type>}}void{{</type>}}
 
-  - Adds a WebSocket to the set attached to this object. `ws.accept()` must NOT have been called separately. Once called, any incoming messages will be delivered by calling the Durable Object's `webSocketMessage()` handler, and `webSocketClose()` will be invoked upon disconnect. After calling this, the WebSocket is accepted, so its `send()` and `close()` methods can be used to send messages, but its `addEventListener()` method won't ever receive any events as they'll be delivered to the Durable Object instead. `tags` are optional string tags which can be used to look up the WebSocket with `getWebSockets()`. Each tag is limited to 256 characters, and each WebSocket is limited to 10 tags associated with it. This API has a maximum of 32,768 WebSockets connected per Durable Object instance, but the cpu and memory usage of a given workload may further limit the practical number of simultaneous connections. 
+  - Adds a WebSocket to the set attached to this object. `ws.accept()` must NOT have been called separately. Once called, any incoming messages will be delivered by calling the Durable Object's `webSocketMessage()` handler, and `webSocketClose()` will be invoked upon disconnect. After calling this, the WebSocket is accepted, so its `send()` and `close()` methods can be used to send messages, but its `addEventListener()` method won't ever receive any events as they'll be delivered to the Durable Object instead. `tags` are optional string tags which can be used to look up the WebSocket with `getWebSockets()`. Each tag is limited to 256 characters, and each WebSocket is limited to 10 tags associated with it.
+  - This API has a maximum of 32,768 WebSockets connected per Durable Object instance, but the CPU and memory usage of a given workload may further limit the practical number of simultaneous connections. 
 
 - {{<code>}}state.getWebSockets(tag{{<param-type>}}string{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}){{</code>}} : {{<type>}}Array\<WebSocket>{{</type>}}
 


### PR DESCRIPTION
This PR:

* Adds the new Hibernation API to the changelog
* Clarifies "why" a user should consider the Hibernation API (i.e. can reduce billable duration charges)
* Some formatting fixes for readability.