### PR TITLE
[ZT] Fix Gateway action wording

### DIFF
--- a/content/cloudflare-one/insights/logs/gateway-logs/_index.md
+++ b/content/cloudflare-one/insights/logs/gateway-logs/_index.md
@@ -71,7 +71,7 @@ These settings will only apply to logs displayed in Zero Trust. Logpush data is 
 | blockedAlwaysCategory  | Domain or hostname is always blocked by Cloudflare.         |
 | allowedOnNoLocation    | Allowed because query did not match a Gateway DNS location. |
 | allowedOnNoPolicyMatch | Allowed because query did not match a policy.               |
-| overrideForSafeSearch  | Response was overridden by a SafeSearch policy.             |
+| overrideForSafeSearch  | Response was overridden by a Safe Search policy.            |
 | overrideApplied        | Response was overridden by an Override policy.              |
 
 {{</table-wrap>}}

--- a/content/cloudflare-one/policies/filtering/dns-policies/_index.md
+++ b/content/cloudflare-one/policies/filtering/dns-policies/_index.md
@@ -38,7 +38,7 @@ These are the action types you can choose from:
 - [Allow](#allow)
 - [Block](#block)
 - [Override](#override)
-- [SafeSearch](#safesearch)
+- [Safe Search](#safe-search)
 - [YouTube Restricted Mode](#youtube-restricted-mode)
 
 ### Allow
@@ -81,7 +81,7 @@ Policies with Override actions allow you to respond to all DNS queries for a giv
 
 {{<Aside>}}The Override action cannot be used with selectors evaluated after resolution, including **Authoritative Nameserver IP**, **Resolved IP**, and any DNS response values.{{</Aside>}}
 
-### SafeSearch
+### Safe Search
 
 API value: `safesearch`
 
@@ -89,9 +89,9 @@ SafeSearch is a feature of search engines that helps you filter explicit or offe
 
 You can use Cloudflare Gateway to enable SafeSearch on search engines like Google, Bing, Yandex, YouTube and DuckDuckGo. For example, to enable SafeSearch for Google, you can create the following policy:
 
-| Selector | Operator | Value        | Action     |
-| -------- | -------- | ------------ | ---------- |
-| Domain   | Is       | `google.com` | SafeSearch |
+| Selector | Operator | Value        | Action      |
+| -------- | -------- | ------------ | ----------- |
+| Domain   | Is       | `google.com` | Safe Search |
 
 ### YouTube Restricted Mode
 

--- a/content/cloudflare-one/policies/filtering/http-policies/_index.md
+++ b/content/cloudflare-one/policies/filtering/http-policies/_index.md
@@ -132,7 +132,7 @@ For more information, refer to our list of [content categories](/cloudflare-one/
 Only applies to traffic sent through the [WARP client](/cloudflare-one/connections/connect-devices/warp/set-up-warp/#gateway-with-warp-default).
 {{</Aside>}}
 
-{{<render file="gateway/_destination-continent.md" withParameters="http..dst_ip">}}
+{{<render file="gateway/_destination-continent.md" withParameters="http.dst_ip">}}
 
 ### Destination Country
 


### PR DESCRIPTION
Change wording for `SafeSearch` action to `Safe Search` to match our policy builder. This retains the use of `SafeSearch` in body text as the majority of listed search engines (Google, Bing, YouTube) refer to the feature without a space.