### PR TITLE
[Chore] Migrate littlefoot out of headers

### DIFF
--- a/content/_headers
+++ b/content/_headers
@@ -6,6 +6,4 @@ https://:project.pages.dev/*
   Link: <https://cdn.cookielaw.org/consent/d3bba612-bde9-4daa-93e3-a78dab7d1a86/OtAutoBlock.js>; rel=preload; as=script
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/css@3.5.1>; rel=preload; as=style
   Link: <https://cdn.jsdelivr.net/npm/@docsearch/js@3.5.1>; rel=preload; as=script
-  Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js>; rel=preload; as=script
-  Link: <https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css>; rel=preload; as=style
   Link: <https://8MU1G3QO9P-dsn.algolia.net>; rel=preconnect; crossorigin

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,6 @@
+{{- $littlefootJS := "https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js" -}}
+{{- $littlefootCSS := "https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" -}}
+
 <!doctype html>
 <html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
@@ -11,6 +14,10 @@
     {{- else -}}
       <link rel="stylesheet preconnect" href="/style.css" />
     {{- end -}}
+
+    <link rel="preload" href="{{$littlefootCSS}}" as="style">
+    <link rel="preload" href="{{$littlefootJS}}" as="script" />
+    <link rel="stylesheet" href="{{$littlefootCSS}}" />
 
     
     {{- block "styles" . -}}{{- end -}} 
@@ -26,6 +33,7 @@
   </head>
   <body>
     {{- block "main" . -}}{{- end -}}
-    {{- partial "littlefoot" -}}
+    <script defer src="{{$littlefootJS}}" type="application/javascript" ></script> 
+    <script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>
   </body>
 </html>

--- a/layouts/partials/littlefoot.html
+++ b/layouts/partials/littlefoot.html
@@ -1,4 +1,0 @@
-<link rel="preload" href="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" as="style" onload="this.onload=null;this.rel='stylesheet'"/>
-    <noscript><link rel="preload" href="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" as="style"></noscript>
-    <script defer src="https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.js" type="application/javascript" ></script> 
-    <script type="application/javascript"> document.addEventListener('DOMContentLoaded', () => littlefoot.default()) </script>

--- a/static/home.css
+++ b/static/home.css
@@ -3437,6 +3437,17 @@ blockquote .DocsMarkdown--header-anchor-positioner {
     margin: 0 48px 0 16px;
 }
 
+.DocSearch-Help a {
+    text-decoration: underline;
+    color: var(--docsearch-highlight-color);
+    font-weight: 600;
+}
+
+.DocSearch-HitsFooter a {
+    color: var(--docsearch-highlight-color);
+    font-weight: 600;
+}
+
 .DocsMobileHeader {
     position: absolute;
     display: flex;
@@ -3780,15 +3791,4 @@ td>code,
 
 .changelogDate {
     width: 8em;
-}
-
-.DocSearch-Help a {
-    text-decoration: underline;
-    color: var(--docsearch-highlight-color);
-    font-weight: 600;
-}
-
-.DocSearch-HitsFooter a {
-    color: var(--docsearch-highlight-color);
-    font-weight: 600;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -4444,6 +4444,17 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   width: unset !important;
 }
 
+.DocSearch-Help a {
+  text-decoration: underline;
+  color: var(--docsearch-highlight-color);
+  font-weight: 600;
+}
+
+.DocSearch-HitsFooter a {
+  color: var(--docsearch-highlight-color);
+  font-weight: 600;
+}
+
 .DocsMobileHeader {
   position: absolute;
   display: flex;
@@ -5653,15 +5664,4 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
   -webkit-transition: all 0.1s ease 0.1s;
   transition: all 0.1s ease 0.1s;
   visibility: visible;
-}
-
-.DocSearch-Help a {
-  text-decoration: underline;
-  color: var(--docsearch-highlight-color);
-  font-weight: 600;
-}
-
-.DocSearch-HitsFooter a {
-  color: var(--docsearch-highlight-color);
-  font-weight: 600;
 }


### PR DESCRIPTION
Don't need these resources loading on pages with the homepage layout, so adding the `preload` statements inline.

Validation:
- Littlefoot does not load on the homepage --> developer tools & `Network` tab shouldn't show `littlefoot` in any of the loaded resources
- On docs pages, `littlefoot` should load.
- On docs pages with footnotes, those should render --> https://remove-littlefoot-preheaders.cloudflare-docs-7ou.pages.dev/dns/zone-setups/partial-setup/dns-resolution/ 