### PR TITLE
Update use-cases.md - remove wildcard from contains example

### DIFF
--- a/content/waf/rate-limiting-rules/use-cases.md
+++ b/content/waf/rate-limiting-rules/use-cases.md
@@ -33,7 +33,7 @@ The following rule performs rate limiting on incoming requests with a given base
 {{<example>}}
 
 Expression:<br />
-`(http.request.uri.path contains "/product*" and http.request.method eq "POST")`
+`(http.request.uri.path contains "/product" and http.request.method eq "POST")`
 
 Rule characteristics:
 


### PR DESCRIPTION
Removed asterisk `*` from Example 2 `http.request.uri.path contains "/product*"`.  
`contains` operator does not need or support wildcards (and a literal match does not make sense here).