### PR TITLE
Clarify that the limitation for Proxy refers to HTTP traffic only

### DIFF
--- a/content/dns/zone-setups/zone-transfers/cloudflare-as-secondary/_index.md
+++ b/content/dns/zone-setups/zone-transfers/cloudflare-as-secondary/_index.md
@@ -22,7 +22,7 @@ B & C <--DNS lookups--> D[Resolver] <--DNS lookups--> E((User))
 ## How to
 
 - [Set up incoming zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup/)
-- Proxy traffic through Cloudflare with [Secondary DNS Override](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/)
+- Proxy HTTP traffic through Cloudflare with [Secondary DNS Override](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/)
 
 ## Availability
 


### PR DESCRIPTION
Cloudflare employee here.

The limitation for Proxy traffic isn't obvious that Cloudflare talks about HTTP proxy (not DNS traffic).