### PR TITLE
[DNS] Email records shouldn't be proxied

### DIFF
--- a/content/dns/manage-dns-records/how-to/email-records.md
+++ b/content/dns/manage-dns-records/how-to/email-records.md
@@ -24,7 +24,7 @@ To route emails to your mail server, you need to [create two DNS records](/dns/m
 
      | **Type** | **Name** | **IPv4 address** | **Proxy status** |
      | -------- | -------- | ---------------- | ---------------- |
-     | A        | `mail`   | `192.0.2.1`      | Proxied          |
+     | A        | `mail`   | `192.0.2.1`      | DNS-only         |
 
      <details>
       <summary>API example</summary>


### PR DESCRIPTION
Proxied email records can at worst break email delivery and at best cause rDNS issues since we automatically assign a random subdomain to reveal the real IP.

Additionally the API example underneath uses `proxied: false` which is the opposite  of the GUI example here.

This has caused confusion for customers configuring their email records.

If we want to encourage customers to proxy mail records, we could add a callout for Enterprise Spectrum.