### PR TITLE
[Ruleset Engine] Update curl examples

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/agentless/dns/dns-over-https.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/dns/dns-over-https.md
@@ -155,7 +155,7 @@ highlight: [3, 4, 7]
 curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/organizations/doh/<ID>" \
      -H "X-Auth-Email: <EMAIL>" \
      -H "X-Auth-Key: <API_KEY>" \
-     -H "Content-Type: application/json" \
+     -H "Content-Type: application/json"
 ```
 
 If you get an `access.api.error.service_token_not_found` error, check that `<SERVICE_TOKEN_ID>` is the value of `id` and not `client_id`.
@@ -250,8 +250,8 @@ Request a DoH token for the user, using your service token to authenticate into 
 ```bash
 curl -s -X GET "https://<TEAM_NAME>.cloudflareaccess.com/cdn-cgi/access/doh-token?account-id=<ACCOUNT_ID>&user-id=<USER_ID>&auth-domain=<TEAM_NAME>.cloudflareaccess.com" \
      -H "Cf-Access-Client-Id: <CLIENT_ID>" \
-     -H "Cf-Access-Client-Secret: <CLIENT_SECRET>"
-     -H "Content-Type: application/json" \
+     -H "Cf-Access-Client-Secret: <CLIENT_SECRET>" \
+     -H "Content-Type: application/json"
 ```
 
 The response contains a unique DoH token associated with the user. This token expires in 24 hours. We recommend setting up a refresh flow for the DoH token instead of generating a new one for every DoH query.

--- a/content/cloudflare-one/connections/connect-devices/agentless/dns/dns-over-https.md
+++ b/content/cloudflare-one/connections/connect-devices/agentless/dns/dns-over-https.md
@@ -152,10 +152,10 @@ highlight: [3, 4, 7]
 ### 2. Enable DoH functionality for the service token
 
 ```bash
-curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/organizations/doh/<ID>" \
-     -H "X-Auth-Email: <EMAIL>" \
-     -H "X-Auth-Key: <API_KEY>" \
-     -H "Content-Type: application/json"
+curl --request PUT "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/organizations/doh/<ID>" \
+     --header "X-Auth-Email: <YOUR_EMAIL>" \
+     --header "X-Auth-Key: <API_KEY>" \
+     --header "Content-Type: application/json"
 ```
 
 If you get an `access.api.error.service_token_not_found` error, check that `<SERVICE_TOKEN_ID>` is the value of `id` and not `client_id`.

--- a/content/logs/faq/logpush.md
+++ b/content/logs/faq/logpush.md
@@ -74,5 +74,5 @@ Simply updating a Logpush job does not push the job from v1 to v2. To upgrade a 
 $ curl -sX PUT https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logpush/jobs/<JOB_ID> \
 -H "X-Auth-Email: <EMAIL>" \
 -H "X-Auth-Key: <API_KEY>" \
--d '{"logstream":true}' \
+-d '{"logstream":true}'
 ```

--- a/content/ruleset-engine/basic-operations/add-rule-phase-rulesets.md
+++ b/content/ruleset-engine/basic-operations/add-rule-phase-rulesets.md
@@ -26,14 +26,15 @@ Instead of relying on the automatic creation of an entry point ruleset, you can 
 
 The following example sets the rules of a phase entry point ruleset at the zone level for the `http_request_firewall_managed` phase using the [Update a zone ruleset](/api/operations/updateZoneRuleset) API operation.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -102,15 +103,16 @@ header: Response
 <summary>Example: Add a single rule to a phase entry point ruleset at the zone level</summary>
 <div>
 
