### PR TITLE
[Chore] Only run show-changed-files if PR is open

### DIFF
--- a/.github/workflows/show-changed-files.yml
+++ b/.github/workflows/show-changed-files.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   changed-files-links:
     name: Show Changed Files
-    if: github.event.issue.pull_request && github.event.comment.user.id == 73139402 && contains(github.event.comment.body, 'Deploy successful')
+    if: github.event.issue.pull_request && github.event.issue.state == 'open' && github.event.comment.user.id == 73139402 && contains(github.event.comment.body, 'Deploy successful')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Based on the [workflow histories](https://github.com/cloudflare/cloudflare-docs/actions/workflows/show-changed-files.yml):
a) it looks like the Pages bot updates the build links incredibly frequently, even for closed PRs.
b) we're running our action on all of those closed PRs, which could be leading to delays in actions.

Based on the parameters in [get an event details](https://docs.github.com/en/rest/issues/events?apiVersion=2022-11-28#get-an-issue-event), we can constrain the check by only looking at `open` issues (PRs are a type of issue and it's easier to access the top-level prop).