### PR TITLE
Clarify transform rules examples for different plans.

### DIFF
--- a/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
+++ b/content/images/cloudflare-images/serve-images/serve-images-custom-domains.md
@@ -33,11 +33,40 @@ In this example, `<ACCOUNT_HASH>`, `<IMAGE_ID>` and `<VARIANT_NAME>` are the sam
 
 By default, Images are served from the `/cdn-cgi/imagedelivery/` path. You can use Transform Rules to rewrite URLs and serve images from custom paths.
 
+### Basic version
+
+Free and Pro plans only support string matching rules that do not require regular expressions.
+
+This example lets you rewrite a request from `example.com/images` to `example.com/cdn-cgi/imagedelivery/<ACCOUNT HASH>`.
+
+To create a rule:
+
+1. Log in to the Cloudflare dashboard and select your account and website. 
+2. Select **Rules** > **Transform Rules**.
+3. Select **Create rule**.
+4. Under **When incoming requests match...**, select **Edit expression**
+4. In the text field, enter `starts_with(http.request.uri.path, "/images")`.
+5. Under **Path**, select **Rewrite to**.
+6. Select *Dynamic* and enter the following in the text field.
+
+```txt
+concat(
+  "/cdn-cgi/imagedelivery/<ACCOUNT HASH>",
+  substring(http.request.uri.path, 7)
+)
+```
+
+7. Select **Deploy** when you are done.
+
+### Advanced version
+
 {{<Aside type="note">}}
 
-This feature requires a Business or WAF Advanced plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
+This feature requires a Business or Enterprise plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
 
 {{</Aside>}}
+
+This example lets you rewrite a request from `example.com/images/some-image-id/w100,h300` to `example.com/cdn-cgi/imagedelivery/<ACCOUNT HASH>/some-image-id/width=100,height=300` and implies [Flexible variants](/images/cloudflare-images/transform/flexible-variants/) feature is turned on.
 
 To create a rule:
 
@@ -51,13 +80,11 @@ To create a rule:
 
 ```txt
 regex_replace(
-  http.request.uri.path,
-  "^/images/",
-  "/cdn-cgi/imagedelivery/<ACCOUNT HASH>/"
+  http.request.uri.path, 
+  "^/images/(.*)\\?w([0-9]+)&h([0-9]+)$",
+  "/cdn-cgi/imagedelivery/<ACCOUNT HASH>/${1}/width=${2},height=${3}"
 )
 ```
-
-7. Select **Deploy** when you are done.
 
 ## Limitations
 When using a custom domain, it is not possible to directly set up WAF rules that act on requests hitting the `/cdn-cgi/imagedelivery/` path. If you need to set up WAF rules, you can:

--- a/content/images/image-resizing/serve-images-custom-paths.md
+++ b/content/images/image-resizing/serve-images-custom-paths.md
@@ -28,9 +28,40 @@ To direct the request to the origin server, you can check for the string `image-
 
 `...and (not (any(http.request.headers["via"][*] contains "image-resizing")))`
 
-## Serve images from custom paths 
+## Serve images from custom paths
 
 By default, requests to transform images through Image Resizing are served from the `/cdn-cgi/image/` path.
+You can use Transform Rules to rewrite URLs.
+
+### Basic version
+
+Free and Pro plans only support string matching rules that do not require regular expressions.
+
+This example lets you rewrite a request from `example.com/images` to `example.com/cdn-cgi/image/`:
+
+```txt
+---
+header: Text in Expression Editor
+---
+(starts_with(http.request.uri.path, "/images")) and (not (any(http.request.headers["via"][*] contains "image-resizing")))
+```
+
+```txt
+---
+header: Text in Path > Rewrite to... > Dynamic
+---
+concat("/cdn-cgi/images", substring(http.request.uri.path, 7))
+```
+
+### Advanced version
+
+{{<Aside type="note">}}
+
+This feature requires a Business or Enterprise plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
+
+{{</Aside>}}
+
+There is an advanced version of Transform Rules supporting regular expressions.
 
 This example lets you rewrite a request from `example.com/images` to `example.com/cdn-cgi/image/`:
 
@@ -45,10 +76,16 @@ header: Text in Expression Editor
 ---
 header: Text in Path > Rewrite to... > Dynamic
 ---
-regex_replace(   http.request.uri.path,   "^/images/",   "/cdn-cgi/image/" )
+regex_replace(http.request.uri.path, "^/images/", "/cdn-cgi/image/")
 ```
 
 ## Modify existing URLS to be compatible with Image Resizing
+
+{{<Aside type="note">}}
+
+This feature requires a Business or Enterprise plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
+
+{{</Aside>}}
 
 This example lets you rewrite your URL parameters to be compatible with Image Resizing:
 
@@ -73,6 +110,12 @@ regex_replace(
 Leave the **Query** > **Rewrite to...** > *Static* field empty.
 
 ## Pass every image requested on your zone through Image Resizing
+
+{{<Aside type="note">}}
+
+This feature requires a Business or Enterprise plan to enable regex in Transform Rules. Refer to [Cloudflare Transform Rules Availability](/rules/transform/#availability) for more information.
+
+{{</Aside>}}
 
 This example lets you pass every image that is requested on your zone through Image Resizing with the `format=auto` option:
 


### PR DESCRIPTION
Add examples for Free and Pro plans using basic version of transform rules. Plain string matching and concatenation is sufficient enough for most of the use cases.