### PR TITLE
[Chore] exclude partials from comment-changed-files workflow

### DIFF
--- a/.github/workflows/comment-changed-filenames.yml
+++ b/.github/workflows/comment-changed-filenames.yml
@@ -28,7 +28,7 @@ jobs:
           files=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" | \
-            jq -r '.[] | select(.status=="renamed" or .status=="removed") | select (.filename | contains("_partial") | not) | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end' | \
+            jq -r '.[] | select(.status=="renamed" or .status=="removed") | select (.filename | contains("_partials") | not) | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end' | \
             sed -e 's|^content||' -e 's|/_index\.md$|/|' -e 's|/index\.md$|/|' -e 's|\.md$|/|')
           # Use random delimiter for security reasons
           delimiter="$(openssl rand -hex 8)"

--- a/.github/workflows/comment-changed-filenames.yml
+++ b/.github/workflows/comment-changed-filenames.yml
@@ -28,7 +28,7 @@ jobs:
           files=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" | \
-            jq -r '.[] | select(.status=="renamed" or .status=="removed") | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end' | \
+            jq -r '.[] | select(.status=="renamed" or .status=="removed") | select (.filename | contains("_partial") | not) | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end' | \
             sed -e 's|^content||' -e 's|/_index\.md$|/|' -e 's|/index\.md$|/|' -e 's|\.md$|/|')
           # Use random delimiter for security reasons
           delimiter="$(openssl rand -hex 8)"


### PR DESCRIPTION
Example where it occurs: https://github.com/cloudflare/cloudflare-docs/pull/11647#issuecomment-1794536390

```sh
➜  ~ curl https://api.github.com/repos/cloudflare/cloudflare-docs/pulls/11647/files -s | jq -r '.[] | select(.status=="renamed" or .status=="removed") | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end'
content/workers/_partials/_wrangler_survey.md
➜  ~ curl https://api.github.com/repos/cloudflare/cloudflare-docs/pulls/11647/files -s | jq -r '.[] | select(.status=="renamed" or .status=="removed") | select (.filename | contains("_partials") | not) | select(.filename | endswith(".md")) | if .status == "renamed" then .previous_filename else .filename end'
➜  ~
```

cc @kodster28 