### PR TITLE
Fixed typos from permissions.md, azure.md and okta.md

### DIFF
--- a/content/email-security/account-setup/permissions.md
+++ b/content/email-security/account-setup/permissions.md
@@ -31,8 +31,8 @@ Users created at child level will only have access to the assigned child account
 
 - **Super Admin**: Has full access to the account and can make any configuration changes. Can access **Settings** (the gear icon).
 - **Configuration Admin**: Can make configuration changes and manage users, except for Super Admin. Has no ability to review messages.
-- **SOC Analyst**: Can search, review and retract messages. Has no admin capabilites or access to **Settings** (the gear icon).
-- **Viewer**: Only has access to metrics withing the system. No access to **Settings** (the gear icon).
+- **SOC Analyst**: Can search, review and retract messages. Has no admin capabilities or access to **Settings** (the gear icon).
+- **Viewer**: Only has access to metrics within the system. No access to **Settings** (the gear icon).
 
 {{<table-wrap>}}
 

--- a/content/email-security/account-setup/sso/azure.md
+++ b/content/email-security/account-setup/sso/azure.md
@@ -93,7 +93,7 @@ Now that the application configuration is complete, update **User Assignments** 
 7. In **Metadata XML** paste the XML metadata you downloaded in the previous step 11. You can open the downloaded file with a text editor to copy all the text. Make sure there are no leading carriage returns or spaces when you copy the text. Your copied text should begin with:
 
     ```txt
-    <?xml version="1.0" encoding="utf-8"?><EntityDescriptor ID="_<YOUR_DESCRIPTIOR_ID>" entityID="https://<YOUR_ENTITY_ID> " xmlns="urn:oasis:names:tc:SAML:2.0:metadata">...
+    <?xml version="1.0" encoding="utf-8"?><EntityDescriptor ID="_<YOUR_DESCRIPTOR_ID>" entityID="https://<YOUR_ENTITY_ID> " xmlns="urn:oasis:names:tc:SAML:2.0:metadata">...
     ```
 8. Select **Update Settings** to save your configuration.
 

--- a/content/email-security/account-setup/sso/okta.md
+++ b/content/email-security/account-setup/sso/okta.md
@@ -65,7 +65,7 @@ You will need to manually create an app for Area 1 in Okta.
 13. Scroll down to **Optional**. You might need to enlarge the text box to copy and save all the XML data. You will need this information to  finish configuration in the Area 1 dashboard. The start of the metadata should be similar to the following:
 
     ```txt
-    <?xml version="1.0" encoding="utf-8"?><EntityDescriptor ID="_<YOUR_DESCRIPTIOR_ID>" entityID="https://<YOUR_ENTITY_ID> " xmlns="urn:oasis:names:tc:SAML:2.0:metadata">...
+    <?xml version="1.0" encoding="utf-8"?><EntityDescriptor ID="_<YOUR_DESCRIPTOR_ID>" entityID="https://<YOUR_ENTITY_ID> " xmlns="urn:oasis:names:tc:SAML:2.0:metadata">...
     ```
 
     ![Copy and save the XML metadata to use later in the Area 1 dashboard](/images/email-security/sso/okta/step13-optional.png)


### PR DESCRIPTION
This pull request fixes some typos from `permissions.md`, `azure.md` and `okta.md` files. I request repository maintainers to review and merge it.
capabilites -> capabilities 
withing -> within 
DESCRIPTIOR -> DESCRIPTOR
