### PR TITLE
d1: remove incorrect .all([column]) syntax

### DIFF
--- a/content/d1/platform/client-api.md
+++ b/content/d1/platform/client-api.md
@@ -117,7 +117,7 @@ If the query returns no rows, then first() will return ```null```.
 
 If the query returns rows, but ```column``` does not exist, then first() will throw the ```D1_ERROR``` exception.
 
-### await stmt.all( [column] )
+### await stmt.all()
 Returns all rows and metadata.
 
 ```js


### PR DESCRIPTION
Docs incorrect. Fixing!

<img width="715" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/18544/1a26cadb-bbf6-446b-bf0f-9f95213f1415">
