### PR TITLE
[Chore] Track glossary tooltip views via zaraz custom events

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -284,6 +284,7 @@ export function toggleSidebar() {
 export function zarazTrackDocEvents() {
   const links = document.getElementsByClassName("DocsMarkdown--link");
   const dropdowns = document.getElementsByTagName("details")
+  const glossaryTooltips = document.getElementsByClassName("glossary-tooltip")
   addEventListener("DOMContentLoaded", () => {
     if (links.length > 0) {
       for (const link of links as any) {  // Type cast to any for iteration
@@ -307,6 +308,16 @@ export function zarazTrackDocEvents() {
         });
     }
   }
+  if (glossaryTooltips.length > 0) {
+    for (const tooltip of glossaryTooltips as any) { 
+      tooltip.addEventListener("pointerleave", () => {
+        $zarazGlossaryTooltipEvent(tooltip.getAttribute('aria-label'))
+      });
+      tooltip.addEventListener("blur", () => {
+        $zarazGlossaryTooltipEvent(tooltip.getAttribute('aria-label'))
+      });
+  }
+}
   });
 }
 
@@ -316,6 +327,10 @@ function $zarazLinkEvent(type: string, link: Element) {
 
 function $zarazDropdownEvent(summary: string) {
   zaraz.track('dropdown click', {text: summary.innerText})
+}
+
+function $zarazGlossaryTooltipEvent(term: string) {
+  zaraz.track('glossary definition view', {term: term})
 }
 
 export function zarazTrackHomepageLinks() {

--- a/assets/events.ts
+++ b/assets/events.ts
@@ -330,7 +330,7 @@ function $zarazDropdownEvent(summary: string) {
 }
 
 function $zarazGlossaryTooltipEvent(term: string) {
-  zaraz.track('glossary definition view', {term: term})
+  zaraz.track('glossary tooltip view', {term: term})
 }
 
 export function zarazTrackHomepageLinks() {


### PR DESCRIPTION
<img width="807" alt="Screenshot 2023-12-12 at 5 12 01 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/26727299/2131641e-20ba-48ad-b1b0-7779e2700974">
