### PR TITLE
[Logs] Update log fields that were renamed/deprecated

### DIFF
--- a/content/logs/get-started/enable-destinations/ibm-qradar/index.md
+++ b/content/logs/get-started/enable-destinations/ibm-qradar/index.md
@@ -6,13 +6,13 @@ layout: single
 
 # Enable Logpush to IBM QRadar
 
-To configure a QRadar/Cloudflare integration you have the option to use one of the following methods: 
+To configure a QRadar/Cloudflare integration you have the option to use one of the following methods:
 
 * [HTTP Receiver protocol](/logs/get-started/enable-destinations/ibm-qradar/#http-receiver-protocol)
 * [Amazon AWS S3 Rest API](/logs/get-started/enable-destinations/ibm-qradar/#amazon-aws-s3-rest-api)
 
 ## HTTP Receiver Protocol
-To send Cloudflare logs to QRadar you need to create a [Logpush job to HTTP endpoints](/logs/get-started/enable-destinations/http/) via API. Below you can find two curl examples of how to send Cloudflare Firewalls events and Cloudflare HTTP events to QRadar.
+To send Cloudflare logs to QRadar you need to create a [Logpush job to HTTP endpoints](/logs/get-started/enable-destinations/http/) via API. Below you can find two curl examples of how to send Cloudflare Firewall events and Cloudflare HTTP events to QRadar.
 
 ### Cloudflare Firewall events
 
@@ -20,13 +20,13 @@ To send Cloudflare logs to QRadar you need to create a [Logpush job to HTTP endp
 curl https://api.cloudflare.com/client/v4/zones/{zone_id}/logpush/jobs \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
---data '{ 
-  "name": "<name>", 
-  "logpull_options": "fields=Action,ClientIP,ClientASN,ClientASNDescription,ClientCountry,ClientIPClass,ClientRefererHost,ClientRefererPath,ClientRefererQuery,ClientRefererScheme,ClientRequestHost,ClientRequestMethod,ClientRequestPath,ClientRequestProtocol,ClientRequestQuery,ClientRequestScheme,ClientRequestUserAgent,EdgeColoCode,EdgeResponseStatus,Kind,MatchIndex,Metadata,OriginResponseStatus,OriginatorRayID,RayID,RuleID,Source,Datetime&timestamps=rfc3339", 
-  "destination_conf": "<QRadar_URL:LogSource_Port>", 
-  "max_upload_bytes": 5000000, 
-  "max_upload_records": 1000, 
-  "dataset": "firewall_events", 
+--data '{
+  "name": "<name>",
+  "logpull_options": "fields=Action,ClientIP,ClientASN,ClientASNDescription,ClientCountry,ClientIPClass,ClientRefererHost,ClientRefererPath,ClientRefererQuery,ClientRefererScheme,ClientRequestHost,ClientRequestMethod,ClientRequestPath,ClientRequestProtocol,ClientRequestQuery,ClientRequestScheme,ClientRequestUserAgent,EdgeColoCode,EdgeResponseStatus,Kind,MatchIndex,Metadata,OriginResponseStatus,OriginatorRayID,RayID,RuleID,Source,Datetime&timestamps=rfc3339",
+  "destination_conf": "<QRadar_URL:LogSource_Port>",
+  "max_upload_bytes": 5000000,
+  "max_upload_records": 1000,
+  "dataset": "firewall_events",
   "enabled": true
 }'
 ```
@@ -39,10 +39,10 @@ curl https://api.cloudflare.com/client/v4/zones/{zone_id}/logpush/jobs \
 --header "X-Auth-Key: <API_KEY>" \
 --data '{
   "name": "<name>",
-  "logpull_options": "fields=ClientRequestMethod,EdgeResponseStatus,ClientIP,ClientSrcPort,CacheCacheStatus,ClientCountry,ClientDeviceType,ClientIPClass,ClientMTLSAuthCertFingerprint,ClientMTLSAuthStatus,ClientRegionCode,ClientRequestBytes,ClientRequestHost,ClientRequestPath,ClientRequestProtocol,ClientRequestReferer,ClientRequestScheme,ClientRequestSource,ClientRequestURI,ClientRequestUserAgent,ClientSSLCipher,ClientSSLProtocol,ClientXRequestedWith,EdgeEndTimestamp,EdgeRateLimitAction,EdgeRateLimitID,EdgeRequestHost,EdgeResponseBodyBytes,EdgeResponseBytes,EdgeServerIP,EdgeStartTimestamp,FirewallMatchesActions,FirewallMatchesRuleIDs,FirewallMatchesSources,OriginIP,OriginResponseStatus,OriginSSLProtocol,ParentRayID,RayID,SecurityLevel,WAFAction,WAFAttackScore,WAFProfile,WAFRuleID,WAFRuleMessage,WAFSQLiAttackScore,WAFXSSAttackScore,EdgeStartTimestamp&timestamps=rfc3339", 
-  "destination_conf": "<QRadar_URL:LogSource_Port>", "max_upload_bytes": 5000000, 
-  "max_upload_records": 1000, 
-  "dataset": "http_requests", 
+  "logpull_options": "fields=ClientRequestMethod,EdgeResponseStatus,ClientIP,ClientSrcPort,CacheCacheStatus,ClientCountry,ClientDeviceType,ClientIPClass,ClientMTLSAuthCertFingerprint,ClientMTLSAuthStatus,ClientRegionCode,ClientRequestBytes,ClientRequestHost,ClientRequestPath,ClientRequestProtocol,ClientRequestReferer,ClientRequestScheme,ClientRequestSource,ClientRequestURI,ClientRequestUserAgent,ClientSSLCipher,ClientSSLProtocol,ClientXRequestedWith,EdgeEndTimestamp,EdgeRequestHost,EdgeResponseBodyBytes,EdgeResponseBytes,EdgeServerIP,EdgeStartTimestamp,SecurityActions,SecurityRuleIDs,SecuritySources,OriginIP,OriginResponseStatus,OriginSSLProtocol,ParentRayID,RayID,SecurityAction,WAFAttackScore,SecurityRuleID,SecurityRuleDescription,WAFSQLiAttackScore,WAFXSSAttackScore,EdgeStartTimestamp&timestamps=rfc3339",
+  "destination_conf": "<QRadar_URL:LogSource_Port>", "max_upload_bytes": 5000000,
+  "max_upload_records": 1000,
+  "dataset": "http_requests",
   "enabled": true
 }'
 ```

--- a/content/logs/instant-logs.md
+++ b/content/logs/instant-logs.md
@@ -44,7 +44,7 @@ Instant Logs has a maximum data rate supported. For high volume domains, we samp
 
 {{</Aside>}}
 
-- **Filters** - Use filters to drill down into specific events. Filters consist of three parts: key, operator and value. The keys we support are **Client ASN**, **CacheCacheStatus**, **ClientCountry**, **ClientIP**, **ClientRequestHost**, **ClientRequestMethod**, **ClientRequestPath**, **EdgeResponseStatus**, **FirewallMatchesAction**, and **FirewallMatchesRuleIDs**.
+- **Filters** - Use filters to drill down into specific events. Filters consist of three parts: key, operator and value. The keys we support are **Client ASN**, **CacheCacheStatus**, **ClientCountry**, **ClientIP**, **ClientRequestHost**, **ClientRequestMethod**, **ClientRequestPath**, **EdgeResponseStatus**, **SecurityActions**, and **SecurityRuleIDs**.
 
 This is the list of the supported operators that we have available:
 

--- a/content/logs/tutorials/parsing-json-log-data.md
+++ b/content/logs/tutorials/parsing-json-log-data.md
@@ -10,7 +10,7 @@ weight: 86
 
 After downloading your Cloudflare Logs data, you can use different tools to parse and analyze your logs.
 
-In this tutorial, you will learn how to parse your JSON log data using _jq_. To get started with _jq_, visit the [_jq_ official site](https://stedolan.github.io/jq/).
+In this tutorial, you will learn how to parse your JSON log data using _jq_. To get started with _jq_, visit the [_jq_ official site](https://jqlang.github.io/jq/).
 
 {{<Aside type="note" header="Note">}}
 
@@ -75,7 +75,7 @@ $ jq 'select(.OriginResponseStatus == 502) | .ClientRequestURI' logs.json | sort
 To find out the top IP addresses blocked by the Cloudflare WAF, use the following query:
 
 ```sh
-$ jq -r 'select(.WAFAction == "drop") | .ClientIP' logs.json | sort -n | uniq -c | sort -n
+$ jq -r 'select(.SecurityAction == "block") | .ClientIP' logs.json | sort -n | uniq -c | sort -n
 1 127.0.0.1
 ```
 


### PR DESCRIPTION
Renames and removes log fields from tutorials and examples according to the security fields changes described in the following page:
https://developers.cloudflare.com/logs/reference/change-notices/2023-02-01-security-fields-updates/

Renamed log fields:
* `WAFRuleID` => `SecurityRuleID`
* `WAFRuleMessage` => `SecurityRuleDescription`
* `WAFAction` => `SecurityAction`
* `FirewallMatchesRuleIDs` => `SecurityRuleIDs`
* `FirewallMatchesActions` => `SecurityActions`
* `FirewallMatchesSources` => `SecuritySources`

Removed log fields:

* `WAFProfile`
* `EdgeRateLimitAction`
* `EdgeRateLimitID`
* `SecurityLevel`

Not changed in this PR:
- [Splunk page](https://developers.cloudflare.com/analytics/analytics-integrations/splunk/) in Analytics - May require an update to the Cloudflare Splunk app
- [Google Cloud page](https://developers.cloudflare.com/analytics/analytics-integrations/google-cloud/) in Analytics - The template may require an update (could not confirm if it was up to date)