### PR TITLE
[Hyperdrive] Update wrangler.toml field

### DIFF
--- a/content/hyperdrive/_partials/_create-hyperdrive-config.md
+++ b/content/hyperdrive/_partials/_create-hyperdrive-config.md
@@ -46,7 +46,7 @@ node_compat = true # required for database drivers to function
 
 # Pasted from the output of `wrangler hyperdrive create $NAME --connection-string=[...]` above.
 [[hyperdrive]]
-name = "HYPERDRIVE"
+binding = "HYPERDRIVE"
 id = ""
 ```
 


### PR DESCRIPTION
To bind your Hyperdrive configuration to your Worker, bindings should have a string `binding` but is listed as `name` in the examples. 

Wrangler throws this error:
```
✘ [ERROR] Processing wrangler.toml configuration:

    - "hyperdrive[0]" bindings should have a string "binding" field but got
  {"name":"HYPERDRIVE","id":"xxxxxxxxxxxxxxxebacd416874"}.
```

Small pr to update the partials that is used by all the examples. Thanks!