### PR TITLE
Fix redirect to Service Bindings Docs

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -922,7 +922,7 @@
 /workers/learning/getting-started/ /workers/get-started/guide/ 301
 /workers/learning/profiling-workers/ /workers/learning/ 301
 /workers/platform/scripts/ /api/operations/worker-script-list-workers 301
-/workers/platform/services/ /workers/ 301
+/workers/platform/services/ /workers/configuration/bindings/about-service-bindings/ 301
 /workers/platform/web-assembly/ /workers/platform/webassembly/ 301
 /workers/platform/web-assembly/javascript/ /workers/platform/webassembly/javascript/ 301
 /workers/platform/web-assembly/rust/ /workers/platform/webassembly/rust/ 301


### PR DESCRIPTION
`wrangler init` / `npx create cloudflare` generate Workers that provide the following link to the Developer Docs, to learn more about Service Bindings

```
https://developers.cloudflare.com/workers/platform/services
```

Currently this redirects to `/workers`, but the intent is that this page links to the Service Bindings docs.

We should update `cloudflare/workers-sdk` as well, but updating here first since there are older versions of this out there in the wild.

https://github.com/search?q=repo%3Acloudflare%2Fworkers-sdk%20https%3A%2F%2Fdevelopers.cloudflare.com%2Fworkers%2Fplatform%2Fservices&type=code