### PR TITLE
fix constellation client api broken heading

### DIFF
--- a/content/constellation/platform/client-api.md
+++ b/content/constellation/platform/client-api.md
@@ -109,7 +109,7 @@ Naming a tensor is optional, it can be a useful key for mapping operations when 
 #### A scalar
 
 ```javascript
-   new Tensor(TensorType.Int16, 123);
+  new Tensor(TensorType.Int16, 123);
 ```
 
 #### Arrays
@@ -198,7 +198,7 @@ export type InferenceSession = {
 };
 ```
 
-###InferenceSession methods
+### InferenceSession methods
 
 #### new InferenceSession()
 


### PR DESCRIPTION
I just noticed this broken heading in the constellation client API page and figured I could quickly fix it 🙂 
(plus a javascript line misaligned)

| Before | After |
|--------|--------|
| ![Screenshot 2023-09-21 at 00 09 28](https://github.com/cloudflare/cloudflare-docs/assets/61631103/d52acb63-a447-4f2e-802b-7355f380052e) |![Screenshot 2023-09-21 at 00 10 05](https://github.com/cloudflare/cloudflare-docs/assets/61631103/134d5436-a7a0-41b3-98de-d49387d8dea7) |