### PR TITLE
[D1] set hideChildren to false for /examples/

### DIFF
--- a/content/d1/examples/_index.md
+++ b/content/d1/examples/_index.md
@@ -1,6 +1,6 @@
 ---
 type: overview
-hideChildren: true
+hideChildren: false
 pcx_content_type: navigation
 title: Examples
 weight: 10


### PR DESCRIPTION
This PR sets `hideChildren: false` so that the examples are listed (and thus more discoverable) in the sidebar, mirroring other docs.

Once we have 20+ examples we can hide it, but we don't have that problem today.