### PR TITLE
Document Cloudflare Pages ignoring ports when matching _headers rules

### DIFF
--- a/content/pages/_partials/_headers_redirects_placeholders.md
+++ b/content/pages/_partials/_headers_redirects_placeholders.md
@@ -1,0 +1,11 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+inputParameters: type
+---
+
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) followed by a letter indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:[A-Za-z]\w*`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+
+Similarly, the matched value can be used in the $1 values with `:placeholder_name`.

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -22,7 +22,7 @@ Header rules are defined in multi-line blocks. The first line of a block is the 
   [name]: [value]
 ```
 
-Using absolute URLs is supported, though be aware that they must begin with `https` and specifying a port is not supported. Cloudflare Pages ignores the incoming request's port and protocol when matching against an incoming request. For example, a rule like `https://example.com/path` would match against requests to `other://example.com:1234/path`.
+Using absolute URLs is supported, though be aware that absolute URLs must begin with `https` and specifying a port is not supported. Cloudflare Pages ignores the incoming request's port and protocol when matching against an incoming request. For example, a rule like `https://example.com/path` would match against requests to `other://example.com:1234/path`.
 
 You can define as many `[name]: [value]` pairs as you require on subsequent lines. For example:
 
@@ -89,9 +89,7 @@ The matched value can be referenced within the header value as the `:splat` plac
 
 #### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) followed by a letter indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:[A-Za-z]\w*`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
-
-Similarly, the matched value can be used in the header values with `:placeholder_name`.
+{{<render file="_headers_redirects_placeholders.md" withParameters="header">}}
 
 ```txt
 ---

--- a/content/pages/platform/headers.md
+++ b/content/pages/platform/headers.md
@@ -22,6 +22,8 @@ Header rules are defined in multi-line blocks. The first line of a block is the 
   [name]: [value]
 ```
 
+Using absolute URLs is supported, though be aware that they must begin with `https` and specifying a port is not supported. Cloudflare Pages ignores the incoming request's port and protocol when matching against an incoming request. For example, a rule like `https://example.com/path` would match against requests to `other://example.com:1234/path`.
+
 You can define as many `[name]: [value]` pairs as you require on subsequent lines. For example:
 
 ```txt
@@ -46,8 +48,8 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 
 {{<table-wrap>}}
 
-| Request URL                                   | Headers                                                                                                                               |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Request URL                                     | Headers                                                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `https://custom.domain/secure/page`             | `X-Frame-Options: DENY` <br /> `X-Content-Type-Options: nosniff ` <br /> `Referrer-Policy: no-referrer`                               |
 | `https://custom.domain/static/image.jpg`        | `Access-Control-Allow-Origin: *` <br /> `X-Robots-Tag: nosnippet`                                                                     |
 | `https://myproject.pages.dev/home`              | `X-Robots-Tag: noindex`                                                                                                               |
