### PR TITLE
[workers] Fix Signing & Basic Auth examples + add playground links

### DIFF
--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -14,12 +14,12 @@ layout: example
 
 {{<Aside type="info">}}
 
-This example Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers)
+This example Worker makes use of the [Node.js Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
 {{</Aside>}}
 
 {{<Aside type="warning" header="Caution when using in production">}}
 
-This code is provided as a sample, and is not suitable for production use. Basic Authentication sends credentials unencrypted, and must be used with an HTTPS connection to be considered secure. For a production-ready authentication system, consider using [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
+This code is provided as a sample, and is not suitable for production use. Basic Authentication sends credentials unencrypted, and must be used with an HTTPS connection to be considered secure. For a production-ready authentication system, consider using [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/).
 
 {{</Aside>}}
 

--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -7,13 +7,14 @@ tags:
   - Authentication
 pcx_content_type: configuration
 title: HTTP Basic Authentication
+playground: https://workers.cloudflare.com/playground#LYVwNgLglgDghgJwgegGYHsHALQBM4RwDcABAEbogB2+CAngLzbPYDqApmQNJQQBimYACFKNRHQCqAKwDiAGQAsCgB4A1MgFkEAZQCMCKUIBcLFh268BWEdVqTZileq16DQgLAAoAMLoqEdn9sABEoAGcYdDDeKD8jEgwsPAJiEio4YHYGACJ8QgA6KTDs0lQoMECMrNyUwuKvX39AiGwAFToYdni4GBgwKABjAliqZCk4ADc4MIGEWAgAamB0XHB2Ly92ZUikElx2VDhwCBIAb08ASHTM+OyAUWUMvvYSAEEABQBJbIAaS8IAOZheIAbWyWyeFV+JGyPSg0OyCHYET8YXY2QAun8AL5ETxeUzMcw8fiCGxiejSeRKNSaHT6QwNPwBIKhFHRaBxBKCZKEUjXapQGhbOolBLlSqZHJC-bKUVMppBdqdbq9fpDTmjcZTGZzGCLZarCobTzIABUZs8JDNJG0AAt0AB3MIkB2OkgQdAkJFhCBzAYnOADAbIl0gaJUAEeu0vAASrVa7xIQmmgxIMxjwDg+StNoAAmiXnaIBAYMDkMh9hN2GB0J0EPllgAvcpgbOYAHIQLYCTaSvoAZhZDmZDxxPIV4gCAx-yDYZ+XMkAvsIslstGCue9BgML5KDsCCofId5DF4BgZAIVADADsADZdDfc7nkJ5PFBgDsTqdkyBUKh2AQEhsQSBB0GAEgAHIqBWLoyD-ACEEgvFPAGVETkCND9iAhg0nYd1Wi2CA7ioLDAIACgAShQ81LWtEh3jAgIAxIOAATgIVfQ9D8hSjAhCAGABrF0yDodM4AAsAxLQz9EF4kgpjAEBkRIcN5IAA2gYBeO0CT2DuABHEA4DAdSc3ogAlA5AI9L1i1LctK3Yata3rXcBlrEBcFQNskXyGTkEdTBBMAocEGoLT2GwOEh0dThsFmDpPWQABiLTeLCPT2CMkzuSA5YkT2A8OJ3Rc83gBAMjOX05kjEC4BIMqKqq04at4kCyEa+i8yRCAQAQKgXVOCht3YOAqGxF9PFQagAxGbjtMjXSAMM4ywHIuAfnISizkuNDBsDIQ6ACF1cMw2CG3O-YNuovb0PII6TpIM7SIu-IrvYciyFuy4oFQEgNse5F8lEgI5ECAFpxIABCBhcLIIHd1B9hwcjacdvOC4LgrW0-QykhQC4sgXmnF5MsyEgKjRu0SCFEhMGw2ySBkir2EubHkBIR1eBpxL9XQfIwhAMgIAqfJ0qWvTVpM9nev6qgEhMtE8QuSbLjlgbmfofnBeF0X2HFnjJZWnL1rgRGtoR47kVutWti-IrDmOXbsYtS56Pd-Nmog04rKM5EIBApF-a4z2l29s5TneV5tG0VgAHkLOCeI2rqkDAgmRqLm6jXBqz61XwuaY6FIhIDwGO1yOD5TfS2jOMfZ-auKEGPPm8AB9Xs7gs56oLgXBFuQt8sZxgBNSgudbPD2FwViFf7xaSHgMIwiChBcHyEhWjtcJ0wdcBZ+J9mcf4oMY1nz0SDoSggNYYKbOmOeSEw7WAlntFZgPHMR85qzEKZ+y64KxVhrHWUK-lPLeV8gbAKa8QoICHPtMoAJ+rzlGB-XqQ5G73RbtoNu7do6x17hnfIhC46J2CCQAA-FQqCy9V4MyHtgg6qkEBgF7lQfCJAJAWTkFXbKNcID5H6mAH6WNV68ArgDER+R4DTgFA3LGFwhhoigsgSCRh2ZY1znhd0VkUSDU+pBV4VBr6cOZuNViwZQzRiLOBdg8AAQG0gmIrGKiXiQWQLWAElAIAaK0RzEgnwqCKSgHkEmMYYSTmnJgKATY0HZFdGNRmolvQHnlvJBqY4kwKAAAy6G-konGHA9hehgicNENBWIwlYLU7A0SZzQA1OiJJ-dAJbUftOXeQUD4ejmACJxCAAknyXnWEAMBaYK1JuQMCzp2m02AJkXAUACA1jEtMQS8lEhaxns0FZO5WLsSFIU7R6TNacL0ciSIhjyKQTkOgAZM96ZTnyJBLaP5fQEHDPEPJuhgKuOUdMDxyAF5Cg0S7IpnNt4vGyA02J8TNSJJjG0oCu9KknEdDOViU5Glzjfic5R90jgxLmAi+auFq4B3yMi7Cu4nEQFuXC0laCXEqyUX9AG0NiUOmZZqRRSiLg6IuSQfR1y0S3PHiAaeF8vTeOOW8iFArPl9WBCQX5fwBVYxpaFeImNNWBMYuBfULppnhhstsz++xZxKwJUoyCtTWD1JxXs5p4LIIpmiAMNJJlgA5GAGJGYYDoQV0QGiCAOQJCtD4NgAAHNkN5ASsbYg1QK7Et1U0BKbicEEGZ2CZDrq9fYuAMS925fCtBgs+i8FuVBAFgToVvBxeWzUrTGaEwqYQXY3MoYesGFtDAYBaxxUPus9M8AQwEo5eRaGH1Z4AB853pgrnml4sNcLutTAMFxirTl9XOVw0VqIjEaBMokJZ2KSVxLQa2wCrz3npkICqn5uTcn-LZUm4eSis07KtdAJWvchAIVvagMCwByKzq2pBMgQK7wKBceLdA2g8aRioihAVOMG1moGlUEgAAyJe0wGHr1YoVCI-QTipOmWUBBJw0K1ioASisDAAB8z9HifgqLcLDAojD0LXrgbImb7oyi2L3S1eybUieUPHVAtyjCsqEywrDYmkS-v2buIWZBU4AnIrkraUn01fvuvQlTuzrU7l1lp5DOmpMkAWCQXQdap3QwlgCZa+lTbkVwfgruFktpYZ2gumGrn3PS3Wt5juZCtr0MovypRQqD1XKPRKienCnmXzlQxhVeqlWPu+Wq-JKaBXaoQbqxNP8GKgeNbY1SaIgIWtUxJiz5WLj2rqQ0l1qy3W9q9UiH1fqA1oU6MGu0oaDwRqjbG+NRWlHJsTWm99qtP27vlrokVSWbmQUADwbgBI-ZIJK10kwXgwDmFMAIViQwr2htlxNyr8sACYX0zYuCV1VOW7XeDPlFRofptxupgtgX0mB2AJs1XN1NhmlsftlmchWwrD2bYAHLoBOAIWwd6zgPq+aqvJCg32XDm7iAkhJiSWDJKIOwVJHC0hcAyDwPhmTNBCOESIHIRjxDPbyVIAochxTADJA2Z4wBijKFTKovOawC+pRAc82QFQshaMqLoHoiLID6BxKgJoAA80Ngjx28K0Ue7w7iuhl2AZjngtdC8puNAEORAjZAtxcK3ySnfO8yIQZmo2EHjeyJG6NcaSDIDd1rj3DVAHYAEVACYOQAAaPZXjYF8LJaAZAoTM0Z-4HInw7gMBnk4xJwf2ah+KmkcX2QJj7kdF+RJ+0Fe87CdOBgVZBhRW5rgac+mqAxBMoDoYFQGAFNyYXkP0B9bMe8JAnyiAXh3wQPAl07w2x0ABGBWwWvkBj4qCH-oVBBJaKRGAHIvo6AVDCDGA8gmlF2iRKgHIgDHLq5X2vmg+QqwnZWBAygUCZ9v+coFSXexQHCAU-GBFeK-bGJ3DfGlC3S4LXCgXAOgEPZZTODyQjHIafH0R3LRLXD8KMMIBAAYe-NcR-ZfVfCnP-CYD-DeDyb-TAg2KsNAaBXcGASMEfYvSsaPEPLMIUN3Z3FA5mNsFeXne+BBbAbxdAR3DfFAvgrXGAPgi4DgfnexaGbhVRLpRfMgl-GVFXLiXAU7F4BqOfeBLaT+VZapfYZYWyAJc-GfemKgXfdgDpKpTFQIb1RAoqPodAMSZZJEAMKSJmaZfPF4VJMNaASMVSCZOAAJSfOg6BC7UQIRHAtXWQu0XQZjVgUbE4XeIw0QqhaA9InA+QgJV4EgWIryegkgYwmyXeAAKUmDgG0FmHmAz32CvgnkdDmHO2nAIEOxoDP3aP6i5k4BsN4BBxdGyT6QkjKC9V8PYH8LEjpnKJ-yREghdGCMpgHDQRdEQAp1sQCTXjAFwA6UHSdHkmvilQyy2POzIkEKiBJi9AuKAkCFniwxdDpgZhsk9ACR9GuR0NJgggKheCMkGEEikmSOKKUSt3SNaHoFphOCeLRDAFQAKNkMhKUXjgVieMpgOGyJ2PEg41n1EOjF6N3nCioG7wiL8GjDRTGM3gOyGCoACRnl4HhMpmj0MKqULBqx9GOBdBjD8hIDuGWROGmTkRpjgAoGrCZhBRgCgGsKVRXFdCdBqwhEJKqOJNG36JUmWX-EAmaG9F8WBn2wnkZNYh3C9BZIgACWmVuMvm5MxQIDWNGRXigDT05MPlqijGxM4WUGyP2Aagyz+gNghJD2QB4KoCgOQAQKQMt1PDNwt2J1MFJ1JGsAp3ECpxpGcHpDcHlyZzZFZxiC5E5zyG53LzD1LJFwlB52yDT3QDIDlwZ0VEVw6GVx6CrQ1BGDGDCD8BNFOGyAjPbkNDWGyCMGyCk1FGxCTLME4BJCsGEHTMpAcCzLpFcEMGYC8CAA
 weight: 1001
 layout: example
 ---
 
 {{<Aside type="warning" header="Caution when using in production">}}
 
-This code is provided as a sample, and is not suitable for production code without protecting against timing attacks. To learn how to implement production-safe code, refer to the [`timingSafeEqual` example](/workers/examples/protect-against-timing-attacks/) for more information on how to mitigate against timing attacks in your Workers code.
+This code is provided as a sample, and is not suitable for production use. Basic Authentication sends credentials unencrypted, and must be used with an HTTPS connection to be considered secure. For a production-ready authentication system, consider using [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
 
 {{</Aside>}}
 
@@ -26,135 +27,107 @@ This code is provided as a sample, and is not suitable for production code witho
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication
  * @see https://tools.ietf.org/html/rfc7617
  *
- * A user-id containing a colon (":") character is invalid, as the
- * first colon in a user-pass string separates user and password.
  */
+
+import { Buffer } from 'node:buffer';
+
+const encoder = new TextEncoder();
+
+/**
+ * Protect against timing attacks by safely comparing values using `timingSafeEqual`.
+ * Refer to https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#timingsafeequal for more details
+ * @param {string} a 
+ * @param {string} b 
+ * @returns {boolean}
+ */
+function timingSafeEqual(a, b) {
+	const aBytes = encoder.encode(a);
+	const bBytes = encoder.encode(b);
+
+	if (aBytes.byteLength !== bBytes.byteLength) {
+		// Strings must be the same length in order to compare
+		// with crypto.subtle.timingSafeEqual
+		return false;
+	}
+
+	return crypto.subtle.timingSafeEqual(aBytes, bBytes);
+}
+
 export default {
-  async fetch(request) {
-    const BASIC_USER = "admin";
-    const BASIC_PASS = "admin";
+	/**
+	 * 
+	 * @param {Request} request 
+	 * @param {{PASSWORD: string}} env 
+	 * @returns 
+	 */
+	async fetch(request, env) {
+		const BASIC_USER = 'admin';
 
-    /**
-     * Throws exception on verification failure.
-     * @param {string} user
-     * @param {string} pass
-     * @throws {UnauthorizedException}
-     */
-    async function verifyCredentials(user, pass) {
-      if (BASIC_USER !== user) {
-        throw new UnauthorizedException("Invalid credentials.");
-      }
+		// You will need an admin password. This should be
+		// attached to your Worker as an encrypted secret.
+		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+		const BASIC_PASS = env.PASSWORD ?? 'password';
 
-      if (BASIC_PASS !== pass) {
-        throw new UnauthorizedException("Invalid credentials.");
-      }
-    }
+		const url = new URL(request.url);
 
-    /**
-     * Parse HTTP Basic Authorization value.
-     * @param {Request} request
-     * @throws {BadRequestException}
-     * @returns {{ user: string, pass: string }}
-     */
-    async function basicAuthentication(request) {
-      const Authorization = request.headers.get("Authorization");
+		switch (url.pathname) {
+			case '/':
+				return new Response('Anyone can access the homepage.');
 
-      const [scheme, encoded] = Authorization.split(" ");
+			case '/logout':
+				// Invalidate the "Authorization" header by returning a HTTP 401.
+				// We do not send a "WWW-Authenticate" header, as this would trigger
+				// a popup in the browser, immediately asking for credentials again.
+				return new Response('Logged out.', { status: 401 });
 
-      // The Authorization header must start with Basic, followed by a space.
-      if (!encoded || scheme !== "Basic") {
-        throw new BadRequestException("Malformed authorization header.");
-      }
+			case '/admin': {
+				// The "Authorization" header is sent when authenticated.
+				const authorization = request.headers.get('Authorization');
+				if (!authorization) {
+					return new Response('You need to login.', {
+						status: 401,
+						headers: {
+							// Prompts the user for credentials.
+							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
+						},
+					});
+				}
+				const [scheme, encoded] = authorization.split(' ');
 
-      // Decodes the base64 value and performs unicode normalization.
-      // @see https://datatracker.ietf.org/doc/html/rfc7613#section-3.3.2 (and #section-4.2.2)
-      // @see https://dev.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-      const buffer = Uint8Array.from(atob(encoded), (character) =>
-        character.charCodeAt(0)
-      );
-      const decoded = new TextDecoder().decode(buffer).normalize();
+				// The Authorization header must start with Basic, followed by a space.
+				if (!encoded || scheme !== 'Basic') {
+					return new Response('Malformed authorization header.', { status: 400 });
+				}
 
-      // The username & password are split by the first colon.
-      //=> example: "username:password"
-      const index = decoded.indexOf(":");
+				const credentials = Buffer.from(encoded, 'base64').toString();
 
-      // The user & password are split by the first colon and MUST NOT contain control characters.
-      // @see https://tools.ietf.org/html/rfc5234#appendix-B.1 (=> "CTL = %x00-1F / %x7F")
-      if (index === -1 || /[\0-\x1F\x7F]/.test(decoded)) {
-        throw new BadRequestException("Invalid authorization value.");
-      }
+				// The username & password are split by the first colon.
+				//=> example: "username:password"
+				const index = credentials.indexOf(':');
+				const user = credentials.substring(0, index);
+				const pass = credentials.substring(index + 1);
 
-      return {
-        user: decoded.substring(0, index),
-        pass: decoded.substring(index + 1),
-      };
-    }
+				if (!timingSafeEqual(BASIC_USER, user) || !timingSafeEqual(BASIC_PASS, pass)) {
+					return new Response('You need to login.', {
+						status: 401,
+						headers: {
+							// Prompts the user for credentials.
+							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
+						},
+					});
+				}
 
-    async function UnauthorizedException(reason) {
-      this.status = 401;
-      this.statusText = "Unauthorized";
-      this.reason = reason;
-    }
+				return new Response('🎉 You have private access!', {
+					status: 200,
+					headers: {
+						'Cache-Control': 'no-store',
+					},
+				});
+			}
+		}
 
-    async function BadRequestException(reason) {
-      this.status = 400;
-      this.statusText = "Bad Request";
-      this.reason = reason;
-    }
-
-    const { protocol, pathname } = new URL(request.url);
-
-    // In the case of a Basic authentication, the exchange MUST happen over an HTTPS (TLS) connection to be secure.
-    if (
-      "https:" !== protocol ||
-      "https" !== request.headers.get("x-forwarded-proto")
-    ) {
-      throw new BadRequestException("Please use a HTTPS connection.");
-    }
-
-    switch (pathname) {
-      case "/":
-        return new Response("Anyone can access the homepage.");
-
-      case "/logout":
-        // Invalidate the "Authorization" header by returning a HTTP 401.
-        // We do not send a "WWW-Authenticate" header, as this would trigger
-        // a popup in the browser, immediately asking for credentials again.
-        return new Response("Logged out.", { status: 401 });
-
-      case "/admin": {
-        // The "Authorization" header is sent when authenticated.
-        if (request.headers.has("Authorization")) {
-          // Throws exception when authorization fails.
-          const { user, pass } = basicAuthentication(request);
-          verifyCredentials(user, pass);
-
-          // Only returns this response when no exception is thrown.
-          return new Response("You have private access.", {
-            status: 200,
-            headers: {
-              "Cache-Control": "no-store",
-            },
-          });
-        }
-
-        // Not authenticated.
-        return new Response("You need to login.", {
-          status: 401,
-          headers: {
-            // Prompts the user for credentials.
-            "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
-          },
-        });
-      }
-
-      case "/favicon.ico":
-      case "/robots.txt":
-        return new Response(null, { status: 204 });
-    }
-
-    return new Response("Not Found.", { status: 404 });
-  },
+		return new Response('Not Found.', { status: 404 });
+	},
 };
 ```
 
@@ -162,135 +135,104 @@ export default {
 {{<tab label="ts">}}
 
 ```ts
-const handler: ExportedHandler = {
-  async fetch(request: Request) {
-    const BASIC_USER = "admin";
-    const BASIC_PASS = "admin";
+/**
+ * Shows how to restrict access using the HTTP Basic schema.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication
+ * @see https://tools.ietf.org/html/rfc7617
+ *
+ */
 
-    /**
-     * Throws exception on verification failure.
-     * @param {string} user
-     * @param {string} pass
-     * @throws {UnauthorizedException}
-     */
-    async function verifyCredentials(user, pass) {
-      if (BASIC_USER !== user) {
-        throw new UnauthorizedException("Invalid credentials.");
-      }
+import { Buffer } from 'node:buffer';
 
-      if (BASIC_PASS !== pass) {
-        throw new UnauthorizedException("Invalid credentials.");
-      }
-    }
+const encoder = new TextEncoder();
 
-    /**
-     * Parse HTTP Basic Authorization value.
-     * @param {Request} request
-     * @throws {BadRequestException}
-     * @returns {{ user: string, pass: string }}
-     */
-    async function basicAuthentication(request) {
-      const Authorization = request.headers.get("Authorization");
+/**
+ * Protect against timing attacks by safely comparing values using `timingSafeEqual`.
+ * Refer to https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#timingsafeequal for more details
+ */
+function timingSafeEqual(a: string, b: string) {
+	const aBytes = encoder.encode(a);
+	const bBytes = encoder.encode(b);
 
-      const [scheme, encoded] = Authorization.split(" ");
+	if (aBytes.byteLength !== bBytes.byteLength) {
+		// Strings must be the same length in order to compare
+		// with crypto.subtle.timingSafeEqual
+		return false;
+	}
 
-      // The Authorization header must start with Basic, followed by a space.
-      if (!encoded || scheme !== "Basic") {
-        throw new BadRequestException("Malformed authorization header.");
-      }
+	return crypto.subtle.timingSafeEqual(aBytes, bBytes);
+}
 
-      // Decodes the base64 value and performs unicode normalization.
-      // @see https://datatracker.ietf.org/doc/html/rfc7613#section-3.3.2 (and #section-4.2.2)
-      // @see https://dev.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-      const buffer = Uint8Array.from(atob(encoded), (character) =>
-        character.charCodeAt(0)
-      );
-      const decoded = new TextDecoder().decode(buffer).normalize();
+export default <ExportedHandler<{ PASSWORD: string }>>{
+	async fetch(request, env) {
+		const BASIC_USER = 'admin';
 
-      // The username & password are split by the first colon.
-      //=> example: "username:password"
-      const index = decoded.indexOf(":");
+		// You will need an admin password. This should be
+		// attached to your Worker as an encrypted secret.
+		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+		const BASIC_PASS = env.PASSWORD ?? 'password';
 
-      // The user & password are split by the first colon and MUST NOT contain control characters.
-      // @see https://tools.ietf.org/html/rfc5234#appendix-B.1 (=> "CTL = %x00-1F / %x7F")
-      if (index === -1 || /[\0-\x1F\x7F]/.test(decoded)) {
-        throw new BadRequestException("Invalid authorization value.");
-      }
+		const url = new URL(request.url);
 
-      return {
-        user: decoded.substring(0, index),
-        pass: decoded.substring(index + 1),
-      };
-    }
+		switch (url.pathname) {
+			case '/':
+				return new Response('Anyone can access the homepage.');
 
-    async function UnauthorizedException(reason) {
-      this.status = 401;
-      this.statusText = "Unauthorized";
-      this.reason = reason;
-    }
+			case '/logout':
+				// Invalidate the "Authorization" header by returning a HTTP 401.
+				// We do not send a "WWW-Authenticate" header, as this would trigger
+				// a popup in the browser, immediately asking for credentials again.
+				return new Response('Logged out.', { status: 401 });
 
-    async function BadRequestException(reason) {
-      this.status = 400;
-      this.statusText = "Bad Request";
-      this.reason = reason;
-    }
+			case '/admin': {
+				// The "Authorization" header is sent when authenticated.
+				const authorization = request.headers.get('Authorization');
+				if (!authorization) {
+					return new Response('You need to login.', {
+						status: 401,
+						headers: {
+							// Prompts the user for credentials.
+							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
+						},
+					});
+				}
+				const [scheme, encoded] = authorization.split(' ');
 
-    const { protocol, pathname } = new URL(request.url);
+				// The Authorization header must start with Basic, followed by a space.
+				if (!encoded || scheme !== 'Basic') {
+					return new Response('Malformed authorization header.', { status: 400 });
+				}
 
-    // In the case of a Basic authentication, the exchange MUST happen over an HTTPS (TLS) connection to be secure.
-    if (
-      "https:" !== protocol ||
-      "https" !== request.headers.get("x-forwarded-proto")
-    ) {
-      throw new BadRequestException("Please use a HTTPS connection.");
-    }
+				const credentials = Buffer.from(encoded, 'base64').toString();
 
-    switch (pathname) {
-      case "/":
-        return new Response("Anyone can access the homepage.");
+				// The username & password are split by the first colon.
+				//=> example: "username:password"
+				const index = credentials.indexOf(':');
+				const user = credentials.substring(0, index);
+				const pass = credentials.substring(index + 1);
 
-      case "/logout":
-        // Invalidate the "Authorization" header by returning a HTTP 401.
-        // We do not send a "WWW-Authenticate" header, as this would trigger
-        // a popup in the browser, immediately asking for credentials again.
-        return new Response("Logged out.", { status: 401 });
+				if (!timingSafeEqual(BASIC_USER, user) || !timingSafeEqual(BASIC_PASS, pass)) {
+					return new Response('You need to login.', {
+						status: 401,
+						headers: {
+							// Prompts the user for credentials.
+							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
+						},
+					});
+				}
 
-      case "/admin": {
-        // The "Authorization" header is sent when authenticated.
-        if (request.headers.has("Authorization")) {
-          // Throws exception when authorization fails.
-          const { user, pass } = basicAuthentication(request);
-          verifyCredentials(user, pass);
+				return new Response('🎉 You have private access!', {
+					status: 200,
+					headers: {
+						'Cache-Control': 'no-store',
+					},
+				});
+			}
+		}
 
-          // Only returns this response when no exception is thrown.
-          return new Response("You have private access.", {
-            status: 200,
-            headers: {
-              "Cache-Control": "no-store",
-            },
-          });
-        }
-
-        // Not authenticated.
-        return new Response("You need to login.", {
-          status: 401,
-          headers: {
-            // Prompts the user for credentials.
-            "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
-          },
-        });
-      }
-
-      case "/favicon.ico":
-      case "/robots.txt":
-        return new Response(null, { status: 204 });
-    }
-
-    return new Response("Not Found.", { status: 404 });
-  },
+		return new Response('Not Found.', { status: 404 });
+	},
 };
-
-export default handler;
 ```
 
 {{</tab>}}

--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -12,6 +12,11 @@ weight: 1001
 layout: example
 ---
 
+{{<Aside type="info">}}
+
+This example Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers)
+{{</Aside>}}
+
 {{<Aside type="warning" header="Caution when using in production">}}
 
 This code is provided as a sample, and is not suitable for production use. Basic Authentication sends credentials unencrypted, and must be used with an HTTPS connection to be considered secure. For a production-ready authentication system, consider using [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
@@ -29,105 +34,110 @@ This code is provided as a sample, and is not suitable for production use. Basic
  *
  */
 
-import { Buffer } from 'node:buffer';
+import { Buffer } from "node:buffer";
 
 const encoder = new TextEncoder();
 
 /**
  * Protect against timing attacks by safely comparing values using `timingSafeEqual`.
  * Refer to https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#timingsafeequal for more details
- * @param {string} a 
- * @param {string} b 
+ * @param {string} a
+ * @param {string} b
  * @returns {boolean}
  */
 function timingSafeEqual(a, b) {
-	const aBytes = encoder.encode(a);
-	const bBytes = encoder.encode(b);
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
 
-	if (aBytes.byteLength !== bBytes.byteLength) {
-		// Strings must be the same length in order to compare
-		// with crypto.subtle.timingSafeEqual
-		return false;
-	}
+  if (aBytes.byteLength !== bBytes.byteLength) {
+    // Strings must be the same length in order to compare
+    // with crypto.subtle.timingSafeEqual
+    return false;
+  }
 
-	return crypto.subtle.timingSafeEqual(aBytes, bBytes);
+  return crypto.subtle.timingSafeEqual(aBytes, bBytes);
 }
 
 export default {
-	/**
-	 * 
-	 * @param {Request} request 
-	 * @param {{PASSWORD: string}} env 
-	 * @returns 
-	 */
-	async fetch(request, env) {
-		const BASIC_USER = 'admin';
+  /**
+   *
+   * @param {Request} request
+   * @param {{PASSWORD: string}} env
+   * @returns
+   */
+  async fetch(request, env) {
+    const BASIC_USER = "admin";
 
-		// You will need an admin password. This should be
-		// attached to your Worker as an encrypted secret.
-		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
-		const BASIC_PASS = env.PASSWORD ?? 'password';
+    // You will need an admin password. This should be
+    // attached to your Worker as an encrypted secret.
+    // Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+    const BASIC_PASS = env.PASSWORD ?? "password";
 
-		const url = new URL(request.url);
+    const url = new URL(request.url);
 
-		switch (url.pathname) {
-			case '/':
-				return new Response('Anyone can access the homepage.');
+    switch (url.pathname) {
+      case "/":
+        return new Response("Anyone can access the homepage.");
 
-			case '/logout':
-				// Invalidate the "Authorization" header by returning a HTTP 401.
-				// We do not send a "WWW-Authenticate" header, as this would trigger
-				// a popup in the browser, immediately asking for credentials again.
-				return new Response('Logged out.', { status: 401 });
+      case "/logout":
+        // Invalidate the "Authorization" header by returning a HTTP 401.
+        // We do not send a "WWW-Authenticate" header, as this would trigger
+        // a popup in the browser, immediately asking for credentials again.
+        return new Response("Logged out.", { status: 401 });
 
-			case '/admin': {
-				// The "Authorization" header is sent when authenticated.
-				const authorization = request.headers.get('Authorization');
-				if (!authorization) {
-					return new Response('You need to login.', {
-						status: 401,
-						headers: {
-							// Prompts the user for credentials.
-							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
-						},
-					});
-				}
-				const [scheme, encoded] = authorization.split(' ');
+      case "/admin": {
+        // The "Authorization" header is sent when authenticated.
+        const authorization = request.headers.get("Authorization");
+        if (!authorization) {
+          return new Response("You need to login.", {
+            status: 401,
+            headers: {
+              // Prompts the user for credentials.
+              "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
+            },
+          });
+        }
+        const [scheme, encoded] = authorization.split(" ");
 
-				// The Authorization header must start with Basic, followed by a space.
-				if (!encoded || scheme !== 'Basic') {
-					return new Response('Malformed authorization header.', { status: 400 });
-				}
+        // The Authorization header must start with Basic, followed by a space.
+        if (!encoded || scheme !== "Basic") {
+          return new Response("Malformed authorization header.", {
+            status: 400,
+          });
+        }
 
-				const credentials = Buffer.from(encoded, 'base64').toString();
+        const credentials = Buffer.from(encoded, "base64").toString();
 
-				// The username & password are split by the first colon.
-				//=> example: "username:password"
-				const index = credentials.indexOf(':');
-				const user = credentials.substring(0, index);
-				const pass = credentials.substring(index + 1);
+        // The username & password are split by the first colon.
+        //=> example: "username:password"
+        const index = credentials.indexOf(":");
+        const user = credentials.substring(0, index);
+        const pass = credentials.substring(index + 1);
 
-				if (!timingSafeEqual(BASIC_USER, user) || !timingSafeEqual(BASIC_PASS, pass)) {
-					return new Response('You need to login.', {
-						status: 401,
-						headers: {
-							// Prompts the user for credentials.
-							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
-						},
-					});
-				}
+        if (
+          !timingSafeEqual(BASIC_USER, user) ||
+          !timingSafeEqual(BASIC_PASS, pass)
+        ) {
+          return new Response("You need to login.", {
+            status: 401,
+            headers: {
+              // Prompts the user for credentials.
+              "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
+            },
+          });
+        }
 
-				return new Response('🎉 You have private access!', {
-					status: 200,
-					headers: {
-						'Cache-Control': 'no-store',
-					},
-				});
-			}
-		}
+        return new Response("🎉 You have private access!", {
+          status: 200,
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        });
+      }
+    }
 
-		return new Response('Not Found.', { status: 404 });
-	},
+    return new Response("Not Found.", { status: 404 });
+  },
 };
 ```
 
@@ -142,7 +152,7 @@ export default {
  *
  */
 
-import { Buffer } from 'node:buffer';
+import { Buffer } from "node:buffer";
 
 const encoder = new TextEncoder();
 
@@ -151,87 +161,92 @@ const encoder = new TextEncoder();
  * Refer to https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#timingsafeequal for more details
  */
 function timingSafeEqual(a: string, b: string) {
-	const aBytes = encoder.encode(a);
-	const bBytes = encoder.encode(b);
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
 
-	if (aBytes.byteLength !== bBytes.byteLength) {
-		// Strings must be the same length in order to compare
-		// with crypto.subtle.timingSafeEqual
-		return false;
-	}
+  if (aBytes.byteLength !== bBytes.byteLength) {
+    // Strings must be the same length in order to compare
+    // with crypto.subtle.timingSafeEqual
+    return false;
+  }
 
-	return crypto.subtle.timingSafeEqual(aBytes, bBytes);
+  return crypto.subtle.timingSafeEqual(aBytes, bBytes);
 }
 
 export default <ExportedHandler<{ PASSWORD: string }>>{
-	async fetch(request, env) {
-		const BASIC_USER = 'admin';
+  async fetch(request, env) {
+    const BASIC_USER = "admin";
 
-		// You will need an admin password. This should be
-		// attached to your Worker as an encrypted secret.
-		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
-		const BASIC_PASS = env.PASSWORD ?? 'password';
+    // You will need an admin password. This should be
+    // attached to your Worker as an encrypted secret.
+    // Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+    const BASIC_PASS = env.PASSWORD ?? "password";
 
-		const url = new URL(request.url);
+    const url = new URL(request.url);
 
-		switch (url.pathname) {
-			case '/':
-				return new Response('Anyone can access the homepage.');
+    switch (url.pathname) {
+      case "/":
+        return new Response("Anyone can access the homepage.");
 
-			case '/logout':
-				// Invalidate the "Authorization" header by returning a HTTP 401.
-				// We do not send a "WWW-Authenticate" header, as this would trigger
-				// a popup in the browser, immediately asking for credentials again.
-				return new Response('Logged out.', { status: 401 });
+      case "/logout":
+        // Invalidate the "Authorization" header by returning a HTTP 401.
+        // We do not send a "WWW-Authenticate" header, as this would trigger
+        // a popup in the browser, immediately asking for credentials again.
+        return new Response("Logged out.", { status: 401 });
 
-			case '/admin': {
-				// The "Authorization" header is sent when authenticated.
-				const authorization = request.headers.get('Authorization');
-				if (!authorization) {
-					return new Response('You need to login.', {
-						status: 401,
-						headers: {
-							// Prompts the user for credentials.
-							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
-						},
-					});
-				}
-				const [scheme, encoded] = authorization.split(' ');
+      case "/admin": {
+        // The "Authorization" header is sent when authenticated.
+        const authorization = request.headers.get("Authorization");
+        if (!authorization) {
+          return new Response("You need to login.", {
+            status: 401,
+            headers: {
+              // Prompts the user for credentials.
+              "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
+            },
+          });
+        }
+        const [scheme, encoded] = authorization.split(" ");
 
-				// The Authorization header must start with Basic, followed by a space.
-				if (!encoded || scheme !== 'Basic') {
-					return new Response('Malformed authorization header.', { status: 400 });
-				}
+        // The Authorization header must start with Basic, followed by a space.
+        if (!encoded || scheme !== "Basic") {
+          return new Response("Malformed authorization header.", {
+            status: 400,
+          });
+        }
 
-				const credentials = Buffer.from(encoded, 'base64').toString();
+        const credentials = Buffer.from(encoded, "base64").toString();
 
-				// The username and password are split by the first colon.
-				//=> example: "username:password"
-				const index = credentials.indexOf(':');
-				const user = credentials.substring(0, index);
-				const pass = credentials.substring(index + 1);
+        // The username and password are split by the first colon.
+        //=> example: "username:password"
+        const index = credentials.indexOf(":");
+        const user = credentials.substring(0, index);
+        const pass = credentials.substring(index + 1);
 
-				if (!timingSafeEqual(BASIC_USER, user) || !timingSafeEqual(BASIC_PASS, pass)) {
-					return new Response('You need to login.', {
-						status: 401,
-						headers: {
-							// Prompts the user for credentials.
-							'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
-						},
-					});
-				}
+        if (
+          !timingSafeEqual(BASIC_USER, user) ||
+          !timingSafeEqual(BASIC_PASS, pass)
+        ) {
+          return new Response("You need to login.", {
+            status: 401,
+            headers: {
+              // Prompts the user for credentials.
+              "WWW-Authenticate": 'Basic realm="my scope", charset="UTF-8"',
+            },
+          });
+        }
 
-				return new Response('🎉 You have private access!', {
-					status: 200,
-					headers: {
-						'Cache-Control': 'no-store',
-					},
-				});
-			}
-		}
+        return new Response("🎉 You have private access!", {
+          status: 200,
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        });
+      }
+    }
 
-		return new Response('Not Found.', { status: 404 });
-	},
+    return new Response("Not Found.", { status: 404 });
+  },
 };
 ```
 

--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -205,7 +205,7 @@ export default <ExportedHandler<{ PASSWORD: string }>>{
 
 				const credentials = Buffer.from(encoded, 'base64').toString();
 
-				// The username & password are split by the first colon.
+				// The username and password are split by the first colon.
 				//=> example: "username:password"
 				const index = credentials.indexOf(':');
 				const user = credentials.substring(0, index);

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -19,7 +19,7 @@ The following worker will:
 
 * For request URLs beginning with `/verify/`, verify the signed URL and allow the request through.
 
-It makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/)
+This Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/)
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
@@ -48,7 +48,7 @@ export default {
 		const url = new URL(request.url);
 
 		// This is a demonstration Worker that allows unauthenticated access to both
-		// /generate and /verify. In a real application you'd want to make sure that
+		// /generate and /verify. In a real application you would want to make sure that
 		// users could only generate signed URLs when authenticated
 		if (url.pathname.startsWith('/generate/')) {
 			url.pathname = url.pathname.replace('/generate/', '/verify/');
@@ -59,7 +59,7 @@ export default {
 			const expiry = Date.now() + expirationMs;
 
 			// This array contains all the data about the request that you want to be able to verify
-			// Here we only sign the expiry and the pathname, but often you'll want to
+			// Here we only sign the expiry and the pathname, but often you will want to
 			// include more data (for instance, the URL hostname or query parameters)
 			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -14,7 +14,7 @@ layout: example
 
 You can both verify and generate signed requests from within a Worker using the [Web Crypto APIs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle).
 
-The following worker will:
+The following Worker will:
 * For request URLs beginning with `/generate/`, replace `/generate/` with `/verify/`, sign the resulting path with its timestamp, and return the full, signed URL in the response body.
 
 * For request URLs beginning with `/verify/`, verify the signed URL and allow the request through.

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -14,7 +14,7 @@ layout: example
 
 {{<Aside type="info">}}
 
-This example Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers)
+This example Worker makes use of the [Node.js Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
 {{</Aside>}}
 
 You can both verify and generate signed requests from within a Worker using the [Web Crypto APIs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle).

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -12,97 +12,120 @@ weight: 1001
 layout: example
 ---
 
+{{<Aside type="info">}}
+
+This example Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers)
+{{</Aside>}}
+
 You can both verify and generate signed requests from within a Worker using the [Web Crypto APIs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle).
 
 The following Worker will:
-* For request URLs beginning with `/generate/`, replace `/generate/` with `/verify/`, sign the resulting path with its timestamp, and return the full, signed URL in the response body.
 
-* For request URLs beginning with `/verify/`, verify the signed URL and allow the request through.
+- For request URLs beginning with `/generate/`, replace `/generate/` with `/verify/`, sign the resulting path with its timestamp, and return the full, signed URL in the response body.
 
-This Worker makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/)
+- For request URLs beginning with `/verify/`, verify the signed URL and allow the request through.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
 
 ```js
-import { Buffer } from 'node:buffer';
+import { Buffer } from "node:buffer";
 
 const encoder = new TextEncoder();
 
 export default {
-	/**
-	 * 
-	 * @param {Request} request 
-	 * @param {{SECRET_DATA: string}} env 
-	 * @returns 
-	 */
-	async fetch(request, env) {
-		// You will need some secret data to use as a symmetric key. This should be
-		// attached to your Worker as an encrypted secret.
-		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
-		const secretKeyData = encoder.encode(env.SECRET_DATA ?? 'my secret symmetric key');
+  /**
+   *
+   * @param {Request} request
+   * @param {{SECRET_DATA: string}} env
+   * @returns
+   */
+  async fetch(request, env) {
+    // You will need some secret data to use as a symmetric key. This should be
+    // attached to your Worker as an encrypted secret.
+    // Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+    const secretKeyData = encoder.encode(
+      env.SECRET_DATA ?? "my secret symmetric key"
+    );
 
-		// Import your secret as a CryptoKey for both 'sign' and 'verify' operations
-		const key = await crypto.subtle.importKey('raw', secretKeyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+    // Import your secret as a CryptoKey for both 'sign' and 'verify' operations
+    const key = await crypto.subtle.importKey(
+      "raw",
+      secretKeyData,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"]
+    );
 
-		const url = new URL(request.url);
+    const url = new URL(request.url);
 
-		// This is a demonstration Worker that allows unauthenticated access to both
-		// /generate and /verify. In a real application you would want to make sure that
-		// users could only generate signed URLs when authenticated
-		if (url.pathname.startsWith('/generate/')) {
-			url.pathname = url.pathname.replace('/generate/', '/verify/');
-			// Signed requests expire after one minute. Note that you should choose
-			// expiration durations dynamically, depending on, for example, the path or a query
-			// parameter.
-			const expirationMs = 60000;
-			const expiry = Date.now() + expirationMs;
+    // This is a demonstration Worker that allows unauthenticated access to both
+    // /generate and /verify. In a real application you would want to make sure that
+    // users could only generate signed URLs when authenticated
+    if (url.pathname.startsWith("/generate/")) {
+      url.pathname = url.pathname.replace("/generate/", "/verify/");
+      // Signed requests expire after one minute. Note that you should choose
+      // expiration durations dynamically, depending on, for example, the path or a query
+      // parameter.
+      const expirationMs = 60000;
+      const expiry = Date.now() + expirationMs;
 
-			// This array contains all the data about the request that you want to be able to verify
-			// Here we only sign the expiry and the pathname, but often you will want to
-			// include more data (for instance, the URL hostname or query parameters)
-			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
+      // This array contains all the data about the request that you want to be able to verify
+      // Here we only sign the expiry and the pathname, but often you will want to
+      // include more data (for instance, the URL hostname or query parameters)
+      const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-			const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(dataToAuthenticate));
+      const mac = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        encoder.encode(dataToAuthenticate)
+      );
 
-			// Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
-			// for more details on using NodeJS APIs in Workers
-			const base64Mac = Buffer.from(mac).toString('base64');
+      // Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
+      // for more details on using NodeJS APIs in Workers
+      const base64Mac = Buffer.from(mac).toString("base64");
 
-			url.searchParams.set('mac', base64Mac);
-			url.searchParams.set('expiry', expiry.toString());
+      url.searchParams.set("mac", base64Mac);
+      url.searchParams.set("expiry", expiry.toString());
 
-			return new Response(`${url.pathname}${url.search}`);
-		} else if (url.pathname.startsWith('/verify/')) {
-			// Make sure you have the minimum necessary query parameters.
-			if (!url.searchParams.has('mac') || !url.searchParams.has('expiry')) {
-				return new Response('Missing query parameter', { status: 403 });
-			}
+      return new Response(`${url.pathname}${url.search}`);
+    } else if (url.pathname.startsWith("/verify/")) {
+      // Make sure you have the minimum necessary query parameters.
+      if (!url.searchParams.has("mac") || !url.searchParams.has("expiry")) {
+        return new Response("Missing query parameter", { status: 403 });
+      }
 
-			const expiry = Number(url.searchParams.get('expiry'));
+      const expiry = Number(url.searchParams.get("expiry"));
 
-			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
+      const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-			const receivedMac = Buffer.from(url.searchParams.get('mac'), 'base64');
+      const receivedMac = Buffer.from(url.searchParams.get("mac"), "base64");
 
-			// Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
-			// symmetric keys, you could implement this by calling crypto.subtle.sign() and
-			// then doing a string comparison -- this is insecure, as string comparisons
-			// bail out on the first mismatch, which leaks information to potential
-			// attackers.
-			const verified = await crypto.subtle.verify('HMAC', key, receivedMac, encoder.encode(dataToAuthenticate));
+      // Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
+      // symmetric keys, you could implement this by calling crypto.subtle.sign() and
+      // then doing a string comparison -- this is insecure, as string comparisons
+      // bail out on the first mismatch, which leaks information to potential
+      // attackers.
+      const verified = await crypto.subtle.verify(
+        "HMAC",
+        key,
+        receivedMac,
+        encoder.encode(dataToAuthenticate)
+      );
 
-			if (!verified) {
-				return new Response('Invalid MAC', { status: 403 });
-			}
+      if (!verified) {
+        return new Response("Invalid MAC", { status: 403 });
+      }
 
-			if (Date.now() > expiry) {
-				return new Response(`URL expired at ${new Date(expiry)}`, { status: 403 });
-			}
-		}
+      if (Date.now() > expiry) {
+        return new Response(`URL expired at ${new Date(expiry)}`, {
+          status: 403,
+        });
+      }
+    }
 
-		return fetch(new URL(url.pathname, 'https://example.com'), request);
-	},
+    return fetch(new URL(url.pathname, "https://example.com"), request);
+  },
 };
 ```
 
@@ -110,80 +133,98 @@ export default {
 {{<tab label="ts">}}
 
 ```ts
-import { Buffer } from 'node:buffer';
+import { Buffer } from "node:buffer";
 
 const encoder = new TextEncoder();
 
 export default <ExportedHandler<{ SECRET_DATA: string }>>{
-	async fetch(request, env) {
-		// You will need some secret data to use as a symmetric key. This should be
-		// attached to your Worker as an encrypted secret.
-		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
-		const secretKeyData = encoder.encode(env.SECRET_DATA ?? 'my secret symmetric key');
+  async fetch(request, env) {
+    // You will need some secret data to use as a symmetric key. This should be
+    // attached to your Worker as an encrypted secret.
+    // Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+    const secretKeyData = encoder.encode(
+      env.SECRET_DATA ?? "my secret symmetric key"
+    );
 
-		// Import your secret as a CryptoKey for both 'sign' and 'verify' operations
-		const key = await crypto.subtle.importKey('raw', secretKeyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+    // Import your secret as a CryptoKey for both 'sign' and 'verify' operations
+    const key = await crypto.subtle.importKey(
+      "raw",
+      secretKeyData,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"]
+    );
 
-		const url = new URL(request.url);
+    const url = new URL(request.url);
 
-		// This is a demonstration Worker that allows unauthenticated access to both
-		// /generate and /verify. In a real application you'd want to make sure that
-		// users could only generate signed URLs when authenticated
-		if (url.pathname.startsWith('/generate/')) {
-			url.pathname = url.pathname.replace('/generate/', '/verify/');
-			// Signed requests expire after one minute. Note that you should choose
-			// expiration durations dynamically, depending on, for example, the path or a query
-			// parameter.
-			const expirationMs = 60000;
-			const expiry = Date.now() + expirationMs;
+    // This is a demonstration Worker that allows unauthenticated access to both
+    // /generate and /verify. In a real application you'd want to make sure that
+    // users could only generate signed URLs when authenticated
+    if (url.pathname.startsWith("/generate/")) {
+      url.pathname = url.pathname.replace("/generate/", "/verify/");
+      // Signed requests expire after one minute. Note that you should choose
+      // expiration durations dynamically, depending on, for example, the path or a query
+      // parameter.
+      const expirationMs = 60000;
+      const expiry = Date.now() + expirationMs;
 
-			// This array contains all the data about the request that you want to be able to verify
-			// Here we only sign the expiry and the pathname, but often you'll want to
-			// include more data (for instance, the URL hostname or query parameters)
-			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
+      // This array contains all the data about the request that you want to be able to verify
+      // Here we only sign the expiry and the pathname, but often you'll want to
+      // include more data (for instance, the URL hostname or query parameters)
+      const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-			const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(dataToAuthenticate));
+      const mac = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        encoder.encode(dataToAuthenticate)
+      );
 
-			// Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
-			// for more details on using NodeJS APIs in Workers
-			const base64Mac = Buffer.from(mac).toString('base64');
+      // Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
+      // for more details on using NodeJS APIs in Workers
+      const base64Mac = Buffer.from(mac).toString("base64");
 
-			url.searchParams.set('mac', base64Mac);
-			url.searchParams.set('expiry', expiry.toString());
+      url.searchParams.set("mac", base64Mac);
+      url.searchParams.set("expiry", expiry.toString());
 
-			return new Response(`${url.pathname}${url.search}`);
-		} else if (url.pathname.startsWith('/verify/')) {
-			// Make sure you have the minimum necessary query parameters.
-			if (!url.searchParams.has('mac') || !url.searchParams.has('expiry')) {
-				return new Response('Missing query parameter', { status: 403 });
-			}
+      return new Response(`${url.pathname}${url.search}`);
+    } else if (url.pathname.startsWith("/verify/")) {
+      // Make sure you have the minimum necessary query parameters.
+      if (!url.searchParams.has("mac") || !url.searchParams.has("expiry")) {
+        return new Response("Missing query parameter", { status: 403 });
+      }
 
-			const expiry = Number(url.searchParams.get('expiry'));
+      const expiry = Number(url.searchParams.get("expiry"));
 
-			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
+      const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-			const receivedMac = Buffer.from(url.searchParams.get('mac'), 'base64');
+      const receivedMac = Buffer.from(url.searchParams.get("mac"), "base64");
 
-			// Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
-			// symmetric keys, you could implement this by calling crypto.subtle.sign() and
-			// then doing a string comparison -- this is insecure, as string comparisons
-			// bail out on the first mismatch, which leaks information to potential
-			// attackers.
-			const verified = await crypto.subtle.verify('HMAC', key, receivedMac, encoder.encode(dataToAuthenticate));
+      // Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
+      // symmetric keys, you could implement this by calling crypto.subtle.sign() and
+      // then doing a string comparison -- this is insecure, as string comparisons
+      // bail out on the first mismatch, which leaks information to potential
+      // attackers.
+      const verified = await crypto.subtle.verify(
+        "HMAC",
+        key,
+        receivedMac,
+        encoder.encode(dataToAuthenticate)
+      );
 
-			if (!verified) {
-				return new Response('Invalid MAC', { status: 403 });
-			}
+      if (!verified) {
+        return new Response("Invalid MAC", { status: 403 });
+      }
 
-			if (Date.now() > expiry) {
-				return new Response(`URL expired at ${new Date(expiry)}`, { status: 403 });
-			}
-		}
+      if (Date.now() > expiry) {
+        return new Response(`URL expired at ${new Date(expiry)}`, {
+          status: 403,
+        });
+      }
+    }
 
-		return fetch(new URL(url.pathname, 'https://example.com'), request);
-	},
+    return fetch(new URL(url.pathname, "https://example.com"), request);
+  },
 };
