### PR TITLE
[Wrangler] Update commands list

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -344,6 +344,10 @@ $ wrangler d1 migrations apply <DATABASE_NAME> [OPTIONS]
 
 ## `hyperdrive`
 
+{{<Aside type="note">}}
+Hyperdrive is currently in open beta. Report Hyperdrive bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+{{</Aside>}}
+
 Manage [Hyperdrive](/hyperdrive/) database configurations.
 
 ### `create`
@@ -429,6 +433,10 @@ $ wrangler hyperdrive get <ID> [OPTIONS]
 ---
 
 ## vectorize
+
+{{<Aside type="note">}}
+Vectorize is currently in open beta. Report Vectorize bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+{{</Aside>}}
 
 Interact with a [Vectorize](/vectorize/) vector database.
 
@@ -1822,7 +1830,7 @@ $ wrangler whoami
 ## deployments
 
 {{<Aside type="note">}}
-Deployments are currently in Public Beta and subcommands are currently in Beta. Report deployments bugs to the [Wrangler team](https://github.com/cloudflare/wrangler2/issues/new/choose).
+Deployments are currently in open beta. Report deployments bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 {{</Aside>}}
 
 For more information about deployments and how they work, refer to [Deployments](/workers/configuration/deployments).
@@ -1913,6 +1921,10 @@ binding = "MY_KV"
 ```
 
 ## rollback
+
+{{<Aside type="note">}}
+Rollback is currently in open beta. Report rollback bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+{{</Aside>}}
 
 Rollback to a specified deployment by ID, or to the previous deployment if no ID is provided. The command will prompt you for confirmation of the rollback. On confirmation, you will be prompted to provide an optional message.
 


### PR DESCRIPTION
Update the wrangler commands page with respect to commands that are currently in beta. This is in conjunction with work in wrangler (https://github.com/cloudflare/workers-sdk/pull/3735) to clean up the output of the help command, which includes having clearer indication of commands that are in beta.