### PR TITLE
Fix "Deploy a Next.js site" docs link

### DIFF
--- a/content/pages/framework-guides/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/deploy-a-nextjs-site.md
@@ -101,7 +101,7 @@ export async function GET(request: Request) {
 {{</tab>}}
 {{</tabs>}}
 
-For more examples of this and for Next.js versions prior to v13.3.1, refer to [`@cloudflare/next-on-pages` examples](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md).
+For more examples of this and for Next.js versions prior to v13.3.1, refer to [`@cloudflare/next-on-pages` examples](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/supported.md).
 
 ### Create a GitHub repository
 


### PR DESCRIPTION
The file was moved in https://github.com/cloudflare/next-on-pages/commit/14a0e774f4b55777761080ab1c668c02a13d5481#diff-5add51cde034c40591c5d54166f2c8b856d2df8ceb6e969241675c23d8a422c6