-
 ```
 
 {{</tab>}}

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -6,91 +6,103 @@ tags:
   - Security
   - WebCrypto
 pcx_content_type: configuration
+playground: https://workers.cloudflare.com/playground#LYVwNgLglgDghgJwgegGYHsHALQBM4RwDcABAEbogB2+CAngLzbMutvvsCMA7AMwBsABgAs3AEwDOwsQE5+AVm79hnMcN58xADnWCAXB0NG2PASPGTpcxctXrNO3oICwAKADC6KhACm37AAiUADOMOjBUNBeeiQYWHgExCRUcMA+DABE+IQAdABWwRmkqFBgfqnpWYn5hW6e3n4Q2AAqdDA+MXAwMGBQAMYEUF7IeXAAbnDBfQiwEADUwOi44D5ubj4AHmFIJLg+qHDgECQA3q4AkClpMRkAohupPT4kAIIACgCSGQA0F4QA5sEYgBtDKbR5lH4kDJdKBQjIIHyhLzBHwZAC6vwAvkRXG5jATDKYhKIJPwpLIFEoVGoNLxtLo6l5fP4gsiIlEqDE4jhskkrpUoDRNjUirFSuU0pkhXsNqKmQ1-K12p1ur0BpyRuNJtNZgslis1q4oMBtscTiQAEIgVCoHwIEhY2IIdDAEgAcioSw6ZBtdoQ7txrj6KOOfhDewdDGSPgA7iRmpsILcqBH7QAKACUQc2Zt2+0OkFOF2QACpSxcSKWSJXqwABeAIVKnABKPgAjiAkRAnYjO92a+cqyQG4hmycTgBlW7uFu3ZoAfQCL2aLxiwQgMyo-yxTr8Y0Hw7riIgIAQVGCh9LyAukzoqdiPggfQAFum+12N98SPvM8XzucyDICQACalAkLGpRgDGPi4CQwSus8qLTE+uyJCQEDoCQICoiQkx4fBdDAGkm79CQADWPh0DkCYviE8EvpQYBwWQPgXIBwEEIQr6wRhWF0JQDoAOqYJRDr4XAVA-qm9AwL4cHISeOTsUBJBtv6fEkC+EAQDAQJAXsYw+GA6DtAgwQ5H0JkgLgqBgIgPiWa6yCxqJ9rBMgIZUCU-xnoMwyKU+HnsV5G7wT4KEQAA0lRATodG4beggOSJXs6b7jk06zvOS4ri8JAAPwFR6wB0OFkWEcRT4zH0FFUe62auCpwEfKamDHAJZ7lSeeGXnAJDuLJmExWVcTkOgEAvh6ET-FQ7p4TQHpGTMqB0PNpn2v5F4haGdVldGcCxnAkQkNMbSYTkwQgGQEBlDkJpmiN6buk2sbut+gXRbFiTfhaAoxO6AASACyLzuO9WmTC+AOToDLzYGI8j8PNWLfgcYCot+wLujNc3fu6y1QKt7roo1O0XscZ7QdGVBxiQACqLYADLvh2n4QDkVNkwBqnNHRl70f1eyLBTTaciQIkIGJGEvgQeFgCZsaXtQhyTY0-QELxcB9H0SKXph42Tc1JDIP8fibb4C1wcghOrTRHxSf1iJwNBXQ9Br4ude6cFHd4mnAHAlHwWezyTQQxs4e5p1MXBXhgGVZu02LSFQLNvGM0zl6xi+fh4SAaveB7sHsUTJDplTOTwJNAqXYQSDBEJkRvu6pvm8nyANX+ZwAecFdVy+AokNGfcEAPFQ5IiPTaz4z2t0nmsd-jNv2kTdAd41PeqZOqe03BH7dpeuZQIieGoL4DpeM8wBCvnjkkAAchNoeyx14HBIx4Bwa+6DhGxm-AUfMWQwpLLCASiXY95UgawVnQb8ex2g0CFP8EgXg0aYB-A8U0ZRvxqxIP3FB4kSD9noOxDieCxwkXtMpHuoUwxbGPltYGl5oxCEEGw3ENDdqAP2iQOKvgcheljFmEgcwMEwAYZyJhQZ-60UFggJsZUvKECFH1BWMtnh8jwhQfO6iSD7zCmHV+IAIKSWOAbViWiyiaVtnQUhqlAb2meLGZ4ccyq410dwq2uj+4Cm-L6Y46Az65y9mo32Zj0B2OAkKKyNkr6YA0ehdMY0VGEFTD4HBOcGbMy0uECAg90HELKo2Co59giZlIbQtChBmjoBePnHOhcNTPGjAAKUnAAeXvrXLc-xV7pmBCPauFRvzcNJtIgClSA61QOkdE6Z05LoEutdW6jlcbPRBmDCGlFYHSTTMlVKM8+Q1LqQXaATTMzcx5sBdS9pNLaV0vpZAhljIbXMpZaytl7KIicsAFyblzLIAQNQaAaRsCwg8l6PYBQbwyLGosE+exlEYxQVJHCSCH7ejaa8T4AspKSzEsECpu0yCTB8MoYG2sh5Wj9FQ1ALpgDpimZmHImFJykW3M9ElqJlANXGb3BAYBLo+EQK+N4FCLKoggM9KZEMuVkuEBSvoG8AIV1RCKl8YqmzAAlU+Z63CIbcJZegNlPSsyXPOCeM8UlabxjbMiC8M8AAGAASE4gyx5pCxK61VwqECvixI65Ve4MbPFLuXAVldR41w3IgCADcm6zxsevLukSSAUqDldE+nVIZGV0dfKgJoQBulprrYIwREBlUKeQrVT53LUIAmGgAhD69VmrUgWVlsEaV2sGokAAD59pIM2iNaq-UavFTkTter6H0E7v+HulrzwxltUiMIDrnrAxCBEbcRCuz0GrSU+0EMLQxtPECEgwhBC8EdMq84WImqcIpmI4+PD75FtYggcNgrR2ionWbKV7p9UXL5ZUo5tT6nqyaVStpnTulIL6QMiNPjhnPvoGMh9EzdqIl1lAIyuBFVUutLaWl9Kv1CtbX+3V7oZWZnxnKnl5rVL01wvMi6V0bp3RscIg2vlEBwTgP8Y6T6QXoq4trciFkSDbzSSQDZ7hlaolTcEIiJEap7WCN+bNIZP4kAemUNIftJr0TIIol2vQd2scWexlZl0d7CMkrgVNBddjoFE-BdlyCQymkQCELwJBmAy3okFh1fQQ7fnwhuHp0dvMzAQttGRJLSgoJ0X53BJRzLHGvsEAOz4Xzfmzv0KaZRA64p5FtTSYQWTQBdqmsTfQCX1vOJU22UBeIzOOscSzSyOOOS40DUG4NvzbO-NhnwuHYKKpGamJKKVptpTAychpZzNbAYw+cJtLXYIpp7hap8Vrl1qVXSiGe7oHYTF6HBAbx73MEBwjES916sS3vvaQsNfDHKCOEQAPlQ3QbbC69tLptYd+1qJ0yOozqhrWxxXXA-e+lGdf2A2-Ru2e+7V6b0cIAve7HGHF1STtLl9MwOM5keQ2kfG9y9J6CAuCLBjkvMNRG2zbsG9UauBxHiVwhIeesGJOYMkFJrDUjsHSBkTgFRVcCCEMIHJgHckwLyRIpABSZGcWALzjltLADAGKEoZRVcZHV5rydEAdcZEl40FobQOgYSTMgKeQojQAB5G0BHae4ZoIE3i3C0mbsAX3XDO+19Bey25Mh+AyIH84wfhW4GjzHki-VXyIElZkemzQABi2AtAZBNgn53Se-e6WwGzXDmQAAa2B6bw08N56AZBITR0VBATIHxbgMFgmbPPyAC9F8N2MVrsYzR56UY0NXUBcCTQYIZfoPhsCQSn3l3TBbqtgGwFMF26ROA5EED3gv0AVlffcB8uyDkJb-MvG8eydB-gumoLgZ3yBD9lAL+Z8ipDERgEyBuOgZR34+BPgZCkIviIioCZBU6PJTy37340A5CGQwAui4DvKUCfIOTwE+BjAuTGSa4b4QB-4M5lrAE8zR5P45xwDx4PrO4UC4B0AF64C4anT2RlqZBn6IiFAJ4x4mjILBB+oQE6TU5ATQF36UBwEIFIEoE2RsGOSGRoBfJIiVzbj77sRP4MFjB95CacHO5qFMGTDBBq6X7YAmT-DoBR6qG4ZaEwCcHnBCQ4GISNoMy4RGZX434iEP6aS+BhS4AzC5r9T4r2jfgoSawETCxYSYSkLnDvzn5xxCjpJeLZy5zOy0H5g9DoBlQMHYa3RlQGy4Jd7PAmbhQ6ToogAwB4QREn6oHSF4Q6yiEcykJP5WH1EvicBfZCQvy6Z9QX5Sz2gFRkEtH1GNE7b5QVFSHyFdHSz0QtLaiTi6hyTRx7AkDZqxgzCWyGKQw0D-6LGCQQQ+BkAREcg+A4yybNDNBvAYRNi2hkQZERRZEr4DSn7yFHF5EkAmQajAJ9SwFwRqwRGuQCq4DhYKzoCQQ7rZoGyvHBFphMG-yaSdQOh+BwSRzmR3GYCRh8QRHsFrpfFhE5xujwrPCdj9DkTxz1EO5aHNFfbND7onSwmohgCoB9GWHWHtJSSwkvH7DHCCzwQQjPD+EOhrH0RApUAFo7qpb8zwSRB3xgTGIDBUARGwQnQnS9C+GLSojPzPDsFHCXg5zfIkC3AMFmKZL4JwAUC5oGzICwhok7aqk5Lxi5GYJPDjG3KywbFIi7BEz+iNB6KUCeE0RSmnSSTywIQ-j6kRG4KQkGzWnZwEBHGy4RCN7PAObkBRasm0wbAcl7D9RglEyOQkmDEx7IABxCikHIA0F0FB7IAh6B74i868786kiWCUg2A0j2D0iOAuAeDMhW5siy6RDy6xCK4JCEAq4VCZBJ58h64SiG6N7oBkAW4dkt7W4qh4RqgezAIjBxZGgnAZCFlUALiLDLCQh6AZAygigFAZBYjVk1mEh1kWDkhWBUi2C0gOC6DMBuBAA
 title: Sign requests
 weight: 1001
 layout: example
 ---
 
+You can both verify and generate signed requests from within a Worker using the [Web Crypto APIs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle).
+
+The following worker will:
+* For request URLs beginning with `/generate/`, replace `/generate/` with `/verify/`, sign the resulting path with its timestamp, and return the full, signed URL in the response body.
+
+* For request URLs beginning with `/verify/`, verify the signed URL and allow the request through.
+
+It makes use of the [Node.JS Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/)
+
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
 
 ```js
