### PR TITLE
[SSL, ZT, Support] Cannot disable Always use HTTP with Page Rules

### DIFF
--- a/content/cloudflare-one/policies/access/_index.md
+++ b/content/cloudflare-one/policies/access/_index.md
@@ -74,7 +74,7 @@ This ensures that everyone connecting from outside your specified IP range will 
 
 {{<Aside type="note">}}
 
-When applying a Bypass action, security settings revert to the defaults configured for the zone and any configured page rules. If **Always use HTTPS** is enabled for the site, then traffic to the bypassed destination continues in HTTPS. If it is not or you applied page rules to disable it, traffic is HTTP.
+When applying a Bypass action, security settings revert to the defaults configured for the zone and any configured page rules. If **Always use HTTPS** is enabled for the site, then traffic to the bypassed destination continues in HTTPS. If **Always use HTTPS** is disabled, traffic is HTTP.
 
 {{</Aside>}}
 

--- a/content/rules/url-forwarding/single-redirects/examples.md
+++ b/content/rules/url-forwarding/single-redirects/examples.md
@@ -42,9 +42,9 @@ Request URL                        | Target URL                       | Status c
 `example.com/contact-us/?state=TX` | `example.com/contacts/?state=TX` | `301`
 `example.com/team/`                | (unchanged)                      | n/a
 
-## Redirect requests for administration area to HTTPS
+## Redirect admin area requests to HTTPS
 
-This example dynamic redirect for zone `example.com` will redirect requests for the administration area of an online store to HTTPS, keeping the original path and query string.
+This example dynamic redirect for zone `example.com` will redirect requests for the administration area of a specific subdomain (`store.example.com`) to HTTPS, keeping the original path and query string.
 
 {{<example>}}
 

--- a/content/rules/url-forwarding/single-redirects/examples.md
+++ b/content/rules/url-forwarding/single-redirects/examples.md
@@ -42,25 +42,31 @@ Request URL                        | Target URL                       | Status c
 `example.com/contact-us/?state=TX` | `example.com/contacts/?state=TX` | `301`
 `example.com/team/`                | (unchanged)                      | n/a
 
-## Redirect all requests to HTTPS
+## Redirect requests for administration area to HTTPS
 
-This example dynamic redirect for zone `example.com` will redirect visitors to HTTPS for the main domain and all subdomains, keeping the original path and query string.
+This example dynamic redirect for zone `example.com` will redirect requests for the administration area of an online store to HTTPS, keeping the original path and query string.
 
 {{<example>}}
 
 **When incoming requests match**
 
 * **Field:** _SSL/HTTPS_
-* **Value:** Off
+* **Value:** _Off_
 
 _And_
 
 * **Field:** _Hostname_
-* **Operator:** _ends with_
-* **Value:** `example.com`
+* **Operator:** _equals_
+* **Value:** `store.example.com`
+
+_And_
+
+* **Field:** _URI Path_
+* **Operator:** _starts with_
+* **Value:** `/admin`
 
 If you are using the Expression Editor, enter the following expression:<br>
-`(not ssl and ends_with(http.host, "example.com"))`
+`(not ssl and http.host eq "store.example.com" and starts_with(http.request.uri.path, "/admin"))`
 
 **Then**
 
@@ -71,17 +77,17 @@ If you are using the Expression Editor, enter the following expression:<br>
 
 {{</example>}}
 
-The rule expression includes _SSL/HTTPS: Off_ (or `not ssl`) to avoid redirect loops.
+The rule includes _SSL/HTTPS: Off_ (`not ssl` in the rule expression) to avoid redirect loops.
 
 For example, the redirect rule would perform the following redirects:
 
