### PR TITLE
[Cloudflare Images] add requirement notice for serve images from custom paths

### DIFF
--- a/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
+++ b/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
@@ -33,6 +33,8 @@ In this example, `<ACCOUNT_HASH>`, `<IMAGE_ID>` and `<VARIANT_NAME>` are the sam
 
 By default, Images are served from the `/cdn-cgi/imagedelivery/` path. You can use Transform Rules to rewrite URLs and serve images from custom paths.
 
+{{<Aside type="note">}}This feature requires a Business or WAF Advanced plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](https://developers.cloudflare.com/rules/transform/#availability) for more information.{{</Aside>}}
+
 To create a rule:
 
 1. Log in to the Cloudflare dashboard and select your account and website. 

--- a/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
+++ b/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
@@ -33,7 +33,11 @@ In this example, `<ACCOUNT_HASH>`, `<IMAGE_ID>` and `<VARIANT_NAME>` are the sam
 
 By default, Images are served from the `/cdn-cgi/imagedelivery/` path. You can use Transform Rules to rewrite URLs and serve images from custom paths.
 
-{{<Aside type="note">}}This feature requires a Business or WAF Advanced plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](https://developers.cloudflare.com/rules/transform/#availability) for more information.{{</Aside>}}
+{{<Aside type="note">}}
+
+This feature requires a Business or WAF Advanced plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
+
+{{</Aside>}}
 
 To create a rule:
 


### PR DESCRIPTION
Save time for customers without a business plan or higher while trying to set a custom path to serve Cloudflare images. 

```
not entitled: the use of function regex_replace is not allowed, a Business plan or a WAF Advanced plan is required
```