### PR TITLE
Fix hyperdrive create invocations

### DIFF
--- a/content/hyperdrive/_partials/_create-hyperdrive-config.md
+++ b/content/hyperdrive/_partials/_create-hyperdrive-config.md
@@ -23,7 +23,7 @@ Most database providers will provide a connection string you can directly copy-a
 To create a Hyperdrive configuration with the [Wrangler CLI](/workers/wrangler/install-and-update/), open your terminal and run the following command, pasting the connection string provided from your database host, or replacing `user`, `password`, `HOSTNAME_OR_IP_ADDRESS`, `port`, and `database_name` placeholders with those specific to your database:
 
 ```sh
-$ wrangler hyperdrive create <database-name-here> --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
+$ wrangler hyperdrive create $NAME --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
 ```
 
 {{<Aside type="note">}}
@@ -44,7 +44,7 @@ compatibility_date = "2023-09-11"
 
 node_compat = true # required for database drivers to function
 
-# Pasted from the output of `wrangler hyperdrive database create $NAME --connection-string=[...]` above.
+# Pasted from the output of `wrangler hyperdrive create $NAME --connection-string=[...]` above.
 [[hyperdrive]]
 name = "HYPERDRIVE"
 id = ""

--- a/content/hyperdrive/get-started.md
+++ b/content/hyperdrive/get-started.md
@@ -228,7 +228,7 @@ In the code above, you have:
 
 1. Created a new database `Client` configured to connect to your database via Hyperdrive.
 2. Connected to the database via `await client.connect()`.
-3. Initiated a simple query via `await client.query()` that outputs all tables (user and system created) in the database.
+3. Initiated a query via `await client.query()` that outputs all tables (user and system created) in the database.
 4. Returned the response as JSON to the client.
 
 ## 5. Deploy your database

--- a/content/hyperdrive/get-started.md
+++ b/content/hyperdrive/get-started.md
@@ -111,7 +111,7 @@ Most database providers will provide a connection string you can directly copy-a
 To create a Hyperdrive connection, run the `wrangler` command, replacing the placeholder values passed to the `--connection-string` flag with the values of your existing database:
 
 ```sh
-$ wrangler hyperdrive database create $CONFIG_NAME --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name
+$ wrangler hyperdrive create $NAME --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
 ```
 
 If successful, the command will output your new Hyperdrive configuration:


### PR DESCRIPTION
They shouldn't include "database" anymore, and they need a closing quotation mark.