-Request URL                                      | Target URL                                       | Status code
--------------------------------------------------|--------------------------------------------------|------------
-`http://example.com/`                            | `https://example.com/`                           | `301`
-`http://example.com/calendar?show_details=true`  | `https://example.com/calendar?show_details=true` | `301`
-`http://store.example.com/admin/`                | `https://store.example.com/admin/`               | `301`
-`https://example.com/calendar?show_details=true` | (unchanged)                                      | n/a
-`https://store.example.com/admin/`               | (unchanged)                                      | n/a
+Request URL                                       | Target URL                                         | Status code
+--------------------------------------------------|----------------------------------------------------|------------
+`http://store.example.com/admin/products/`        | `https://store.example.com/admin/products/`        | `301`
+`https://store.example.com/admin/products/`       | (unchanged)                                        | n/a
+`http://store.example.com/admin/?logged_out=true` | `https://store.example.com/admin/?logged_out=true` | `301`
+`http://store.example.com/?all_items=true`        | (unchanged)                                        | n/a
+`http://example.com/admin/`                       | (unchanged)                                        | n/a
 
 ## Redirect UK and France visitors to their specific subdomains
 

--- a/content/rules/url-forwarding/single-redirects/examples.md
+++ b/content/rules/url-forwarding/single-redirects/examples.md
@@ -10,7 +10,7 @@ meta:
 
 The following sections contain example single redirect rule configurations.
 
-## Redirect visitors to the new URL of a page
+## Redirect visitors to the new URL of a specific page
 
 This example static redirect for zone `example.com` will redirect visitors requesting the `/contact-us/` page to the new page URL `/contacts/`.
 
@@ -41,6 +41,47 @@ Request URL                        | Target URL                       | Status c
 `example.com/contact-us/`          | `example.com/contacts/`          | `301`
 `example.com/contact-us/?state=TX` | `example.com/contacts/?state=TX` | `301`
 `example.com/team/`                | (unchanged)                      | n/a
+
+## Redirect all requests to HTTPS
+
+This example dynamic redirect for zone `example.com` will redirect visitors to HTTPS for the main domain and all subdomains, keeping the original path and query string.
+
+{{<example>}}
+
+**When incoming requests match**
+
+* **Field:** _SSL/HTTPS_
+* **Value:** Off
+
+_And_
+
+* **Field:** _Hostname_
+* **Operator:** _ends with_
+* **Value:** `example.com`
+
+If you are using the Expression Editor, enter the following expression:<br>
+`(not ssl and ends_with(http.host, "example.com"))`
+
+**Then**
+
+* **Type:** _Dynamic_
+* **Expression:** `concat("https://", http.host, http.request.uri.path)`
+* **Status code:** _301_
+* **Preserve query string:** Enabled
+
+{{</example>}}
+
+The rule expression includes _SSL/HTTPS: Off_ (or `not ssl`) to avoid redirect loops.
+
+For example, the redirect rule would perform the following redirects:
+
+Request URL                                      | Target URL                                       | Status code
+-------------------------------------------------|--------------------------------------------------|------------
+`http://example.com/`                            | `https://example.com/`                           | `301`
+`http://example.com/calendar?show_details=true`  | `https://example.com/calendar?show_details=true` | `301`
+`http://store.example.com/admin/`                | `https://store.example.com/admin/`               | `301`
+`https://example.com/calendar?show_details=true` | (unchanged)                                      | n/a
+`https://store.example.com/admin/`               | (unchanged)                                      | n/a
 
 ## Redirect UK and France visitors to their specific subdomains
 

