### PR TITLE
Move SW syntax content for ScheduledEvent to ESM migration page

### DIFF
--- a/content/workers/learning/migrate-to-module-workers.md
+++ b/content/workers/learning/migrate-to-module-workers.md
@@ -185,6 +185,31 @@ export default {
 };
 ```
 
+
+---
+
+## Cron triggers
+
+To handle a [Cron Trigger](/workers/platform/triggers/cron-triggers/) event in a Worker written with ES modules syntax, implement a [`scheduled()` event handler](/workers/runtime-apis/scheduled-event/#syntax-es-modules), which is the equivalent of listening for a `scheduled` event in Service Worker syntax.
+
+This example code:
+
+```js
+addEventListener("scheduled", (event) => {
+  // ...
+});
+```
+
+Then becomes:
+
+```js
+export default {
+  async scheduled(event, env, ctx) {
+    // ...
+  },
+};
+```
+
 ## Access `event` or `context` data
 
 Workers often need access to data not in the `request` object. For example, sometimes Workers use [`waitUntil`](/workers/runtime-apis/fetch-event/#waituntil) to delay execution. Workers using ES modules format can access `waitUntil` via the `context` parameter. Refer to [ES modules parameters](/workers/runtime-apis/fetch-event/#parameters) for  more information.

--- a/content/workers/runtime-apis/scheduled-event.md
+++ b/content/workers/runtime-apis/scheduled-event.md
@@ -7,7 +7,7 @@ title: ScheduledEvent
 
 ## Background
 
-A `ScheduledEvent` is the event type for scheduled requests to a Worker. It is the `Object` passed through as the `event` when a Worker is invoked by a Worker's [Cron Trigger](/workers/platform/triggers/cron-triggers/). `ScheduledEvent` is supported in Workers written with [Service Worker syntax](#syntax-service-worker) and [ES modules syntax](#syntax-module-worker).
+A `ScheduledEvent` is the event type for scheduled requests to a Worker. It is the `Object` passed through as the `event` when a Worker is invoked by a Worker's [Cron Trigger](/workers/platform/triggers/cron-triggers/).
 
 {{<Aside type="note" header="Testing Scheduled Events">}}
 
@@ -25,7 +25,7 @@ $ curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
 
 ---
 
-## Syntax: ES modules
+## Syntax
 
 A `ScheduledEvent` can be handled in Workers functions written using the [ES modules format](/workers/learning/migrate-to-module-workers/) by adding a `scheduled` function to your module's exported handlers:
 
@@ -71,46 +71,5 @@ When a Workers script is invoked by a [Cron Trigger](/workers/platform/triggers/
 - {{<code>}}ctx.waitUntil(promise{{<param-type>}}Promise{{</param-type>}}){{</code>}} : {{<type>}}void{{</type>}}
 
   - Use this method to notify the runtime to wait for asynchronous tasks (for example, logging, analytics to third-party services, streaming and caching). The first `ctx.waitUntil` to fail will be observed and recorded as the status in the [Cron Trigger](/workers/platform/triggers/cron-triggers/) Past Events table. Otherwise, it will be reported as a success.
-
-{{</definitions>}}
-
----
-
-## Syntax: Service Worker
-
-A `ScheduledEvent` can be handled in Workers functions written using the Service Worker syntax by attaching to the `scheduled` event with `addEventListener`:
-
-```js
-addEventListener("scheduled", (event) => {
-  event.waitUntil(handleScheduled(event));
-});
-```
-
-### Properties
-
-{{<definitions>}}
-
-- `event.cron` {{<type>}}string{{</type>}}
-
-  - The value of the [Cron Trigger](/workers/platform/triggers/cron-triggers/) that started the `ScheduledEvent`.
-
-- `event.type` {{<type>}}string{{</type>}}
-
-  - The type of event. This will always return `"scheduled"`.
-
-- `event.scheduledTime` {{<type>}}number{{</type>}}
-  - The time the `ScheduledEvent` was scheduled to be executed in milliseconds since January 1, 1970, UTC. It can be parsed as {{<code>}}new Date(event.scheduledTime){{</code>}}
-
-{{</definitions>}}
-
-### Methods
-
-When a Workers script is invoked by a [Cron Trigger](/workers/platform/triggers/cron-triggers/), the Workers runtime starts a `ScheduledEvent` which will be handled by the event listener registered for the type `"scheduled"`. The event handler can invoke the following methods of the `event` object to control what happens next:
-
-{{<definitions>}}
-
-- {{<code>}}event.waitUntil(promise{{<param-type>}}Promise{{</param-type>}}){{</code>}} : {{<type>}}void{{</type>}}
-
-  - Use this method to notify the runtime to wait for asynchronous tasks (for example, logging, analytics to third-party services, streaming and caching). The first `event.waitUntil` to fail will be observed and recorded as the status in the [Cron Trigger](/workers/platform/triggers/cron-triggers/) Past Events table. Otherwise, it will be reported as a Success.
 
 {{</definitions>}}


### PR DESCRIPTION
- Consolidates all info on Service Worker syntax to `/workers/learning/migrate-to-module-workers`
- Reduces repetitive / duplicate information on this page
- Simplifies getting started
- refs https://github.com/cloudflare/cloudflare-docs/issues/9670