### PR TITLE
Removed dupe redirect

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -865,7 +865,6 @@
 /workers/reference/apis/response/ /workers/runtime-apis/response/ 301
 /workers/reference/apis/streams/ /workers/runtime-apis/streams/ 301
 /workers/learning/using-streams/ /workers/runtime-apis/streams/ 301
-/workers/runtime-apis/streams/use-streams/ /workers/runtime-apis/streams/ 301
 /workers/reference/apis/web-crypto/ /workers/runtime-apis/web-crypto/ 301
 /workers/reference/cache-api/ /workers/runtime-apis/cache/ 301
 /workers/reference/cloudflare-features/ /workers/runtime-apis/request/ 301


### PR DESCRIPTION
https://github.com/cloudflare/cloudflare-docs/blob/production/content/_redirects#L868
&&
https://github.com/cloudflare/cloudflare-docs/blob/production/content/_redirects#L1009

are the same entry
