### PR TITLE
Update Gateway 504 advice

### DIFF
--- a/content/cloudflare-one/faq/teams-troubleshooting.md
+++ b/content/cloudflare-one/faq/teams-troubleshooting.md
@@ -60,9 +60,9 @@ If none of the above scenarios apply, contact Cloudflare support with the follow
 
 For more troubleshooting information, refer to [Support](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/#error-526-invalid-ssl-certificate).
 
-## I see error 504 when browsing to a website.
+## I see error 504 or timeouts when browsing to a website.
 
-Gateway presents an **HTTP response code: 504** error page when the website publishes an `AAAA` (IPv6) DNS record but does not respond over IPv6. When Gateway attempts to connect over IPv6, the connection will timeout. This issue is caused by a misconfiguration on the origin you are trying to reach. We are working on adding Happy Eyeballs support to Gateway, which will automatically fallback to IPv4 if IPv6 fails. In the meantime, you can either add the domain to your [split tunnel configuration](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) or create a [Gateway DNS policy](/cloudflare-one/policies/gateway/dns-policies/) to block the query record type `AAAA` for the specific domain. For example:
+Gateway may present an **HTTP response code: 504** error page - or your browser may display generic timeout errors - when a website publishes an `AAAA` (IPv6) DNS record but does not respond over IPv6. When Gateway attempts to connect over IPv6, the connection will timeout. This issue is caused by a misconfiguration on the origin you are trying to reach. We are working on adding Happy Eyeballs support to Gateway, which will automatically fallback to IPv4 if IPv6 fails. In the meantime, you can either add the domain to your [split tunnel configuration](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) or create a [Gateway DNS policy](/cloudflare-one/policies/gateway/dns-policies/) to block the query record type `AAAA` for the specific domain. For example:
 
 | Selector          | Operator | Value         | Logic | Action |
 | ----------------- | -------- | ------------- | ----- | ------ |


### PR DESCRIPTION
The known issue of Gateway erroring when websites advertise AAAA records but don't accept IPv6 connections isn't guaranteed to result in a 504. We've seen other errors including generic browser ones.

Additionally, "Gateway presents..." has been changed to "Gateway may present..." as the current wording suggests that a 504 _only_ shows for this specific IPv6 issue, which isn't the case.