### PR TITLE
[Durable Object] Remove extra space in class name

### DIFF
--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -77,7 +77,7 @@ export default {
   }
 }
 
-export class YourDurableObject implements Durable Object {
+export class YourDurableObject implements DurableObject {
   constructor(public state: DurableObjectState, env: Env) {
       this.state = state;
       // Ensure you pass your bindings and environment variables into


### PR DESCRIPTION
Changes "Durable Object" -> "DurableObject".