### PR TITLE
Redirect /constellation to /workers-ai

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1141,6 +1141,7 @@
 # Constellation
 /constellation/platform/wrangler/ /constellation/ 301
 /constellation/platform/ /constellation/ 301
+/constellation/ /workers-ai/ 301
 
 # zaraz
 


### PR DESCRIPTION
@sdayman noted this is confusing since current Constellation page doesn't mention anything about Workers AI being the right, current way to get started with AI inference on our platform.

cc @pdwittig @pedrosousa 