### PR TITLE
Add missing redirect to new Durable Objects alarms doc

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -274,6 +274,7 @@
 
 # durable-objects
 /durable-objects/api/hibernatable-websockets-api/ /durable-objects/api/websockets/ 301
+/durable-objects/api/alarms-in-durable-objects/ /durable-objects/api/alarms/ 301
 
 # email-routing
 /email-routing/enable-email-routing/ /email-routing/get-started/enable-email-routing/ 301


### PR DESCRIPTION
refs https://github.com/cloudflare/cloudflare-docs/pull/11164

cc @joshthoward — I think the broken links checker missed this in CI because after the changes in the PR, there were no remaining internal links to the previous URL. (found this when Googling Durable Objects alarms to look something up)

https://github.com/cloudflare/cloudflare-docs/pull/11164/files#diff-0ec33e799c2763600c4d75f426a207e5a5faf5604c815e8918bcf77b845f8d28L48

@kodster28 — I wonder if the dream broken link checker would gather up all links in both the changed version and in production, and check if in the changed version, any links from either were broken?