### PR TITLE
Cloudflare DNS for Mozilla Firefox configuration guide update

### DIFF
--- a/content/1.1.1.1/encryption/dns-over-https/encrypted-dns-browsers.md
+++ b/content/1.1.1.1/encryption/dns-over-https/encrypted-dns-browsers.md
@@ -12,9 +12,9 @@ Some browsers might already have this setting enabled.
 ## Mozilla Firefox
 
 1. Select the menu button > **Settings**.
-2. In the **General** menu, scroll down to access **Network Settings**.
-3. Select **Settings**.
-4. Select **Enable DNS over HTTPS**. By default, it resolves to Cloudflare DNS.
+2. Select **Privacy & Security**, and scroll down to **DNS over HTTPS**.
+3. Default DNS-over-HTTPS is activated.
+4. Select **Increased Protection** or **Maximum Protection** to choose Cloudflare DNS, which is the default for these options.
 
 ## Google Chrome
 


### PR DESCRIPTION
Mozilla made changes in the DoH configuration, I have updated the guide with the corresponding changes to be consistent with the changes made by Mozilla in Firefox.

More info: https://support.mozilla.org/en-US/kb/dns-over-https