+import { Buffer } from 'node:buffer';
+
+const encoder = new TextEncoder();
+
 export default {
-  async fetch(request) {
-    // You will need some super-secret data to use as a symmetric key.
-    const encoder = new TextEncoder();
-    const secretKeyData = encoder.encode("my secret symmetric key");
+	/**
+	 * 
+	 * @param {Request} request 
+	 * @param {{SECRET_DATA: string}} env 
+	 * @returns 
+	 */
+	async fetch(request, env) {
+		// You will need some secret data to use as a symmetric key. This should be
+		// attached to your Worker as an encrypted secret.
+		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+		const secretKeyData = encoder.encode(env.SECRET_DATA ?? 'my secret symmetric key');
 
-    // Convert a ByteString (a string whose code units are all in the range
-    // [0, 255]), to a Uint8Array. If you pass in a string with code units larger
-    // than 255, their values will overflow.
-    function byteStringToUint8Array(byteString) {
-      const ui = new Uint8Array(byteString.length);
-      for (let i = 0; i < byteString.length; ++i) {
-        ui[i] = byteString.charCodeAt(i);
-      }
-      return ui;
-    }
+		// Import your secret as a CryptoKey for both 'sign' and 'verify' operations
+		const key = await crypto.subtle.importKey('raw', secretKeyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
 
-    const url = new URL(request.url);
+		const url = new URL(request.url);
 
-    // If the path does not begin with our protected prefix, pass the request through
-    if (!url.pathname.startsWith("/verify/")) {
-      return fetch(request);
-    }
+		// This is a demonstration Worker that allows unauthenticated access to both
+		// /generate and /verify. In a real application you'd want to make sure that
+		// users could only generate signed URLs when authenticated
+		if (url.pathname.startsWith('/generate/')) {
+			url.pathname = url.pathname.replace('/generate/', '/verify/');
+			// Signed requests expire after one minute. Note that you should choose
+			// expiration durations dynamically, depending on, for example, the path or a query
+			// parameter.
+			const expirationMs = 60000;
+			const expiry = Date.now() + expirationMs;
 
-    // Make sure you have the minimum necessary query parameters.
-    if (!url.searchParams.has("mac") || !url.searchParams.has("expiry")) {
-      return new Response("Missing query parameter", { status: 403 });
-    }
+			// This array contains all the data about the request that you want to be able to verify
+			// Here we only sign the expiry and the pathname, but often you'll want to
+			// include more data (for instance, the URL hostname or query parameters)
+			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-    const key = await crypto.subtle.importKey(
-      "raw",
-      secretKeyData,
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["verify"]
-    );
+			const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(dataToAuthenticate));
 
-    // Extract the query parameters we need and run the HMAC algorithm on the
-    // parts of the request we are authenticating: the path and the expiration
-    // timestamp. It is crucial to pad the input data, for example, by adding a symbol
-    // in-between the two fields that can never occur on the right side. In this
-    // case, use the @ symbol to separate the fields.
-    const expiry = Number(url.searchParams.get("expiry"));
-    const dataToAuthenticate = `${url.pathname}@${expiry}`;
+			// Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
+			// for more details on using NodeJS APIs in Workers
+			const base64Mac = Buffer.from(mac).toString('base64');
 
-    // The received MAC is Base64-encoded, so you have to go to some trouble to
-    // get it into a buffer type that crypto.subtle.verify() can read.
-    const receivedMacBase64 = url.searchParams.get("mac");
-    const receivedMac = byteStringToUint8Array(atob(receivedMacBase64));
+			url.searchParams.set('mac', base64Mac);
+			url.searchParams.set('expiry', expiry.toString());
 
-    // Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
-    // symmetric keys, you could implement this by calling crypto.subtle.sign() and
-    // then doing a string comparison -- this is insecure, as string comparisons
-    // bail out on the first mismatch, which leaks information to potential
-    // attackers.
-    const verified = await crypto.subtle.verify(
-      "HMAC",
-      key,
-      receivedMac,
-      encoder.encode(dataToAuthenticate)
-    );
+			return new Response(`${url.pathname}${url.search}`);
+		} else if (url.pathname.startsWith('/verify/')) {
+			// Make sure you have the minimum necessary query parameters.
+			if (!url.searchParams.has('mac') || !url.searchParams.has('expiry')) {
+				return new Response('Missing query parameter', { status: 403 });
+			}
 
-    if (!verified) {
-      const body = "Invalid MAC";
-      return new Response(body, { status: 403 });
-    }
+			const expiry = Number(url.searchParams.get('expiry'));
 
-    if (Date.now() > expiry) {
-      const body = `URL expired at ${new Date(expiry)}`;
-      return new Response(body, { status: 403 });
-    }
+			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-    // you have verified the MAC and expiration time; you can now pass the request
-    // through.
-    return fetch(request);
-  },
+			const receivedMac = Buffer.from(url.searchParams.get('mac'), 'base64');
+
+			// Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
+			// symmetric keys, you could implement this by calling crypto.subtle.sign() and
+			// then doing a string comparison -- this is insecure, as string comparisons
+			// bail out on the first mismatch, which leaks information to potential
+			// attackers.
+			const verified = await crypto.subtle.verify('HMAC', key, receivedMac, encoder.encode(dataToAuthenticate));
+
+			if (!verified) {
+				return new Response('Invalid MAC', { status: 403 });
+			}
+
+			if (Date.now() > expiry) {
+				return new Response(`URL expired at ${new Date(expiry)}`, { status: 403 });
+			}
+		}
+
+		return fetch(new URL(url.pathname, 'https://example.com'), request);
+	},
 };
 ```
 
@@ -98,236 +110,80 @@ export default {
 {{<tab label="ts">}}
 
 ```ts
