### PR TITLE
[Docs] Fix typos in compound words

### DIFF
--- a/content/bots/concepts/feedback-loop.md
+++ b/content/bots/concepts/feedback-loop.md
@@ -34,8 +34,8 @@ If Cloudflare is unable to detect a portion of automated traffic on your site, s
 | Fuzzing | Finding implementation bugs through the use of malformed data injection in an automated fashion. |
 | Scraping | Automated retrieval of valuable or proprietary information from an Internet application. |
 | Spamming | The abuse of content forms to send spam. |
-| Token Cracking | Identification of valid token codes providing some form of user benefit within the application. | 
-| Vulnerability Scanning | Systematic enumeration and examination of identifiable, guessable and unknown content locations, paths, file names, parameters, in order to find weaknesses and points where a security vulnerability might exist. |
+| Token Cracking | Identification of valid token codes providing some form of user benefit within the application. |
+| Vulnerability Scanning | Systematic enumeration and examination of identifiable, guessable and unknown content locations, paths, file names, parameters, to find weaknesses and points where a security vulnerability might exist. |
 
 ## Submit a report
 
@@ -43,7 +43,7 @@ If Cloudflare is unable to detect a portion of automated traffic on your site, s
 2. Go to **Security** > **Bots**.
 3. Apply one or more bot score filters.
 4. Select **Report incorrect data** and fill out the form.
-5. Select **Submit**. 
+5. Select **Submit**.
 
 ## Via the API
 
@@ -88,7 +88,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/zones/023e105f4ecef8ad9ca31a8
 
  ```json
 # Output
-Null 
+Null
 ```
 
 ### List feedback reports
@@ -98,7 +98,7 @@ Null
 curl -X GET 'https://api.cloudflare.com/client/v4/zones/4e6d50a41172bca54f222576aec3fc2b/bot_management/feedback' \
      -H "X-Auth-Email: user@example.com" \
      -H "X-Auth-Key: c2547eb745079dac9320b638f5e225cf483cc5cfdda41" \
-     -H "Content-Type: application/json" \ 
+     -H "Content-Type: application/json"
 ```
 ```json
  # Output
@@ -154,9 +154,9 @@ curl -X GET 'https://api.cloudflare.com/client/v4/zones/4e6d50a41172bca54f222576
 `requests_by_score`
 
 ```json
-{ 
-  "1": 50, 
-  "10": 50 
+{
+  "1": 50,
+  "10": 50
 }
 ```
 
@@ -164,7 +164,7 @@ curl -X GET 'https://api.cloudflare.com/client/v4/zones/4e6d50a41172bca54f222576
 
 ```json
 {
-  "machine_learning": 75, 
+  "machine_learning": 75,
   "heuristics": 25
 }
 ```
