### PR TITLE
R2 Demo Worker update (demo-worker.md)

### DIFF
--- a/content/r2/examples/demo-worker.md
+++ b/content/r2/examples/demo-worker.md
@@ -64,7 +64,7 @@ export default {
         object.writeHttpMetadata(headers)
         headers.set('etag', object.httpEtag)
         if (object.range) {
-          headers.set("content-range", `bytes ${object.range.offset}-${object.range.end}/${object.size}`)
+          headers.set("content-range", `bytes ${object.range.offset}-${object.range.end ?? object.size - 1}/${object.size}`)
         }
         const status = object.body ? (request.headers.get("range") !== null ? 206 : 200) : 304
         return new Response(object.body, {


### PR DESCRIPTION
Fix request with Range=0-

If the request uses a range of 0- (which is valid) then object.range.end will be undefined. That would give a content-range of 0-undefined/x. When it really should be 0-(x-1)/x. It is x-1 since that value is inclusive

I used the following resources for info on the range and content-range headers:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range