-const handler: ExportedHandler = {
-  async fetch(request) {
-    // You will need some super-secret data to use as a symmetric key.
-    const encoder = new TextEncoder();
-    const secretKeyData = encoder.encode("my secret symmetric key");
+import { Buffer } from 'node:buffer';
 
-    // Convert a ByteString (a string whose code units are all in the range
-    // [0, 255]), to a Uint8Array. If you pass in a string with code units larger
-    // than 255, their values will overflow.
-    function byteStringToUint8Array(byteString) {
-      const ui = new Uint8Array(byteString.length);
-      for (let i = 0; i < byteString.length; ++i) {
-        ui[i] = byteString.charCodeAt(i);
-      }
-      return ui;
-    }
+const encoder = new TextEncoder();
 
-    const url = new URL(request.url);
+export default <ExportedHandler<{ SECRET_DATA: string }>>{
+	async fetch(request, env) {
+		// You will need some secret data to use as a symmetric key. This should be
+		// attached to your Worker as an encrypted secret.
+		// Refer to https://developers.cloudflare.com/workers/configuration/secrets/
+		const secretKeyData = encoder.encode(env.SECRET_DATA ?? 'my secret symmetric key');
 
-    // If the path does not begin with our protected prefix, pass the request through
-    if (!url.pathname.startsWith("/verify/")) {
-      return fetch(request);
-    }
+		// Import your secret as a CryptoKey for both 'sign' and 'verify' operations
+		const key = await crypto.subtle.importKey('raw', secretKeyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
 
-    // Make sure you have the minimum necessary query parameters.
-    if (!url.searchParams.has("mac") || !url.searchParams.has("expiry")) {
-      return new Response("Missing query parameter", { status: 403 });
-    }
+		const url = new URL(request.url);
 
-    const key = await crypto.subtle.importKey(
-      "raw",
-      secretKeyData,
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["verify"]
-    );
+		// This is a demonstration Worker that allows unauthenticated access to both
+		// /generate and /verify. In a real application you'd want to make sure that
+		// users could only generate signed URLs when authenticated
+		if (url.pathname.startsWith('/generate/')) {
+			url.pathname = url.pathname.replace('/generate/', '/verify/');
+			// Signed requests expire after one minute. Note that you should choose
+			// expiration durations dynamically, depending on, for example, the path or a query
+			// parameter.
+			const expirationMs = 60000;
+			const expiry = Date.now() + expirationMs;
 
-    // Extract the query parameters we need and run the HMAC algorithm on the
-    // parts of the request we are authenticating: the path and the expiration
-    // timestamp. It is crucial to pad the input data, for example, by adding a symbol
-    // in-between the two fields that can never occur on the right side. In this
-    // case, use the @ symbol to separate the fields.
-    const expiry = Number(url.searchParams.get("expiry"));
-    const dataToAuthenticate = `${url.pathname}@${expiry}`;
+			// This array contains all the data about the request that you want to be able to verify
+			// Here we only sign the expiry and the pathname, but often you'll want to
+			// include more data (for instance, the URL hostname or query parameters)
+			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
 
-    // The received MAC is Base64-encoded, so you have to go to some trouble to
-    // get it into a buffer type that crypto.subtle.verify() can read.
-    const receivedMacBase64 = url.searchParams.get("mac");
-    const receivedMac = byteStringToUint8Array(atob(receivedMacBase64));
+			const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(dataToAuthenticate));
 
-    // Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
-    // symmetric keys, you could implement this by calling crypto.subtle.sign() and
-    // then doing a string comparison -- this is insecure, as string comparisons
-    // bail out on the first mismatch, which leaks information to potential
-    // attackers.
-    const verified = await crypto.subtle.verify(
-      "HMAC",
-      key,
-      receivedMac,
-      encoder.encode(dataToAuthenticate)
-    );
+			// Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/
+			// for more details on using NodeJS APIs in Workers
+			const base64Mac = Buffer.from(mac).toString('base64');
 
-    if (!verified) {
-      const body = "Invalid MAC";
-      return new Response(body, { status: 403 });
-    }
+			url.searchParams.set('mac', base64Mac);
+			url.searchParams.set('expiry', expiry.toString());
 
-    if (Date.now() > expiry) {
-      const body = `URL expired at ${new Date(expiry)}`;
-      return new Response(body, { status: 403 });
-    }
+			return new Response(`${url.pathname}${url.search}`);
+		} else if (url.pathname.startsWith('/verify/')) {
+			// Make sure you have the minimum necessary query parameters.
+			if (!url.searchParams.has('mac') || !url.searchParams.has('expiry')) {
+				return new Response('Missing query parameter', { status: 403 });
+			}
 
-    // you have verified the MAC and expiration time; you can now pass the request
-    // through.
-    return fetch(request);
-  },
+			const expiry = Number(url.searchParams.get('expiry'));
+
+			const dataToAuthenticate = JSON.stringify([url.pathname, expiry]);
+
+			const receivedMac = Buffer.from(url.searchParams.get('mac'), 'base64');
+
+			// Use crypto.subtle.verify() to guard against timing attacks. Since HMACs use
+			// symmetric keys, you could implement this by calling crypto.subtle.sign() and
+			// then doing a string comparison -- this is insecure, as string comparisons
+			// bail out on the first mismatch, which leaks information to potential
+			// attackers.
+			const verified = await crypto.subtle.verify('HMAC', key, receivedMac, encoder.encode(dataToAuthenticate));
+
+			if (!verified) {
+				return new Response('Invalid MAC', { status: 403 });
+			}
+
+			if (Date.now() > expiry) {
+				return new Response(`URL expired at ${new Date(expiry)}`, { status: 403 });
+			}
+		}
+
+		return fetch(new URL(url.pathname, 'https://example.com'), request);
+	},
 };
 
-export default handler;
-```
-
-{{</tab>}}
-{{</tabs>}}
-
----
-
-{{<content-column>}}
-
-## Generating signed requests
-
-You can generate signed requests from within a Worker using the [Web Crypto APIs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle).
-
-{{<Aside type="note">}}
-
-Signed requests expire after one minute. Cloudflare recommends choosing expiration durations dynamically, depending on the path or a query parameter.
-
-{{</Aside>}}
-
-For request URLs beginning with `/generate/`, replace `/generate/` with `/verify/`, sign the resulting path with its timestamp, and return the full, signed URL in the response body.
-
-{{</content-column>}}
-
-{{<tabs labels="js | ts">}}
-{{<tab label="js" default="true">}}
-
-```js
-export default {
-  async fetch(request) {
-    async function generateSignedUrl(url) {
-      // You will need some super-secret data to use as a symmetric key.
-      const encoder = new TextEncoder();
-      const secretKeyData = encoder.encode("my secret symmetric key");
-      const key = await crypto.subtle.importKey(
-        "raw",
-        secretKeyData,
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"]
-      );
-
-      // Signed requests expire after one minute. Note that you could choose
-      // expiration durations dynamically, depending on, for example, the path or a query
-      // parameter.
-      const expirationMs = 60000;
-      const expiry = Date.now() + expirationMs;
-      // The signature will be computed for the pathname and the expiry timestamp.
-      // The two fields must be separated or padded to ensure that an attacker
-      // will not be able to use the same signature for other pathname/expiry pairs.
-      // The @ symbol is guaranteed not to appear in expiry, which is a (decimal)
-      // number, so you can safely use it as a separator here. When combining more
-      // fields, consider JSON.stringify-ing an array of the fields instead of
-      // concatenating the values.
-      const dataToAuthenticate = `${url.pathname}@${expiry}`;
-
-      const mac = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(dataToAuthenticate)
-      );
-
-      // `mac` is an ArrayBuffer, so you need to make a few changes to get
-      // it into a ByteString, and then a Base64-encoded string.
-      let base64Mac = btoa(String.fromCharCode(...new Uint8Array(mac)));
-
-      // must convert "+" to "-" as urls encode "+" as " "
-      base64Mac = base64Mac.replaceAll("+", "-");
-      url.searchParams.set("mac", base64Mac);
-      url.searchParams.set("expiry", expiry);
-
-      return new Response(url);
-    }
-
-    const url = new URL(request.url);
-    const prefix = "/generate/";
-    if (url.pathname.startsWith(prefix)) {
-      // Replace the "/generate/" path prefix with "/verify/", which we
-      // use in the first example to recognize authenticated paths.
-      url.pathname = `/verify/${url.pathname.slice(prefix.length)}`;
-      return await generateSignedUrl(url);
-    } else {
-      return fetch(request);
-    }
-  },
-};
-```
-
-{{</tab>}}
-{{<tab label="ts">}}
-
-```ts
-const handler: ExportedHandler = {
-  async fetch(request: Request) {
-    async function generateSignedUrl(url) {
-      // You will need some super-secret data to use as a symmetric key.
-      const encoder = new TextEncoder();
-      const secretKeyData = encoder.encode("my secret symmetric key");
-      const key = await crypto.subtle.importKey(
-        "raw",
-        secretKeyData,
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"]
-      );
-
-      // Signed requests expire after one minute. Note that you could choose
-      // expiration durations dynamically, depending on, for example, the path or a query
-      // parameter.
-      const expirationMs = 60000;
-      const expiry = Date.now() + expirationMs;
-      // The signature will be computed for the pathname and the expiry timestamp.
-      // The two fields must be separated or padded to ensure that an attacker
-      // will not be able to use the same signature for other pathname/expiry pairs.
-      // The @ symbol is guaranteed not to appear in expiry, which is a (decimal)
-      // number, so you can safely use it as a separator here. When combining more
-      // fields, consider JSON.stringify-ing an array of the fields instead of
-      // concatenating the values.
-      const dataToAuthenticate = `${url.pathname}@${expiry}`;
-
-      const mac = await crypto.subtle.sign(
-        "HMAC",
-        key,
-        encoder.encode(dataToAuthenticate)
-      );
-
-      // `mac` is an ArrayBuffer, so you need to make a few changes to get
-      // it into a ByteString, and then a Base64-encoded string.
-      let base64Mac = btoa(String.fromCharCode(...new Uint8Array(mac)));
-
-      // must convert "+" to "-" as urls encode "+" as " "
-      base64Mac = base64Mac.replaceAll("+", "-");
-      url.searchParams.set("mac", base64Mac);
-      url.searchParams.set("expiry", expiry);
-
-      return new Response(url);
-    }
-
-    const url = new URL(request.url);
-    const prefix = "/generate/";
-    if (url.pathname.startsWith(prefix)) {
-      // Replace the "/generate/" path prefix with "/verify/", which we
-      // use in the first example to recognize authenticated paths.
-      url.pathname = `/verify/${url.pathname.slice(prefix.length)}`;
-      return await generateSignedUrl(url);
-    } else {
-      return fetch(request);
-    }
-  },
-};
-
-export default handler;
 ```
 
 {{</tab>}}

--- a/layouts/_default/example.html
+++ b/layouts/_default/example.html
@@ -1,33 +1,40 @@
 {{ define "main" }}
-  {{- $type := default "overview" .Params.type -}}
+{{- $type := default "overview" .Params.type -}}
 
-  <div class="DocsPage">
-    {{- partial "skipcontent" . -}}
-    {{- partial "topbar.mobile" . -}}
-    {{- partial "sidebar.nav" . -}}
+<div class="DocsPage">
+  {{- partial "skipcontent" . -}}
+  {{- partial "topbar.mobile" . -}}
+  {{- partial "sidebar.nav" . -}}
 
-    <div class="DocsToolbar">
-      {{- partial "topbar.search" . -}}
-      {{- partial "topbar.tools" . -}}
-    </div>
-
-    <main class="DocsBody">
-      <div id="docs-content" data-reach-skip-nav-content></div>
-      {{- partial "breadcrumbs" . -}}
-
-      <div class="DocsContent" id="main" page-type="{{ $type }}">
-        <article class="DocsMarkdown">
-          <h1>{{ .Title }}</h1>
-
-          <div class="DocsMarkdown--content-column">
-            {{- .Params.Summary -}}
-          </div>
-
-          {{- .Content -}}
-        </article>
-      </div>
-    </main>
-
-    {{ partial "footer" . }}
+  <div class="DocsToolbar">
+    {{- partial "topbar.search" . -}}
+    {{- partial "topbar.tools" . -}}
   </div>
+
+  <main class="DocsBody">
+    <div id="docs-content" data-reach-skip-nav-content></div>
+    {{- partial "breadcrumbs" . -}}
+
+    <div class="DocsContent" id="main" page-type="{{ $type }}">
+      <article class="DocsMarkdown">
+        <h1>{{ .Title }}</h1>
+        {{ if .Params.Playground }}
+        <div class="DocsMarkdown--content-column">
+          <a href="{{- .Params.Playground -}}" class="DocsMarkdown--link" target="_blank" rel="noopener">
+            <span class="DocsMarkdown--link-content">Try in Workers Playground</span>
+            {{- partialCached "external.icon" . -}}
+          </a>
+        </div>
+        {{ end }}
+        <div class="DocsMarkdown--content-column">
+          {{- .Params.Summary -}}
+        </div>
+
+        {{- .Content -}}
+      </article>
+    </div>
+  </main>
+
+  {{ partial "footer" . }}
+</div>
 {{ end }}


### PR DESCRIPTION
Fixes #9431, fixes #11104, fixes #9497

This PR:
* Fixes the Basic authentication example to actually check the username and password
* Fixes the Sign/Verify example to properly decode from base64

It also adds a "Try in Worker Playground" to both examples, which can be used for more examples in time

cc @deadlypants1973 