### PR TITLE
[Chore] Add concurrency to GH actions

### DIFF
--- a/.github/workflows/comment-changed-filenames.yml
+++ b/.github/workflows/comment-changed-filenames.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - production
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   flag_changed_filenames:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,6 +6,10 @@ name: Label PRs
 
 on: [pull_request_target]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   
   label_products:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compile:
     name: Assign PCX

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   spell-check:


### PR DESCRIPTION
This only affects the non-required actions for PRs. Should give us some soak time before we'd roll this out for required actions.

Goal is to reduce the # of queued builds and delays that impact our team (since we're limited on runners in our repo).