### PR TITLE
Images: Change docs for nextjs pages integration

### DIFF
--- a/content/images/image-resizing/integration-with-frameworks.md
+++ b/content/images/image-resizing/integration-with-frameworks.md
@@ -8,7 +8,50 @@ weight: 9
 
 ## Next.js
 
-Image Resizing can be used automatically with Next.js' [`next/image` component](https://nextjs.org/docs/api-reference/next/image). With a [custom loader](https://nextjs.org/docs/api-reference/next/image#loader) which applies Cloudflare Image Resizing, `next/image` will set an optimal width and quality for a given client.
+Image Resizing can be used automatically with the Next.js [`<Image />` component](https://nextjs.org/docs/api-reference/next/image).
+
+To use Image Resizing, define a global image loader or multiple custom loaders for each `<Image />` component.
+
+Next.js will request the image with the correct parameters for width and quality.
+
+Image Resizing will be responsible for caching and serving an optimal format to the client.
+
+### Global Loader
+
+To use Image Resizing with **all** your app's images, define a global [loaderFile](https://nextjs.org/docs/pages/api-reference/components/image#loaderfile) for your app.
+
+Add the following settings to the **next.config.js** file located at the root our your Next.js application.
+
+```js
+module.exports = {
+  images: {
+    loader: 'custom',
+    loaderFile: './imageLoader.js',
+  },
+}
+```
+
+Next, create the `imageLoader.js` file in the specified path (relative to the root of your Next.js application).
+
+```js
+const normalizeSrc = src => {
+  return src.startsWith('/') ? src.slice(1) : src;
+};
+
+const cloudflareLoader = ({ src, width, quality }) => {
+  const params = [`width=${width}`];
+  if (quality) {
+    params.push(`quality=${quality}`);
+  }
+  const paramsString = params.join(',');
+  return `/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`;
+};
+```
+
+### Custom Loaders
+
+Alternatively, define a loader for each `<Image />` component.
+
 
 ```js
 import Image from 'next/image';
@@ -38,8 +81,6 @@ const MyImage = props => {
   );
 };
 ```
-
-To avoid having to specify a custom loader for every `<Image/>` component, configure a global [loaderFile](https://nextjs.org/docs/pages/api-reference/components/image#loaderfile) for your Next.js app.
 
 {{<Aside type="note">}}
 

--- a/content/images/image-resizing/integration-with-frameworks.md
+++ b/content/images/image-resizing/integration-with-frameworks.md
@@ -38,7 +38,7 @@ const normalizeSrc = src => {
   return src.startsWith('/') ? src.slice(1) : src;
 };
 
-const cloudflareLoader = ({ src, width, quality }) => {
+export default function cloudflareLoader ({ src, width, quality }) {
   const params = [`width=${width}`];
   if (quality) {
     params.push(`quality=${quality}`);

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -205,4 +205,28 @@ export async function GET(request: Request) {
 };
 ```
 
+## Statically imported images on Pages
+
+Pages does not currently support the default Next.js image optimization API. As a result, static imports of images break.
+
+```js
+import Image from 'next/image';
+import MyImage from './myImage.png';
+
+const MyImage = props => {
+  return (
+    <Image
+      src={MyImage} // <- Not supported
+      alt="Picture of the author"
+      width={500}
+      height={500}
+    />
+  );
+};
+```
+
+To use image assets, upload your statically imported images to a remote provider like [Cloudflare Images](https://www.cloudflare.com/en-gb/products/cloudflare-images/) or [R2](https://www.cloudflare.com/en-gb/products/r2/).
+
+To serve optimized images, define a global [loaderFile](/images/image-resizing/integration-with-frameworks/) for your app and integrate on-demand resizing with [flexible image variants](/images/cloudflare-images/transform/flexible-variants/) (for Cloudflare Images) or [Image Resizing](/images/image-resizing/url-format/) (for all other remote sources).
+
 {{<render file="_learn-more.md" withParameters="Next.js">}}


### PR DESCRIPTION
Images: Change docs for nextjs pages integration
    
    - Add information for users who experience broken images after Next.js
      migration von Vercel to CF Pages
    - Add mention of global loaderFile for Next.js Image component.