### PR TITLE
[Docs] Specify exact version of node-html-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "fromnow": "3.0.1",
     "mermaid": "9.1.7",
-    "node-html-parser": "^6.1.4",
+    "node-html-parser": "6.1.6",
     "vue": "^3.2.45"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue detected in PR #10610:
https://github.com/cloudflare/cloudflare-docs/actions/runs/6116498965/job/16609839109

`node-html-parser` version 6.1.8 seems to have triggered a couple of false positives in the link crawler. 

Trying to solve the issue for now by always using a specific (working) version of `node-html-parser` (version 6.1.6).

