### PR TITLE
[Terraform] Remove duplicate links

### DIFF
--- a/content/terraform/additional-configurations/_index.md
+++ b/content/terraform/additional-configurations/_index.md
@@ -7,7 +7,3 @@ weight: 4
 # Additional configurations
 
 {{<directory-listing>}}
-* [Single Redirects](/rules/url-forwarding/single-redirects/terraform-example/)
-* [Configuration Rules](/rules/configuration-rules/terraform-example/)
-* [Origin Rules](/rules/origin-rules/terraform-example/)
-* [Cache Rules](/cache/how-to/cache-rules/#terraform-example)


### PR DESCRIPTION
Remove duplicate links now that the `directory-listing` shortcode also handles external links.

Before this proposed change:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/25c551d7-0869-4a2a-8e06-1f3a961a0aef)
