### PR TITLE
[CF1] Consolidate cloudflared installation instructions

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/aws.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/aws.md
@@ -64,16 +64,27 @@ Now that we have EC2 up and running in AWS, you can log in to your instance.
 
 1. Run `sudo su` to gain full admin rights to the Virtual Machine.
 
-1. Run `apt install wget` to install any relevant dependencies for your new instance.
+1. Run `apt install curl` to install any relevant dependencies for your new instance.
 
-1. Install `cloudflared` on your instance. In this example, we are running a Debian-based instance, so download the Debian build of `cloudflared`:
+1. Install `cloudflared` on your instance. In this example, we are running a Debian-based instance, so download the Debian package of `cloudflared`:
+
+   Add Cloudflare's package signing key:
 
    ```sh
-   $ wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+   sudo mkdir -p --mode=0755 /usr/share/keyrings
+   curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
    ```
 
+   Add Cloudflare's apt repo to your apt repositories:
+
    ```sh
-   $ dpkg -i cloudflared-linux-amd64.deb
+   echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+   ```
+
+   Update repositories and install cloudflared:
+
+   ```sh
+   sudo apt-get update && sudo apt-get install cloudflared
    ```
 
 1. Run the following command to authenticate `cloudflared` with your Cloudflare account. The command will launch a browser window where you will be prompted to log in with your Cloudflare account and pick any zone you have added to Cloudflare.

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/azure.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/azure.md
@@ -47,14 +47,25 @@ Create two Ubuntu 20.04 LTS VMs, and make sure you record their internal IP addr
 
 1. Run `sudo su` to gain full admin rights to the Virtual Machine.
 
-1. Install `cloudflared` on your instance. In this example, we are running a Debian-based instance, so download the Debian build of `cloudflared`:
+1. Install `cloudflared` on your instance. In this example, we are running a Debian-based instance, so use the Debian package of `cloudflared`:
+
+   Add Cloudflare's package signing key:
 
    ```sh
-   $ wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+   sudo mkdir -p --mode=0755 /usr/share/keyrings
+   curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
    ```
 
+   Add Cloudflare's apt repo to your apt repositories:
+
    ```sh
-   $ dpkg -i cloudflared-linux-amd64.deb
+   echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+   ```
+
+   Update repositories and install cloudflared:
+
+   ```sh
+   sudo apt-get update && sudo apt-get install cloudflared
    ```
 
 1. Run the following command to authenticate `cloudflared` with your Cloudflare account. The command will launch a browser window where you will be prompted to log in with your Cloudflare account and pick any zone you have added to Cloudflare.

