### PR TITLE
[R2] Fix R2.list() return types

### DIFF
--- a/content/r2/api/workers/workers-api-reference.md
+++ b/content/r2/api/workers/workers-api-reference.md
@@ -84,7 +84,7 @@ export default {
   - Deletes the given {{<code>}}values{{</code>}} and metadata under the associated {{<code>}}keys{{</code>}}. Once the delete succeeds, returns {{<code>}}void{{</code>}}.
    - R2 deletes are strongly consistent. Once the Promise resolves, all subsequent read operations will no longer see the provided key value pairs globally.
 
-- {{<code>}}list(options{{<param-type>}}R2ListOptions{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}) {{<type>}}Promise\<{{<param-type>}}R2Objects{{</param-type>}}|{{<param-type>}}null{{</param-type>}}>{{</type>}}{{</code>}}
+- {{<code>}}list(options{{<param-type>}}R2ListOptions{{</param-type>}}{{<prop-meta>}}optional{{</prop-meta>}}) {{<type>}}Promise\<{{<param-type>}}R2Objects{{</param-type>}}>{{</type>}}{{</code>}}
 
   - Returns an {{<code>}}R2Objects{{</code>}} containing a list of {{<code>}}R2Object{{</code>}} contained within the bucket. By default, returns the first 1000 entries.
 


### PR DESCRIPTION
Currently docs say it's return type is `Promise<R2Objects | null>`, but actually it is `Promise<R2Objects>`.

![image](https://github.com/cloudflare/cloudflare-docs/assets/6259812/a209f186-30af-4104-ad8d-153b7ad989f5)

> https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#bucket-method-definitions

TypeScript definitions is also defined as `Promise<R2Objects>`.

![image](https://github.com/cloudflare/cloudflare-docs/assets/6259812/71593415-8ae0-4b78-8a36-6c8123bb97bf)

See also https://github.com/cloudflare/workerd/blob/f5388c93bed7f753fccc9ce766d3247e3d2103bf/src/workerd/api/r2-bucket.h#L335