### PR TITLE
d1: Update local-development.md

### DIFF
--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -63,11 +63,40 @@ Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to 
 
 ## Persist data
 
-**By default, in wrangler `3.0.0` and above, data is persisted across each run of `wrangler dev`**. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
+{{<Aside type="note" heading="Changes in wrangler v3">}}
+
+By default, in wrangler `3.0.0` and above, data is persisted across each run of `wrangler dev`. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
+
+{{</Aside>}}
 
 Use `wrangler dev --persist-to=/path/to/file` to persist data to a specific location. This can be useful when working in a team (allowing you to share) the same copy, when deploying via CI/CD (to ensure the same starting state), or as a way to keep data when migrating across machines.
 
 Users of wrangler `2.x` must use the `--persist` flag: previous versions of wrangler did not persist data by default.
+
+## Programmatically testing
+
+Wrangler exposes an [`unstable_dev()`](/workers/wrangler/api/) that allows you to run a local HTTP server for testing Workers and D1. You can run [migrations](/d1/platform/migrations/) against a local database by setting a `preview_database_id` in your `wrangler.toml` configuration.
+
+Given the below `wrangler.toml` configuration:
+
+```toml
+---
+filename: wrangler.toml
+---
+[[ d1_databases ]]
+binding = "DB" # i.e. if you set this to "DB", it will be available in your Worker at `env.DB`
+database_name = "your-database" # the name of your D1 database, set when created
+database_id = "<UUID>" # The unique ID of your D1 database, returned when you create your database or run `
+preview_database_id = "local-test-db" # A user-defined ID for your local test database.
+```
+
+Migrations can be run locally as part of your CI/CD setup by passing the `--local` flag to `wrangler`:
+
+```sh
+$ wrangler d1 migrations apply your-database --local
+```
+
+Review the [`unstable_dev()`](/workers/wrangler/api/#usage) documentation for more details on how to use the API.
 
 ## Related resources
 

--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -65,7 +65,7 @@ Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to 
 
 {{<Aside type="note" heading="Changes in wrangler v3">}}
 
-By default, in wrangler `3.0.0` and above, data is persisted across each run of `wrangler dev`. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
+By default, in Wrangler v3 and above, data is persisted across each run of `wrangler dev`. If your local development and testing requires or assumes an empty database, you should start with a `DROP TABLE <tablename>` statement to delete existing tables before using `CREATE TABLE` to re-create them.
 
 {{</Aside>}}
 
@@ -73,9 +73,9 @@ Use `wrangler dev --persist-to=/path/to/file` to persist data to a specific loca
 
 Users of wrangler `2.x` must use the `--persist` flag: previous versions of wrangler did not persist data by default.
 
-## Programmatically testing
+## Test programmatically
 
-Wrangler exposes an [`unstable_dev()`](/workers/wrangler/api/) that allows you to run a local HTTP server for testing Workers and D1. You can run [migrations](/d1/platform/migrations/) against a local database by setting a `preview_database_id` in your `wrangler.toml` configuration.
+Wrangler exposes an [`unstable_dev()`](/workers/wrangler/api/) that allows you to run a local HTTP server for testing Workers and D1. Run [migrations](/d1/platform/migrations/) against a local database by setting a `preview_database_id` in your `wrangler.toml` configuration.
 
 Given the below `wrangler.toml` configuration:
 
@@ -100,8 +100,8 @@ $ wrangler d1 migrations apply your-database --local
 
 The following example shows how to use Wrangler's `unstable_dev()` API to:
 
-* Run migrations against your local test database, as defined by `preview_database_id`
-* Make a request to an endpoint defined in your Worker - in this example, `/api/users/?limit=2`
+* Run migrations against your local test database, as defined by `preview_database_id`.
+* Make a request to an endpoint defined in your Worker. This example uses `/api/users/?limit=2`.
 * Validate the returned results match, including the `Response.status` and the JSON our API returns.
 
 ```ts


### PR DESCRIPTION
This PR:

- Makes it clearer how to test D1 programmatically (as a start)
- Links out to the `unstable_dev` docs at https://developers.cloudflare.com/workers/wrangler/api/