### PR TITLE
fix: various Pages Functions destructuring examples

### DIFF
--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -92,8 +92,8 @@ declare namespace App {
 4. Access the added KV or Durable objects (or generally any [binding](/pages/platform/functions/bindings/)) in your endpoint with `env`:
 
 ```js
-export async function post({ request, platform }) {
-  const counter = platform.env.COUNTER.idFromName("A");
+export async function post(context) {
+  const counter = context.platform.env.COUNTER.idFromName("A");
 }
 ```
 

--- a/content/pages/how-to/refactor-a-worker-to-pages-functions.md
+++ b/content/pages/how-to/refactor-a-worker-to-pages-functions.md
@@ -5,20 +5,20 @@ title: Refactor a Worker to a Pages Function
 
 # Refactor a Worker to a Pages Function
 
-In this guide, you will learn how to refactor a Worker made to intake form submissions to a Pages Function that can be hosted on your Cloudflare Pages application. [Pages Functions](/pages/platform/functions/) is a serverless function that lives within the same project directory as your application and is deployed with Cloudflare Pages. It enables you to run server-side code that adds dynamic functionality without running a dedicated server. You may want to refactor a Worker to a Pages Function for one of these reasons: 
+In this guide, you will learn how to refactor a Worker made to intake form submissions to a Pages Function that can be hosted on your Cloudflare Pages application. [Pages Functions](/pages/platform/functions/) is a serverless function that lives within the same project directory as your application and is deployed with Cloudflare Pages. It enables you to run server-side code that adds dynamic functionality without running a dedicated server. You may want to refactor a Worker to a Pages Function for one of these reasons:
 
 1. If you manage a serverless function that your Pages application depends on and wish to ship the logic without managing a Worker as a separate service.
 2. If you are migrating your Worker to Pages Functions and want to use the routing and middleware capabilities of Pages Functions.
 
 {{<Aside type= "note">}}
 
-You can import your Worker to a Pages project without using Functions by creating a `_worker.js` file in the output directory of your Pages project. This [Advanced mode](/pages/platform/functions/advanced-mode/) requires writing your Worker with [Module syntax](/workers/learning/migrate-to-module-workers/). 
+You can import your Worker to a Pages project without using Functions by creating a `_worker.js` file in the output directory of your Pages project. This [Advanced mode](/pages/platform/functions/advanced-mode/) requires writing your Worker with [Module syntax](/workers/learning/migrate-to-module-workers/).
 
 However, when using the `_worker.js` file in Pages, the entire `/functions` directory is ignored – including its routing and middleware characteristics.
 
 {{</Aside>}}
 
-## General refactoring steps 
+## General refactoring steps
 
 1. Remove the `addEventListener()` method and its event response and replace it with the appropriate `OnRequest` method. Refer to [Functions](/pages/platform/functions/get-started/) to select the appropriate method for your Function.
 2. Pass the `context` object as an argument to your new `OnRequest` method to access the properties of the context parameter: `request`,`env`,`params` and `next`.
@@ -26,21 +26,21 @@ However, when using the `_worker.js` file in Pages, the entire `/functions` dire
 
 ## Background
 
-To explain the process of refactoring, this guide uses a simple form submission example. 
+To explain the process of refactoring, this guide uses a simple form submission example.
 
-Form submissions can be handled by Workers but can also be a good use case for Pages Functions, since forms are most times specific to a particular application. 
+Form submissions can be handled by Workers but can also be a good use case for Pages Functions, since forms are most times specific to a particular application.
 
 Assuming you are already using a Worker to handle your form, you would have deployed this Worker and then added the URL to your form action attribute in your HTML form. This means that when you change how the Worker handles your submissions, you must make changes to the Worker script. If the logic in your Worker is used by more than one application, Pages Functions would not be a good use case.
 
 However, it can be beneficial to use a [Pages Function](/pages/platform/functions/) when you would like to organize your function logic in the same project directory as your application.
 
-Building your application using Pages Functions can help you manage your client and serverless logic from the same place and make it easier to write and debug your code. 
+Building your application using Pages Functions can help you manage your client and serverless logic from the same place and make it easier to write and debug your code.
 
 ## Handle form entries with Airtable and Workers
 
 An [Airtable](https://airtable.com/) is a low-code platform for building collaborative applications. It helps customize your workflow, collaborate, and handle form submissions. For this example, you will utilize Airtable's form submission feature.
 
-[Airtable](https://airtable.com/) can be used to store entries of information in different tables for the same account. When creating a Worker for handling the submission logic, the first step is to use [Wrangler](/workers/wrangler/install-and-update/) to initialize a new Worker within a specific folder or at the root of your application. 
+[Airtable](https://airtable.com/) can be used to store entries of information in different tables for the same account. When creating a Worker for handling the submission logic, the first step is to use [Wrangler](/workers/wrangler/install-and-update/) to initialize a new Worker within a specific folder or at the root of your application.
 
 This step creates the boilerplate to write your Airtable submission Worker. After writing your Worker, you can deploy it to Cloudflare's global network after you [configure your project for deployment](/workers/wrangler/configuration/). Refer to the Workers documentation for a full tutorial on how to [handle form submission with Workers](/workers/tutorials/handle-form-submissions-with-airtable/).
 
@@ -112,7 +112,7 @@ const HandleAirtableData = (body) => {
 
 ### Refactor your Worker
 
-To refactor the above Worker, go to your Pages project directory and create a `/functions` folder. In `/functions`, create a `form.js` file. This file will handle form submissions. 
+To refactor the above Worker, go to your Pages project directory and create a `/functions` folder. In `/functions`, create a `form.js` file. This file will handle form submissions.
 
 Then, in the `form.js` file, export a single `onRequestPost`:
 
@@ -120,8 +120,8 @@ Then, in the `form.js` file, export a single `onRequestPost`:
 ---
 filename: functions/form.js
 ---
-export async function onRequestPost({ request, env }) {
-	return await submitHandler({ request, env });
+export async function onRequestPost(context) {
+	return await submitHandler(context);
 }
 
 ```
@@ -137,12 +137,12 @@ Now, you will introduce the `submitHandler` function and pass the `env` paramete
 filename: functions/form.js
 highlight: [4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22]
 ---
-export async function onRequestPost({ request, env }) {
-	return await submitHandler({ request, env });
+export async function onRequestPost(context) {
+	return await submitHandler(context);
 }
 
-async function submitHandler({ request, env }) {
-  const body = await request.formData();
+async function submitHandler(context) {
+  const body = await context.request.formData();
 
   const { first_name, last_name, email, phone, subject, message } =
     Object.fromEntries(body);

--- a/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
+++ b/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
@@ -7,7 +7,7 @@ title: Use Pages Functions for A/B testing
 
 In this guide, you will learn how to use [Pages Functions](/pages/platform/functions/) for A/B testing in your Pages projects. A/B testing is a user experience research methodology applied when comparing two or more versions of a web page or application. With A/B testing, you can serve two or more versions of a webpage to users and divide traffic to your site.
 
-## Overview 
+## Overview
 
 Configuring different versions of your application for A/B testing will be unique to your specific use case. For all developers, A/B testing setup can be simplified into a few helpful principles.
 
@@ -17,18 +17,18 @@ To ensure that a user remains in the group you have given, you will set and stor
 
 ## Set up your Pages Function
 
-In your project, you can handle the logic for A/B testing using [Pages Functions](/pages/platform/functions/). Pages Functions allows you to handle server logic from within your Pages project. 
+In your project, you can handle the logic for A/B testing using [Pages Functions](/pages/platform/functions/). Pages Functions allows you to handle server logic from within your Pages project.
 
 To begin:
 
  1. Go to your Pages project directory on your local machine.
- 2. Create a `/functions` directory. Your application server logic will live in the `/functions` directory. 
+ 2. Create a `/functions` directory. Your application server logic will live in the `/functions` directory.
 
 ## Add middleware logic
 
 Pages Functions have utility functions that can reuse chunks of logic which are executed before and/or after route handlers. These are called [middleware](/pages/platform/functions/middleware/). Following this guide, middleware will allow you to intercept requests to your Pages project before they reach your site.
 
-In your `/functions` directory, create a `_middleware.js` file. 
+In your `/functions` directory, create a `_middleware.js` file.
 
 {{<Aside type="Note">}}
 
@@ -36,7 +36,7 @@ When you create your `_middleware.js` file at the base of your `/functions` fold
 
 {{</Aside>}}
 
-Following the Functions naming convention, the `_middleware.js` file exports a single async `onRequest` function that accepts a `request`, `env` and `next` as an argument. 
+Following the Functions naming convention, the `_middleware.js` file exports a single async `onRequest` function that accepts a `request`, `env` and `next` as an argument.
 
 ```js
 ---
@@ -44,9 +44,9 @@ filename: /functions/_middleware.js
 ---
 const abTest = async ({request, next, env}) => {
   /*
-  Todo: 
+  Todo:
   1. Conditional statements to check for the cookie
-  2. Assign cookies based on percentage, then serve 
+  2. Assign cookies based on percentage, then serve
   */
 }
 
@@ -65,9 +65,9 @@ const newHomepagePathName = "/test"
 
 const abTest = async ({request, next, env}) => {
   /*
-  Todo: 
+  Todo:
   1. Conditional statements to check for the cookie
-  2. Assign cookie based on percentage then serve 
+  2. Assign cookie based on percentage then serve
   */
 }
 
@@ -88,7 +88,7 @@ const newHomepagePathName = "/test"
 
 const abTest = async ({request, next, env}) => {
   /*
-  Todo: 
+  Todo:
   1. Assign cookies based on randomly generated percentage, then serve
   */
 
@@ -130,8 +130,8 @@ highlight: 20-36
 const cookieName = "ab-test-cookie"
 const newHomepagePathName = "/test"
 
-const abTest = async ({ request, next, env }) => {
-  const url = new URL(request.url)
+const abTest = async (context) => {
+  const url = new URL(context.request.url)
   // if homepage
   if (url.pathname === "/") {
     // if cookie ab-test-cookie=new then change the request to go to /test
@@ -142,23 +142,23 @@ const abTest = async ({ request, next, env }) => {
     if (cookie && cookie.includes(`${cookieName}=new`)) {
       // pass the request to /test
       url.pathname = newHomepagePathName
-      return env.ASSETS.fetch(url)
+      return context.env.ASSETS.fetch(url)
     } else {
       const percentage = Math.floor(Math.random() * 100)
       let version = "current" // default version
-      // change pathname and version name for 50% of traffic 
+      // change pathname and version name for 50% of traffic
       if (percentage < 50) {
         url.pathname = newHomepagePathName
         version = "new"
       }
       // get the static file from ASSETS, and attach a cookie
-      const asset = await env.ASSETS.fetch(url)
+      const asset = await context.env.ASSETS.fetch(url)
       let response = new Response(asset.body, asset)
       response.headers.append("Set-Cookie", `${cookieName}=${version}; path=/`)
       return response
     }
   }
-  return next()
+  return context.next()
 };
 
 export const onRequest = [abTest];
@@ -172,4 +172,4 @@ After you have deployed your application, review your middleware Function:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. In Account Home, select **Workers & Pages**.
-3. In **Overview**, select your Pages project > **Settings** > **Functions** > **Configuration**. 
+3. In **Overview**, select your Pages project > **Settings** > **Functions** > **Configuration**.

--- a/content/pages/platform/functions/debugging-and-logging.md
+++ b/content/pages/platform/functions/debugging-and-logging.md
@@ -4,7 +4,7 @@ title: Debugging and logging
 weight: 12
 ---
 
-# Debugging and logging 
+# Debugging and logging
 
 Access your Functions logs by using the Cloudflare dashboard or the [Wrangler CLI](/workers/wrangler/commands/#deployment-tail).
 
@@ -25,17 +25,16 @@ There are two ways to start a logging session:
 
 ## Add custom logs
 
-Custom logs are `console.log()` statements that you can add yourself inside your Functions. When streaming logs for deployments that contain these Functions, the statements will appear in both `wrangler pages deployment tail` and dashboard outputs. 
+Custom logs are `console.log()` statements that you can add yourself inside your Functions. When streaming logs for deployments that contain these Functions, the statements will appear in both `wrangler pages deployment tail` and dashboard outputs.
 
 Below is an example of a custom `console.log` statement  inside a Pages Function:
 
 ```js
 ---
-filename: 
+filename:
 ---
 export async function onRequest(context) {
-  const { request }  = context;
-  console.log(`[LOGGING FROM /hello]: Request came from ${request.url}`);
+  console.log(`[LOGGING FROM /hello]: Request came from ${context.request.url}`);
 
   return new Response("Hello, world!");
 }
@@ -51,7 +50,7 @@ Your dashboard will display:
 
 ## View logs with Wrangler
 
-`wrangler pages deployment tail` enables developers to livestream logs for a specific project and deployment. 
+`wrangler pages deployment tail` enables developers to livestream logs for a specific project and deployment.
 
 To get started, run `wrangler pages deployment tail` in your Pages project directory. This will log any incoming requests to your application in your local terminal.
 
@@ -87,7 +86,7 @@ To view logs for your `production` or `preview` environments associated with any
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account.
 2. In **Account Home**, select **Workers & Pages**.
-3. Select your Pages project, go to the deployment you want to view logs for and select **View details** > **Functions**. 
+3. Select your Pages project, go to the deployment you want to view logs for and select **View details** > **Functions**.
 
 Logging is available for all customers (Free, Paid, Enterprise).
 

--- a/content/pages/platform/functions/examples/ab-testing.md
+++ b/content/pages/platform/functions/examples/ab-testing.md
@@ -18,8 +18,8 @@ filename: /functions/_middleware.js
 const cookieName = "ab-test-cookie"
 const newHomepagePathName = "/test"
 
-const abTest = async ({ request, next, env }) => {
-  const url = new URL(request.url)
+const abTest = async (context) => {
+  const url = new URL(context.request.url)
   // if homepage
   if (url.pathname === "/") {
     // if cookie ab-test-cookie=new then change the request to go to /test
@@ -30,23 +30,23 @@ const abTest = async ({ request, next, env }) => {
     if (cookie && cookie.includes(`${cookieName}=new`)) {
       // pass the request to /test
       url.pathname = newHomepagePathName
-      return env.ASSETS.fetch(url)
+      return context.env.ASSETS.fetch(url)
     } else {
       const percentage = Math.floor(Math.random() * 100)
       let version = "current" // default version
-      // change pathname and version name for 50% of traffic 
+      // change pathname and version name for 50% of traffic
       if (percentage < 50) {
         url.pathname = newHomepagePathName
         version = "new"
       }
       // get the static file from ASSETS, and attach a cookie
-      const asset = await env.ASSETS.fetch(url)
+      const asset = await context.env.ASSETS.fetch(url)
       let response = new Response(asset.body, asset)
       response.headers.append("Set-Cookie", `${cookieName}=${version}; path=/`)
       return response
     }
   }
-  return next()
+  return context.next()
 };
 
 export const onRequest = [abTest];

--- a/content/pages/platform/functions/examples/cors-headers.md
+++ b/content/pages/platform/functions/examples/cors-headers.md
@@ -9,7 +9,7 @@ weight: 1002
 layout: example
 ---
 
-This example is a snippet from our Cloudflare Pages Template repo. 
+This example is a snippet from our Cloudflare Pages Template repo.
 
 ```ts
 ---
@@ -30,8 +30,8 @@ export const onRequestOptions: PagesFunction = async () => {
 };
 
 // Set CORS to all /api responses
-export const onRequest: PagesFunction = async ({ next }) => {
-  const response = await next();
+export const onRequest: PagesFunction = async (context) => {
+  const response = await context.next();
   response.headers.set('Access-Control-Allow-Origin', '*');
   response.headers.set('Access-Control-Max-Age', '86400');
   return response;

--- a/content/pages/platform/functions/plugins/hcaptcha.md
+++ b/content/pages/platform/functions/plugins/hcaptcha.md
@@ -27,10 +27,10 @@ export const onRequestPost: PagesFunction[] = [
     secret: "0x0000000000000000000000000000000000000000",
     sitekey: "10000000-ffff-ffff-ffff-000000000001",
   }),
-  (async ({ request }) => {
+  (async (context) => {
     // Request has been validated as coming from a human
 
-    const formData = await request.formData()
+    const formData = await context.request.formData()
 
     // Store user credentials
 


### PR DESCRIPTION
This PR simply updates a few remaining Pages Functions examples to use `context` directly instead of destructuring. Most of the Pages docs already do this, but this was missed in a few places, mainly with Plugins.

Destructuring is often non-obvious, especially to beginners, so this makes the examples easier to understand.