-The following example adds a single rule to a phase entry point ruleset (with ID `<RULESET_ID>`) at the zone level using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation.
+The following example adds a single rule to a phase entry point ruleset (with ID `{ruleset_id}`) at the zone level using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) API operation.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/zone/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl https://api.cloudflare.com/client/v4/zone/{zone_id}/rulesets/{ruleset_id}/rules \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "action": "execute",
   "action_parameters": {
     "id": "<MANAGED_RULESET_ID>"

--- a/content/ruleset-engine/basic-operations/deploy-rulesets.md
+++ b/content/ruleset-engine/basic-operations/deploy-rulesets.md
@@ -26,16 +26,17 @@ To apply a rule to every request in a phase at the **zone** level, set the rule 
 
 ## Example
 
-The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of a given zone (`<ZONE_ID>`) by adding a rule that executes the managed ruleset.
+The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of a given zone (`{zone_id}`) by adding a rule that executes the managed ruleset.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",

--- a/content/ruleset-engine/basic-operations/view-rulesets.md
+++ b/content/ruleset-engine/basic-operations/view-rulesets.md
@@ -20,8 +20,8 @@ You can list the available rulesets for a zone, account, or phase.
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 The response displays the following rulesets:
@@ -81,8 +81,8 @@ header: Response
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 The response displays the following rulesets:
@@ -157,8 +157,8 @@ The following example lists the rules in version `2` of the `http_request_firewa
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint/versions/2" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint/versions/2 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json
@@ -206,8 +206,8 @@ The following example lists the rules in version `2` of a managed ruleset (the m
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<MANAGED_RULESET_ID>/versions/2" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{managed_ruleset_id}/versions/2 \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ```json

--- a/content/ruleset-engine/custom-rulesets/_index.md
+++ b/content/ruleset-engine/custom-rulesets/_index.md
@@ -2,6 +2,7 @@
 title: Work with custom rulesets
 pcx_content_type: navigation
 weight: 7
+layout: single
 ---
 
 # Work with custom rulesets

--- a/content/ruleset-engine/custom-rulesets/add-rules-ruleset.md
+++ b/content/ruleset-engine/custom-rulesets/add-rules-ruleset.md
@@ -21,14 +21,15 @@ You can use other API operations depending on the type of operation:
 
 The following request adds two rules to a custom ruleset. These will be the only two rules in the ruleset.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<CUSTOM_RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{custom_ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
@@ -93,14 +94,15 @@ To update one or more rules in a custom ruleset, use the [Update an account rule
 
 The following request edits one rule in a custom ruleset and updates the execution order of the rules.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "id": "<CUSTOM_RULE_ID_2>",

--- a/content/ruleset-engine/custom-rulesets/create-custom-ruleset.md
+++ b/content/ruleset-engine/custom-rulesets/create-custom-ruleset.md
@@ -15,13 +15,14 @@ Use the [Create an account ruleset](/api/operations/createAccountRuleset) API op
 
 The following request creates a new custom ruleset:
 
-```json
+```bash
 ---
 header: Request
 ---
-curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "name": "Custom Ruleset 1",
   "description": "My First Custom Ruleset",
   "kind": "custom",

--- a/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
+++ b/content/ruleset-engine/custom-rulesets/deploy-custom-ruleset.md
@@ -24,21 +24,22 @@ Regarding the expression of the rule deploying the ruleset, you must use parenth
 
 The following `PUT` request adds a rule that executes a custom ruleset when the zone name matches `example.com`.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_custom/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_custom/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
-      "action":"execute",
-      "description":"Execute custom ruleset",
+      "action": "execute",
+      "description": "Execute custom ruleset",
       "expression": "(cf.zone.name == \"example.com\") and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
-        "id":"<CUSTOM_RULESET_ID>"
+        "id": "<CUSTOM_RULESET_ID>"
       }
     },
     {

--- a/content/ruleset-engine/managed-rulesets/_index.md
+++ b/content/ruleset-engine/managed-rulesets/_index.md
@@ -3,7 +3,7 @@ title: Work with managed rulesets
 pcx_content_type: navigation
 type: overview
 weight: 6
-layout: list
+layout: single
 ---
 
 # Work with managed rulesets

--- a/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/deploy-managed-ruleset.md
@@ -21,20 +21,21 @@ Use the following workflow to deploy a managed ruleset to a phase at the account
 
 ### Example
 
-The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of your account (`<ACCOUNT_ID>`) by creating a rule that executes the managed ruleset. The rules in the managed ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
+The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of your account (`{account_id}`) by creating a rule that executes the managed ruleset. The rules in the managed ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
 
 {{<Aside type="warning">}}
 Managed rulesets deployed at the account level will only apply to incoming traffic of zones on an Enterprise plan. The expression of your `execute` rule must end with `and cf.zone.plan eq "ENT"` or else the API operation will fail.
 {{</Aside>}}
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -95,16 +96,17 @@ Use the following workflow to deploy a managed ruleset to a phase at the zone le
 
 ### Example
 
-The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of a given zone (`<ZONE_ID>`) by creating a rule that executes the managed ruleset.
+The following example deploys a managed ruleset to the `http_request_firewall_managed` phase of a given zone (`{zone_id}`) by creating a rule that executes the managed ruleset.
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",

--- a/content/ruleset-engine/managed-rulesets/override-examples/deploy-cmr-joomla-only.md
+++ b/content/ruleset-engine/managed-rulesets/override-examples/deploy-cmr-joomla-only.md
@@ -26,11 +26,12 @@ This example uses the [Update ruleset](/ruleset-engine/rulesets-api/update/) ope
 <summary>Example: Enable only Joomla rules using category overrides at the zone level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -53,7 +54,7 @@ curl -X PUT \
 }'
 ```
 
-*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for the specified zone (`<ZONE_ID>`).
+*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the ruleset of a phase that will apply the Cloudflare Managed Ruleset to requests for the specified zone (`{zone_id}`).
 *   `"enabled": false` defines an override at the ruleset level that disables all rules in the managed ruleset.
 *   `"categories": [{"category": "joomla", "action": "block", "enabled": true}]` defines an override at the tag level that enables the Joomla rules and sets their action to `block`.
 
@@ -64,15 +65,16 @@ curl -X PUT \
 <summary>Example: Enable only Joomla rules using category overrides at the account level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
-      "expression": "cf.zone.name eq \"example.com\"",
+      "expression": "cf.zone.name eq \"example.com\" and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {
@@ -108,11 +110,12 @@ This example uses a `PUT` request to add two overrides to the rule that executes
 <summary>Example: Add more than one category override at the zone level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -146,15 +149,16 @@ curl -X PUT \
 <summary>Example: Add more than one category override at the account level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/account/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/account/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
-      "expression": "cf.zone.name eq \"example.com\"",
+      "expression": "cf.zone.name eq \"example.com\" and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {

--- a/content/ruleset-engine/managed-rulesets/override-examples/deploy-cmr-wordpress-block.md
+++ b/content/ruleset-engine/managed-rulesets/override-examples/deploy-cmr-wordpress-block.md
@@ -22,11 +22,12 @@ The example below uses the [Update ruleset](/ruleset-engine/rulesets-api/update/
 <summary>Example: Use tag overrides to set WordPress rules to Block at the zone level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -54,15 +55,16 @@ curl -X PUT \
 <summary>Example: Use tag overrides to set WordPress rules to Block at the account level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
-      "expression": "cf.zone.name eq \"example.com\"",
+      "expression": "cf.zone.name eq \"example.com\" and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {

--- a/content/ruleset-engine/managed-rulesets/override-examples/enable-selected-rules.md
+++ b/content/ruleset-engine/managed-rulesets/override-examples/enable-selected-rules.md
@@ -22,15 +22,16 @@ The following `PUT` request uses the [Update ruleset](/ruleset-engine/rulesets-a
 
 In this example:
 
-*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the phase entry point ruleset to execute a managed ruleset for requests in the specified zone (`<ZONE_ID>`).
+*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the phase entry point ruleset to execute a managed ruleset for requests in the specified zone (`{zone_id}`).
 *   `"enabled": false` defines an override at the ruleset level to disable all rules in the managed ruleset.
 *   `"rules": [{"id": "<RULE_ID_1>", "action": "block", "enabled": true}, {"id": "<RULE_ID_2>", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -73,15 +74,16 @@ In this example:
 *   `"enabled": false` defines an override at the ruleset level to disable all rules in the managed ruleset.
 *   `"rules": [{"id": "<RULE_ID_1>", "action": "block", "enabled": true}, {"id": "<RULE_ID_2>", "action": "log", "enabled": true}]` defines a list of overrides at the rule level to enable two individual rules.
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
-      "expression": "cf.zone.name eq \"example.com\"",
+      "expression": "cf.zone.name eq \"example.com\" and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {

--- a/content/ruleset-engine/managed-rulesets/override-examples/override-ddos-rule-sensitivity.md
+++ b/content/ruleset-engine/managed-rulesets/override-examples/override-ddos-rule-sensitivity.md
@@ -20,11 +20,12 @@ The example below uses the [Update ruleset](/ruleset-engine/rulesets-api/update/
 <summary>Example: Use an override to set the sensitivity of an HTTP DDoS rule at the zone level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/ddos_l7/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/ddos_l7/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",

--- a/content/ruleset-engine/managed-rulesets/override-examples/override-ruleset-tag-rule.md
+++ b/content/ruleset-engine/managed-rulesets/override-examples/override-ruleset-tag-rule.md
@@ -25,15 +25,17 @@ The request below uses the [Update ruleset](/ruleset-engine/rulesets-api/update/
 
 In this example:
 
-*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset to execute a managed ruleset for requests addressed to a zone (`<ZONE_ID>`).
+*   `"id": "<MANAGED_RULESET_ID>"` adds a rule to the `http_request_firewall_managed` phase entry point ruleset to execute a managed ruleset for requests addressed to a zone (`{zone_id}`).
 *   `"enabled": false` defines an override at the ruleset level to disable all rules in the managed ruleset.
 *   `"categories": [{"category": "wordpress", "action": "log", "enabled": true}, {"category": "drupal", "action": "log", "enabled": true}]` defines an override at the tag level to enable rules tagged with `wordpress` or `drupal` and sets their action to `log`.
 *   `"rules": [{"id": "<RULE_ID>", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -82,14 +84,16 @@ In this example:
 *   `"categories": [{"category": "wordpress", "action": "log", "enabled": true}, {"category": "drupal", "action": "log", "enabled": true}]` defines an override at the tag level to enable rules tagged with `wordpress` or `drupal` and sets their action to `log`.
 *   `"rules": [{"id": "<RULE_ID>", "action": "block", "enabled": true}]` defines an override at the rule level that enables one individual rule and sets the action to `block`.
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
-      "expression": "cf.zone.name eq \"example.com\"",
+      "expression": "cf.zone.name eq \"example.com\" and cf.zone.plan eq \"ENT\"",
       "action_parameters": {
         "id": "<MANAGED_RULESET_ID>",
         "overrides": {

--- a/content/ruleset-engine/managed-rulesets/override-managed-ruleset.md
+++ b/content/ruleset-engine/managed-rulesets/override-managed-ruleset.md
@@ -81,11 +81,12 @@ The following request adds a rule that executes a managed ruleset in the `http_r
 <summary>Example: Execute a managed ruleset with overrides in a phase at the zone level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "description": "Deploy managed ruleset, enabling a specific rule with log action",
   "rules": [
     {
@@ -117,11 +118,12 @@ The following request adds a rule that executes a managed ruleset in the `http_r
 <summary>Example: Execute a managed ruleset with overrides in a phase at the account level</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "description": "Deploy managed ruleset for example.com, overriding the rules action to log",
   "rules": [
     {

--- a/content/ruleset-engine/rulesets-api/add-rule.md
+++ b/content/ruleset-engine/rulesets-api/add-rule.md
@@ -14,8 +14,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Create an account ruleset rule][ar-account] | `POST /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules` |
-| [Create a zone ruleset rule][ar-zone] | `POST /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules` |
+| [Create an account ruleset rule][ar-account] | `POST /accounts/{account_id}/rulesets/{ruleset_id}/rules` |
+| [Create a zone ruleset rule][ar-zone] | `POST /zones/{zone_id}/rulesets/{ruleset_id}/rules` |
 
 [ar-account]: /api/operations/createAccountRulesetRule
 [ar-zone]: /api/operations/createZoneRulesetRule
@@ -28,16 +28,17 @@ Invoking this method creates a new version of the ruleset.
 
 ## Example
 
-The following example adds a rule to ruleset `<RULESET_ID>` of zone `<ZONE_ID>`. The ruleset ID was previously obtained using the [List zone rulesets](/api/operations/listZoneRulesets) operation, and corresponds to the entry point ruleset for the `http_request_firewall_custom` phase.
+The following example adds a rule to ruleset `{ruleset_id}` of zone `{zone_id}`. The ruleset ID was previously obtained using the [List zone rulesets](/api/operations/listZoneRulesets) operation, and corresponds to the entry point ruleset for the `http_request_firewall_custom` phase.
 
 <details open>
 <summary>Request</summary>
 <div>
 
-```json
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "action": "js_challenge",
   "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
   "description": "challenge GB and FR or based on IP Reputation"

--- a/content/ruleset-engine/rulesets-api/create.md
+++ b/content/ruleset-engine/rulesets-api/create.md
@@ -14,8 +14,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Create an account ruleset][cr-account] | `POST /accounts/<ACCOUNT_ID>/rulesets` |
-| [Create a zone ruleset][cr-zone] | `POST /zones/<ZONE_ID>/rulesets` |
+| [Create an account ruleset][cr-account] | `POST /accounts/{account_id}/rulesets` |
+| [Create a zone ruleset][cr-zone] | `POST /zones/{zone_id}/rulesets` |
 
 [cr-account]: /api/operations/createAccountRuleset
 [cr-zone]: /api/operations/createZoneRuleset
@@ -50,15 +50,15 @@ The following parameters are required:
       <td>String</td>
       <td><p>Allowed values:
           <ul>
-            <li><em>custom</em> - creates a custom ruleset</li>
-            <li><em>root</em> - creates a phase entry point ruleset at the account level</li>
-            <li><em>zone</em> - creates a phase entry point ruleset at the zone level</li>
+            <li><code>custom</code>: Creates a custom ruleset</li>
+            <li><code>root</code>: Creates a phase entry point ruleset at the account level</li>
+            <li><code>zone</code>: Creates a phase entry point ruleset at the zone level</li>
           </ul>
         </p></td>
     </tr>
     <tr>
       <td><code>phase</code></td>
-      <td>The name of the phase where the ruleset will be created.</td>
+      <td>The name of the <a href="/ruleset-engine/about/phases/">phase</a> where the ruleset will be created.</td>
       <td>String</td>
       <td>Check the specific Cloudflare product documentation for more information on the phases where you can create rulesets for that product.</td>
     </tr>
@@ -75,10 +75,11 @@ The following example request creates a custom ruleset in the `http_request_fire
 <summary>Request</summary>
 <div>
 
-```json
-curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "name": "Example custom ruleset",
   "kind": "custom",
   "description": "Example ruleset description",
@@ -142,10 +143,11 @@ You do not have to use this method to create a phase entry point ruleset — Clo
 <summary>Request</summary>
 <div>
 
-```json
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "name": "Zone-level phase entry point",
   "kind": "zone",
   "description": "This ruleset executes a managed ruleset.",

--- a/content/ruleset-engine/rulesets-api/delete-rule.md
+++ b/content/ruleset-engine/rulesets-api/delete-rule.md
@@ -14,8 +14,8 @@ Use one of the following API endpoints:
 
 | Operation                                    | Method + Endpoint                                                     |
 | -------------------------------------------- | --------------------------------------------------------------------- |
-| [Delete an account ruleset rule][dr-account] | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
-| [Delete a zone ruleset rule][dr-zone]        | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>`       |
+| [Delete an account ruleset rule][dr-account] | `DELETE /accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id}` |
+| [Delete a zone ruleset rule][dr-zone]        | `DELETE /zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}`       |
 
 [dr-account]: /api/operations/deleteAccountRulesetRule
 [dr-zone]: /api/operations/deleteZoneRulesetRule
@@ -24,16 +24,16 @@ If the delete operation succeeds, the API method call returns a `200 OK` HTTP st
 
 ## Example
 
-The following example deletes rule `<RULE_ID_1>` belonging to ruleset `<RULESET_ID>`.
+The following example deletes rule `{rule_id_1}` belonging to ruleset `{ruleset_id}`.
 
 <details open>
 <summary>Request</summary>
 <div>
 
 ```bash
-curl -X DELETE \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
--H "Authorization: Bearer <API_TOKEN>"
+curl --request DELETE \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id_1} \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>

--- a/content/ruleset-engine/rulesets-api/delete.md
+++ b/content/ruleset-engine/rulesets-api/delete.md
@@ -21,8 +21,8 @@ Use one of the following API endpoints:
 
 | Operation                               | Method + Endpoint                                     |
 | --------------------------------------- | ----------------------------------------------------- |
-| [Delete an account ruleset][dr-account] | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>` |
-| [Delete a zone ruleset][dr-zone]        | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>`       |
+| [Delete an account ruleset][dr-account] | `DELETE /accounts/{account_id}/rulesets/{ruleset_id}` |
+| [Delete a zone ruleset][dr-zone]        | `DELETE /zones/{zone_id}/rulesets/{ruleset_id}`       |
 
 [dr-account]: /api/operations/deleteAccountRuleset
 [dr-zone]: /api/operations/deleteZoneRuleset
@@ -45,9 +45,9 @@ The following example request deletes an existing ruleset.
 ---
 header: Request
 ---
-curl -X DELETE \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>"
+curl --request DELETE \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 ## Delete ruleset version
@@ -56,10 +56,10 @@ Deletes a specific version of a ruleset.
 
 Use one of the following API endpoints:
 
-| Operation                                             | Method + Endpoint                                                               |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Delete an account ruleset version][drv-account] | `DELETE /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>` |
-| [Delete a zone ruleset version][drv-zone]        | `DELETE /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>`       |
+| Operation                                        | Method + Endpoint                                                               |
+| -------------------------------------------------| ------------------------------------------------------------------------------- |
+| [Delete an account ruleset version][drv-account] | `DELETE /accounts/{account_id}/rulesets/{ruleset_id}/versions/{version_number}` |
+| [Delete a zone ruleset version][drv-zone]        | `DELETE /zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_number}`       |
 
 [drv-account]: /api/operations/deleteAccountRulesetVersion
 [drv-zone]: /api/operations/deleteZoneRulesetVersion
@@ -84,7 +84,7 @@ The following example request deletes a version of an existing ruleset.
 ---
 header: Request
 ---
-curl -X DELETE \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>" \
--H "Authorization: Bearer <API_TOKEN>"
+curl --request DELETE \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}/versions/{version_number} \
+--header "Authorization: Bearer <API_TOKEN>"
 ```

--- a/content/ruleset-engine/rulesets-api/endpoints.md
+++ b/content/ruleset-engine/rulesets-api/endpoints.md
@@ -11,13 +11,13 @@ For some operations, you can use specific endpoints provided by the Rulesets API
 For example, instead of using the following endpoint:
 
 ```txt
-PUT /zones/<ZONE_ID>/rulesets/<RULESET_ID>
+PUT /zones/{zone_id}/rulesets/{ruleset_id}
 ```
 
 You can use the following endpoint:
 
 ```txt
-PUT /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint
+PUT /zones/{zone_id}/rulesets/phases/{phase_name}/entrypoint
 ```
 
 To invoke a Rulesets API operation, append the endpoint to the Cloudflare API base URL:
@@ -32,7 +32,7 @@ For help with endpoints and pagination, refer to [Getting Started: Endpoints](/f
 
 {{<Aside>}}
 
-The Rulesets API endpoints require a value for `<ACCOUNT_ID>` or `<ZONE_ID>`.
+The Rulesets API endpoints require a value for `{account_id}` or `{zone_id}`.
 
 To retrieve a list of accounts you have access to, use the [List Accounts](/api/operations/accounts-list-accounts) operation. Note the IDs of the accounts you want to manage.
 

--- a/content/ruleset-engine/rulesets-api/json-object.md
+++ b/content/ruleset-engine/rulesets-api/json-object.md
@@ -12,7 +12,7 @@ A fully populated ruleset object has the following JSON structure.
 
 ```json
 {
-  "id": "ruleset-id",
+  "id": "6a359df138c442b385d20140d4d96919",
   "name": "Example Ruleset",
   "description": "Description of Example Ruleset",
   "kind": "custom",
@@ -20,14 +20,14 @@ A fully populated ruleset object has the following JSON structure.
   "phase": "http_request_firewall_custom",
   "rules": [
     {
-      "id": "rule-id",
+      "id": "fdb0dd271f3f40b19679cc5d91396024",
       "version": "2",
       "action": "block",
       "expression": "cf.zone.name eq \"example.com\" ",
-      "last_updated": "2020-07-20T10:44:29.124515Z"
+      "last_updated": "2022-07-20T10:44:29.124515Z"
     }
   ],
-  "last_updated": "2020-07-20T10:44:29.124515Z"
+  "last_updated": "2022-07-20T10:44:29.124515Z"
 }
 ```
 
@@ -114,7 +114,7 @@ The table lists the properties of a ruleset object.
       <td>
         <code>phase</code>
       </td>
-      <td>The phase to which the ruleset belongs.</td>
+      <td>The <a href="/ruleset-engine/about/phases/">phase</a> to which the ruleset belongs.</td>
       <td>String</td>
       <td>
         <code>phase</code> is immutable.
@@ -147,12 +147,12 @@ A fully populated rule JSON object has the following structure:
 
 ```json
 {
-  "id": "rule-id",
+  "id": "fdb0dd271f3f40b19679cc5d91396024",
   "version": "2",
   "action": "block",
   "categories": ["wordpress"],
   "expression": "cf.zone.name eq \"example.com\"",
-  "last_updated": "2020-07-20T10:44:29.124515Z",
+  "last_updated": "2022-07-20T10:44:29.124515Z",
   "enabled": true
 }
 ```
@@ -194,7 +194,7 @@ The JSON object properties for a rule are defined as follows:
       </td>
       <td>Defines what happens when there’s a match for the rule expression.</td>
       <td>String</td>
-      <td>The available actions depend on the phase where the rule's ruleset is executed.</td>
+      <td>The available actions depend on the <a href="/ruleset-engine/about/phases/">phase</a> where the rule's ruleset is executed.</td>
     </tr>
     <tr>
       <td>
@@ -205,7 +205,7 @@ The JSON object properties for a rule are defined as follows:
         given tag.
       </td>
       <td>Array of strings</td>
-      <td>Read-only. Only available in WAF Managed Rules.</td>
+      <td>Read-only. Only available in <a href="/waf/managed-rules/">WAF Managed Rules</a>.</td>
     </tr>
     <tr>
       <td>

--- a/content/ruleset-engine/rulesets-api/update-rule.md
+++ b/content/ruleset-engine/rulesets-api/update-rule.md
@@ -14,8 +14,8 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Update an account ruleset rule][ur-account] | `PATCH /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
-| [Update a zone ruleset rule][ur-zone] | `PATCH /zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID>` |
+| [Update an account ruleset rule][ur-account] | `PATCH /accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id}` |
+| [Update a zone ruleset rule][ur-zone] | `PATCH /zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}` |
 
 [ur-account]: /api/operations/updateAccountRulesetRule
 [ur-zone]: /api/operations/updateZoneRulesetRule
@@ -30,11 +30,12 @@ To update the definition of a rule, include the new rule definition in the reque
 <summary>Request</summary>
 <div>
 
-```json
-curl -X PATCH \
-"https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id_1} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "action": "js_challenge",
   "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
   "description": "challenge GB and FR or based on IP Reputation"
@@ -65,7 +66,7 @@ The response includes the complete ruleset after updating the rule.
         "action": "js_challenge",
         "expression": "(ip.geoip.country eq \"GB\" or ip.geoip.country eq \"FR\") or cf.threat_score > 0",
         "description": "challenge GB and FR or based on IP Reputation",
-        "last_updated": "2021-03-22T12:54:58.144683Z",
+        "last_updated": "2023-03-22T12:54:58.144683Z",
         "ref": "<RULE_REF_1>",
         "enabled": true
       },
@@ -74,12 +75,12 @@ The response includes the complete ruleset after updating the rule.
         "version": "1",
         "action": "challenge",
         "expression": "not http.request.uri.path matches \"^/api/.*$\"",
-        "last_updated": "2020-11-23T11:36:24.192361Z",
+        "last_updated": "2022-11-23T11:36:24.192361Z",
         "ref": "<RULE_REF_2>",
         "enabled": true
       }
     ],
