### PR TITLE
Remove reference to end-to-end encryption.

### DIFF
--- a/content/fundamentals/glossary.md
+++ b/content/fundamentals/glossary.md
@@ -260,7 +260,7 @@ The amount of data transferred from the origin server to Cloudflare within a cer
 
 ## Origin Certificate
 
-A Cloudflare Origin Certificate is a free TLS certificate issued by Cloudflare that can be installed on your origin server to facilitate end-to-end encryption for your visitors using HTTPS.
+A Cloudflare Origin Certificate is a free TLS certificate issued by Cloudflare that can be installed on your origin server to facilitate making sure your data is encrypted in transit from Cloudflare to your origin server using HTTPS.
 
 **Related terms:** TLS
 **Relevant links:** [Cloudflare Origin Certificates](/ssl/origin-configuration/origin-ca/)


### PR DESCRIPTION
Origin certs don't provide end-to-end encryption, they provide hop-by-hop encryption / encryption in transit.