### PR TITLE
[Demo] Vanilla Hugo codeblocks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,11 +36,10 @@ tutorial_token = "xxa5a7d4c9-db72-424d-860d-ae68ff7f60ac"
 			unsafe = true
 	[markup.highlight]
 		tabWidth = 2
-		style = "github"
+		style = "github-dark"
 		codeFences = true
 		guessSyntax = true
 		lineNumbersInTable = true
-		noClasses = false
 		lineNoStart = 1
 		lineNos = false
 		hl_Lines = ""

--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -24,9 +24,6 @@ The following example shows you how to define a Remix [`loader`](https://remix.r
 * Bindings are passed through on the `context.env` parameter passed to a `LoaderFunction`.
 * If you configured a [binding](/pages/platform/functions/bindings/#d1-databases) named `DB`, then you would access D1's [client API](/d1/platform/client-api/#query-statement-methods) methods via `context.env.DB`.
 
-{{<tabs labels="ts">}}
-{{<tab label="ts" default="true">}}
-
 ```ts
 ---
 filename: app/routes/_index.tsx
@@ -59,5 +56,3 @@ export default function Index() {
   );
 }
 ```
-{{</tab>}}
-{{</tabs>}}

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,4 +1,0 @@
-<div class="code-container">
-    <unparsed-codeblock data-language="{{ .Type }}" data-code="{{ urlquery .Inner }}"></unparsed-codeblock>
-    <vue-component name="CodeCopy"></vue-component>
-</div>


### PR DESCRIPTION
If you run `hugo server`, you get codeblocks due to advances in Hugo's built-in [markdown render hooks](https://gohugo.io/templates/render-hooks/#render-hooks-for-code-blocks) (note that local builds will then be visible on http://localhost:1313/).

Definitely breaks our current implementation of tabs and the headings + other stuff we've added + need more padding + copy code functions.... but maybe this is a better solution than the current approach with Vite.

Note, the local dev experience is also a lot better b/c you only have to refresh a single page + builds don't hang.

cc: @penalosa, @pedrosousa 