### PR TITLE
fix markdown for plan table

### DIFF
--- a/content/support/Other Languages/日本語/CloudflareのPage Rulesを理解した上で設定する（Page Rulesチュートリアル）.md
+++ b/content/support/Other Languages/日本語/CloudflareのPage Rulesを理解した上で設定する（Page Rulesチュートリアル）.md
@@ -33,41 +33,10 @@ Page Ruleを定義し、URLパターンが一致するたびに、複数のア�
 
 | **プラン** | **許可されているページルール数の上限** |
 | --- | --- |
-| 
-Free
-
- | 
-
-3
-
- |
-| 
-
-Pro
-
- | 
-
-20
-
- |
-| 
-
-Business
-
- | 
-
-50
-
- |
-| 
-
-Enterprise
-
- | 
-
-125
-
- |
+| Free | 3 |
+| Pro | 20 |
+| Business | 50 |
+| Enterprise | 125 |
 
 Freeプラン、Proプラン、Businessプランのドメインに関しては、（最大100まで）[追加のルールを購入](https://www.cloudflare.com/features-page-rules/)できます。
 


### PR DESCRIPTION
The plan comparison table in the overview was corrupted in the following page.

https://developers.cloudflare.com/support/other-languages/日本語/cloudflareのpage-rulesを理解した上で設定するpage-rulesチュートリアル/