### PR TITLE
pages: fix Remix bindings example

### DIFF
--- a/content/pages/framework-guides/deploy-a-remix-site.md
+++ b/content/pages/framework-guides/deploy-a-remix-site.md
@@ -83,7 +83,7 @@ A [binding](/pages/platform/functions/bindings/) allows your application to inte
 
 To access bound resources within a Remix application, you need to configure a [Remix `loader` function](https://remix.run/docs/en/main/route/loader).
 
-In the following example, we have a KV namespace called `PRODUCTS_KV` [bound to our Pages Function](/pages/platform/functions/bindings/#kv-namespaces). The `PRODUCTS_KV` binding is accessible on the `context` parameter passed to a `LoaderFunction` as `context.env.BINDING_NAME`.
+The following example uses a KV namespace called `PRODUCTS_KV` [bound to a Pages Function](/pages/platform/functions/bindings/#kv-namespaces). The `PRODUCTS_KV` binding is accessible on the `context` parameter passed to a `LoaderFunction` as `context.env.<BINDING_NAME>`.
 
 The following example shows a Remix `LoaderFunction` accessing a KV namespace in Remix:
 
@@ -131,7 +131,7 @@ export default function Product() {
 }
 ```
 
-Visit the [Remix documentation](https://remix.run/docs/en/main/guides/data-loading) to learn more about data loading within a Remix application.
+Refer to the [Remix documentation](https://remix.run/docs/en/main/guides/data-loading) to learn more about data loading within a Remix application.
 
 #### Durable Objects
 

--- a/content/pages/framework-guides/deploy-a-remix-site.md
+++ b/content/pages/framework-guides/deploy-a-remix-site.md
@@ -11,7 +11,7 @@ In this guide, you will create a new Remix application and deploy to Cloudflare 
 
 ## Setting up a new project
 
-Start by installing the latest version of Remix. Create a new project directory and then intialize a Remix project by running:
+Start by installing the latest version of Remix. Create a new project directory and then initialize a Remix project by running:
 
 ```sh
 $ npx create-remix@latest

--- a/content/pages/framework-guides/deploy-a-remix-site.md
+++ b/content/pages/framework-guides/deploy-a-remix-site.md
@@ -96,14 +96,20 @@ import type { LoaderArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
 
+// Define the bindings associated with our Function
+// so that they are typed
+interface Env {
+  PRODUCTS_KV: KVNamespace;
+}
+
 export const loader: LoaderFunction = async ({
   context,
   params,
 }) => {
   // Bindings are accessible on context.env
-  let productsKV = context.env.PRODUCTS_KV as KVNamespace
+  let env = context.env as Env
   return json(
-    await productsKV.get<{ name: string }>(`product-${params.productId}`, {
+    await env.PRODUCTS_KV.get<{ name: string }>(`product-${params.productId}`, {
       type: "json",
     })
   );


### PR DESCRIPTION
Bindings are on `context.env` within a `LoaderFunction`, not `context`.