### PR TITLE
[workers] remove @latest from C3 yarn install mentions

### DIFF
--- a/content/browser-rendering/get-started/screenshots.md
+++ b/content/browser-rendering/get-started/screenshots.md
@@ -27,7 +27,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/durable-objects/get-started.md
+++ b/content/durable-objects/get-started.md
@@ -39,7 +39,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/kv/get-started.md
+++ b/content/kv/get-started.md
@@ -39,7 +39,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -54,7 +54,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/workers/get-started/guide.md
+++ b/content/workers/get-started/guide.md
@@ -43,7 +43,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/workers/tutorials/configure-your-cdn/index.md
+++ b/content/workers/tutorials/configure-your-cdn/index.md
@@ -34,7 +34,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn" no-code="true">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}

--- a/content/workers/tutorials/postgres/index.md
+++ b/content/workers/tutorials/postgres/index.md
@@ -35,7 +35,7 @@ $ npm create cloudflare@latest
 {{<tab label="yarn" no-code="true">}}
 
 ```sh
-$ yarn create cloudflare@latest
+$ yarn create cloudflare
 ```
 
 {{</tab>}}


### PR DESCRIPTION
`@latest` is not necessary for yarn. Removing it seems to take care of random install issues.

Reference: https://github.com/cloudflare/workers-sdk/issues/3998