### PR TITLE
[KV] Clean up formatting around pricing table

### DIFF
--- a/content/workers/_partials/_kv_pricing.md
+++ b/content/workers/_partials/_kv_pricing.md
@@ -5,9 +5,9 @@ _build:
   list: never
 ---
 
-{{<table-wrap>}}
-
 Workers KV is included in both the Free and Paid [Workers plans](/workers/platform/pricing/).
+
+{{<table-wrap>}}
 
 |                 | Free plan<sup>1</sup> | Paid plan                         |
 | --------------- | --------------------- | --------------------------------- |
@@ -19,4 +19,4 @@ Workers KV is included in both the Free and Paid [Workers plans](/workers/platfo
 
 {{</table-wrap>}}
 
-1.  The Workers Free plan includes limited Workers KV usage. All limits reset daily at 00:00 UTC. If you exceed any one of these limits, further operations of that type will fail with an error.
+<sup>1</sup> The Workers Free plan includes limited Workers KV usage. All limits reset daily at 00:00 UTC. If you exceed any one of these limits, further operations of that type will fail with an error.


### PR DESCRIPTION
Move the "Workers KV is included in.." note outside the table block so this doesn't happen:
![image](https://github.com/cloudflare/cloudflare-docs/assets/14004943/0ae93963-2622-4ffc-9ffb-0b3273044cb1)

And replace the `1.` with the small 1 to match the one inside the table header 