### PR TITLE
Turnstile: Add pre-clearance changelog and update csp for it

### DIFF
--- a/content/fundamentals/reference/policies-compliances/content-security-policies.md
+++ b/content/fundamentals/reference/policies-compliances/content-security-policies.md
@@ -39,4 +39,4 @@ To use certain Cloudflare features, however, you may need to update the headers 
 | [Bot products](/bots/) | Refer to [JavaScript detections and CSPs](/bots/reference/javascript-detections/#if-you-have-a-content-security-policy-csp).|
 | [Page Shield](/page-shield/) | Refer to [Page Shield CSP Header format](/page-shield/reference/csp-header/). |
 | [Zaraz](/zaraz/) | No updates required ([details](https://blog.cloudflare.com/cloudflare-zaraz-supports-csp/)).|
-| [Turnstile](/turnstile/) | Refer to [Turnstile FAQ](/turnstile/frequently-asked-questions/#how-does-content-security-policy-need-to-be-configured-for-turnstile).|
+| [Turnstile](/turnstile/) | Refer to [Turnstile CSP](/turnstile/reference/content-security-policy/).|

--- a/content/turnstile/frequently-asked-questions.md
+++ b/content/turnstile/frequently-asked-questions.md
@@ -15,7 +15,7 @@ structured_data: true
 
 The HTTP Content-Security-Policy response header allows website administrators to control resources the user agent is allowed to load for a given page.
 
-For specifics regarding Turnstile, see the [Content Security Policy](/turnstile/reference/content-security-policy/) section.
+For specifics regarding Turnstile, refer to the [Content Security Policy](/turnstile/reference/content-security-policy/).
 
 {{</faq-answer>}}
 {{</faq-item>}}

--- a/content/turnstile/frequently-asked-questions.md
+++ b/content/turnstile/frequently-asked-questions.md
@@ -13,16 +13,9 @@ structured_data: true
 
 {{<faq-answer>}}
 
-The HTTP Content-Security-Policy response header allows website administrators to control resources the user agent is allowed to load for a given page. 
+The HTTP Content-Security-Policy response header allows website administrators to control resources the user agent is allowed to load for a given page.
 
-We recommend using the nonce-based approach documented with [CSP3](https://w3c.github.io/webappsec-csp/#framework-directive-source-list). Make sure to include your nonce in the `api.js` script tag and we will handle the rest. Cloudflare Turnstile works with **strict-dynamic**.
-
-Alternatively, add the following values to the directives:
-
-* **script-src**: `https://challenges.cloudflare.com`
-* **frame-src**: `https://challenges.cloudflare.com`
-
-We recommend validating your CSP with [Google's CSP Evaluator](https://csp-evaluator.withgoogle.com/).
+For specifics regarding Turnstile, see the [Content Security Policy](/turnstile/reference/content-security-policy/) section.
 
 {{</faq-answer>}}
 {{</faq-item>}}
@@ -49,7 +42,7 @@ Visitor Solve Rate is the percentage of tokens that were solved but have not nec
 
 {{<faq-answer>}}
 
-API Solve Rate is the share of tokens that were siteverified compared to issued. 
+API Solve Rate is the share of tokens that were siteverified compared to issued.
 
 {{</faq-answer>}}
 {{</faq-item>}}
@@ -130,11 +123,11 @@ The siteverify API must not be called by the front end as this may reveal the se
 
 {{<faq-answer>}}
 
-Dummy sitekeys can be used from any domain, including on `localhost`. 
+Dummy sitekeys can be used from any domain, including on `localhost`.
 
 Cloudflare recommends that sitekeys used in production do not allow local domains (`localhost`, `127.0.0.1`), but users can choose to add local domains to the list of allowed domains.
 
-Refer to [Testing](/turnstile/reference/testing/) for more information. 
+Refer to [Testing](/turnstile/reference/testing/) for more information.
 
 {{</faq-answer>}}
 {{</faq-item>}}
@@ -157,7 +150,7 @@ Currently, a Turnstile token can have up to 2048 characters.
 
 {{<faq-answer>}}
 
-Turnstile is hosted under `challenges.cloudflare.com`. 
+Turnstile is hosted under `challenges.cloudflare.com`.
 
 {{</faq-answer>}}
 {{</faq-item>}}
@@ -167,7 +160,7 @@ Turnstile is hosted under `challenges.cloudflare.com`.
 
 {{<faq-answer>}}
 
-We currently do not offer an easy and official way to embed Turnstile in a React Native application. 
+We currently do not offer an easy and official way to embed Turnstile in a React Native application.
 
 An HTML page rendered in a [WebView](https://github.com/react-native-webview/react-native-webview) can use Turnstile. The page must be loaded from a domain allowed to use the [sitekey](/turnstile/reference/domain-management/), either using `uri` or by specifying the `html` and `baseUrl` options.
 
@@ -225,7 +218,7 @@ If you encounter an endless challenge loop, try disabling your browser extension
 {{<faq-question level=2 text="What languages does Turnstile support?" >}}
 {{<faq-answer>}}
 
-Refer to the [list of supported languages](/turnstile/reference/supported-languages/) for more information. 
+Refer to the [list of supported languages](/turnstile/reference/supported-languages/) for more information.
 
 {{</faq-answer>}}
 {{</faq-item>}}

--- a/content/turnstile/reference/content-security-policy.md
+++ b/content/turnstile/reference/content-security-policy.md
@@ -18,8 +18,8 @@ Alternatively, add the following values to your CSP header:
 
 We recommend validating your CSP with [Google's CSP Evaluator](https://csp-evaluator.withgoogle.com/).
 
-## With Pre-Clearance
+## Pre-Clearance support
 
-If you are using [Turnstile in pre-clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests), Turnstile sets the `cf_clearance` cookie by doing a fetch request to a special endpoint in [`/cdn-cgi/`](https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/) of your domain.
+If you are using [Turnstile in pre-clearance mode](/turnstile/reference/pre-clearance-support/), Turnstile sets the `cf_clearance` cookie by doing a fetch request to a special endpoint in [`/cdn-cgi/`](/fundamentals/reference/cdn-cgi-endpoint/) of your domain.
 
 For this request to succeed, your `connect-src` directive must include `'self'`.

--- a/content/turnstile/reference/content-security-policy.md
+++ b/content/turnstile/reference/content-security-policy.md
@@ -20,6 +20,6 @@ We recommend validating your CSP with [Google's CSP Evaluator](https://csp-evalu
 
 ## With Pre-Clearance
 
-If you are using [Turnstile in pre-clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests), Turnstile sets the `cf_clearance` cookie by doing a fetch request to a special endoint in [`/cdn-cgi/`](https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/) of your domain.
+If you are using [Turnstile in pre-clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests), Turnstile sets the `cf_clearance` cookie by doing a fetch request to a special endpoint in [`/cdn-cgi/`](https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/) of your domain.
 
 For this request to succeed, your `connect-src` directive must include `'self'`.

--- a/content/turnstile/reference/content-security-policy.md
+++ b/content/turnstile/reference/content-security-policy.md
@@ -1,0 +1,25 @@
+---
+title: Content Security Policy
+pcx_content_type: reference
+weight: 16
+layout: single
+---
+
+# Content Security Policy
+
+The HTTP Content-Security-Policy response header allows website administrators to control resources the user agent is allowed to load for a given page.
+
+We recommend using the nonce-based approach documented with [CSP3](https://w3c.github.io/webappsec-csp/#framework-directive-source-list). Make sure to include your nonce in the `api.js` script tag and we will handle the rest. Cloudflare Turnstile works with **strict-dynamic**.
+
+Alternatively, add the following values to your CSP header:
+
+- **script-src**: `https://challenges.cloudflare.com`
+- **frame-src**: `https://challenges.cloudflare.com`
+
+We recommend validating your CSP with [Google's CSP Evaluator](https://csp-evaluator.withgoogle.com/).
+
+## With Pre-Clearance
+
+If you are using [Turnstile in pre-clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests), Turnstile sets the `cf_clearance` cookie by doing a fetch request to a special endoint in [`/cdn-cgi/`](https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/) of your domain.
+
+For this request to succeed, your `connect-src` directive must include `'self'`.

--- a/data/changelogs/turnstile.yaml
+++ b/data/changelogs/turnstile.yaml
@@ -4,7 +4,7 @@ productName: Turnstile
 entries:
 - publish_date: '2023-12-18'
   description: |-
-    - Added [Pre-Clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests)
+    - Added [Pre-Clearance mode](/turnstile/reference/pre-clearance-support/).
 - publish_date: '2023-08-24'
   description: |-
     - Added [Client-side errors](/turnstile/reference/client-side-errors).

--- a/data/changelogs/turnstile.yaml
+++ b/data/changelogs/turnstile.yaml
@@ -2,6 +2,9 @@
 link: "/turnstile/changelog/"
 productName: Turnstile
 entries:
+- publish_date: '2023-12-18'
+  description: |-
+    - Added [Pre-Clearance mode](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests)
 - publish_date: '2023-08-24'
   description: |-
     - Added [Client-side errors](/turnstile/reference/client-side-errors).


### PR DESCRIPTION
Add changelog for https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests

Move CSP into its own reference section to add CSP specific to pre-clearance mode.