### PR TITLE
[Chore] Added more metadata properties for reporting scraping

### DIFF
--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -75,6 +75,12 @@
   <meta name="twitter:description" content="{{ $description }}" />
   <meta name="twitter:card" content="summary_large_image" />
 
+  <!-- Add metadata for reporting -->
+  <meta name="pcx_word_count" content="{{- $.Context.FuzzyWordCount -}}">
+  <meta name="pcx_last_modified" content="{{- $.Context.Lastmod.Format "2006-01-02" -}}">
+  {{- with .Context.Params.last_reviewed -}}
+  <meta name="pcx_last_reviewed" content="{{ .Format "2006-01-02" }}" />
+  {{- end -}}
   {{- with .Context.Params.pcx_content_type -}}
   <meta name="pcx_content_type" content="{{ . }}" />
   {{- end -}}


### PR DESCRIPTION
Adds the following metadata properties:
- `pcx_word_count`
- `pcx_last_modified`
- `pcx_last_reviewed` (only added if that value is added in the page frontmatter)