### PR TITLE
[Chore] Add glossary VS Code snippets

### DIFF
--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -203,7 +203,7 @@
     "body": [
       "{{<glossary-tooltip term_id=\"${1:term}\">}}$0$TM_SELECTED_TEXT{{</glossary-tooltip>}}",
     ],
-    "description": "Adds a new glossary reference with the (short) definition in a tooltip",
+    "description": "Adds a new glossary reference, displaying its definition as a tooltip",
     "scope": "markdown"
   },
   "Glossary definition": {

--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -197,5 +197,21 @@
     ],
     "description": "Create FAQ entry (heading level 2, default)",
     "scope": "markdown"
-},
+  },
+  "Glossary tooltip": {
+    "prefix": ["glossarytooltip"],
+    "body": [
+      "{{<glossary-tooltip term_id=\"${1:term}\">}}$0$TM_SELECTED_TEXT{{</glossary-tooltip>}}",
+    ],
+    "description": "Adds a new glossary reference with the (short) definition in a tooltip",
+    "scope": "markdown"
+  },
+  "Glossary definition": {
+    "prefix": ["glossarydefinition"],
+    "body": [
+      "{{<glossary-definition term_id=\"${1:term}\">}}",
+    ],
+    "description": "Adds the definition of a glossary entry in the current location",
+    "scope": "markdown"
+  },
 }

--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -8,14 +8,16 @@ Prefixes | Description
 ---|---
 `asideheader` | Inserts an `Aside` shortcode with header text.
 `asidenoheader` | Inserts an `Aside` shortcode without a header.
-`ccol` | Surrounds the current selection with `content-column` shortcodes.
-`tblwrap` | Surrounds the current selection with `table-wrap` shortcodes.
+`ccol` | Inserts `content-column` shortcodes.
+`tblwrap` | Inserts `table-wrap` shortcodes.
 `directory` | Inserts a `directory-listing` shortcode.
 `faqentry` or `faqitem` | Inserts shortcodes for an entire FAQ entry (question and answer).
 `headerfullfile` | Inserts a file header for a complete Markdown file.
 `headingpill` or `pillheading` | Inserts shortcode for a heading with a pill stating the release status (for example, Beta).
 `metatitle` | Inserts meta title fields in existing Markdown header. Used to complement a full file header (refer to `headerfullfile`).
 `metadescription` | Inserts meta description fields in existing Markdown header. Used to complement a full file header (refer to `headerfullfile`).
+`glossarydefinition` | Adds the definition of a glossary entry in the current location.
+`glossarytooltip` | Adds a new glossary reference, displaying its (short) definition as a tooltip.
 `headerpartialfile` | Inserts a header for a partial Markdown file.
 `headerpartialfileparams` | Inserts a header for a partial Markdown file with input parameters.
 `inlinepill` or `pillinline` | Inserts shortcode for an inline pill (appearing after a piece of text) stating the release status (for example, Beta).
@@ -27,23 +29,24 @@ Prefixes | Description
 Triggering one of the available snippets will insert their body content at the current cursor position.
 
 Additionally, the following snippets support surrounding existing text:
-* `Aside with header`
-* `Aside without header`
-* `Surround with content-column`
-* `Surround with table-wrap`
-* `Create collapsible details section`
+* `asideheader`
+* `asidenoheader`
+* `ccol`
+* `detailssection` or `collapsible`
+* `glossarytooltip`
+* `tblwrap`
 
 ### How to use
 
 Note: Make sure you open the root folder of your cloned repository in Visual Studio Code (VS Code), so that VS Code correctly detects the snippets file stored in the `.vscode/` sub-folder.
 
 To enter a snippet:
-1. Enter the snippet prefix and press `Ctrl+Space` (`Command+Space` on a Mac).
-2. Select the desired snippet and press `Enter`.
-3. (Optional) Enter or select a value for the first placeholder supported by the snippet, if any, and press `Tab` to move to the next placeholder. Keep replacing placeholders and pressing `Tab`. When there are no more placeholders, pressing `Tab` will end the process.
+1. Enter the snippet prefix and press <kbd>Ctrl</kbd>+<kbd>Space</kbd> (<kbd>Command</kbd>+<kbd>Space</kbd> on a Mac).
+2. Select the desired snippet and press <kbd>Enter</kbd>.
+3. (Optional) Enter or select a value for the first placeholder supported by the snippet, if any, and press <kbd>Tab</kbd> to move to the next placeholder. Keep replacing placeholders and pressing <kbd>Tab</kbd>. When there are no more placeholders, pressing <kbd>Tab</kbd> will end the process.
 
 To surround existing content with a snippet:
 1. Select the text you wish to surround with a snippet.
-2. Enter the snippet prefix (temporarily replacing the selected text) and press `Ctrl+Space` (`Command+Space` on a Mac).
-3. Select the desired snippet and press `Enter`. VS Code will insert the snippet body and paste the previously selected content in the correct location.
-4. (Optional) Enter or select a value for the first placeholder supported by the snippet, if any, and press `Tab` to move to the next placeholder. Keep replacing placeholders and pressing `Tab`. When there are no more placeholders, pressing `Tab` will end the process.
+2. Press <kbd>F1</kbd>, search for the **Snippets: Surround with Snippet...** command, and press <kbd>Enter</kbd>.
+3. Select the desired snippet from the list. VS Code will insert the snippet body and paste the previously selected content in the correct location.
+4. (Optional) Enter or select a value for the first placeholder supported by the snippet, if any, and press <kbd>Tab</kbd> to move to the next placeholder. Keep replacing placeholders and pressing <kbd>Tab</kbd>. When there are no more placeholders, pressing <kbd>Tab</kbd> will end the process.


### PR DESCRIPTION
Adds two new VS Code snippets for glossary definitions and glossary tooltips.
Also updates some outdated instructions.