### PR TITLE
Add documentation about MailChannels domain lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ Additionally, this project includes a CI step for ensuring consistent code style
 $ npm run lint
 ```
 
-Finally, some of these code-style errors may be fixed automatically. To do so, you may run:
-
-```sh
-$ npm run format
-```
-
 ## Deployment
 
 Our docs are deployed using [Cloudflare Pages](https://pages.cloudflare.com). Every commit pushed to production will automatically deploy to [developers.cloudflare.com](https://developers.cloudflare.com), and any pull requests opened will have a corresponding staging URL available in the pull request comments.

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -17,7 +17,7 @@ For standard setup with Cloudflare Pages, see [Enabling MailChannels for your Ac
 ## Installation
 
 ```sh
-npm install @cloudflare/pages-plugin-mailchannels
+$ npm install @cloudflare/pages-plugin-mailchannels
 ```
 
 ## Usage
@@ -140,7 +140,7 @@ You can generate your DKIM credentials using [OpenSSL](https://www.openssl.org/)
 1. Generate your private key and DNS record by running the command below in your terminal:
 
 ```sh
-openssl genrsa 2048 | tee private_key.pem | openssl rsa -outform der | openssl base64 -A > private_key.txt
+$ openssl genrsa 2048 | tee private_key.pem | openssl rsa -outform der | openssl base64 -A > private_key.txt
 ```
 
 {{<Aside type="note" header="Command breakdown">}}
@@ -150,7 +150,7 @@ openssl genrsa 2048 | tee private_key.pem | openssl rsa -outform der | openssl b
 {{</Aside>}}
 
 ```sh
