### PR TITLE
[Logs] Clarify API token permissions for R2 logpush

### DIFF
--- a/content/logs/get-started/enable-destinations/r2/index.md
+++ b/content/logs/get-started/enable-destinations/r2/index.md
@@ -33,7 +33,7 @@ Before getting started:
 
     - Zone scope, logs edit permissions.
 
-    - Account scope, R2 write permissions.
+    - Account scope, R2 edit permissions.
 
 ## Manage via the Cloudflare dashboard
 


### PR DESCRIPTION
We currently tell people their API token needs "write permissions"

When creating an API token for R2, the options actually presented in the dashboard are either Read or Edit — there is no "Write" option:

<img width="781" alt="Screenshot 2023-09-28 at 5 27 40 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/1221592/f3f3255a-66d3-4c45-803f-f56fa63794e7">

This PR changes this to be "Edit" so that someone following the docs is clear on what they need to do.