### PR TITLE
Use ctx.req.url when fetching assets

### DIFF
--- a/content/pages/framework-guides/deploy-a-hono-site.md
+++ b/content/pages/framework-guides/deploy-a-hono-site.md
@@ -32,7 +32,7 @@ To serve static files like CSS, image or JavaScript files, add the following to 
 
 ```javascript
 app.get("/public/*", async (ctx) => {
-  return await ctx.env.ASSETS.fetch(ctx.req.url);
+  return await ctx.env.ASSETS.fetch(ctx.req.raw);
 });
 ```
 

--- a/content/pages/framework-guides/deploy-a-hono-site.md
+++ b/content/pages/framework-guides/deploy-a-hono-site.md
@@ -32,7 +32,7 @@ To serve static files like CSS, image or JavaScript files, add the following to 
 
 ```javascript
 app.get("/public/*", async (ctx) => {
-  return await ctx.env.ASSETS.fetch(ctx.req);
+  return await ctx.env.ASSETS.fetch(ctx.req.url);
 });
 ```
 


### PR DESCRIPTION
Because the fetch API expects a full URL, the example fails with:

```
Fetch API cannot load: [object Object]
```

The issues is passing the full Hono request object isn't handled by the `ASSETS.fetch` function.

Changing to `ctx.req.url` causes the assets to properly load as expected.