### PR TITLE
[Workers] Add Strict Compression, Strict Crypto compatibility flags

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/strict-compression.md
+++ b/content/workers/_partials/_platform-compatibility-dates/strict-compression.md
@@ -1,0 +1,16 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Strict compression error checking"
+# sort date incremented by 1, noCfBotManagementDefault has the same
+# compatibility date but was added first.
+sort_date: "2023-08-02"
+enable_date: "2023-08-01"
+enable_flag: "strict_compression_checks"
+disable_flag: "no_strict_compression_checks"
+---
+
+Perform additional error checking in the Web Compression API and throw an error if a `DecompressionStream` has trailing data or gets closed before the full compressed data has been provided.

--- a/content/workers/_partials/_platform-compatibility-dates/strict-compression.md
+++ b/content/workers/_partials/_platform-compatibility-dates/strict-compression.md
@@ -13,4 +13,4 @@ enable_flag: "strict_compression_checks"
 disable_flag: "no_strict_compression_checks"
 ---
 
-Perform additional error checking in the Web Compression API and throw an error if a `DecompressionStream` has trailing data or gets closed before the full compressed data has been provided.
+Perform additional error checking in the Compression Streams API and throw an error if a `DecompressionStream` has trailing data or gets closed before the full compressed data has been provided.

--- a/content/workers/_partials/_platform-compatibility-dates/strict-crypto.md
+++ b/content/workers/_partials/_platform-compatibility-dates/strict-crypto.md
@@ -1,0 +1,20 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Strict crypto error checking"
+# sort date increased by 2, noCfBotManagementDefault and strictCompression have
+# the same compatibility date but was added earlier.
+sort_date: "2023-08-03"
+enable_date: "2023-08-01"
+enable_flag: "strict_crypto_checks"
+disable_flag: "no_strict_crypto_checks"
+---
+
+Perform additional error checking in the Web Crypto API to conform with the specification and reject possibly unsafe key parameters:
+- For RSA key generation, key sizes are required to be multiples of 128 bits as boringssl may otherwise truncate the key.
+- The size of imported RSA keys must be at least 256 bits and at most 16384 bits, as with newly generated keys.
+- The public exponent for imported RSA keys is restricted to the commonly used values `[3, 17, 37, 65537]`.
+- In conformance with the specification, an error will be thrown when trying to import a public ECDH key with non-empty usages.

--- a/content/workers/platform/changelog.md
+++ b/content/workers/platform/changelog.md
@@ -13,7 +13,7 @@ rss: file
 - `AbortSignal.any()` is now available.
 - Updated V8 to 11.4.
 - The `URLSearchParams` class' `delete()` and `has()` methods now accept an optional second argument to specify the search parameter’s value. This is potentially a breaking change so is gated behind the new `urlsearchparams_delete_has_value_arg` and `url_standard` compatibility flags.
-- Added compatibility flag `strict_compression_checks` for additional `DecompressionStream` error checking.
+- Added compatibility flag [`strict_compression_checks`](/workers/platform/compatibility-dates/#strict-compression-error-checking) for additional `DecompressionStream` error checking.
 
 ## 2023-05-26
 


### PR DESCRIPTION
Add the new `strictCompression`compatibility flag, implemented in https://github.com/cloudflare/workerd/commit/4460d51f5fa9c5b4d73833508d3b91f4cd1b5eb4#diff-c7fa8ca455dd055174097625258de733986b4df090ed5e56b260ff2ed9b71b9a

It might be useful to get https://github.com/cloudflare/cloudflare-docs/pull/9244 in first as the flag added in that PR was added first and a comment refers to it. I am working on some more compat flag changes, but wanted to get this one in first.