### PR TITLE
Removing unsupported example with Bulk Redirect

### DIFF
--- a/content/rules/url-forwarding/bulk-redirects/reference/csv-file-format.md
+++ b/content/rules/url-forwarding/bulk-redirects/reference/csv-file-format.md
@@ -25,7 +25,6 @@ All the lines in this example are valid lines that you can import in the dashboa
 ```txt
 example.com/contacts,https://example.net/contact-us,301,,,,
 example.com/about,https://example.net/about-us,,FALSE,TRUE,,
-"example.com/search?q=bar,baz",https://example.net/search,,TRUE
 example.com/docs,https://example.com/draft-docs,302,,TRUE
 ```
 


### PR DESCRIPTION
Cloudflare employee here.

Bulk Redirect doesn't support query string in the source URL. As of today, this is different than Redirect Rule. https://developers.cloudflare.com/rules/url-forwarding/bulk-redirects/reference/url-components/