### PR TITLE
Cursor Assistant: uses Vectorize instead of DO

### DIFF
--- a/content/workers/ai/_index.html
+++ b/content/workers/ai/_index.html
@@ -20,8 +20,8 @@ layout: list
       <a class="DocsMarkdown--link" href="/workers/">Cloudflare Workers</a> and
       <a
         class="DocsMarkdown--link"
-        href="/durable-objects/"
-        >Durable Objects</a
+        href="/vectorize/"
+        >Vectorize</a
       >. Cursor is here to help answer your Cloudflare Workers and Developer
       Platform questions, so ask away!
     </p>


### PR DESCRIPTION
Update the doc at https://developers.cloudflare.com/workers/ai/ to mention that it uses Vectorize instead of Durable Object now.