### PR TITLE
docs: cloudflare r2 tf: best practices, v5 aws

### DIFF
--- a/content/r2/examples/terraform-aws.md
+++ b/content/r2/examples/terraform-aws.md
@@ -22,29 +22,32 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 4"
+      version = "~> 5"
     }
   }
 }
 
 provider "aws" {
-  region     = "us-east-1"
+  region = "us-east-1"
+
   access_key = <R2 Access Key>
   secret_key = <R2 Secret Key>
+
   skip_credentials_validation = true
-  skip_region_validation = true
-  skip_requesting_account_id = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+
   endpoints {
     s3 = "https://<account id>.r2.cloudflarestorage.com"
   }
 }
 
-resource "aws_s3_bucket" "cloudflare-bucket" {
-  bucket = "my-tf-test-bucket"
+resource "aws_s3_bucket" "default" {
+  bucket = "<org>-test"
 }
 
-resource "aws_s3_bucket_cors_configuration" "public_bucket_cors" {
-  bucket   = aws_s3_bucket.cloudflare-bucket.id
+resource "aws_s3_bucket_cors_configuration" "default" {
+  bucket   = aws_s3_bucket.default.id
 
   cors_rule {
     allowed_methods = ["GET"]
@@ -52,17 +55,19 @@ resource "aws_s3_bucket_cors_configuration" "public_bucket_cors" {
   }
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "life_cycles" {
-  bucket = aws_s3_bucket.cloudflare-bucket.id
+resource "aws_s3_bucket_lifecycle_configuration" "default" {
+  bucket = aws_s3_bucket.default.id
+
   rule {
-    id = "expire-bucket"
+    id     = "expire-bucket"
     status = "Enabled"
     expiration {
       days = 1
     }
   }
+
   rule {
-    id = "abort-multipart-upload"
+    id     = "abort-multipart-upload"
     status = "Enabled"
     abort_incomplete_multipart_upload {
       days_after_initiation = 1

--- a/content/r2/examples/terraform-aws.md
+++ b/content/r2/examples/terraform-aws.md
@@ -3,7 +3,7 @@ title: Terraform (AWS)
 pcx_content_type: configuration
 ---
 
-# Configure R2 with Terraform
+# Configure R2 with Terraform 
 
 {{<render file="_keys.md">}}<br>
 


### PR DESCRIPTION
## what
- docs: cloudflare r2 tf: best practices, v5 aws

## why
- remove kebab-case in name and addresses
- remove redundant resoure names
- latest aws provider
- terraform fmt

## references
- https://developers.cloudflare.com/r2/examples/terraform-aws/