### PR TITLE
Update BYOIP developer documentation w/ Cloudflare's ASN

### DIFF
--- a/content/byoip/concepts/loa.md
+++ b/content/byoip/concepts/loa.md
@@ -1,30 +1,30 @@
 ---
-title: Letter of Authorization
+title: Letter of Agency
 pcx_content_type: concept
 weight: 3
 meta:
-  title: Letter of Authorization (LOA)
+  title: Letter of Agency (LOA)
 ---
 
-# Letter of Authorization (LOA)
+# Letter of Agency (LOA)
 
-A Letter of Authorization (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on behalf of another entity.
+A Letter of Agency (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on behalf of another entity.
 
-The letter must contain both the prefixes you are authorizing Cloudflare to announce and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you are welcome to use Cloudflare's ASN. If you want to use Cloudflare's ASN, inform your account team and they will provide the AS number to put in the LOA document.
+The letter must contain both the prefixes you are authorizing Cloudflare to announce and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you are welcome to use Cloudflare's ASN, which is AS 209242.
 
 {{<Aside type="note" header="Note">}}
-An LOA is a formal document which should be on company letterhead and contain a wet signature. The Letter of Authorization must be a PDF. Transit providers may reject the LOA if it is in a JPG or PNG format.
+An LOA is a formal document which should be on company letterhead and contain a wet signature. The Letter of Agency must be a PDF. Transit providers may reject the LOA if it is in a JPG or PNG format.
 {{</Aside>}}
 
 You can use the below template when creating an LOA document.
 
 ```txt
 ---
-header: Letter of Authorization template
+header: Letter of Agency template
 ---
 [COMPANY LETTERHEAD]
 
-LETTER OF AUTHORIZATION ("LOA")
+LETTER OF AGENCY ("LOA")
 
 [DATE]
 

--- a/content/byoip/concepts/loa.md
+++ b/content/byoip/concepts/loa.md
@@ -8,12 +8,14 @@ meta:
 
 # Letter of Agency (LOA)
 
-A Letter of Agency (LOA) is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on behalf of another entity.
+A Letter of Agency (LOA) - sometimes referred to as a Letter of Authorization - is a document that authorizes Cloudflare to announce a prefix(es) on behalf of another entity. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on behalf of another entity.
 
-The letter must contain both the prefixes you are authorizing Cloudflare to announce and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you are welcome to use Cloudflare's ASN, which is AS 209242.
+The letter must contain both the prefixes you are authorizing Cloudflare to announce and which ASN they will be announced under. Cloudflare can announce a prefix under your ASN or you can use Cloudflare's ASN, which is AS 209242.
 
 {{<Aside type="note" header="Note">}}
+
 An LOA is a formal document which should be on company letterhead and contain a wet signature. The Letter of Agency must be a PDF. Transit providers may reject the LOA if it is in a JPG or PNG format.
+
 {{</Aside>}}
 
 You can use the below template when creating an LOA document.

--- a/content/byoip/get-started/index.md
+++ b/content/byoip/get-started/index.md
@@ -17,7 +17,7 @@ Cloudflare requires a service-specific configuration for your prefixes, as well 
 There are two major prerequisites before Cloudflare can begin onboarding your IP space.
 
 1.  You must verify your [Internet Routing Registry (IRR)](/byoip/concepts/irr-entries/) records are up to date with the correct prefix or ASN information.
-2.  Cloudflare must receive a [Letter of Authorization (LOA)](/byoip/concepts/loa/) to announce your prefixes, which we will share with our transit partners as evidence that we are allowed to announce the route.
+2.  Cloudflare must receive a [Letter of Agency (LOA)](/byoip/concepts/loa/) to announce your prefixes, which we will share with our transit partners as evidence that we are allowed to announce the route.
 
 Optionally, if you use the Resource Public Key Infrastructure (RPKI) protocol to sign your routes, Cloudflare can help with this as well. Contact your account team know if you are interested in using RPKI.
 
@@ -39,5 +39,5 @@ Using a Cloudflare IP may be a good option if you:
 To protect your network using a Cloudflare IP address, contact your account manager. 
 
 {{<Aside type="note">}}
-When you use a Cloudflare-managed IP space, you do not need to provide a Letter of Authorization (LOA) and advertise your prefixes that are associated with bringing your own IP.
+When you use a Cloudflare-managed IP space, you do not need to provide a Letter of Agency (LOA) and advertise your prefixes that are associated with bringing your own IP.
 {{</Aside>}}

--- a/content/magic-transit/cloudflare-ips.md
+++ b/content/magic-transit/cloudflare-ips.md
@@ -16,4 +16,4 @@ To protect your network using a Cloudflare IP address, contact your account mana
 - Confirm [tunnel](/magic-transit/how-to/run-tunnel-health-checks/) and endpoint health checks were properly configured.
 - Update your infrastructure at your own pace to use the allocated Cloudflare IPs.
 
-When you use a Cloudflare-managed IP space, you do not need a [Letter Of Authorization (LOA)](/magic-transit/prerequisites/#draft-letter-of-authorization). You can skip this step from the Prerequisites page.
+When you use a Cloudflare-managed IP space, you do not need a [Letter Of Authorization (LOA)](/magic-transit/prerequisites/#draft-letter-of-agency). You can skip this step from the Prerequisites page.

--- a/content/magic-transit/get-started.md
+++ b/content/magic-transit/get-started.md
@@ -20,7 +20,7 @@ After your call with Cloudflare, complete the [prerequisites](/magic-transit/pre
 
 ## 3. Run pre-flight checks
 
-After Cloudflare stages the tunnels, Cloudflare validates tunnel connectivity, Letter of Authorization (LOA), Internet Routing Registry (IRR), and maximum segment size (MSS) configurations.
+After Cloudflare stages the tunnels, Cloudflare validates tunnel connectivity, Letter of Agency (LOA), Internet Routing Registry (IRR), and maximum segment size (MSS) configurations.
 
 ## 4. Advertise prefixes
 

--- a/content/magic-transit/prerequisites.md
+++ b/content/magic-transit/prerequisites.md
@@ -18,9 +18,9 @@ The routers at your tunnel endpoints must meet the following requirements to ens
 - Allow configuration of at least one tunnel per Internet service provider (ISP).
 - Support maximum segment size (MSS) clamping.
 
-## Draft Letter of Authorization
+## Draft Letter of Agency
 
-Draft a [Letter of Authorization (LOA)](/byoip/concepts/loa/) that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on your behalf. See this [LOA template](/byoip/concepts/loa/) for an example.
+Draft a [Letter of Agency (LOA)](/byoip/concepts/loa/) - sometimes referred to as a Letter of Authorization - that identifies the prefixes you want to advertise and gives Cloudflare permission to announce them. The LOA is required by Cloudflare's transit providers so they can accept the routes Cloudflare advertises on your behalf. See this [LOA template](/byoip/concepts/loa/) for an example.
 
 If you are an Internet service provider (ISP) and advertising prefixes on behalf of a customer, an LOA is required for the ISP and for the customer.
 
@@ -28,7 +28,7 @@ If you are using a [Cloudflare IP address](/magic-transit/cloudflare-ips/), you 
 
 {{<Aside type="note" header="Note">}}
 
-The Letter of Authorization must be a PDF. Transit providers may reject the LOA if it is a JPG or PNG.
+The LOA must be a PDF. Transit providers may reject the LOA if it is a JPG or PNG.
 
 {{</Aside>}}
 

--- a/content/network-interconnect/set-up-cni/configure-cross-connect.md
+++ b/content/network-interconnect/set-up-cni/configure-cross-connect.md
@@ -12,7 +12,7 @@ The Cloudflare Infrastructure uses your information to configure the cross-conne
 
 ## Physical links
 
-To configure the network cross-connect for physical links, Cloudflare generates a Letter of Authorization (LOA)/service key and sends it to you. After you receive the LOA, you can:
+To configure the network cross-connect for physical links, Cloudflare generates a Letter of Agency (LOA)/service key - sometimes referred to as a Letter of Authorization - and sends it to you. After you receive the LOA, you can:
 
 - Order cross-connects at the locations the LOA specifies.
 - Verify when the cross-connects are complete.


### PR DESCRIPTION
The Cloudflare documentation is missing our AS number, which causes unnecessary delays for BYOIP customers as there is a round trip discussion to the Addressing Team w/ the same question and same answer (our AS number) each time.

This change updates the docs to have our AS number present in the documentation so that this delay can be avoided. Further, the term LOA stands for Letter of Agency, not Authorization, and I have updated the documentation to reflect this.