### PR TITLE
Workers: Add user limits documentation

### DIFF
--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -123,6 +123,12 @@ A Worker that serves 100 million requests per month, and uses an average of 7 mi
 
 {{</table-wrap>}}
 
+{{<Aside type="note" header="Custom limits">}}
+
+The Standard Usage Model is flexible, allowing for many diverse workflows, but some customers may want additional safety measures to prevent accidental runaway bills or denial-of-wallet attacks. You can configure the maximum amount of CPU time that can be used per invocation by [defining limits in your Worker's `wrangler.toml` file](/workers/wrangler/configuration/#limits), or via the Cloudflare dashboard.
+
+{{</Aside>}}
+
 ### How to switch Usage Models
 
 When an account is first upgraded to the Paid plan, the Unbound plan is used as the default Usage Model. To change your default account-wide Usage Model:

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -137,6 +137,10 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
 
   - Enables Workers Trace Events Logpush for a Worker. Any scripts with this property will automatically get picked up by the Workers Logpush job configured for your account. Defaults to `false`.
 
+- `limits` {{<type-link href="#limits">}}Limits{{</type-link>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - Configures limits to be imposed on execution at runtime. Refer to [Limits](#limits).
+
 {{</definitions>}}
 
 ## Non-inheritable keys
@@ -330,6 +334,28 @@ header: wrangler.toml
 command = "npm run build"
 cwd = "build_cwd"
 watch_dir = "build_watch_dir"
+```
+
+## Limits
+
+You can impose limits on your Worker's behavior at runtime. Only supported for the [Standard Usage Model](/workers/platform/pricing/#standard-usage-model). Limits are only enforced when deployed to Cloudflare's Network, not in local development.
+
+{{<definitions>}}
+
+- `cpu_ms` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The maximum CPU time allowed per invocation, in milliseconds.
+
+{{</definitions>}}
+
+Example:
+
+```toml
+---
+header: wrangler.toml
+---
+[limits]
+cpu_ms = 100
 ```
 
 ## Bindings


### PR DESCRIPTION
Adds documentation to wrangler configuration and the standard usage model about the new limits configuration