### PR TITLE
[Vectorize] add more pricing examples

### DIFF
--- a/content/vectorize/examples/_index.md
+++ b/content/vectorize/examples/_index.md
@@ -1,0 +1,12 @@
+---
+type: overview
+hideChildren: false
+pcx_content_type: navigation
+title: Examples
+weight: 10
+layout: list
+---
+
+# Examples
+
+{{<list-examples>}}

--- a/content/vectorize/examples/langchain.md
+++ b/content/vectorize/examples/langchain.md
@@ -1,0 +1,9 @@
+---
+pcx_content_type: navigation
+title: LangChain Integration
+weight: 2
+external_link: https://js.langchain.com/docs/modules/data_connection/vectorstores/integrations/cloudflare_vectorize
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/vectorize/platform/pricing.md
+++ b/content/vectorize/platform/pricing.md
@@ -23,6 +23,21 @@ You are not billed for CPU, memory, "active index hours", or the number of index
 
 {{<render file="_vectorize-pricing.md" productFolder="workers">}}
 
+## Usage examples
+
+The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index:
+
+| Workload               | Dimensions per vector  | Stored dimensions    | Queries per month    | Calculation         | Estimated total      |
+| ---------------------- | ---------------------- | -------------------- | -------------------- | ------------------- | -------------------- |
+| Experimenting          | 384                    | 5,000 vectors        | 10,000               | `(5000+10000)*384*(0.040/1000000)` | $0.24 / mo <sup>included</sup> |
+| Scaling                | 768                    | 25,000 vectors       | 50,000               | `(25000+50000)*768*(0.040/1000000)` | $2.31 / mo <sup>partial</sup> |
+| Production             | 768                    | 50,000 vectors       | 200,000               | `(50000+200000)*768*(0.040/1000000)` | $7.68 / mo |
+| Large                  | 768                    | 250,000 vectors       | 500,000               | `(250000+500000)*768*(0.040/1000000)` | $23.04 / mo |
+| XL                     | 1536                   | 500,000 vectors      | 1,000,000             | `(500000+1000000)*1536*(0.040/1000000)` | $92.16 / mo |
+
+<sup>included</sup> All of this usage would fall into the Vectorize usage included within the Workers free or paid plan.
+<sup>most</sup> Most of this usage would fall into the Vectorize usage included within the Workers paid plan.
+
 ## Frequently Asked Questions
 
 Frequently asked questions related to Vectorize pricing:

--- a/content/vectorize/platform/pricing.md
+++ b/content/vectorize/platform/pricing.md
@@ -25,7 +25,7 @@ You are not billed for CPU, memory, "active index hours", or the number of index
 
 ### Usage examples
 
-The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index. These estimates do not include the Vectorize usage that's part of the 
+The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index. These estimates do not include the Vectorize usage that's part of the Workers free and paid plans.
 
 | Workload               | Dimensions per vector  | Stored dimensions    | Queries per month    | Calculation         | Estimated total      |
 | ---------------------- | ---------------------- | -------------------- | -------------------- | ------------------- | -------------------- |

--- a/content/vectorize/platform/pricing.md
+++ b/content/vectorize/platform/pricing.md
@@ -23,19 +23,20 @@ You are not billed for CPU, memory, "active index hours", or the number of index
 
 {{<render file="_vectorize-pricing.md" productFolder="workers">}}
 
-## Usage examples
+### Usage examples
 
-The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index:
+The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index. These estimates do not include the Vectorize usage that's part of the 
 
 | Workload               | Dimensions per vector  | Stored dimensions    | Queries per month    | Calculation         | Estimated total      |
 | ---------------------- | ---------------------- | -------------------- | -------------------- | ------------------- | -------------------- |
-| Experimenting          | 384                    | 5,000 vectors        | 10,000               | `(5000+10000)*384*(0.040/1000000)` | $0.24 / mo <sup>included</sup> |
+| Experiment             | 384                    | 5,000 vectors        | 10,000               | `(5000+10000)*384*(0.040/1000000)` | $0.24 / mo <sup>included</sup> |
 | Scaling                | 768                    | 25,000 vectors       | 50,000               | `(25000+50000)*768*(0.040/1000000)` | $2.31 / mo <sup>partial</sup> |
 | Production             | 768                    | 50,000 vectors       | 200,000               | `(50000+200000)*768*(0.040/1000000)` | $7.68 / mo |
 | Large                  | 768                    | 250,000 vectors       | 500,000               | `(250000+500000)*768*(0.040/1000000)` | $23.04 / mo |
 | XL                     | 1536                   | 500,000 vectors      | 1,000,000             | `(500000+1000000)*1536*(0.040/1000000)` | $92.16 / mo |
 
 <sup>included</sup> All of this usage would fall into the Vectorize usage included within the Workers free or paid plan.
+
 <sup>most</sup> Most of this usage would fall into the Vectorize usage included within the Workers paid plan.
 
 ## Frequently Asked Questions

--- a/content/vectorize/platform/pricing.md
+++ b/content/vectorize/platform/pricing.md
@@ -25,7 +25,7 @@ You are not billed for CPU, memory, "active index hours", or the number of index
 
 ### Usage examples
 
-The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index. These estimates do not include the Vectorize usage that's part of the Workers free and paid plans.
+The following table defines a number of example use-cases and the estimated monthly cost for querying a Vectorize index. These estimates do not include the Vectorize usage that is part of the Workers Free and Paid plans.
 
 | Workload               | Dimensions per vector  | Stored dimensions    | Queries per month    | Calculation         | Estimated total      |
 | ---------------------- | ---------------------- | -------------------- | -------------------- | ------------------- | -------------------- |

--- a/content/vectorize/platform/pricing.md
+++ b/content/vectorize/platform/pricing.md
@@ -35,9 +35,9 @@ The following table defines a number of example use-cases and the estimated mont
 | Large                  | 768                    | 250,000 vectors       | 500,000               | `(250000+500000)*768*(0.040/1000000)` | $23.04 / mo |
 | XL                     | 1536                   | 500,000 vectors      | 1,000,000             | `(500000+1000000)*1536*(0.040/1000000)` | $92.16 / mo |
 
-<sup>included</sup> All of this usage would fall into the Vectorize usage included within the Workers free or paid plan.
+<sup>included</sup> All of this usage would fall into the Vectorize usage included in the Workers Free or Paid plan.
 
-<sup>most</sup> Most of this usage would fall into the Vectorize usage included within the Workers paid plan.
+<sup>most</sup> Most of this usage would fall into the Vectorize usage included within the Workers Paid plan.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
This PR:

- Adds pricing examples to Vectorize.
- Adds a link to the LangChain module (future: fuller example within our docs) - https://js.langchain.com/docs/modules/data_connection/vectorstores/integrations/cloudflare_vectorize