### PR TITLE
fix(pages): don't recommend an old version of wrangler for Pages

### DIFF
--- a/content/pages/platform/direct-upload.md
+++ b/content/pages/platform/direct-upload.md
@@ -30,7 +30,7 @@ Below is the supported file types for each Direct Upload options:
 
 ### Set up Wrangler
 
-To begin, [install and set up the latest version of Wrangler](/workers/wrangler/install-and-update/). Note that Pages relies on Wrangler v2.
+To begin, [install and set up the latest version of Wrangler](/workers/wrangler/install-and-update/).
 
 #### Create your project
 


### PR DESCRIPTION
This is from when wrangler v1 was a thing.

Pages works fine with wrangler v2 and v3, and with v1 deprecated and barely referenced anywhere more, it's probably safe to just omit this entirely.