### PR TITLE
[Workers] fix: more idiomatic code for twilio github sms tutorial

### DIFF
--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -142,16 +142,16 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 
 function checkSignature(text, headers, githubSecretToken) {
-  const hmac = createHmac('sha1', githubSecretToken);
+  const hmac = createHmac('sha256', githubSecretToken);
   hmac.update(text, 'utf-8');
   const expectedSignature = hmac.digest('hex');
+  const actualSignature = headers.get('x-hub-signature-256');
 
-  const actualSignature = headers.get('X-Hub-Signature');
+  const trusted = Buffer.from(`sha256=${expectedSignature}`, 'ascii');
+  const untrusted =  Buffer.from(actualSignature, 'ascii');
 
-  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
-  const actualBuffer = Buffer.from(actualSignature, 'hex');
-  return expectedBuffer.byteLength == actualBuffer.byteLength
-    && crypto.timingSafeEqual(expectedBuffer, actualBuffer);
+  return trusted.byteLength == untrusted.byteLength
+    && crypto.timingSafeEqual(trusted, untrusted);
 };
 ```
 

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -38,7 +38,7 @@ $ npm create cloudflare@latest
 ```
 
 For setup, select the following options:
-* `Where do you want to create your application?`: Input `github-twilio-notifications`. 
+* `Where do you want to create your application?`: Input `github-twilio-notifications`.
 * `What type of application do you want to create?`: Select `"Hello World" Worker`.
 * `Do you want to use TypeScript?`: Select `No`.
 * `Do you want to deploy your application?`: Select `Yes`.
