### PR TITLE
[Chore] Fix headers so littlefoot doesn't preload on homepages

### DIFF
--- a/content/_headers
+++ b/content/_headers
@@ -1,10 +1,6 @@
 https://:project.pages.dev/*
  X-Robots-Tag: noindex
 
- /:content/*
- Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js>; rel=preload; as=script
- Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css>; rel=preload; as=style
-
 /*
   Link: <https://cdn.cookielaw.org/scripttemplates/otSDKStub.js>; rel=preload; as=script
   Link: <https://cdn.cookielaw.org/consent/d3bba612-bde9-4daa-93e3-a78dab7d1a86/OtAutoBlock.js>; rel=preload; as=script

--- a/content/_headers
+++ b/content/_headers
@@ -1,13 +1,13 @@
 https://:project.pages.dev/*
  X-Robots-Tag: noindex
 
+ /:content/*
+ Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js>; rel=preload; as=script
+ Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css>; rel=preload; as=style
+
 /*
   Link: <https://cdn.cookielaw.org/scripttemplates/otSDKStub.js>; rel=preload; as=script
   Link: <https://cdn.cookielaw.org/consent/d3bba612-bde9-4daa-93e3-a78dab7d1a86/OtAutoBlock.js>; rel=preload; as=script
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/css@3.5.1>; rel=preload; as=style
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/js@3.5.1>; rel=preload; as=script
   Link: <https://8MU1G3QO9P-dsn.algolia.net>; rel=preconnect; crossorigin
-
-/:content/*
-  Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js>; rel=preload; as=script
-  Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css>; rel=preload; as=style

--- a/content/_headers
+++ b/content/_headers
@@ -6,6 +6,8 @@ https://:project.pages.dev/*
   Link: <https://cdn.cookielaw.org/consent/d3bba612-bde9-4daa-93e3-a78dab7d1a86/OtAutoBlock.js>; rel=preload; as=script
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/css@3.5.1>; rel=preload; as=style
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/js@3.5.1>; rel=preload; as=script
+  Link: <https://8MU1G3QO9P-dsn.algolia.net>; rel=preconnect; crossorigin
+
+/:content/*
   Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js>; rel=preload; as=script
   Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css>; rel=preload; as=style
-  Link: <https://8MU1G3QO9P-dsn.algolia.net>; rel=preconnect; crossorigin

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,6 @@
+{{- $littlefootJS := "https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js" -}}
+{{- $littlefootCSS := "https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" -}}
+
 <!doctype html>
 <html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
@@ -13,6 +16,9 @@
     {{- end -}}
 
     
+    <link rel="preload" href="{{$littlefootJS}}" as="style" />
+    <link rel="preload" href="{{$littlefootCSS}}" as="script" />
+    
     {{- block "styles" . -}}{{- end -}} 
 
     {{- partial "script" (dict "src" "theme.ts" "inline" true "format" "iife") -}}
@@ -26,6 +32,6 @@
   </head>
   <body>
     {{- block "main" . -}}{{- end -}}
-    {{- partial "littlefoot" -}}
+    {{- partial "littlefoot" (dict "js" $littlefootJS "css" $littlefootCSS) -}}
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,6 +18,7 @@
     
     <link rel="preload" href="{{$littlefootJS}}" as="style" />
     <link rel="preload" href="{{$littlefootCSS}}" as="script" />
+    <link rel="stylesheet" href="{{.css}}" />
     
     {{- block "styles" . -}}{{- end -}} 
 
@@ -32,6 +33,7 @@
   </head>
   <body>
     {{- block "main" . -}}{{- end -}}
-    {{- partial "littlefoot" (dict "js" $littlefootJS "css" $littlefootCSS) -}}
+    <script src="{{.js}}" type="application/javascript"></script> 
+    <script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>
   </body>
 </html>

--- a/layouts/partials/littlefoot.html
+++ b/layouts/partials/littlefoot.html
@@ -1,3 +1,0 @@
-<link rel="stylesheet" href="{{.css}}" />
-<script async src="{{.js}}"></script> 
-<script> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>

--- a/layouts/partials/littlefoot.html
+++ b/layouts/partials/littlefoot.html
@@ -1,3 +1,3 @@
 <link rel="stylesheet" href="{{.css}}" />
-<script async src="{{.js}}" type="application/javascript" ></script> 
-<script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>
+<script async src="{{.js}}"></script> 
+<script> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>

--- a/layouts/partials/littlefoot.html
+++ b/layouts/partials/littlefoot.html
@@ -1,4 +1,3 @@
-<link rel="preload" href="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" as="style" onload="this.onload=null;this.rel='stylesheet'"/>
-    <noscript><link rel="preload" href="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" as="style"></noscript>
-    <script defer src="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js" type="application/javascript" ></script> 
-    <script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>
+<link rel="stylesheet" href="{{.css}}" />
+<script async src="{{.js}}" type="application/javascript" ></script> 
+<script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>


### PR DESCRIPTION
Validation:
- Littlefoot does not load on the homepage --> developer tools & `Network` tab shouldn't show `littlefoot` in any of the loaded resources
- On docs pages, `littlefoot` should load.
- On docs pages with footnotes, those should render --> https://259659ca.cloudflare-docs-7ou.pages.dev/dns/zone-setups/partial-setup/dns-resolution/ 