### PR TITLE
Update Version Management product support list

### DIFF
--- a/content/version-management/_partials/_product-limitations.md
+++ b/content/version-management/_partials/_product-limitations.md
@@ -5,6 +5,6 @@ _build:
   list: never
 ---
 
-Version Management does not currently support versioning for [Bot Management](/bots/plans/bm-subscription/) or [API Shield](/api-shield/).
+Version Management does not currently support versioning for [Waiting Room](/waiting-room/), [China Network](/china-network/), [WAF Attack Score](/waf/about/waf-attack-score/) and [API Shield](/api-shield/).
 
 Additionally, you cannot currently manage versioning through the [Cloudflare API](/api/) or deploy Workers used by zones that have enabled versioning via [Wrangler](/workers/wrangler/).

--- a/content/version-management/changelog.md
+++ b/content/version-management/changelog.md
@@ -1,0 +1,16 @@
+---
+pcx_content_type: changelog
+title: Changelog
+weight: 11
+layout: changelog
+changelog_file_name: version-management
+outputs:
+    - html
+    - rss
+---
+
+# Changelog
+
+<!-- Actual content lives in /data/changelogs/version-management.yaml. Update the file there for new entries to appear here. For more details, refer to https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/#yaml-file -->
+
+{{<product-changelog>}}

--- a/data/changelogs/version-management.yaml
+++ b/data/changelogs/version-management.yaml
@@ -1,0 +1,8 @@
+---
+link: "/version-management/changelog/"
+productName: Version Management
+entries:
+- publish_date: '2023-09-20'
+  title: "Support for Bot Management"
+  description: |-
+    - Version Management now supports versioning for [Bot Management](/bots/plans/bm-subscription/).


### PR DESCRIPTION
This PR is to update Version Management overview page to remove Bot Management from the list of unsupported products and adding Waiting Room and China Network instead.