### PR TITLE
performance.now(), performance.timeOrigin

### DIFF
--- a/content/workers/runtime-apis/performance.md
+++ b/content/workers/runtime-apis/performance.md
@@ -1,23 +1,23 @@
 ---
 pcx_content_type: configuration
-title: Performance & Timers
+title: Performance and Timers
 ---
 
 # Performance
 
 ## Background
 
-The Workers Runtime supports a subset of the [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance), used to measure timing and performance and timing of subrequests and other operations.
+The Workers runtime supports a subset of the [`Performance` API](https://developer.mozilla.org/en-US/docs/Web/API/Performance), used to measure timing and performance and timing of subrequests and other operations.
 
 ### `performance.now()`
 
-The [`performance.now()` method](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) returns timestamp in milliseconds, representing the time elapsed since `performance.timeOrigin`
+The [`performance.now()` method](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) returns timestamp in milliseconds, representing the time elapsed since `performance.timeOrigin`.
 
-When Workers are deployed to Cloudflare, as a security measure to [mitigate against Spectre attacks](/workers/learning/security-model/#step-1-disallow-timers-and-multi-threading), APIs that return timers, including [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) and [`Date.now()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now), only advance or increment after I/O occurs. Consider the followoing examples:
+When Workers are deployed to Cloudflare, as a security measure to [mitigate against Spectre attacks](/workers/learning/security-model/#step-1-disallow-timers-and-multi-threading), APIs that return timers, including [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) and [`Date.now()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now), only advance or increment after I/O occurs. Consider the following examples:
 
 ```typescript
 ---
-header: Time is "frozen" — start will have the exact same value as end.
+header: Time is frozen — start will have the exact same value as end.
 ---
 const start = performance.now();
 for (let i = 0; i < 1e6; i++) {
@@ -37,7 +37,7 @@ const end = performance.now();
 const timing = end - start; // duration of the subrequest to developers.cloudflare.com
 ```
 
-This means you can use the `performance.now()` or `Date.now()` APIs in order to measure the timing of a subrequest, fetching a key from KV, an object from R2, or any other form of I/O in your Worker.
+By wrapping a subrequest in calls to `performance.now()` or `Date.now()` APIs, you can measure the timing of a subrequest, fetching a key from KV, an object from R2, or any other form of I/O in your Worker.
 
 In local development, however, timers will increment regardless of whether I/O happens or not. This means that if you need to measure timing of a piece of code that is CPU intensive, that does not involve I/O, you can run your Worker locally, via [Wrangler](/workers/wrangler/), which uses the open-source Workers runtime, [workerd](https://github.com/cloudflare/workerd) — the same runtime that your Worker runs in when deployed to Cloudflare.
 
@@ -45,6 +45,6 @@ In local development, however, timers will increment regardless of whether I/O h
 
 The [`performance.timeOrigin()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin) API is a read-only property that returns a baseline timestamp to base other measurements off of.
 
-In the Workers Runtime, calling `timeOrigin()` returns 0.
+In the Workers runtime, calling `timeOrigin()` returns 0.
 
 

--- a/content/workers/runtime-apis/performance.md
+++ b/content/workers/runtime-apis/performance.md
@@ -1,0 +1,50 @@
+---
+pcx_content_type: configuration
+title: Performance & Timers
+---
+
+# Performance
+
+## Background
+
+The Workers Runtime supports a subset of the [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance), used to measure timing and performance and timing of subrequests and other operations.
+
+### `performance.now()`
+
+The [`performance.now()` method](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) returns timestamp in milliseconds, representing the time elapsed since `performance.timeOrigin`
+
+When Workers are deployed to Cloudflare, as a security measure to [mitigate against Spectre attacks](/workers/learning/security-model/#step-1-disallow-timers-and-multi-threading), APIs that return timers, including [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) and [`Date.now()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now), only advance or increment after I/O occurs. Consider the followoing examples:
+
+```typescript
+---
+header: Time is "frozen" — start will have the exact same value as end.
+---
+const start = performance.now();
+for (let i = 0; i < 1e6; i++) {
+  // do expensive work
+}
+const end = performance.now();
+const timing = end - start; // 0
+```
+
+```typescript
+---
+header: Time advances, because a subrequest has occurred between start and end.
+---
+const start = performance.now();
+const response = await fetch("https://developers.cloudflare.com/");
+const end = performance.now();
+const timing = end - start; // duration of the subrequest to developers.cloudflare.com
+```
+
+This means you can use the `performance.now()` or `Date.now()` APIs in order to measure the timing of a subrequest, fetching a key from KV, an object from R2, or any other form of I/O in your Worker.
+
+In local development, however, timers will increment regardless of whether I/O happens or not. This means that if you need to measure timing of a piece of code that is CPU intensive, that does not involve I/O, you can run your Worker locally, via [Wrangler](/workers/wrangler/), which uses the open-source Workers runtime, [workerd](https://github.com/cloudflare/workerd) — the same runtime that your Worker runs in when deployed to Cloudflare.
+
+### `performance.timeOrigin`
+
+The [`performance.timeOrigin()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin) API is a read-only property that returns a baseline timestamp to base other measurements off of.
+
+In the Workers Runtime, calling `timeOrigin()` returns 0.
+
+


### PR DESCRIPTION
We missed documenting this back in May: https://developers.cloudflare.com/workers/platform/changelog/#2023-05-12