-    "last_updated": "2021-03-22T12:54:58.144683Z",
+    "last_updated": "2023-03-22T12:54:58.144683Z",
     "phase": "http_request_firewall_custom"
   },
   "success": true,
@@ -126,14 +127,15 @@ The following examples build upon the following (abbreviated) ruleset:
 
 The following request with the `position` object places rule `<RULE_ID_2>` as the first rule:
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PATCH \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_2>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id_2} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "position": {
     "before": ""
   }
@@ -148,14 +150,15 @@ In this case, the new rule order would be:
 
 The following request with the `position` object places rule `<RULE_ID_2>` after rule 3:
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PATCH \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_2>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id_2} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "position": {
     "after": "<RULE_ID_3>"
   }
@@ -170,14 +173,15 @@ In this case, the new rule order would be:
 
 The following request with the `position` object places rule `<RULE_ID_1>` in position 3, becoming the third rule in the ruleset:
 
-```json
+```bash
 ---
 header: Request
 ---
-curl -X PATCH \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/rules/<RULE_ID_1>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id_1} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "position": {
     "index": 3
   }

--- a/content/ruleset-engine/rulesets-api/update.md
+++ b/content/ruleset-engine/rulesets-api/update.md
@@ -14,10 +14,10 @@ Use one of the following API endpoints:
 
 | Operation | Method + Endpoint |
 |-----------|-------------------|
