### PR TITLE
[D1] Match endpoints to code example in build-a-comments-api/index.md

### DIFF
--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -33,8 +33,8 @@ $ npm install hono
 ## 2. Initialize your Hono application
 
 In `src/worker.js`, initialize a new Hono application, and define the following endpoints:
-- `GET /API/posts/:slug/comments`.
-- `POST /get/api/:slug/comments`.
+- `GET /api/posts/:slug/comments`.
+- `POST /api/posts/:slug/comments`.
 
 ```js
 ---


### PR DESCRIPTION
I went through the tutorial and noticed, that the described endpoints do not match the shown example code. 

EDIT:
- changed the Product name from `Workers` to `D1`