### PR TITLE
R2: Add a note about lack of object listing support in public buckets

### DIFF
--- a/content/r2/buckets/public-buckets.md
+++ b/content/r2/buckets/public-buckets.md
@@ -16,6 +16,12 @@ Public buckets can be set up in either one of two ways:
 To configure WAF custom rules, caching, access controls, or bot management for your bucket, you must do so through a custom domain.
 Using a custom domain does not require enabling `r2.dev`.
 
+{{<Aside type="note">}}
+
+Public buckets do not let you list the contents of your buckets at the root of your (sub) domain currently.
+
+{{</Aside>}}
+
 ## Custom domains
 
 ### Caching

--- a/content/r2/buckets/public-buckets.md
+++ b/content/r2/buckets/public-buckets.md
@@ -18,7 +18,7 @@ Using a custom domain does not require enabling `r2.dev`.
 
 {{<Aside type="note">}}
 
-Public buckets do not let you list the contents of your buckets at the root of your (sub) domain currently.
+Currently, public buckets do not let you list the bucket contents at the root of your (sub) domain.
 
 {{</Aside>}}
 


### PR DESCRIPTION
This is a common question,