### PR TITLE
[DLS] Update Logpush datasets supported for Gateway DNS

### DIFF
--- a/content/data-localization/metadata-boundary/logpush-datasets.md
+++ b/content/data-localization/metadata-boundary/logpush-datasets.md
@@ -24,7 +24,7 @@ Be aware that if you enable CMB for a dataset that does not support your region,
 | CASB Findings | Account | ✘ | ✅ | ✘ |
 | Device Posture Results | Account | ✘ | ✅ | ✘ |
 | DNS Firewall logs | Account | ✅ | ✅ | ✘ |
-| Gateway DNS | Account | ✘ | ✅ | ✘ |
+| Gateway DNS | Account | ✅ | ✅ | ✅ |
 | Gateway HTTP | Account | ✅ | ✅ | ✅ |
 | Gateway Network | Account | ✅ | ✅ | ✅ |
 | Magic IDS Detections | Account | ✅ | ✅ | ✘ |


### PR DESCRIPTION
This updates Logspush datasets supported for Gateway DNS, which now respects CMB and is available with EU CMB region properly.