@@ -188,13 +188,13 @@ curl -X GET 'https://api.cloudflare.com/client/v4/zones/4e6d50a41172bca54f222576
   }
 ```
 
-### Expression Fields 
+### Expression fields
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `cf.bot_management.ja3_hash` | string | This provides an SSL/TLS fingerprint to help you identify potential bot requests. |
 | `cf.bot_management.score` | integer | This represents the likelihood that a request originates from a bot using a score from 1-99. |
-| `http.host` | string | This represents the host name used in the full request URI. |
+| `http.host` | string | This represents the hostname used in the full request URI. |
 | `http.request.uri.path` | string | This represents the URI path of the request. |
 | `http.user_agent` | string | This represents the HTTP user agent which is a request header that contains a characteristic string to allow identification of the client operating system and web browser. |
 | `ip.geoip.asnum` | integer | This represents the 16- or 32-bit integer representing the Autonomous System (AS) number associated with client IP address. |
@@ -203,9 +203,9 @@ curl -X GET 'https://api.cloudflare.com/client/v4/zones/4e6d50a41172bca54f222576
 
 ## Recommendations when submitting a report
 
-When you submit a report, use the filters available in the Bot Analytics dashboard to ensure that your report includes only the traffic that received an incorrect score. In addition to filtering by a score (required), you may want to filter by user-agent, IP, ASN or JA3 to more precisely highlight the section of traffic that was scored incorrectly. 
+When you submit a report, use the filters available in the Bot Analytics dashboard to ensure that your report includes only the traffic that received an incorrect score. In addition to filtering by a score (required), you may want to filter by user-agent, IP, ASN or JA3 to more precisely highlight the section of traffic that was scored incorrectly.
 
-If you are not certain if some traffic received an incorrect score, keep this traffic in the report.  
+If you are not certain if some traffic received an incorrect score, keep this traffic in the report.
 
 We appreciate any comments you wish to leave in the description field that might help our team better understand these requests in the context of typical traffic to your domain.
 
@@ -217,9 +217,9 @@ We appreciate any comments you wish to leave in the description field that might
 
 {{</Aside>}}
 
-After submitting a false positive, you can explicitly allow the traffic if you are confident that this traffic source cannot be used for abuse in the future. To allow traffic, you can create a **Firewall Rule** with an [allow](/firewall/cf-firewall-rules/actions/) action or **Custom Rule** with a [Skip the remaining custom rules](/waf/custom-rules/skip/options/) action that matches the characteristics of your false positive report. We recommend any allow or skip rule that you create uses the most narrow possible scope, including restricting the request methods and URIs that the expected traffic has access to, in order to limit potential abuse.   
+After submitting a false positive, you can explicitly allow the traffic if you are confident that this traffic source cannot be used for abuse in the future. To allow traffic, you can create a **Firewall Rule** with an [allow](/firewall/cf-firewall-rules/actions/) action or **Custom Rule** with a [Skip the remaining custom rules](/waf/custom-rules/skip/options/) action that matches the characteristics of your false positive report. We recommend any allow or skip rule that you create uses the most narrow possible scope, including restricting the request methods and URIs that the expected traffic has access to, in order to limit potential abuse.
 
-* Allowing a **[JA3 fingerprint](/bots/concepts/ja3-fingerprint/)**:  If you want to allow access to a stable software client that does not come from a dedicated IP, you can do so by looking up the JA3 fingerprint(s) used by that client in the Bot Analytics dashboard, and creating a **Custom Rule** or **Firewall Rule** to allow traffic based on that JA3 fingerprint. JA3 fingerprints will only match a client’s TLS library, so be cautious in looking for both overlap with other clients and with variation based on the operating system. <br><br>Cloudflare does not recommend relying on JA3 rules for mobile applications that may be abused. If you have questions about how to securely allow traffic from your mobile application, please contact your account team. 
+* Allowing a **[JA3 fingerprint](/bots/concepts/ja3-fingerprint/)**:  If you want to allow access to a stable software client that does not come from a dedicated IP, you can do so by looking up the JA3 fingerprint(s) used by that client in the Bot Analytics dashboard, and creating a **Custom Rule** or **Firewall Rule** to allow traffic based on that JA3 fingerprint. JA3 fingerprints will only match a client’s TLS library, so be cautious in looking for both overlap with other clients and with variation based on the operating system. <br><br>Cloudflare does not recommend relying on JA3 rules for mobile applications that may be abused. If you have questions about how to securely allow traffic from your mobile application, please contact your account team.
 
 {{<Aside>}}
 
@@ -232,4 +232,4 @@ After submitting a false positive, you can explicitly allow the traffic if you a
 
 ## Recommendations after submitting a false negative
 
-After submitting a false negative report, you can explicitly block or rate-limit the incorrectly scored traffic using a combination of characteristics such as IP address, JA3 fingerprint, ASN, and user-agent. Before blocking or rate-limiting based on JA3 fingerprint, please use Bot Analytics to confirm that fingerprint is not being used by legitimate traffic sources. 
+After submitting a false negative report, you can explicitly block or rate-limit the incorrectly scored traffic using a combination of characteristics such as IP address, JA3 fingerprint, ASN, and user-agent. Before blocking or rate-limiting based on JA3 fingerprint, please use Bot Analytics to confirm that fingerprint is not being used by legitimate traffic sources.

--- a/content/china-network/concepts/china-dns.md
+++ b/content/china-network/concepts/china-dns.md
@@ -17,7 +17,7 @@ Before you enable China Authoritative DNS, you should confirm that over 90% of t
 After you [enable the Cloudflare China Network service](/china-network/get-started/), do the following:
 
 1. Ensure that your domain is using a [full setup](/dns/zone-setups/full-setup/). Cloudflare needs to be your authoritative DNS provider to enable China DNS.
-2. Update your domain registrar with the assigned in-China name servers. These name servers are displayed in the Cloudflare dashboard.
+2. Update your domain registrar with the assigned in-China nameservers. These nameservers are displayed in the Cloudflare dashboard.
 3. Test your configuration by checking if the domain resolves correctly.
 
 For further assistance, contact your sales team.

--- a/content/cloudflare-one/connections/connect-devices/agentless/dns/locations/_index.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/dns/locations/_index.md
@@ -40,7 +40,7 @@ If you think someone else is wrongfully using this IPv4 address, [let us know](h
 5. (Optional) Toggle the following settings:
 
    - **Set as Default DNS Location** sets this location as the default in your DNS policy builder.
-   - **Enable EDNS client subnet** sends a user's IP geolocation to authoritative DNS name servers.
+   - **Enable EDNS client subnet** sends a user's IP geolocation to authoritative DNS nameservers.
 
      [EDNS client subnet (ECS)](https://en.wikipedia.org/wiki/EDNS_Client_Subnet) helps reduce latency by routing the user to the closest origin server. Cloudflare has enabled EDNS in a privacy preserving way by not sending the user's exact IP address but rather a /24 range which contains their IP address.
 

--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/warp-logs.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/warp-logs.md
@@ -26,7 +26,7 @@ This will place a `warp-debugging-info-<date>-<time>.zip` on your Desktop.
 
 {{</tab>}}
 {{<tab label="windows" no-code="true">}}
- 
+
 1. Open a Command Prompt or Powershell window.
 2. Run the `warp-diag` tool:
     ```bash
