### PR TITLE
Durable Objects: Link to Storage & Rust docs

### DIFF
--- a/content/durable-objects/api/workers-rs.md
+++ b/content/durable-objects/api/workers-rs.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Rust API
+
+external_link: https://github.com/cloudflare/workers-rs?tab=readme-ov-file#durable-objects
+weight: 20
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/durable-objects/platform/storage-options.md
+++ b/content/durable-objects/platform/storage-options.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: Storage Options guide
+
+external_link: /workers/platform/storage-options/
+weight: 30
+_build:
+  publishResources: false
+  render: never
+---


### PR DESCRIPTION
This PR links out to:

- The storage options guide from the DO docs: https://developers.cloudflare.com/workers/platform/storage-options/
- The workers-rs library examples

Our other storage products do this already.