### PR TITLE
[Workers KV] Fixing plan syntax

### DIFF
--- a/layouts/shortcodes/plan.html
+++ b/layouts/shortcodes/plan.html
@@ -1,6 +1,6 @@
 {{ $map := dict "enterprise" "Enterprise-only" "pro" "Pro and above" "business"
 "Business and above" "all" "Available on all plans" "paid" "Available on paid plans"
-"add-on" "Add-on feature" "ent-add-on" "Enterprise-only paid add-on" "workers_all" "Available on both free and paid Workers plans"
+"add-on" "Add-on feature" "ent-add-on" "Enterprise-only paid add-on" "workers_all" "Available on free and paid plans"
 "workers_paid" "Available on Workers paid plans" }}
 
 {{ with .Get "id" }}

--- a/layouts/shortcodes/plan.html
+++ b/layouts/shortcodes/plan.html
@@ -1,7 +1,7 @@
 {{ $map := dict "enterprise" "Enterprise-only" "pro" "Pro and above" "business"
 "Business and above" "all" "Available on all plans" "paid" "Available on paid plans"
-"add-on" "Add-on feature" "ent-add-on" "Enterprise-only paid add-on" "workers_all" "Available on free and paid plans"
-"workers_paid" "Available on Workers paid plans" }}
+"add-on" "Add-on feature" "ent-add-on" "Enterprise-only paid add-on" "workers_all" "Available on Free and Paid plans"
+"workers_paid" "Available on Workers Paid plan" }}
 
 {{ with .Get "id" }}
 


### PR DESCRIPTION
The `workers_all` plan type was created for Workers KV (obviously can be used for any other product). Making a minor syntax change. 