### PR TITLE
[D1] Add Time Travel documentation

### DIFF
--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -11,9 +11,9 @@ rss: file
 
 ### Time Travel
 
-[Time Travel](/d1/learning/time-travel/) is now available. Time Travel allows you to restore a D1 database back to any minute within the last 30 days (Workers paid plans) or 7 days (Workers free plans), at no additional cost for storage or restore operations.
+[Time Travel](/d1/learning/time-travel/) is now available. Time Travel allows you to restore a D1 database back to any minute within the last 30 days (Workers Paid plan) or 7 days (Workers Free plan), at no additional cost for storage or restore operations.
 
-Refer to the [Time Travel documentation](/d1/learning/time-travel/) to learn how to travel backwards in time.
+Refer to the [Time Travel](/d1/learning/time-travel/) documentation to learn how to travel backwards in time.
 
 Databases using D1's [new storage subsystem](https://blog.cloudflare.com/d1-turning-it-up-to-11/) can use Time Travel. Time Travel replaces the [snapshot-based backups](/d1/learning/backups/) used for legacy alpha databases.
 

--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -13,7 +13,7 @@ rss: file
 
 [Time Travel](/d1/learning/time-travel/) is now available. Time Travel allows you to restore a D1 database back to any minute within the last 30 days (Workers paid plans) or 7 days (Workers free plans), at no additional cost for storage or restore operations.
 
-Refer to the [Time Travel documentation](/d1/learning/time-travel) to learn how to travel backwards in time.
+Refer to the [Time Travel documentation](/d1/learning/time-travel/) to learn how to travel backwards in time.
 
 Databases using D1's [new storage subsystem](https://blog.cloudflare.com/d1-turning-it-up-to-11/) can use Time Travel. Time Travel replaces the [snapshot-based backups](/d1/learning/backups/) used for legacy alpha databases.
 

--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -7,7 +7,7 @@ rss: file
 
 # Changelog
 
-## 2023-07-14
+## 2023-07-27
 
 ### Time Travel
 

--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -7,6 +7,16 @@ rss: file
 
 # Changelog
 
+## 2023-07-14
+
+### Time Travel
+
+[Time Travel](/d1/learning/time-travel/) is now available. Time Travel allows you to restore a D1 database back to any minute within the last 30 days (Workers paid plans) or 7 days (Workers free plans), at no additional cost for storage or restore operations.
+
+Refer to the [Time Travel documentation](/d1/learning/time-travel) to learn how to travel backwards in time.
+
+Databases using D1's [new storage subsystem](https://blog.cloudflare.com/d1-turning-it-up-to-11/) can use Time Travel. Time Travel replaces the [snapshot-based backups](/d1/learning/backups/) used for legacy alpha databases.
+
 ## 2023-06-16
 
 ### Generated columns documentation

--- a/content/d1/learning/backups.md
+++ b/content/d1/learning/backups.md
@@ -1,5 +1,5 @@
 ---
-title: Backups
+title: Backups (Legacy)
 weight: 9
 pcx_content_type: concept
 ---

--- a/content/d1/learning/backups.md
+++ b/content/d1/learning/backups.md
@@ -8,6 +8,16 @@ pcx_content_type: concept
 
 D1 has built-in support for creating and restoring backups of your databases, including support for scheduled automatic backups and manual backup management.
 
+{{<Aside type="warning" header="Time Travel">}}
+
+The snapshot based backups described in this documentation are deprecated, and limited to the original alpha databases.
+
+Databases using D1's [new storage subsystem](https://blog.cloudflare.com/d1-turning-it-up-to-11/) can use Time Travel. Time Travel replaces the [snapshot-based backups](/d1/learning/backups/) used for legacy alpha databases.
+
+To understand which storage subsystem your database uses, run `wrangler d1 info YOUR_DATABASE` and inspect the `version` field in the output. Databases with `version: beta` support the new Time Travel API. Databases with `version: alpha` only support the older, snapshot-based backup API.
+
+{{</Aside>}}
+
 ## Automatic backups
 
 D1 automatically backs up your databases every hour on your behalf, and [retains backups for 24 hours](/d1/platform/limits/). Backups will block access to the DB while they are running. In most cases this should only be a second or two, and any requests that arrive during the backup will be queued.

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -1,5 +1,5 @@
 ---
