### PR TITLE
[Docs] Fix invalid aside types

### DIFF
--- a/content/magic-wan/configuration/manually/third-party/pfsense.md
+++ b/content/magic-wan/configuration/manually/third-party/pfsense.md
@@ -13,7 +13,7 @@ This tutorial explains how to set up a policy-based or route-based IPsec VPN wit
 2. Choose an interface from the **Available network ports** list.
 3. Select **Add**. The **General Configuration** dialog displays.
 
-{{<Aside header="Note">}}
+{{<Aside type="note" header="Note">}}
 
 You may need to adjust the MSS on the LAN interface. With the selected IPsec encryption ciphers, 1406 is the idle MSS as pfSense will subtract 40 from the value you specify.
 

--- a/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
+++ b/content/pages/how-to/use-worker-for-ab-testing-in-pages.md
@@ -30,7 +30,7 @@ Pages Functions have utility functions that can reuse chunks of logic which are 
 
 In your `/functions` directory, create a `_middleware.js` file.
 
-{{<Aside type="Note">}}
+{{<Aside type="note">}}
 
 When you create your `_middleware.js` file at the base of your `/functions` folder, the middleware will run for all routes on your project. Learn more about [middleware routing](/pages/platform/functions/middleware/).
 

--- a/content/support/Third-Party Software/Content Management System (CMS)/Cloudflare WordPress Plugin Automatic Cache Management.md
+++ b/content/support/Third-Party Software/Content Management System (CMS)/Cloudflare WordPress Plugin Automatic Cache Management.md
@@ -21,7 +21,7 @@ Automatic Cache Management uses native hooks built into WordPress. The Cloudflar
 -   switch\_theme
 -   customize\_save\_after
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 This feature works great [when caching HTML on
 WordPress](https://support.cloudflare.com/hc/articles/236166048) with
 the Bypass Cache on Cookie setting.

--- a/content/support/Third-Party Software/Content Management System (CMS)/Using the Cloudflare plugin with WordPress.md
+++ b/content/support/Third-Party Software/Content Management System (CMS)/Using the Cloudflare plugin with WordPress.md
@@ -53,7 +53,7 @@ After installing the Cloudflare WordPress plugin, to configure plugin settings,
 2.  Enter your Cloudflare login credentials, including your email and Cloudflare **API key**, then click **Save API Credentials**.
     -   For more information about the API key and how to retrieve it, review our [documentation](https://support.cloudflare.com/hc/articles/200167836-Managing-API-Tokens-and-Keys#h12345682).
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 To ensure that the Cloudflare plugin works optimally on your WordPress
 site, apply the default plugin settings by clicking **Apply** in
 **Settings**.

--- a/content/support/Troubleshooting/HTTP Status Codes/4xx Client Error.md
+++ b/content/support/Troubleshooting/HTTP Status Codes/4xx Client Error.md
@@ -168,7 +168,7 @@ nginx specific response code to indicate when the connection has been closed by 
 
 -   This will be shown in [Cloudflare Logs](https://support.cloudflare.com/hc/en-us/articles/216672448-Enterprise-Log-Share-REST-API) and status code analytics for Enterprise customers.
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 Since Cloudflare was built on nginx, we also have a 499 HTTP code in Cloudflare Logs
 and analytics for connections which are terminated before we have finished
 processing the request. It is expected behavior to see these in your

--- a/content/support/Troubleshooting/Planned maintenance/Disruptive Maintenance Windows.md
+++ b/content/support/Troubleshooting/Planned maintenance/Disruptive Maintenance Windows.md
@@ -14,13 +14,13 @@ Maintenances will be published on the status page using a _calendar_ that is upd
 
 During these maintenance windows, customers may experience a slight increase in latency to the edge location which is under maintenance.
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 All dates in the calendar are in UTC Timezone.
 {{</Aside>}}
 
 ### Maintenance Calendar links
 
-[Download iCal](https://calendar.google.com/calendar/ical/c_83vui762nfm498l9a0ciojbju0%40group.calendar.google.com/public/basic.ics "Download iCal")  
+[Download iCal](https://calendar.google.com/calendar/ical/c_83vui762nfm498l9a0ciojbju0%40group.calendar.google.com/public/basic.ics "Download iCal")
 [Add to Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y184M3Z1aTc2Mm5mbTQ5OGw5YTBjaW9qYmp1MEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t "Add to Google Calendar")
 
 ### Notifications

--- a/content/support/Troubleshooting/Restoring Visitor IPs/Restoring original visitor IPs.md
+++ b/content/support/Troubleshooting/Restoring Visitor IPs/Restoring original visitor IPs.md
@@ -260,7 +260,7 @@ extforward.headers = ("CF-Connecting-IP")
 (repeat for all Cloudflare IPs listed at https://www.cloudflare.com/ips/)
 ```
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 If your origin connects to the Internet with IPv6,
 **\$HTTP\[\"remoteip\"\]**, which is required for matching the remote IP
 ranges does not work when IPv6 is enabled. Using the above method will

--- a/content/support/Troubleshooting/Website Under Attack/Using Cloudflare Logs (ELS) to Investigate DDoS Traffic (Enterprise Only).md
+++ b/content/support/Troubleshooting/Website Under Attack/Using Cloudflare Logs (ELS) to Investigate DDoS Traffic (Enterprise Only).md
@@ -30,7 +30,7 @@ Gather the following information:
 4.  Start time (example format: 1529171100)
 5.  End time (example format: 1529171100)
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 For the purposes of this tutorial, you can use the following website to
 convert times to Unix time: <https://www.epochconverter.com/>
 {{</Aside>}}

--- a/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors.md
+++ b/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors.md
@@ -308,7 +308,7 @@ persist.
 -   If you are the site owner, review [Cloudflare Rate Limiting thresholds](/waf/reference/legacy/old-rate-limiting/) and adjust your Rate Limiting configuration.
 -   If your Rate Limiting blocks requests in a short time period (i.e. 1 second) try increasing the time period to 10 seconds.
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 If you expect a new Cloudflare Worker to exceed rate limits, refer to
 the [Workers
 documentation](/workers/platform/limits)

--- a/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
+++ b/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
@@ -288,7 +288,7 @@ Contact your hosting provider to exclude the following common causes at your or
 -   No [SNI](https://developers.cloudflare.com/fundamentals/reference/glossary/#server-name-indication-sni) support
 -   The [cipher suites](/ssl/origin-configuration/cipher-suites/) presented by Cloudflare to the origin do not match the cipher suites supported by the origin web server
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 If 525 errors occur intermittently, review the origin web server error
 logs to determine the cause. Configure Apache to [log mod\_ssl
 errors](https://cwiki.apache.org/confluence/display/HTTPD/DebuggingSSLProblems#Enable_SSL_logging).
@@ -314,7 +314,7 @@ Error 526 occurs when these two conditions are true:
 
 **Resolution**
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 For a potential quick fix, set **SSL** to *Full* instead of *Full
 (strict)* in the **Overview** tab of your Cloudflare **SSL/TLS** app for
 the domain.
@@ -424,7 +424,7 @@ If TLS/SSL errors occur, check the following on the origin web server and ensure
 -   the SAN or Common Name of the origin web server’s SSL certificate contains the requested or target hostname
 -   **SSL** is set to [Full or Full (Strict)](/ssl/origin-configuration/ssl-modes) in the **Overview** tab of the Cloudflare **SSL/TLS** app
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 If your origin web server SSL certificate is self-signed, [set
 *validate.cert=0* in
 *railgun.conf*](/railgun/user-guide/railgun-ca-certificates).

--- a/content/support/Troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.md
+++ b/content/support/Troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.md
@@ -206,7 +206,7 @@ When troubleshooting HTTP errors in responses from Cloudflare, test whether your
 $ curl -svo /dev/null http://example.com --connect-to ::203.0.113.34
 ```
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 If you have multiple origin web servers, test each one to ensure there
 are no response differences. If you observe the issue when connecting
 directly to your origin web server, contact your hosting provider for
@@ -239,7 +239,7 @@ curl -svo /dev/null https://example.com/ -w "\nContent Type: %{content_type} \
 
 [Explanation of this timing output](https://blog.cloudflare.com/a-question-of-timing/) is found on the Cloudflare blog.
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 As demonstrated in the preceding example, cleaner results are achieved
 by denoting a new line with **\\n** before each variable. Otherwise, all
 metrics are displayed together on a single line.
@@ -271,7 +271,7 @@ The following cURL command shows the SSL certificate served by Cloudflare during
 $ curl -svo /dev/null https://www.example.com/ 2>&1 | egrep -v "^{.*$|^}.*$|^* http.*$"
 ```
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 2*\>&1 \| egrep -v \"\^{.*\$\|\^}.*\$\|\^* http.\*\$\" \*cleans and
 parses the TLS handshake and certificate information.
 {{</Aside>}}
@@ -303,7 +303,7 @@ ___
 
 Traceroute is a network diagnostic tool that measures the route latency of packets across a network. Most operating systems support the _traceroute_ command. If you experience connectivity issues with your Cloudflare-proxied website and [ask Cloudflare Support for assistance](/support/contacting-cloudflare-support/), ensure to provide output from a traceroute.
 
-{{<Aside type="tip">}}
+{{<Aside type="note">}}
 Timeouts are possible for ping results because Cloudflare limits ping
 requests.
 {{</Aside>}}

--- a/content/workers/examples/basic-auth.md
+++ b/content/workers/examples/basic-auth.md
@@ -12,7 +12,7 @@ weight: 1001
 layout: example
 ---
 
-{{<Aside type="info">}}
+{{<Aside type="note">}}
 
 This example Worker makes use of the [Node.js Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
 {{</Aside>}}

--- a/content/workers/examples/openai-sdk-streaming.md
+++ b/content/workers/examples/openai-sdk-streaming.md
@@ -35,7 +35,7 @@ export default {
 			console.log(part.choices[0]?.delta?.content || '');
 			writer.write(textEncoder.encode(part.choices[0]?.delta?.content || ''));
 		}
-		
+
 		writer.close();
 
 		// Send readable back to the browser so it can read the stream content
@@ -44,7 +44,7 @@ export default {
 };
 ```
 
-{{<Aside type="Note">}}
+{{<Aside type="note">}}
 
 In order to run this code, you must install the OpenAI SDK by running `npm i openai`.
 

--- a/content/workers/examples/signing-requests.md
+++ b/content/workers/examples/signing-requests.md
@@ -12,7 +12,7 @@ weight: 1001
 layout: example
 ---
 
-{{<Aside type="info">}}
+{{<Aside type="note">}}
 
 This example Worker makes use of the [Node.js Buffer API](/workers/runtime-apis/nodejs/buffer/), which is available as part of the Worker's runtime [Node.js compatibility mode](/workers/runtime-apis/nodejs/). To run this Worker, you will need to [enable the `nodejs_compat` compatibility flag](http://localhost:5173/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
 {{</Aside>}}

--- a/content/workers/examples/turnstile-html-rewriter.md
+++ b/content/workers/examples/turnstile-html-rewriter.md
@@ -84,7 +84,7 @@ export default handler;
 {{</tab>}}
 {{</tabs>}}
 
-{{<Aside type= "Note">}}
+{{<Aside type="note">}}
 This is only half the implementation for Turnstile. The corresponding token that is a result of a widget being rendered also needs to be verified using the [siteverify API](/turnstile/get-started/server-side-validation/). Refer to the example below for one such implementation.
 {{</Aside>}}
 


### PR DESCRIPTION
Officially, we only support `note` and `warning` asides (i.e., these are the only types that have specific CSS styles).