### PR TITLE
[R2] Fix R2PutOptions types

### DIFF
--- a/content/r2/api/workers/workers-api-reference.md
+++ b/content/r2/api/workers/workers-api-reference.md
@@ -272,7 +272,7 @@ There are 3 variations of arguments that can be used in a range:
 
 {{<definitions>}}
 
-- {{<code>}}onlyIf{{<param-type>}}R2Conditional{{</param-type>}}{{</code>}}
+- {{<code>}}onlyIf{{<param-type>}}R2Conditional{{</param-type>}}|{{<param-type>}}Headers{{</param-type>}}{{</code>}}
 
   - Specifies that the object should only be stored given satisfaction of certain conditions in the `R2Conditional`. Refer to [Conditional operations](#conditional-operations).
 


### PR DESCRIPTION
It seems that `R2PutOptions.onlyIf` should accept `Headers` like `R2GetOptions.onlyIf` does.

https://github.com/cloudflare/workerd/blob/main/src/workerd/api/r2-bucket.h#L151