### PR TITLE
Create how-range-requests-work-at-cloudflare.md

### DIFF
--- a/content/cache/concepts/how-range-requests-work -at-cloudflare.md
+++ b/content/cache/concepts/how-range-requests-work -at-cloudflare.md
@@ -1,0 +1,19 @@
+---
+title: How range requests work at Cloudflare
+pcx_content_type: concept
+---
+
+# How range requests work at Cloudflare
+
+Here's a flowchart to explain the current state of how Cloudflare supports range requests.
+
+## How does Cloudflare serve range requests to eyeballs?
+
+![How range requests work at Cloudflare: How does Cloudflare serve range requests to eyeballs?
+](<img width="718" alt="Screenshot 2023-09-20 at 18 42 02" src="https://github.com/cloudflare/cloudflare-docs/assets/72239208/cbf0818e-87e0-41a0-a9b4-a1a7c78630bc">)
+
+
+## How does Cloudflare request ranges from origins?
+
+![How range requests work at Cloudflare: How does Cloudflare request ranges from origins?
+](<img width="655" alt="Screenshot 2023-09-20 at 18 41 40" src="https://github.com/cloudflare/cloudflare-docs/assets/72239208/8a24047c-e154-4cbf-83de-2b5d922a4e05">)


### PR DESCRIPTION
As per PCX-8069, we have been receiving requests from customers on which they need to understand how Range Requests work with Cloudflare. We currently have the following internal wiki for this:

https://wiki.cfdata.org/display/~gagan/How+range+requests+work+at+Cloudflare

If possible, it would be helpful for customers to have a similar public source of this flow.