### PR TITLE
Update limits.md

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -333,6 +333,6 @@ Durable Objects have been built such that the number of Objects in the system do
 
 ---
 
-## Format limitations on Using Image Resizing with Workers 
+## Image Resizing with Workers 
 
-It will be the same Limitations when using Image Resizing without workers. Please refer here: [Format limitations](/images/image-resizing/format-limitations/#limits-per-format).
+When using Image Resizing with Workers, refer to [Image Resizing documentation](/images/image-resizing/format-limitations/#limits-per-format) for more information on limits.

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -335,4 +335,4 @@ Durable Objects have been built such that the number of Objects in the system do
 
 ## Image Resizing with Workers 
 
-When using Image Resizing with Workers, refer to [Image Resizing documentation](/images/image-resizing/format-limitations/#limits-per-format) for more information on limits.
+When using Image Resizing with Workers, refer to [Image Resizing documentation](/images/image-resizing/format-limitations/#limits-per-format) for more information on the applied limits.

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -330,3 +330,9 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 Durable Objects scale well across Objects, but each object is inherently single-threaded. A baseline of 100 req/sec is a good floor estimate of the request rate an individual Object can handle, though this will vary with workload.
 
 Durable Objects have been built such that the number of Objects in the system do not need to be limited. You can create and run as many separate objects as you want. The main limit to your usage of Durable Objects is the total storage limit per account - if you need more storage, contact your account team.
+
+---
+
+## Format limitations on Using Image Resizing with Workers 
+
+It will be the same Limitations when using Image Resizing without workers. Please refer here: [Format limitations](/images/image-resizing/format-limitations/#limits-per-format).


### PR DESCRIPTION
to clarify the limitation for IR is the same when using workers VS not using workers. 

added:

## Format limitations on Using Image Resizing with Workers 

It will be the same Limitations when using Image Resizing without workers. Please refer here: [Format limitations](/images/image-resizing/format-limitations/#limits-per-format).