@@ -36,7 +36,7 @@ This will place a `warp-debugging-info-<date>-<time>.zip` on your Desktop.
 
 {{</tab>}}
 {{<tab label="linux" no-code="true">}}
- 
+
 1. Open a Terminal window.
 2. Run the `warp-diag` tool:
     ```sh
@@ -99,7 +99,7 @@ The `warp-debugging-info-<date>-<time>.zip` archive contains the following files
 
 The `warp-debugging-info` folder may contain multiple versions of the same log, such as `daemon.log`, `daemon.1.log`, and `daemon.2.log`. Since logs can get very long, they are rotated either daily or when they exceed a certain size.
 
-- `<logfile>.log` is the most current log. This is almost always the log you should be looking at, as it shows events that occured on the day you ran the `warp-diag` command.
+- `<logfile>.log` is the most current log. This is almost always the log you should be looking at, as it shows events that occurred on the day you ran the `warp-diag` command.
 - `<logfile>.1.log` shows events from the previous day.
 - `<logfile>.2.log` shows events from two days before.
 

--- a/content/cloudflare-one/faq/cloudflare-tunnels-faq.md
+++ b/content/cloudflare-one/faq/cloudflare-tunnels-faq.md
@@ -46,7 +46,7 @@ Yes. Cloudflare Tunnel supports gRPC for services within a [private network](/cl
 
 {{<faq-answer>}}
 
-Cloudflare offers two modes of setup: [Full Setup](/dns/zone-setups/full-setup/), in which the domain uses Cloudflare DNS name servers, and [Partial Setup](/dns/zone-setups/partial-setup/) (also known as CNAME setup) in which the domain uses non-Cloudflare DNS servers.
+Cloudflare offers two modes of setup: [Full Setup](/dns/zone-setups/full-setup/), in which the domain uses Cloudflare DNS nameservers, and [Partial Setup](/dns/zone-setups/partial-setup/) (also known as CNAME setup) in which the domain uses non-Cloudflare DNS servers.
 
 The best experience with Cloudflare Tunnel is using Full Setup because Cloudflare manages DNS for the domain and can automatically configure DNS records for newly started Tunnels.
 

--- a/content/cloudflare-one/policies/filtering/dns-policies/_index.md
+++ b/content/cloudflare-one/policies/filtering/dns-policies/_index.md
@@ -115,7 +115,7 @@ Gateway matches DNS traffic against the following selectors, or criteria:
 
 ### Authoritative Nameserver IP
 
-Use this selector to match against the IP address of the authoritative name server IP address.
+Use this selector to match against the IP address of the authoritative nameserver IP address.
 
 | UI name                     | API example                                |
 | --------------------------- | ------------------------------------------ |

--- a/content/email-security/_partials/_mx-deployment-prerequisites.md
+++ b/content/email-security/_partials/_mx-deployment-prerequisites.md
@@ -7,9 +7,9 @@ _build:
 
 ## Prerequisites
 
-To ensure changes made in this tutorial take effect quickly, update the Time to Live (TTL) value of the existing MX records on your domains to five minutes. Do this on all the domains you will be deploying. 
+To ensure changes made in this tutorial take effect quickly, update the Time to Live (TTL) value of the existing MX records on your domains to five minutes. Do this on all the domains you will be deploying.
 
-Changing the TTL value instructs DNS servers on how long to cache this value before requesting an update from the responsible name server. You need to change the TTL value before changing your MX records to Cloudflare Area 1. This will ensure that changes take effect quickly and can also be reverted quickly if needed. If your DNS manager does not allow for a TTL of five minutes, set it to the lowest possible setting.
+Changing the TTL value instructs DNS servers on how long to cache this value before requesting an update from the responsible nameserver. You need to change the TTL value before changing your MX records to Cloudflare Area 1. This will ensure that changes take effect quickly and can also be reverted quickly if needed. If your DNS manager does not allow for a TTL of five minutes, set it to the lowest possible setting.
 
 To check your existing TTL, open a terminal window and run the following command against your domain:
 
@@ -33,7 +33,7 @@ $ dig mx <YOUR_DOMAIN>
 <YOUR_DOMAIN>.	300	IN	MX	10 mailstream-west.mxrecord.io.
 ```
 
