### PR TITLE
[DDoS Protection] Update ATP docs

### DIFF
--- a/content/byoip/how-to/configure-dynamic-advertisement.md
+++ b/content/byoip/how-to/configure-dynamic-advertisement.md
@@ -11,15 +11,6 @@ To prevent issues and simplify the advertisement process during an attack scenar
 
 {{</Aside>}}
 
-## Before you start (Magic Transit customers only)
-
-If you are advertising a new prefix or enabling the advertisement of an existing IP prefix (changing it from _Withdrawn_ to _Advertised_), make sure you disable [Advanced TCP Protection](/ddos-protection/tcp-protection/) first.
-
-After enabling the prefix advertisement or advertising a new prefix, do the following:
-
-1.  Ensure that the traffic is being successfully routed via the Cloudflare network. Check the Network Analytics dashboard or [use `traceroute`](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#perform-a-traceroute) to analyze the path IP packets are taking.
-2.  Re-enable Advanced TCP Protection.
-
 ## Configure dynamic advertisement via the dashboard
 
 To configure IP prefix assignment from your Cloudflare account home, use the **Status** drop-down list in the **IP Prefixes** dialog, as outlined below.
@@ -42,16 +33,16 @@ Most dynamic advertisement operations require that you supply the Cloudflare ID 
 
 {{<tabs labels="Dashboard | API">}}
 {{<tab label="dashboard" no-code="true">}}
- 
+
 1. Log in to your [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account.
 2. Go to **IP Addresses** > **IP Prefixes**.
 3. Find the CIDR for which you want the Prefix ID, and select the arrow next to it.
 4. The Prefix ID is the value under **API Tag**. Select **Copy** to add the value to your clipboard.
- 
+
 {{</tab>}}
 {{<tab label="api" no-code="true">}}
- 
+
 To obtain Prefix IDs using the API, refer to the [List Prefixes](/api/operations/ip-address-management-prefixes-list-prefixes) operation in the Cloudflare API.
- 
+
 {{</tab>}}
 {{</tabs>}}

--- a/content/ddos-protection/tcp-protection/_index.md
+++ b/content/ddos-protection/tcp-protection/_index.md
@@ -15,6 +15,8 @@ Advanced TCP Protection can simultaneously protect against different kinds of at
 * Pinpointed attacks targeting a specific destination IP/port combination.
 * Broad attacks targeting multiple IP addresses of an IP prefix at the same time.
 
+Advanced TCP Protection can track TCP connections even when they move between Cloudflare data centers.
+
 ## Availability
 
 Advanced TCP Protection is available to all [Magic Transit](/magic-transit/) customers, and is disabled by default. Protection for simpler TCP-based DDoS attacks is also included as part of the [Network-layer DDoS Attack Protection managed ruleset](/ddos-protection/managed-rulesets/network/).

--- a/content/ddos-protection/tcp-protection/how-to/add-prefix.md
+++ b/content/ddos-protection/tcp-protection/how-to/add-prefix.md
@@ -6,12 +6,6 @@ weight: 2
 
 # Add a prefix
 
-## Before you start
-
-Cloudflare recommends that you switch any Advanced TCP Protection rules currently in mitigation mode to monitoring mode before adding a new prefix to Advanced TCP Protection. Refer to [Rule settings](/ddos-protection/tcp-protection/rule-settings/#mode) for more information on execution modes.
-
----
-
 To add a [prefix](/ddos-protection/tcp-protection/concepts/#prefixes) to Advanced TCP Protection:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.


### PR DESCRIPTION
Addresses PCX-6910 (and also PCX-7657 and PCX-7936).

* Mention that ATP can track connections across data centers.
* Remove recommendation for switching to monitoring mode before adding new prefixes.
* Remove note in BYOIP documentation about disabling ATP when adding/advertising prefixes.