### PR TITLE
[Workers] Changelog support for _index pages

### DIFF
--- a/content/workers/platform/changelog/_index.md
+++ b/content/workers/platform/changelog/_index.md
@@ -3,6 +3,7 @@ pcx_content_type: changelog
 title: Changelog
 meta:
     description: Review recent changes to Cloudflare Workers.
+sidebar_toc: true
 layout: changelog
 changelog_file_name: workers
 outputs:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,6 +12,10 @@
     </div>
 
     <main class="DocsBody">
+      {{ with .Params.sidebar_toc }}
+      {{ partial "sidebar.toc" . }}
+      {{- $type = "document" -}}
+      {{- end -}}
       <div id="docs-content" data-reach-skip-nav-content></div>
       {{- partial "breadcrumbs" . -}}
 


### PR DESCRIPTION
Adding a new frontmatter property to override the default layout for _index.md pages. Helps re-add the ToC to the workers changelog.