### PR TITLE
[Pages] Create docs API for build presets and read in build-configuration.md

### DIFF
--- a/content/pages/_partials/_build-configuration.md
+++ b/content/pages/_partials/_build-configuration.md
@@ -1,0 +1,120 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+build_configs:
+  create-react-app:
+    display_name: Create React App
+    build_command: npm run build
+    build_output_directory: build
+  gatsby:
+    display_name: Gatsby
+    build_command: gatsby build
+    build_output_directory: public
+  keywork:
+    display_name: Keywork
+    build_command: yarn build
+    build_output_directory: dist
+  next-js:
+    display_name: Next.js
+    build_command: npx @cloudflare/next-on-pages@1
+    build_output_directory: .vercel/output/static
+  next-js-static:
+    display_name: Next.js (Static HTML Export)
+    build_command: next build && next export
+    build_output_directory: out
+  nuxt-js:
+    display_name: Nuxt.js
+    build_command: npm run build
+    build_output_directory: dist
+  qwik:
+    display_name: Qwik
+    build_command: npm run build
+    build_output_directory: dist
+  remix:
+    display_name: Remix
+    build_command: npm run build
+    build_output_directory: public
+  svelte:
+    display_name: Svelte
+    build_command: npm run build
+    build_output_directory: public
+  sveltekit:
+    display_name: SvelteKit
+    build_command: npm run build
+    build_output_directory: .svelte-kit/cloudflare
+  vue:
+    display_name: Vue
+    build_command: npm run build
+    build_output_directory: dist
+  astro:
+    display_name: Astro
+    build_command: npm run build
+    build_output_directory: dist
+  angular-cli:
+    display_name: Angular (Angular CLI)
+    build_command: ng build --prod
+    build_output_directory: dist
+  brunch:
+    display_name: Brunch
+    build_command: brunch build --production
+    build_output_directory: public
+  docusaurus:
+    display_name: Docusaurus
+    build_command: npm run build
+    build_output_directory: build
+  eleventy:
+    display_name: Eleventy
+    build_command: eleventy
+    build_output_directory: _site
+  ember-js:
+    display_name: Ember.js
+    build_command: ember build
+    build_output_directory: dist
+  gitbook:
+    display_name: GitBook
+    build_command: gitbook build
+    build_output_directory: _book
+  gridsome:
+    display_name: Gridsome
+    build_command: gridsome build
+    build_output_directory: dist
+  hugo:
+    display_name: Hugo
+    build_command: hugo
+    build_output_directory: public
+  jekyll:
+    display_name: Jekyll
+    build_command: jekyll build
+    build_output_directory: _site
+  mkdocs:
+    display_name: Mkdocs
+    build_command: mkdocs build
+    build_output_directory: site
+  pelican:
+    display_name: Pelican
+    build_command: pelican content
+    build_output_directory: output
+  react-static:
+    display_name: React Static
+    build_command: react-static build
+    build_output_directory: dist
+  slate:
+    display_name: Slate
+    build_command: ./deploy.sh
+    build_output_directory: build
+  umi:
+    display_name: Umi
+    build_command: umi build
+    build_output_directory: dist
+  vuepress:
+    display_name: VuePress
+    build_command: vuepress build
+    build_output_directory: .vuepress/dist
+  zola:
+    display_name: Zola
+    build_command: zola build
+    build_output_directory: public
+---

--- a/content/pages/platform/build-configuration.md
+++ b/content/pages/platform/build-configuration.md
@@ -1,8 +1,12 @@
 ---
 pcx_content_type: concept
 title: Build configuration
+layout: build-configuration
+rss: https://github.com/cloudflare/cloudflare-docs/commits/production/content/pages/_partials/_build-configuration.atom
+outputs:
+  - html
+  - json
 ---
-
 # Build configuration
 
 You may tell Cloudflare Pages how your site needs to be built as well as where its output files will be located.
@@ -32,40 +36,7 @@ Cloudflare maintains a list of build configurations for popular frameworks and t
 
 If you are not using a framework, leave the **Build command** field blank.
 
