### PR TITLE
[R2] Update aws-sdk-go example for R2

### DIFF
--- a/content/r2/examples/aws/aws-sdk-go.md
+++ b/content/r2/examples/aws/aws-sdk-go.md
@@ -38,6 +38,7 @@ func main() {
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithEndpointResolverWithOptions(r2Resolver),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyId, accessKeySecret, "")),
+		config.WithRegion("auto"),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/content/r2/examples/aws/aws-sdk-go.md
+++ b/content/r2/examples/aws/aws-sdk-go.md
@@ -3,7 +3,7 @@ title: aws-sdk-go
 pcx_content_type: configuration
 ---
 
-# Configure `aws-sdk-go` for R2
+# Configure `aws-sdk-go` for R2 
 
 {{<render file="_keys.md">}}<br>
 


### PR DESCRIPTION
Updates the example for using R2 with aws-sdk-go. The current example returns an error of `operation error S3: ListBuckets, resolve auth scheme: resolve endpoint: endpoint rule error, Invalid region: region was not a valid DNS name`