### PR TITLE
[Chore] Fix html properties for FAQ pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 {{- $littlefootCSS := "https://unpkg.com/littlefoot@4.0.0-11/dist/littlefoot.css" -}}
 
 <!doctype html>
-<html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{- with $.Page.Params.structured_data -}}{{- if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
+<html lang="{{ .Site.LanguageCode }}" theme="light" is-docs-page js-focus-visible-polyfill-available {{ with $.Page.Params.structured_data -}}{{ if eq $.Page.Params.pcx_content_type "faq" -}}itemscope itemtype="https://schema.org/FAQPage"{{- end -}}{{- end -}}>
   <head>
     {{- if eq (os.Getenv "CF_PAGES_BRANCH") "production" -}}
     {{- partial "onetrust" -}}


### PR DESCRIPTION
Removing the `-` from the left opening shortcodes will ensure that the whitespace is preserved (and `itemscope` isn't smushed together with the previous attribute).