### PR TITLE
Suggestion to include accounts created with typos in this page, and to mention that the customers should export / import DNS records

### DIFF
--- a/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
+++ b/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
@@ -14,7 +14,7 @@ You will have to move or transfer domains from one Cloudflare account to another
 
 * Lose access to your email address or Cloudflare account.
 
-* Registered a Cloudflare account with a typo in your emai.
+* Registered a Cloudflare account with a typo in your email.
 
 {{<Aside type="note">}}
 

--- a/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
+++ b/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
@@ -36,7 +36,7 @@ To transfer a domain from one Cloudflare account to another, you will need:
 Before transferring an active Cloudflare domain to another Cloudflare account, you must remove any [DNSSEC configurations](/dns/dnssec/) and [add-ons or subscriptions](/fundamentals/account-and-billing/account-maintenance/cancel-subscription/).
 
 We also recommend [exporting](/dns/manage-dns-records/how-to/import-and-export/#export-records) the DNS records of your zone while it is in the previous account. Then, you can [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) the correct DNS records into the new account.
-If you miss this step Cludflare will automaticly import your proxied dns records and you should find an 1000 error. If that happends, please follow this [tutorial](https://community.cloudflare.com/t/fixing-error-1000-dns-points-to-prohibited-ip/178709) to fix this issue. 
+If you miss this step, Cloudflare will import your proxied dns records might experience a [1000 error](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/). 
 
 {{</Aside>}}
 

--- a/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
+++ b/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
@@ -35,7 +35,7 @@ To transfer a domain from one Cloudflare account to another, you will need:
 
 Before transferring an active Cloudflare domain to another Cloudflare account, you must remove any [DNSSEC configurations](/dns/dnssec/) and [add-ons or subscriptions](/fundamentals/account-and-billing/account-maintenance/cancel-subscription/).
 
-We also recommend you to export the DNS records of your zone(s) before adding each zone in the new account, so that you may import the correct DNS records in the new account when adding each zone in the new account. You may learn how to export/import your DNS records [here](https://developers.cloudflare.com/dns/manage-dns-records/how-to/import-and-export/).
+We also recommend [exporting](/dns/manage-dns-records/how-to/import-and-export/#export-records) the DNS records of your zone while it is in the previous account. Then, you can [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) the correct DNS records into the new account.
 If you miss this step Cludflare will automaticly import your proxied dns records and you should find an 1000 error. If that happends, please follow this [tutorial](https://community.cloudflare.com/t/fixing-error-1000-dns-points-to-prohibited-ip/178709) to fix this issue. 
 
 {{</Aside>}}

--- a/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
+++ b/content/fundamentals/get-started/basic-tasks/manage-domains/move-domain.md
@@ -14,6 +14,8 @@ You will have to move or transfer domains from one Cloudflare account to another
 
 * Lose access to your email address or Cloudflare account.
 
+* Registered a Cloudflare account with a typo in your emai.
+
 {{<Aside type="note">}}
 
 If you have [two-factor authentication (2FA)](https://support.cloudflare.com/hc/articles/200167906) enabled and access to backup codes, you can use those codes to access your Cloudflare account.
@@ -32,6 +34,9 @@ To transfer a domain from one Cloudflare account to another, you will need:
 {{<Aside type="warning">}}
 
 Before transferring an active Cloudflare domain to another Cloudflare account, you must remove any [DNSSEC configurations](/dns/dnssec/) and [add-ons or subscriptions](/fundamentals/account-and-billing/account-maintenance/cancel-subscription/).
+
+We also recommend you to export the DNS records of your zone(s) before adding each zone in the new account, so that you may import the correct DNS records in the new account when adding each zone in the new account. You may learn how to export/import your DNS records [here](https://developers.cloudflare.com/dns/manage-dns-records/how-to/import-and-export/).
+If you miss this step Cludflare will automaticly import your proxied dns records and you should find an 1000 error. If that happends, please follow this [tutorial](https://community.cloudflare.com/t/fixing-error-1000-dns-points-to-prohibited-ip/178709) to fix this issue. 
 
 {{</Aside>}}
 


### PR DESCRIPTION
I'm seeing some tickets about customers that created accounts with a typo in their emails, added zones, and at some point, as some operations require a verified email they notice the typo, but then it is too late, and the only option we provide for this customers is to create a new account, and move the zones to the new account.

I think we should include in our documentation that the best way to move zones from one account to another account is by exporting DNS records before moving the zone, because some times, customers move the zones, and Cloudflare will import the proxied IPs instead of the origin IPs, which will generate a 1000 error. 

Here is a ticket example (https://cloudflare.zendesk.com/agent/tickets/2831953).