-echo -n "v=DKIM1;p=" > dkim_record.txt && openssl rsa -in private_key.pem -pubout -outform der | openssl base64 -A >> dkim_record.txt
+$ echo -n "v=DKIM1;p=" > dkim_record.txt && openssl rsa -in private_key.pem -pubout -outform der | openssl base64 -A >> dkim_record.txt
 ```
 
 This creates a public key from the private key (`openssl rsa -in priv_key.pem -pubout -outform der`), encodes it in base64 (`openssl base 64 -A`), and finally writes it to the `dkim_record.txt` file.

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -93,11 +93,11 @@ Then, add the MailChannels DNS record:
 
 1. In **Account Home**, select the website you would like to add an SPF record for.
 2. Select **DNS** > **Records** > **Add Record**.
-3. Add the following TXT DNS record:
+3. Add the following TXT DNS record, replacing `myaccount.workers.dev` with your own workers subdomain.
 
-| Type | Name            | Content                            | Note                                                            |
-|------|-----------------|------------------------------------|-----------------------------------------------------------------|
-| TXT  | `_mailchannels` | `v=mc1 cfid=myaccount.workers.dev` | Replace `myaccount.workers.dev` with your own workers subdomain |
+| Type | Name            | Content                            |
+|------|-----------------|------------------------------------|
+| TXT  | `_mailchannels` | `v=mc1 cfid=myaccount.workers.dev` |
 
 You can find more details about the domain lockdown record and more complex use-cases on MailChannel's [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) support article.
 
@@ -109,9 +109,13 @@ To use both MailChannels and Cloudflare Email Routing:
 2. Select **DNS** > **Records** > **Add Record**.
 3. Add the following TXT DNS record:
 
-| Type | Name | Content                                                                     | Note                                                                                                  |
-|------|------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
-| TXT  | `@`  | `v=spf1 include:_spf.mx.cloudflare.net include:relay.mailchannels.net -all` | If you already have an SPF record, add the `include:...` entries to it instead of creating a new one. |
+| Type | Name | Content                                                                     |
+|------|------|-----------------------------------------------------------------------------|
+| TXT  | `@`  | `v=spf1 include:_spf.mx.cloudflare.net include:relay.mailchannels.net -all` |
+
+{{<Aside type= "note" header="Existing SPF Record">}}
+ If you have an existing SPF record for your domain, add the `include:...` entries to it instead of creating a new one.
+{{</Aside>}}
 
 ## DKIM support for Mailchannels API
 
@@ -161,12 +165,12 @@ Next, look in your generated `dkim_record.txt` file for your DKIM credentials, a
 2. In the menu on the left select **DNS** > **Records** > **Add Record**.
 3. Add the following TXT DNS record:
 
-| Type | Name                      | Content                                 | Note                                                                                                                                                                 |
-|------|---------------------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| TXT  | `mailchannels._domainkey` | Paste the contents of `dkim_record.txt` | You may name this record anything following the format of `<selector key>._domainkey`, but make sure to update the selector key in the Pages Function example below. |
+| Type | Name                      | Content                                 |
+|------|---------------------------|-----------------------------------------|
+| TXT  | `mailchannels._domainkey` | Paste the contents of `dkim_record.txt` | 
 
-{{<Aside type= "note" header="Selector value">}}
-You can choose any value as the selector, as long as it is permitted as a DNS hostname (that is, all lowercase letters, numbers and hyphens).
+{{<Aside type= "note" header="Use a Different Selector">}}
+You can substitute `mailchannels.domainkey` for any name of the format `<selector key>._domainkey`. You can choose any value as the selector, as long as it is permitted as a DNS hostname (that is, all lowercase letters, numbers and hyphens).
 {{</Aside>}}
 
 4. Add the content of your `dkim_record.txt` file in the content field.

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -11,7 +11,7 @@ The MailChannels Pages Plugin intercepts all form submissions made which have th
 {{<Aside type="note">}}
 To use the Mailchannels Pages Plugin, you must first add a [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) to the domain you are sending email from. For more information, refer to the [Mailchannels documentation](https://support.mailchannels.com/hc/en-us/articles/4565898358413-Sending-Email-from-Cloudflare-Workers-using-MailChannels-Send-API).
 
-For standard setup with Cloudflare Pages, see [Enabling MailChannels for your Account](#enabling-mailchannels-for-your-account---domain-lockdown) below.
+For standard setup with Cloudflare Pages, refer to [Enabling MailChannels for your Account](#enabling-mailchannels-for-your-account---domain-lockdown) below.
 
 {{</Aside>}}
 
@@ -78,23 +78,23 @@ The `method` and `action` attributes of the HTML form do not need to be set. The
 
 For more information about MailChannels and the options they support, refer to [the documentation](https://mailchannels.zendesk.com/hc/en-us/articles/4565898358413-Sending-Email-from-Cloudflare-Workers-using-MailChannels-Send-API).
 
-## Enabling MailChannels for your Account - Domain Lockdown
+## Enable MailChannels for your account - Domain Lockdown
 
-To enable MailChannels to send email on your behalf through Cloudflare Pages Functions, you have to setup a [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) for the domain you are sending email from.
+To enable MailChannels to send emails on your behalf through Cloudflare Pages Functions, you have to setup a [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) for the domain you are sending emails from.
 
-For most cases, all this involves is adding a `TXT` entry to your DNS.
+For most cases, setting up a Domain Lockdown DNS record involves adding a `TXT` entry to your DNS. Refer to the following steps to set up a Domain Lockdown DNS record.
 
-First, grab your account's workers subdomain:
+First, find your account's `workers.dev` subdomain:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
-2. In Account Home, select **Workers & Pages**, then **Overview**.
-3. On the right-hand side, note your worker's *Subdomain*. It's likely something similar to `myaccount.workers.dev`.
+2. Select **Workers & Pages** > **Overview**.
+3. On the right-hand side of **Overview**, note your `workers.dev` **Subdomain**. It will be similar to `myaccount.workers.dev` and customizable by you.
 
-Then, add the MailChannels DNS record:
+After you have found your `workers.dev` subdomain, add the MailChannels DNS record:
 
 1. In **Account Home**, select the website you would like to add an SPF record for.
 2. Select **DNS** > **Records** > **Add Record**.
-3. Add the following TXT DNS record, replacing `myaccount.workers.dev` with your own workers subdomain.
+3. Add the following TXT DNS record, replacing `myaccount.workers.dev` with your own `workers.dev` subdomain.
 
 {{<example>}}
 
@@ -104,7 +104,7 @@ Then, add the MailChannels DNS record:
 
 {{</example>}}
 
-You can find more details about the domain lockdown record and more complex use-cases in MailChannel's [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) support article.
+Find more details about the domain lockdown record and more complex use cases in MailChannel's [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) support article.
 
 ## SPF support for MailChannels
 
@@ -122,8 +122,8 @@ To use both MailChannels and Cloudflare Email Routing:
 
 {{</example>}}
 
-{{<Aside type= "note" header="Existing SPF Record">}}
- If you have an existing SPF record for your domain, add the `include:...` entries to it instead of creating a new one.
+{{<Aside type= "note" header="Existing SPF record">}}
+If you have an existing SPF record for your domain, add the `include:...` entries to it instead of creating a new one.
 {{</Aside>}}
 
 ## DKIM support for Mailchannels API
@@ -136,7 +136,7 @@ Setting up DKIM for use in your MailChannels Pages Plugin is optional, but will 
 
 To add a DKIM signature to a message, add the following fields to the `personalization` object for the message:
 
-**`dkim_domain`**: The domain you are sending the email from. For example, if you are sending an email from `support@mydomin.com`, set this to `mydomain.com`.
+**`dkim_domain`**: The domain you are sending the email from. For example, if you are sending an email from `support@mydomain.com`, set this to `mydomain.com`.
 
 **`dkim_selector`**: Specifies where to find the associated public key in your DNS records. For example, if you make the DKIM record available at `mailchannels._domainkey.mydomain.com`, set this to `mailchannels`.
 
@@ -182,8 +182,8 @@ Next, look in your generated `dkim_record.txt` file for your DKIM credentials, a
 
 {{</example>}}
 
-{{<Aside type= "note" header="Use a Different Selector">}}
-You can substitute `mailchannels.domainkey` for any name of the format `<selector key>._domainkey`. You can choose any value as the selector, as long as it is permitted as a DNS hostname (that is, all lowercase letters, numbers and hyphens).
+{{<Aside type= "note" header="Use a different selector">}}
+You can substitute `mailchannels.domainkey` for any name with the format `<selector_key>._domainkey`. You can choose any value as the selector, as long as it is permitted as a DNS hostname (that is, all lowercase letters, numbers and hyphens).
 {{</Aside>}}
 
 Your record should look like:

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -31,7 +31,7 @@ import mailChannelsPlugin from "@cloudflare/pages-plugin-mailchannels";
 export const onRequest: PagesFunction = mailChannelsPlugin({
   personalizations: [
     {
-      to: [{ name: "ACME Support", email: "support@example.com" }],
+      to: [{ name: "Some User", email: "someuser@example.com" }],
     },
   ],
   from: {
@@ -135,9 +135,9 @@ Setting up DKIM for use in your MailChannels Pages Plugin is optional, but will 
 
 To add a DKIM signature to a message, add the following fields to the `personalization` object for the message:
 
-**`dkim_domain`**: The domain you are sending the email from. For example, if you are sending an email from `support@example.com`, set this to `example.com`.
+**`dkim_domain`**: The domain you are sending the email from. For example, if you are sending an email from `support@mydomin.com`, set this to `mydomain.com`.
 
-**`dkim_selector`**: Specifies where to find the associated public key in your DNS records. For example, if you make the DKIM record available at `mailchannels._domainkey.example.com`, set this to `mailchannels`.
+**`dkim_selector`**: Specifies where to find the associated public key in your DNS records. For example, if you make the DKIM record available at `mailchannels._domainkey.mydomain.com`, set this to `mailchannels`.
 
 **`dkim_private_key`**: The base-64 encoded private key.
 
@@ -207,9 +207,9 @@ import mailChannelsPlugin from "@cloudflare/pages-plugin-mailchannels";
 export const onRequest: PagesFunction = (context) => mailChannelsPlugin({
   personalizations: [
     {
-      to: [{ name: "Some User", email: "user@cloudflare.com" }],
+      to: [{ name: "Some User", email: "someuser@example.com" }],
       // This value has to be the domain you added DKIM records to and where you're sending your email from
-      "dkim_domain": "example.com", 
+      "dkim_domain": "mydomain.com", 
       // This value has be the same as the selector you chose for your DKIM record name
       // For example, use "mailchannels" if you used mailchannels._domainkey as your record name
       "dkim_selector": "mailchannels", 

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -12,6 +12,7 @@ The MailChannels Pages Plugin intercepts all form submissions made which have th
 To use the Mailchannels Pages Plugin, you must first add a [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) to the domain you are sending email from. For more information, refer to the [Mailchannels documentation](https://support.mailchannels.com/hc/en-us/articles/4565898358413-Sending-Email-from-Cloudflare-Workers-using-MailChannels-Send-API).
 
 For standard setup with Cloudflare Pages, see [Enabling MailChannels for your Account](#enabling-mailchannels-for-your-account---domain-lockdown) below.
+
 {{</Aside>}}
 
 ## Installation

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -95,11 +95,15 @@ Then, add the MailChannels DNS record:
 2. Select **DNS** > **Records** > **Add Record**.
 3. Add the following TXT DNS record, replacing `myaccount.workers.dev` with your own workers subdomain.
 
+{{<example>}}
+
 | Type | Name            | Content                            |
 |------|-----------------|------------------------------------|
 | TXT  | `_mailchannels` | `v=mc1 cfid=myaccount.workers.dev` |
 
-You can find more details about the domain lockdown record and more complex use-cases on MailChannel's [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) support article.
+{{</example>}}
+
+You can find more details about the domain lockdown record and more complex use-cases in MailChannel's [Domain Lockdown DNS record](https://support.mailchannels.com/hc/en-us/articles/16918954360845-Secure-your-domain-name-against-spoofing-with-Domain-Lockdown-) support article.
 
 ## SPF support for MailChannels
 
@@ -109,9 +113,13 @@ To use both MailChannels and Cloudflare Email Routing:
 2. Select **DNS** > **Records** > **Add Record**.
 3. Add the following TXT DNS record:
 
+{{<example>}}
+
 | Type | Name | Content                                                                     |
 |------|------|-----------------------------------------------------------------------------|
 | TXT  | `@`  | `v=spf1 include:_spf.mx.cloudflare.net include:relay.mailchannels.net -all` |
+
+{{</example>}}
 
 {{<Aside type= "note" header="Existing SPF Record">}}
  If you have an existing SPF record for your domain, add the `include:...` entries to it instead of creating a new one.
@@ -165,15 +173,19 @@ Next, look in your generated `dkim_record.txt` file for your DKIM credentials, a
 2. In the menu on the left select **DNS** > **Records** > **Add Record**.
 3. Add the following TXT DNS record:
 
-| Type | Name                      | Content                                 |
-|------|---------------------------|-----------------------------------------|
-| TXT  | `mailchannels._domainkey` | Paste the contents of `dkim_record.txt` | 
+{{<example>}}
+
+| Type | Name                      | Content                                  |
+|------|---------------------------|------------------------------------------|
+| TXT  | `mailchannels._domainkey` | Insert the contents of `dkim_record.txt` | 
+
+{{</example>}}
 
 {{<Aside type= "note" header="Use a Different Selector">}}
 You can substitute `mailchannels.domainkey` for any name of the format `<selector key>._domainkey`. You can choose any value as the selector, as long as it is permitted as a DNS hostname (that is, all lowercase letters, numbers and hyphens).
 {{</Aside>}}
 
-4. Add the content of your `dkim_record.txt` file in the content field.
+Your record should look like:
 
 ![Follow the instructions above to add DKIM credentials to your DNS records](/images/pages/platform/functions/mailchannel_DKIM_DNS_setup.png)
 
@@ -188,7 +200,7 @@ The following code block shows an example of using DKIM with the MailChannels Pa
 ```typescript
 ---
 filename: functions/_middleware.ts
