### PR TITLE
Clarify pricing page and avoid extra wide table

### DIFF
--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -28,8 +28,8 @@ Workers are available under two Usage Models: Bundled and Unbound. Usage Models 
 
 |             |  Requests<sup>1</sup>                                               | Duration                                                                                  | CPU time |
 | ----------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Free**    |  100,000 per day                                                    | no charge for duration                                                                    | 10 milliseconds of CPU time per invocation                 |
-| **Bundled** |  10 million included per month <br /> +$0.50 per additional million | no charge for duration                                                                    | 50 milliseconds CPU time per invocation                    |
+| **Free**    |  100,000 per day                                                    | No charge for duration                                                                    | 10 milliseconds of CPU time per invocation                 |
+| **Bundled** |  10 million included per month <br /> +$0.50 per additional million | No charge for duration                                                                    | 50 milliseconds CPU time per invocation                    |
 | **Unbound** |  1 million included per month <br /> +$0.15 per additional million  | 400,000 GB-s included per month <br /> +$12.50 per additional million GB-s<sup>2,3</sup>  | 30 seconds of CPU time per invocation <br /> 15 minutes of CPU time per [Cron Trigger](/workers/configuration/cron-triggers/) or [Queue Consumer](/queues/platform/javascript-apis/#consumer) invocation        |
 
 {{</table-wrap>}}

--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -24,15 +24,13 @@ All [Pages Functions](/pages/platform/functions/) are billed as Workers. All pri
 
 Workers are available under two Usage Models: Bundled and Unbound. Usage Models are settings on your Workers that specify how you are billed for usage, as well as the upper [limits](/workers/platform/limits/#worker-limits) for how many milliseconds of CPU time your Worker can use per invocation.
 
-Workers on the Bundled usage model are billed purely base
-
 {{<table-wrap>}}
 
-|             |  Requests<sup>1</sup>                                           | Duration                                           | CPU time [limits](/workers/platform/limits/#worker-limits) |
-| ----------- | --------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------- |
-| **Free**    |  100,000 per day                                                | no charge for duration                             | 10 milliseconds of CPU time per invocation   |
-| **Bundled** |  10 million included per month, +$0.50 per additional million   | no charge for duration                             | 50 milliseconds CPU time per invocation      |
-| **Unbound** |  1 million included per month, +$0.15 per additional million    | 400,000 GB-s, + $12.50/million GB-s<sup>2,3</sup>  | 30 seconds of CPU time per invocation, 15 minutes of CPU time per [Cron Trigger](/workers/configuration/cron-triggers/) or [Queue Consumer](/queues/platform/javascript-apis/#consumer) invocation        |
+|             |  Requests<sup>1</sup>                                               | Duration                                                                                  | CPU time [limits](/workers/platform/limits/#worker-limits) |
+| ----------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Free**    |  100,000 per day                                                    | no charge for duration                                                                    | 10 milliseconds of CPU time per invocation                 |
+| **Bundled** |  10 million included per month <br /> +$0.50 per additional million | no charge for duration                                                                    | 50 milliseconds CPU time per invocation                    |
+| **Unbound** |  1 million included per month <br /> +$0.15 per additional million  | 400,000 GB-s included per month <br /> +$12.50 per additional million GB-s<sup>2,3</sup>  | 30 seconds of CPU time per invocation <br /> 15 minutes of CPU time per [Cron Trigger](/workers/configuration/cron-triggers/) or [Queue Consumer](/queues/platform/javascript-apis/#consumer) invocation        |
 
 {{</table-wrap>}}
 

--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -20,12 +20,19 @@ All [Pages Functions](/pages/platform/functions/) are billed as Workers. All pri
 
 ## Workers
 
+### Usage models
+
+Workers are available under two Usage Models: Bundled and Unbound. Usage Models are settings on your Workers that specify how you are billed for usage, as well as the upper [limits](/workers/platform/limits/#worker-limits) for how many milliseconds of CPU time your Worker can use per invocation.
+
+Workers on the Bundled usage model are billed purely base
+
 {{<table-wrap>}}
 
-|          | Free plan                  | Paid Plan - Bundled                | Paid plan - Unbound                               |
-| -------- | -------------------------- | ---------------------------------- | ------------------------------------------------- |
-| Requests<sup>1</sup> | 100,000 / day              | 10 million / month, +$0.50/million | 1 million / month, + $0.15/million                |
-| Duration | 10 ms CPU time / invocation | 50 ms CPU time / invocation        | 400,000 GB-s, + $12.50/million GB-s<sup>2,3</sup> |
+|             |  Requests<sup>1</sup>                                           | Duration                                           | CPU time [limits](/workers/platform/limits/#worker-limits) |
+| ----------- | --------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------- |
+| **Free**    |  100,000 per day                                                | no charge for duration                             | 10 milliseconds of CPU time per invocation   |
+| **Bundled** |  10 million included per month, +$0.50 per additional million   | no charge for duration                             | 50 milliseconds CPU time per invocation      |
+| **Unbound** |  1 million included per month, +$0.15 per additional million    | 400,000 GB-s, + $12.50/million GB-s<sup>2,3</sup>  | 30 seconds of CPU time per invocation, 15 minutes of CPU time per [Cron Trigger](/workers/configuration/cron-triggers/) or [Queue Consumer](/queues/platform/javascript-apis/#consumer) invocation        |
 
 {{</table-wrap>}}
 
@@ -34,10 +41,6 @@ All [Pages Functions](/pages/platform/functions/) are billed as Workers. All pri
 2.  Cloudflare will bill for duration charges based on the higher of your wall time or CPU time, with a multiple of 8 applied to the CPU time to account for the processing power allotted to your Worker. Cloudflare will not bill for wall time duration charges beyond the execution [limit](/workers/platform/limits/#worker-limits) given.
 
 3.  Duration billing will charge for the 128 MB of memory allocated to your Worker, regardless of actual usage. If your account has significant traffic to a single Worker, multiple instances of that Worker may run in the same isolate on the same physical machine and share the 128 MB of memory. These Workers are still billed as if they were separate instances, with each being charged as if it had its own 128 MB of memory.
-
-### Usage models
-
-Workers are available under two Usage Models: Bundled and Unbound. Usage Models are settings on your Workers that specify the upper [limits](/workers/platform/limits/) for how long a Worker can execute. In addition to different limits, Workers on the Bundled Usage Model have usage billing based on requests only, while Workers on Unbound have usage billing based on requests and duration at the rates shown under [Pricing](/workers/platform/pricing/#pricing).
 
 #### Default usage model
 

--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -26,7 +26,7 @@ Workers are available under two Usage Models: Bundled and Unbound. Usage Models 
 
 {{<table-wrap>}}
 
-|             |  Requests<sup>1</sup>                                               | Duration                                                                                  | CPU time [limits](/workers/platform/limits/#worker-limits) |
+|             |  Requests<sup>1</sup>                                               | Duration                                                                                  | CPU time |
 | ----------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **Free**    |  100,000 per day                                                    | no charge for duration                                                                    | 10 milliseconds of CPU time per invocation                 |
 | **Bundled** |  10 million included per month <br /> +$0.50 per additional million | no charge for duration                                                                    | 50 milliseconds CPU time per invocation                    |


### PR DESCRIPTION
- Makes each plan its own row, rather than its own column.
- Creates a separate column for CPU time — the existing table was confusing as it had CPU time under the "Duration" row.
- Layout ensures that less content is cutoff when at common width

**Before:**
<img width="642" alt="Screenshot 2023-09-14 at 4 54 36 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/1221592/4adddfad-a4bf-4354-8e93-2d669fa853dd">


**After:**

<img width="664" alt="Screenshot 2023-09-14 at 4 54 21 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/1221592/fe63a2f4-3687-4c60-97b2-97e9ad9042aa">
