### PR TITLE
[Workers] revise Fetch API page

### DIFF
--- a/content/workers/runtime-apis/fetch.md
+++ b/content/workers/runtime-apis/fetch.md
@@ -9,26 +9,39 @@ meta:
 
 The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asynchronously fetching resources via HTTP requests inside of a Worker.
 
-The `fetch` method is implemented on the `ServiceWorkerGlobalScope`. Refer to [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/fetch) for more information.
-
 {{<Aside type="note">}}
 
-Asynchronous tasks such as `fetch` are not executed at the top level in a Worker script and must be executed within a `fetch()` handler. Learn more about [the Request context](/workers/runtime-apis/request/#the-request-context).
+Asynchronous tasks such as `fetch` are not executed at the top level in a Worker and must be executed within a [handler](/workers/runtime-apis/handlers/). Learn more about [the Request context](/workers/runtime-apis/request/#the-request-context).
 
 {{</Aside>}}
 
 {{<Aside type="warning" header="Worker to Worker">}}
 
-Worker-to-Worker `fetch` requests are now possible with [Service bindings](/workers/configuration/bindings/about-service-bindings/).
+Worker-to-Worker `fetch` requests are possible with [Service bindings](/workers/configuration/bindings/about-service-bindings/).
 
 {{</Aside>}}
 
+## Syntax
+
+{{<tabs labels="js/esm | js/sw">}}
+{{<tab label="js/esm" default="true">}}
+
+```js
 ---
-
-## Constructor
-
-<!-- This code example needs more work -->
-
+highlight: [3-7]
+---
+export default {
+  async scheduled(event, env, ctx) {
+    return await fetch("https://example.com", {
+      headers: {
+        "X-Source": "Cloudflare-Workers",
+      },
+    });
+  },
+};
+```
+{{</tab>}}
+{{<tab label="js/sw">}}
 ```js
 ---
 highlight: [8]
@@ -44,8 +57,8 @@ async function eventHandler(event) {
   return resp;
 }
 ```
-
-<!-- Where do we have the return type in this format? -->
+{{</tab>}}
+{{</tabs>}}
 
 {{<definitions>}}
 
@@ -67,8 +80,6 @@ async function eventHandler(event) {
   - The content of the request.
 
 {{</definitions>}}
-
----
 
 ## Related resources
 


### PR DESCRIPTION
PCX-9302

This PR aims to:
- revise this page for appropriate JS terminology 
- add ES modules code
- remove notion that fetch api can only be used in a fetch handler -> any handler can use fetch, link to handler docs
- remove mention of service worker global scope 

#10627 