### PR TITLE
[AI] Fix references to D1 binding

### DIFF
--- a/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
+++ b/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
@@ -242,7 +242,7 @@ app.post('/notes', async (c) => {
 			return c.text("Missing text", 400);
   } 
 
-  const { results } = await c.env.DATABASE.prepare("INSERT INTO notes (text) VALUES (?) RETURNING *")
+  const { results } = await c.env.DB.prepare("INSERT INTO notes (text) VALUES (?) RETURNING *")
     .bind(text)
     .run()
 
@@ -321,7 +321,7 @@ app.get('/', async (c) => {
   let notes = []
   if (vecIds.length) {
     const query = `SELECT * FROM notes WHERE id IN (${vecIds.join(", ")})`
-    const { results } = await c.env.DATABASE.prepare(query).bind().all()
+    const { results } = await c.env.DB.prepare(query).bind().all()
     if (results) notes = results.map(vec => vec.text)
   }
 


### PR DESCRIPTION
The docs makes you add a binding on `env.DB` but the code examples then start using `env.DATABASE`. This corrects that to `env.DB` instead.

I also found an `inputs`/`messages` discrepancy, but that is already reported in #11026