-{{<table-wrap>}}
-
-| Framework/tool               | Build command                        | Build directory             |
-| ---------------------------- | ------------------------------------ | --------------------------- |
-| Angular (Angular CLI)        | `ng build`                           | `dist`                      |
-| Astro                        | `npm run build`                      | `dist`                      |
-| Brunch                       | `brunch build --production`          | `public`                    |
-| Docusaurus                   | `npm run build`                      | `build`                     |
-| Eleventy                     | `eleventy`                           | `_site`                     |
-| Ember.js                     | `ember build`                        | `dist`                      |
-| Expo                         | `expo build:web`                     | `web-build`                 |
-| Gatsby                       | `gatsby build`                       | `public`                    |
-| GitBook                      | `gitbook build`                      | `_book`                     |
-| Gridsome                     | `gridsome build`                     | `dist`                      |
-| Hugo                         | `hugo`                               | `public`                    |
-| Jekyll                       | `jekyll build`                       | `_site`                     |
-| Jigsaw                       | `vendor/bin/jigsaw build production` | `build_production`          |
-| mdBook                       | `mdbook build`                       | `book`                      |
-| MkDocs                       | `mkdocs build`                       | `site`                      |
-| Next.js (Static HTML Export) | `next build && next export`          | `out`                       |
-| Nuxt 2                       | `nuxt generate`                      | `dist`                      |
-| Nuxt 3+                      | `nuxt build`                         | `dist`                      |
-| Pelican                      | `pelican content [-s settings.py]`   | `output`                    |
-| Quasar                       | `quasar build`                       | `dist/spa`                  |
-| React (create-react-app)     | `npm run build`                      | `build`                     |
-| React Static                 | `react-static build`                 | `dist`                      |
-| Remix                        | `npm run build`                      | `public`                    |
-| Slate                        | `./deploy.sh`                        | `build`                     |
-| Svelte                       | `npm run build`                      | `public`                    |
-| Umi                          | `umi build`                          | `dist`                      |
-| Vue                          | `npm run build`                      | `public`                    |
-| VuePress                     | `vuepress build $directory`          | `$directory/.vuepress/dist` |
-
-{{</table-wrap>}}
+{{<pages-build-presets-table>}}
 
 ## Environment variables
 

--- a/functions/pages/platform/build-configuration.json.ts
+++ b/functions/pages/platform/build-configuration.json.ts
@@ -1,0 +1,5 @@
+// Will replace this with rewrites/proxying when eventually supported
+
+export const onRequest = ({ request, next }) => {
+  return next("/pages/platform/build-configuration/index.json", request);
+};

--- a/layouts/_default/build-configuration.json.json
+++ b/layouts/_default/build-configuration.json.json
@@ -1,0 +1,2 @@
+{{- $file := $.Site.GetPage "content/pages/_partials/_build-configuration.md" -}}
+{{- $file.Params.build_configs | jsonify -}}

--- a/layouts/shortcodes/pages-build-presets-table.html
+++ b/layouts/shortcodes/pages-build-presets-table.html
@@ -1,0 +1,24 @@
+{{- $file := $.Site.GetPage "content/pages/_partials/_build-configuration.md" -}}
+
+<div class="DocsMarkdown--table-wrap">
+  <div class="DocsMarkdown--table-wrap-inner">
+    <table>
+      <thead>
+        <tr>
+          <th>Framework/tool</th>
+          <th>Build command</th>
+          <th>Build directory</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $_, $v := $file.Params.build_configs }}
+        <tr>
+          <td>{{$v.display_name}}</td>
+          <td><code>{{$v.build_command}}</code></td>
+          <td><code>{{$v.build_output_directory}}</code></td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
The only changes to docs content is in build-configuration.md, but the content that users see should be identical to before. The table is pulled out into a separate shortcode `pages-build-presets-table.html` which reads from the `_build-configuration.md`. This PR allow us to keep dashboard presets in sync with the docs similar to https://github.com/cloudflare/cloudflare-docs/pull/8594.

cc: @jrf0110 @GregBrimble @WalshyDev 