### PR TITLE
[pages] fix setting up documentation in deploy-an-asto-site.md

### DIFF
--- a/content/pages/framework-guides/deploy-an-astro-site.md
+++ b/content/pages/framework-guides/deploy-an-astro-site.md
@@ -11,7 +11,7 @@ Refer to the [Astro Docs](https://docs.astro.build/) to learn more about Astro o
 
 In this guide, you will create a new Astro application and deploy it using Cloudflare Pages.
 
-## Setting up a new project
+## Set up a new project
 
 To use `create-cloudflare` to create a new Astro project, run the following command:
 

--- a/content/pages/framework-guides/deploy-an-astro-site.md
+++ b/content/pages/framework-guides/deploy-an-astro-site.md
@@ -13,8 +13,6 @@ In this guide, you will create a new Astro application and deploy it using Cloud
 
 ## Setting up a new project
 
-`create-cloudflare` will then install dependencies, including the [Wrangler](/workers/wrangler/install-and-update/#check-your-wrangler-version) CLI and the `@astrojs/cloudflare` adapter, and ask you setup questions.
-
 To use `create-cloudflare` to create a new Astro project, run the following command:
 
 ```sh
@@ -27,7 +25,7 @@ Astro will ask:
 
 2. If you want to initialize a Git repository. We recommend you to select `No` and follow this guide's [Git instructions](/pages/framework-guides/deploy-an-astro-site/#create-a-github-repository) below. If you select `Yes`, do not follow the below Git instructions precisely but adjust them to your needs.
 
-`create-cloudflare` will then install dependencies, including the [Wrangler](/workers/wrangler/install-and-update/#check-your-wrangler-version) CLI and the `@sveltejs/adapter-cloudflare` adapter, and ask you setup questions.
+`create-cloudflare` will then install dependencies, including the [Wrangler](/workers/wrangler/install-and-update/#check-your-wrangler-version) CLI and the `@astrojs/cloudflare` adapter, and ask you setup questions.
 
 ### Astro configuration
 


### PR DESCRIPTION
- Remove a redundant (seemed to be out of place) line in the documentation that was later repeated

- fix incorrect reference to @sveltejs/adapter-cloudflare to be @astrojs/cloudflare