### PR TITLE
Fix typo in AsyncLocalStorage docs

### DIFF
--- a/content/workers/runtime-apis/nodejs/asynclocalstorage.md
+++ b/content/workers/runtime-apis/nodejs/asynclocalstorage.md
@@ -33,7 +33,7 @@ const asyncLocalStorage = new AsyncLocalStorage();
 
 - `getStore()` : {{<type>}}any{{</type>}}
 
-  - Returns the current stored. If called outside of an asynchronous context initialized by calling `asyncLocalStorage.run()`, it returns `undefined`.
+  - Returns the current store. If called outside of an asynchronous context initialized by calling `asyncLocalStorage.run()`, it returns `undefined`.
 
 - {{<code>}}run(store{{<param-type>}}any{{</param-type>}}, callback{{<param-type>}}function{{</param-type>}}, ...args{{<param-type>}}arguments{{</param-type>}}){{</code>}} : {{<type>}}any{{</type>}}
 


### PR DESCRIPTION
I feel a little silly making a PR for just one insignificant typo, but I ran across it while reading the docs for other purposes and figure we're better off fixing it.