### PR TITLE
Clarify firewall documentation

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture.md
@@ -350,7 +350,7 @@ $ ip route get 169.254.0.0
 
 #### System firewall
 
-In Split Tunnel Exclude mode, WARP also modifies the operating system firewall to enforce your Split Tunnel rules. This adds a layer of protection in case a service bypasses the routing table and tries to send traffic directly through another interface. For example, if traffic to `203.0.113.0` is supposed to be inspected by Gateway, we create a firewall rule that blocks `203.0.113.0` on all interfaces except for `utun`.
+WARP also modifies the operating system firewall to enforce your Split Tunnel rules. This adds a layer of protection in case a service bypasses the routing table and tries to send traffic directly through another interface. For example, if traffic to `203.0.113.0` is supposed to be inspected by Gateway, we create a firewall rule that blocks `203.0.113.0` on all interfaces except for `utun`.
 
 ## iOS, Android, and ChromeOS
 

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture.md
@@ -350,7 +350,7 @@ $ ip route get 169.254.0.0
 
 #### System firewall
 
-WARP also modifies the operating system firewall to enforce your Split Tunnel rules. This adds a layer of protection in case a service bypasses the routing table and tries to send traffic directly through another interface. For example, if traffic to `203.0.113.0` is supposed to be inspected by Gateway, we create a firewall rule that blocks `203.0.113.0` on all interfaces except for `utun`.
+WARP modifies the operating system firewall to enforce your Split Tunnel rules. This adds a layer of protection in case a service bypasses the routing table and tries to send traffic directly through another interface. For example, if traffic to `203.0.113.0` is supposed to be inspected by Gateway, we create a firewall rule that blocks `203.0.113.0` on all interfaces except for `utun`.
 
 ## iOS, Android, and ChromeOS
 


### PR DESCRIPTION
The WARP client manages a firewall in both split tunnel exclude and split tunnel includes modes to verify that included hosts have all traffic sent over the tunnel