### PR TITLE
[D1] Add new /examples page

### DIFF
--- a/content/d1/examples/_index.md
+++ b/content/d1/examples/_index.md
@@ -3,7 +3,7 @@ type: overview
 hideChildren: true
 pcx_content_type: navigation
 title: Examples
-weight: 1
+weight: 10
 layout: list
 ---
 

--- a/content/d1/examples/_index.md
+++ b/content/d1/examples/_index.md
@@ -1,0 +1,12 @@
+---
+type: overview
+hideChildren: true
+pcx_content_type: navigation
+title: Examples
+weight: 1
+layout: list
+---
+
+# Examples
+
+{{<list-examples>}}

--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -1,0 +1,60 @@
+---
+type: example
+summary: Query your D1 database from a Remix application
+tags:
+  - Remix
+  - D1
+pcx_content_type: configuration
+title: Query D1 from Remix
+weight: 2
+layout: example
+---
+
+Remix is a full-stack web framework that operates on both client and server. You can query your D1 database(s) easily from Remix with Remix's [data loading](https://remix.run/docs/en/1.18.1/guides/data-loading) API with the [`useLoaderData`](https://remix.run/docs/en/1.18.1/hooks/use-loader-data) hook.
+
+To set up a new Remix site on Cloudflare Pages that can query D1:
+
+1. Refer to [the Remix guide](/pages/framework-guides/deploy-a-remix-site/)
+2. Install the Cloudflare adapter within your Remix project: `npm i @remix-run/cloudflare`
+3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases)
+4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
+
+The following example shows how to define a Remix [`loader`](https://remix.run/docs/en/1.18.1/route/loader) that has a binding to a D1 database. Bindings are passed through on the `context.env` parameter passed to a `LoaderFunction`. If you configured a [binding](/pages/platform/functions/bindings/#d1-databases) named `DB`, then you would access D1's [client API](/d1/platform/client-api/#query-statement-methods) methods via `context.env.DB`.
+
+{{<tabs labels="ts">}}
+{{<tab label="ts" default="true">}}
+
+```ts
+---
+filename: app/routes/_index.tsx
+---
+import type { LoaderArgs } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+import { useLoaderData } from "@remix-run/react";
+
+interface Env {
+  DB: D1Database;
+}
+
+export const loader: LoaderFunction = async ({ context, params }) => {
+  let env = context.env as Env;
+
+  let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").run();
+  return json(results);
+};
+
+export default function Index() {
+  const results = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
+      <h1>Welcome to Remix</h1>
+      <div>
+        A value from D1:
+        <pre>{JSON.stringify(results)}</pre>
+      </div>
+    </div>
+  );
+}
+```
+{{</tab>}}
+{{</tabs>}}

--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -1,6 +1,6 @@
 ---
 type: example
-summary: Query your D1 database from a Remix application
+summary: Query your D1 database from a Remix application.
 tags:
   - Remix
   - D1
@@ -14,12 +14,15 @@ Remix is a full-stack web framework that operates on both client and server. You
 
 To set up a new Remix site on Cloudflare Pages that can query D1:
 
-1. Refer to [the Remix guide](/pages/framework-guides/deploy-a-remix-site/)
-2. Install the Cloudflare adapter within your Remix project: `npm i @remix-run/cloudflare`
-3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases)
+1. Refer to [the Remix guide](/pages/framework-guides/deploy-a-remix-site/).
+2. Install the Cloudflare adapter within your Remix project: `npm i @remix-run/cloudflare`.
+3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases).
 4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
 