-| [Update an account ruleset][ur-account] | `PUT /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>` |
-| [Update a zone ruleset][ur-zone] | `PUT /zones/<ZONE_ID>/rulesets/<RULESET_ID>` |
-| [Update an account entry point ruleset][uep-account] | `PUT /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
-| [Update a zone entry point ruleset][uep-zone] | `PUT /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
+| [Update an account ruleset][ur-account] | `PUT /accounts/{account_id}/rulesets/{ruleset_id}` |
+| [Update a zone ruleset][ur-zone] | `PUT /zones/{zone_id}/rulesets/{ruleset_id}` |
+| [Update an account entry point ruleset][uep-account] | `PUT /accounts/{account_id}/rulesets/phases/{phase_name}/entrypoint` |
+| [Update a zone entry point ruleset][uep-zone] | `PUT /zones/{zone_id}/rulesets/phases/{phase_name}/entrypoint` |
 
 [ur-account]: /api/operations/updateAccountRuleset
 [ur-zone]: /api/operations/updateZoneRuleset
@@ -38,11 +38,12 @@ Use this API method to set the rules of a ruleset. You must include all the rule
 <summary>Request</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -79,10 +80,10 @@ curl -X PUT \
         "action_parameters": {
           "id": "<MANAGED_RULESET_ID>"
         },
