### PR TITLE
[ZT] Clarify indicator feed selector

### DIFF
--- a/content/cloudflare-one/_partials/gateway/_indicator-feed.md
+++ b/content/cloudflare-one/_partials/gateway/_indicator-feed.md
@@ -6,7 +6,7 @@ _build:
 inputParameters: API_param
 ---
 
-Use this selector to match against custom indicator feeds supplied by designated third-party vendors.
+Use this selector to match against custom indicator feeds. To use indicator feeds, a designated third-party vendor must assign them to your account.
 
 | UI name        | API example         | Evaluation phase      |
 | -------------- | ------------------- | --------------------- |

--- a/content/cloudflare-one/_partials/gateway/_indicator-feed.md
+++ b/content/cloudflare-one/_partials/gateway/_indicator-feed.md
@@ -6,7 +6,7 @@ _build:
 inputParameters: API_param
 ---
 
-Use this selector to match against custom indicator feeds. To use indicator feeds, a designated third-party vendor must assign them to your account.
+Use this selector to match against custom indicator feeds. To enable this selector, a designated third-party vendor must assign a custom indicator feed to your account.
 
 | UI name        | API example         | Evaluation phase      |
 | -------------- | ------------------- | --------------------- |


### PR DESCRIPTION
Make it clearer that the indicator feeds must be assigned to your account by a third-party vendor. This will be updated later with a link to a more in-depth write-up and/or intel docs.

PCX-8154