### PR TITLE
Issue 9995: adding known issue description for WARP + Docker on Linux…

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
@@ -45,7 +45,7 @@ The [Windows Teredo](https://learn.microsoft.com/en-us/windows/win32/teredo/abou
 
 Currently [Docker](https://www.docker.com/products/container-runtime/) on Linux does not perform the underlying network tunnel MTU changes required by WARP. This can cause connectivity issues inside of a Docker container when WARP is enabled on the host machine. For example, `curl -v https://cloudflare.com > /dev/null` will fail if run from a Docker container that is using the default bridge network driver.
 
-Until Docker changes this behaviour, WARP + Docker users on Linux can manually reconfigure the MTU on the Docker network interface. You can either modify `/etc/docker/daemon.json` to include:
+Until Docker changes this behaviour, WARP + Docker users on Linux can manually reconfigure the MTU on Docker's network interface. You can either modify `/etc/docker/daemon.json` to include:
 
 ```json
   {
@@ -53,9 +53,13 @@ Until Docker changes this behaviour, WARP + Docker users on Linux can manually r
   }
 ```
 
-or create a Docker network with a working MTU size:
+or create a Docker network with a working MTU value:
 
 ```sh
 $ docker network create -o "com.docker.network.driver.mtu=1420" my-docker-network
 ```
+
+The MTU value should be set to the MTU of your host's default interface minus 80 bytes for the WARP protocol overhead. Most MTUs are 1500, therefore 1420 should work for most people.
+
+
 

--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
@@ -43,19 +43,19 @@ The [Windows Teredo](https://learn.microsoft.com/en-us/windows/win32/teredo/abou
 
 ## Docker on Linux with bridged networking
 
-Currently [Docker](https://www.docker.com/products/container-runtime/) on 
-Linux does not respond to underlying network tunnel mtu changes. This can be seen with WARP Gateway enabled
-when a basic TLS GET `curl -v https://cloudflare.com > /dev/null` fails 
-inside a Docker container that is using the default bridge network driver. 
-Until Docker changes this behaviour, WARP + Docker users on Linux can modify 
-`/etc/docker/daemon.json` to include: 
-```
+Currently [Docker](https://www.docker.com/products/container-runtime/) on Linux does not perform the underlying network tunnel MTU changes required by WARP. This can cause connectivity issues inside of a Docker container when WARP is enabled on the host machine. For example, `curl -v https://cloudflare.com > /dev/null` will fail if run from a Docker container that is using the default bridge network driver.
+
+Until Docker changes this behaviour, WARP + Docker users on Linux can manually reconfigure the MTU on the Docker network interface. You can either modify `/etc/docker/daemon.json` to include:
+
+```json
   {
       "mtu":1420
   }
-``` 
-or create a Docker network with a configuration modified for a working mtu size:
 ```
-  docker network create \
-    -o "com.docker.network.driver.mtu=1420" my-docker-network
+
+or create a Docker network with a working MTU size:
+
+```sh
+$ docker network create -o "com.docker.network.driver.mtu=1420" my-docker-network
 ```
+

--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
@@ -40,3 +40,22 @@ Cisco Meraki devices have a bug where WARP traffic can sometimes be identified a
 ## Windows Teredo
 
 The [Windows Teredo](https://learn.microsoft.com/en-us/windows/win32/teredo/about-teredo) interface conflicts with the WARP client. Since Teredo and WARP will fight for control over IPv6 traffic routing, you must disable Terado on your Windows device. This allows the WARP client to provide IPv6 connectivity on the device.
+
+## Docker on Linux with bridged networking
+
+Currently [Docker](https://www.docker.com/products/container-runtime/) on 
+Linux does not respond to underlying network tunnel mtu changes. This can be seen with WARP Gateway enabled
+when a basic TLS GET `curl -v https://cloudflare.com > /dev/null` fails 
+inside a Docker container that is using the default bridge network driver. 
+Until Docker changes this behaviour, WARP + Docker users on Linux can modify 
+`/etc/docker/daemon.json` to include: 
+```
+  {
+      "mtu":1420
+  }
+``` 
+or create a Docker network with a configuration modified for a working mtu size:
+```
+  docker network create \
+    -o "com.docker.network.driver.mtu=1420" my-docker-network
+```

--- a/content/warp-client/known-issues-and-faq.md
+++ b/content/warp-client/known-issues-and-faq.md
@@ -70,5 +70,5 @@ The WARP client for Windows requires .NET Framework version 4.7.2 or later to be
 
 - Applications or sites that rely on location information to enforce content licensing agreements (for example, certain games, video streaming, music streaming, or radio streaming) may not function properly. We are working on a product update that will allow these clients to work, by not sending their traffic through WARP.
 
-- See [Known Limitations](/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations/)
+- Refer to [Known Limitations](/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations/)
   for information on devices, software, and configurations that are incompatible with Cloudflare WARP.

--- a/content/warp-client/known-issues-and-faq.md
+++ b/content/warp-client/known-issues-and-faq.md
@@ -68,4 +68,7 @@ The WARP client for Windows requires .NET Framework version 4.7.2 or later to be
 
 ## Known issues
 
-Applications or sites that rely on location information to enforce content licensing agreements (for example, certain games, video streaming, music streaming, or radio streaming) may not function properly. We are working on a product update that will allow these clients to work, by not sending their traffic through WARP.
+- Applications or sites that rely on location information to enforce content licensing agreements (for example, certain games, video streaming, music streaming, or radio streaming) may not function properly. We are working on a product update that will allow these clients to work, by not sending their traffic through WARP.
+
+- See [Known Limitations](/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations/)
+  for information on devices, software, and configurations that are incompatible with Cloudflare WARP.


### PR DESCRIPTION
Issue 9995: adding known issue description for WARP + Docker on Linux relating to mtu size

closes #9995 

[Issue 9995](https://github.com/cloudflare/cloudflare-docs/issues/9995)

Updates to WARP known issues and link from WARP Client to the same list of limitations