### PR TITLE
[Pages] Update Pages Queue bindings in bindings.md

### DIFF
--- a/content/pages/platform/functions/bindings.md
+++ b/content/pages/platform/functions/bindings.md
@@ -265,7 +265,7 @@ Below is an example of how to use Queue Producers in your Function. In this exam
 {{<tab label="js" default="true">}}
 ```js
 export async function onRequest(context) {
-  await env.MY_QUEUE.send({
+  await context.env.MY_QUEUE.send({
     url: request.url,
     method: request.method,
     headers: Object.fromEntries(request.headers),
@@ -278,11 +278,11 @@ export async function onRequest(context) {
 {{<tab label="ts">}}
 ```ts
 interface Env {
-  MY_QUEUE: Queue;
+  MY_QUEUE: Queue<any>;
 }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
-  await env.MY_QUEUE.send({
+  await context.env.MY_QUEUE.send({
     url: request.url,
     method: request.method,
     headers: Object.fromEntries(request.headers),


### PR DESCRIPTION
This PR updates the Queue bindings to use `context.env` instead of the nonexisting `env` variable, and correctly types the Queue as the generic `Queue<T>` in the TypeScript example.