### PR TITLE
[D1] Increase Limits

### DIFF
--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -28,7 +28,7 @@ Many of these limits will increase during D1's [public beta](/workers/platform/b
 | Maximum bound parameters per query                 | 100                                          |
 | Maximum arguments per SQL function                 | 32                                           |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern | 50 bytes                               |
-| Maximum bindings per Workers script                 | Approximately 5,000 <sup>bindings</sup>     |
+| Maximum bindings per Workers script                 | Approximately 5,000 <sup>1</sup>     |
 
 {{<Aside type="note">}}
 
@@ -40,6 +40,6 @@ Refer to the [Storage options guide](/workers/learning/storage-options/) to revi
 
 <sup>beta</sup> This is a beta-only limitation. The maximum storage per-database, storage per-account and number of databases will automatically increase for paid plans during the course of D1's public beta.
 
-<sup>bindings</sup> A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to ~5,000 D1 databases to a single Worker script.
+<sup>1</sup> A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to ~5,000 D1 databases to a single Worker script.
 
 Request adjustments to limits that conflict with your project goals by contacting Cloudflare. To make a request, complete the [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform), or speak to your account team. Not all limits can be increased.

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -1,4 +1,4 @@
-1---
+---
 pcx_content_type: concept
 title: Limits
 ---

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -1,4 +1,4 @@
----
+1---
 pcx_content_type: concept
 title: Limits
 ---
@@ -11,11 +11,13 @@ Many of these limits will increase during D1's [public beta](/workers/platform/b
 
 {{</Aside>}}
 
+
+
 | Feature                                            | Limit                                        |
 | -------------------------------------------------- | -------------------------------------------- | 
-| Databases                                          | 25 (Workers Paid) <sup>beta</sup> / 10 (Free) |
+| Databases                                          | 50,000 (Workers Paid) <sup>beta</sup> / 10 (Free) |
 | Maximum database size                              | 2 GB (Workers Paid) <sup>beta</sup> / 500 MB (Free) |
-| Maximum storage per account                        | 10 GB (Workers Paid) <sup>beta</sup> / 5 GB (Free) |
+| Maximum storage per account                        | 50 GB (Workers Paid) <sup>beta</sup> / 5 GB (Free) |
 | [Time Travel](/d1/learning/time-travel/) duration (point-in-time recovery) | 30 days (Workers Paid) / 7 days (Free) |
 | Maximum Time Travel restore operations             | 10 restores per 10 minute (per database)     |
 | Queries per Worker invocation (read [subrequest limits](/workers/platform/limits/#how-many-subrequests-can-i-make))                      | 50 (Bundled) / 1000 (Unbound)

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -28,6 +28,7 @@ Many of these limits will increase during D1's [public beta](/workers/platform/b
 | Maximum bound parameters per query                 | 100                                          |
 | Maximum arguments per SQL function                 | 32                                           |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern | 50 bytes                               |
+| Maximum bindings per Workers script                 | Approximately 5,000 <sup>bindings</sup>     |
 
 {{<Aside type="note">}}
 
@@ -38,5 +39,7 @@ Refer to the [Storage options guide](/workers/learning/storage-options/) to revi
 {{</Aside>}}
 
 <sup>beta</sup> This is a beta-only limitation. The maximum storage per-database, storage per-account and number of databases will automatically increase for paid plans during the course of D1's public beta.
+
+<sup>bindings</sup> A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to ~5,000 D1 databases to a single Worker script.
 
 Request adjustments to limits that conflict with your project goals by contacting Cloudflare. To make a request, complete the [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform), or speak to your account team. Not all limits can be increased.

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,7 +5,7 @@ entries:
 - publish_date: '2023-10-03'
   title: Create up to 50,000 D1 databases 
   description: |-
-    Developers using D1 on a Workers paid plan can now create up to 50,000 databases as part of ongoing increases to D1's limits.
+    Developers using D1 on a Workers Paid plan can now create up to 50,000 databases as part of ongoing increases to D1's limits.
 
     * This further enables database-per-user use-cases and allows you to isolate data between customers.
     * Total storage per account is now 50 GB.

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -2,6 +2,17 @@
 link: "/d1/changelog/"
 productName: D1
 entries:
+- publish_date: '2023-10-05'
+  title: Database limits substantially increased
+  description: |-
+    Developers using D1 on a Workers paid plan can now create up to 50,000 databases as part of ongoing increases to D1's limits.
+
+    * This further enables database-per-user use-cases and allows you to isolate data between customers.
+    * Total storage per account is now 50 GB.
+    * D1's [analytics and metrics](/d1/platform/metrics-analytics/) provide per-database usage data.
+
+    If you need to create more than 50,000 databases or need more per-account storage, [reach out](/d1/platform/limits] to the D1 team to discuss.
+
 - publish_date: '2023-09-28'
   title: The D1 public beta is here
   description: |-

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -2,8 +2,8 @@
 link: "/d1/changelog/"
 productName: D1
 entries:
-- publish_date: '2023-10-05'
-  title: Database limits substantially increased
+- publish_date: '2023-10-03'
+  title: Create up to 50,000 D1 databases 
   description: |-
     Developers using D1 on a Workers paid plan can now create up to 50,000 databases as part of ongoing increases to D1's limits.
 


### PR DESCRIPTION
This PR:

- [x] Documents increased per-account database limits (25 -> 50,000)
- [x] Per-account storage limits (10GB -> 50GB)
- [x] How script metadata limits apply.
