### PR TITLE
[Tunnel] Fix typo on cloudflared command in tunnel run docs.

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
+++ b/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
@@ -12,7 +12,7 @@ This page lists general-purpose configuration options for a Cloudflare Tunnel. Y
 
 | Syntax            | Default |
 | ----------------- | ------- |
-| `cloudlared tunnel --autoupdate-freq <FREQ> run <UUID or NAME>`  | `24h`   |
+| `cloudflared tunnel --autoupdate-freq <FREQ> run <UUID or NAME>`  | `24h`   |
 
 Configures autoupdate frequency. See also: [`no-autoupdate`](#no-autoupdate).
 
@@ -24,7 +24,7 @@ For locally-managed tunnels only.
 
 | Syntax | Default |
 | --------| ------ |
-| `cloudlared tunnel --config <PATH> run <UUID or NAME>`  | `~/.cloudflared/config.yml` |
+| `cloudflared tunnel --config <PATH> run <UUID or NAME>`  | `~/.cloudflared/config.yml` |
 
 Specifies the path to a [configuration file](/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/) in YAML format.
 
@@ -32,7 +32,7 @@ Specifies the path to a [configuration file](/cloudflare-one/connections/connect
 
 | Syntax                    | Environment Variable       |
 | ------------------------- | -------------------------- |
-| `cloudlared tunnel --edge-bind-address <IP> run <UUID or NAME>` | `TUNNEL_EDGE_BIND_ADDRESS` |
+| `cloudflared tunnel --edge-bind-address <IP> run <UUID or NAME>` | `TUNNEL_EDGE_BIND_ADDRESS` |
 
 Specifies the outgoing IP address used to establish a connection between `cloudflared` and the Cloudflare global network.
 
@@ -44,7 +44,7 @@ The IP version of `edge-bind-address` will override [`edge-ip-version`](#edge-ip
 
 | Syntax                  | Default | Environment Variable     |
 | ----------------------- | ------- | ------------------------ |
-| `cloudlared tunnel --edge-ip-version <VERSION> run <UUID or NAME>`  | `auto`  | `TUNNEL_EDGE_IP_VERSION` |
+| `cloudflared tunnel --edge-ip-version <VERSION> run <UUID or NAME>`  | `auto`  | `TUNNEL_EDGE_IP_VERSION` |
 
 Specifies the IP address version (IPv4 or IPv6) used to establish a connection between `cloudflared` and the Cloudflare global network. Available values are `auto`, `4`, and `6`.
 
@@ -54,7 +54,7 @@ The value `auto` relies on the host operating system to determine which IP versi
 
 | Syntax         | Default | Environment Variable  |
 | -------------- | ------- | --------------------- |
-| `cloudlared tunnel --grace-period <PERIOD> run <UUID or NAME>` | `30s`   | `TUNNEL_GRACE_PERIOD` |
+| `cloudflared tunnel --grace-period <PERIOD> run <UUID or NAME>` | `30s`   | `TUNNEL_GRACE_PERIOD` |
 
 When `cloudflared` receives SIGINT/SIGTERM it will stop accepting new requests, wait for in-progress requests to terminate, then shut down. Waiting for in-progress requests will timeout after this grace period, or when a second SIGTERM/SIGINT is received.
 
@@ -62,7 +62,7 @@ When `cloudflared` receives SIGINT/SIGTERM it will stop accepting new requests, 
 
 | Syntax          | Environment Variable |
 | --------------- | -------------------- |
-| `cloudlared tunnel --logfile <PATH> run <UUID or NAME>` | `TUNNEL_LOGFILE`     |
+| `cloudflared tunnel --logfile <PATH> run <UUID or NAME>` | `TUNNEL_LOGFILE`     |
 
 Saves application log to this file. Mainly useful for reporting issues. For more details on what information you need when contacting Cloudflare support, refer to [this guide](/cloudflare-one/faq/cloudflare-tunnels-faq/).
 
@@ -70,7 +70,7 @@ Saves application log to this file. Mainly useful for reporting issues. For more
 
 | Syntax           | Default | Environment Variable |
 | ---------------- | ------- | -------------------- |
-| `cloudlared tunnel --loglevel <VALUE> run <UUID or NAME>`  | `info`  | `TUNNEL_LOGLEVEL`    |
+| `cloudflared tunnel --loglevel <VALUE> run <UUID or NAME>`  | `info`  | `TUNNEL_LOGLEVEL`    |
 
 Specifies the verbosity of logging. The default `info` level does not produce much output, but you may wish to use the `warn` level in production. Available values are: `debug`, `info`, `warn`, `error`, `fatal`.
 
@@ -78,7 +78,7 @@ Specifies the verbosity of logging. The default `info` level does not produce mu
 
 | Syntax          | Default      | Environment Variable |
 | --------------- | ------------ | -------------------- |
-| `cloudlared tunnel --metrics <IP:PORT> run <UUID or NAME>`| `localhost:` | `TUNNEL_METRICS`     |
+| `cloudflared tunnel --metrics <IP:PORT> run <UUID or NAME>`| `localhost:` | `TUNNEL_METRICS`     |
 
 Exposes a Prometheus endpoint on the specified IP address/port, which you can then query for usage metrics. For <IP>, enter the local address of the server running `cloudflared` (for example, `127.0.0.1` or `0.0.0.0`).
 
@@ -86,7 +86,7 @@ Exposes a Prometheus endpoint on the specified IP address/port, which you can th
 
 | Syntax          | Default | Environment Variable |
 | --------------- | ------- | -------------------- |
-| `cloudlared tunnel --no-autoupdate <BOOLEAN> run <UUID or NAME>`  | `false` | `NO_AUTOUPDATE`      |
+| `cloudflared tunnel --no-autoupdate <BOOLEAN> run <UUID or NAME>`  | `false` | `NO_AUTOUPDATE`      |
 
 When `false`, `cloudflared` will periodically check for updates and restart with the new version. See also: [`autoupdate-freq`](#autoupdate-freq). Restarts are performed by spawning a new process that connects to the Cloudflare global network. On successful connection, the old process will gracefully shut down after handling all outstanding requests.
 
@@ -100,7 +100,7 @@ For locally-managed tunnels only.
 
 | Syntax             | Default                   | Environment Variable |
 | ------------------ | ------------------------- | -------------------- |
-|  `cloudlared tunnel --origincert <PATH> run <UUID or NAME>` | `~/.cloudflared/cert.pem` | `TUNNEL_ORIGIN_CERT` |
+|  `cloudflared tunnel --origincert <PATH> run <UUID or NAME>` | `~/.cloudflared/cert.pem` | `TUNNEL_ORIGIN_CERT` |
 
 Specifies the [account certificate](/cloudflare-one/connections/connect-networks/deploy-tunnels/tunnel-permissions/#locally-managed-tunnels) for one of your zones, authorizing the client to serve as an origin for that zone. You can obtain a certificate by using the `cloudflared tunnel login` command or by visiting `https://dash.cloudflare.com/argotunnel`.
 
@@ -108,7 +108,7 @@ Specifies the [account certificate](/cloudflare-one/connections/connect-networks
 
 | Syntax          | Environment Variable |
 | --------------- | -------------------- |
-| `cloudlared tunnel --pidfile <PATH> run <UUID or NAME>`| `TUNNEL_PIDFILE`     |
+| `cloudflared tunnel --pidfile <PATH> run <UUID or NAME>`| `TUNNEL_PIDFILE`     |
 
 Writes the application's process identifier (PID) to this file after the first successful connection. Mainly useful for scripting and service integration.
 
@@ -116,7 +116,7 @@ Writes the application's process identifier (PID) to this file after the first s
 
 | Syntax     | Default | Environment Variable        |
 | ---------- | ------- | --------------------------- |
-| `cloudlared tunnel --protocol <VALUE> run <UUID or NAME>` | `auto`  | `TUNNEL_TRANSPORT_PROTOCOL` |
+| `cloudflared tunnel --protocol <VALUE> run <UUID or NAME>` | `auto`  | `TUNNEL_TRANSPORT_PROTOCOL` |
 
 Specifies the protocol used to establish a connection between `cloudflared` and the Cloudflare global network. Available values are `auto`, `http2`, `h2mux`, and `quic`.
 
@@ -126,7 +126,7 @@ The `auto` value will automatically configure the `quic` protocol. If `cloudflar
 
 | Syntax     |Environment Variable        |
 | ---------- | --------------------------- |
-| `cloudlared tunnel --region <VALUE> run <UUID or NAME>` | `TUNNEL_REGION` |
+| `cloudflared tunnel --region <VALUE> run <UUID or NAME>` | `TUNNEL_REGION` |
 
 Allows you to choose the regions to which connections are established. Currently the only available value is `us`, which routes all connections through data centers in the United States. Omit or leave empty to connect to the global region.
 
@@ -134,7 +134,7 @@ Allows you to choose the regions to which connections are established. Currently
 
 | Syntax          | Default | Environment Variable |
 | --------------- | ------- | -------------------- |
-| `cloudlared tunnel --retries <VALUE> run <UUID or NAME>` | `5`     | `TUNNEL_RETRIES`     |
+| `cloudflared tunnel --retries <VALUE> run <UUID or NAME>` | `5`     | `TUNNEL_RETRIES`     |
 
 Specifies the maximum number of retries for connection/protocol errors. Retries use exponential backoff (retrying at 1, 2, 4, 8, 16 seconds by default), so it is not recommended that you increase this value significantly.
 
@@ -142,7 +142,7 @@ Specifies the maximum number of retries for connection/protocol errors. Retries 
 
 | Syntax                 | Environment Variable |
 | ---------------------- | -------------------- |
-| `cloudlared tunnel --tag <KEY=VAL> run <UUID or NAME>` | `TUNNEL_TAG`         |
+| `cloudflared tunnel --tag <KEY=VAL> run <UUID or NAME>` | `TUNNEL_TAG`         |
 
 Specifies custom tags used to identify this tunnel. Multiple tags may be specified by adding additional `--tag <KEY=VAL>` flags to the command. If entering multiple tags into a configuration file, delimit with commas: `tag: {KEY1=VALUE1, KEY2=VALUE2}`.
 
@@ -154,6 +154,6 @@ For remotely-managed tunnels only.
 
 | Syntax        | Environment Variable |
 | ------------- | -------------------- |
-| `cloudlared tunnel run --token <TUNNEL_TOKEN>` | `TUNNEL_TOKEN`       |
+| `cloudflared tunnel run --token <TUNNEL_TOKEN>` | `TUNNEL_TOKEN`       |
 
 Associates the `cloudflared` instance with a specific tunnel. The tunnel's token is shown in the dashboard when you first [create the tunnel](/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/). You can also retrieve the token using the [API](/api/operations/cloudflare-tunnel-get-a-cloudflare-tunnel-token).

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -215,7 +215,7 @@ The following configuration defines the specifications for the GCP virtual machi
 
 ### Export variables to Ansible
 
-The following Terraform resource exports the tunnel ID and other variables to `tf_ansible_vars_file.yml`. Ansible will use this data to configure and run `cloudlared` on the server.
+The following Terraform resource exports the tunnel ID and other variables to `tf_ansible_vars_file.yml`. Ansible will use this data to configure and run `cloudflared` on the server.
 
 1. In your configuration directory, create a new `tf` file:
 


### PR DESCRIPTION
- Fixes typos on cloudflared in Tunnel docs.
- Also fixes the same type in Ansible docs.