### PR TITLE
Fix incorrect code example in build-a-retrieval-augmented-generation-ai.md

### DIFF
--- a/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
+++ b/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
@@ -111,7 +111,7 @@ export default {
     const answer = await ai.run(
       '@cf/meta/llama-2-7b-chat-int8',
       {
-        inputs: [
+        messages: [
           { role: 'user', content: `What is the square root of 9?` }
         ]
       }
@@ -214,7 +214,7 @@ app.get('/', async (c) => {
   const answer = await ai.run(
     '@cf/meta/llama-2-7b-chat-int8',
     {
-      inputs: [
+      messages: [
         { role: 'user', content: `What is the square root of 9?` }
       ]
     }
@@ -334,7 +334,7 @@ app.get('/', async (c) => {
   const { response: answer } = await ai.run(
     '@cf/meta/llama-2-7b-chat-int8',
     {
-      inputs: [
+      messages: [
         ...(notes.length ? [{ role: 'system', content: contextMessage }] : []),
         { role: 'system', content: systemPrompt },
         { role: 'user', content: question }


### PR DESCRIPTION
Fix incorrect call for Worker AI text generation call

The field name should be `messages` instead of `inputs` according to API Schema
[LLM Text Generation API Schema](https://developers.cloudflare.com/workers-ai/models/llm/#api-schema)

```const answer = await ai.run(
      '@cf/meta/llama-2-7b-chat-int8',
      {
        messages: [
        inputs: [
          { role: 'user', content: `What is the square root of 9?` }
        ]
      }
    )
```
