### PR TITLE
Update 1.1.1.1 macOS Setup Docs `macos.md` to match macOS Ventura 13 UI

### DIFF
--- a/content/1.1.1.1/setup/macos.md
+++ b/content/1.1.1.1/setup/macos.md
@@ -13,9 +13,9 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 1. Go to **System Settings**. You can find it by pressing <kbd>Command</kbd> + <kbd>Space</kbd> on your keyboard and typing `System Settings`.
 3. Go to **Network**.
 4. Select a network service.
-5. Select **Details...**.
+5. Select **Details**.
 6. Go to **DNS**.
-7. Under **DNS Servers**, select **Add(+)**.
+7. Under **DNS Servers**, select **Add**.
 8. {{<render file="_all-ipv4.md">}}
 9. {{<render file="_all-ipv6.md">}}
 10. Select **OK**.

--- a/content/1.1.1.1/setup/macos.md
+++ b/content/1.1.1.1/setup/macos.md
@@ -11,11 +11,11 @@ meta:
 Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
 1. Go to **System Settings**. You can find it by pressing <kbd>Command</kbd> + <kbd>Space</kbd> on your keyboard and typing `System Settings`.
-3. Click the **Network** icon in the sidebar.
-4. Click a network service on the right.
-5. Click **Details...**.
-6. Select the **DNS** tab.
-7. Click the **Add(+)** button at the bottom of the DNS servers list, then enter DNS address one by one.
+3. Go to **Network**.
+4. Select a network service.
+5. Select **Details...**.
+6. Go to **DNS**.
+7. Under **DNS Servers**, select **Add(+)**.
 8. {{<render file="_all-ipv4.md">}}
 9. {{<render file="_all-ipv6.md">}}
 10. Select **OK**.

--- a/content/1.1.1.1/setup/macos.md
+++ b/content/1.1.1.1/setup/macos.md
@@ -10,12 +10,15 @@ meta:
 
 Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
-1. Go to **System Preferences**. You can find it by pressing <kbd>Command</kbd> + <kbd>Space</kbd> on your keyboard and typing `System Preferences`.
-2. Select the **Network** icon > **Advanced**.
-3. Select the **DNS** tab.
-4. {{<render file="_all-ipv4.md">}}
-5. {{<render file="_all-ipv6.md">}}
-6. Select **OK** > **Apply**.
+1. Go to **System Settings**. You can find it by pressing <kbd>Command</kbd> + <kbd>Space</kbd> on your keyboard and typing `System Settings`.
+3. Click the **Network** icon in the sidebar.
+4. Click a network service on the right.
+5. Click **Details...**.
+6. Select the **DNS** tab.
+7. Click the **Add(+)** button at the bottom of the DNS servers list, then enter DNS address one by one.
+8. {{<render file="_all-ipv4.md">}}
+9. {{<render file="_all-ipv6.md">}}
+10. Select **OK**.
 
 {{<render file="_captive-portals.md">}}
 


### PR DESCRIPTION
Update 1.1.1.1 DNS setup for macOS Ventura 13 new settings UI.


![image](https://github.com/cloudflare/cloudflare-docs/assets/31113245/901f0e9c-3e0d-4745-9d9b-ddc8676c654a)
![image](https://github.com/cloudflare/cloudflare-docs/assets/31113245/128f34ff-7452-436a-b4c4-60b1b6501087)


Updated instructions are based on [official Apple guide for changing DNS settings](https://support.apple.com/en-euro/guide/mac-help/mh14127/13.0/mac/13.0).