--- a/content/cloudflare-one/connections/connect-networks/downloads/_index.md
+++ b/content/cloudflare-one/connections/connect-networks/downloads/_index.md
@@ -73,6 +73,8 @@ A Docker image of `cloudflared` is [available on DockerHub](https://hub.docker.c
 
 ## Deprecated releases
 
-Cloudflare supports the previous year of `cloudflared` releases. For example, if the [latest version](https://github.com/cloudflare/cloudflared/releases) is `2023.5.1`, version `2022.5.1` and later are supported. Deprecated versions may be impacted by breaking changes unrelated to feature availability.
+Cloudflare currently supports versions of cloudflared that are **within one year** of the most recent release. Breaking changes unrelated to feature availability may be introduced that will impact versions released more than one year ago. You can read more about upgrading cloudflared in our [developer documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/#updating-cloudflared).
+
+For example, as of January 2023 Cloudflare will support cloudflared version 2023.1.1 to cloudflared 2022.1.1.
 
 To update `cloudflared`, refer to [these instructions](/cloudflare-one/connections/connect-networks/downloads/update-cloudflared/).

--- a/content/cloudflare-one/connections/connect-networks/downloads/update-cloudflared.md
+++ b/content/cloudflare-one/connections/connect-networks/downloads/update-cloudflared.md
@@ -12,7 +12,7 @@ Updates will cause `cloudflared` to restart which will impact traffic currently 
 
 To update `cloudflared` for a tunnel [created through the dashboard](/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/):
 
-{{<tabs labels="Windows | macOS | Debian | Red Hat | Docker">}}
+{{<tabs labels="Windows | macOS | Debian | Red Hat | Docker | Other">}}
 {{<tab label="windows" no-code="true">}}
 
 Run the following command:
@@ -40,6 +40,24 @@ This updates `cloudflared` and automatically restarts the service.
 
 {{</tab>}}
 {{<tab label="debian" no-code="true">}}
+
+**If installed via apt:**
+
+1. Update the `cloudflared` package:
+
+```sh
+$ sudo apt-get upgrade cloudflared
+```
+
+2. Restart the service:
+
+```sh
+$ sudo systemctl restart cloudflared.service
+```
+
+**If installed manually via `dpkg -i`:**
+
+You can check if `cloudflared` was installed by a package manager by running `ls -la /usr/local/etc/cloudflared/` and looking for `.installedFromPackageManager` in the output.
 
 1. Update the `cloudflared` package:
 
@@ -79,17 +97,18 @@ $ sudo systemctl restart cloudflared.service
 This creates a new container from the latest `cloudflared` image. You can now delete the old container.
 
 {{</tab>}}
-{{</tabs>}}
+{{<tab label="other" no-code="true">}}
 
-## Locally-managed tunnels
-
-If you installed `cloudflared` from GitHub binaries or from source, run the following command:
+If you installed `cloudflared` from GitHub-provided binaries or from source, you can run the following command:
 
 ```sh
 $ cloudflared update
 ```
 
-If you installed `cloudflared` with a package manager, you must update it using the same package manager. On Linux, you can check if `cloudflared` is owned by a package manager by running `ls -la /usr/local/etc/cloudflared/` and looking for `.installedFromPackageManager` in the output.
+If you installed `cloudflared` with a package manager, you must update it using the same package manager. You can check if `cloudflared` was installed by a package manager by running `ls -la /usr/local/etc/cloudflared/` and looking for `.installedFromPackageManager` in the output.
+
+{{</tab>}}
+{{</tabs>}}
 
 ## Update with Cloudflare Load Balancer
 

--- a/content/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel.md
+++ b/content/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel.md
@@ -45,24 +45,45 @@ Alternatively, you can [download the latest Darwin amd64 release](/cloudflare-on
 {{</tab>}}
 {{<tab label="linux" no-code="true">}}
 
-1. Download `cloudflared` on your machine. Visit the [downloads](/cloudflare-one/connections/connect-networks/downloads/) page to find the right package for your OS.
+Additional package details can be found on the [downloads](/cloudflare-one/connections/connect-networks/downloads/) page.
 
-2. Install `cloudflared`:
+**Debian and Ubuntu APT install**
 
-**.deb install**
+Use the apt package manager to install `cloudflared` on compatible machines.
 
-Use the deb package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` is used in this example.
+1. Add Cloudflare's package signing key:
 
 ```sh
-$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb && sudo dpkg -i cloudflared-linux-amd64.deb
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
 ```
 
-**​.rpm install**
-
-Use the rpm package manager to install `cloudflared` on compatible machines. `amd64 / x86-64` is used in this example.
+2. Add Cloudflare's apt repo to your apt repositories:
 
 ```sh
-$ wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-x86_64.rpm
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+```
+
+3. Update repositories and install cloudflared:
+
+```sh
+sudo apt-get update && sudo apt-get install cloudflared
+```
+
+**RHEL RPM install**
+
+Use the rpm package manager to install `cloudflared` on compatible machines.
+
+1. Add Cloudflare's repository:
+
+```sh
+curl -fsSL https://pkg.cloudflare.com/cloudflared-ascii.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
+```
+
+2. Update repositories and install cloudflared:
+
+```sh
+sudo yum update && sudo yum install cloudflared
 ```
 
 **Arch Linux**
@@ -73,6 +94,10 @@ Use `pacman` to install `cloudflared` on compatible machines.
 ```sh
 $ pacman -Syu cloudflared
 ```
+
+**Other**
+
+Alternatively you can download the `cloudflared` binary or the linux packages to your machine and install manually. Visit the [downloads](/cloudflare-one/connections/connect-networks/downloads/) page to find the right package for your OS.
 
 {{</tab>}}
 {{<tab label="build from source" no-code="true">}}

--- a/content/cloudflare-one/tutorials/gitlab.md
+++ b/content/cloudflare-one/tutorials/gitlab.md
@@ -156,12 +156,7 @@ Select **Next** and **Next** again on the **Setup** page - this example does not
 
 Cloudflare Tunnel creates a secure, outbound-only, connection between this machine and Cloudflare's network. With an outbound-only model, you can prevent any direct access to this machine and lock down any externally exposed points of ingress. And with that, no open firewall ports.
 
-Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the DigitalOcean machine with the two commands below.
-
-```sh
-$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
-$ sudo dpkg -i ./cloudflared-linux-amd64.deb
-```
+Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the DigitalOcean machine by following the instructions listed on the [Downloads](/cloudflare-one/connections/connect-networks/downloads/) page.
 
 Once installed, authenticate the instance of `cloudflared` with the following command.
 

--- a/content/cloudflare-one/tutorials/kubectl.md
+++ b/content/cloudflare-one/tutorials/kubectl.md
@@ -42,12 +42,7 @@ You can connect to machines over `kubectl` using Cloudflare's Zero Trust platfor
 
 Cloudflare Tunnel creates a secure, outbound-only connection between this machine and Cloudflare's network. With an outbound-only model, you can prevent any direct access to this machine and lock down any externally exposed points of ingress. And with that, no open firewall ports.
 
-Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install `cloudflared` with the commands below. You can find releases for other operating systems [here](https://github.com/cloudflare/cloudflared/releases).
-
-```sh
-$ sudo wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
-$ sudo dpkg -i ./cloudflared-linux-amd64.deb
-```
+Cloudflare Tunnel is made possible through a lightweight daemon from Cloudflare called `cloudflared`. Download and then install that on the DigitalOcean machine by following the instructions listed on the [Downloads](/cloudflare-one/connections/connect-networks/downloads/) page.
 
 ## Authenticate `cloudflared`
 


### PR DESCRIPTION
Favor Linux installation instructions for cloudflared that use the available package manager instead of `dpkg -i`-based installs. Additionally captures update instructions of cloudflared to simplify updates.

Backported many of these install instructions into the tutorials to reference the downloads page of cloudflared instead of using the manual `dpkg -i` method.

Update "Deprecated releases" language to match that is listed in cloudflared's main repo.

- TUN-7864