-The following example shows how to define a Remix [`loader`](https://remix.run/docs/en/1.18.1/route/loader) that has a binding to a D1 database. Bindings are passed through on the `context.env` parameter passed to a `LoaderFunction`. If you configured a [binding](/pages/platform/functions/bindings/#d1-databases) named `DB`, then you would access D1's [client API](/d1/platform/client-api/#query-statement-methods) methods via `context.env.DB`.
+The following example shows how to define a Remix [`loader`](https://remix.run/docs/en/1.18.1/route/loader) that has a binding to a D1 database.
+
+* Bindings are passed through on the `context.env` parameter passed to a `LoaderFunction`.
+* If you configured a [binding](/pages/platform/functions/bindings/#d1-databases) named `DB`, then you would access D1's [client API](/d1/platform/client-api/#query-statement-methods) methods via `context.env.DB`.
 
 {{<tabs labels="ts">}}
 {{<tab label="ts" default="true">}}

--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -39,7 +39,7 @@ interface Env {
 export const loader: LoaderFunction = async ({ context, params }) => {
   let env = context.env as Env;
 
-  let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").run();
+  let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").all();
   return json(results);
 };
 

--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -16,10 +16,10 @@ To set up a new Remix site on Cloudflare Pages that can query D1:
 
 1. Refer to [the Remix guide](/pages/framework-guides/deploy-a-remix-site/).
 2. Install the Cloudflare adapter within your Remix project: `npm i @remix-run/cloudflare`.
-3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases).
+3. Bind a D1 database to your [Pages Function](/pages/platform/functions/bindings/#d1-databases).
 4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
 
-The following example shows how to define a Remix [`loader`](https://remix.run/docs/en/1.18.1/route/loader) that has a binding to a D1 database.
+The following example shows you how to define a Remix [`loader`](https://remix.run/docs/en/1.18.1/route/loader) that has a binding to a D1 database.
 
 * Bindings are passed through on the `context.env` parameter passed to a `LoaderFunction`.
 * If you configured a [binding](/pages/platform/functions/bindings/#d1-databases) named `DB`, then you would access D1's [client API](/d1/platform/client-api/#query-statement-methods) methods via `context.env.DB`.

--- a/content/d1/examples/d1-and-sveltekit.md
+++ b/content/d1/examples/d1-and-sveltekit.md
@@ -1,6 +1,6 @@
 ---
 type: example
-summary: Query a D1 database from a SvelteKit application
+summary: Query a D1 database from a SvelteKit application.
 tags:
   - SvelteKit
   - Svelte
@@ -15,12 +15,15 @@ layout: example
 
 To set up a new SvelteKit site on Cloudflare Pages that can query D1:
 
-1. Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)a
-2. Install the Cloudflare adapter within your SvelteKit project: `npm i -D @sveltejs/adapter-cloudflare`
-3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases)
+1. Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare).
+2. Install the Cloudflare adapter within your SvelteKit project: `npm i -D @sveltejs/adapter-cloudflare`.
+3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases).
 4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
 
-The following example shows a server endpoint configured to query D1. Bindings are available on the `platform` parameter passed to each endpoint, via `platform.env.BINDING_NAME`. With SvelteKit's [file-based routing](https://kit.svelte.dev/docs/routing), the server endpoint defined in `src/routes/api/users/+server.ts` is available at `/api/users` within your SvelteKit app.
+The following example shows a server endpoint configured to query D1.
+
+* Bindings are available on the `platform` parameter passed to each endpoint, via `platform.env.BINDING_NAME`.
+* With SvelteKit's [file-based routing](https://kit.svelte.dev/docs/routing), the server endpoint defined in `src/routes/api/users/+server.ts` is available at `/api/users` within your SvelteKit app.
 
 The example also shows how to configure both your app-wide types within `src/app.d.ts` to recognize your `D1Database` binding, and import the `@sveltejs/adapter-cloudflare` adapter into `svelte.config.js` and configure it to apply to all of your routes.
 

--- a/content/d1/examples/d1-and-sveltekit.md
+++ b/content/d1/examples/d1-and-sveltekit.md
@@ -20,12 +20,12 @@ To set up a new SvelteKit site on Cloudflare Pages that can query D1:
 3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases).
 4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
 
-The following example shows a server endpoint configured to query D1.
+The following example shows you how to create a server endpoint configured to query D1.
 
 * Bindings are available on the `platform` parameter passed to each endpoint, via `platform.env.BINDING_NAME`.
 * With SvelteKit's [file-based routing](https://kit.svelte.dev/docs/routing), the server endpoint defined in `src/routes/api/users/+server.ts` is available at `/api/users` within your SvelteKit app.
 
-The example also shows how to configure both your app-wide types within `src/app.d.ts` to recognize your `D1Database` binding, and import the `@sveltejs/adapter-cloudflare` adapter into `svelte.config.js` and configure it to apply to all of your routes.
+The example also shows you how to configure both your app-wide types within `src/app.d.ts` to recognize your `D1Database` binding, import the `@sveltejs/adapter-cloudflare` adapter into `svelte.config.js`, and configure it to apply to all of your routes.
 
 {{<tabs labels="ts">}}
 {{<tab label="ts" default="true">}}

--- a/content/d1/examples/d1-and-sveltekit.md
+++ b/content/d1/examples/d1-and-sveltekit.md
@@ -1,0 +1,88 @@
+---
+type: example
+summary: Query a D1 database from a SvelteKit application
+tags:
+  - SvelteKit
+  - Svelte
+  - D1
+pcx_content_type: configuration
+title: Query D1 from SvelteKit
+weight: 3
+layout: example
+---
+
+[SvelteKit](https://kit.svelte.dev/) is a full-stack framework that combines the Svelte front-end framework with Vite for server-side capabilities and rendering. You can query D1 from SvelteKit by configuring a [server endpoint](https://kit.svelte.dev/docs/routing#server) with a binding to your D1 database(s).
+
+To set up a new SvelteKit site on Cloudflare Pages that can query D1:
+
+1. Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)a
+2. Install the Cloudflare adapter within your SvelteKit project: `npm i -D @sveltejs/adapter-cloudflare`
+3. Bind a D1 database [to your Pages Function](/pages/platform/functions/bindings/#d1-databases)
+4. Pass the `--d1=BINDING_NAME` flag when developing locally. `BINDING_NAME` should match what call in your code: for example, `--d1=DB`.
+
+The following example shows a server endpoint configured to query D1. Bindings are available on the `platform` parameter passed to each endpoint, via `platform.env.BINDING_NAME`. With SvelteKit's [file-based routing](https://kit.svelte.dev/docs/routing), the server endpoint defined in `src/routes/api/users/+server.ts` is available at `/api/users` within your SvelteKit app.
+
+The example also shows how to configure both your app-wide types within `src/app.d.ts` to recognize your `D1Database` binding, and import the `@sveltejs/adapter-cloudflare` adapter into `svelte.config.js` and configure it to apply to all of your routes.
+
+{{<tabs labels="ts">}}
+{{<tab label="ts" default="true">}}
+```ts
+---
+filename: src/routes/api/users/+server.ts
+---
+import type { RequestHandler } from "@sveltejs/kit";
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET({ request, platform }) {
+  let result = await platform.env.DB.prepare(
+    "SELECT * FROM users LIMIT 5"
+  ).run();
+  return new Response(JSON.stringify(result));
+}
+```
+```ts
+---
+filename: src/app.d.ts
+---
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare global {
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    interface Platform {
+      env: {
+        DB: D1Database;
+      };
+      context: {
+        waitUntil(promise: Promise<any>): void;
+      };
+      caches: CacheStorage & { default: Cache };
+    }
+  }
+}
+
+export {};
+```
+```js
+---
+filename: svelte.config.js
+---
+import adapter from '@sveltejs/adapter-cloudflare';
+
+export default {
+    kit: {
+        adapter: adapter({
+            // See below for an explanation of these options
+            routes: {
+                include: ['/*'],
+                exclude: ['<all>']
+            }
+        })
+    }
+};
+
+```
+{{</tab>}}
+{{</tabs>}}


### PR DESCRIPTION
This PR:

- Adds a new `/d1/examples/` page with the same structure as https://developers.cloudflare.com/workers/examples/
- Adds a Remix + D1 example
- Adds a SvelteKit + D1 example

More framework examples will be added in future PRs.