### PR TITLE
[Vectorize] Clarify page title

### DIFF
--- a/content/vectorize/platform/client-api.md
+++ b/content/vectorize/platform/client-api.md
@@ -1,10 +1,10 @@
 ---
-title: Workers API
+title: Vectorize Workers API
 pcx_content_type: concept
 weight: 2
 ---
 
-# Workers API
+# Vectorize Workers API
 
 This page covers the Vectorize API available within [Cloudflare Workers](/workers/), including usage examples.
 


### PR DESCRIPTION
I found this page confusing:

![IMG_7101](https://github.com/cloudflare/cloudflare-docs/assets/9599/1ebec8a1-c678-450f-94fc-8f22ea99812a)

I was looking for API documentation for Vectorize.

The page title "Workers API" initially made me think this was about some other general API for working with Cloudflare Workers.