### PR TITLE
Clarify restrictions for index names

### DIFF
--- a/content/vectorize/get-started/embeddings.md
+++ b/content/vectorize/get-started/embeddings.md
@@ -80,7 +80,7 @@ $ cd embeddings-tutorial
 
 To create an index, use the `wrangler vectorize create` command and provide a name for the index. A good index name is:
 
-- A combination of ASCII characters, shorter than 32 characters, and uses dashes (-) instead of spaces.
+- A combination of lowercase and/or numeric ASCII characters, shorter than 32 characters, starts with a letter, and uses dashes (-) instead of spaces.
 - Descriptive of the use-case and environment - for example, "production-doc-search" or "dev-recommendation-engine"
 - Only used for describing the index, and is not directly referenced in code.
 

--- a/content/vectorize/get-started/intro.md
+++ b/content/vectorize/get-started/intro.md
@@ -79,7 +79,7 @@ $ cd vectorize-tutorial
 
 To create an index, you will need to use the `wrangler vectorize create` command and provide a name for the index. A good index name is:
 
-- A combination of ASCII characters, shorter than 32 characters, and uses dashes (-) instead of spaces.
+- A combination of lowercase and/or numeric ASCII characters, shorter than 32 characters, starts with a letter, and uses dashes (-) instead of spaces.
 - Descriptive of the use-case and environment - for example, "production-doc-search" or "dev-recommendation-engine"
 - Only used for describing the index, and is not directly referenced in code.
 


### PR DESCRIPTION
Hey!
It was not clear to someone in the Discord that Vectorize index names were not allowed to contain uppercase letters. This PR clarifies that the names should consist of lowercase or numeric characters. I also added that they must start with a letter, since starting an index name with a number also is not allowed.

The getting started guides seemed like the only appropriate place to put this. 