### PR TITLE
Update _cloudflared-debian-install.md

### DIFF
--- a/content/cloudflare-one/_partials/_cloudflared-debian-install.md
+++ b/content/cloudflare-one/_partials/_cloudflared-debian-install.md
@@ -15,7 +15,7 @@ $ curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/shar
 2. Add Cloudflare's apt repo to your apt repositories:
 
 ```sh
-$ echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+$ echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
 ```
 
 3. Update repositories and install cloudflared:


### PR DESCRIPTION
This does write
```
deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main
```
verbatim to `/etc/apt/sources.list.d/cloudflared.list` making `apt-get update` fail with the following error message.

```
# apt-get update
...
Ign:4 https://pkg.cloudflare.com/cloudflared $(lsb_release InRelease
Err:5 https://pkg.cloudflare.com/cloudflared $(lsb_release Release
  404  Not Found [IP: 104.18.1.118 443]
Reading package lists... Done
E: The repository 'https://pkg.cloudflare.com/cloudflared $(lsb_release Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
``` 

Bash command substitution requires double quotes here.