-        "last_updated": "2021-03-17T15:42:37.917815Z"
+        "last_updated": "2023-03-17T15:42:37.917815Z"
       }
     ],
-    "last_updated": "2021-03-17T15:42:37.917815Z",
+    "last_updated": "2023-03-17T15:42:37.917815Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,
@@ -98,17 +99,18 @@ curl -X PUT \
 
 To deploy a ruleset, create a rule with `"action": "execute"` that executes the ruleset, and add the ruleset ID to the `action_parameters` field in the `id` parameter.
 
-The following example deploys a managed ruleset to the zone-level `http_request_firewall_managed` phase of a zone (`<ZONE_ID>`).
+The following example deploys a managed ruleset to the zone-level `http_request_firewall_managed` phase of a zone (`{zone_id}`).
 
 <details open>
 <summary>Request</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/phases/http_request_firewall_managed/entrypoint" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "rules": [
     {
       "action": "execute",
@@ -148,12 +150,12 @@ curl -X PUT \
         },
         "expression": "true",
         "description": "Execute Cloudflare Managed Ruleset on my phase entry point",
-        "last_updated": "2021-03-21T11:02:08.769537Z",
+        "last_updated": "2023-03-21T11:02:08.769537Z",
         "ref": "<RULE_REF_1>",
         "enabled": true
       }
     ],
