### PR TITLE
[cloudflare-one] Keep local tunnel file extenstion consistent

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel.md
+++ b/content/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel.md
@@ -200,7 +200,7 @@ $ cloudflared tunnel run <UUID or NAME>
 If your configuration file has a custom name or is not in the `.cloudflared` directory, add the `--config` flag and specify the path.
 
 ```sh
-$ cloudflared tunnel --config /path/your-config-file.yaml run <UUID or NAME>
+$ cloudflared tunnel --config /path/your-config-file.yml run <UUID or NAME>
 ```
 
 {{<Aside>}}


### PR DESCRIPTION
Keeps the file extension consistent across the example.