### PR TITLE
[Chore] Remove bottom margin from code block

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3968,6 +3968,7 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 .DocsMarkdown blockquote> :last-child,
 .DocsMarkdown details> :last-child,
 .DocsMarkdown details summary+div> :last-child,
+.DocsMarkdown details summary+div> :last-child pre.CodeBlock,
 .DocsMarkdown li> :not(ul):not(ol):not(pre):not(figure):not(table):last-child,
 .DocsMarkdown ol> :last-child,
 .DocsMarkdown ul> :last-child {


### PR DESCRIPTION
Removes bottom margin from a code block when it is the last content element of a `<details>` section.

Before:

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/5c5d7551-54cf-4dd2-8816-8f967baacbd7)

After:

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/647fa580-8c1b-43a5-bb2c-a0a9abc84cd9)