-    "last_updated": "2021-03-21T11:02:08.769537Z",
+    "last_updated": "2023-03-21T11:02:08.769537Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,
@@ -165,7 +167,7 @@ curl -X PUT \
 </div>
 </details>
 
-For more information on deploying rulesets, check [Deploy rulesets](/ruleset-engine/basic-operations/deploy-rulesets/).
+For more information on deploying rulesets, refer to [Deploy rulesets](/ruleset-engine/basic-operations/deploy-rulesets/).
 
 ## Example - Update ruleset description
 
@@ -181,11 +183,12 @@ You cannot update the description or the rules in a managed ruleset. You can onl
 <summary>Request</summary>
 <div>
 
-```json
-curl -X PUT \
-"https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>" \
--d '{
+```bash
+curl --request PUT \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>" \
+--header "Content-Type: application/json" \
+--data '{
   "description": "My updated phase entry point"
 }'
 ```
@@ -210,7 +213,7 @@ The response includes the complete ruleset definition, including all the rules.
     "rules": [
       // (...)
     ],
-    "last_updated": "2021-03-30T10:49:11.006109Z",
+    "last_updated": "2023-03-30T10:49:11.006109Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,

--- a/content/ruleset-engine/rulesets-api/view.md
+++ b/content/ruleset-engine/rulesets-api/view.md
@@ -22,13 +22,13 @@ Use one of the following API endpoints:
 
 | Operation                           | Method + Endpoint                     |
 | ----------------------------------- | ------------------------------------- |
-| [List account rulesets][lr-account] | `GET /accounts/<ACCOUNT_ID>/rulesets` |
-| [List zone rulesets][lr-zone]       | `GET /zones/<ZONE_ID>/rulesets`       |
+| [List account rulesets][lr-account] | `GET /accounts/{account_id}/rulesets` |
+| [List zone rulesets][lr-zone]       | `GET /zones/{zone_id}/rulesets`       |
 
 [lr-account]: /api/operations/listAccountRulesets
 [lr-zone]: /api/operations/listZoneRulesets
 
-The result includes rulesets across all phases at a given level (account or zone). The `phase` field in each result element indicates the phase where that ruleset is defined.
+The result includes rulesets across all phases at a given level (account or zone). The `phase` field in each result element indicates the [phase](/ruleset-engine/about/phases/) where that ruleset is defined.
 
 Also, the list of rulesets at the zone level includes the account-level rulesets you may want to deploy to the specified zone.
 
@@ -47,8 +47,8 @@ The result does not include the list of rules in the ruleset. Check [View a spec
 <div>
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -67,7 +67,7 @@ curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets" \
       "description": "",
       "kind": "zone",
       "version": "5",
-      "last_updated": "2021-03-18T18:30:08.122758Z",
+      "last_updated": "2023-03-18T18:30:08.122758Z",
       "phase": "http_request_firewall_managed"
     }
   ],
@@ -88,10 +88,10 @@ Use one of the following API endpoints:
 
 | Operation                                      | Method + Endpoint                                                    |
 | ---------------------------------------------- | -------------------------------------------------------------------- |
-| [Get an account ruleset][gr-account]           | `GET /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>`                   |
-| [Get a zone ruleset][gr-zone]                  | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>`                         |
-| [Get an account entry point ruleset][gep-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint` |
-| [Get a zone entry point ruleset][gep-zone]       | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint`       |
+| [Get an account ruleset][gr-account]           | `GET /accounts/{account_id}/rulesets/{ruleset_id}`                   |
+| [Get a zone ruleset][gr-zone]                  | `GET /zones/{zone_id}/rulesets/{ruleset_id}`                         |
+| [Get an account entry point ruleset][gep-account] | `GET /accounts/{account_id}/rulesets/phases/{phase_name}/entrypoint` |
+| [Get a zone entry point ruleset][gep-zone]       | `GET /zones/{zone_id}/rulesets/phases/{phase_name}/entrypoint`       |
 
 [gr-account]: /api/operations/getAccountRuleset
 [gr-zone]: /api/operations/getZoneRuleset
@@ -116,8 +116,8 @@ The API returns a `404 Not Found` HTTP status code under these conditions:
 <div>
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -144,10 +144,10 @@ curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>
         "action_parameters": {
           "id": "<MANAGED_RULESET_ID>"
         },
-        "last_updated": "2021-03-17T15:42:37.917815Z"
+        "last_updated": "2023-03-17T15:42:37.917815Z"
       }
     ],
