### PR TITLE
Update _before-you-begin.md

### DIFF
--- a/content/registrar/_partials/_before-you-begin.md
+++ b/content/registrar/_partials/_before-you-begin.md
@@ -11,9 +11,6 @@ _build:
 * [Add the domain](/fundamentals/get-started/setup/add-site/) you are transferring to your Cloudflare account.
 * [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records) in the Cloudflare dashboard.
 * [Change your DNS nameservers](/dns/zone-setups/full-setup/) to Cloudflare.
-* Disable DNSSEC by:
-  * Removing the DS record at your current DNS host.
-  * [Disabling DNSSEC](/registrar/get-started/enable-dnssec/) in the Cloudflare dashboard.
 * If initiating multiple transfers, notify your financial institution to prevent them from flagging these charges as fraudulent.
 * Renew your domain if it is within 15 days of expiration.
 * Unlock your domain at your current registrar.


### PR DESCRIPTION
Registrar now requires an active domain before a transfer can proceed, meaning it is not typically possible to transfer with broken DNSSEC. Thus, we no longer need to issue this advice. Internally we also attempt reset the DS record after every transfer to alleviate.