-In the above example, TTL is shown in seconds as `300` (or five minutes). 
+In the above example, TTL is shown in seconds as `300` (or five minutes).
 
 If you are using Cloudflare for DNS, you can leave the [TTL setting as **Auto**](/dns/manage-dns-records/reference/ttl/).
 

--- a/content/fundamentals/glossary.md
+++ b/content/fundamentals/glossary.md
@@ -242,7 +242,7 @@ mTLS is a common security practice that uses client TLS certificates to provide 
 
 ## nameserver
 
-A nameserver is a dedicated server that translates human readable host names into IP addresses. Nameservers like root servers, TLD servers, and authoritative nameservers are fundamental components of the Domain Name System (DNS).
+A nameserver is a dedicated server that translates human readable hostnames into IP addresses. Nameservers like root servers, TLD servers, and authoritative nameservers are fundamental components of the Domain Name System (DNS).
 
 **Related terms:** DNS
 
@@ -330,7 +330,7 @@ Static content is website content that can be delivered to an end user directly 
 
 ## Subject Alternative Name (SAN)
 
-The SAN field of an SSL certificate specifies additional host names (sites, IP addresses, common names, subdomains, root domains, etc.) protected by a single SSL Certificate.
+The SAN field of an SSL certificate specifies additional hostnames (sites, IP addresses, common names, subdomains, root domains, etc.) protected by a single SSL Certificate.
 
 ## subscription, add-on, or plan extension
 

