### PR TITLE
Update Chrome cert policy

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cloudflare-cert.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cloudflare-cert.md
@@ -275,7 +275,7 @@ Some applications require the use of a publicly trusted certificate — they do 
 
 #### Chrome
 
-In macOS and Windows, [Chrome uses the operating system root store](https://support.google.com/chrome/answer/95617?visit_id=638297158670039236-3119581239&p=root_store&rd=1#zippy=%2Cmanage-device-certificates-on-mac-windows). In other operating systems, such as Linux and ChromeOS, you may have to install the Cloudflare certificate to your browser manually.
+Current versions of Chrome [use the Chrome internal trust store](https://www.chromium.org/Home/chromium-security/root-ca-policy/#introduction) meaning that you will likely have to install the Cloudflare certificate to your browser manually.
 
 1. Download the [Cloudflare certificate](/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem) in `.pem` format.
 2. In Chrome, go to **Settings** > **Privacy and security** > **Security**.

--- a/content/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cloudflare-cert.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cloudflare-cert.md
@@ -275,7 +275,9 @@ Some applications require the use of a publicly trusted certificate — they do 
 
 #### Chrome
 
-Current versions of Chrome [use the Chrome internal trust store](https://www.chromium.org/Home/chromium-security/root-ca-policy/#introduction) meaning that you will likely have to install the Cloudflare certificate to your browser manually.
+Versions of Chrome before Chrome 113 use the [operating system root store](https://support.google.com/chrome/answer/95617?visit_id=638297158670039236-3119581239&p=root_store&rd=1#zippy=%2Cmanage-device-certificates-on-mac-windows) on macOS and Windows. Chrome 113 and newer on macOS and Windows -- and all versions on Linux and ChromeOS -- use the [Chrome internal trust store](https://www.chromium.org/Home/chromium-security/root-ca-policy/#introduction).
+
+To install the Cloudflare certificate to Chrome manually:
 
 1. Download the [Cloudflare certificate](/cloudflare-one/static/documentation/connections/Cloudflare_CA.pem) in `.pem` format.
 2. In Chrome, go to **Settings** > **Privacy and security** > **Security**.


### PR DESCRIPTION
Cloudflare customer pointed out that since Chrome 113, Google Chrome does not support using 'platform supplied certificate verifier and roots' (see https://chromeenterprise.google/policies/#ChromeRootStoreEnabled) 

and per the Chrome Root Program Policy doc at https://www.chromium.org/Home/chromium-security/root-ca-policy/#introduction ,

 "In Chrome 105, Chrome began a platform-by-platform transition from relying on the host operating system’s Root Store to its own on Windows, macOS, ChromeOS, Linux, and Android."

Suggested language change to reflect need to update Chrome rather than OS root, given this policy.