### PR TITLE
fix: remove Pages commands beta warning

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1316,11 +1316,6 @@ If sampling persists after using options to filter messages, consider using [ins
 
 Configure Cloudflare Pages.
 
-{{<Aside type="warning">}}
-The `wrangler pages ...` commands are in beta.<br>
-Report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose.
-{{</Aside>}}
-
 ### `dev`
 
 Develop your full stack Pages application locally.


### PR DESCRIPTION
As per https://github.com/cloudflare/workers-sdk/pull/3415, these commands are no longer beta