### PR TITLE
[Docs] Update collapse alt text

### DIFF
--- a/layouts/partials/sidebar.nav.html
+++ b/layouts/partials/sidebar.nav.html
@@ -102,7 +102,7 @@
       </div>
     </div>
     <div class="toggleSidebar" >
-    <button id="toggleSidebarButton" style="width: 2em; height: 2em;" title="Click to collapse and expand the sidebar navigation">
+    <button id="toggleSidebarButton" style="width: 2em; height: 2em;" title="Select to collapse and expand the sidebar navigation">
       <svg id="toggleSidebarSVG" aria-hidden="true" class="" height="1" width="1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path id="toggleSidebarSVGPath" d="M15 2a1 1 0 0 0-1 1v10a1 1 0 0 0 2 0V3a1 1 0 0 0-1-1zm-10.407.993l-4.3 4.3a1 1 0 0 0 0 1.414l4.3 4.3a1 1 0 0 0 1.415-1.416L3.417 9H10a1 1 0 1 0 0-2H3.417l2.591-2.591a1 1 0 1 0-1.415-1.416z"></path></svg>
     </button>
   </div>


### PR DESCRIPTION
Update sidenav collapse button alt text to use 'select' instead of 'click'.