-title: Time Travel & Backups
+title: Time Travel and backups
 pcx_content_type: concept
 weight: 3
 ---
@@ -8,9 +8,9 @@ weight: 3
 
 Time Travel is D1's approach to backups and point-in-time-recovery, and allows you to restore a database to any minute within the last 30 days.
 
-* You do not need to enable Time Travel: it is always on.
+* You do not need to enable Time Travel. It is always on.
 * Database history and restoring a database incur no additional costs.
-* Time Travel automatically creates [bookmarks](#terminology) on your behalf: you do not need to manually trigger or remember to initiate a backup.
+* Time Travel automatically creates [bookmarks](#terminology) on your behalf. You do not need to manually trigger or remember to initiate a backup.
 
 By not having to rely on scheduled backups and/or manually initiated backups, you can go back in time and restore a database prior to a failed migration or schema change, a `DELETE` or `UPDATE` statement without a specific `WHERE` clause, and in the future, fork/copy a production database directly.
 
@@ -24,9 +24,9 @@ To understand which storage subsystem your database uses, run `wrangler d1 info 
 
 ## Terminology
 
-Time Travel introduces the concept of a "bookmark" to D1: a bookmark represents the state of a database at a specific point in time, and is effectively an append-only log.
+Time Travel introduces the concept of a "bookmark" to D1. A bookmark represents the state of a database at a specific point in time, and is effectively an append-only log.
 
-* Bookmarks are lexicographically sortable: sorting a list of bookmarks will order them from oldest-to-newest
+* Bookmarks are lexicographically sortable. Sorting orders a list of bookmarks from oldest-to-newest.
 * Bookmarks older than 30 days are invalid and cannot be used as a restore point.
 * Restoring a database to a specific bookmark does not remove or delete older bookmarks. For example, if you restore to a bookmark representing the state of your database 10 minutes ago, and determine that you needed to restore to an earlier point in time, you can still do so.
 
@@ -62,7 +62,7 @@ $ wrangler d1 time-travel info YOUR_DATABASE --timestamp="2023-07-09T17:31:11+00
 
 ## Restore a database
 
-To restore a database a specific point-in-time:
+To restore a database to a specific point-in-time:
 
 {{<Aside type="warning">}}
 
@@ -89,7 +89,7 @@ In-flight queries and transactions will be cancelled.
 Note that:
 
 * Timestamps are converted to a deterministic, stable bookmark. The same timestamp will always represent the same bookmark.
-* Queries in flight will be cancelled, and an error returned to the client
+* Queries in flight will be cancelled, and an error returned to the client.
 * The restore operation will return a [bookmark](#terminology) that allows you to [undo](#undo-a-restore) and revert the database.
 
 ## Undo a restore
@@ -97,7 +97,7 @@ Note that:
 You can undo a restore by:
 
 * Taking note of the previous bookmark returned as part of a `wrangler d1 time-travel restore` operation
-* Restore directly to a bookmark in the past, prior to your last restore.
+* Restoring directly to a bookmark in the past, prior to your last restore.
 
 To fetch a bookmark from an earlier state
 
@@ -114,6 +114,6 @@ $ wrangler d1 time-travel info YOUR_DATABASE
 
 ## Notes
 
-* You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date %+s`
+* You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date %+s`.
 * Time Travel does not yet allow you to clone or fork an existing database to a new copy. In the future, Time Travel will allow you to easily fork (clone) an existing database into a new database, or overwrite an existing database.
 * You can restore a database back to a point in time up to 30 days in the past (Workers Paid plans) or 7 days (Workers free plans). See the [Limits](/d1/platform/limits/) page for details on Time Travel's limits.

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -1,0 +1,87 @@
+---
+title: Time Travel & Backups
+pcx_content_type: concept
+weight: 3
+---
+
+# Time Travel
+
+Time Travel is D1's approach to backups and point-in-time-recovery, and allows you to restore a database to any minute within the last 30 days.
+
+* You do not need to enable Time Travel: it is always on.
+* Database history and restoring a database incur no additional costs.
+* Time Travel automatically creates [bookmarks](#terminology) on your behalf: you do not need to manually trigger or remember to initiate a backup.
+
+By not having to rely on scheduled backups and/or manually initiated backups, you can go back in time and restore a database prior to a failed migration or schema change, a `DELETE` or `UPDATE` statement without a specific `WHERE` clause, and in the future, fork/copy a production database directly.
+
+{{<Aside type="note" header="Support for Time Travel">}}
+
+Databases using D1's [new storage subsystem](https://blog.cloudflare.com/d1-turning-it-up-to-11/) can use Time Travel. Time Travel replaces the [snapshot-based backups](/d1/learning/backups/) used for legacy alpha databases.
+
+To understand which storage subsystem your database uses, run `wrangler d1 info YOUR_DATABASE` and inspect the `version` field in the output. Databases with `version: beta` support the new Time Travel API. Databases with `version: alpha` only support the older, snapshot-based backup API.
+
+{{</Aside>}}
+
+## Terminology
+
+Time Travel introduces the concept of a "bookmark" to D1: a bookmark represents the state of a database at a specific point in time, and is effectively an append-only log.
+
+* Bookmarks are lexigraphically sortable: sorting a list of bookmarks will order them from oldest-to-newest
+* Bookmarks older than 30 days are invalid and cannot be used as a restore point.
+* Restoring a database to a specific bookmark does not remove or delete older bookmarks. For example, if you restore to a bookmark representing the state of your database 10 minutes ago, and determine that you needed to restore to an earlier point in time, you can still do so.
+
+Bookmarks can be derived from a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) (seconds since Jan 1st, 1970), and conversion between a specific timestamp and a bookmark is deterministic (stable).
+
+## Retrieve a bookmark
+
+You can retrieve a bookmark for the current timestamp by calling the `d1 show` command, which defaults to returning the current bookmark:
+
+```sh
+$ wrangler d1 time-travel show YOUR_DATABASE
+```
+
+To retrieve the bookmark for a timestamp in the past, pass the `--at-timestamp` flag with a valid Unix timestamp:
+
+```sh
+$ wrangler d1 time-travel show YOUR_DATABASE --at-timestamp=UNIX_TIMESTAMP
+```
+
+## Restore a database
+
+To restore a database a specific point-in-time:
+
+{{<Aside type="warning">}}
+
+Restoring a database to a specific point-in-time is a _destructive_ operation, and overwrites the database in place. In the future, D1 will support branching & cloning databases using Time Travel.
+
+{{</Aside>}}
+
+```sh
+$ wrangler d1 time-travel restore YOUR_DATABASE --at-timestamp=UNIX_TIMESTAMP
+
+# Example output:
+...
+```
+
+Note that:
+
+* Queries in flight will be cancelled, and an error returned to the client
+* The restore operation will return a [bookmark](#terminology) that allows you to [undo](#undo-a-restore) and revert the database.
+
+## Undo a restore
+
+You can undo a restore by:
+
+* Taking note of the previous bookmark returned as part of a `wrangler d1 restore` operation
+* Restore directly to a bookmark in the past, prior to your last restore.
+
+```sh
+# Get a historical bookmark
+$ wrangler d1 time-travel info 
+```
+
+## Notes
+
+* You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date %+s`
+* Time Travel does not yet allow you to clone or fork an existing database to a new copy. In the future, Time Travel will allow you to easily fork (clone) an existing database into a new database, or overwrite an existing database.
+* You can restore a database back to a point in time up to 30 days in the past (Workers Paid plans) or 7 days (Workers free plans). See the [Limits](/d1/platform/limits/) page for details on Time Travel's limits.

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -99,7 +99,7 @@ You can undo a restore by:
 * Taking note of the previous bookmark returned as part of a `wrangler d1 time-travel restore` operation
 * Restoring directly to a bookmark in the past, prior to your last restore.
 
-To fetch a bookmark from an earlier state
+To fetch a bookmark from an earlier state:
 
 ```sh
 # Get a historical bookmark
@@ -116,4 +116,4 @@ $ wrangler d1 time-travel info YOUR_DATABASE
 
 * You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date %+s`.
 * Time Travel does not yet allow you to clone or fork an existing database to a new copy. In the future, Time Travel will allow you to easily fork (clone) an existing database into a new database, or overwrite an existing database.
-* You can restore a database back to a point in time up to 30 days in the past (Workers Paid plans) or 7 days (Workers free plans). See the [Limits](/d1/platform/limits/) page for details on Time Travel's limits.
+* You can restore a database back to a point in time up to 30 days in the past (Workers Paid plan) or 7 days (Workers Free plan). See the [Limits](/d1/platform/limits/) page for details on Time Travel's limits.

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -32,19 +32,32 @@ Time Travel introduces the concept of a "bookmark" to D1: a bookmark represents 
 
 Bookmarks can be derived from a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) (seconds since Jan 1st, 1970), and conversion between a specific timestamp and a bookmark is deterministic (stable).
 
+## Timestamps
+
+Time Travel supports two timestamp formats:
+
+* [Unix timestamps](https://developer.mozilla.org/en-US/docs/Glossary/Unix_time), which correspond to seconds since January 1st, 1970 at midnight. This is always in UTC.
+* The [JavaScript date-time string format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format), which is a simplified version of the ISO-8601 timestamp format. An valid date-time string for the July 27, 2023 at 11:18AM in Americas/New_York (EST) would look like `2023-07-27T11:18:53.000-04:00`. 
+
 ## Retrieve a bookmark
 
 You can retrieve a bookmark for the current timestamp by calling the `d1 info` command, which defaults to returning the current bookmark:
 
 ```sh
 $ wrangler d1 time-travel info YOUR_DATABASE
+
+# Example output
+🚧 Time Traveling...
+⚠️ The current bookmark is '00000085-0000024c-00004c6d-8e61117bf38d7adb71b934ebbf891683'
+⚡️ To restore to this specific bookmark, run:
+ `wrangler d1 time-travel restore YOUR_DATABASE --bookmark=00000085-0000024c-00004c6d-8e61117bf38d7adb71b934ebbf891683`
 ```
 
-To retrieve the bookmark for a timestamp in the past, pass the `--at-timestamp` flag with a valid Unix or RFC3339 timestamp:
+To retrieve the bookmark for a timestamp in the past, pass the `--timestamp` flag with a valid Unix or RFC3339 timestamp:
 
 ```sh
 # Using an RFC3339 timestamp, including the timezone:
-$ wrangler d1 time-travel info YOUR_DATABASE --timestamp='2023-07-09T17:31:11+00:00"
+$ wrangler d1 time-travel info YOUR_DATABASE --timestamp="2023-07-09T17:31:11+00:00"
 ```
 
 ## Restore a database
@@ -58,14 +71,24 @@ Restoring a database to a specific point-in-time is a _destructive_ operation, a
 {{</Aside>}}
 
 ```sh
-$ wrangler d1 time-travel restore YOUR_DATABASE --at-timestamp=UNIX_TIMESTAMP
+$ wrangler d1 time-travel restore YOUR_DATABASE --timestamp=UNIX_TIMESTAMP
 
 # Example output:
-...
+🚧 Restoring database YOUR_DATABASE from bookmark 00000080-ffffffff-00004c60-390376cb1c4dd679b74a19d19f5ca5be
+
+⚠️ This will overwrite all data in database YOUR_DATABASE.
+In-flight queries and transactions will be cancelled.
+
+✔ OK to proceed (y/N) … yes
+⚡️ Time travel in progress...
+✅ Database YOUR_DATABASE restored back to bookmark 00000080-ffffffff-00004c60-390376cb1c4dd679b74a19d19f5ca5be
+
+↩️ To undo this operation, you can restore to the previous bookmark: 00000085-ffffffff-00004c6d-2510c8b03a2eb2c48b2422bb3b33fad5
 ```
 
 Note that:
 
+* Timestamps are converted to a deterministic, stable bookmark. The same timestamp will always represent the same bookmark.
 * Queries in flight will be cancelled, and an error returned to the client
 * The restore operation will return a [bookmark](#terminology) that allows you to [undo](#undo-a-restore) and revert the database.
 
@@ -73,12 +96,20 @@ Note that:
 
 You can undo a restore by:
 
-* Taking note of the previous bookmark returned as part of a `wrangler d1 restore` operation
+* Taking note of the previous bookmark returned as part of a `wrangler d1 time-travel restore` operation
 * Restore directly to a bookmark in the past, prior to your last restore.
+
+To fetch a bookmark from an earlier state
 
 ```sh
 # Get a historical bookmark
-$ wrangler d1 time-travel info 
+$ wrangler d1 time-travel info YOUR_DATABASE
+
+# Example output
+🚧 Time Traveling...
+⚠️ The current bookmark is '00000085-0000024c-00004c6d-8e61117bf38d7adb71b934ebbf891683'
+⚡️ To restore to this specific bookmark, run:
+ `wrangler d1 time-travel restore YOUR_DATABASE --bookmark=00000085-0000024c-00004c6d-8e61117bf38d7adb71b934ebbf891683`
 ```
 
 ## Notes

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -26,7 +26,7 @@ To understand which storage subsystem your database uses, run `wrangler d1 info 
 
 Time Travel introduces the concept of a "bookmark" to D1: a bookmark represents the state of a database at a specific point in time, and is effectively an append-only log.
 
-* Bookmarks are lexigraphically sortable: sorting a list of bookmarks will order them from oldest-to-newest
+* Bookmarks are lexicographically sortable: sorting a list of bookmarks will order them from oldest-to-newest
 * Bookmarks older than 30 days are invalid and cannot be used as a restore point.
 * Restoring a database to a specific bookmark does not remove or delete older bookmarks. For example, if you restore to a bookmark representing the state of your database 10 minutes ago, and determine that you needed to restore to an earlier point in time, you can still do so.
 

--- a/content/d1/learning/time-travel.md
+++ b/content/d1/learning/time-travel.md
@@ -34,16 +34,17 @@ Bookmarks can be derived from a [Unix timestamp](https://en.wikipedia.org/wiki/U
 
 ## Retrieve a bookmark
 
-You can retrieve a bookmark for the current timestamp by calling the `d1 show` command, which defaults to returning the current bookmark:
+You can retrieve a bookmark for the current timestamp by calling the `d1 info` command, which defaults to returning the current bookmark:
 
 ```sh
-$ wrangler d1 time-travel show YOUR_DATABASE
+$ wrangler d1 time-travel info YOUR_DATABASE
 ```
 
-To retrieve the bookmark for a timestamp in the past, pass the `--at-timestamp` flag with a valid Unix timestamp:
+To retrieve the bookmark for a timestamp in the past, pass the `--at-timestamp` flag with a valid Unix or RFC3339 timestamp:
 
 ```sh
-$ wrangler d1 time-travel show YOUR_DATABASE --at-timestamp=UNIX_TIMESTAMP
+# Using an RFC3339 timestamp, including the timezone:
+$ wrangler d1 time-travel info YOUR_DATABASE --timestamp='2023-07-09T17:31:11+00:00"
 ```
 
 ## Restore a database

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -15,7 +15,7 @@ Many of these limits will increase during D1's [public alpha](/workers/platform/
 | -------------------------------------------------- | -------------------------------------------- | 
 | Databases                                          | 10 per account <sup>1</sup>                  |
 | Database size                                      | 100 MB <sup>2</sup>                          |
-| Time Travel duration (point-in-time recovery)      | 30 days (Workers Paid) / 7 days (Free)       |
+| [Time Travel](/d1/learning/time-travel/) duration (point-in-time recovery)      | 30 days (Workers Paid) / 7 days (Free)       |
 | Maximum Time Travel restore operations             | 10 restores per 10 minute (per database)     |
 | Queries per Worker invocation (see [subrequest limits](/workers/platform/limits/#how-many-subrequests-can-i-make))                      | 50 (Bundled) / 1000 (Unbound)
 | Maximum [database backups](/d1/learning/backups/)  | 24 hours (backups are hourly) (alpha only)   |

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -16,6 +16,7 @@ Many of these limits will increase during D1's [public alpha](/workers/platform/
 | Databases                                          | 10 per account <sup>1</sup>                  |
 | Database size                                      | 100 MB <sup>2</sup>                          |
 | Time Travel duration (point-in-time recovery)      | 30 days (Workers Paid) / 7 days (Free)       |
+| Maximum Time Travel restore operations             | 10 restores per 10 minute (per database)     |
 | Queries per Worker invocation (see [subrequest limits](/workers/platform/limits/#how-many-subrequests-can-i-make))                      | 50 (Bundled) / 1000 (Unbound)
 | Maximum [database backups](/d1/learning/backups/)  | 24 hours (backups are hourly) (alpha only)   |
 | Maximum number of columns per table                | 100                                          |

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -194,9 +194,9 @@ $ wrangler d1 time-travel restore <DATABASE_NAME> [OPTIONS]
 - `DATABASE_NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
   - The name of the D1 database to execute a query on.
 - `--bookmark` {{<type>}}string{{</type>}}
-  - ...
+  - A D1 bookmark representing the state of a database at a specific point in time.
 - `--timestamp` {{<type>}}string{{</type>}}
-  - ...
+  - A Unix timestamp or JavaScript date-time string within the last 30 days.
   {{</definitions>}}
 
 ### `time-travel info`
@@ -212,7 +212,7 @@ $ wrangler d1 time-travel info <DATABASE_NAME> [OPTIONS]
 - `DATABASE_NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
   - The name of the D1 database to execute a query on.
 - `--timestamp` {{<type>}}string{{</type>}}
-  - ...
+  - A Unix timestamp or JavaScript date-time string within the last 30 days.
   {{</definitions>}}
 
 ### `backup create`

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -186,7 +186,7 @@ $ wrangler d1 execute <DATABASE_NAME> [OPTIONS]
 Restore a database to a specific point-in-time using [Time Travel](/d1/learning/time-travel/).
 
 ```sh
-$ wrangler d1 time-travel <DATABASE_NAME> [OPTIONS]
+$ wrangler d1 time-travel restore <DATABASE_NAME> [OPTIONS]
 ```
 
 {{<definitions>}}
@@ -204,7 +204,7 @@ $ wrangler d1 time-travel <DATABASE_NAME> [OPTIONS]
 Inspect the current state of a database for a specific point-in-time using [Time Travel](/d1/learning/time-travel/).
 
 ```sh
-$ wrangler d1 time-travel <DATABASE_NAME> [OPTIONS]
+$ wrangler d1 time-travel info <DATABASE_NAME> [OPTIONS]
 ```
 
 {{<definitions>}}

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -181,6 +181,40 @@ $ wrangler d1 execute <DATABASE_NAME> [OPTIONS]
 - Note that you must provide either `--command` or `--file` for this command to run successfully.
   {{</definitions>}}
 
+### `time-travel restore`
+
+Restore a database to a specific point-in-time using [Time Travel](/d1/learning/time-travel/).
+
+```sh
+$ wrangler d1 time-travel <DATABASE_NAME> [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `DATABASE_NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+  - The name of the D1 database to execute a query on.
+- `--bookmark` {{<type>}}string{{</type>}}
+  - ...
+- `--timestamp` {{<type>}}string{{</type>}}
+  - ...
+  {{</definitions>}}
+
+### `time-travel info`
+
+Inspect the current state of a database for a specific point-in-time using [Time Travel](/d1/learning/time-travel/).
+
+```sh
+$ wrangler d1 time-travel <DATABASE_NAME> [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `DATABASE_NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+  - The name of the D1 database to execute a query on.
+- `--timestamp` {{<type>}}string{{</type>}}
+  - ...
+  {{</definitions>}}
+
 ### `backup create`
 
 Initiate a D1 backup.

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -196,7 +196,7 @@ $ wrangler d1 time-travel restore <DATABASE_NAME> [OPTIONS]
 - `--bookmark` {{<type>}}string{{</type>}}
   - A D1 bookmark representing the state of a database at a specific point in time.
 - `--timestamp` {{<type>}}string{{</type>}}
-  - A Unix timestamp or JavaScript date-time string within the last 30 days.
+  - A Unix timestamp or JavaScript date-time `string` within the last 30 days.
   {{</definitions>}}
 
 ### `time-travel info`
@@ -212,7 +212,7 @@ $ wrangler d1 time-travel info <DATABASE_NAME> [OPTIONS]
 - `DATABASE_NAME` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
   - The name of the D1 database to execute a query on.
 - `--timestamp` {{<type>}}string{{</type>}}
-  - A Unix timestamp or JavaScript date-time string within the last 30 days.
+  - A Unix timestamp or JavaScript date-time `string` within the last 30 days.
   {{</definitions>}}
 
 ### `backup create`


### PR DESCRIPTION
This PR:

- [x] Adds new documentation for Time Travel
- [x] Updates the wrangler docs to detail the `wrangler d1 time-travel` commands: https://developers.cloudflare.com/workers/wrangler/commands/#d1
- [x] Updates the existing Backups documentation to reference Time Travel for new databases
- [x] Adds a /d1/changelog entry for Time Travel

Relates to https://github.com/cloudflare/workers-sdk/pull/3579 