@@ -123,11 +123,8 @@ async fetch(request, env, ctx) {
   try {
     const formData = await request.json();
     const headers = await request.headers;
-    const action = headers.get('X-GitHub-Event');
-    const repo_name = formData.repository.full_name;
-    const sender_name = formData.sender.login;
 
-    if (!checkSignature(formData, headers, env.GITHUB_SECRET_TOKEN)) {
+    if (await checkSignature(formData, headers, env.GITHUB_SECRET_TOKEN) === false) {
       return new Response("Wrong password, try again", {status: 403});
     }
   } catch (e) {
@@ -136,25 +133,26 @@ async fetch(request, env, ctx) {
 },
 ```
 
-The `checkSignature` function will use the crypto library to hash the received payload with your known secret key to ensure it matches the request hash. GitHub uses an HMAC hexdigest to compute the hash in the SHA1 format. You will place this function at the top of your `index.js` file, before your export.
+The `checkSignature` function will use the node crypto library to hash the received payload with your known secret key to ensure it matches the request hash. GitHub uses an HMAC hexdigest to compute the hash in the SHA1 format. You will place this function at the top of your `index.js` file, before your export.
 
 ```js
 ---
 filename: worker.js - checkSignature()
 ---
-const crypto = require('crypto');
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { Buffer } from 'node:buffer';
 
 async function checkSignature(formData, headers, githubSecretToken) {
-  let hmac = crypto.createHmac('sha1', githubSecretToken);
+  const hmac = createHmac('sha1', githubSecretToken);
   hmac.update(formData, 'utf-8');
-  let expectedSignature = hmac.digest('hex');
+  const expectedSignature = hmac.digest('hex');
 
-  let actualSignature = headers.get('X-Hub-Signature');
+  const actualSignature = headers.get('X-Hub-Signature');
 
   const expectedBuffer = Buffer.from(expectedSignature, 'hex');
   const actualBuffer = Buffer.from(actualSignature, 'hex');
-  return expectedBuffer.byteLength == actualBuffer.byteLength &&
-             crypto.timingSafeEqual(expectedBuffer, actualBuffer);
+  return expectedBuffer.byteLength == actualBuffer.byteLength
+    && crypto.timingSafeEqual(expectedBuffer, actualBuffer);
 };
 ```
 
@@ -163,13 +161,13 @@ To make this work, you need to use [`wrangler secret put`](/workers/wrangler/com
 $ npx wrangler secret put GITHUB_SECRET_TOKEN
 ```
 
-Add the node_compat flag to your `wrangler.toml` file:
+Add the nodejs_compat flag to your `wrangler.toml` file:
 
 ```toml
 ---
 filename: "wrangler.toml"
 ---
-node_compat = true
+compatability_flags = ["nodejs_compat"]
 ```
 
 ---
@@ -186,14 +184,15 @@ Create a new function called `sendText()` that will handle making the request to
 filename: worker.js - sendText()
 ---
 async function sendText(accountSid, authToken, message) {
-  const endpoint = 'https://api.twilio.com/2010-04-01/Accounts/' + accountSid + '/Messages.json';
+  const endpoint = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
 
-  let encoded = new URLSearchParams();
-  encoded.append('To', "%YOUR_PHONE_NUMBER%");
-  encoded.append('From', "%YOUR_TWILIO_NUMBER%");
-  encoded.append('Body', message);
+  const encoded = new URLSearchParams({
+    'To': "%YOUR_PHONE_NUMBER%",
+    'From': "%YOUR_TWILIO_NUMBER%",
+    'Body': message
+  });
 
-  let token = btoa(accountSid + ':' + authToken);
+  const token = btoa(`${accountSid}:${authToken}`);
 
   const request = {
     body: encoded,
@@ -201,12 +200,13 @@ async function sendText(accountSid, authToken, message) {
     headers: {
       'Authorization': `Basic ${token}`,
       'Content-Type': 'application/x-www-form-urlencoded',
-    },}
+    }
+  };
 
-  let result = await fetch(endpoint, request);
-  result = await result.json();
+  const response = await fetch(endpoint, request);
+  const result = await response.json();
 
-  return new Response(JSON.stringify(result));
+  return Response.json(result);
 };
 ```
 
@@ -225,28 +225,28 @@ filename: worker.js - fetch()
 ---
 async fetch(request, env, ctx) {
   if(request.method !== 'POST') {
-      return new Response('Please send a POST request!');
+    return new Response('Please send a POST request!');
   }
   try {
     const formData = await request.json();
     const headers = await request.headers;
     const action = headers.get('X-GitHub-Event');
-    const repo_name = formData.repository.full_name;
-    const sender_name = formData.sender.login;
+    const repoName = formData.repository.full_name;
+    const senderName = formData.sender.login;
 
-    if (!checkSignature(formData, headers)) {
+    if (await checkSignature(formData, headers) === false) {
       return new Response("Wrong password, try again", {status: 403});
     }
 
     return await sendText(
-        env.TWILIO_ACCOUNT_SID,
-        env.TWILIO_AUTH_TOKEN,
-        `${sender_name} completed ${action} onto your repo ${repo_name}`
+      env.TWILIO_ACCOUNT_SID,
+      env.TWILIO_AUTH_TOKEN,
+      `${senderName} completed ${action} onto your repo ${repoName}`
     );
   } catch (e) {
     return new Response(`Error:  ${e}`);
   }
-},
+};
 ```
 
 Run the `npx wrangler publish` command to redeploy your Worker project:

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -143,7 +143,7 @@ import { Buffer } from 'node:buffer';
 
 function checkSignature(text, headers, githubSecretToken) {
   const hmac = createHmac('sha256', githubSecretToken);
-  hmac.update(text, 'utf-8');
+  hmac.update(text);
   const expectedSignature = hmac.digest('hex');
   const actualSignature = headers.get('x-hub-signature-256');
 

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -166,7 +166,7 @@ Add the nodejs_compat flag to your `wrangler.toml` file:
 ---
 filename: "wrangler.toml"
 ---
-compatability_flags = ["nodejs_compat"]
+compatibility_flags = ["nodejs_compat"]
 ```
 
 ---

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -122,7 +122,7 @@ async fetch(request, env, ctx) {
   }
   try {
     const formData = await request.json();
-    const headers = await request.headers;
+    const headers = request.headers;
 
     if (await checkSignature(formData, headers, env.GITHUB_SECRET_TOKEN) === false) {
       return new Response("Wrong password, try again", {status: 403});
@@ -229,7 +229,7 @@ async fetch(request, env, ctx) {
   }
   try {
     const formData = await request.json();
-    const headers = await request.headers;
+    const headers = request.headers;
     const action = headers.get('X-GitHub-Event');
     const repoName = formData.repository.full_name;
     const senderName = formData.sender.login;

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -186,8 +186,8 @@ async function sendText(accountSid, authToken, message) {
   const endpoint = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
 
   const encoded = new URLSearchParams({
-    'To': "%YOUR_PHONE_NUMBER%",
-    'From': "%YOUR_TWILIO_NUMBER%",
+    'To': '%YOUR_PHONE_NUMBER%',
+    'From': '%YOUR_TWILIO_NUMBER%',
     'Body': message
   });
 
@@ -229,7 +229,7 @@ async fetch(request, env, ctx) {
   try {
     const rawBody = await request.text();
     if (!checkSignature(rawBody, request.headers)) {
-      return new Response("Wrong password, try again", {status: 403});
+      return new Response('Wrong password, try again', {status: 403});
     }
 
     const action = request.headers.get('X-GitHub-Event');

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -132,7 +132,7 @@ async fetch(request, env, ctx) {
 },
 ```
 
-The `checkSignature` function will use the node crypto library to hash the received payload with your known secret key to ensure it matches the request hash. GitHub uses an HMAC hexdigest to compute the hash in the SHA1 format. You will place this function at the top of your `index.js` file, before your export.
+The `checkSignature` function will use the Node.js crypto library to hash the received payload with your known secret key to ensure it matches the request hash. GitHub uses an HMAC hexdigest to compute the hash in the SHA-256 format. You will place this function at the top of your `index.js` file, before your export.
 
 ```js
 ---
@@ -151,7 +151,7 @@ function checkSignature(text, headers, githubSecretToken) {
   const untrusted =  Buffer.from(actualSignature, 'ascii');
 
   return trusted.byteLength == untrusted.byteLength
-    && crypto.timingSafeEqual(trusted, untrusted);
+    && timingSafeEqual(trusted, untrusted);
 };
 ```
 
@@ -228,7 +228,7 @@ async fetch(request, env, ctx) {
   }
   try {
     const rawBody = await request.text();
-    if (!checkSignature(rawBody, request.headers)) {
+    if (!checkSignature(rawBody, request.headers, env.GITHUB_SECRET_TOKEN)) {
       return new Response('Wrong password, try again', {status: 403});
     }
 

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -123,7 +123,7 @@ async fetch(request, env, ctx) {
   try {
     const rawBody = await request.text();
 
-    if (await checkSignature(rawBody, request.headers, env.GITHUB_SECRET_TOKEN) === false) {
+    if (!checkSignature(rawBody, request.headers, env.GITHUB_SECRET_TOKEN)) {
       return new Response("Wrong password, try again", {status: 403});
     }
   } catch (e) {
@@ -141,7 +141,7 @@ filename: worker.js - checkSignature()
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 
-async function checkSignature(text, headers, githubSecretToken) {
+function checkSignature(text, headers, githubSecretToken) {
   const hmac = createHmac('sha1', githubSecretToken);
   hmac.update(text, 'utf-8');
   const expectedSignature = hmac.digest('hex');
@@ -228,7 +228,7 @@ async fetch(request, env, ctx) {
   }
   try {
     const rawBody = await request.text();
-    if (await checkSignature(rawBody, request.headers) === false) {
+    if (!checkSignature(rawBody, request.headers)) {
       return new Response("Wrong password, try again", {status: 403});
     }
 


### PR DESCRIPTION
This fixes a bunch of code issues with the github twilio tutorial, including:

- the `checkSignature` being async, meaning it was returning a promise and always therefore being truthy
	- this previously meant that this would never ever fail
- hmac updating for the crypto functions only taking a string
   - with above, the hmac was actually getting set to an invalid stringified `[object Object]`, but because `checkSignature` always returned truthy, it was never failing
- use `x-hub-signature-256` for validation instead of legacy `x-hub-signature`. ref: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
- better usage of `const` vs `let`
- nicer response handling
- improved indentation
- using `nodejs_compat` instead of `node_compat`
- consistent variable casing
- and other small issues