-    "last_updated": "2021-03-17T15:42:37.917815Z",
+    "last_updated": "2023-03-17T15:42:37.917815Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,
@@ -167,10 +167,10 @@ Use one of the following API endpoints:
 
 | Operation                                                  | Method + Endpoint                                                             |
 | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [List account ruleset versions][lv-account]                | `GET /accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions`                   |
-| [List zone ruleset versions][lv-zone]                      | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions`                         |
-| [List account entry point ruleset versions][lev-account]   | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions` |
-| [List zone entry point ruleset versions][lev-zone]         | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions`       |
+| [List account ruleset versions][lv-account]                | `GET /accounts/{account_id}/rulesets/{ruleset_id}/versions`                   |
+| [List zone ruleset versions][lv-zone]                      | `GET /zones/{zone_id}/rulesets/{ruleset_id}/versions`                         |
+| [List account entry point ruleset versions][lev-account]   | `GET /accounts/{account_id}/rulesets/phases/{phase_name}/entrypoint/versions` |
+| [List zone entry point ruleset versions][lev-zone]         | `GET /zones/{zone_id}/rulesets/phases/{phase_name}/entrypoint/versions`       |
 
 [lv-account]: /api/operations/listAccountRulesetVersions
 [lv-zone]: /api/operations/listZoneRulesetVersions
@@ -188,8 +188,8 @@ When the specified phase entry point ruleset does not exist, this API method ret
 <div>
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/versions \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -208,7 +208,7 @@ curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>
       "description": "",
       "kind": "zone",
       "version": "1",
-      "last_updated": "2021-02-17T11:15:13.128705Z",
+      "last_updated": "2023-02-17T11:15:13.128705Z",
       "phase": "http_request_firewall_managed"
     },
     {
@@ -217,7 +217,7 @@ curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>
       "description": "",
       "kind": "zone",
       "version": "2",
-      "last_updated": "2021-02-17T11:24:06.869326Z",
+      "last_updated": "2023-02-17T11:24:06.869326Z",
       "phase": "http_request_firewall_managed"
     }
   ],
@@ -238,10 +238,10 @@ Use one of the following API endpoints:
 
 | Operation                                                  | Method + Endpoint                                                                              |
 |------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| [Get an account ruleset version][grv-account]              | `GET /account/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>`                    |
-| [Get a zone ruleset version][grv-zone]                     | `GET /zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>`                         |
-| [Get an account entry point ruleset version][gerv-account] | `GET /accounts/<ACCOUNT_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions/<VERSION_NUMBER>` |
-| [Get a zone entry point ruleset version][gerv-zone]        | `GET /zones/<ZONE_ID>/rulesets/phases/<PHASE_NAME>/entrypoint/versions/<VERSION_NUMBER>`       |
+| [Get an account ruleset version][grv-account]              | `GET /account/{account_id}/rulesets/{ruleset_id}/versions/{version_number}`                    |
+| [Get a zone ruleset version][grv-zone]                     | `GET /zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_number}`                         |
+| [Get an account entry point ruleset version][gerv-account] | `GET /accounts/{account_id}/rulesets/phases/{phase_name}/entrypoint/versions/{version_number}` |
+| [Get a zone entry point ruleset version][gerv-zone]        | `GET /zones/{zone_id}/rulesets/phases/{phase_name}/entrypoint/versions/{version_number}`       |
 
 [grv-account]: /api/operations/getAccountRulesetVersions
 [grv-zone]: /api/operations/getZoneRulesetVersions
@@ -257,8 +257,8 @@ When the specified phase entry point ruleset does not exist, this API method ret
 <div>
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>/versions/<VERSION_NUMBER>" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_number} \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -285,10 +285,10 @@ curl "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/rulesets/<RULESET_ID>
         "action_parameters": {
           "id": "<MANAGED_RULESET_ID>"
         },
-        "last_updated": "2021-03-17T15:42:37.917815Z"
+        "last_updated": "2023-03-17T15:42:37.917815Z"
       }
     ],
-    "last_updated": "2021-03-17T15:42:37.917815Z",
+    "last_updated": "2023-03-17T15:42:37.917815Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,
@@ -312,7 +312,7 @@ Returns a list of all the rules in a managed ruleset with a specific tag.
 
 | Operation                                            | Method + Endpoint                                                                                      |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| [List rules in account ruleset version by tag][lrbt] | `GET /accounts/<ACCOUNT_ID>/rulesets/<MANAGED_RULESET_ID>/versions/<VERSION_NUMBER>/by_tag/<TAG_NAME>` |
+| [List rules in account ruleset version by tag][lrbt] | `GET /accounts/{account_id}/rulesets/{managed_ruleset_id}/versions/{version_number}/by_tag/{tag_name}` |
 
 [lrbt]: /api/operations/listAccountRulesetVersionRulesByTag
 
@@ -323,8 +323,8 @@ Returns a list of all the rules in a managed ruleset with a specific tag.
 <div>
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULESET_ID>/versions/2/by_tag/wordpress" \
--H "Authorization: Bearer <API_TOKEN>"
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}/versions/2/by_tag/wordpress \
+--header "Authorization: Bearer <API_TOKEN>"
 ```
 
 </div>
@@ -356,7 +356,7 @@ curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULES
           "wordpress"
         ],
         "description": "Drupal, Wordpress - DoS - XMLRPC - CVE:CVE-2014-5265, CVE:CVE-2014-5266, CVE:CVE-2014-5267",
-        "last_updated": "2021-03-19T16:54:32.942986Z",
+        "last_updated": "2023-03-19T16:54:32.942986Z",
         "ref": "<RULE_REF_1>",
         "enabled": true
       },
