### PR TITLE
[Queues] Add notes on consumer concurrency and retries

### DIFF
--- a/content/queues/learning/batching-retries.md
+++ b/content/queues/learning/batching-retries.md
@@ -103,6 +103,12 @@ Each retry counts as an additional read operation per [Queues pricing](/queues/p
 
 When a single message within a batch fails to be delivered, the entire batch is retried, unless you have [explicitly acknowledged](#explicit-acknowledgement) a message (or messages) within that batch. For example, if a batch of 10 messages is delivered, but the 8th message fails to be delivered, all 10 messages will be retried and thus redelivered to your consumer in full.
 
+{{<Aside type="warning" header="Retried messages and consumer concurrency">}}
+
+Retrying messages with `.retry()` or calling `.retryAll()` on a batch will cause the consumer to autoscale down if consumer concurrency is enabled. Refer to [Consumer concurrency](/queues/learning/consumer-concurrency/) to learn more. 
+
+{{</Aside>}}
+
 ## Dead Letter Queues
 
 A Dead Letter Queue (DLQ) is a common concept in a messaging system, and represents where messages are sent when a delivery failure occurs with a consumer after `max_retries` is reached. A Dead Letter Queue is just like any other queue, and can be produced to and consumed from independently. 

--- a/content/queues/learning/consumer-concurrency.md
+++ b/content/queues/learning/consumer-concurrency.md
@@ -26,6 +26,12 @@ The number of consumers concurrently invoked for a queue will autoscale based on
 
 Where possible, Queues will optimize for keeping your backlog from growing exponentially, in order to minimize scenarios where the backlog of messages in a queue grows to the point that they would reach the [message retention limit](/queues/platform/limits/) before being processed.
 
+{{<Aside type="warning" header="Consumer concurrency and retried messages">}}
+
+Retrying messages with `.retry()` or calling `.retryAll()` on a batch will count as a failed invocation and cause the consumer to autoscale down. If your consumer concurrency remains at 1 but your consumer's `max_concurrency` is something higher, it is usually due to messages being retried, preventing your consumer from scaling up.
+
+{{</Aside>}}
+
 ### Example
 
 If you are writing 100 messages/second to a queue with a single concurrent consumer that takes 5 seconds to process a batch of 100 messages, the number of messages in-flight will continue to grow at a rate faster than your consumer can keep up.

--- a/content/queues/platform/configuration.md
+++ b/content/queues/platform/configuration.md
@@ -84,5 +84,6 @@ Refer to [Limits](/queues/platform/limits) to review the maximum values for each
 - {{<code>}}max_concurrency{{</code>}} {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
   - The maximum number of concurrent consumers allowed to run at once. Leaving this unset will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
+  - Refer to [Consumer concurrency](/queues/learning/consumer-concurrency/) for more information on how consumers autoscale, particularly when messages are retried.
 
 {{</definitions>}}

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -500,6 +500,7 @@ To bind Queues to your consumer Worker, assign an array of the below object to t
 - `max_concurrency` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
   - The maximum number of concurrent consumers allowed to run at once. Leaving this unset will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
+  - Refer to [Consumer concurrency](/queues/learning/consumer-concurrency/) for more information on how consumers autoscale, particularly when messages are retried.
 
 {{</definitions>}}
 


### PR DESCRIPTION
This PR adds several warning notes about retried messages causing consumers to autoscale down. Several users on Discord were confused about this since this behaviour isn't explicitly stated in the docs. 

(Inclusive language check failure is not part of my PR, but I can address it if desired!)

TODO:
- [x] Once #10156 is merged, rebase and add the same warning to the Wrangler bindings page