### PR TITLE
[ZT] Remove ZT 'Dashboard' and update links

### DIFF
--- a/content/cloudflare-one/_partials/gateway/_debugging-policies.md
+++ b/content/cloudflare-one/_partials/gateway/_debugging-policies.md
@@ -5,6 +5,6 @@ _build:
   list: never
 ---
 
-1. In the Zero Trust dashboard, go to **Gateway** > **Firewall policies**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Gateway** > **Firewall policies**.
 2. Disable all DNS, Network, and HTTP policies and see if the issue persists. It may take up to two minutes for the change to take effect. Note that all policy enforcement happens on the Cloudflare global network, not on your local device.
 3. Slowly re-enable your policies. Once you have narrowed down the issue, modify the policies or their [order of enforcement](/cloudflare-one/policies/filtering/order-of-enforcement/).

--- a/content/cloudflare-one/applications/scan-apps/casb-dlp.md
+++ b/content/cloudflare-one/applications/scan-apps/casb-dlp.md
@@ -24,7 +24,7 @@ Refer to the [DLP documentation](/cloudflare-one/policies/data-loss-prevention/d
 
 ### Add a new integration
 
-1. In the [Zero Trust dashboard](https://one.dash.cloudflare.com/), go to **CASB** > **Integrations**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **CASB** > **Integrations**.
 2. Select **Add integration** and choose a [supported integration](#supported-integrations).
 3. During the setup process, you will be prompted to select DLP profiles for the integration.
 4. Select **Save integration**.
@@ -33,7 +33,7 @@ CASB will scan every publicly accessible file in the integration for text that m
 
 ### Modify an existing integration
 
-1. In the [Zero Trust dashboard](https://dash.teams.cloudflare.com), go to **CASB** > **Integrations**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **CASB** > **Integrations**.
 2. Choose a [supported integration](#supported-integrations) and select **Configure**.
 3. Under **DLP profiles**, select the profiles that you want the integration to scan for.
 4. Select **Save integration**.
@@ -55,6 +55,7 @@ In order to scan historical data, you must enable the DLP profile during the [in
 ## Limitations
 
 DLP will only scan:
+
 - Files that are visible to anyone on the Internet.
 - [Text-based files](/cloudflare-one/policies/data-loss-prevention/#supported-file-types) such as documents, spreadsheets, and PDFs. Images are not supported.
 - Files ≤ 100 MB.

--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/common-issues.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/common-issues.md
@@ -21,14 +21,14 @@ If WARP is stuck in the `Disconnected` state or frequently changes between `Conn
 In your [WARP debug logs](/cloudflare-one/connections/connect-devices/warp/troubleshooting/warp-logs), `daemon.log` will typically show one or more of the following errors:
 
 - Happy Eyeball checks failing:
-    ```txt
-    ERROR main_loop: warp::warp::happy_eyeballs: Happy eyeballs error Custom { kind: NotConnected, error: "All Happy Eyeballs checks failed" }
-    ```
+  ```txt
+  ERROR main_loop: warp::warp::happy_eyeballs: Happy eyeballs error Custom { kind: NotConnected, error: "All Happy Eyeballs checks failed" }
+  ```
 - Many other checks timing out:
-    ```txt
-    ERROR warp::warp::connectivity_check: DNS check failed error=ResolveError { kind: Timeout }
-    WARN warp::warp::connectivity_check: Tunnel trace failed request::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("connectivity.cloudflareclient.com")), port: None, path: "/cdn-cgi/trace", query: None, fragment: None }, source: TimedOut }
-    ```
+  ```txt
+  ERROR warp::warp::connectivity_check: DNS check failed error=ResolveError { kind: Timeout }
+  WARN warp::warp::connectivity_check: Tunnel trace failed request::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("connectivity.cloudflareclient.com")), port: None, path: "/cdn-cgi/trace", query: None, fragment: None }, source: TimedOut }
+  ```
 
 Here are the most common reasons why this issue occurs:
 
@@ -45,37 +45,39 @@ Configure the third-party service to exempt the [IP addresses required by WARP](
 The most common places we see interference with WARP from VPNs are:
 
 - **Control of traffic routing:** In `daemon.log`, you will see a large number of routing table changes. For example,
-    ```txt
-    DEBUG warp::warp_service: Routes changed:
-        Added; Interface: 8; Destination: 10.133.27.201/32; Next hop: 100.64.0.2;
-        Added; Interface: 8; Destination: 10.133.27.202/32; Next hop: 100.64.0.2;
-    DEBUG warp::warp_service: Routes changed:
-        Added; Interface: 8; Destination: 10.133.27.203/32; Next hop: 100.64.0.2;
-        Added; Interface: 8; Destination: 10.133.27.204/32; Next hop: 100.64.0.2;
-    DEBUG warp::warp_service: Routes changed:
-        Added; Interface: 8; Destination: 10.133.27.205/32; Next hop: 100.64.0.2;
-    ```
-    This indicates that a third-party VPN is fighting WARP for control over the routing table.
+
+  ```txt
+  DEBUG warp::warp_service: Routes changed:
+      Added; Interface: 8; Destination: 10.133.27.201/32; Next hop: 100.64.0.2;
+      Added; Interface: 8; Destination: 10.133.27.202/32; Next hop: 100.64.0.2;
+  DEBUG warp::warp_service: Routes changed:
+      Added; Interface: 8; Destination: 10.133.27.203/32; Next hop: 100.64.0.2;
+      Added; Interface: 8; Destination: 10.133.27.204/32; Next hop: 100.64.0.2;
+  DEBUG warp::warp_service: Routes changed:
+      Added; Interface: 8; Destination: 10.133.27.205/32; Next hop: 100.64.0.2;
+  ```
+
+  This indicates that a third-party VPN is fighting WARP for control over the routing table.
 
 - **Control of DNS:** In `daemon.log`, you will see a large number of DNS changes followed by this warning:
 
-    ```txt
-    WARN main_loop: warp::warp_service: Reinforcing DNS settings. Is something else fighting us?
-    ```
+  ```txt
+  WARN main_loop: warp::warp_service: Reinforcing DNS settings. Is something else fighting us?
+  ```
 
-    The daemon may also note that some other process has already bound to the UDP and TCP sockets:
+  The daemon may also note that some other process has already bound to the UDP and TCP sockets:
 
-    ```txt
-    WARN warp::warp: Unable to bind local UDP socket error=Os { code: 48, kind: AddrInUse, message: "Address already in use" } sockaddr=127.0.2.2:53
-    WARN warp::warp: Unable to bind local TCP socket error=Os { code: 48, kind: AddrInUse, message: "Address already in use" } sockaddr=127.0.2.2:53
-    ```
+  ```txt
+  WARN warp::warp: Unable to bind local UDP socket error=Os { code: 48, kind: AddrInUse, message: "Address already in use" } sockaddr=127.0.2.2:53
+  WARN warp::warp: Unable to bind local TCP socket error=Os { code: 48, kind: AddrInUse, message: "Address already in use" } sockaddr=127.0.2.2:53
+  ```
 
 To confirm that the VPN is the source of the issue, temporarily uninstall (not disable or disconnect) the VPN.
 
 #### Solution
 
 1. Disable all DNS enforcement on the VPN. WARP must be the last client to touch the primary and secondary DNS server on the default interface.
-2. On the Zero Trust dashboard, create a [Split Tunnel rule](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) to exclude the VPN server you are connecting to (for example, `vpnserver.3rdpartyvpn.example.com`).
+2. In [Zero Trust](https://one.dash.cloudflare.com/), create a [Split Tunnel rule](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) to exclude the VPN server you are connecting to (for example, `vpnserver.3rdpartyvpn.example.com`).
 3. Configure your VPN to only include routes to your internal resources. Make sure that the VPN routes do not overlap with the routes [included in the WARP tunnel](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/).
 
 For more information, refer to our [guide](/cloudflare-one/connections/connect-devices/warp/deployment/vpn/) for running VPNs alongside the WARP client.
@@ -171,5 +173,5 @@ Some applications require traffic to flow either all inside or all outside of th
 #### Solution
 
 1. Determine the IP addresses and/or domains required for your application to function. Common Internet search terms include `<app-name> split tunnel list`, `<app-name> allow list`, or `<app-name> firewall ips`.
-2. In the Zero Trust dashboard, go to your [Split Tunnel settings](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/).
+2. In [Zero Trust](https://one.dash.cloudflare.com/), go to your [Split Tunnel settings](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/).
 3. Depending on the application, either include or exclude all of the necessary IPs and/or domains. For Microsoft applications, we provide a [one-click action](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#directly-route-office-365-traffic) to exclude all Office 365 IPs.

--- a/content/cloudflare-one/policies/data-loss-prevention/dlp-policies/_index.md
+++ b/content/cloudflare-one/policies/data-loss-prevention/dlp-policies/_index.md
@@ -60,11 +60,11 @@ Different sites will send requests in different ways. For example, some sites wi
 
 ## 4. View DLP logs
 
-1. In the [Zero Trust dashboard](https://dash.teams.cloudflare.com), go to **Logs** > **Gateway** > **HTTP**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Logs** > **Gateway** > **HTTP**.
 2. Select **Filter**.
 3. Choose an item under one of the following filters:
-    * **DLP Profiles** shows the requests which matched a specific DLP profile.
-    * **Policy** shows the requests which matched a specific DLP policy.
+   - **DLP Profiles** shows the requests which matched a specific DLP profile.
+   - **Policy** shows the requests which matched a specific DLP policy.
 
 You can expand an individual row to view details about the request. To see the data that triggered the DLP policy, [configure payload logging](/cloudflare-one/policies/data-loss-prevention/dlp-policies/payload-logging/).
 

--- a/content/cloudflare-one/policies/data-loss-prevention/dlp-profiles/_index.md
+++ b/content/cloudflare-one/policies/data-loss-prevention/dlp-profiles/_index.md
@@ -11,7 +11,7 @@ A DLP profile is a collection of regular expressions (also known as detection en
 
 ## Configure a predefined profile
 
-1. In the [Zero Trust dashboard](https://dash.teams.cloudflare.com), go to **DLP** > **DLP Profiles**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **DLP** > **DLP Profiles**.
 2. Choose a [predefined profile](/cloudflare-one/policies/data-loss-prevention/dlp-profiles/predefined-profiles/) and select **Configure**.
 3. Enable one or more **Detection entries** according to your preferences. The DLP Profile matches using the OR logical operator — if multiple entries are enabled, your data needs to match only one of the entries.
 4. Select **Save profile**.
@@ -25,7 +25,7 @@ You can now use this profile in a [DLP policy](/cloudflare-one/policies/data-los
 3. Enter a name and optional description for the profile.
 4. Add custom or existing detection entries.
 
-    {{<render file="_dlp-entries.md">}}
+   {{<render file="_dlp-entries.md">}}
 
 5. (Optional) Configure [**Advanced settings**](/cloudflare-one/policies/data-loss-prevention/dlp-profiles/advanced-settings/) for the profile.
 6. Select **Save profile**.


### PR DESCRIPTION
Removes remaining instances of "Zero Trust dashboard" (where applicable) and 
updates the link from `dash.teams` to `one.dash`.
