### PR TITLE
[Docs] Add Markdown support to `details` headers

### DIFF
--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -2,7 +2,7 @@
 
 <details class="DocsMarkdown"
   {{ with .Get "open" }} open{{ end }}>
-    <summary>{{ $header }}</summary>
+    <summary>{{ $header | markdownify }}</summary>
     <div>
       {{- .Page.RenderString .Inner -}}
     </div>


### PR DESCRIPTION
Some `{{<details>}}` headers use Markdown syntax, but the formatting wasn't being rendered.

Examples:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/54422dfa-414f-466a-b85a-db8577740f71)

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/2fd145f8-cf76-4643-8ecb-2461e081655f)

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/30f0d053-56a8-41c2-b297-4a58b89c3a4b)

After:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/9d1e6b14-942f-4274-a603-8d3812169fca)

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/460b3fa3-f8b8-4b8f-8b03-e14a6aa0880c)

![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/248646c0-48d2-40c3-b676-bc8233021d5b)
