### PR TITLE
Bump DO RPS Limit in Worker Product

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -305,7 +305,7 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 
 - 30s of CPU time per request, including websocket messages
 
-Durable Objects scale well across Objects, but each object is inherently single-threaded. A baseline of 100 req/sec is a good floor estimate of the request rate an individual Object can handle, though this will vary with workload.
+Durable Objects scale well across Objects, but each object is inherently single-threaded. A baseline of 1,000 requests per second is a good floor estimate of the request rate an individual Object can handle, though this will vary with workload.
 
 Durable Objects have been built such that the number of Objects in the system do not need to be limited. You can create and run as many separate objects as you want. The main limit to your usage of Durable Objects is the total storage limit per account - if you need more storage, contact your account team.
 


### PR DESCRIPTION
Closes #10550.

Increases 100 rps soft-limit in [Workers Limits](https://developers.cloudflare.com/workers/platform/limits/#durable-objects) to 1k to mirror [DO Product Limits](https://developers.cloudflare.com/durable-objects/platform/limits/).

~~May also want to add some extra clarifiers about what exactly a soft-limit entails, as it may not be clear atm.~~

Should the DO section in the Worker Product be a link to the DO product Limit section, since otherwise you may have other issues like this, where changes to one aren't reflected in the other?