### PR TITLE
docs: fix puppeteer binding type

### DIFF
--- a/content/browser-rendering/get-started/screenshots.md
+++ b/content/browser-rendering/get-started/screenshots.md
@@ -124,10 +124,10 @@ export default {
 Update `src/worker.ts` with your Worker code:
 
 ```ts
-import puppeteer from "@cloudflare/puppeteer";
+import puppeteer, { BrowserWorker } from "@cloudflare/puppeteer";
 
 interface Env {
-	MYBROWSER: Fetcher;
+	MYBROWSER: BrowserWorker;
 	BROWSER_KV_DEMO: KVNamespace;
 }
 


### PR DESCRIPTION
Following the present docs, a type error will occur due to a mismatch in the Fetcher vs BrowserWorker types.

![image](https://github.com/cloudflare/cloudflare-docs/assets/78360666/deb9d4f0-e6e9-4bbe-b09b-e3e4121c0a8d)
