### PR TITLE
[GH actions] Continue on error

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -20,7 +20,9 @@ jobs:
           node-version: 18.1
 
       - name: Install Dependencies
-        run: npm install @actions/core @actions/github
+        run: |
+          npm init -y
+          npm install @actions/core @actions/github
 
       - name: Add product labels
         env:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18.1
 
       - name: Install Dependencies
-        run: npm install --ignore-scripts @actions/core @actions/github
+        run: npm install @actions/core @actions/github
 
       - name: Add product labels
         env:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -20,9 +20,7 @@ jobs:
           node-version: 18.1
 
       - name: Install Dependencies
-        run: |
-          npm init -y
-          npm install @actions/core @actions/github
+        run: npm install --ignore-scripts @actions/core @actions/github
 
       - name: Add product labels
         env:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   label_prs:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
 
     steps:
       - name: Checkout Repository
@@ -29,6 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/workflow-scripts/label-products.js
+        continue-on-error: true
 
       - name: Add PR size
         env:
@@ -43,6 +41,7 @@ jobs:
           l_max_size: '1000'
           xl_label: 'size/xl'
         run: node .github/workflow-scripts/label-pr-size.js
+        continue-on-error: true
 
   spell-check:
     runs-on: ubuntu-latest
@@ -77,6 +76,5 @@ jobs:
         id: codespell
         uses: codespell-project/actions-codespell@v1
         with:
-          check_filenames: true
           skip: nothing
           path: ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
Current permissions don't let our `PR_helper` check apply labels on all PRs. This is trying to add in an option to fail gracefully.