### PR TITLE
[WAF][Challenges]  Add User-Agent Spoofing warning to challenges page

### DIFF
--- a/content/waf/reference/cloudflare-challenges.md
+++ b/content/waf/reference/cloudflare-challenges.md
@@ -72,6 +72,12 @@ Challenges are not supported by Microsoft Internet Explorer.
 
 If your visitors encounter issues using a major browser besides Internet Explorer, they should upgrade their browser.
 
+{{<Aside type="note">}}
+
+Modifying the browser's default User-Agent might lead to unpassable challenge loops due to the request deviating from expected browser behavior.
+
+{{</Aside>}}
+
 ### Mobile browsers
 
 Challenges are not supported for desktop mode on mobile browsers or mobile mode on desktop browsers.


### PR DESCRIPTION
As discussed, we are missing a challenge loop user agent spoof warning in the challenges page.