### PR TITLE
Fix compat date API

### DIFF
--- a/functions/workers/platform/compatibility-dates.json.ts
+++ b/functions/workers/platform/compatibility-dates.json.ts
@@ -1,5 +1,5 @@
 // Will replace this with rewrites/proxying when eventually supported
 
 export const onRequest = ({ request, next }) => {
-  return next("/workers/platform/compatibility-dates/index.json", request);
+  return next("/workers/configuration/compatibility-dates/index.json", request);
 };


### PR DESCRIPTION
Compat date page got moved in the Workers docs reshuffling, this fixes that.

https://walshy-fix-compat-date-api.cloudflare-docs-7ou.pages.dev/workers/platform/compatibility-dates.json