### PR TITLE
Response Header Modification: Add `set-cookie` caveat

### DIFF
--- a/content/rules/transform/response-header-modification/_index.md
+++ b/content/rules/transform/response-header-modification/_index.md
@@ -40,5 +40,5 @@ To modify HTTP headers in the **request**, refer to [HTTP request header modific
 
 * Modifying `cache-control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control` headers will not change the way Cloudflare caches an object. Instead, you should create a [Cache Rule](/cache/how-to/cache-rules/).
 
-* Setting the `set-cookie` header will result in overwriting any preexisting `set-cookie` headers, including those added by other Cloudflare products. This includes the header responsible for setting a cookie used by Bot Management.
+* Setting the `set-cookie` header will result in overwriting all preexisting `set-cookie` headers, including those added by other Cloudflare products (e.g. Bot Management).
   * Instead, use "Add" to add a new `set-cookie` header. (Note that only a string literal value is supported at this time). 

--- a/content/rules/transform/response-header-modification/_index.md
+++ b/content/rules/transform/response-header-modification/_index.md
@@ -40,5 +40,6 @@ To modify HTTP headers in the **request**, refer to [HTTP request header modific
 
 * Modifying `cache-control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control` headers will not change the way Cloudflare caches an object. Instead, you should create a [Cache Rule](/cache/how-to/cache-rules/).
 
-* Setting the `set-cookie` header will result in overwriting all preexisting `set-cookie` headers, including those added by other Cloudflare products (e.g. Bot Management).
-  * Instead, use "Add" to add a new `set-cookie` header. (Note that only a string literal value is supported at this time). 
+* To add a `set-cookie` header to the response, make sure you use the _Add_ operation instead of _Set static_/_Set dynamic_. Using one of the _Set_ operations will remove any `set-cookie` headers already in the response, including those added by other Cloudflare products such as Bot Management.
+
+* Currently you can only use the _Add_ operation with a literal string value.

--- a/content/rules/transform/response-header-modification/_index.md
+++ b/content/rules/transform/response-header-modification/_index.md
@@ -40,4 +40,5 @@ To modify HTTP headers in the **request**, refer to [HTTP request header modific
 
 * Modifying `cache-control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control` headers will not change the way Cloudflare caches an object. Instead, you should create a [Cache Rule](/cache/how-to/cache-rules/).
 
-* Modifying the `set-cookie` header will result in overwriting any preexisting `set-cookie` headers, including those added by other Cloudflare products. This includes the header responsible for setting a cookie used by Bot Management.
+* Setting the `set-cookie` header will result in overwriting any preexisting `set-cookie` headers, including those added by other Cloudflare products. This includes the header responsible for setting a cookie used by Bot Management.
+  * Instead, use "Add" to add a new `set-cookie` header. (Note that only a string literal value is supported at this time). 

--- a/content/rules/transform/response-header-modification/_index.md
+++ b/content/rules/transform/response-header-modification/_index.md
@@ -39,3 +39,5 @@ To modify HTTP headers in the **request**, refer to [HTTP request header modific
 * Any response header modifications will also apply to Cloudflare error pages and [custom error pages](/support/more-dashboard-apps/cloudflare-custom-pages/configuring-custom-pages-error-and-challenge/).
 
 * Modifying `cache-control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control` headers will not change the way Cloudflare caches an object. Instead, you should create a [Cache Rule](/cache/how-to/cache-rules/).
+
+* Modifying the `set-cookie` header will result in overwriting any preexisting `set-cookie` headers, including those added by other Cloudflare products. This includes the header responsible for setting a cookie used by Bot Management.


### PR DESCRIPTION
I'm not sure about exact wording here (suggestions/rewrites very welcome), but I think it could be very useful to call out the fact that the set-cookie header is a special case (in terms of IETF standards), and that this results in caveats for its use with the current version of the Response Header Modification feature.

I think the Response Header Modification functionality may have been written with a more general header case in mind ([RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.3:~:text=Multiple%20message%2Dheader%20fields,fields%20with%20the%20same)), whereas `set-cookie` is a special case in which multiple headers of the same name can be sent AND can't be collapsed together into a single header. The exceptional behavior of `set-cookie` leads to design constraints for any feature like Response Header Modification, and necessarily involves tradeoffs. I think it would be very valuable to list this particular tradeoff in this section of the documentation, because it's (IMO) non-obvious.