### PR TITLE
Update managed-networks.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -53,7 +53,7 @@ To serve the TLS certificate using Python:
             self.wfile.write(b'OK')
             return
 
-   server = http.server.HTTPServer(('0.0.0.0', 3333), BasicHandler)
+   server = http.server.ThreadingHTTPServer(('0.0.0.0', 3333), BasicHandler)
    sslcontext = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
    sslcontext.load_cert_chain(certfile='./example.pem', keyfile='./example.key')
    server.socket = sslcontext.wrap_socket(server.socket, server_side=True)

--- a/content/learning-paths/get-started/account-setup/_index.md
+++ b/content/learning-paths/get-started/account-setup/_index.md
@@ -7,7 +7,7 @@ layout: learning-module
 
 # Account setup
 
-Make sure your zone's basics are configured properly. 
+Make sure your zone's basics are configured properly.
 
 ## Objectives
 


### PR DESCRIPTION
Not a python expert but this example seems to deadlock if there's a single hanging TCP connection refusing to close.

Can repro with ...
```
$ openssl s_client -connect 127.0.0.1:3333
```
... and a parallel curl. 

Basically simulating two WARP clients trying to connect to the server. First client leaves connection hanging, second client can't connect and is unable to detect Managed Network.