### PR TITLE
Remove --cask option

### DIFF
--- a/content/terraform/advanced-topics/import-cloudflare-resources.md
+++ b/content/terraform/advanced-topics/import-cloudflare-resources.md
@@ -26,7 +26,7 @@ If you use Homebrew on macOS, open a terminal and run the following commands:
 
 ```sh
 $ brew tap cloudflare/cloudflare
-$ brew install --cask cloudflare/cloudflare/cf-terraforming
+$ brew install cloudflare/cloudflare/cf-terraforming
 ```
 
 If you are using a different OS, [download the latest release](https://github.com/cloudflare/cf-terraforming/releases) from the `cf-terraforming` GitHub repository.


### PR DESCRIPTION
The cask flag was deprecated a while ago and running `brew install --cask ...` will return

```shell
brew install --cask cloudflare/cloudflare/cf-terraforming
Warning: Cask 'cf-terraforming' is unavailable: '/opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/Casks/cf-terraforming.rb' does not exist.
```