### PR TITLE
[Docs] Update spell check action

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.x
 
@@ -39,4 +39,4 @@ jobs:
         run: echo ${{ env.CHANGED_FILES }}
 
       - name: Check for Spelling Errors
-        run: codespell --count --skip ./.git ${{ env.CHANGED_FILES }}
+        run: codespell --count --skip="*.js,./.git" ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
* Updates `actions/setup-python@v2` to `actions/setup-python@v3` (since GitHub dropped support for the `node12` runtime and [we're getting warnings](https://github.com/cloudflare/cloudflare-docs/actions/runs/5542032639)). Check the [details for the 3.0.0 release](https://github.com/actions/setup-python/releases/tag/v3.0.0).
* Ignores `*.js` files when checking for spelling errors, since minified JavaScript files are triggering many false positives (for example, [check this job run](https://github.com/cloudflare/cloudflare-docs/actions/runs/5542032639/jobs/10116192182)).