### PR TITLE
[ZT] Fix a couple assorted typos in IdP docs

### DIFF
--- a/content/cloudflare-one/_partials/_one-time-pin.md
+++ b/content/cloudflare-one/_partials/_one-time-pin.md
@@ -5,7 +5,7 @@ _build:
   list: never
 ---
 
-1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Authenticaton**.
+1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Authentication**.
 2. Under **Login methods**, select **Add new**.
 3. Select **One-time PIN**.
 4. If your organization uses a third-party email scanning service (for example, Mimecast or Barracuda), add `noreply@notify.cloudflare.com` to the email scanning allowlist.

--- a/content/cloudflare-one/identity/authorization-cookie/validating-json.md
+++ b/content/cloudflare-one/identity/authorization-cookie/validating-json.md
@@ -8,13 +8,13 @@ weight: 1
 
 When Cloudflare sends a request to your origin, the request will include an [application token](/cloudflare-one/identity/authorization-cookie/application-token/) as a `Cf-Access-Jwt-Assertion` request header and as a `CF_Authorization` cookie.
 
-Cloudflare signs the token with a key pair unique to your account. You should validate the token with your public key to ensure that that the request came from Access and not a malicious third party.
+Cloudflare signs the token with a key pair unique to your account. You should validate the token with your public key to ensure that the request came from Access and not a malicious third party.
 
 ## Access signing keys
 
 The public key for the signing key pair is located at `https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/certs`.
 
-By default, the Access rotates the signing key every 6 weeks. This means you will need to programmatically or manually update your keys as they rotate. Previous keys remain valid for 7 days after rotation to allow time for you to make the update.
+By default, Access rotates the signing key every 6 weeks. This means you will need to programmatically or manually update your keys as they rotate. Previous keys remain valid for 7 days after rotation to allow time for you to make the update.
 
 You can also manually rotate the key using the [API](/api/operations/access-key-configuration-rotate-access-keys). This can be done for testing or security purposes.
 
@@ -248,7 +248,7 @@ def hello_world():
 if __name__ == '__main__':
     app.run()
 ```
-### Javascript example
+### JavaScript example
 
 ```javascript
 const express = require('express');

--- a/content/cloudflare-one/identity/idp-integration/centrify.md
+++ b/content/cloudflare-one/identity/idp-integration/centrify.md
@@ -48,11 +48,6 @@ These steps help you set up Centrify as your identity provider:
 
 1.  Take note of the Client ID, Client Secret, OpenID Connect Issuer URL, and Application ID from the Settings tab.
 
-         {{<Aside>}}
-
-    Do not use the forward slash from the **Settings** tab.
-    {{</Aside>}}
-
 1.  Go to the **User Access** tab.
 
 1.  Select the roles to grant access to your application.

--- a/content/cloudflare-one/identity/idp-integration/okta-saml.md
+++ b/content/cloudflare-one/identity/idp-integration/okta-saml.md
@@ -94,9 +94,11 @@ SAML attributes are only refreshed during authentications with the Okta identity
         "attributes": [
             "email",
             "group",
-            "email_attribute_name": "",
-            "sign_request": false,
-            "idp_public_cert": "MIIDpDCCAoygAwIBAgIGAV2ka+55MA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG\nA1UEC.....GF/Q2/MHadws97cZg\nuTnQyuOqPuHbnN83d/2l1NSYKCbHt24o"
+        ],
+        "email_attribute_name": "",
+        "sign_request": false,
+        "idp_public_certs": [
+            "MIIDpDCCAoygAwIBAgIGAV2ka+55MA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEG\nA1UEC.....GF/Q2/MHadws97cZg\nuTnQyuOqPuHbnN83d/2l1NSYKCbHt24o"
         ]
     },
     "type": "saml",

--- a/content/cloudflare-one/identity/idp-integration/pingone-oidc.md
+++ b/content/cloudflare-one/identity/idp-integration/pingone-oidc.md
@@ -27,3 +27,17 @@ The PingOne® cloud platform from PingIdentity provides SSO identity management.
 15. Select **Save**.
 
 You can now [test your connection](/cloudflare-one/identity/idp-integration#test-idps-in-zero-trust) and create [Access policies](/cloudflare-one/policies/access/) based on the configured login method.
+
+## Example API Configuration
+
+```json
+{
+  "config": {
+    "client_id": "<your client id>",
+    "client_secret": "<your client secret>",
+    "ping_env_id": "<your ping environment id>"
+  },
+  "type": "ping",
+  "name": "my example idp"
+}
+```

--- a/content/cloudflare-one/identity/idp-integration/pingone-oidc.md
+++ b/content/cloudflare-one/identity/idp-integration/pingone-oidc.md
@@ -28,7 +28,7 @@ The PingOne® cloud platform from PingIdentity provides SSO identity management.
 
 You can now [test your connection](/cloudflare-one/identity/idp-integration#test-idps-in-zero-trust) and create [Access policies](/cloudflare-one/policies/access/) based on the configured login method.
 
-## Example API Configuration
+## Example API configuration
 
 ```json
 {


### PR DESCRIPTION
- Fix typos in one-time-pin and validating-json
- Add example API configuration for PingOne
- Fix okta-saml example api configuration
- Remove an Aside from centrify - I verified on my account that the forward slash does not need to be ignored. This also was causing rendering bugs within the admin dashboard and docs page.
