### PR TITLE
[Pages] Add Bun to ​​V2 build system for Pages

### DIFF
--- a/content/pages/_partials/_platform-language-support-and-tools/v2.md
+++ b/content/pages/_partials/_platform-language-support-and-tools/v2.md
@@ -64,6 +64,11 @@ tools:
     default: "3.6.3"
     supported: "Any version"
     environment_variable: "YARN_VERSION"
+  - name: Bun
+    default: "1.0.1"
+    supported: "Any version"
+    environment_variable: "BUN_VERSION"
+
 build_environment:
   operating_system: "Ubuntu `22.04.2`"
   architecture: "x86_64"

--- a/content/pages/_partials/_platform-language-support-and-tools/v2.md
+++ b/content/pages/_partials/_platform-language-support-and-tools/v2.md
@@ -68,7 +68,6 @@ tools:
     default: "1.0.1"
     supported: "Any version"
     environment_variable: "BUN_VERSION"
-
 build_environment:
   operating_system: "Ubuntu `22.04.2`"
   architecture: "x86_64"


### PR DESCRIPTION
According to a message in the Discord server, the default version of bun is `1.0.1` and can be overwritten by using the `BUN_VERSION` env var. Now that Bun is now installed by default in V2, it makes sense to document this.

https://discord.com/channels/595317990191398933/1134543567004631121/1152321372786274314