@@ -87,7 +89,7 @@ The matched value can be referenced within the header value as the `:splat` plac
 
 #### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:\w+`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) followed by a letter indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:[A-Za-z]\w*`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
 
 Similarly, the matched value can be used in the header values with `:placeholder_name`.
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -36,6 +36,7 @@ filename: _redirects
 /blog/* https://blog.my.domain/:splat
 /products/:code/:name /products?code=:code&name=:name
 ```
+
 {{<Aside type= "note">}}
 
 In the case of some frameworks, such as Jekyll, you may need to manually copy and paste your `_redirects` file to the build output directory. To do this:
@@ -58,17 +59,17 @@ Cloudflare currently offers limited support for advanced redirects. More support
 
 {{<table-wrap>}}
 
-| Feature                             | Support | Example                                                         | Notes                                                                                             |
-| ----------------------------------- | ------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Redirects (301, 302, 303, 307, 308) | Yes     | `/home / 301`                                                   | 302 is used as the default status code.                                                            |
-| Rewrites (other status codes)       | No      | `/blog/* /blog/404.html 404`                                    |                                                                                                   |
-| Splats                              | Yes     | `/blog/* /blog/:splat`                                          | Refer to [Splats](#splats).                                                                             |
-| Placeholders                        | Yes     | `/blog/:year/:month/:date/:slug /news/:year/:month/:date/:slug` | Refer to [Placeholders](#placeholders).                                                                |
-| Query Parameters                    | No      | `/shop id=:id /blog/:id 301`                                    |                                                                                                   |
-| Proxying                            | Yes     | `/blog/* /news/:splat 200`                                      | Refer to [Proxying](#proxying).                                                                   |
-| Domain-level redirects              | No      | `workers.example.com/* workers.example.com/blog/:splat 301`     |                                                                                                   |
-| Redirect by country or language     | No      | `/ /us 302 Country=us`                                          |                                                                                                   |
-| Redirect by cookie                  | No      | `/\* /preview/:splat 302 Cookie=preview`                        |                                                                                                   |
+| Feature                             | Support | Example                                                         | Notes                                   |
+| ----------------------------------- | ------- | --------------------------------------------------------------- | --------------------------------------- |
+| Redirects (301, 302, 303, 307, 308) | Yes     | `/home / 301`                                                   | 302 is used as the default status code. |
+| Rewrites (other status codes)       | No      | `/blog/* /blog/404.html 404`                                    |                                         |
+| Splats                              | Yes     | `/blog/* /blog/:splat`                                          | Refer to [Splats](#splats).             |
+| Placeholders                        | Yes     | `/blog/:year/:month/:date/:slug /news/:year/:month/:date/:slug` | Refer to [Placeholders](#placeholders). |
+| Query Parameters                    | No      | `/shop id=:id /blog/:id 301`                                    |                                         |
+| Proxying                            | Yes     | `/blog/* /news/:splat 200`                                      | Refer to [Proxying](#proxying).         |
+| Domain-level redirects              | No      | `workers.example.com/* workers.example.com/blog/:splat 301`     |                                         |
+| Redirect by country or language     | No      | `/ /us 302 Country=us`                                          |                                         |
+| Redirect by cookie                  | No      | `/\* /preview/:splat 302 Cookie=preview`                        |                                         |
 
 {{</table-wrap>}}
 
@@ -84,7 +85,7 @@ The matched value can be used in the redirect location with `:splat`.
 
 ### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon indicates the start of a placeholder, and the placeholder name that follows may be composed of alphanumeric characters and underscores, `:\w+`. A placeholder with any given name can only be used once in the URL. Placeholders match all characters apart from the delimiter, which: when part of the host, is a period or a forward-slash; and when part of the path, is a forward-slash.
+A placeholder can be defined with `:placeholder_name`. A colon (`:`) followed by a letter indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:[A-Za-z]\w*`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
 
 Similarly, the matched value can be used in the redirect location with `:placeholder_name`.
 
@@ -108,11 +109,12 @@ For example, if you have added `/about/faq/* /about/faqs 200` to your `_redirect
 /about/faq/*
   Link: </about/faqs>; rel="canonical"
 ```
+
 {{</Aside>}}
 
 ## Surpass `_redirects` limits
 
-A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Use [Bulk Redirects (beta)](/rules/url-forwarding/bulk-redirects/) to handle redirects that surpasses the 2,100 redirect rules limit set by Pages. 
+A [`_redirects`](/pages/platform/limits/#redirects) file has a maximum of 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Use [Bulk Redirects (beta)](/rules/url-forwarding/bulk-redirects/) to handle redirects that surpasses the 2,100 redirect rules limit set by Pages.
 
 {{<Aside type="note">}}
 

--- a/content/pages/platform/redirects.md
+++ b/content/pages/platform/redirects.md
@@ -85,9 +85,14 @@ The matched value can be used in the redirect location with `:splat`.
 
 ### Placeholders
 
-A placeholder can be defined with `:placeholder_name`. A colon (`:`) followed by a letter indicates the start of a placeholder and the placeholder name that follows must be composed of alphanumeric characters and underscores (`:[A-Za-z]\w*`). Every named placeholder can only be referenced once. Placeholders match all characters apart from the delimiter, which when part of the host, is a period (`.`) or a forward-slash (`/`) and may only be a forward-slash (`/`) when part of the path.
+{{<render file="_headers_redirects_placeholders.md" withParameters="redirect">}}
 
-Similarly, the matched value can be used in the redirect location with `:placeholder_name`.
+```txt
+---
+filename: _redirects
+---
+/movies/:title /media/:title
+```
 
 ### Proxying
 


### PR DESCRIPTION
Cloudflare Pages is going to ignore the incoming request's port when evaluating `_headers` rules to match against. It already ignores the protocol.