### PR TITLE
Changed format to earliest supported + format

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/download-warp/_index.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/download-warp/_index.md
@@ -29,7 +29,7 @@ Alternatively, download the client from one of the following links after checkin
 
 |                      |    |
 | ---------------------| ---|
-| **OS version**       | Catalina, Big Sur, Monterey, Ventura|
+| **OS version**       | Catalina+ (10.15+)
 | **OS type**          | 64-bit only |
 | **HD space**         | 75 MB|
 | **Memory**           | 35 MB |


### PR DESCRIPTION
Changed the format for supported version listings to reduce maintenance burden. 

Reviewing the EOL statuses of the macOS versions it appears that Catalina and Big Sur are EOL and the oldest supported version is macOS Monterey 12.6.2

https://computing.cs.cmu.edu/desktop/os-lifecycle

We may need to bump the minimum supported version to the oldest version supported by apple to ensure that we are not suggesting the use of an outdated OS. 