### PR TITLE
[Workers] fix typescript examples in workers page

### DIFF
--- a/content/workers/examples/aggregate-requests.md
+++ b/content/workers/examples/aggregate-requests.md
@@ -82,7 +82,7 @@ const handler: ExportedHandler = {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(response) {
+    async function gatherResponse(response: Response) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {

--- a/content/workers/examples/fetch-html.md
+++ b/content/workers/examples/fetch-html.md
@@ -28,7 +28,7 @@ export default {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(response) {
+    async function gatherResponse(respons: Responsee) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {

--- a/content/workers/examples/fetch-html.md
+++ b/content/workers/examples/fetch-html.md
@@ -28,7 +28,7 @@ export default {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(respons: Responsee) {
+    async function gatherResponse(response) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {
@@ -73,7 +73,7 @@ const handler: ExportedHandler = {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(response) {
+    async function gatherResponse(response: Response) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {

--- a/content/workers/examples/fetch-json.md
+++ b/content/workers/examples/fetch-json.md
@@ -72,7 +72,7 @@ const handler: ExportedHandler = {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(response) {
+    async function gatherResponse(response: Response) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {

--- a/content/workers/examples/post-json.md
+++ b/content/workers/examples/post-json.md
@@ -87,7 +87,7 @@ const handler: ExportedHandler = {
      * Use await gatherResponse(..) in an async function to get the response body
      * @param {Response} response
      */
-    async function gatherResponse(response) {
+    async function gatherResponse(response: Response) {
       const { headers } = response;
       const contentType = headers.get("content-type") || "";
       if (contentType.includes("application/json")) {


### PR DESCRIPTION
I have corrected the errors in the TypeScript examples on the workers page.
The changes made are as follows:

```diff
- async function gatherResponse(respons) {
+ async function gatherResponse(response: Response) {
```

To be:

<img width="512" alt="スクリーンショット 2023-08-15 21 25 13" src="https://github.com/cloudflare/cloudflare-docs/assets/12913947/35e03936-01ee-4e36-b555-f0c1616ef3fc">
<img width="512" alt="スクリーンショット 2023-08-15 21 25 35" src="https://github.com/cloudflare/cloudflare-docs/assets/12913947/d82b4c5c-a0d5-48ca-91d5-ecdd0a8dc063">
<img width="512" alt="スクリーンショット 2023-08-15 21 26 27" src="https://github.com/cloudflare/cloudflare-docs/assets/12913947/f6c21638-fc1d-465c-ad3d-5808373dabaf">
<img width="512" alt="スクリーンショット 2023-08-15 21 26 44" src="https://github.com/cloudflare/cloudflare-docs/assets/12913947/93136e5b-ac90-4e65-acf8-63ba12bc27d6">
