### PR TITLE
Update plugin-compatibility.md of APO

### DIFF
--- a/content/automatic-platform-optimization/about/plugin-compatibility.md
+++ b/content/automatic-platform-optimization/about/plugin-compatibility.md
@@ -18,7 +18,7 @@ The Cloudflare APO WordPress plugin does not support multisite WordPress install
 
 ## Compatible plugins
 
-- [FlyingPress](https://flying-press.com/)
+- [FlyingPress](https://flyingpress.com/)
 - [WP Rocket](https://community.cloudflare.com/t/cloudflares-apo-with-wp-rockets-minified-css/225906/3?u=yevgen) **version 3.8.6 or later**
 - [BigCommerce](https://wordpress.org/plugins/bigcommerce/)
 - [Easy Digital Downloads](https://wordpress.org/plugins/easy-digital-downloads/)


### PR DESCRIPTION
FlyingPress recently changed the domain from `flying-press.com` to `flyingpress.com`