### PR TITLE
[Queues] Update docs with `contentType` option in "platform/javascript-apis.md"

### DIFF
--- a/content/queues/platform/javascript-apis.md
+++ b/content/queues/platform/javascript-apis.md
@@ -94,7 +94,7 @@ type MessageSendRequest<Body = any> = {
 - {{<code>}}contentType{{<param-type>}}QueuesContentType{{</param-type>}}{{</code>}}
 
   - The explicit content type of a message so it can be previewed correctly with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature. Optional argument.
-  - This option is primarily for internal use as of now. In the future, this will be used by alternative consumer types to explicitly mark messages as serialized so they can be consumed in the desired type.
+  - As of now, this option is for internal use. In the future, `contentType` will be used by alternative consumer types to explicitly mark messages as serialized so they can be consumed in the desired type.
   - See [QueuesContentType](#QueuesContentType) for possible values.
 
 {{</definitions>}}

--- a/content/queues/platform/javascript-apis.md
+++ b/content/queues/platform/javascript-apis.md
@@ -22,7 +22,7 @@ An example of writing a single message to a Queue:
 
 ```ts
 type Environment = {
-  readonly MY_QUEUE: Queue;
+  readonly MY_QUEUE: Queue<any>;
 };
 
 export default {
@@ -54,14 +54,14 @@ A binding that allows a producer to send messages to a Queue.
 
 ```ts
 interface Queue<Body = any> {
-  send(body: Body): Promise<void>;
+  send(body: Body, options?: { contentType?: QueuesContentType }): Promise<void>;
   sendBatch(messages: Iterable<MessageSendRequest<Body>>): Promise<void>;
 }
 ```
 
 {{<definitions>}}
 
-- {{<code>}}send(body{{<param-type>}}any{{</param-type>}}){{</code>}} {{<type>}}Promise\<void>{{</type>}}
+- {{<code>}}send(body{{<param-type>}}any{{</param-type>}}, options?{{<param-type>}}{ contentType?: QueuesContentType }{{</param-type>}}){{</code>}} {{<type>}}Promise\<void>{{</type>}}
 
   - Sends a message to the Queue. The body can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
   - When the promise resolves, the message is confirmed to be written to disk.
@@ -80,6 +80,7 @@ A wrapper type used for sending message batches.
 ```ts
 type MessageSendRequest<Body = any> = {
   body: Body;
+  contentType?: QueuesContentType;
 };
 ```
 
@@ -90,7 +91,21 @@ type MessageSendRequest<Body = any> = {
   - The body of the message.
   - The body can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
 
+- {{<code>}}contentType{{<param-type>}}QueuesContentType{{</param-type>}}{{</code>}}
+
+  - The explicit content type of a message so it can be previewed correctly with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature. Optional argument.
+  - This option is primarily for internal use as of now. In the future, this will be used by alternative consumer types to explicitly mark messages as serialized so they can be consumed in the desired type.
+  - See [QueuesContentType](#QueuesContentType) for possible values.
+
 {{</definitions>}}
+
+### `QueuesContentType`
+
+A union type containing valid message content types.
+
+```ts
+type QueuesContentType = "text" | "bytes" | "json" | "v8";
+```
 
 ## Consumer
 

--- a/content/queues/platform/javascript-apis.md
+++ b/content/queues/platform/javascript-apis.md
@@ -110,7 +110,7 @@ type QueuesContentType = "text" | "bytes" | "json" | "v8";
 - Use `"text"` to send a `String`. This content type can be previewed with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature.
 - Use `"json"` to send a JavaScript object that can be JSON-serialized. This content type can be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com).
 - Use `"bytes"` to send an `ArrayBuffer`. This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded.
-- Use `"v8"` to send a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (for example `Date`and `Map`). This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded. `"v8"` is the default content type.
+- Use `"v8"` to send a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (for example `Date` and `Map`). This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded. `"v8"` is the default content type.
 
 If you specify an invalid content type, or if your specified content type does not match the message content's type, the send operation will fail with an error.
 

--- a/content/queues/platform/javascript-apis.md
+++ b/content/queues/platform/javascript-apis.md
@@ -107,10 +107,10 @@ A union type containing valid message content types.
 type QueuesContentType = "text" | "bytes" | "json" | "v8";
 ```
 
-- Use `"text"` if you're sending a string. This content type can be previewed with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature.
-- Use `"json"` if you're sending a JavaScript object that can be JSON-serialized. This content type can be previewed from the dashboard.
-- Use `"bytes"` if you're sending an `ArrayBuffer`. This content type cannot be previewed from the dashboard and will display as Base64-encoded.
-- Use `"v8"` if you're sending a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (e.g. `Date`s, `Map`s). This content type cannot be previewed from the dashboard and will display as Base64-encoded. `"v8"` is the default content type.
+- Use `"text"` to send a `String`. This content type can be previewed with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature.
+- Use `"json"` to send a JavaScript object that can be JSON-serialized. This content type can be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com).
+- Use `"bytes"` to send an `ArrayBuffer`. This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded.
+- Use `"v8"` to send a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (for example `Date`and `Map`). This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded. `"v8"` is the default content type.
 
 If you specify an invalid content type, or if your specified content type does not match the message content's type, the send operation will fail with an error.
 

--- a/content/queues/platform/javascript-apis.md
+++ b/content/queues/platform/javascript-apis.md
@@ -107,6 +107,13 @@ A union type containing valid message content types.
 type QueuesContentType = "text" | "bytes" | "json" | "v8";
 ```
 
+- Use `"text"` if you're sending a string. This content type can be previewed with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature.
+- Use `"json"` if you're sending a JavaScript object that can be JSON-serialized. This content type can be previewed from the dashboard.
+- Use `"bytes"` if you're sending an `ArrayBuffer`. This content type cannot be previewed from the dashboard and will display as Base64-encoded.
+- Use `"v8"` if you're sending a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (e.g. `Date`s, `Map`s). This content type cannot be previewed from the dashboard and will display as Base64-encoded. `"v8"` is the default content type.
+
+If you specify an invalid content type, or if your specified content type does not match the message content's type, the send operation will fail with an error.
+
 ## Consumer
 
 These APIs allow a consumer Worker to consume messages from a Queue.


### PR DESCRIPTION
This PR updates the types referenced on the Queues 'Javascript APIs' page to reflect the new `contentType` option.

TODO:
- [x] Hold on merging this until cloudflare/workerd#879 is merged