### PR TITLE
[Docs] Update `directory-listing` shortcode

### DIFF
--- a/layouts/shortcodes/directory-listing.html
+++ b/layouts/shortcodes/directory-listing.html
@@ -15,8 +15,8 @@
     {{ $path = .Path }}
   {{ end }}
   {{- $x := .RelPermalink -}}
-  {{- $title := .Title -}}
-  {{- $meta := .Params.meta.description -}}
+    {{- $title := .Title -}}
+  {{- $meta := default "" .Params.meta.description -}}
   {{- $self := eq $x $current -}}
   {{- $delta := sub (len (split $x "/")) $len -}}
   {{- if and (not $self) (hasPrefix $x $current) (lt $delta 2) (not .Params.hidden) -}}
@@ -33,7 +33,11 @@
   {{- $path = replaceRE `(.{1}$)` "$1/" (replaceRE `(^.{1})` "/$1" (replace $path ".md" "")) -}}
   {{- $delta2 := sub (len (split $path "/")) $len -}}
   {{- if and (hasPrefix $path $current) (lt $delta2 2) -}}
-  {{- $link = printf "[%s](%s): %s" $title . $meta -}}
+    {{- if (eq $meta "") -}}
+      {{- $link = printf "[%s](%s)" $title . -}}
+    {{- else -}}
+      {{- $link = printf "[%s](%s): %s" $title . $meta -}}
+    {{- end -}}
   <li>
     {{- $.Page.RenderString $link -}}
   </li>

--- a/layouts/shortcodes/directory-listing.html
+++ b/layouts/shortcodes/directory-listing.html
@@ -10,9 +10,9 @@
 {{- range (where .Site.Pages "Section" $section).ByWeight -}}
   {{ $path := "" }}
   {{ with .File }}
-    {{ $path = .Path }}
+    {{ $path = (replace .Path "\\" "/") }}
   {{ else }}
-    {{ $path = .Path }}
+    {{ $path = (replace .Path "\\" "/") }}
   {{ end }}
   {{- $x := .RelPermalink -}}
     {{- $title := .Title -}}


### PR DESCRIPTION
All external links were expected to have a meta description, but this only makes sense if we're showing page descriptions.

Before:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/c90e1846-4c2e-4a8f-95ad-f629719ffc29)
URL: https://developers.cloudflare.com/speed/optimization/images/

After:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/c56be7b8-2f6a-4bc7-b1db-7bfd3430e517)
URL: https://pedro-2023-07-26-update-dire.cloudflare-docs-7ou.pages.dev/speed/optimization/images/

Directory listings with external links that were showing descriptions were unaffected:
* Before: URL: https://developers.cloudflare.com/load-balancing/get-started/
* After: https://pedro-2023-07-26-update-dire.cloudflare-docs-7ou.pages.dev/load-balancing/get-started/

---

This PR also includes a Windows-specific fix for path handling in the same component (external links were not appearing when using the local dev server).
