### PR TITLE
[Docs] Revert node version to 18.10.0 (volta config)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "wrangler": "^2.9.1"
   },
   "volta": {
-    "node": "20.3.0"
+    "node": "18.10.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
It was changed inadvertently in an unrelated PR: #9390.
