### PR TITLE
Clarify that it is possible to edit logpush output options via the dash

### DIFF
--- a/content/logs/reference/log-output-options.md
+++ b/content/logs/reference/log-output-options.md
@@ -10,6 +10,8 @@ Jobs in Logpush now have a new key **output_options** which replaces **logpull_o
 
 Edge Logstream jobs do not support this yet.
 
+You can modify log output options via the Cloudflare dashboard when creating or editing a Logpush job, or via the API as shown below.
+
 ## Replace logpull_options
 
 Previously, Logpush jobs could be customized by specifying the list of fields, sampling rate, and timestamp format in **logpull_options** as [URL-encoded parameters](/logs/get-started/api-configuration/#options). For example:


### PR DESCRIPTION
### Problem

I was chasing down an issue with logs, and by default `EdgeStartTimestamp` and `EdgeEndTimestamp` are RFC3339.

I needed to change this to UnixNano. So I looked this up in our developer docs:

https://developers.cloudflare.com/logs/reference/log-output-options/

The docs made no mention of the dashboard, so I assumed this was only available via the API.

Only later, when editing a Logpush job in the Dashboard, did I realize that this is actually available, it is just quite hidden as an expandable "advanced options" section at the bottom of a long page of log fields:

<img width="1079" alt="Screenshot 2023-09-28 at 6 18 31 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/1221592/3d33ba12-43e4-438a-8fbf-8712027df8d1">

### Suggestion

This PR adds a simple callout that notes that this is possible to do via the dashboard. It might be worthwhile considering how to make this clearer from within the dashboard, but that's separate from the docs change. cc @jsells1 