### PR TITLE
[Workers for Platforms] Update note for unsupported outbound workers use cases

### DIFF
--- a/content/cloudflare-for-platforms/workers-for-platforms/platform/outbound-workers.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/platform/outbound-workers.md
@@ -120,6 +120,6 @@ export default {
 
 {{<Aside type ="note">}}
 
-Outbound Workers do not intercept fetch requests from Service Bindings or mTLS certificate bindings. 
+Outbound Workers do not intercept fetch requests made from Durable Objects or mTLS certificate bindings. 
 
 {{</Aside>}}

--- a/content/cloudflare-for-platforms/workers-for-platforms/platform/outbound-workers.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/platform/outbound-workers.md
@@ -120,6 +120,6 @@ export default {
 
 {{<Aside type ="note">}}
 
-Outbound Workers do not intercept fetch requests made from Durable Objects or mTLS certificate bindings. 
+Outbound Workers do not intercept fetch requests made from [Durable Objects](/durable-objects/) or [mTLS certificate bindings](/workers/runtime-apis/mtls/). 
 
 {{</Aside>}}


### PR DESCRIPTION
Outbound Workers do indeed intercept fetch requests from service bindings - and after the support for namespaced-script-implemented Durable Objects, a limitation is that, while you can invoke Durable Objects correctly, an Outbound Worker will not intercept outbound fetches made from that DO