### PR TITLE
docs: added forwardemail.net to vendor-specific DNS records guides

### DIFF
--- a/content/dns/manage-dns-records/reference/vendor-specific-records.md
+++ b/content/dns/manage-dns-records/reference/vendor-specific-records.md
@@ -82,6 +82,10 @@ Then, add Azure’s required records to [Cloudflare DNS](/dns/manage-dns-records
 
 ## Miscellaneous vendors
 
+### Forward Email
+
+To use Cloudflare with Forward Email, refer to [Forward Email configuration with Cloudflare](https://forwardemail.net/guides/cloudflare).
+
 ### ClickFunnels
 
 You can configure Cloudflare to work with ClickFunnels. The process requires updating your Cloudflare DNS settings.


### PR DESCRIPTION
Hi there!  We've added Forward Email <https://forwardemail.net> to the docs for this page https://developers.cloudflare.com/dns/manage-dns-records/reference/vendor-specific-records/.  Specifically we linked to the Cloudflare guide at https://forwardemail.net/guides/cloudflare.  Our guide is translated to 24 different languages.  Recently we were added to BitWarden as well <https://bitwarden.com/blog/add-privacy-and-security-using-email-aliases-with-bitwarden/>.