### PR TITLE
[Chore] Move Alex config to file

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -56,16 +56,11 @@ jobs:
         if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
 
       - name: Spelling Errors
-        run: codespell --count --skip="*.js,./.git,./content/support/Other Languages/*" ${{ env.CHANGED_FILES }}
+        run: codespell --count --skip="*.js,./.git" ${{ env.CHANGED_FILES }}
         if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
 
       - name: Case Police
         run: case-police ${{ env.CHANGED_FILES }} --disable DoS
-        if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
-
-      - name: Create .alexrc file
-        run: |
-          echo '{ "allow": ["actors-actresses", "attacks", "attack", "hooks", "host-hostess", "hostesses-hosts", "invalid", "just", "period", "remains"], "profanitySureness": 2 }' > .alexrc
         if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
 
       - name: Alex (inclusive language)

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
 
       - name: Spelling Errors
-        run: codespell --count --skip="*.js,./.git" ${{ env.CHANGED_FILES }}
+        run: codespell --count --skip="*.js,./.git,./content/support/Other Languages/*" ${{ env.CHANGED_FILES }}
         if: ${{ !cancelled() && env.CHANGED_FILES != '' }}
 
       - name: Case Police

--- a/content/.alexrc
+++ b/content/.alexrc
@@ -1,0 +1,16 @@
+{
+  "allow": [
+    "actors-actresses",
+    "attacks",
+    "attack",
+    "hooks",
+    "host-hostess",
+    "hostesses-hosts",
+    "invalid",
+    "just",
+    "period",
+    "remains",
+    "special"
+  ],
+  "profanitySureness": 2
+}

--- a/content/waf/tools/ip-access-rules/parameters.md
+++ b/content/waf/tools/ip-access-rules/parameters.md
@@ -2,9 +2,9 @@
 title: Parameters
 pcx_content_type: reference
 weight: 3
+layout: list
 meta:
   title: IP Access rule parameters
-layout: list
 ---
 
 # Parameters


### PR DESCRIPTION
Creates an `.alexrc` config file under `/content/` because:
- We're only checking Markdown files, which all live under this folder.
- Alex still finds it (goes up one folder at a time from the file being checked, searching for a config file).
- It avoids polluting the root folder with yet another config file.

Also:
- Removes Alex config file creation step in the "spell-check" GitHub workflow.
