### PR TITLE
[Workers] non-reference wrangler commands need 'npx' in front of them

### DIFF
--- a/content/workers/configuration/cron-triggers/index.md
+++ b/content/workers/configuration/cron-triggers/index.md
@@ -129,7 +129,7 @@ Changes such as adding a new Cron Trigger, updating an old Cron Trigger, or dele
 Test  Cron Triggers using `Wrangler` by passing in the `--test-scheduled` flag to [`wrangler dev`](/workers/wrangler/commands/#dev). This will expose a `/__scheduled` route which can be used to test using a HTTP request. To simulate different cron patterns, a `cron` query parameter can be passed in.
 
 ```sh
-$ wrangler dev --test-scheduled
+$ npx wrangler dev --test-scheduled
 
 $ curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
 ```

--- a/content/workers/configuration/secrets.md
+++ b/content/workers/configuration/secrets.md
@@ -37,7 +37,7 @@ To add a secret to a Worker, run the [`wrangler secret put` command](/workers/wr
 ---
 filename: wrangler secret put
 ---
-$ wrangler secret put <KEY>
+$ npx wrangler secret put <KEY>
 ```
 
 #### Via the dashboard
@@ -63,7 +63,7 @@ To delete a secret from your Worker project, run the [`wrangler secret delete` c
 ---
 filename: wrangler secret delete
 ---
-$ wrangler secret delete <KEY>
+$ npx wrangler secret delete <KEY>
 ```
 
 ### Via the dashboard

--- a/content/workers/examples/cron-trigger.md
+++ b/content/workers/examples/cron-trigger.md
@@ -64,7 +64,7 @@ The recommended way of testing Cron Triggers is using Wrangler.
 Cron Triggers can be tested using Wrangler by passing in the `--test-scheduled` flag to [`wrangler dev`](/workers/wrangler/commands/#dev). This will expose a `/__scheduled` route which can be used to test using a HTTP request. To simulate different cron patterns, a `cron` query parameter can be passed in.
 
 ```sh
-$ wrangler dev --test-scheduled
+$ npx wrangler dev --test-scheduled
 
 $ curl "http://localhost:8787/__scheduled?cron=0+*+*+*+*"
 ```

--- a/content/workers/examples/multiple-cron-triggers.md
+++ b/content/workers/examples/multiple-cron-triggers.md
@@ -73,7 +73,7 @@ The recommended way of testing Cron Triggers is using Wrangler.
 Cron Triggers can be tested using Wrangler by passing in the `--test-scheduled` flag to [`wrangler dev`](/workers/wrangler/commands/#dev). This will expose a `/__scheduled` route which can be used to test using a HTTP request. To simulate different cron patterns, a `cron` query parameter can be passed in.
 
 ```sh
-$ wrangler dev --test-scheduled
+$ npx wrangler dev --test-scheduled
 
 $ curl "http://localhost:8787/__scheduled?cron=*%2F3+*+*+*+*"
 ```

--- a/content/workers/observability/log-from-workers.md
+++ b/content/workers/observability/log-from-workers.md
@@ -75,7 +75,7 @@ async function handleRequest(request) {
 After you deploy the above code, run `wrangler tail` in your terminal, and then access your Worker. Your terminal will display:
 
 ```sh
-$ wrangler tail --format=pretty
+$ npx wrangler tail --format=pretty
 [2021-08-18 17:06:55] [LAX] [Ok] GET https://logging-example.jkup.workers.dev/
  | [Info] Request came from city: Pacifica in country: US
 [2021-08-18 17:06:56] [LAX] [Ok] GET https://logging-example.jkup.workers.dev/favicon.ico
@@ -111,7 +111,7 @@ The output of each `wrangler tail` log is a structured JSON object:
 By piping the output to tools like [`jq`](https://stedolan.github.io/jq/), you can query and manipulate the requests to look for specific information:
 
 ```sh
-$ wrangler tail | jq .event.request.url
+$ npx wrangler tail | jq .event.request.url
 "https://www.bytesized.xyz/"
 "https://www.bytesized.xyz/component---src-pages-index-js-a77e385e3bde5b78dbf6.js"
 "https://www.bytesized.xyz/page-data/app-data.json"

--- a/content/workers/runtime-apis/handlers/scheduled.md
+++ b/content/workers/runtime-apis/handlers/scheduled.md
@@ -16,7 +16,7 @@ You can test the behavior of your `scheduled()` handler in local development usi
 Cron Triggers can be tested using `Wrangler` by passing in the `--test-scheduled` flag to [`wrangler dev`](/workers/wrangler/commands/#dev). This will expose a `/__scheduled` route which can be used to test using a http request. To simulate different cron patterns, a `cron` query parameter can be passed in.
 
 ```sh
-$ wrangler dev --test-scheduled
+$ npx wrangler dev --test-scheduled
 
 $ curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
 ```

--- a/content/workers/runtime-apis/mTLS.md
+++ b/content/workers/runtime-apis/mTLS.md
@@ -28,7 +28,7 @@ The `wrangler mtls-certificate upload` command requires the [SSL and Certificate
 {{</Aside>}}
 
 ```sh
-$ wrangler mtls-certificate upload --cert cert.pem --key key.pem --name my-client-cert
+$ npx wrangler mtls-certificate upload --cert cert.pem --key key.pem --name my-client-cert
 ```
 
 Then, update your Worker project's `wrangler.toml` file to create an mTLS certificate binding:

--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -43,7 +43,7 @@ compatibility_flags = [ "nodejs_compat" ]
 To enable `nodejs_compat` in local development, pass the [`--compatibility-flags`](/workers/wrangler/commands/#dev-1) argument with the `nodejs_compat` flag to `wrangler pages dev`:
 
 ```sh
-$ wrangler pages dev [<DIRECTORY>] --compatibility-flags="nodejs_compat"
+$ npx wrangler pages dev [<DIRECTORY>] --compatibility-flags="nodejs_compat"
 ```
 
 For additional options, refer to the list of [Pages-specific CLI commands](/workers/wrangler/commands/#dev-1).

--- a/content/workers/tutorials/build-a-jamstack-app/index.md
+++ b/content/workers/tutorials/build-a-jamstack-app/index.md
@@ -36,7 +36,7 @@ In your terminal, create a Worker project with your desired project name; for ex
 ---
 header: Generate a project
 ---
-$ wrangler init todos
+$ npx wrangler init todos
 $ cd todos
 ```
 
@@ -89,7 +89,7 @@ To get started with KV, set up a namespace. All of your cached data will be stor
 ---
 header: Create a new KV namespace
 ---
-$ wrangler kv:namespace create "TODOS" --preview
+$ npx wrangler kv:namespace create "TODOS" --preview
 ```
 
 Namespaces can be added to your application by defining them inside your Wrangler configuration. Copy your newly created namespace ID, and in your `wrangler.toml`, define a `kv_namespaces` key to set up your namespace:

--- a/content/workers/tutorials/build-a-slackbot/index.md
+++ b/content/workers/tutorials/build-a-slackbot/index.md
@@ -658,7 +658,7 @@ To use this constant inside of your codebase, use the [`wrangler secret`](/worke
 ---
 header: Set the SLACK_WEBHOOK_URL secret
 ---
-$ wrangler secret put SLACK_WEBHOOK_URL
+$ npx wrangler secret put SLACK_WEBHOOK_URL
 Enter the secret text you’d like assigned to the variable name on the script named slack-bot-ENVIRONMENT_NAME: https://hooks.slack.com/services/abc123
 ```
 

--- a/content/workers/tutorials/configure-your-cdn/index.md
+++ b/content/workers/tutorials/configure-your-cdn/index.md
@@ -54,12 +54,12 @@ If you choose to deploy, you will be asked to authenticate (if not logged in alr
 Before you integrate R2 bucket access into your Worker application, an R2 bucket must be created:
 
 ```sh
-$ wrangler r2 bucket create <YOUR_BUCKET_NAME>
+$ npx wrangler r2 bucket create <YOUR_BUCKET_NAME>
 ```
 Replace `<YOUR_BUCKET_NAME>` with the name you want to assign to your bucket. List your account's R2 buckets to verify that a new bucket has been added:
 
 ```sh
-$ wrangler r2 bucket list
+$ npx wrangler r2 bucket list
 ```
 
 ## Configure access to an R2 bucket
@@ -119,7 +119,7 @@ Next, you will add the ability to upload to your R2 bucket using authentication.
 Create a secret value of your choice -- for instance, a random string or password. Using the Wrangler CLI, add the secret to your project as `AUTH_SECRET`:
 
 ```sh
-$ wrangler secret put AUTH_SECRET
+$ npx wrangler secret put AUTH_SECRET
 ```
 
 Now, add a new code path that handles a `PUT` HTTP request. This new code will check that the previously uploaded secret is correctly used for authentication, and then upload to R2 using `MY_BUCKET.put(key, data)`:

--- a/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
+++ b/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
@@ -49,7 +49,7 @@ Create a new R2 bucket using [`wrangler r2 bucket create`](/workers/wrangler/com
 Note that bucket names must be lowercase and can only contain dashes.
 
 ```sh
-$ wrangler r2 bucket create <BUCKET_NAME>
+$ npx wrangler r2 bucket create <BUCKET_NAME>
 ```
 
 Next, upload a file using [`npx wrangler r2 object put`](/workers/wrangler/commands/#put-2). `<PATH>` is the combined bucket and file path of the file you want to upload -- for example, `finetune.jsonl`. Replace `<FILE_NAME>` with the local filename of your fine-tune document.

--- a/content/workers/tutorials/deploy-a-realtime-chat-app/index.md
+++ b/content/workers/tutorials/deploy-a-realtime-chat-app/index.md
@@ -29,7 +29,7 @@ $ git clone https://github.com/cloudflare/workers-chat-demo.git
 After you have cloned the repository, authenticate Wrangler by running:
 
 ```sh
-$ wrangler login
+$ npx wrangler login
 ```
 
 ## Deploy your project

--- a/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
+++ b/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
@@ -342,7 +342,7 @@ async fn handle_slash(text: String) -> Result<Response> {
 After you have finished updating your project, start a local server for developing your Worker by running:
 
 ```sh
-$ wrangler dev
+$ npx wrangler dev
 ```
 
 This should spin up a `localhost` instance with the image displayed:
@@ -377,7 +377,7 @@ A `.workers.dev` domain will be generated for your Worker after running `wrangle
 Create a Worker to serve the image you uploaded to Images by running:
 
 ```sh
-$ wrangler init thumbnail-image
+$ npx wrangler init thumbnail-image
 ```
 
 This will create a new Worker project named `thumbnail-image`. In the `src/index.js` file, add the following code block:

--- a/content/workers/tutorials/handle-form-submissions-with-airtable/index.md
+++ b/content/workers/tutorials/handle-form-submissions-with-airtable/index.md
@@ -131,7 +131,7 @@ Run `wrangler secret put`, passing `AIRTABLE_ACCESS_TOKEN` as the name of your s
 ---
 header: Set the `AIRTABLE_ACCESS_TOKEN` secret with Wrangler
 ---
-$ wrangler secret put AIRTABLE_ACCESS_TOKEN
+$ npx wrangler secret put AIRTABLE_ACCESS_TOKEN
 Enter the secret text you would like assigned to the variable AIRTABLE_ACCESS_TOKEN on the script named airtable-form-handler:
 ******
 🌀  Creating the secret for script name airtable-form-handler

--- a/content/workers/tutorials/manage-projects-with-lerna/index.md
+++ b/content/workers/tutorials/manage-projects-with-lerna/index.md
@@ -33,7 +33,7 @@ Inside of `packages`, where `lerna` will look for your projects, you can create 
 header: Create projects using Wrangler
 ---
 $ cd packages
-$ wrangler init my-api
+$ npx wrangler init my-api
 
 # If you have existing projects, you can clone them into the directory:
 $ git clone https://github.com/cloudflare/worker-template.git
@@ -46,8 +46,8 @@ This approach to managing your Workers projects can become incredibly powerful w
 header: Create projects using Wrangler
 ---
 $ cd packages
-$ wrangler init public-api
-$ wrangler init private-api
+$ npx wrangler init public-api
+$ npx wrangler init private-api
 ```
 
 Next to your API projects, create a new package `handlers`, which can be imported into each project:

--- a/content/workers/tutorials/postgres/index.md
+++ b/content/workers/tutorials/postgres/index.md
@@ -93,7 +93,7 @@ Replace `username`, `password`, `host`, `port`, and `database` with the appropri
 Set your connection string as a [secret](/workers/configuration/secrets/) so that it is not stored as plain text. Use [`wrangler secret put`](/workers/wrangler/commands/#secret) with the example variable name `DB_URL`:
 
 ```sh
-$ wrangler secret put DB_URL
+$ npx wrangler secret put DB_URL
 ➜  wrangler secret put DB_URL
 -------------------------------------------------------
 ? Enter a secret value: › ********************
@@ -120,7 +120,7 @@ DB_NAME = "productsdb"
 To set your password as a [secret](/workers/configuration/secrets/) so that it is not stored as plain text, use [`wrangler secret put`](/workers/wrangler/commands/#secret). `DB_PASSWORD` is an example variable name for this secret to be accessed in your Worker:
 
 ```sh
-$ wrangler secret put DB_PASSWORD
+$ npx wrangler secret put DB_PASSWORD
 -------------------------------------------------------
 ? Enter a secret value: › ********************
 ✨ Success! Uploaded secret DB_PASSWORD

--- a/content/workers/tutorials/workers-kv-from-rust/index.md
+++ b/content/workers/tutorials/workers-kv-from-rust/index.md
@@ -35,7 +35,7 @@ $ git commit -m 'Initial commit'
 To be able to access Workers KV, define a binding for a particular KV namespace in the `wrangler.toml` file generated in your new project's directory. If you do not have an existing namespace, create one using `wrangler`. For example, a namespace called `KV_FROM_RUST` would be created by running:
 
 ```sh
-$ wrangler kv:namespace create "KV_FROM_RUST"
+$ npx wrangler kv:namespace create "KV_FROM_RUST"
 🌀  Creating namespace with title "workers-kv-from-rust-KV_FROM_RUST"
 ✨  Success!
 Add the following to your configuration file:

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1934,7 +1934,7 @@ wrangler login [OPTIONS]
   - List all the available OAuth scopes with descriptions.
 - `--scopes $SCOPES` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Allows to choose your set of OAuth scopes. The set of scopes must be entered in a whitespace-separated list,
-    for example, `$ wrangler login --scopes account:read user:read`.
+    for example, `$ npx wrangler login --scopes account:read user:read`.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/environments.md
+++ b/content/workers/wrangler/environments.md
@@ -129,7 +129,7 @@ Published my-worker-staging
 ```
 
 ```sh
-~/my-worker $ wrangler deploy --env production
+~/my-worker $ npx wrangler deploy --env production
 Uploaded my-worker-production
 Published my-worker-production
   example.com/*

--- a/content/workers/wrangler/migration/v1-to-v2/update-v1-to-v2.md
+++ b/content/workers/wrangler/migration/v1-to-v2/update-v1-to-v2.md
@@ -47,7 +47,7 @@ $ npm install -g wrangler
 To check that you have installed the correct Wrangler version, run:
 
 ```sh
-$ wrangler --version
+$ npx wrangler --version
 ```
 
 ## Test Wrangler v2 on your previous projects
@@ -60,7 +60,7 @@ Run the `wrangler dev` command. This will show any warnings or errors that shoul
 Note that in most cases, the messages will include actionable instructions on how to resolve the issue.
 
 ```sh
-$ wrangler dev
+$ npx wrangler dev
 ```
 
 - Errors need to be fixed before Wrangler can build your Worker.


### PR DESCRIPTION
PCX-9321

As per guidance to install locally, all commands other than reference commands (like /workers/wrangler/commands/) need `npx`in front of them or they will not function. 