### PR TITLE
Update cache-control.md

### DIFF
--- a/content/cache/concepts/cache-control.md
+++ b/content/cache/concepts/cache-control.md
@@ -361,7 +361,7 @@ This configuration indicates the asset is fresh for 600 seconds. The asset can b
 
 ### Edge Cache TTL
 
-[Edge Cache TTL](/cache/how-to/edge-browser-cache-ttl/#edge-cache-ttl) Page Rules override `s-maxage` and disable revalidation directives if present. When Origin Cache-Control is enabled at Cloudflare, the original Cache-Control header passes downstream from our edge even if Edge Cache TTL overrides are present. Otherwise, when Origin Cache-Control is disabled at Cloudflare (the default), Cloudflare overrides the origin cache control.
+[Edge Cache TTL](/cache/how-to/edge-browser-cache-ttl/#edge-cache-ttl) Page Rules override `s-maxage` and disable revalidation directives if present. When Origin Cache-Control is enabled at Cloudflare, the original Cache-Control header passes downstream from our edge even if Edge Cache TTL overrides are present. Otherwise, when Origin Cache-Control is disabled at Cloudflare, Cloudflare overrides the origin cache control.
 
 ### Browser Cache TTL
 


### PR DESCRIPTION
Origin Cache-Control is not disabled at Cloudflare by default. It's disabled by default in Enterprise Plans but enabled in the remaining plans by default. This causes confusion as the remaining documentation already clears that up: https://developers.cloudflare.com/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/#:~:text=Origin%20Cache%20Control%20is%20enabled%20by%20default%20for%20Free%2C%20Pro%2C%20and%20Business%20domains%20and%20disabled%20by%20default%20for%20Enterprise%20domains