### PR TITLE
Document GraphQL API's new support for arrays of primitives

### DIFF
--- a/content/analytics/graphql-api/features/filtering/index.md
+++ b/content/analytics/graphql-api/features/filtering/index.md
@@ -82,9 +82,19 @@ filters
 
 Operator support varies, depending on the node type and node name.
 
-#### Common operators
+#### Array operators
 
-The following operators are supported for all types:
+The following operators are supported for all array types:
+
+| Operator | Comparison                                      |
+| -------- | ----------------------------------------------- |
+| `has`    | array contains a value                          |
+| `hasall` | array contains all of a list of values          |
+| `hasany` | array contains at least one of a list of values |
+
+#### Scalar operators
+
+The following operators are supported for all scalar types:
 
 | Operator | Comparison          |
 | -------- | ------------------- |
@@ -172,6 +182,45 @@ httpRequestsAdaptiveGroups(
 WHERE datetime="2018-01-01T10:00:00Z"
   AND ((clientCountryName = "US") OR (clientCountryName = "GB"))
 ```
+
+### Filter an array by one value
+
+The following GraphQL examples show how to filter an array field to only return data
+that includes a specific value. The SQL equivalent follows.
+
+#### GraphQL {#001}
+
+```graphql
+mnmFlowDataAdaptiveGroups(filter: {ruleIDs_has: "rule-id"}) {
+    ...
+}
+```
+
+#### SQL {#002}
+
+```sql
+WHERE has(ruleIDs, 'rule-id')
+```
+
+### Filter an array by multiple values
+
+The following GraphQL examples show how to filter an array field to only return data
+that includes several values. The SQL equivalent follows.
+
+#### GraphQL {#001}
+
+```graphql
+mnmFlowDataAdaptiveGroups(filter: {ruleIDs_hasall: ["rule-id-1", "rule-id-2"]}) {
+    ...
+}
+```
+
+#### SQL {#002}
+
+```sql
+WHERE has(ruleIDs, 'rule-id-1') AND has(ruleIDs, 'rule-id-2')
+```
+
 ### Filter end users
 
 Add the `requestSource` filter for `eyeball` to return request, data transfer, and visit data about only the end users of your website. This will exclude actions taken by Cloudflare products (for example, cache purge,  healthchecks, Workers subrequests) on your zone.  

--- a/content/analytics/graphql-api/features/filtering/index.md
+++ b/content/analytics/graphql-api/features/filtering/index.md
@@ -7,7 +7,7 @@ layout: single
 
 # Filtering
 
-Filters constrain queries to a particular account or set of zones, requests by date, or those from a specific user agent, for example. Without filters, queries can suffer performance degradation, results can easily exceed supported bounds, and the data returned can be noisy.
+Filters constrain queries to a particular account or set of zones, requests by date, or those from a specific user agent, for example. Without filters, queries can suffer performance degradation, results can exceed supported bounds, and the data returned can be noisy.
 
 ## Filter Structure
 

--- a/content/analytics/graphql-api/features/nested-structures/index.md
+++ b/content/analytics/graphql-api/features/nested-structures/index.md
@@ -7,7 +7,7 @@ layout: single
 
 # Nested Structures
 
-Two kinds of nested structures that behave in special ways are supported: **arrays** and **maps**. Fields of either of these types are arrays; when they are part part of query result, which is already an array of objects, they become nested arrays.
+Two kinds of nested structures that are supported: **arrays** and **maps**. Fields of either of these types are arrays; when they are part part of query result, which is already an array of objects, they become nested arrays.
 
 ## Arrays
 
@@ -16,7 +16,7 @@ The GraphQL API supports two different sorts of arrays:
 - Some arrays contain scalar types (for example, `[String]`) and function like ordinary fields that [can be filtered](/analytics/graphql-api/features/filtering/)
 - Some arrays contain more complex types (for example, `[Subrequest]`.) The following section describes their behaviour.
 
-Arrays of non-scalar types behave as a special kind of single value. There is no way to paginate through, filter, filter by, group, or group by the array.
+Arrays of non-scalar types behave as a single value. There is no way to paginate through, filter, filter by, group, or group by the array.
 
 On the other hand, you can choose which fields of the underlying type you want fetched.
 

--- a/content/analytics/graphql-api/features/nested-structures/index.md
+++ b/content/analytics/graphql-api/features/nested-structures/index.md
@@ -11,7 +11,12 @@ Two kinds of nested structures that behave in special ways are supported: **arra
 
 ## Arrays
 
-Arrays behave as a special kind of single value. There is no way to paginate through, filter, filter by, group, or group by the array.
+The GraphQL API supports two different sorts of arrays:
+
+- Some arrays contain scalar types (for example, `[String]`) and function like ordinary fields that [can be filtered](/analytics/graphql-api/features/filtering/)
+- Some arrays contain more complex types (for example, `[Subrequest]`.) The following section describes their behaviour.
+
+Arrays of non-scalar types behave as a special kind of single value. There is no way to paginate through, filter, filter by, group, or group by the array.
 
 On the other hand, you can choose which fields of the underlying type you want fetched.
 


### PR DESCRIPTION
As widely requested, GraphQL API now supports arrays of primitive types. This will be used for things like lists of tags.

This commit adjusts the existing documentation. It adds a list of the new array operators: `_has`, `_hasall` and `_hasany`. We could maybe do with usage examples for all 3, but the existing documentation just offers a very quick summary.

It also adjusts some documentation for Nested arrays, to try and disambiguate between the limited filtering of those fields vs the more featured filtering of the new arrays of primitives.