### PR TITLE
Fix dead Mistral link

### DIFF
--- a/content/workers-ai/models/text-generation.md
+++ b/content/workers-ai/models/text-generation.md
@@ -163,7 +163,7 @@ Here's an example of a simple question, without templating:
 };
 ```
 
-Here's an input example of a [Mistral](https://docs.mistral.ai/llm/mistral-instruct-v0.1#chat-template) chat template prompt:
+Here's an input example of a [Mistral](https://docs.mistral.ai/models/#chat-template) chat template prompt:
 
 ```javascript
 {


### PR DESCRIPTION
Workers AI link to Mistral chat template was dead. Fixed it with a similar one.