### PR TITLE
Fix typo on deploy worker yaml

### DIFF
--- a/content/workers/wrangler/ci-cd.md
+++ b/content/workers/wrangler/ci-cd.md
@@ -55,7 +55,8 @@ filename: .github/workflows/push.yml
 name: Deploy Worker
 on:
   push:
-    main
+    branches:
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nested object required under push (ie: branches)