### PR TITLE
Add redirect for KV runtime APIs

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1117,6 +1117,7 @@
 /workers/runtime-apis/scheduled-event/ /workers/runtime-apis/handlers/scheduled/ 301
 /workers/runtime-apis/fetch-event/ /workers/runtime-apis/handlers/fetch/ 301
 /workers/runtime-apis/add-event-listener/ /workers/learning/migrate-to-module-workers/ 301
+/workers/runtime-apis/kv/ /kv/api/ 301
 /workers/wrangler/workers-kv/ /kv/ 301
 /workers/databases/native-integrations/momento/ /workers/configuration/integrations/momento/ 301
 /workers/databases/connect-to-postgres/ /hyperdrive/learning/connect-to-postgres/ 301


### PR DESCRIPTION
This URL currently 404s:

https://developers.cloudflare.com/workers/runtime-apis/kv/

I think we missed a redirect in https://github.com/cloudflare/cloudflare-docs/pull/10901

cc @deadlypants1973 — my bad, didn't catch this in review