### PR TITLE
Fix image signing example

### DIFF
--- a/content/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens.md
+++ b/content/images/cloudflare-images/serve-images/serve-private-images-using-signed-url-tokens.md
@@ -44,8 +44,8 @@ async function generateSignedUrl(url) {
   // `url` now looks like
   // https://imagedelivery.net/cheeW4oKsx5ljh8e8BoL2A/bc27a117-9509-446b-8c69-c81bfeac0a01/mobile?exp=1631289275
 
-  const stringToSign = url.pathname + '?' + url.searchParams.toString();
-  // for example, /cheeW4oKsx5ljh8e8BoL2A/bc27a117-9509-446b-8c69-c81bfeac0a01/mobile?exp=1631289275
+  const stringToSign = url.pathname;
+  // for example, /cheeW4oKsx5ljh8e8BoL2A/bc27a117-9509-446b-8c69-c81bfeac0a01/mobile
 
   // Generate the signature
   const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(stringToSign));


### PR DESCRIPTION
When following the image signing example, and signing the path with the query string included as per the example, I got the following error message:

```
ERROR 9425: Image access denied: check failed: Malformed data found: The URL signature does not match. Expecting SHA-256 HMAC of the path without domain nor query string
```

I removed the query string parameters from the string being signed and everything worked. The updated example reflects the changes I made in my code to make this work.