### PR TITLE
update the image section of the next.js guide

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -205,19 +205,15 @@ export async function GET(request: Request) {
 };
 ```
 
-## The Image component
+## `Image` component
 
-The Cloudflare network does not provide the same image optimization support as the Vercel network does, because of this
-the Next.js' `<Image />` component behaves differently from how it would in the Vercel network.
+The Cloudflare network does not provide the same image optimization support as the Vercel network does, because of this the Next.js' `<Image />` component behaves differently from how it would in the Vercel network.
 
- - If you build your application as a static one the `<Image />` component won't actually serve images at all.
+ - If you build your application as a static site, the `<Image />` component will not serve any images.
 
- - If you build your application using `@cloudflare/next-on-pages` the component will work but not perform any image optimization
-(regardless of the props you pass to it).
+ - If you build your application using `@cloudflare/next-on-pages`, the component will work but it will not perform any image optimization (regardless of the [props](https://react.dev/learn/passing-props-to-a-component) you pass to it).
 
-Both cases can be improved by setting up proper [loaders](https://nextjs.org/docs/pages/api-reference/components/image#loader) for
- the `<Image />` component which allow you to use any image optimization service you want. In case you'd like to use the [Cloudflare
- Images](https://www.cloudflare.com/en-gb/products/cloudflare-images) please check out our [Next.js image resizing integration guide](/images/image-resizing/integration-with-frameworks/#nextjs).
+Both cases can be improved by setting up proper [loaders](https://nextjs.org/docs/pages/api-reference/components/image#loader) for the `<Image />` component, which allow you to use any image optimization service you want. To use [Cloudflare Images](/images/cloudflare-images/), refer to the [Next.js image resizing integration guide](/images/image-resizing/integration-with-frameworks/#nextjs).
 
 
 {{<render file="_learn-more.md" withParameters="Next.js">}}

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -208,15 +208,15 @@ export async function GET(request: Request) {
 ## The Image component
 
 The Cloudflare network does not provide the same image optimization support as the Vercel network does, because of this
-the Next.js' `<Image />` component behaves differently from how it would when deployed to the Vercel network.
+the Next.js' `<Image />` component behaves differently from how it would in the Vercel network.
 
  - If you build your application as a static one the `<Image />` component won't actually serve images at all.
 
- - If you build your application using `@cloudflare/next-on-pages` the component will work but not perform any image optimization,
-regardless on the props you provide to it.
+ - If you build your application using `@cloudflare/next-on-pages` the component will work but not perform any image optimization
+(regardless of the props you pass to it).
 
 Both cases can be improved by setting up proper [loaders](https://nextjs.org/docs/pages/api-reference/components/image#loader) for
- the `<Image />` component, which allow you to use any image optimization service you want. In case you'd like to use the [Cloudflare
+ the `<Image />` component which allow you to use any image optimization service you want. In case you'd like to use the [Cloudflare
  Images](https://www.cloudflare.com/en-gb/products/cloudflare-images) please check out our [Next.js image resizing integration guide](/images/image-resizing/integration-with-frameworks/#nextjs).
 
 

--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -205,28 +205,19 @@ export async function GET(request: Request) {
 };
 ```
 
-## Statically imported images on Pages
+## The Image component
 
-Pages does not currently support the default Next.js image optimization API. As a result, static imports of images break.
+The Cloudflare network does not provide the same image optimization support as the Vercel network does, because of this
+the Next.js' `<Image />` component behaves differently from how it would when deployed to the Vercel network.
 
-```js
-import Image from 'next/image';
-import MyImage from './myImage.png';
+ - If you build your application as a static one the `<Image />` component won't actually serve images at all.
 
-const MyImage = props => {
-  return (
-    <Image
-      src={MyImage} // <- Not supported
-      alt="Picture of the author"
-      width={500}
-      height={500}
-    />
-  );
-};
-```
+ - If you build your application using `@cloudflare/next-on-pages` the component will work but not perform any image optimization,
+regardless on the props you provide to it.
 
-To use image assets, upload your statically imported images to a remote provider like [Cloudflare Images](https://www.cloudflare.com/en-gb/products/cloudflare-images/) or [R2](https://www.cloudflare.com/en-gb/products/r2/).
+Both cases can be improved by setting up proper [loaders](https://nextjs.org/docs/pages/api-reference/components/image#loader) for
+ the `<Image />` component, which allow you to use any image optimization service you want. In case you'd like to use the [Cloudflare
+ Images](https://www.cloudflare.com/en-gb/products/cloudflare-images) please check out our [Next.js image resizing integration guide](/images/image-resizing/integration-with-frameworks/#nextjs).
 
-To serve optimized images, define a global [loaderFile](/images/image-resizing/integration-with-frameworks/) for your app and integrate on-demand resizing with [flexible image variants](/images/cloudflare-images/transform/flexible-variants/) (for Cloudflare Images) or [Image Resizing](/images/image-resizing/url-format/) (for all other remote sources).
 
 {{<render file="_learn-more.md" withParameters="Next.js">}}


### PR DESCRIPTION
Updating the `<Image />` section of the next.js guide since we've make the component work out of the box in our adapter (`@cloudflare/next-on-pages`)