### PR TITLE
[Zone Versioning] API Access prereq

### DIFF
--- a/content/version-management/_index.md
+++ b/content/version-management/_index.md
@@ -39,4 +39,5 @@ To use Version Management, the following must all be true:
 - Your zone has migrated to use [Custom Rules](/waf/reference/migration-guides/firewall-rules-to-custom-rules/) instead of Firewall Rules (deprecated).
 - Your account uses the [new WAF](https://blog.cloudflare.com/new-cloudflare-waf/) (if not, contact your account team).
 - Your user account must have an API Key provisioned (if not, [view your API Key](/fundamentals/api/get-started/keys/#view-your-global-api-key)).
+- Your user account must have API Access enabled (learn how to [control API Access](/fundamentals/api/how-to/control-api-access/)).
 - You must use the dashboard to manage versioning.

--- a/content/version-management/_index.md
+++ b/content/version-management/_index.md
@@ -39,5 +39,5 @@ To use Version Management, the following must all be true:
 - Your zone has migrated to use [Custom Rules](/waf/reference/migration-guides/firewall-rules-to-custom-rules/) instead of Firewall Rules (deprecated).
 - Your account uses the [new WAF](https://blog.cloudflare.com/new-cloudflare-waf/) (if not, contact your account team).
 - Your user account must have an API Key provisioned (if not, [view your API Key](/fundamentals/api/get-started/keys/#view-your-global-api-key)).
-- Your user account must have API Access enabled (learn how to [control API Access](/fundamentals/api/how-to/control-api-access/)).
+- Your user account must have API Access enabled. Refer to [control API Access](/fundamentals/api/how-to/control-api-access/) for more information.
 - You must use the dashboard to manage versioning.


### PR DESCRIPTION
Zone Versioning requires API Access to be enabled for the user's account, otherwise cloning of Version Zero will fail.