### PR TITLE
Add redirect for dash logpush doc link

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -516,6 +516,7 @@
 /logs/logpush/s3-compatible-endpoints/ /logs/get-started/enable-destinations/s3-compatible-endpoints/ 301
 /logs/reference/logpush-api-configuration/ /logs/get-started/api-configuration/ 301
 /logs/reference/logpush-api-configuration/filters/ /logs/reference/filters/ 301
+# Non-slashed version is being used in the Cloudflare dashboard
 /logs/reference/logpush-api-configuration/custom-fields /logs/reference/custom-fields/ 301
 /logs/reference/logpush-api-configuration/custom-fields/ /logs/reference/custom-fields/ 301
 /logs/reference/logpush-api-configuration/examples/example-logpush-curl/ /logs/tutorials/examples/example-logpush-curl/ 301

--- a/content/_redirects
+++ b/content/_redirects
@@ -516,6 +516,7 @@
 /logs/logpush/s3-compatible-endpoints/ /logs/get-started/enable-destinations/s3-compatible-endpoints/ 301
 /logs/reference/logpush-api-configuration/ /logs/get-started/api-configuration/ 301
 /logs/reference/logpush-api-configuration/filters/ /logs/reference/filters/ 301
+/logs/reference/logpush-api-configuration/custom-fields /logs/reference/custom-fields/ 301
 /logs/reference/logpush-api-configuration/custom-fields/ /logs/reference/custom-fields/ 301
 /logs/reference/logpush-api-configuration/examples/example-logpush-curl/ /logs/tutorials/examples/example-logpush-curl/ 301
 


### PR DESCRIPTION
The docs link on the zone-level logpush Custom Fields section (https://dash.cloudflare.com/?to=/:account/:zone/analytics/logs) is going to https://developers.cloudflare.com/logs/reference/logpush-api-configuration/custom-fields (no trailing slash) which is 404ing and not being caught by the existing `/logs/reference/logpush-api-configuration/custom-fields/` redirect

This puts up a working redirect while we update the dash link