### PR TITLE
typo: primariy → primary

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/_index.md
+++ b/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/_index.md
@@ -7,7 +7,7 @@ layout: single
 
 # Connect private networks
 
-A private network has two primarily components: the server and the client. The server's infrastructure (whether that is a single application, multiple applications, or a network segment) is connected to Cloudflare's global network by Cloudflare Tunnel. This is done by running the `cloudflared` daemon on the server.
+A private network has two primary components: the server and the client. The server's infrastructure (whether that is a single application, multiple applications, or a network segment) is connected to Cloudflare's global network by Cloudflare Tunnel. This is done by running the `cloudflared` daemon on the server.
 
 On the client side, end users connect to Cloudflare's global network using the Cloudflare WARP client. The WARP client can be rolled out to your entire organization in just a few minutes using your in-house MDM tooling.  When users connect to an IP made available through Cloudflare Tunnel, WARP sends their connection through Cloudflare’s network to the corresponding tunnel.
 

--- a/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/_index.md
+++ b/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/_index.md
@@ -7,7 +7,7 @@ layout: single
 
 # Connect private networks
 
-A private network has two primariy components: the server and the client. The server's infrastructure (whether that is a single application, multiple applications, or a network segment) is connected to Cloudflare's global network by Cloudflare Tunnel. This is done by running the `cloudflared` daemon on the server.
+A private network has two primarily components: the server and the client. The server's infrastructure (whether that is a single application, multiple applications, or a network segment) is connected to Cloudflare's global network by Cloudflare Tunnel. This is done by running the `cloudflared` daemon on the server.
 
 On the client side, end users connect to Cloudflare's global network using the Cloudflare WARP client. The WARP client can be rolled out to your entire organization in just a few minutes using your in-house MDM tooling.  When users connect to an IP made available through Cloudflare Tunnel, WARP sends their connection through Cloudflare’s network to the corresponding tunnel.
 


### PR DESCRIPTION
Seems like a typo. Thank you for your work.