### PR TITLE
[Chore] Update "detailssection" VS Code snippet to use shortcode

### DIFF
--- a/.vscode/devdocs.code-snippets
+++ b/.vscode/devdocs.code-snippets
@@ -171,16 +171,13 @@
     "Create collapsible details section": {
       "prefix": ["detailssection", "collapsible"],
       "body": [
-        "<details>",
-        "<summary>${1:header}</summary>",
-        "<div>",
+        "{{<details header=\"${1:header}\">}}",
         "",
         "$0$TM_SELECTED_TEXT",
         "",
-        "</div>",
-        "</details>",
+        "{{</details>}}",
       ],
-      "description": "Creates a new collapsible <details> element with a title and a body",
+      "description": "Creates a new collapsible details section with a title and a body",
       "scope": "markdown"
   },
   "Create FAQ entry": {

--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -24,7 +24,7 @@ Prefixes | Description
 `partialinclude` or `renderpartial` | Inserts a `render` shortcode to include content from a partial in the current document.
 `partialincludeparams` or `renderpartialparams` | Inserts a `render` shortcode to include content from a partial with input parameters in the current document.
 `twotabs` or `addtabs` | Inserts a new tabs section with two tabs for dashboard and API instructions.
-`detailssection` or `collapsible` | Inserts a collapsible `<details>` HTML element.
+`detailssection` or `collapsible` | Inserts a collapsible details section.
 
 Triggering one of the available snippets will insert their body content at the current cursor position.
 


### PR DESCRIPTION
Insert the new `{{<details>}}` shortcode instead of HTML elements directly.