### PR TITLE
Add Full SSL/TLS encryption requirement to gRPC support article

### DIFF
--- a/content/support/Network/Understanding Cloudflare gRPC support.md
+++ b/content/support/Network/Understanding Cloudflare gRPC support.md
@@ -39,7 +39,7 @@ ___
 Follow the instructions below to enable gRPC:
 
 {{<Aside type="note">}}
-Make sure that the hostname that hosts your gRPC endpoint is set to [proxied (orange-cloud)](/dns/manage-dns-records/reference/proxied-dns-records/) and that you use at least the [Full SSL/TLS encryption mode](/ssl/origin-configuration/ssl-modes/).
+Make sure that the hostname that hosts your gRPC endpoint is set to [proxied (orange-cloud)](/dns/manage-dns-records/reference/proxied-dns-records/) and that you use at least the [Full SSL/TLS encryption mode](/ssl/origin-configuration/ssl-modes/full/).
 {{</Aside>}}
 
 1.  Log in to your Cloudflare account.

--- a/content/support/Network/Understanding Cloudflare gRPC support.md
+++ b/content/support/Network/Understanding Cloudflare gRPC support.md
@@ -44,6 +44,10 @@ domain](https://support.cloudflare.com/hc/articles/200169626) that hosts
 your gRPC endpoint.
 {{</Aside>}}
 
+{{<Aside type="note">}}
+[Full SSL/TLS encryption mode for domain](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca#3-change-ssltls-mode) that hosts your gRPC endpoint.
+{{</Aside>}}
+
 1.  Log in to your Cloudflare account.
 2.  Select the appropriate domain.
 3.  Click the **Network** app.

--- a/content/support/Network/Understanding Cloudflare gRPC support.md
+++ b/content/support/Network/Understanding Cloudflare gRPC support.md
@@ -39,13 +39,7 @@ ___
 Follow the instructions below to enable gRPC:
 
 {{<Aside type="note">}}
-[Orange-cloud the
-domain](https://support.cloudflare.com/hc/articles/200169626) that hosts
-your gRPC endpoint.
-{{</Aside>}}
-
-{{<Aside type="note">}}
-[Full SSL/TLS encryption mode for domain](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca#3-change-ssltls-mode) that hosts your gRPC endpoint.
+Make sure that the hostname that hosts your gRPC endpoint is set to [proxied (orange-cloud)](/dns/manage-dns-records/reference/proxied-dns-records/) and that you use at least the [Full SSL/TLS encryption mode](/ssl/origin-configuration/ssl-modes/).
 {{</Aside>}}
 
 1.  Log in to your Cloudflare account.


### PR DESCRIPTION
Added missing info about needed Full SSL/TLS encryption requirement for gRPC in Proxy mode.