### PR TITLE
[Workers] Add Workers crypto_preserve_public_exponent compatibility flag

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/crypto-preserve-public-exponent.md
+++ b/content/workers/_partials/_platform-compatibility-dates/crypto-preserve-public-exponent.md
@@ -1,0 +1,14 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "WebCrypto preserve publicExponent field"
+sort_date: "2023-12-01"
+enable_date: "2023-12-01"
+enable_flag: "crypto_preserve_public_exponent"
+disable_flag: "no_crypto_preserve_public_exponent"
+---
+
+In the WebCrypto API, the `publicExponent` field of the algorithm of RSA keys would previously be an `ArrayBuffer`. Using this flag, `publicExponent` is a `Uint8Array` as mandated by the specification.

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -2,6 +2,11 @@
 link: "/workers/platform/changelog/"
 productName: Workers
 entries:
+- publish_date: '2023-10-20'
+  description: |-
+    - Added the [`crypto_preserve_public_exponent`](/workers/configuration/compatibility-dates/#crypto-preserve-public-exponent)
+      compatibility flag to correct a wrong type being used in the algorithm field of RSA keys in
+      the WebCrypto API.
 - publish_date: '2023-10-18'
   description: |-
     - The limit of 3 Cron Triggers per Worker has been removed. Account-level limits on the total number of


### PR DESCRIPTION
Add the new cryptoPreservePublicExponent compatibility flag, implemented in https://github.com/cloudflare/workerd/commit/461a1371b1c28cb825820d0bf5ca59d288ee3161 and now available in production.