### PR TITLE
vectorize: Update limits.md

### DIFF
--- a/content/vectorize/changelog.md
+++ b/content/vectorize/changelog.md
@@ -7,6 +7,12 @@ rss: file
 
 # Changelog
 
+## 2023-10-03
+
+### Increased indexes per account limits
+
+You can now create up to 100 Vectorize indexes per account. See the [limits documentation](/vectorize/platform/limits/) for details on other limits, many of which will increase during the beta period.
+
 ## 2023-09-27
 
 ### Vectorize now in open beta

--- a/content/vectorize/changelog.md
+++ b/content/vectorize/changelog.md
@@ -11,7 +11,7 @@ rss: file
 
 ### Increased indexes per account limits
 
-You can now create up to 100 Vectorize indexes per account. See the [limits documentation](/vectorize/platform/limits/) for details on other limits, many of which will increase during the beta period.
+You can now create up to 100 Vectorize indexes per account. Read the [limits documentation](/vectorize/platform/limits/) for details on other limits, many of which will increase during the beta period.
 
 ## 2023-09-27
 

--- a/content/vectorize/platform/limits.md
+++ b/content/vectorize/platform/limits.md
@@ -15,7 +15,7 @@ The following limits apply to accounts, indexes and vectors (as specified):
 
 | Feature                           | Current Limit                               |
 | --------------------------------- | ------------------------------------------- |
-| Indexes per account               | 10 indexes <sup>beta</sup>                  |
+| Indexes per account               | 100 indexes <sup>beta</sup>                 |
 | Maximum dimensions per vector     | 1536 dimensions <sup>beta</sup>             |
 | Maximum vector ID length          | 64 bytes                                    |
 | Metadata per vector               | 10KiB <sup>beta</sup>                       |


### PR DESCRIPTION
This PR:

- Updates the Limits docs: you can now have 100 indexes per account
- Adds a changelog entry for the same