### PR TITLE
[workers] Update new-url-parser-implementation.md

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -11,4 +11,4 @@ enable_flag: "url_standard"
 disable_flag: "url_original"
 ---
 
-The original Workers `URL` API implementation is not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/). Cloudflare has added a new implementation that is fully compliant. However, since the new implementation is not completely backwards compatible, it is disabled by default. Use the `url_standard` flag to enable the new implementation.
+The original Workers `URL` API implementation was not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/), differing in several ways, including how validation and URL encoding was performed. Use the `url_standard` flag to opt-in to the backwards-incompatible change to use a fully compliant `URL` API implementation.

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -11,4 +11,20 @@ enable_flag: "url_standard"
 disable_flag: "url_original"
 ---
 
-The original implementation of the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) API in Workers was not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/), differing in several ways, including how validation and URL encoding was performed. Set the compatibility date of your Worker to a date after `2022-10-31` or enable the `url_standard` compatibility flag to opt-in the fully spec compliant `URL` API implementation.
+The original implementation of the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) API in Workers was not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/), differing in several ways, including:
+
+* The original implementation collapsed sequences of multiple slashes into a single slash:
+
+  `new URL("https://example.com/a//b").toString() === "https://example.com/a/b"`
+
+* The original implementation would throw `"TypeError: Invalid URL string."` if it encountered invalid percent-encoded escape sequences, like `https://example.com/a%%b`.
+
+* The original implementation would percent-encode or percent-decode certain content differently:
+
+  `new URL("https://example.com/a%40b?c d%20e?f").toString() === "https://example.com/a@b?c+d+e%3Ff"`
+
+* The original implementation lacked more recently implemented `URL` features, like [`URL.canParse()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static).
+
+Set the compatibility date of your Worker to a date after `2022-10-31` or enable the `url_standard` compatibility flag to opt-in the fully spec compliant `URL` API implementation.
+
+See also the [`response_redirect_url_standard` compatibility flag](/workers/configuration/compatibility-dates/#use-a-spec-compliant-url-implementation-in-redirects) , which affects the URL implementation used in `Response.redirect()`.

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -27,4 +27,4 @@ The original implementation of the [`URL`](https://developer.mozilla.org/en-US/d
 
 Set the compatibility date of your Worker to a date after `2022-10-31` or enable the `url_standard` compatibility flag to opt-in the fully spec compliant `URL` API implementation.
 
-See also the [`response_redirect_url_standard` compatibility flag](/workers/configuration/compatibility-dates/#use-a-spec-compliant-url-implementation-in-redirects) , which affects the URL implementation used in `Response.redirect()`.
+Refer to the [`response_redirect_url_standard` compatibility flag](/workers/configuration/compatibility-dates/#use-a-spec-compliant-url-implementation-in-redirects) , which affects the URL implementation used in `Response.redirect()`.

--- a/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
+++ b/content/workers/_partials/_platform-compatibility-dates/new-url-parser-implementation.md
@@ -11,4 +11,4 @@ enable_flag: "url_standard"
 disable_flag: "url_original"
 ---
 
-The original Workers `URL` API implementation was not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/), differing in several ways, including how validation and URL encoding was performed. Use the `url_standard` flag to opt-in to the backwards-incompatible change to use a fully compliant `URL` API implementation.
+The original implementation of the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) API in Workers was not fully compliant with the [WHATWG URL Standard](https://url.spec.whatwg.org/), differing in several ways, including how validation and URL encoding was performed. Set the compatibility date of your Worker to a date after `2022-10-31` or enable the `url_standard` compatibility flag to opt-in the fully spec compliant `URL` API implementation.


### PR DESCRIPTION
Update description of the `new-url-parser-implementation` compatibility flag to provide a bit more detail and reflect the fact that it is now the current default.