### PR TITLE
Fix openai-sdk-streaming.md example

### DIFF
--- a/content/workers/examples/openai-sdk-streaming.md
+++ b/content/workers/examples/openai-sdk-streaming.md
@@ -31,12 +31,14 @@ export default {
 		const textEncoder = new TextEncoder();
 
 		// loop over the data as it is streamed from OpenAI and write it using our writeable
-		for await (const part of stream) {
-			console.log(part.choices[0]?.delta?.content || '');
-			writer.write(textEncoder.encode(part.choices[0]?.delta?.content || ''));
-		}
+		(async () => {
+			for await (const part of stream) {
+				console.log(part.choices[0]?.delta?.content || '');
+				writer.write(textEncoder.encode(part.choices[0]?.delta?.content || ''));
+			}
 
-		writer.close();
+			writer.close();
+		})()
 
 		// Send readable back to the browser so it can read the stream content
 		return new Response(readable);


### PR DESCRIPTION
The provided example is wrong because the Response is returned only after the streaming from OpenAI is finished. Hence the whole OpenAI response is returned in a single chunk.

Wrapping writing to the stream into self-invoked async function fixes the problem because the Response is then returned right away without waiting for Stream to finish