### PR TITLE
fix code copy btn for light mode

### DIFF
--- a/components/CodeCopy.vue
+++ b/components/CodeCopy.vue
@@ -141,7 +141,7 @@ function copyCode(e: MouseEvent) {
 }
 
 [theme="dark"] .copyCode-button:hover,
-.copyCode-button:focus {
+[theme="dark"] .copyCode-button:focus {
   cursor: pointer;
   background-color: var(--code-block-background-color);
   --focus-shadow: 0 0 0 var(--focus-size) var(--focus-color);


### PR DESCRIPTION
Fixes an issue with the `CodeCopy` component where we were not properly isolating darkmode style to darkmode only. 


<img width="1475" alt="Screenshot 2023-09-19 at 17 04 03" src="https://github.com/cloudflare/cloudflare-docs/assets/13870224/af153acd-be13-42b7-86ed-cbccf92c53bd">
