### PR TITLE
[Workers] Remove per-worker cron limits

### DIFF
--- a/content/workers/examples/multiple-cron-triggers.md
+++ b/content/workers/examples/multiple-cron-triggers.md
@@ -17,7 +17,6 @@ export default {
   async scheduled(event, env, ctx) {
     // Write code for updating your API
     switch (event.cron) {
-      // You can set up to three schedules maximum.
       case "*/3 * * * *":
         // Every three minutes
         await updateAPI();
@@ -44,7 +43,6 @@ const handler: ExportedHandler = {
   async scheduled(event, env, ctx) {
     // Write code for updating your API
     switch (event.cron) {
-      // You can set up to three schedules maximum.
       case "*/3 * * * *":
         // Every three minutes
         await updateAPI();

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -18,7 +18,6 @@ title: Limits
 | [Worker size](#worker-size)                                                     | 1 MB      | 10 MB      |
 | [Worker startup time](#worker-startup-time)                                     | 400 ms    | 400 ms    |
 | [Number of Workers](#number-of-workers)                                         | 100       | 500       |
-| Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per Worker | 3         | 3         |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account| 5         | 250       |
 
 {{</table-wrap>}}

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -2,6 +2,10 @@
 link: "/workers/platform/changelog/"
 productName: Workers
 entries:
+- publish_date: '2023-10-18'
+  description: |-
+    - The limit of 3 cron triggers per Worker has been removed. Account-level limits on the total number of
+      cron triggers across all Workers still apply.
 - publish_date: '2023-09-14'
   description: |-
     - An implementation of the [`node:crypto`](/workers/runtime-apis/nodejs/crypto/)

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -4,7 +4,7 @@ productName: Workers
 entries:
 - publish_date: '2023-10-18'
   description: |-
-    - The limit of 3 cron triggers per Worker has been removed. Account-level limits on the total number of
+    - The limit of 3 Cron Triggers per Worker has been removed. Account-level limits on the total number of
       cron triggers across all Workers still apply.
 - publish_date: '2023-09-14'
   description: |-

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -5,7 +5,7 @@ entries:
 - publish_date: '2023-10-18'
   description: |-
     - The limit of 3 Cron Triggers per Worker has been removed. Account-level limits on the total number of
-      cron triggers across all Workers still apply.
+      Cron Triggers across all Workers still apply.
 - publish_date: '2023-09-14'
   description: |-
     - An implementation of the [`node:crypto`](/workers/runtime-apis/nodejs/crypto/)


### PR DESCRIPTION
- There is no longer a limit on the number of cron schedules per worker
- The limit on total cron schedules per account still applies