### PR TITLE
[Workers] fix typo repeated word in protect-against-timing-attacks.md

### DIFF
--- a/content/workers/examples/protect-against-timing-attacks.md
+++ b/content/workers/examples/protect-against-timing-attacks.md
@@ -1,6 +1,6 @@
 ---
 type: example
-summary: Protect against timing attacks using by safely comparing values using timingSafeEqual.
+summary: Protect against timing attacks by safely comparing values using timingSafeEqual.
 tags:
   - Security
 pcx_content_type: configuration

--- a/content/workers/examples/protect-against-timing-attacks.md
+++ b/content/workers/examples/protect-against-timing-attacks.md
@@ -1,6 +1,6 @@
 ---
 type: example
-summary: Protect against timing attacks by safely comparing values using timingSafeEqual.
+summary: Protect against timing attacks by safely comparing values using `timingSafeEqual`.
 tags:
   - Security
 pcx_content_type: configuration


### PR DESCRIPTION
- docs(using-timingSafeEqual): fix typo repeated word