### PR TITLE
[r2] Change Get started link to S3-Compatibility

### DIFF
--- a/content/r2/get-started.md
+++ b/content/r2/get-started.md
@@ -62,5 +62,5 @@ You will receive a confirmation message after a successful upload.
 Cloudflare provides multiple ways for developers to access their R2 buckets:
 
 - [Workers Runtime API](/r2/api/workers/workers-api-usage/)
-- [S3 API compatibility](/r2/api/s3/tokens/)
+- [S3 API compatibility](/r2/api/s3/api/)
 - [Public buckets](/r2/buckets/public-buckets/)


### PR DESCRIPTION
The **S3 API compatibility** link on the [R2 Get Started](https://developers.cloudflare.com/r2/get-started/) page currently points to **Generate an S3 auth token**. This PR points it back to [https://developers.cloudflare.com/r2/api/s3/api/](https://developers.cloudflare.com/r2/api/s3/api/).