### PR TITLE
Add Runtime team to codeowners for compat date partials

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@
 /content/workers/configuration/compatibility-dates/ @irvinebroque @cloudflare/pcx-technical-writing
 /content/workers/learning/migrate-to-module-workers/ @irvinebroque @cloudflare/pcx-technical-writing
 /content/workers/learning/security-model/ @irvinebroque @cloudflare/pcx-technical-writing
+/content/workers/_partials/_platform-compatibility-dates/ @irvinebroque @kflansburg @cloudflare/pcx-technical-writing
 
 # Firewall Rules & WAF
 /content/firewall/ @cloudflare/firewall @cloudflare/pcx-technical-writing


### PR DESCRIPTION
I missed this on first pass of setting up codeowners.

refs https://github.com/cloudflare/cloudflare-docs/pull/10609 — want to ensure we can quickly review these and get changes out