### PR TITLE
wildcard domains are not supported for Pages

### DIFF
--- a/content/dns/manage-dns-records/reference/wildcard-dns-records.md
+++ b/content/dns/manage-dns-records/reference/wildcard-dns-records.md
@@ -24,6 +24,12 @@ To create a wildcard DNS record, [create a DNS record](/dns/manage-dns-records/h
 
 {{</example>}}
 
+{{<Aside type="warning">}}
+
+If your project is on [Cloudflare Pages](/pages/), note that wildcard custom domains are not supported. Refer to [known issues](/pages/platform/known-issues/#custom-domains) for details.
+
+{{</Aside>}}
+
 You can also create a wildcard DNS record specifically for a deeper subdomain. For example, if you wanted to create a wildcard record on `*.www.example.com`, you would create a record with `*.www` in the name field.
 
 {{<example>}}
@@ -43,8 +49,6 @@ Customers on all plans can create and proxy wildcard DNS records.
 If you are using a [partial zone setup](/dns/zone-setups/partial-setup/) for your DNS, Cloudflare does not automatically provision SSL/TLS certificates for your wildcard record.
 
 {{<render file="_partial-zone-acm-dcv-wildcard.md" productFolder="ssl" >}}
-
-It is currently not possible to have wildcard custom domains for [Cloudflare Pages](/pages/) - refer to the [known issues](/pages/platform/known-issues/#custom-domains) for details.
 
 ## Additional information
 

--- a/content/dns/manage-dns-records/reference/wildcard-dns-records.md
+++ b/content/dns/manage-dns-records/reference/wildcard-dns-records.md
@@ -44,6 +44,8 @@ If you are using a [partial zone setup](/dns/zone-setups/partial-setup/) for you
 
 {{<render file="_partial-zone-acm-dcv-wildcard.md" productFolder="ssl" >}}
 
+It is currently not possible to have wildcard custom domains for [Cloudflare Pages](/pages/) - refer to the [known issues](/pages/platform/known-issues/#custom-domains) for details.
+
 ## Additional information
 
 For more information on wildcard records — as well as more details about their limitations — refer to the [introductory blog post](https://blog.cloudflare.com/wildcard-proxy-for-everyone/).


### PR DESCRIPTION
Just adding a cross reference from "wildcard dns records" over to the cloudflare pages known limitations (which includes that currently custome domain wildcards are not supported).

(i would suggest inserting that the current workaround is to use workers sites, but not sure that that works either)