### PR TITLE
[D1] update page weight and title

### DIFF
--- a/content/d1/learning/database-commands.md
+++ b/content/d1/learning/database-commands.md
@@ -1,5 +1,5 @@
 ---
-title: Debug D1
+title: Database commands
 weight: 20
 pcx_content_type: concept
 ---

--- a/content/d1/learning/using-d1-from-pages.md
+++ b/content/d1/learning/using-d1-from-pages.md
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Using D1 from Pages 
 
 external_link: /pages/platform/functions/bindings/#d1-databases 
-weight: 20
+weight: 99
 _build:
   publishResources: false
   render: never


### PR DESCRIPTION
Fixes a bug where two pages had `weight: 20` - which causes one page to not be displayed. We always want the Pages doc link to be at the bottom of the list so it's easy to find/see.