### PR TITLE
Update example plist and mobile config

### DIFF
--- a/content/cloudflare-one/static/documentation/connections/CloudflareWARP.mobileconfig
+++ b/content/cloudflare-one/static/documentation/connections/CloudflareWARP.mobileconfig
@@ -21,16 +21,12 @@
   <key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>auto_connect</key>
-			<integer>1</integer>
-			<key>organization</key>
-			<string>yourorganization</string>
-			<key>service_mode</key>
-			<string>warp</string>
-			<key>support_url</key>
-			<string>https://support.example.com</string>
-			<key>switch_locked</key>
-			<false/>
+    	<key>organization</key>
+    	<string>yourorganization</string>
+    	<key>auto_connect</key>
+    	<integer>120</integer>
+    	<key>onboarding</key>
+    	<false/>
 			<key>PayloadDisplayName</key>
 			<string>Warp Configuration</string>
 			<key>PayloadIdentifier</key>

--- a/content/cloudflare-one/static/documentation/connections/com.cloudflare.warp.plist
+++ b/content/cloudflare-one/static/documentation/connections/com.cloudflare.warp.plist
@@ -2,15 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>enable</key>
-	<true />
-	<key>gateway_unique_id</key>
-	<string>your_gateway_doh_subdomain</string>
 	<key>organization</key>
 	<string>yourorganization</string>
-	<key>service_mode</key>
-	<string>warp</string>
-	<key>support_url</key>
-	<string>https://support.example.com</string>
+	<key>auto_connect</key>
+	<integer>120</integer>
+	<key>onboarding</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
The old example used a param that we no longer support. Modifying the example to a better starting template