### PR TITLE
[Analytics Engine] tiny punctuation fix

### DIFF
--- a/content/analytics/analytics-engine/_index.md
+++ b/content/analytics/analytics-engine/_index.md
@@ -6,7 +6,7 @@ weight: 1
 
 {{<beta>}} Workers Analytics Engine {{</beta>}}
 
-Workers Analytics Engine is a new way to quickly get analytics about anything using Cloudflare Workers. Whether you are developing a new software application, deploying a fleet of IoT devices, or just writing an edge worker, it is critical to know what is happening. Teams need analytics to understand how many users are signing up, whether your devices are online, and what is happening in the business logic of your workers.
+Workers Analytics Engine is a new way to quickly get analytics about anything, using Cloudflare Workers. Whether you are developing a new software application, deploying a fleet of IoT devices, or just writing an edge worker, it is critical to know what is happening. Teams need analytics to understand how many users are signing up, whether your devices are online, and what is happening in the business logic of your workers.
 
 Also, as our customer you may need to expose analytics to your customers. With Workers Analytics Engine, you can quickly deploy analytics about your own product that your customers can use.
 


### PR DESCRIPTION
The current punctuation implies Workers Analytics Engine is a new way to get analytics about anything on the Workers platform. 

This PR makes it clearer that it's for getting analytics *about anything*, using the Workers Platform.