### PR TITLE
Fix chrony documentation URL in nts.md

### DIFF
--- a/content/time-services/nts.md
+++ b/content/time-services/nts.md
@@ -17,6 +17,6 @@ The NTS protocol is divided into two phases:
 
 ## Next steps
 
-[Chrony](https://chrony.tuxfamily.org/doc/devel/chrony.conf.html) and [NTPsec](https://www.ntpsec.org/) have support for NTS. Read the relevant documentation for guidance on setting them up to point to our time service, `time.cloudflare.com`.
+[Chrony](https://chrony-project.org/documentation.html) and [NTPsec](https://www.ntpsec.org/) have support for NTS. Read the relevant documentation for guidance on setting them up to point to our time service, `time.cloudflare.com`.
 
 If you would like to hear about the development of additional clients or updates on our service or would like to announce that your client supports NTS, send an email `time-services+subscribe@cloudflare.com` and then reply to the confirmation email to be added to our distribution list.


### PR DESCRIPTION
The old url returns 404 now. Since there doesn't seem to be a direct link for devel version anymore, let's just point to the overall documentation page.