### PR TITLE
Potential typo in cache rules required permissions

### DIFF
--- a/content/cache/how-to/cache-rules/create-api.md
+++ b/content/cache/how-to/cache-rules/create-api.md
@@ -146,6 +146,6 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
 
 The API token used in API requests to manage Cache Rules must have the following permissions:
 
-* _Zone_ > _Config Rules_ > _Edit_
+* _Zone_ > _Cache Rules_ > _Edit_
 * _Account Rulesets_ > _Edit_
 * _Account Filter Lists_ > _Edit_


### PR DESCRIPTION
It seems that you need cache rules permission to use cache rules, not config rules. At least I wasn't able to edit cache rules via Terraform with a token having config rules permission instead of cache rules permission.