### PR TITLE
Deansundquist cloudflared ports and ips us region

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
+++ b/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
@@ -28,7 +28,7 @@ When setting the [region parameter to US](https://developers.cloudflare.com/clou
 | Destination | Port | Protocols |
 | ----------- | -------- | --------- |
 | `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
-| `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
+| `us-region2.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
 
 ## Test connectivity with dig
 

--- a/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
+++ b/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
@@ -8,6 +8,10 @@ weight: 3
 
 Users can implement a positive security model with Cloudflare Tunnel by restricting traffic originating from `cloudflared`. The parameters below can be configured for egress traffic inside of a firewall.
 
+## Destinations and ports
+
+### Global region (default)
+
 | Destination | Port | Protocols |
 | ----------- | -------- | --------- |
 | `region1.v2.argotunnel.com` | 7844 | TCP/UDP (`http2`/`quic`) |
@@ -21,9 +25,9 @@ Opening port 443 for connections to `update.argotunnel.com` is optional. Failure
 
 {{</Aside>}}
 
-## Setting the Region Parameter to US 
+### US region
 
-When setting the [region parameter to US](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/install-and-setup/tunnel-guide/local/local-management/arguments/#region) the above destinations, `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com`, will be replaced with the following: 
+If you set the [`region` parameter](/cloudflare-one/connections/connect-networks/install-and-setup/tunnel-guide/local/local-management/arguments/#region) to US, `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com` are replaced with the following:
 
 | Destination | Port | Protocols |
 | ----------- | -------- | --------- |

--- a/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
+++ b/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
@@ -10,8 +10,8 @@ Users can implement a positive security model with Cloudflare Tunnel by restrict
 
 | Destination | Port | Protocols |
 | ----------- | -------- | --------- |
-| `region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
-| `region2.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
+| `region1.v2.argotunnel.com` | 7844 | TCP/UDP (`http2`/`quic`) |
+| `region2.v2.argotunnel.com` | 7844 | TCP/UDP (`http2`/`quic`) |
 | `api.cloudflare.com`        | 443  | TCP (HTTPS) |
 | `update.argotunnel.com`     | 443  | TCP (HTTPS) |
 
@@ -27,8 +27,8 @@ When setting the [region parameter to US](https://developers.cloudflare.com/clou
 
 | Destination | Port | Protocols |
 | ----------- | -------- | --------- |
-| `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
-| `us-region2.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
+| `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`http2`/`quic`) |
+| `us-region2.v2.argotunnel.com` | 7844 | TCP/UDP (`http2`/`quic`) |
 
 ## Test connectivity with dig
 

--- a/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
+++ b/content/cloudflare-one/connections/connect-networks/install-and-setup/ports-and-ips.md
@@ -21,6 +21,15 @@ Opening port 443 for connections to `update.argotunnel.com` is optional. Failure
 
 {{</Aside>}}
 
+## Setting the Region Parameter to US 
+
+When setting the [region parameter to US](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/install-and-setup/tunnel-guide/local/local-management/arguments/#region) the above destinations, `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com`, will be replaced with the following: 
+
+| Destination | Port | Protocols |
+| ----------- | -------- | --------- |
+| `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
+| `us-region1.v2.argotunnel.com` | 7844 | TCP/UDP (`h2mux`, `http2`, and `quic`) |
+
 ## Test connectivity with dig
 
 To test your connectivity to Cloudflare, you can use the `dig` command to query the hostnames listed above. Note that `cloudflared` defaults to connecting with IPv4.


### PR DESCRIPTION
The Ports and IP page for Cloudflared doesn't address the hosts that are used if the region is set to US.  