### PR TITLE
[workers-ai] Fix up code block styles

### DIFF
--- a/content/workers-ai/platform/workers-pages-sdk.md
+++ b/content/workers-ai/platform/workers-pages-sdk.md
@@ -18,7 +18,7 @@ Workers AI requires an `Ai` instance before you can run a model.
 
 ```typescript
 export class Ai {
-    constructor(binding: any)
+  constructor(binding: any);
 }
 
 export type Ai = {
@@ -38,37 +38,37 @@ import { Ai } from "@cloudflare/ai";
 const ai = new Ai(env.AI);
 ```
 
-* **env.AI** is the project [binding](/workers-ai/platform/bindings/) defined in your `wrangler.toml` configuration.
+- **env.AI** is the project [binding](/workers-ai/platform/bindings/) defined in your `wrangler.toml` configuration.
 
 #### async ai.run()
 
 Runs a model. Takes a model as the first parameter, and an object as the second parameter.
 
 ```javascript
-import { Ai } from '@cloudflare/ai'
+import { Ai } from "@cloudflare/ai";
 
 // sessionOptions are optional
-const ai = new Ai(env.AI, { sessionOptions: { ctx }});
+const ai = new Ai(env.AI, { sessionOptions: { ctx } });
 
-const answer = ai.run('@cf/meta/llama-2-7b-chat-int8', {
-    prompt: "What is the origin of the phrase 'Hello, World'"
+const answer = ai.run("@cf/meta/llama-2-7b-chat-int8", {
+  prompt: "What is the origin of the phrase 'Hello, World'",
 });
 ```
 
 Optionally, you can pass a `streaming` parameter to the `run` method. This will return a stream of results as they are available.
 
 ```javascript
-import { Ai } from '@cloudflare/ai'
+import { Ai } from "@cloudflare/ai";
 
 // sessionOptions are optional
-const ai = new Ai(env.AI, { sessionOptions: { ctx }});
+const ai = new Ai(env.AI, { sessionOptions: { ctx } });
 
-const answer = await ai.run('@cf/meta/llama-2-7b-chat-int8',
-    prompt: "What is the origin of the phrase 'Hello, World'",
-    stream: true
-);
+const answer = await ai.run("@cf/meta/llama-2-7b-chat-int8", {
+  prompt: "What is the origin of the phrase 'Hello, World'",
+  stream: true,
+});
 
 return new Response(answer, {
-    headers: { "content-type": "text/event-stream" }
+  headers: { "content-type": "text/event-stream" },
 });
 ```


### PR DESCRIPTION
My initial motivation was to fix syntax errors in code blocks.

![image](https://github.com/cloudflare/cloudflare-docs/assets/6259812/5577c43d-be88-4e55-999d-aea9bf6b2961)

Then, as the code styles were not aligned, fixed them together by `prettier`.