--- a/content/ssl/edge-certificates/additional-options/always-use-https.md
+++ b/content/ssl/edge-certificates/additional-options/always-use-https.md
@@ -49,7 +49,7 @@ To enable or disable **Always Use HTTPS** with the API, send a [`PATCH`](/api/op
 
 #### Page Rules
 
-If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** at the zone level and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature for specific URLs.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** at the domain level and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature for specific URLs.
 
 #### Redirects
 

--- a/content/ssl/edge-certificates/additional-options/always-use-https.md
+++ b/content/ssl/edge-certificates/additional-options/always-use-https.md
@@ -47,12 +47,6 @@ To enable or disable **Always Use HTTPS** with the API, send a [`PATCH`](/api/op
 
 ### Encrypt some visitor traffic
 
-#### Page Rules
-
-If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** at the domain level and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature for specific URLs.
-
-#### Redirects
-
 If you only want specific subdomains redirected to HTTPS, redirect on a URL basis using Cloudflare [Bulk Redirects](/rules/url-forwarding/bulk-redirects/).
 
 For example, you could forward traffic from a specific subdomain to HTTPS. You would likely want to include **Subpath matching** and **Preserve path suffix** to ensure requests to `http://example.com/examples` go to `https://example.com/examples`.

--- a/content/ssl/edge-certificates/additional-options/always-use-https.md
+++ b/content/ssl/edge-certificates/additional-options/always-use-https.md
@@ -47,9 +47,9 @@ To enable or disable **Always Use HTTPS** with the API, send a [`PATCH`](/api/op
 
 ### Encrypt some visitor traffic
 
-#### Configuration rules
+#### Page Rules
 
-If only some parts of your application can support HTTPS traffic, use [Configuration Rules](/rules/configuration-rules/create-dashboard/) to selectively disable **Always Use HTTPS**.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** at the zone level and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature for specific URLs.
 
 #### Redirects
 

--- a/content/ssl/edge-certificates/encrypt-visitor-traffic.md
+++ b/content/ssl/edge-certificates/encrypt-visitor-traffic.md
@@ -34,4 +34,4 @@ To avoid these issues, enable [Automatic HTTPS Rewrites](/ssl/edge-certificates/
 
 If your entire application can support HTTPS traffic, enable [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/#encrypt-all-visitor-traffic).
 
-If only some parts of your application can support HTTPS traffic, use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively disable **Always Use HTTPS**.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature.

--- a/content/ssl/edge-certificates/encrypt-visitor-traffic.md
+++ b/content/ssl/edge-certificates/encrypt-visitor-traffic.md
@@ -34,4 +34,4 @@ To avoid these issues, enable [Automatic HTTPS Rewrites](/ssl/edge-certificates/
 
 If your entire application can support HTTPS traffic, enable [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/#encrypt-all-visitor-traffic).
 
-If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use [Page Rules](/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/) to selectively enable this feature.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use a [dynamic redirect](/rules/url-forwarding/single-redirects/) to selectively perform the redirect to HTTPS. Refer to [Redirect admin area requests to HTTPS](/rules/url-forwarding/single-redirects/examples/#redirect-admin-area-requests-to-https) for an example.

--- a/content/support/Page Rules/Understanding and configuring Cloudflare Page Rules (Page Rules Tutorial).md
+++ b/content/support/Page Rules/Understanding and configuring Cloudflare Page Rules (Page Rules Tutorial).md
@@ -166,7 +166,7 @@ Below is the full list of settings available, presented in the order that they a
 
 | **Setting** | **Description** | **Plans** |
 | --- | --- | --- |
-| [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/) |  Turn on or off the **Always Use HTTPS** feature. If enabled, any `http://` URL is converted to `https://` through a 301 redirect.<br/><br/>If this option does not appear, you do not have an active **Edge Certificate**. | All |
+| [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/) | Enable **Always Use HTTPS** feature. If enabled, any `http://` URL is converted to `https://` through a 301 redirect.<br/><br/>If this option does not appear, you do not have an active **Edge Certificate**. | All |
 | [Auto Minify](/support/speed/optimization-file-size/using-cloudflare-auto-minify/) | Indicate which file extensions to minify automatically.{{<render file="_configuration-rule-promotion.md" productFolder="rules">}} | All |
 | [Automatic HTTPS Rewrites](/ssl/edge-certificates/additional-options/automatic-https-rewrites/) | Turn on or off **Automatic HTTPS Rewrites**.{{<render file="_configuration-rule-promotion.md" productFolder="rules">}} | All |
 | [Browser Cache TTL](/cache/how-to/edge-browser-cache-ttl/) | Control how long resources cached by client browsers remain valid. The Cloudflare UI and API both prohibit setting **Browser Cache TTL** to _0_ for non-Enterprise domains. | All |


### PR DESCRIPTION
Addresses PCX-7521.

You can only use Page Rules to enforce (or enable) **Always use HTTPS** — there's no option to disable it.