### PR TITLE
[Pages] Attempt to clear up domain limit text

### DIFF
--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -21,11 +21,13 @@ Builds will timeout after 20 minutes.
 
 ## Custom domains
 
-A Cloudflare Pages project can be attached to a certain number of domains per plan.
+A Pages project can add up to a specific number of custom domains. This limit is on a per-project basis.
 
 | Free | Pro | Business | Enterprise |
 | ---- | --- | -------- | ---------- |
-| 100  | 250 | 500      | 500        |
+| 100  | 250 | 500      | 500[^1]    |
+
+[^1]: If you need more custom domains please contact your account team.
 
 ## Files
 

--- a/content/pages/platform/limits.md
+++ b/content/pages/platform/limits.md
@@ -21,13 +21,13 @@ Builds will timeout after 20 minutes.
 
 ## Custom domains
 
-A Pages project can add up to a specific number of custom domains. This limit is on a per-project basis.
+Based on your Cloudflare plan type, a Pages project is limited to a specific number of custom domains. This limit is on a per-project basis.
 
 | Free | Pro | Business | Enterprise |
 | ---- | --- | -------- | ---------- |
 | 100  | 250 | 500      | 500[^1]    |
 
-[^1]: If you need more custom domains please contact your account team.
+[^1]: If you need more custom domains, contact your account team.
 
 ## Files
 


### PR DESCRIPTION
People commonly got confused that this limit was account wide not per-project and only changes on plan. I've attempted to clear this up but I'm not sure it really cleared anything up :notlikethis:

