### PR TITLE
[D1] Update limits.md

### DIFF
--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -13,8 +13,8 @@ rss: file
 
 Databases using D1's [new storage subsystem](/d1/changelog/#new-default-storage-subsystem) can now grow to 500 MB each, up from the previous 100 MB limit. This applies to both existing and newly created databases.
 
-Visit the [Limits documentation](
-/d1/platform/limits/) for full details on what limits currently apply to D1.
+Refer to [Limits](/d1/platform/limits/) to learn about D1's limits.
+
 
 ## 2023-07-27
 

--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -7,6 +7,15 @@ rss: file
 
 # Changelog
 
+## 2023-08-01
+
+### Per-database limit now 500 MB
+
+Databases using D1's [new storage subsystem)[/d1/changelog/#new-default-storage-subsystem] can now grow to 500 MB each, up from the previous 100 MB limit. This applies to both existing and newly created databases.
+
+Visit the [Limits documentation](
+/d1/platform/limits/) for full details on what limits currently apply to D1.
+
 ## 2023-07-27
 
 ### New default storage subsystem

--- a/content/d1/changelog.md
+++ b/content/d1/changelog.md
@@ -11,7 +11,7 @@ rss: file
 
 ### Per-database limit now 500 MB
 
-Databases using D1's [new storage subsystem)[/d1/changelog/#new-default-storage-subsystem] can now grow to 500 MB each, up from the previous 100 MB limit. This applies to both existing and newly created databases.
+Databases using D1's [new storage subsystem](/d1/changelog/#new-default-storage-subsystem) can now grow to 500 MB each, up from the previous 100 MB limit. This applies to both existing and newly created databases.
 
 Visit the [Limits documentation](
 /d1/platform/limits/) for full details on what limits currently apply to D1.

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -14,7 +14,7 @@ Many of these limits will increase during D1's [public alpha](/workers/platform/
 | Feature                                            | Limit                                        |
 | -------------------------------------------------- | -------------------------------------------- | 
 | Databases                                          | 10 per account <sup>1</sup>                  |
-| Database size                                      | 100 MB <sup>2</sup>                          |
+| Database size                                      | 500 MB [new storage subsystem](/d1/changelog/#new-default-storage-subsystem) - 100 MB (legacy alpha backend) <sup>2</sup>                          |
 | [Time Travel](/d1/learning/time-travel/) duration (point-in-time recovery)      | 30 days (Workers Paid) / 7 days (Free)       |
 | Maximum Time Travel restore operations             | 10 restores per 10 minute (per database)     |
 | Queries per Worker invocation (see [subrequest limits](/workers/platform/limits/#how-many-subrequests-can-i-make))                      | 50 (Bundled) / 1000 (Unbound)


### PR DESCRIPTION
This PR updates the docs and changelog to show that new backends now allow 500MB per DB.