### PR TITLE
Update _product-limitations.md

### DIFF
--- a/content/version-management/_partials/_product-limitations.md
+++ b/content/version-management/_partials/_product-limitations.md
@@ -5,6 +5,6 @@ _build:
   list: never
 ---
 
-Version Management does not currently support versioning for [Waiting Room](/waiting-room/), [China Network](/china-network/), [WAF Attack Score](/waf/about/waf-attack-score/) and [API Shield](/api-shield/).
+Version Management does not currently support versioning for zones entitled to [Waiting Room](/waiting-room/), [China Network](/china-network/), [WAF Attack Score](/waf/about/waf-attack-score/) or [API Shield](/api-shield/).
 
 Additionally, you cannot currently manage versioning through the [Cloudflare API](/api/) or deploy Workers used by zones that have enabled versioning via [Wrangler](/workers/wrangler/).


### PR DESCRIPTION
After a Live chat interaction with a PRE customer (ZD ticket 3016007), we realised the wording here could be improved to clarify that Version Management won't be available in case the zone is entitled to one of these features: Waiting Room, China Network, WAF Attack Score or API Shield. This way being in sync with the current messaging on the dashboard as well.  (PCX-8916)