### PR TITLE
Fix Header Links

### DIFF
--- a/content/rules/compression-rules/examples.md
+++ b/content/rules/compression-rules/examples.md
@@ -29,7 +29,7 @@ The following example rule will disable compression for AVIF images, based on ei
 <summary>Example API request</summary>
 <div>
 
-The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
+The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
 
 ```bash
 curl --request PUT \
@@ -72,7 +72,7 @@ The following example rule will configure GZIP compression as the preferred comp
 <summary>Example API request</summary>
 <div>
 
-The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
+The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
 
 ```bash
 curl --request PUT \
@@ -118,7 +118,7 @@ Since the rule configuration does not include _Auto_ at the end of the custom al
 <summary>Example API request</summary>
 <div>
 
-The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
+The following example sets the rules of an existing [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) (with ID `{ruleset_id}`) for the `http_response_compression` phase to a single compression rule, using the [Update a zone ruleset](/api/operations/updateZoneRuleset) operation:
 
 ```bash
 curl --request PUT \

--- a/content/rules/url-forwarding/bulk-redirects/create-api.md
+++ b/content/rules/url-forwarding/bulk-redirects/create-api.md
@@ -139,7 +139,7 @@ header: Response
 
 Since Bulk Redirect Lists are essentially containers of URL redirects, you have to enable the URL redirects in the list by creating a Bulk Redirect Rule.
 
-Add Bulk Redirect Rules to the [entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) of the `http_request_redirect` phase at the account level. Refer to the [Rulesets API](/ruleset-engine/rulesets-api/) documentation for more information on [creating a ruleset](/ruleset-engine/rulesets-api/create/) and supplying a list of rules for the ruleset.
+Add Bulk Redirect Rules to the [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) of the `http_request_redirect` phase at the account level. Refer to the [Rulesets API](/ruleset-engine/rulesets-api/) documentation for more information on [creating a ruleset](/ruleset-engine/rulesets-api/create/) and supplying a list of rules for the ruleset.
 
 A Bulk Redirect Rule must have:
 

--- a/content/ruleset-engine/about/rulesets.md
+++ b/content/ruleset-engine/about/rulesets.md
@@ -6,7 +6,7 @@ weight: 3
 
 # Rulesets
 
-A ruleset is an ordered set of [rules](/ruleset-engine/about/rules/) that you can apply to traffic on the Cloudflare global network. Rulesets belong to a phase and can only execute in the same phase. To deploy a ruleset to a phase, add a rule that executes the ruleset to the [phase entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset).
+A ruleset is an ordered set of [rules](/ruleset-engine/about/rules/) that you can apply to traffic on the Cloudflare global network. Rulesets belong to a phase and can only execute in the same phase. To deploy a ruleset to a phase, add a rule that executes the ruleset to the [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset).
 
 Rulesets are versioned. Each ruleset modification creates a new version of the ruleset. You can have several versions of a ruleset in use at the same time. When you deploy a ruleset — that is, when you create a rule that executes the ruleset — the most recent version of the ruleset is selected by default.
 

--- a/content/ruleset-engine/basic-operations/add-rule-phase-rulesets.md
+++ b/content/ruleset-engine/basic-operations/add-rule-phase-rulesets.md
@@ -8,7 +8,7 @@ layout: list
 
 # Add rules to phase entry point rulesets
 
-A [phase entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) contains an ordered list of rules that run in that phase. A rule in an entry point ruleset can execute a different ruleset. You can have entry point rulesets for each phase at the account level and at the zone level.
+A [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) contains an ordered list of rules that run in that phase. A rule in an entry point ruleset can execute a different ruleset. You can have entry point rulesets for each phase at the account level and at the zone level.
 
 To add one or more rules to a phase entry point ruleset, use one of the [ruleset update operations](/ruleset-engine/rulesets-api/update/) of the [Rulesets API](/ruleset-engine/rulesets-api/). When you add a rule to an entry point ruleset, the entry point ruleset is created automatically if it does not exist. This API method requires that you include in the request all rules you want to keep in the ruleset, or else they will be removed.
 

--- a/content/ruleset-engine/rules-language/values.md
+++ b/content/ruleset-engine/rules-language/values.md
@@ -142,7 +142,7 @@ The Rules language [operators](/ruleset-engine/rules-language/operators/) do not
 
 ## Lists
 
-Lists allow you to create a group of items and refer to them collectively, by name, in your expressions. There are different types of lists that support items with different data types. Each list can only have items of the same data type. For details on the available list types, refer to [Lists](/waf/tools/lists/#list-types).
+Lists allow you to create a group of items and refer to them collectively, by name, in your expressions. There are different types of lists that support items with different data types. Each list can only have items of the same data type. For details on the available list types, refer to [Lists](/waf/tools/lists/#supported-lists).
 
 
 To refer to a list in a rule expression, use `$<list_name>` and specify the `in` [operator](/ruleset-engine/rules-language/operators/). Only one value in the list has to match the left-hand side of the expression (before the `in` operator) for the simple expression to evaluate to `true`. If there is no match, the expression will evaluate to `false`.

--- a/content/vectorize/learning/query-vectors.md
+++ b/content/vectorize/learning/query-vectors.md
@@ -6,7 +6,7 @@ weight: 5
 
 # Query Vectors
 
-Querying an index, or vector search, enables you to search an index by providing an input vector and returning the nearest vectors based on the [configured distance metric](/vectorize/learning/insert-vectors/#distance-metrics).
+Querying an index, or vector search, enables you to search an index by providing an input vector and returning the nearest vectors based on the [configured distance metric](/vectorize/learning/create-indexes/#distance-metrics).
 
 ## Example query
 

--- a/content/waf/custom-rules/create-api.md
+++ b/content/waf/custom-rules/create-api.md
@@ -9,7 +9,7 @@ weight: 3
 
 Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a Custom Rule via API.
 
-You must deploy custom rules to the `http_request_firewall_custom` [phase entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset).
+You must deploy custom rules to the `http_request_firewall_custom` [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset).
 
 ## Create a custom rule
 

--- a/content/waf/custom-rules/skip/api-examples.md
+++ b/content/waf/custom-rules/skip/api-examples.md
@@ -18,7 +18,7 @@ This page contains examples of different skip rule scenarios for custom rules. T
 
 * The `{zone_id}` value is the [ID of the zone](/fundamentals/setup/find-account-and-zone-ids/) where you want to add the rule.
 
-* The `{ruleset_id}` value is the ID of the [entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). The API examples in this page add a skip rule to an existing ruleset using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) operation.
+* The `{ruleset_id}` value is the ID of the [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) of the `http_request_firewall_custom` phase. For details on obtaining this ruleset ID, refer to [List and view rulesets](/ruleset-engine/rulesets-api/view/). The API examples in this page add a skip rule to an existing ruleset using the [Create a zone ruleset rule](/api/operations/createZoneRulesetRule) operation.
 
     However, the entry point ruleset may not exist yet. In this case, invoke the [Create a zone ruleset](/api/operations/createZoneRuleset) operation to create the entry point ruleset with a skip rule. Refer to [Create ruleset](/ruleset-engine/rulesets-api/create/#example---create-a-zone-level-phase-entry-point-ruleset) for an example.
 

--- a/content/waf/managed-rules/waf-exceptions/define-api.md
+++ b/content/waf/managed-rules/waf-exceptions/define-api.md
@@ -8,7 +8,7 @@ meta:
 
 # Add a WAF exception via API
 
-To add a WAF exception via API, create a rule with `skip` action in a [phase entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset) of the `http_request_firewall_managed` phase. You can define WAF exceptions at the account level and at the zone level.
+To add a WAF exception via API, create a rule with `skip` action in a [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) of the `http_request_firewall_managed` phase. You can define WAF exceptions at the account level and at the zone level.
 
 To configure the WAF exception, define the `action_parameters` object according to the [exception type](/waf/managed-rules/waf-exceptions/#types-of-waf-exceptions).
 

--- a/content/waf/rate-limiting-rules/create-api.md
+++ b/content/waf/rate-limiting-rules/create-api.md
@@ -13,7 +13,7 @@ Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a rate limiting 
 
 A rate limiting rule is similar to a regular rule handled by the Ruleset Engine, but contains an additional `ratelimit` object with the rate limiting configuration. Refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/) for more information on this field and its parameters.
 
-You must deploy rate limiting rules to the `http_ratelimit` [phase entry point ruleset](/ruleset-engine/about/rulesets/#phase-entry-point-ruleset).
+You must deploy rate limiting rules to the `http_ratelimit` [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset).
 
 Rate limiting rules must appear at the end of the rules list.
 


### PR DESCRIPTION
For #11155.

First time doing one of these, not sure if non-employees are even allowed to do them.

Preview available [here](https://fix-header-links.cfdocs-alastair.pages.dev/).

For the glossary-related links, I don't think you **can** link to them, at least right now, since they don't expose any anchors...