### PR TITLE
Add CI for infinite redirects + fix existing issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
         run: pnpm run crawl
         if: success()
 
-      
+      - name: Check - Infinite redirects
+        run: npx tsm bin/find-infinite-redirects.ts
+
   # lint:
   #   name: Lint
   #   runs-on: ubuntu-latest

--- a/bin/find-infinite-redirects.ts
+++ b/bin/find-infinite-redirects.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'fs/promises';
+
+async function main( ){
+  const redirects = await readFile('content/_redirects', { encoding: 'utf-8' });
+
+  let found = 0;
+  for (const line of redirects.split('\n')) {
+    if (line.startsWith('#') || line.trim() === '') continue;
+
+    const [from, to] = line.split(' ');
+
+    if (from === to) {
+      console.log(`Found infinite redirect: ${from} -> ${to}`);
+      found++;
+    }
+  }
+
+  if (found) {
+    console.log(`\nFound ${found} infinite redirects, please fix them before merging :)`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/content/_redirects
+++ b/content/_redirects
@@ -378,11 +378,6 @@
 /fundamentals/security/challenge-passage/ /waf/tools/challenge-passage/ 301
 /fundamentals/glossary/ /fundamentals/reference/glossary/ 301
 /fundamentals/account-and-billing/login/ /fundamentals/basic-tasks/login/ 301
-/fundamentals/account-and-billing/account-security/securing-a-compromised-account/ /fundamentals/account-and-billing/account-security/securing-a-compromised-account/ 301
-/fundamentals/account-and-billing/account-security/zone-holds/ /fundamentals/account-and-billing/account-security/zone-holds/ 301
-/fundamentals/account-and-billing/account-security/review-audit-logs/ /fundamentals/account-and-billing/account-security/review-audit-logs/ 301
-/fundamentals/account-and-billing/account-security/manage-active-sessions/ /fundamentals/account-and-billing/account-security/manage-active-sessions/ 301
-/fundamentals/account-and-billing/account-security/cloudflare-access/ /fundamentals/account-and-billing/account-security/cloudflare-access/ 301
 /fundamentals/account-and-billing/account-maintenance/delete-account/ /fundamentals/account-and-billing/account-billing/delete-account/ 301
 /fundamentals/account-and-billing/account-maintenance/updating-billing-info/ /fundamentals/account-and-billing/account-billing/updating-billing-info/ 301
 /fundamentals/account-and-billing/account-maintenance/understand-invoices/ /fundamentals/account-and-billing/account-billing/understand-invoices/ 301
@@ -448,6 +443,9 @@
 /fundamentals/get-started/basic-tasks/under-ddos-attack/ /fundamentals/basic-tasks/under-ddos-attack/ 301
 /fundamentals/get-started/basic-tasks/test-speed/ /fundamentals/basic-tasks/test-speed/ 301
 /fundamentals/get-started/basic-tasks/ /fundamentals/basic-tasks/ 301
+/fundamentals/get-started/basic-tasks/account-security/securing-a-compromised-account/ /fundamentals/account-and-billing/account-security/securing-a-compromised-account/ 301
+/fundamentals/get-started/basic-tasks/account-security/review-audit-logs/ /fundamentals/account-and-billing/account-security/review-audit-logs/ 301
+/fundamentals/get-started/basic-tasks/account-security/manage-active-sessions/ /fundamentals/account-and-billing/account-security/manage-active-sessions/ 301
 /fundamentals/get-started/reference/cloudflare-site-crawling/ /fundamentals/reference/cloudflare-site-crawling/ 301
 /fundamentals/get-started/reference/content-security-policies/ /fundamentals/reference/policies-compliances/content-security-policies/ 301
 /fundamentals/get-started/reference/cloudflare-ray-id/ /fundamentals/reference/cloudflare-ray-id/ 301


### PR DESCRIPTION
We've had a few infinite loops with redirects so let's detect these in CI pre-merge. The check is simple, if from == to then flag.

This detected a few live in production right now:
```
Found infinite redirect: /fundamentals/account-and-billing/account-security/securing-a-compromised-account/ -> /fundamentals/account-and-billing/account-security/securing-a-compromised-account/
Found infinite redirect: /fundamentals/account-and-billing/account-security/zone-holds/ -> /fundamentals/account-and-billing/account-security/zone-holds/
Found infinite redirect: /fundamentals/account-and-billing/account-security/review-audit-logs/ -> /fundamentals/account-and-billing/account-security/review-audit-logs/
Found infinite redirect: /fundamentals/account-and-billing/account-security/manage-active-sessions/ -> /fundamentals/account-and-billing/account-security/manage-active-sessions/
Found infinite redirect: /fundamentals/account-and-billing/account-security/cloudflare-access/ -> /fundamentals/account-and-billing/account-security/cloudflare-access/

Found 5 infinite redirects, please fix them before merging :)
```
(Example run: https://github.com/cloudflare/cloudflare-docs/actions/runs/6292877008/job/17082711880?pr=10845)

Fixed these as well (if I couldn't find the last location, I removed as they seemed to be a mistake)