### PR TITLE
Update maximum length of a list name

### DIFF
--- a/content/waf/tools/lists/_index.md
+++ b/content/waf/tools/lists/_index.md
@@ -34,7 +34,7 @@ Refer to the page about each list type for details.
 
 The name of a list must comply with the following requirements:
 * The name uses only lowercase letters, numbers, and the underscore (`_`) character in the name. A valid name satisfies this regular expression: `^[a-z0-9_]+$`.
-* The maximum length of a list name is 50 characters.
+* The maximum length of a list name is 20 characters.
 
 ## Working with lists
 


### PR DESCRIPTION
The maximum name of a list name should be `20` characters instead of `50` when creating a new list in `/<CF_ACCOUNT_ID>/configurations/lists/new`.

<img width="461" alt="image" src="https://github.com/licitdev/cloudflare-docs/assets/26413686/85fbd381-4ec4-4239-b613-3ed65d247243">
