### PR TITLE
[DDoS Protection] Fix formatting

### DIFF
--- a/content/ddos-protection/managed-rulesets/http/configure-dashboard.md
+++ b/content/ddos-protection/managed-rulesets/http/configure-dashboard.md
@@ -37,22 +37,22 @@ If you cannot deploy any additional overrides, consider editing an existing over
 
     {{<details header="Configure all the rules in the ruleset (ruleset override)">}}
 
-    1. To always apply a given action for all the rules in the ruleset, select an action in **Ruleset action**.
-    2. To set the sensitivity level for all the rules in the ruleset, select a value in **Ruleset sensitivity**.
+1. To always apply a given action for all the rules in the ruleset, select an action in **Ruleset action**.
+2. To set the sensitivity level for all the rules in the ruleset, select a value in **Ruleset sensitivity**.
 
     {{</details>}}
 
     {{<details header="Configure one or more rules">}}
 
-    1. Under **Rule configuration**, select **Browse rules**.
+1. Under **Rule configuration**, select **Browse rules**.
 
-    2. Search for the rules you wish to configure using the available filters. You can search by [tag](/ddos-protection/managed-rulesets/http/rule-categories/) (also known as category).
+2. Search for the rules you wish to configure using the available filters. You can search by [tag](/ddos-protection/managed-rulesets/http/rule-categories/) (also known as category).
 
-    3. To configure a single rule, select the desired value for a field in the displayed dropdowns next to the rule.
+3. To configure a single rule, select the desired value for a field in the displayed dropdowns next to the rule.
 
-        To configure more than one rule, select the rules using the row checkboxes and update the fields for the selected rules using the dropdowns displayed before the table. You can also configure all the rules with a given tag. For more information, refer to [Configure rules in bulk in a managed ruleset](/waf/managed-rules/deploy-zone-dashboard/#configure-rules-in-bulk-in-a-managed-ruleset).
+    To configure more than one rule, select the rules using the row checkboxes and update the fields for the selected rules using the dropdowns displayed before the table. You can also configure all the rules with a given tag. For more information, refer to [Configure rules in bulk in a managed ruleset](/waf/managed-rules/deploy-zone-dashboard/#configure-rules-in-bulk-in-a-managed-ruleset).
 
-    4. Select **Next**.
+4. Select **Next**.
 
     {{</details>}}
 
@@ -60,6 +60,7 @@ If you cannot deploy any additional overrides, consider editing an existing over
 
 * Tag and rule overrides have priority over ruleset overrides.
 * {{<render file="managed-rulesets/_read-only-rules-note.md">}}
+
     {{</Aside>}}
 
 7. Select **Save**.

--- a/content/ddos-protection/managed-rulesets/network/configure-dashboard.md
+++ b/content/ddos-protection/managed-rulesets/network/configure-dashboard.md
@@ -27,24 +27,24 @@ For more information on the available parameters and allowed values, refer to [R
 
     {{<details header="Configure all the rules in the ruleset (ruleset override)">}}
 
-    1. Select **Next**.
-    2. Enter a name for your override in **Execution name**.
-    3. To always apply a given action for all the rules in the ruleset, select an action in **Ruleset action**.
-    4. To set the sensitivity level for all the rules in the ruleset, select a value in **Ruleset sensitivity**.
+1. Select **Next**.
+2. Enter a name for your override in **Execution name**.
+3. To always apply a given action for all the rules in the ruleset, select an action in **Ruleset action**.
+4. To set the sensitivity level for all the rules in the ruleset, select a value in **Ruleset sensitivity**.
 
     {{</details>}}
 
     {{<details header="Configure one or more rules">}}
 
-    1. Search for the rules you wish to override using the available filters. You can search for tags.
+1. Search for the rules you wish to override using the available filters. You can search for tags.
 
-    2. To override a single rule, select the desired value for a field in the displayed dropdowns next to the rule.
+2. To override a single rule, select the desired value for a field in the displayed dropdowns next to the rule.
 
-        To configure more than one rule, select the rules using the row checkboxes and update the fields for the selected rules using the dropdowns displayed before the table. You can also configure all the rules with a given tag. For more information, refer to [Configure rules in bulk in a managed ruleset](/waf/managed-rules/deploy-zone-dashboard/#configure-rules-in-bulk-in-a-managed-ruleset).
+    To configure more than one rule, select the rules using the row checkboxes and update the fields for the selected rules using the dropdowns displayed before the table. You can also configure all the rules with a given tag. For more information, refer to [Configure rules in bulk in a managed ruleset](/waf/managed-rules/deploy-zone-dashboard/#configure-rules-in-bulk-in-a-managed-ruleset).
 
-    3. Select **Next**.
+3. Select **Next**.
 
-    4. Enter a name for your override in **Execution name**.
+4. Enter a name for your override in **Execution name**.
 
     {{</details>}}
 
@@ -52,6 +52,7 @@ For more information on the available parameters and allowed values, refer to [R
 
 * Tag and rule overrides have priority over ruleset overrides.
 * {{<render file="managed-rulesets/_read-only-rules-note.md">}}
+
     {{</Aside>}}
 
 8. To save and deploy the override, select **Deploy**. If you are not ready to deploy your override, select **Save as Draft**.


### PR DESCRIPTION
The formatting broke when we switched to the `{{<details>}}` shortcode.