### PR TITLE
Link directly to Dash in R2 API token generation docs

### DIFF
--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -13,7 +13,7 @@ You must purchase R2 before you can generate an API token.
 To create an API token: 
 
 1. In **Account Home**, select **R2**.
-2. Under **Account details**, select [**Manage R2 API tokens**](https://dash.cloudflare.com/?to=/:account/r2/api-tokens).
+2. Under **Account details**, select **Manage R2 API tokens**..
 3. Select [**Create API token**](https://dash.cloudflare.com/?to=/:account/r2/api-tokens).
 4. Select the **R2 Token** text to edit your API token name.
 5. Under **Permissions**, choose a permission types for your token. Refer to [Permissions](#permissions) for information about each option.

--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -13,7 +13,7 @@ You must purchase R2 before you can generate an API token.
 To create an API token: 
 
 1. In **Account Home**, select **R2**.
-2. Under **Account details**, select **Manage R2 API tokens**..
+2. Under **Account details**, select **Manage R2 API tokens**.
 3. Select [**Create API token**](https://dash.cloudflare.com/?to=/:account/r2/api-tokens).
 4. Select the **R2 Token** text to edit your API token name.
 5. Under **Permissions**, choose a permission types for your token. Refer to [Permissions](#permissions) for information about each option.

--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -13,8 +13,8 @@ You must purchase R2 before you can generate an API token.
 To create an API token: 
 
 1. In **Account Home**, select **R2**.
-2. Under **Account details**, select **Manage R2 API tokens**.
-3. Select **Create API token**.
+2. Under **Account details**, select [**Manage R2 API tokens**](https://dash.cloudflare.com/?to=/:account/r2/api-tokens).
+3. Select [**Create API token**](https://dash.cloudflare.com/?to=/:account/r2/api-tokens).
 4. Select the **R2 Token** text to edit your API token name.
 5. Under **Permissions**, choose a permission types for your token. Refer to [Permissions](#permissions) for information about each option.
 6. (Optional) If you select the **Object Read and Write** or **Object Read** permissions, you can scope your token to a set of buckets.


### PR DESCRIPTION
Uses `https://dash.cloudflare.com/?to=/:account/r2/api-tokens` URL format to make this easier.