### PR TITLE
Add additional HTTP Header check recommendation to Origin Server Protection page

### DIFF
--- a/content/learning-paths/_partials/_limit-external-connections-application.md
+++ b/content/learning-paths/_partials/_limit-external-connections-application.md
@@ -27,7 +27,7 @@ Only allow traffic with specific (and secret) HTTP headers.
 - **Challenges**:
     - Requires more configuration efforts on application- and server-side to accept those headers.
     - Basic authentication is vulnerable to replay attacks. Because basic authentication does not encrypt user credentials, it is important that traffic always be sent over an encrypted SSL session.
-    - There might be valid use cases for a mismatch in SNI / Host headers such as through [Page Rules](https://developers.cloudflare.com/support/page-rules/using-page-rules-to-rewrite-host-headers/), [Load Balancing](https://developers.cloudflare.com/load-balancing/additional-options/override-http-host-headers/), or [Workers](https://developers.cloudflare.com/workers/runtime-apis/request/), which all offer HTTP Host Header overrides.
+    - There might be valid use cases for a mismatch in SNI / Host headers such as through [Page Rules](/support/page-rules/using-page-rules-to-rewrite-host-headers/), [Load Balancing](/load-balancing/additional-options/override-http-host-headers/), or [Workers](/workers/runtime-apis/request/), which all offer HTTP Host Header overrides.
 - **Process**:
     1. Use [Transform rules](/rules/transform/request-header-modification/) or [Workers](/workers/examples/alter-headers/) to add an HTTP Auth Header.
     2. Configure your origin server to restrict access based on the [HTTP Auth Header](/workers/examples/auth-with-headers/) (or perform [HTTP Basic Authentication](/workers/examples/basic-auth/)).

--- a/content/learning-paths/_partials/_limit-external-connections-application.md
+++ b/content/learning-paths/_partials/_limit-external-connections-application.md
@@ -16,7 +16,7 @@ _build:
 </details>
 
 <details>
-<summary>HTTP Basic Authentication</summary>
+<summary>HTTP Header Validation</summary>
 
 <div>
 
@@ -27,9 +27,11 @@ Only allow traffic with specific (and secret) HTTP headers.
 - **Challenges**:
     - Requires more configuration efforts on application- and server-side to accept those headers.
     - Basic authentication is vulnerable to replay attacks. Because basic authentication does not encrypt user credentials, it is important that traffic always be sent over an encrypted SSL session.
+    - There might be valid use cases for a mismatch in SNI / Host headers such as through [Page Rules](https://developers.cloudflare.com/support/page-rules/using-page-rules-to-rewrite-host-headers/), [Load Balancing](https://developers.cloudflare.com/load-balancing/additional-options/override-http-host-headers/), or [Workers](https://developers.cloudflare.com/workers/runtime-apis/request/), which all offer HTTP Host Header overrides.
 - **Process**:
     1. Use [Transform rules](/rules/transform/request-header-modification/) or [Workers](/workers/examples/alter-headers/) to add an HTTP Auth Header.
     2. Configure your origin server to restrict access based on the [HTTP Auth Header](/workers/examples/auth-with-headers/) (or perform [HTTP Basic Authentication](/workers/examples/basic-auth/)).
+    3. Configure your origin server to restrict access based on the [HTTP Host Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host). Specifically, only allow requests which contain expected HTTP Host Header values, and reject all other requests. 
 
 </div>
 </details>


### PR DESCRIPTION
Customers should be implementing Host header allowlist checks at the origin to prevent various classes of attacks.

eg.

reject `host: evil.com` 
allow `host: example.com`

more context here: https://portswigger.net/web-security/host-header