### PR TITLE
Update Gmail address in integration test

### DIFF
--- a/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
+++ b/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
@@ -54,8 +54,11 @@ When you put your Google Workspace behind Access, users will not be able to log 
 
 ## 4. Test the integration
 
-Find the web address to access your Google Workspace Gmail address in Google Admin console (at admin.google.com) > Apps > Google Workspace > Gmail > Setup. To test the integration, open an incognito browser window and go to your Gmail web address e.g. `https://mail.google.com/a/<your_domain.com>`. An Access login screen should appear.
+1. In your [Google Admin console](https://admin.google.com/), go to **Apps** > **Google Workspace** > **Gmail** > **Setup**,
+2. Copy the **Web address**.
+3. Open an incognito browser window and go to your Gmail web address (for example, `https://mail.google.com/a/<your_domain.com>`).
 
+An Access login screen should appear.
 
 ## Troubleshooting
 

--- a/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
+++ b/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
@@ -54,7 +54,8 @@ When you put your Google Workspace behind Access, users will not be able to log 
 
 ## 4. Test the integration
 
-To test the integration, open an incognito browser window and go to `https://mail.google.com/`. An Access login screen should appear.
+Find the web address to access your Google Workspace Gmail address in Google Admin console (at admin.google.com) > Apps > Google Workspace > Gmail > Setup. To test the integration, open an incognito browser window and go to your Gmail web address e.g. `https://mail.google.com/a/<your_domain.com>`. An Access login screen should appear.
+
 
 ## Troubleshooting
 

--- a/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
+++ b/content/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.md
@@ -55,7 +55,7 @@ When you put your Google Workspace behind Access, users will not be able to log 
 ## 4. Test the integration
 
 1. In your [Google Admin console](https://admin.google.com/), go to **Apps** > **Google Workspace** > **Gmail** > **Setup**,
-2. Copy the **Web address**.
+2. Copy your Gmail **Web address**.
 3. Open an incognito browser window and go to your Gmail web address (for example, `https://mail.google.com/a/<your_domain.com>`).
 
 An Access login screen should appear.


### PR DESCRIPTION
The address "https://mail.google.com/" will not redirect to the Cloudflare Access screen. 
Find the web address to access your Google Workspace Gmail address in Google Admin console (at admin.google.com) > Apps > Google Workspace > Gmail > Setup. To test the integration, open an incognito browser window and go to your Gmail web address e.g. `https://mail.google.com/a/<your_domain.com>`. An Access login screen should appear.
