### PR TITLE
Fix wrong variables and remove extra word in Postman R2 example

### DIFF
--- a/content/r2/examples/postman.md
+++ b/content/r2/examples/postman.md
@@ -46,8 +46,8 @@ Guard this token and the **Access Key ID** and **Secret Access Key** closely. Yo
 After you have created your API token in the Cloudflare dashboard:
 
 1. Go to the [Postman dashboard](https://www.postman.com/cloudflare-r2/workspace/cloudflare-r2/collection/20913290-14ddd8d8-3212-490d-8647-88c9dc557659?action=share&creator=20913290&ctx=documentation) > **Variables**.
-2. Copy `Access Key ID` value from the Cloudflare dashboard and paste it into Postman’s `r2-secret-access-key` variable value and select **Save**.
-3. Copy the `Secret Access Key` value value from the Cloudflare dashboard and paste into Postman’s `r2-access-key-id` variable value and select **Save**.
+2. Copy `Access Key ID` value from the Cloudflare dashboard and paste it into Postman’s `r2-access-key-id` variable value and select **Save**.
+3. Copy the `Secret Access Key` value from the Cloudflare dashboard and paste it into Postman’s `r2-secret-access-key` variable value and select **Save**.
 
 By now, you should have `account-id`, `r2-secret-access-key`, and `r2-access-key-id` set in Postman.
 


### PR DESCRIPTION
`Access Key ID` in this collection is not `r2-secret-access-key` and `Secret Access Key` is not `r2-access-key-id` (as if it wasn't obvious enough from the names). This will throw an error from Cloudflare if used as directed:

> Invalid Argument: Credential access key has length 64, should be 32

Also removed an extra duplicate word.