### PR TITLE
[Docs] Adjust pill alignment for lower level headings

### DIFF
--- a/layouts/shortcodes/alpha.html
+++ b/layouts/shortcodes/alpha.html
@@ -10,9 +10,10 @@
         </span>
         <span>{{- .Page.RenderString .Inner -}}</span>
         {{- printf "</%s>" $heading | safeHTML -}}
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-alpha DocsMarkdown-pill-lower">Alpha</div>
     <!-- Otherwise render as <h1> -->
     {{- else -}}
         <h1 id="{{- $ID -}}">{{- .Page.RenderString .Inner -}}</h1>
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-alpha">Alpha</div>
     {{- end -}}
-    <div class="DocsMarkdown--pill DocsMarkdown--pill-alpha">Alpha</div>
 </div>

--- a/layouts/shortcodes/beta.html
+++ b/layouts/shortcodes/beta.html
@@ -10,9 +10,10 @@
         </span>
         <span>{{- .Page.RenderString .Inner -}}</span>
         {{- printf "</%s>" $heading | safeHTML -}}
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-beta DocsMarkdown-pill-lower">Beta</div>
     <!-- Otherwise render as <h1> -->
     {{- else -}}
         <h1 id="{{- $ID -}}">{{- .Page.RenderString .Inner -}}</h1>
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-beta">Beta</div>
     {{- end -}}
-    <div class="DocsMarkdown--pill DocsMarkdown--pill-beta">Beta</div>
 </div>

--- a/layouts/shortcodes/deprecated.html
+++ b/layouts/shortcodes/deprecated.html
@@ -10,9 +10,10 @@
         </span>
         <span>{{- .Page.RenderString .Inner -}}</span>
         {{- printf "</%s>" $heading | safeHTML -}}
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-deprecated DocsMarkdown-pill-lower">Deprecated</div>
     <!-- Otherwise render as <h1> -->
     {{ else }}
         <h1 id="{{- $ID -}}">{{- .Page.RenderString .Inner -}}</h1>
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-deprecated">Deprecated</div>
     {{ end }}
-    <div class="DocsMarkdown--pill DocsMarkdown--pill-deprecated">Deprecated</div>
 </div>

--- a/static/style.css
+++ b/static/style.css
@@ -5276,7 +5276,7 @@ pre {
   flex-direction: row;
   column-gap: 1em;
 
-  align-items: flex-end;
+  align-items: center;
 }
 
 .DocsMarkdown--pill {
@@ -5286,9 +5286,9 @@ pre {
   padding: 4px 8px;
 
   position: relative;
-  bottom: 1.8em;
-  height: 18px;
+  margin-bottom: 0.75em;
 
+  height: 18px;
   border-radius: 20px;
 
   flex: none;
@@ -5300,6 +5300,12 @@ pre {
   font-size: 12px;
   line-height: 150%;
   /* identical to box height, or 18px */
+}
+
+/* Pills on levels lower than H1 */
+.DocsMarkdown-pill-lower {
+  margin-bottom: initial;
+  margin-top: 2.25em;
 }
 
 .DocsMarkdown--pill-tab {
@@ -5587,7 +5593,7 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
 }
 
 .tutorialPreReqHeader::before {
-  height: 0 !important; 
+  height: 0 !important;
 }
 
 .tutorialStep {
@@ -5650,6 +5656,6 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
   }
 
   .tutorialPreReqHeader {
-    margin-top: 4em !important; 
+    margin-top: 4em !important;
   }
 }


### PR DESCRIPTION
PCX-7209

Adds new CSS class for lower level headings (sub-H1) so pills align with their corresponding titles. Also raise H1 pills slightly.

See `/cloudflare-one/insights/dex/`, `/ssl/edge-certificates/geokey-manager/setup/#geo-key-manager-v2`, and `/cloudflare-one/policies/data-loss-prevention/dlp-policies/#report-false-positives` for examples.