### PR TITLE
workers: update beta page

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -7,8 +7,8 @@ title: Betas
 
 These are the current alphas and betas relevant to the Cloudflare Workers platform.
 
-* Public alphas and betas are openly available, but may have limitations and caveats due to their early stage of development.
-* Private alphas and betas require explicit access to be granted. Go to the documentation to join the relevant product waitlist.
+* **Public alphas and betas are openly available**, but may have limitations and caveats due to their early stage of development.
+* Private alphas and betas require explicit access to be granted. Refer to the documentation to join the relevant product waitlist.
 
 
 | Product                       | Public Alpha  | Private Beta | Public Beta | More Info                                                                  |
@@ -18,6 +18,6 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |               |              |  ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       |               | ✅           |              |[Docs](/pub-sub)                                                            |
 | Queues                        |               |              |  ✅          |[Docs](/queues)                                                             |
-| TCP Workers                   |               |            |     ✅         |[Docs](/workers/runtime-apis/tcp-sockets)             |
+| [TCP Sockets](/workers/runtime-apis/tcp-sockets/)                   |               |            |     ✅         |[Docs](/workers/runtime-apis/tcp-sockets)             |
 | Workers Analytics Engine      |               |             | ✅            |[Docs](/analytics/analytics-engine/)               |
 | Workers Deployments           |               |             | ✅            |[Docs](/workers/platform/deployments)               |


### PR DESCRIPTION
* Make it clearer that there isn't a waitlist for public alphas and betas (this is continually glossed over)
* Rename "TCP Workers" as "TCP Sockets" for clarity, as this is a source of confusion vs. "inbound" TCP Workers