### PR TITLE
[Vectorize] fix link to vectorize limits in _index.md

### DIFF
--- a/content/vectorize/_index.md
+++ b/content/vectorize/_index.md
@@ -50,7 +50,7 @@ Store large amounts of unstructured data without the costly egress bandwidth fee
 
 {{<resource-group>}}
 
-{{<resource header="Limits" href="/d1/platform/limits/" icon="documentation-clipboard">}}Learn about what limits Vectorize has during the open beta and how to work within them.{{</resource>}}
+{{<resource header="Limits" href="/vectorize/platform/limits/" icon="documentation-clipboard">}}Learn about what limits Vectorize has during the open beta and how to work within them.{{</resource>}}
 
 {{<resource header="Storage options" href="/workers/learning/storage-options/" icon="documentation-clipboard">}}Learn more about the storage and database options you can build on with Workers.{{</resource>}}
 


### PR DESCRIPTION
The link on https://developers.cloudflare.com/vectorize/ -> Limits currently points to D1 where the text (and surrounding page) talks about Vectorize. This PR changes the link target to https://developers.cloudflare.com/vectorize/platform/limits/.