### PR TITLE
[Support] Recommended WordPress settings turns IPv6 on, not off

### DIFF
--- a/content/support/Third-Party Software/Content Management System (CMS)/What settings are applied when I click Optimize Cloudflare for WordPress in Cloudflare's WordPress plugin.md
+++ b/content/support/Third-Party Software/Content Management System (CMS)/What settings are applied when I click Optimize Cloudflare for WordPress in Cloudflare's WordPress plugin.md
@@ -22,7 +22,7 @@ If you're using Cloudflare's Wordpress plugin, our "Optimize Cloudflare for Wor
 | Browser Cache TTL | 4 hours |
 | Always Online | On |
 | Development Mode | Disabled |
-| IPV6 Compatibility | Off |
+| IPV6 Compatibility | On |
 | WebSockets | On |
 | IP Geolocation | On |
 | Email Address Obfuscation | On |


### PR DESCRIPTION
"Apply Recommended Cloudflare Settings for WordPress" turns IPv6 on, not off.

![image](https://github.com/cloudflare/cloudflare-docs/assets/14004943/d81e8e50-3163-4ee9-bc76-d47c16519a50)

Tested by turning IPv6 off and then applying recommended settings, which turns it back on again. If it was on, it stays on.