### PR TITLE
[Docs engine] Add new meta property for easier reporting

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -1,6 +1,6 @@
 ---
 title: Cloudflare Docs
-
+layout: home
 meta:
   description: Browse product docs including how-to guides, tutorials, API reference, and sample code.
   title: Home

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -107,6 +107,11 @@
   <meta name="twitter:card" content="summary_large_image" />
 
   <!-- Add metadata for reporting -->
+  {{- if or (ne .Context.Params.layout "home") (eq .Context.Params.pcx_content_type "learning-path") -}}
+  {{- $product := replace (delimit (findRE `\/.*?\/` $rellink 1) "") "/" "" -}}
+  <meta name="pcx_product" content="{{- $product -}}">
+  {{- end -}}
+
   <meta name="pcx_word_count" content="{{- $.Context.FuzzyWordCount -}}">
   {{- $lastMod := $.Context.Lastmod.Format "2006-01-02"  | time -}}
   {{- $diffMod := now.Sub $lastMod -}}


### PR DESCRIPTION
Validation:

- home / products page should not have a meta property of `pcx_product`.
- Pages like /learning-paths/load-balancing/ and `/bots/troubleshooting` should with a `content` equal to `developers.cloudflare.com/{EXTRACT}/blah/blah`.