### PR TITLE
update next.js static preset

### DIFF
--- a/content/pages/_partials/_build-configuration.md
+++ b/content/pages/_partials/_build-configuration.md
@@ -22,7 +22,7 @@ build_configs:
     icon: /icons/framework-icons/logo-next-js.svg
   next-js-static:
     display_name: Next.js (Static HTML Export)
-    build_command: npx next build && npx next export
+    build_command: npx next build
     build_output_directory: out
     icon: /icons/framework-icons/logo-next-js.svg
   nuxt-js:


### PR DESCRIPTION
Before in next you used to build a static site with `next export` that's been updated to just `next build` + a config option:
https://nextjs.org/docs/pages/building-your-application/deploying/static-exports

We did update this in the Next.js guide a while back but forgot to update the preset (as you can see in https://github.com/cloudflare/cloudflare-docs/pull/8939)
