### PR TITLE
[Gateway] Minor fix: correct response for pac file errors in pac-files.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/agentless/pac-files.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/pac-files.md
@@ -113,7 +113,7 @@ https://<SUBDOMAIN>.proxy.cloudflare-gateway.com
 
 {{<Aside type="note">}}
 
-If curl returns a `401` code, it means the public IP of your device does not match the one used to generate the proxy server. Make sure that WARP is turned off on your device and double-check that curl is not using IPv6 (use the `-4` option to force IPv4).
+If curl returns a `403` code, it means the public IP of your device does not match the one used to generate the proxy server. Make sure that WARP is turned off on your device and double-check that curl is not using IPv6 (use the `-4` option to force IPv4).
 
 {{</Aside>}}
 


### PR DESCRIPTION
Back in December 2022 we standardized the proxy endpoint error responses on 403 instead of 401, but missed updating this documentation.