### PR TITLE
Update commands.md to reflect the ability to "Download existing data …

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -264,7 +264,9 @@ $ wrangler d1 backup restore <DATABASE_NAME> <BACKUP_ID>
 
 ### `backup download`
 
-NOTE: This command only works on 'Alpha' databases, it will not work on 'Beta' databases that are currently created. Currently there is no solution to Download existing data to your local machine of a 'Beta' created database.
+{{<Aside type="note">}}
+This command only works on databases created during D1's alpha period. This command will not work on databases that are currently created during the beta period. Currently, there is no solution to download existing data to your local machine of a beta database. Refer to [Time Travel](/d1/learning/time-travel/) in the D1 documentation for more information on D1's approach to backups in its beta period.
+{{</Aside>}}
 
 Download existing data to your local machine.
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -264,6 +264,8 @@ $ wrangler d1 backup restore <DATABASE_NAME> <BACKUP_ID>
 
 ### `backup download`
 
+NOTE: This command only works on 'Alpha' databases, it will not work on 'Beta' databases that are currently created. Currently there is no solution to Download existing data to your local machine of a 'Beta' created database.
+
 Download existing data to your local machine.
 
 ```sh


### PR DESCRIPTION
…to your local machine" not functioning with a beta database

Currently there is not an option to "Download existing data to your local machine" for a beta database. The documentation needs to mention this to avoid confusion.