### PR TITLE
[Chore] fix code block language warnings

### DIFF
--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -64,6 +64,7 @@ export const langs: Record<string, string> = {
   gql: 'graphql',
   svelte: 'html',
   javascript: 'js',
+  jsonc: 'json',
   typescript: 'ts',
   plaintext: 'txt',
   text: 'txt',

--- a/content/pub-sub/guide.md
+++ b/content/pub-sub/guide.md
@@ -222,7 +222,7 @@ $ export BROKER_NAME="TheBrokerYouCreated"
 
 We can now generate an access token for Pub/Sub. We will need both the client ID and the token (a JSON Web Token) itself to authenticate from our MQTT client:
 
-```console
+```sh
 $ curl -s -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pubsub/namespaces/namespace/brokers/is-it-broken/credentials?type=TOKEN&topicAcl=#" | jq '.result | to_entries | .[0]'
 ```
 
@@ -237,8 +237,8 @@ This will output a `key` representing the `clientId`, and a `value` representing
 
 Copy the `value` field and set it as the `BROKER_TOKEN` environmental variable:
 
-```console
-export BROKER_TOKEN="<>"
+```sh
+$ export BROKER_TOKEN="<VALUE>"
 ```
 
 Create a file called `index.js `, making sure that:
@@ -287,7 +287,7 @@ Your client ID and timestamp will be different from above, but you should see a 
 
 If you do not see the message you published, or you are receiving error messages, ensure that:
 
-- The `BROKER_TOKEN` environmental variable is not empty. Try echo `$BROKER_TOKEN`  in your terminal.
+- The `BROKER_TOKEN` environmental variable is not empty. Try echo `$BROKER_TOKEN` in your terminal.
 - You updated the `brokerEndpoint` to match the broker you created. The **Endpoint** field of your broker will show this address and port.
 - You correctly [installed MQTT.js](https://github.com/mqttjs/MQTT.js#install).
 

--- a/content/style-guide/formatting/structure/paragraphs-and-line-breaks.md
+++ b/content/style-guide/formatting/structure/paragraphs-and-line-breaks.md
@@ -9,10 +9,11 @@ title: Paragraphs and line breaks
 
 To start a new paragraph, leave an empty line (with no spaces) before adding the new paragraph content.
 
-``` This sentence is the first one in this paragraph.
+```txt
+This sentence is the first one in this paragraph.
 This second sentence also belongs to the first paragraph.
- 
-This is the first sentence of the second paragraph. 
+
+This is the first sentence of the second paragraph.
 ```
 
 ## Line breaks in Markdown
@@ -23,7 +24,8 @@ If you need to add a line break, use the `<br/>` HTML element.
 
 Example inside a table:
 
-```| Feature                          | Enabled |
+```txt
+| Feature                          | Enabled |
 |----------------------------------|---------|
 | Feature name<br/>Additional info | Yes     |
 ```

--- a/content/workers/runtime-apis/webassembly/javascript.md
+++ b/content/workers/runtime-apis/webassembly/javascript.md
@@ -8,7 +8,7 @@ meta:
 
 # Invoke Wasm from JavaScript
 
-Wasm can be used from within a Worker written in JavaScript or TypeScript by importing a Wasm module, 
+Wasm can be used from within a Worker written in JavaScript or TypeScript by importing a Wasm module,
 and instantiating an instance of this module using [`WebAssembly.instantiate()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate). This can be used to accelerate computationally intensive operations which do not involve significant I/O.
 
 This guide demonstrates the basics of Wasm and JavaScript interoperability.
@@ -19,10 +19,10 @@ In this guide, you will use the WebAssembly Text Format to create a simple Wasm 
 
 Review the following example module (`;;` denotes a comment):
 
-```wat
+```txt
 ;; src/simple.wat
 (module
-  ;; Import a function from JavaScript named `imported_func` 
+  ;; Import a function from JavaScript named `imported_func`
   ;; which takes a single i32 argument and assign to
   ;; variable $i
   (func $i (import "imports" "imported_func") (param i32))
@@ -42,7 +42,7 @@ Review the following example module (`;;` denotes a comment):
 Using [`wat2wasm`](https://github.com/WebAssembly/wabt), convert the WAT format to WebAssembly Binary Format:
 
 ```sh
-wat2wasm src/simple.wat -o src/simple.wasm
+$ wat2wasm src/simple.wat -o src/simple.wasm
 ```
 
 ## Bundling
@@ -69,7 +69,7 @@ const importObject = {
 // the expected imports in `importObject`. This should be
 // done at the top level of the script to avoid instantiation on every request.
 const instance = await WebAssembly.instantiate(mod, importObject);
-    
+
 export default {
   async fetch() {
     // Invoke the `exported_func` from our Wasm Instance with


### PR DESCRIPTION
Fixes the following warnings when building the documentation:

```diff
  vite v4.5.0 building for production...
  transforming...
  <script src="/search-coveo.min.711133da62d576aa24c0cd905f1425b5.js"> in "/search/index.html" can't be bundled without type="module" attribute
  <script src="/tutorial-coveo.min.b4d5cc7e19734ba246d74b89f89c71af.js"> in "/tutorials/index.html" can't be bundled without type="module" attribute
  ✓ 9055 modules transformed.
  rendering chunks...
- [prism] Missing "jsonc" grammar; using "txt" fallback
- [prism] Missing "console" grammar; using "txt" fallback
- [prism] Missing "console" grammar; using "txt" fallback
- [prism] Missing "This" grammar; using "txt" fallback
- [prism] Missing "|" grammar; using "txt" fallback
- [prism] Missing "jsonc" grammar; using "txt" fallback
- [prism] Missing "wat" grammar; using "txt" fallback
  computing gzip size...
```

Note: JSONC is currently only used in Workers changelog entries (obtained from GitHub).