-highlight: [7,8,9]
+highlight: [7-12]
 ---
 import mailChannelsPlugin from "@cloudflare/pages-plugin-mailchannels";
 
@@ -196,8 +208,11 @@ export const onRequest: PagesFunction = (context) => mailChannelsPlugin({
   personalizations: [
     {
       to: [{ name: "Some User", email: "user@cloudflare.com" }],
-      "dkim_domain": "example.com", // This value has to be the domain you added DKIM records to and where you're sending your email from
-      "dkim_selector": "mailchannels", // This value has be the same as the selector you chose for your DKIM record name, for example, use "mailchannels" if you used mailchannels._domainkey as your record name
+      // This value has to be the domain you added DKIM records to and where you're sending your email from
+      "dkim_domain": "example.com", 
+      // This value has be the same as the selector you chose for your DKIM record name
+      // For example, use "mailchannels" if you used mailchannels._domainkey as your record name
+      "dkim_selector": "mailchannels", 
       "dkim_private_key": context.env.DKIM_PRIVATE_KEY
     },
   ],

--- a/content/pages/platform/functions/plugins/mailchannels.md
+++ b/content/pages/platform/functions/plugins/mailchannels.md
@@ -36,7 +36,8 @@ export const onRequest: PagesFunction = mailChannelsPlugin({
   ],
   from: {
     name: "ACME Support",
-    email: "support@example.com",
+    // The domain of your `from` address must be the same as the domain you setup MailChannels Domain Lockdown for (detailed below)
+    email: "support@mydomain.com",
   },
   respondWith: () => {
     return new Response(
@@ -198,7 +199,7 @@ export const onRequest: PagesFunction = (context) => mailChannelsPlugin({
   ],
   from: {
     name: "ACME Support",
-    // The domain of your `from` address must be the same as the domain you setup when you setup MailChannels domain lockdown.
+    // The domain of your `from` address must be the same as the domain you setup MailChannels Domain Lockdown for
     email: "support@mydomain.com",
   },
   respondWith: () => {


### PR DESCRIPTION
- Adds documentation and clarity on what the user has to do to properly use MailChannels on their domain through cloudflare pages, with Domain Lockdown setup.
- Adds some clarification comments to the fields in the example middleware, because the values you use are constrained by the records created previously.
- Adds tables for documenting DNS entries to add, similar to how it's done here: https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-subdomain/
- Removes readme entry for `npm run format`, which is not actually a valid script