### PR TITLE
[workers/wrangler] Fix command TOC link

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -19,7 +19,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`deploy`](#deploy) - Deploy your Worker to Cloudflare.
 - [`dev`](#dev) - Start a local server for developing your Worker.
 - [`publish`](#publish) - Publish your Worker to Cloudflare.
-- [`delete`](#delete) - Delete your Worker from Cloudflare.
+- [`delete`](#delete-3) - Delete your Worker from Cloudflare.
 - [`kv:namespace`](#kvnamespace) - Manage Workers KV namespaces.
 - [`kv:key`](#kvkey) - Manage key-value pairs within a Workers KV namespace.
 - [`kv:bulk`](#kvbulk) - Manage multiple key-value pairs within a Workers KV namespace in batches.


### PR DESCRIPTION
> https://developers.cloudflare.com/workers/wrangler/commands/

Currently,  toc anchor for `wrangler delete` is linked to `#delete`.

![image](https://github.com/cloudflare/cloudflare-docs/assets/6259812/84a5cc11-cdbd-49e9-aeba-f0834e608949)

But `#delete` is used for `wrangler d1 delete`, not `warngler delete`.(maybe because of appearance order?)

![image](https://github.com/cloudflare/cloudflare-docs/assets/6259812/0ac4cc3f-8994-40c3-96c6-8578fc012a2f)

To fix toc link, `#delete-3` should be used here.