### PR TITLE
[workers] update wrangler dev compat with v3.2 release

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -320,7 +320,7 @@ None of the options for this command are required. Many of these options can be 
 
 {{<Aside type="warning">}}
 
-As of Wrangler v3, `wrangler dev` is currently only supported by Debian 12 Bookworm-based distributions, macOS version 13 or greater, and Windows (x86-64 architecture). We are working to increase support for additional operating systems.
+As of Wrangler v3.2.1, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher, macOS version 11 or higher, and Windows (x86-64 architecture).
 
 When using `wrangler dev`, you need to satisfy [`workerd`](https://github.com/cloudflare/workerd)'s `libc++1` runtime dependencies:
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -320,12 +320,7 @@ None of the options for this command are required. Many of these options can be 
 
 {{<Aside type="warning">}}
 
-As of Wrangler v3.2, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher (e.g. Ubuntu 20.04/22.04, Debian 11/12, Fedora 37/38/39), macOS version 11 or higher, and Windows (x86-64 architecture).
-
-When using `wrangler dev`, you need to satisfy [`workerd`](https://github.com/cloudflare/workerd)'s `libc++1` runtime dependencies:
-
-- On Linux: libc++ (for example, the package `libc++1` on Debian Bullseye).
-- On macOS: The XCode command line tools, which can be installed with `xcode-select --install`.
+As of Wrangler v3.2.0, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher (e.g. Ubuntu 20.04/22.04, Debian 11/12, Fedora 37/38/39), macOS version 11 or higher, and Windows (x86-64 architecture).
 
 {{</Aside>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -320,7 +320,7 @@ None of the options for this command are required. Many of these options can be 
 
 {{<Aside type="warning">}}
 
-As of Wrangler v3.2.1, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher, macOS version 11 or higher, and Windows (x86-64 architecture).
+As of Wrangler v3.2, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher, macOS version 11 or higher, and Windows (x86-64 architecture).
 
 When using `wrangler dev`, you need to satisfy [`workerd`](https://github.com/cloudflare/workerd)'s `libc++1` runtime dependencies:
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -320,7 +320,7 @@ None of the options for this command are required. Many of these options can be 
 
 {{<Aside type="warning">}}
 
-As of Wrangler v3.2, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher, macOS version 11 or higher, and Windows (x86-64 architecture).
+As of Wrangler v3.2, `wrangler dev` is supported by any Linux distributions providing `glibc 2.31` or higher (e.g. Ubuntu 20.04/22.04, Debian 11/12, Fedora 37/38/39), macOS version 11 or higher, and Windows (x86-64 architecture).
 
 When using `wrangler dev`, you need to satisfy [`workerd`](https://github.com/cloudflare/workerd)'s `libc++1` runtime dependencies:
 


### PR DESCRIPTION
Update compat notice on `wrangler dev` that as of v3.2 any Linux distribution providing glibc 2.31 or higher (e.g. Ubuntu 20.04/22.04, Debian 11/12, Fedora 37/38/39), and any version of macOS 11 or higher should be supported.