### PR TITLE
Prefer random_password over random_id

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -123,7 +123,7 @@ The following configuration will modify settings in your Cloudflare account.
    # Using `random_password` means the result is treated as sensitive and, thus,
    # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
-     byte_length = 64
+     length = 64
    }
 
    # Creates a new locally-managed tunnel for the GCP VM.

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -121,7 +121,7 @@ The following configuration will modify settings in your Cloudflare account.
    ---
    # Generates a 64-character secret for the tunnel.
    # Using `random_password` means the result is treated as sensitive and, thus,
-   # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
+   # not displayed in console output. Refer to: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
      length = 64
    }

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -120,6 +120,8 @@ The following configuration will modify settings in your Cloudflare account.
    filename: Cloudflare-config.tf
    ---
    # Generates a 35-character secret for the tunnel.
+   # Using `random_password` means the result is treated as sensitive and, thus,
+   # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
      byte_length = 64
    }

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -120,15 +120,15 @@ The following configuration will modify settings in your Cloudflare account.
    filename: Cloudflare-config.tf
    ---
    # Generates a 35-character secret for the tunnel.
-   resource "random_id" "tunnel_secret" {
-     byte_length = 35
+   resource "random_password" "tunnel_secret" {
+     byte_length = 64
    }
 
    # Creates a new locally-managed tunnel for the GCP VM.
-   resource "cloudflare_argo_tunnel" "auto_tunnel" {
+   resource "cloudflare_tunnel" "auto_tunnel" {
      account_id = var.cloudflare_account_id
      name       = "Ansible GCP tunnel"
-     secret     = random_id.tunnel_secret.b64_std
+     secret     = base64sha256(random_password.tunnel_secret.result)
    }
 
    # Creates the CNAME record that routes ssh_app.${var.cloudflare_zone} to the tunnel.

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/ansible.md
@@ -119,7 +119,7 @@ The following configuration will modify settings in your Cloudflare account.
    ---
    filename: Cloudflare-config.tf
    ---
-   # Generates a 35-character secret for the tunnel.
+   # Generates a 64-character secret for the tunnel.
    # Using `random_password` means the result is treated as sensitive and, thus,
    # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
@@ -133,7 +133,7 @@ The following configuration will modify settings in your Cloudflare account.
    ---
    filename: Cloudflare-config.tf
    ---
-   # Generates a 35-character secret for the tunnel.
+   # Generates a 64-character secret for the tunnel.
    # Using `random_password` means the result is treated as sensitive and, thus,
    # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
@@ -135,7 +135,7 @@ The following configuration will modify settings in your Cloudflare account.
    ---
    # Generates a 64-character secret for the tunnel.
    # Using `random_password` means the result is treated as sensitive and, thus,
-   # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
+   # not displayed in console output. Refer to: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
      length = 64
    }

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
@@ -137,7 +137,7 @@ The following configuration will modify settings in your Cloudflare account.
    # Using `random_password` means the result is treated as sensitive and, thus,
    # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
-     byte_length = 64
+     length = 64
    }
 
    # Creates a new locally-managed tunnel for the GCP VM.

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
@@ -134,6 +134,8 @@ The following configuration will modify settings in your Cloudflare account.
    filename: Cloudflare-config.tf
    ---
    # Generates a 35-character secret for the tunnel.
+   # Using `random_password` means the result is treated as sensitive and, thus,
+   # not displayed in console output. See: https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
    resource "random_password" "tunnel_secret" {
      byte_length = 64
    }

--- a/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
+++ b/content/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/terraform.md
@@ -134,15 +134,15 @@ The following configuration will modify settings in your Cloudflare account.
    filename: Cloudflare-config.tf
    ---
    # Generates a 35-character secret for the tunnel.
-   resource "random_id" "tunnel_secret" {
-     byte_length = 35
+   resource "random_password" "tunnel_secret" {
+     byte_length = 64
    }
 
    # Creates a new locally-managed tunnel for the GCP VM.
    resource "cloudflare_tunnel" "auto_tunnel" {
      account_id = var.cloudflare_account_id
      name       = "Terraform GCP tunnel"
-     secret     = random_id.tunnel_secret.b64_std
+     secret     = base64sha256(random_password.tunnel_secret.result)
    }
 
    # Creates the CNAME record that routes http_app.${var.cloudflare_zone} to the tunnel.


### PR DESCRIPTION
`random_id` can be displayed in terraform output while `random_password` will not