### PR TITLE
Update index.md for Regex101 URL

### DIFF
--- a/content/firewall/known-issues-and-faq/index.md
+++ b/content/firewall/known-issues-and-faq/index.md
@@ -45,7 +45,7 @@ The following image illustrates how double quotes are automatically escaped to `
 
 ### Why isn't my regular expression pattern matching working?
 
-If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com?flavor=rust&regex=) or [Rustexp](https://rustexp.lpil.uk).
+If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com/?flavor=rust&regex=) or [Rustexp](https://rustexp.lpil.uk).
 
 Also, note that the `http.request.method` field requires all-caps for method names (for example, `POST`).
 

--- a/content/firewall/known-issues-and-faq/index.md
+++ b/content/firewall/known-issues-and-faq/index.md
@@ -45,7 +45,7 @@ The following image illustrates how double quotes are automatically escaped to `
 
 ### Why isn't my regular expression pattern matching working?
 
-If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com/?flavor=rust) or [Rustexp](https://rustexp.lpil.uk).
+If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com) or [Rustexp](https://rustexp.lpil.uk).
 
 Also, note that the `http.request.method` field requires all-caps for method names (for example, `POST`).
 

--- a/content/firewall/known-issues-and-faq/index.md
+++ b/content/firewall/known-issues-and-faq/index.md
@@ -45,7 +45,7 @@ The following image illustrates how double quotes are automatically escaped to `
 
 ### Why isn't my regular expression pattern matching working?
 
-If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com) or [Rustexp](https://rustexp.lpil.uk).
+If you are using a regular expression, it is recommended that you test it with a tool like [Regular Expressions 101](https://regex101.com?flavor=rust&regex=) or [Rustexp](https://rustexp.lpil.uk).
 
 Also, note that the `http.request.method` field requires all-caps for method names (for example, `POST`).
 


### PR DESCRIPTION
Removed `/?flavor=rust` as choosing the flavor via URL is not supported by Regex101.
A related issue was opened here [https://github.com/firasdib/Regex101/issues/2090](https://github.com/firasdib/Regex101/issues/2090) but the issue was then closed although not fulfilled.

Although the link works, it can confuse the users into thinking they are using 'Rust' flavor, while they are not.