### PR TITLE
Update scim-setup.md

### DIFF
--- a/content/fundamentals/account-and-billing/account-security/scim-setup.md
+++ b/content/fundamentals/account-and-billing/account-security/scim-setup.md
@@ -8,7 +8,7 @@ weight: 4
 
 By connecting a System for Cross-domain Identity Management (SCIM) provider, you can provision access to the Cloudflare dashboard on a per-user basis.
 
-We currently provide SCIM support only for **Azure Active Directory** and **Okta** in Self-Hosted Access applications.
+Currently, we only provide SCIM support for Azure Active Directory and Okta in Self-Hosted Access applications.
 
 For more information about the product, please refer to the blog post: [Announcing SCIM support for Cloudflare Access & Gateway](https://blog.cloudflare.com/access-and-gateway-with-scim/)
 

--- a/content/fundamentals/account-and-billing/account-security/scim-setup.md
+++ b/content/fundamentals/account-and-billing/account-security/scim-setup.md
@@ -10,7 +10,7 @@ By connecting a System for Cross-domain Identity Management (SCIM) provider, you
 
 Currently, we only provide SCIM support for Azure Active Directory and Okta in Self-Hosted Access applications.
 
-For more information about the product, please refer to the blog post: [Announcing SCIM support for Cloudflare Access & Gateway](https://blog.cloudflare.com/access-and-gateway-with-scim/)
+For more information about SCIM support, refer to the [Announcing SCIM support for Cloudflare Access & Gateway](https://blog.cloudflare.com/access-and-gateway-with-scim/) blog post.
 
 This guide will use Okta as the SCIM provider.
 

--- a/content/fundamentals/account-and-billing/account-security/scim-setup.md
+++ b/content/fundamentals/account-and-billing/account-security/scim-setup.md
@@ -8,6 +8,10 @@ weight: 4
 
 By connecting a System for Cross-domain Identity Management (SCIM) provider, you can provision access to the Cloudflare dashboard on a per-user basis.
 
+We currently provide SCIM support only for **Azure Active Directory** and **Okta** in Self-Hosted Access applications.
+
+For more information about the product, please refer to the blog post: [Announcing SCIM support for Cloudflare Access & Gateway](https://blog.cloudflare.com/access-and-gateway-with-scim/)
+
 This guide will use Okta as the SCIM provider.
 
 ## Prerequisites


### PR DESCRIPTION
explaining that we currently provide SCIM support only for Azure Active Directory and Okta in Self-Hosted Access applications to make it clear for the customers in case they are trying integrations with other IDPs.