### PR TITLE
[Chore] Hide footnote backlinks from littlefoot

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5544,3 +5544,7 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
     margin-top: 4em !important;
   }
 }
+
+.footnote-backref {
+  visibility: hidden;
+}


### PR DESCRIPTION
Removes the broken backlink reference that happens when you have multiple footnote locations referencing the same text.

https://remove-footnote-backlinks.cloudflare-docs-7ou.pages.dev/ssl/reference/cipher-suites/supported-cipher-suites/
vs https://developers.cloudflare.com/ssl/reference/cipher-suites/supported-cipher-suites/

![image (23)](https://github.com/cloudflare/cloudflare-docs/assets/26727299/5e4cf0f4-da63-4e66-af9d-2a372a226cad)
