### PR TITLE
Correct filetype on adding CORS headers docs

### DIFF
--- a/content/pages/platform/functions/examples/cors-headers.md
+++ b/content/pages/platform/functions/examples/cors-headers.md
@@ -11,9 +11,9 @@ layout: example
 
 This example is a snippet from our Cloudflare Pages Template repo. 
 
-```js
+```ts
 ---
-filename: /functions/_middleware.js
+filename: /functions/_middleware.ts
 ---
 
 // Respond to OPTIONS method


### PR DESCRIPTION
The example is written in TypeScript but the filename is `_middleware.js` instead of `_middleware.ts`.