--- a/content/images/image-resizing/troubleshooting.md
+++ b/content/images/image-resizing/troubleshooting.md
@@ -28,7 +28,7 @@ When resizing fails, the response body contains an error message explaining the 
 -  9402 — The image was too large or the connection was interrupted. Refer to [Supported formats and limitations](/images/image-resizing/format-limitations/) for more information.
 -  9403 — A [request loop](/images/image-resizing/resize-with-workers/#prevent-request-loops) occurred because the image was already resized or the Worker fetched its own URL. Verify your Worker path and image path on the server do not overlap.
 -  9406 & 9419 — The image URL is a non-HTTPS URL or the URL has spaces or unescaped Unicode. Check your URL and try again.
--  9407 — A lookup error occured with the origin server's domain name. Check your DNS settings and try again.
+-  9407 — A lookup error occurred with the origin server's domain name. Check your DNS settings and try again.
 -  9404 — The image does not exist on the origin server or the URL used to resize the image is wrong. Verify the image exists and check the URL.
 -  9408 — The origin server returned an HTTP 4xx status code and may be denying access to the image. Confirm your image settings and try again.
 -  9509 — The origin server returned an HTTP 5xx status code. This is most likely a problem with the origin server-side software, not Image Resizing.

--- a/content/load-balancing/additional-options/load-balancing-rules/reference.md
+++ b/content/load-balancing/additional-options/load-balancing-rules/reference.md
@@ -97,7 +97,7 @@ Many of these fields are referenced from the [Rules language documentation](/rul
       <td valign="top"><a href="/ruleset-engine/rules-language/fields/#field-http-host"><code>http.host</code></a><br />{{<type>}}String{{</type>}}</td>
       <td>(API-only)</td>
       <td>
-        <p>Represents the host name used in the full request URI.
+        <p>Represents the hostname used in the full request URI.
         </p>
         <p>Example value:
         <br /><code class="InlineCode">www.example.org</code>
@@ -325,7 +325,7 @@ If your traffic is not proxied through Cloudflare, you have access to all the fi
         <p>When <code>true</code>, this field indicates that the EDNS Client Subnet (ECS) address was sent with the DNS request.
         </p>
       </td>
-    </tr>  
+    </tr>
     <tr id="field-dns-rr-opt-client-addr">
       <td valign="top"><code class>dns.rr.opt.client.addr</code><br />{{<type>}}String{{</type>}}</td>
       <td>(API-only)</td>

--- a/content/network-interconnect/_index.md
+++ b/content/network-interconnect/_index.md
@@ -11,7 +11,7 @@ meta:
 Cloudflare Network Interconnect (CNI) allows you to connect your network infrastructure directly with Cloudflare – rather than using the public Internet – for a more reliable and secure experience.
 
 {{<Aside type="note" header="Note">}}
-  
+
   Cloudflare Network Interconnect is only available to customers on an Enterprise plan.
 
 {{</Aside>}}
@@ -38,8 +38,8 @@ Use CNI with other products in Cloudflare's suite for additional benefits.
     </tr>
      <tr>
       <td><span style="white-space: nowrap"><a href="/magic-wan/zero-trust/cloudflare-gateway/">Magic WAN & Gateway</a></span></td>
-      <td><p>Secure Web Gateway inspects and protects traffic from your datacenter.</p></td>
-      <td><p>Provides a secure connection for outbound datacenter traffic that does not traverse the public Internet.</p></td>
+      <td><p>Secure Web Gateway inspects and protects traffic from your data center.</p></td>
+      <td><p>Provides a secure connection for outbound data center traffic that does not traverse the public Internet.</p></td>
     </tr>
     <tr>
       <td><span style="white-space: nowrap"><a href="https://www.cloudflare.com/cdn/">CDN</a></span></td>

--- a/content/registrar/_partials/_before-you-begin.md
+++ b/content/registrar/_partials/_before-you-begin.md
@@ -10,7 +10,7 @@ _build:
 * Create [a Cloudflare account](/fundamentals/account-and-billing/account-setup/create-account/).
 * [Add the domain](/fundamentals/get-started/setup/add-site/) you are transferring to your Cloudflare account.
 * [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records) in the Cloudflare dashboard.
-* [Change your DNS name servers](/dns/zone-setups/full-setup/) to Cloudflare.
+* [Change your DNS nameservers](/dns/zone-setups/full-setup/) to Cloudflare.
 * Disable DNSSEC by:
   * Removing the DS record at your current DNS host.
   * [Disabling DNSSEC](/registrar/get-started/enable-dnssec/) in the Cloudflare dashboard.

--- a/content/registrar/get-started/enable-dnssec.md
+++ b/content/registrar/get-started/enable-dnssec.md
@@ -9,7 +9,7 @@ meta:
 
 The domain name system (DNS) translates domain names into numeric Internet addresses. However, DNS is a fundamentally insecure protocol. It does not guarantee where DNS records come from and accepts any requests given to it.
 
-[DNSSEC](/dns/dnssec/) creates a secure layer to the domain name system by adding cryptographic signatures to DNS records. By doing so, your request can check the signature to verify that the record you need comes from the authoritative name server and was not altered along the way. 
+[DNSSEC](/dns/dnssec/) creates a secure layer to the domain name system by adding cryptographic signatures to DNS records. By doing so, your request can check the signature to verify that the record you need comes from the authoritative nameserver and was not altered along the way.
 
 ## Enable or disable DNSSEC
 

--- a/content/ruleset-engine/rules-language/fields.md
+++ b/content/ruleset-engine/rules-language/fields.md
@@ -59,7 +59,7 @@ The Cloudflare Rules language supports these standard fields:
    <tr id="field-http-host">
       <td valign="top"><code>http.host</code><br />{{<type>}}String{{</type>}}</td>
       <td>
-         <p>Represents the host name used in the full request URI.
+         <p>Represents the hostname used in the full request URI.
          </p>
          <p>Example value:
          <br /><code class="InlineCode">www.example.org</code>

--- a/content/ssl/edge-certificates/additional-options/http-strict-transport-security.md
+++ b/content/ssl/edge-certificates/additional-options/http-strict-transport-security.md
@@ -39,7 +39,7 @@ Once you enabled HSTS, avoid the following actions to ensure visitors can still 
 - [Pausing Cloudflare](https://support.cloudflare.com/hc/articles/203118044#h_8654c523-e31e-4f40-a3c7-0674336a2753) on your site
 - Pointing your nameservers away from Cloudflare
 - Redirecting HTTPS to HTTP
-- Disabling SSL (invalid or expired certificates or certificates with mismatched host names)
+- Disabling SSL (invalid or expired certificates or certificates with mismatched hostnames)
 
 {{<Aside type="warning">}}
 
@@ -51,7 +51,7 @@ If you remove HTTPS before disabling HSTS or before waiting for the duration of 
 
 {{<tabs labels="Dashboard | API">}}
 {{<tab label="dashboard" no-code="true">}}
- 
+
 To enable HSTS using the dashboard:
 
 1.  Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
@@ -62,12 +62,12 @@ To enable HSTS using the dashboard:
 6.  Select **Next**.
 7.  Configure the [HSTS settings](#configuration-settings).
 8.  Select **Save**.
- 
+
 {{</tab>}}
 {{<tab label="api" no-code="true">}}
- 
+
 To enable HSTS with the API, send a [`PATCH`](/api/operations/zone-settings-change-security-header-(-hsts)-setting) request with the `value` object that includes your HSTS settings.
- 
+
 {{</tab>}}
 {{</tabs>}}
 

--- a/content/style-guide/grammar-and-formatting/parts-of-speech/compound-words.md
+++ b/content/style-guide/grammar-and-formatting/parts-of-speech/compound-words.md
@@ -16,19 +16,14 @@ Whitespace is used in our blog posts and product content. For the sake of consis
     <th>Example</th>
   </tr>
   <tr>
-    <td>Nameserver</td>
-    <td>Name servers</td>
+    <td>nameserver</td>
+    <td>name servers</td>
     <td>Change your nameservers to Cloudflare's.</td>
   </tr>
   <tr>
-    <td>Hostname</td>
+    <td>hostname</td>
     <td>host name</td>
     <td>Add a *. SAN (wildcard) to the custom hostname certificate.</td>
-  </tr>
-  <tr>
-    <td>Nameserver</td>
-    <td>Name servers</td>
-    <td>Change your nameservers to Cloudflare's.</td>
   </tr>
   <tr>
     <td>data center</td>
@@ -50,7 +45,7 @@ See these examples:
 
 Now you can **set up** Centrify, OneLogin, and other identity providers with Cloudflare Access.
 
-Learn how to start using SSO to **log in** to the Cloudflare dashboard. 
+Learn how to start using SSO to **log in** to the Cloudflare dashboard.
 
 Make sure to **back up** your data.
 
@@ -62,7 +57,7 @@ Share an account without sharing a **login**.
 
 This allows you to restore your data from the **backup**.
 
-## Hyphenation 
+## Hyphenation
 
 Certain expressions should be hyphenated depending on their position and role in the sentence.
 

--- a/content/style-guide/grammar-and-formatting/structure/tables.md
+++ b/content/style-guide/grammar-and-formatting/structure/tables.md
@@ -14,7 +14,7 @@ Here are some tips when creating tables:
 + Avoid merged cells. When cells are merged, it impacts how a screen reader navigates the page.
 + Avoid too much text.
 + Aim for parallelism within the column.
-+ Keep tables as simple and as small as possible. 
++ Keep tables as simple and as small as possible.
 
 ## When to use tables
 
@@ -31,7 +31,7 @@ Do not use tables to format a page.
 
 ## Markdown examples
 
-**Add a table** 
+**Add a table**
 
 To add a table, use three or more hyphens (---) to create each column’s header, and use pipes (|) to separate each column. For compatibility, you should also add a pipe on either end of the row.
 
@@ -49,7 +49,7 @@ The rendered output looks like this:
 | Header      | Title       |
 | Paragraph   | Text        |
 
- Tip: Creating tables with hyphens and pipes can be tedious. To speed up the process, try using the [Markdown Tables Generator](https://www.tablesgenerator.com/markdown_tables). 
+ Tip: Creating tables with hyphens and pipes can be tedious. To speed up the process, try using the [Markdown Tables Generator](https://www.tablesgenerator.com/markdown_tables).
 
 ## Alignment
 
@@ -71,7 +71,7 @@ The rendered output looks like this:
 
 ## Formatting text in tables
 
-You can format the text within tables. For example, you can add links, code, and emphasis. 
+You can format the text within tables. For example, you can add links, code, and emphasis.
 
 You can’t add headings, blockquotes, lists, horizontal rules, images, or HTML tags.
 
@@ -103,7 +103,7 @@ For complex tables, consider using HTML. The following example is created with H
    <tr>
       <td valign="top"><code>http.host</code><br />{{<type>}}String{{</type>}}</td>
       <td>
-         <p>Represents the host name used in the full request URI.
+         <p>Represents the hostname used in the full request URI.
          </p>
          <p>Example value:
          <br /><code>www.example.org</code>

--- a/content/support/Third-Party Software/Content Management System (CMS)/Using Cloudflare with your Magento 1 online store.md
+++ b/content/support/Third-Party Software/Content Management System (CMS)/Using Cloudflare with your Magento 1 online store.md
@@ -12,7 +12,7 @@ The following steps will help you to activate Cloudflare for your Magento store
 
 1\. Login to your [Cloudflare account](https://www.cloudflare.com/a/login). If you don’t yet have a Cloudflare account, you can sign up [here.](https://web.archive.org/web/20160428154415/https://www.cloudflare.com/sign-up)
 
-2\. Add your domain and follow the steps for full configuration by using your domain registrar interface and pointing your Name Servers to the Cloudflare Name Servers provided.
+2\. Add your domain and follow the steps for full configuration by using your domain registrar interface and pointing your nameservers to the Cloudflare nameservers provided.
 
 We suggest you read the following article that explains the Cloudflare setup process in detail: [https://support.cloudflare.com/hc/en-us/articles/201720164-How-do-I-sign-up-for-Cloudflare-](https://web.archive.org/web/20160428154415/https://support.cloudflare.com/hc/en-us/articles/201720164-How-do-I-sign-up-for-CloudFlare-)
 

--- a/content/support/Third-Party Software/Others/Using Kubernetes on GKE and AWS with Cloudflare Load Balancer.md
+++ b/content/support/Third-Party Software/Others/Using Kubernetes on GKE and AWS with Cloudflare Load Balancer.md
@@ -199,7 +199,7 @@ Now let’s **create a route 53 domain** for the cluster. Kops uses DNS for di
 $ aws route53 create-hosted-zone --name k8saws.usualwebsite.com --caller-reference 1
 ```
 
-It will automatically create four name server (NS) records. You must then set up your NS records in the parent domain, so that records in the domain will resolve.
+It will automatically create four nameserver (NS) records. You must then set up your NS records in the parent domain, so that records in the domain will resolve.
 
 As Authoritative DNS for my domain usualwebsite.com I am using Cloudflare DNS. Just simply [add four NS records](/dns/manage-dns-records/how-to/create-dns-records/) under your DNS provider.
 

--- a/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 1XXX errors.md
+++ b/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 1XXX errors.md
@@ -326,7 +326,7 @@ Common causes for Error 1016 are:
 
 -   A missing DNS _A record_ that mentions origin IP address.
 -   A _CNAME record_ in the Cloudflare DNS points to an unresolvable external domain.
--   The origin host names (CNAMEs) in your Cloudflare [Load Balancer](/load-balancing/) default, region, and fallback pools are unresolvable. Use a fallback pool configured with an origin IP as a backup in case all other pools are unavailable.
+-   The origin hostnames (CNAMEs) in your Cloudflare [Load Balancer](/load-balancing/) default, region, and fallback pools are unresolvable. Use a fallback pool configured with an origin IP as a backup in case all other pools are unavailable.
 -   When creating a Spectrum app with a CNAME origin, you need first to create a CNAME on the Cloudflare DNS side that points to the origin. Please see [Spectrum CNAME origins](/spectrum/get-started/#create-a-spectrum-application-using-a-cname-record) for more details
 
 ### Resolution

--- a/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 5XX errors.md
+++ b/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 5XX errors.md
@@ -95,7 +95,7 @@ HTTP error 503 occurs when your origin web server is overloaded. There are two p
 
 -   Error contains “cloudflare” or “cloudflare-nginx” in the HTML response body.
 
-**Resolution**: A connectivity issue occured in a Cloudflare data center. Provide [Cloudflare support](https://support.cloudflare.com/hc/articles/200172476) with the following information:
+**Resolution**: A connectivity issue occurred in a Cloudflare data center. Provide [Cloudflare support](https://support.cloudflare.com/hc/articles/200172476) with the following information:
 
 1.  Your domain name
 2.  The time and timezone of the 503 error occurrence

--- a/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 5XX errors.md
+++ b/content/support/Troubleshooting/Cloudflare Errors/Troubleshooting Cloudflare 5XX errors.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: troubleshooting
 title: Troubleshooting Cloudflare 5XX errors
-source: 
+source:
 ---
 
 # Troubleshooting Cloudflare 5XX errors – Cloudflare Help Center
@@ -33,7 +33,7 @@ However, if the 500 error contains “cloudflare” or “cloudflare-nginx” in
 
 1.  Your domain name
 2.  The time and timezone of the 500 error occurrence
-3.  The output of _www.example.com/cdn-cgi/trace_ from the browser where the 500 error was observed (replace _www.example.com_ with your actual domain and host name)
+3.  The output of _www.example.com/cdn-cgi/trace_ from the browser where the 500 error was observed (replace _www.example.com_ with your actual domain and hostname)
 
 {{<Aside type="note">}}
 If you observe blank or white pages when visiting your website, confirm
@@ -81,7 +81,7 @@ To avoid delays processing your inquiry, provide these required details to [Clo
 
 1.  Time and timezone the issue occurred.
 2.  URL that resulted in the HTTP 502 or 504 response (for example: _https://www.example.com/images/icons/image1.png_)
-3.  Output from browsing to _www.example.com/cdn-cgi/trace_ (replace _www.example.com_ with the domain and host name that caused the HTTP 502 or 504 error)
+3.  Output from browsing to _www.example.com/cdn-cgi/trace_ (replace _www.example.com_ with the domain and hostname that caused the HTTP 502 or 504 error)
 
 ___
 
@@ -99,7 +99,7 @@ HTTP error 503 occurs when your origin web server is overloaded. There are two p
 
 1.  Your domain name
 2.  The time and timezone of the 503 error occurrence
-3.  The output of _www.example.com/cdn-cgi/trace_ from the browser where the 503 error was observed (replace _www.example.com_ with your actual domain and host name)
+3.  The output of _www.example.com/cdn-cgi/trace_ from the browser where the 503 error was observed (replace _www.example.com_ with your actual domain and hostname)
 
 ___
 

--- a/content/support/Troubleshooting/General Troubleshooting/Gathering information for troubleshooting sites.md
+++ b/content/support/Troubleshooting/General Troubleshooting/Gathering information for troubleshooting sites.md
@@ -160,7 +160,7 @@ cURL is not installed by default in Windows and requires an [install
 wizard](http://curl.haxx.se/dlwiz/).
 {{</Aside>}}
 
-Run the following command to send a standard HTTP GET request to your website (replace _www.example.com_ with your domain and host name):
+Run the following command to send a standard HTTP GET request to your website (replace _www.example.com_ with your domain and hostname):
 
 ```
 $ curl -svo /dev/null http://www.example.com/
@@ -235,7 +235,7 @@ Cloudflare's Help Center.
 
 #### Reviewing Certificates with cURL
 
-The following cURL command shows the SSL certificate served by Cloudflare during an HTTPS request (replace _www.example.com_ with your domain and host name):
+The following cURL command shows the SSL certificate served by Cloudflare during an HTTPS request (replace _www.example.com_ with your domain and hostname):
 
 ```sh
 $ curl -svo /dev/null https://www.example.com/ 2>&1 | egrep -v "^{.*$|^}.*$|^* http.*$"
@@ -246,7 +246,7 @@ $ curl -svo /dev/null https://www.example.com/ 2>&1 | egrep -v "^{.*$|^}.*$|^* h
 parses the TLS handshake and certificate information.
 {{</Aside>}}
 
-To display the origin certificate (assuming one is installed), replace _203.0.113.34_ below with the actual IP address of your origin web server and replace _www.example.com_ with your domain and host name:
+To display the origin certificate (assuming one is installed), replace _203.0.113.34_ below with the actual IP address of your origin web server and replace _www.example.com_ with your domain and hostname:
 
 ```sh
 $ curl -svo /dev/null https://www.example.com --connect-to ::203.0.113.34 2>&1 | egrep -v "^{.*$|^}.*$|^* http.*$"
@@ -278,7 +278,7 @@ Timeouts are possible for ping results because Cloudflare limits ping
 requests.
 {{</Aside>}}
 
-Review the instructions below for running traceroute on different operating systems. Replace _www.example.com_ with your domain and host name in the examples below:
+Review the instructions below for running traceroute on different operating systems. Replace _www.example.com_ with your domain and hostname in the examples below:
 
 1\. Open the **Start** menu.
 

--- a/content/support/Troubleshooting/HTTP Status Codes/4xx Client Error.md
+++ b/content/support/Troubleshooting/HTTP Status Codes/4xx Client Error.md
@@ -45,7 +45,7 @@ If you're seeing a 403 response that contains Cloudflare branding in the respon
 -   Basic Protection level challenges
 -   Most 1xxx Cloudflare error codes
 -   The Browser Integrity Check
--   If you're attempting to access a second level of subdomains (eg-`*.*.example.com`) through Cloudflare using the Cloudflare-issued certificate, a HTTP 403 error will be seen in the browser as these host names are not present on the certificate.
+-   If you're attempting to access a second level of subdomains (eg-`*.*.example.com`) through Cloudflare using the Cloudflare-issued certificate, a HTTP 403 error will be seen in the browser as these hostnames are not present on the certificate.
 
 ### **404 Not Found (**[**RFC7231**](https://tools.ietf.org/html/rfc7231)**)**
 

--- a/content/waiting-room/how-to/create-waiting-room.md
+++ b/content/waiting-room/how-to/create-waiting-room.md
@@ -47,7 +47,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](/f
 Configure your waiting room with the following required parameters in the `data` field:
 
 *  `name` - A unique name for the waiting room. Use only alphanumeric characters, hyphens, and underscores.
-*  `host` - Host name for which you want to configure a waiting room.
+*  `host` - Hostname for which you want to configure a waiting room.
 *  `total_active_users` - The total number of active user sessions on the route at a point in time.
 *  `new_users_per_minute` - The number of new users gaining entry into the route every minute.
 

--- a/content/waiting-room/reference/configuration-settings.md
+++ b/content/waiting-room/reference/configuration-settings.md
@@ -61,7 +61,7 @@ You can customize a variety of options for your waiting rooms.
         <code>host</code>
       </td>
       <td>Yes</td>
-      <td>Host name for which the waiting room will be applied (no wildcards).</td>
+      <td>Hostname for which the waiting room will be applied (no wildcards).</td>
       <td>
         Do not include <code>http://</code> or <code>https://</code>.
       </td>


### PR DESCRIPTION
Fixes the following across docs (where possible):
* `datacenter[s]` => `data center[s]`
* `host name[s]` => `hostname[s]`
* `name server[s]` => `nameserver[s]`

Also:
* `occured` => `occurred`
