### PR TITLE
[5xx] Changing subsection title of 527 troubleshooting guide to match format

### DIFF
--- a/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
+++ b/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
@@ -335,7 +335,7 @@ If the origin server uses a self-signed certificate, configure the domain to use
 
 ___
 
-## 527 Error: Railgun Listener to origin error
+## Error 527: Railgun Listener to origin error
 
 {{<render file="_railgun-deprecation-notice.md" productFolder="railgun">}}
 


### PR DESCRIPTION
Title of subsection in https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/ about 527 errors isn't matching the format of other subsection titles:

![Screenshot from 2023-11-30 10-13-00](https://github.com/cloudflare/cloudflare-docs/assets/415693/35310a56-26fa-41d8-9fd2-e823a3294522)
