### PR TITLE
Clarify Browser Cache TTL override conditions

### DIFF
--- a/content/cache/how-to/edge-browser-cache-ttl/_index.md
+++ b/content/cache/how-to/edge-browser-cache-ttl/_index.md
@@ -17,7 +17,7 @@ For more information on creating page rules, refer to [Create page rules](/cache
 
 The Browser Cache TTL sets the expiration for resources cached in a visitor’s browser. By default, Cloudflare honors the cache expiration set in your `Expires` and `Cache-Control` headers but overrides those headers if:
 
-- The value of the `Cache-Control` header from the origin web server is less than the Browser Cache TTL Cloudflare setting.
+- The value of the `Expires` or `Cache-Control` header from the origin web server is less than the Browser Cache TTL Cloudflare setting.
 - The origin web server does not send a `Cache-Control` or an `Expires` header.
 
 Unless specifically set in a page rule, Cloudflare does not override or insert `Cache-Control` headers if you set **Browser Cache TTL** to **Respect Existing Headers**.


### PR DESCRIPTION
Adding Expires header to Browser Cache TTL conditions