### PR TITLE
[ZT] chore(): Replace the custom response with FastAPI response

### DIFF
--- a/content/cloudflare-one/tutorials/fastapi.md
+++ b/content/cloudflare-one/tutorials/fastapi.md
@@ -77,9 +77,9 @@ def verify_token(request):
             valid_token = True
             break
         except:
-            return responses.return_403("Error decoding token")
+            raise HTTPException(status_code=400, detail="Error decoding token")
     if not valid_token:
-        return responses.return_403("Invalid token")
+        raise HTTPException(status_code=400, detail="Invalid token")
 
     return True
 


### PR DESCRIPTION
I forgot to change this in the PR #9330 created by me. This return statement won't work for people without a custom return package, so I have changed it to the default exception handler.