### PR TITLE
Add citation for dynamic edge IP assignment for proxied domains

### DIFF
--- a/content/fundamentals/_partials/_proxy-status-effects.md
+++ b/content/fundamentals/_partials/_proxy-status-effects.md
@@ -39,4 +39,4 @@ This means that all requests intended for proxied hostnames will go to Cloudflar
         A[Visitor] <-- Connection --> B[Cloudflare global network] <-- Connection --> C[Origin server]
 ```
 
-The Cloudflare assigns specific Anycast IPs to your domain dynamically and may change at any time. This is an expected part of the operation of our Anycast network and does not affect the proxy behavior described above.
+Cloudflare assigns specific Anycast IPs to your domain dynamically and these IPs may change at any time. This is an expected part of the operation of our Anycast network and does not affect the proxy behavior described above.

--- a/content/fundamentals/_partials/_proxy-status-effects.md
+++ b/content/fundamentals/_partials/_proxy-status-effects.md
@@ -39,4 +39,4 @@ This means that all requests intended for proxied hostnames will go to Cloudflar
         A[Visitor] <-- Connection --> B[Cloudflare global network] <-- Connection --> C[Origin server]
 ```
 
-Note that the specific Anycast IPs used for your domain are assigned dynamically and may change at any time. This is an expected part of the operation of our Anycast network and does not affect the proxy behavior described above.
+The Cloudflare assigns specific Anycast IPs to your domain dynamically and may change at any time. This is an expected part of the operation of our Anycast network and does not affect the proxy behavior described above.

--- a/content/fundamentals/_partials/_proxy-status-effects.md
+++ b/content/fundamentals/_partials/_proxy-status-effects.md
@@ -25,7 +25,7 @@ Another way of thinking about this concept is that visitors directly connect wit
 
 ### With Cloudflare
 
-With Cloudflare — meaning your domain or subdomain is using [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/) — DNS lookups for your application's URL will resolve to [Cloudflare Anycast IPs](https://www.cloudflare.com/ips/) instead of their original DNS target.
+With Cloudflare — meaning your domain or subdomain is using [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/) — DNS lookups for your application's URL will resolve to [Cloudflare Anycast IPs](https://www.cloudflare.com/ips/) instead of their original DNS target. 
 
 | URL | Returned IP address |
 | --- | --- |
@@ -38,3 +38,5 @@ This means that all requests intended for proxied hostnames will go to Cloudflar
         accTitle: Connections with Cloudflare
         A[Visitor] <-- Connection --> B[Cloudflare global network] <-- Connection --> C[Origin server]
 ```
+
+Note that the specific Anycast IPs used for your domain are assigned dynamically and may change at any time. This is an expected part of the operation of our Anycast network and does not affect the proxy behavior described above.


### PR DESCRIPTION
While it is understood internally that the default case for proxied zones is that they have dynamically-assigned Cloudflare Anycast IPs, I was not able to determine where this is explicitly stated in our documentation.

As this is a fundamental aspect of our service, I've provisionally added it as a note here. However, if it is already stated somewhere and I've missed it (or if it would be better added to another Developer article) please let me know and/or update this PR.