### PR TITLE
wae: clarify limits

### DIFF
--- a/content/analytics/analytics-engine/get-started.md
+++ b/content/analytics/analytics-engine/get-started.md
@@ -169,4 +169,9 @@ Refer to [Querying Workers Analytics Engine from Grafana](/analytics/analytics-e
 
 ## Limits
 
-Cloudflare will accept up to twenty blobs, twenty doubles, and one index per request. The total size of all blobs in a request must not exceed 5120 bytes and the index must not be more than 96 bytes. Finally, there is also a limit of 25 writes per request.
+The following limits apply to Analytics Engine:
+
+* Analytics Engine will accept up to twenty blobs, twenty doubles, and one index per request.
+* The total size of all blobs in a request must not exceed 5120 bytes
+* Each index must not be more than 96 bytes.
+* There is also a limit of 25 writes (`writeDataPoint` invocations) per client HTTP request 


### PR DESCRIPTION
Clarify the "25 writes per request" limit a little more:

<img width="729" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/18544/45690032-b550-4b8a-a2d7-ba7593991c7e">