@@ -366,13 +366,13 @@ curl "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/rulesets/<RULES
         "action": "block",
         "categories": ["broken-access-control", "cve-2018-12895", "wordpress"],
         "description": "Wordpress - Broken Access Control - CVE:CVE-2018-12895",
-        "last_updated": "2021-03-19T16:54:32.942986Z",
+        "last_updated": "2023-03-19T16:54:32.942986Z",
         "ref": "<RULE_REF_2>",
         "enabled": true
       }
       // (...)
     ],
-    "last_updated": "2021-03-19T16:54:32.942986Z",
+    "last_updated": "2023-03-19T16:54:32.942986Z",
     "phase": "http_request_firewall_managed"
   },
   "success": true,

--- a/content/tenant/_partials/_account-details.md
+++ b/content/tenant/_partials/_account-details.md
@@ -32,7 +32,7 @@ header: Request
 curl -X GET 'https://api.cloudflare.com/client/v4/tenants/<tenant-tag>/accounts?page=1&per_page=10' \
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
--H 'x-auth-key: <API_KEY>' \
+-H 'x-auth-key: <API_KEY>'
 ```
 
 A successful request will return an HTTP status of `200` and a response body containing account information and feature flags for all accounts managed by the Tenant.

--- a/content/tenant/_partials/_account-details.md
+++ b/content/tenant/_partials/_account-details.md
@@ -7,7 +7,7 @@ _build:
 
 {{<definitions>}}
 
-To retreive a list of accounts associated with a Tenant details, send a `GET` request to the `/tenants/<tenant-tag>/accounts` endpoint. You can find the Tenant tag and all Tenants associated with the user with the [**Tenant Details**](/tenant/how-to/get-tenant-details/) API. The Tenant Accounts API also requires pagination passed as query parameters:
+To retrieve a list of accounts associated with a Tenant details, send a `GET` request to the `/tenants/<tenant-tag>/accounts` endpoint. You can find the Tenant tag and all Tenants associated with the user with the [**Tenant Details**](/tenant/how-to/get-tenant-details/) API. The Tenant Accounts API also requires pagination passed as query parameters:
 
 - `page` {{<type>}}number{{</type>}}
 

--- a/content/tenant/_partials/_account-details.md
+++ b/content/tenant/_partials/_account-details.md
@@ -29,7 +29,7 @@ To retrieve a list of accounts associated with a Tenant details, send a `GET` re
 ---
 header: Request
 ---
-curl -X GET 'https://api.cloudflare.com/client/v4/tenants/<tenant-tag>/accounts?page=1&per_page=10' \
+curl https://api.cloudflare.com/client/v4/tenants/<tenant-tag>/accounts?page=1&per_page=10 \
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
 -H 'x-auth-key: <API_KEY>'

--- a/content/tenant/_partials/_tenant-details.md
+++ b/content/tenant/_partials/_tenant-details.md
@@ -18,7 +18,7 @@ header: Request
 curl -X GET 'https://api.cloudflare.com/client/v4/user/tenants' \
 -H 'Content-Type: application/json' \
 -H 'x-auth-email: <EMAIL>' \
--H 'x-auth-key: <API_KEY>' \
+-H 'x-auth-key: <API_KEY>'
 ```
 
 A successful request will return an HTTP status of `200` and a response body containing tenant information, unit information, memberships, and tenant entitlements for all tenants administered by the user.

--- a/content/tenant/_partials/_tenant-details.md
+++ b/content/tenant/_partials/_tenant-details.md
@@ -7,7 +7,7 @@ _build:
 
 {{<definitions>}}
 
-To retreive tenant details, send a `GET` request to the `/user/tenants` endpoint:
+To retrieve tenant details, send a `GET` request to the `/user/tenants` endpoint:
 
 {{</definitions>}}
 

--- a/content/tenant/how-to/manage-accounts.md
+++ b/content/tenant/how-to/manage-accounts.md
@@ -39,7 +39,7 @@ header: Request
 ---
 curl -X GET https://api.cloudflare.com/client/v4/accounts \
 -H 'x-auth-email: <EMAIL>' \
--H 'x-auth-key: <API_KEY>' \
+-H 'x-auth-key: <API_KEY>'
 ```
 
 ```json
@@ -92,7 +92,7 @@ header: Request
 ---
 curl -X DELETE https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID> \
 -H 'x-auth-email: <EMAIL>' \
--H 'x-auth-key: <API_KEY>' \
+-H 'x-auth-key: <API_KEY>'
 ```
 
 A successful request will return the id to confirm the operation:

--- a/content/waiting-room/additional-options/test-waiting-room.md
+++ b/content/waiting-room/additional-options/test-waiting-room.md
@@ -89,7 +89,7 @@ echo '{
   },
   "query": "query UsersQueuedOverTimeQuery($zoneId: string, $filter: ZoneWaitingRoomAnalyticsAdaptiveGroupsFilter_InputObject) {\n  viewer {\n    zones(filter: {zoneTag: $zoneId}) {\n      timeseries: waitingRoomAnalyticsAdaptiveGroups(limit: 5000, filter: $filter, orderBy: [datetimeMinute_ASC]) {\n        avg {\n          totalActiveUsers\n          totalActiveUsersConfig\n          totalQueuedUsers\n          __typename\n        }\n        max {\n          totalQueuedUsers\n          totalActiveUsers\n          totalActiveUsersConfig\n          __typename\n        }\n        min {\n          totalActiveUsersConfig\n          __typename\n        }\n        dimensions {\n          ts: datetimeMinute\n          __typename\n        }\n        __typename\n      }\n      total: waitingRoomAnalyticsAdaptiveGroups(limit: 1, filter: $filter) {\n        max {\n          totalQueuedUsers\n          totalActiveUsers\n          __typename\n        }\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n"
 }' | tr -d '\n' | curl \
-  -X POST \
+  -X POST
 ```
 
 </div>


### PR DESCRIPTION
Also updates the following:
- Updates a few expressions in Ruleset Engine docs that must apply only to Enterprise zones.
- Removes ending slashes from some curl commands (in other tiles).