### PR TITLE
[D1] `id` -> `database_id` for D1 configuration

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -317,7 +317,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
   - The name of the database. This a human-readable name that allows you to distinguish between different databases, and is set when you first create the database.
 
-- `id` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+- `database_id` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
   - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
 


### PR DESCRIPTION
Fix the name of the binding for D1 databases. Current docs list `id` when the configuration value needed is `database_id`