### PR TITLE
Remove references to the 1dot1dot1dot1.cloudflare-dns.com

### DIFF
--- a/content/1.1.1.1/encryption/dns-over-tls.md
+++ b/content/1.1.1.1/encryption/dns-over-tls.md
@@ -9,7 +9,7 @@ By default, DNS is sent over a plaintext connection. DNS over TLS (DoT) is one w
 
 ## How it works
 
-Cloudflare supports DNS over TLS (DoT) on `1.1.1.1` and `1.0.0.1` on port 853. If your DoT client does not support IP addresses, Cloudflare's DoT endpoint can also be reached by hostname on `1dot1dot1dot1.cloudflare-dns.com` and `one.one.one.one`. A stub resolver (the DNS client on a device that talks to the DNS resolver) connects to the resolver over a TLS connection:
+Cloudflare supports DNS over TLS (DoT) on `1.1.1.1` and `1.0.0.1` on port 853. If your DoT client does not support IP addresses, Cloudflare's DoT endpoint can also be reached by hostname on `one.one.one.one`. A stub resolver (the DNS client on a device that talks to the DNS resolver) connects to the resolver over a TLS connection:
 
 1. Before the connection, the DNS stub resolver has stored a base64 encoded SHA256 hash of the TLS certificate from 1.1.1.1 (called SPKI).
 2. DNS stub resolver establishes a TCP connection with `1.1.1.1:853`.

--- a/content/1.1.1.1/encryption/dns-over-tls.md
+++ b/content/1.1.1.1/encryption/dns-over-tls.md
@@ -9,7 +9,7 @@ By default, DNS is sent over a plaintext connection. DNS over TLS (DoT) is one w
 
 ## How it works
 
-Cloudflare supports DNS over TLS (DoT) on `1.1.1.1` and `1.0.0.1` on port 853. If your DoT client does not support IP addresses, Cloudflare's DoT endpoint can also be reached by hostname on `one.one.one.one`. A stub resolver (the DNS client on a device that talks to the DNS resolver) connects to the resolver over a TLS connection:
+Cloudflare supports DNS over TLS (DoT) on `1.1.1.1`, `1.0.0.1`, and the correspsonding IPv6 addresses (`2606:4700:4700::1111` and `2606:4700:4700::1001`) on port `853`. If your DoT client does not support IP addresses, Cloudflare's DoT endpoint can also be reached by hostname on `one.one.one.one`. A stub resolver (the DNS client on a device that talks to the DNS resolver) connects to the resolver over a TLS connection:
 
 1. Before the connection, the DNS stub resolver has stored a base64 encoded SHA256 hash of the TLS certificate from 1.1.1.1 (called SPKI).
 2. DNS stub resolver establishes a TCP connection with `1.1.1.1:853`.

--- a/content/1.1.1.1/encryption/dns-over-tls.md
+++ b/content/1.1.1.1/encryption/dns-over-tls.md
@@ -21,33 +21,33 @@ Cloudflare supports DNS over TLS (DoT) on `1.1.1.1`, `1.0.0.1`, and the corresps
 ## Example
 
 ```sh
-$ kdig -d @1.1.1.1 +tls-ca +tls-host=cloudflare-dns.com  example.com
+$ kdig -d @1.1.1.1 +tls-ca +tls-host=one.one.one.one example.com
 ;; DEBUG: Querying for owner(example.com.), class(1), type(1), server(1.1.1.1), port(853), protocol(TCP)
-;; DEBUG: TLS, imported 170 system certificates
+;; DEBUG: TLS, imported 138 system certificates
 ;; DEBUG: TLS, received certificate hierarchy:
-;; DEBUG:  #1, C=US,ST=CA,L=San Francisco,O=Cloudflare\, Inc.,CN=\*.cloudflare-dns.com
-;; DEBUG:      SHA-256 PIN: yioEpqeR4WtDwE9YxNVnCEkTxIjx6EEIwFSQW+lJsbc=
-;; DEBUG:  #2, C=US,O=DigiCert Inc,CN=DigiCert ECC Secure Server CA
-;; DEBUG:      SHA-256 PIN: PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw=
+;; DEBUG:  #1, C=US,ST=California,L=San Francisco,O=Cloudflare\, Inc.,CN=cloudflare-dns.com
+;; DEBUG:      SHA-256 PIN: GP8Knf7qBae+aIfythytMbYnL+yowaWVeD6MoLHkVRg=
+;; DEBUG:  #2, C=US,O=DigiCert Inc,CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
+;; DEBUG:      SHA-256 PIN: e0IRz5Tio3GA1Xs4fUVWmH1xHDiH2dMbVtCBSkOIdqM=
 ;; DEBUG: TLS, skipping certificate PIN check
 ;; DEBUG: TLS, The certificate is trusted.
-;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(ECDSA-SECP256R1-SHA256)-(AES-256-GC
-;; ->>HEADER<<- opcode: QUERY; status: NOERROR; id: 58548
+;; TLS session (TLS1.3)-(ECDHE-X25519)-(ECDSA-SECP256R1-SHA256)-(AES-256-GCM)
+;; ->>HEADER<<- opcode: QUERY; status: NOERROR; id: 3395
 ;; Flags: qr rd ra; QUERY: 1; ANSWER: 1; AUTHORITY: 0; ADDITIONAL: 1
 
 ;; EDNS PSEUDOSECTION:
-;; Version: 0; flags: ; UDP size: 1536 B; ext-rcode: NOERROR
+;; Version: 0; flags: ; UDP size: 1232 B; ext-rcode: NOERROR
 ;; PADDING: 408 B
 
 ;; QUESTION SECTION:
 ;; example.com.        		IN	A
 
 ;; ANSWER SECTION:
-example.com.        	2347	IN	A	93.184.216.34
+example.com.        	75897	IN	A	93.184.216.34
 
 ;; Received 468 B
-;; Time 2018-03-31 15:20:57 PDT
-;; From 1.1.1.1@853(TCP) in 12.6 ms
+;; Time 2023-06-23 18:05:42 PDT
+;; From 1.1.1.1@853(TCP) in 12.1 ms
 ```
 
 ## Supported TLS versions

--- a/content/1.1.1.1/setup/android.md
+++ b/content/1.1.1.1/setup/android.md
@@ -39,7 +39,7 @@ Android Pie and later supports DNS over TLS to secure your queries through encry
 1. Go to **Settings** > **Network & internet**.
 2. Select **Advanced** > **Private DNS**.
 3. Select the **Private DNS provider hostname** option.
-4. Enter `one.one.one.one` or `1dot1dot1dot1.cloudflare-dns.com` and press **Save**.
+4. Enter `one.one.one.one` and press **Save**.
 
 ### Previous Android versions
 


### PR DESCRIPTION
Landing page of DoH domains, exclude bare IP sites, are redirected to https://one.one.one.one/
and the later support both DoT and DoH. We should demote the 1dot1dot1dot1 subdomain,
which was introduced before Cloudflare acquire the one.one.one domain.

It may not be obvious, the IPv6 addresses also support DoT. This PR update the section to
make it clear.