### PR TITLE
Update managed-networks.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -173,7 +173,7 @@ To check if the WARP client detects the network location:
 
 1. Turn on WARP.
 2. Disconnect and reconnect to the network.
-3. Open a terminal and run `warp-cli get-alternate-network`.
+3. Open a terminal and run `warp-cli debug alternate-network`.
 
 {{<Aside type="note">}}
 The WARP client scans all managed networks on the list every time it detects a network change event from the operating system. To minimize performance impact, we recommend reusing the same TLS endpoint across multiple locations unless you require distinct settings profiles for each location.


### PR DESCRIPTION
This irritated me in the cli when trying to decipher the new correct command that includes no deprecated message, so here is the proposed change. "warp-cli get-alternate-network" is being deprecated, so here is the correct future command that could be displayed on the docs page.