### PR TITLE
[LB] Fix session affinity cookie name

### DIFF
--- a/content/load-balancing/_partials/_session-affinity-by-cookie-process.md
+++ b/content/load-balancing/_partials/_session-affinity-by-cookie-process.md
@@ -7,7 +7,7 @@ _build:
 
 Session affinity automatically directs requests from the same client to the same origin web server:
 
-1.  When a client makes its first request, Cloudflare sets a `cflib` cookie on the client (to track the associated origin web server).
+1.  When a client makes its first request, Cloudflare sets a `__cflb` cookie on the client (to track the associated origin web server).
 2.  Subsequent requests by the same client are forwarded to that origin for the duration of the cookie and as long as the origin server remains healthy.
 3.  If the cookie expires or the origin server becomes unhealthy, Cloudflare sets a new cookie tracking the new failover origin.
 
@@ -15,12 +15,12 @@ Session affinity automatically directs requests from the same client to the same
     flowchart LR
       accTitle: Session affinity process
       accDescr: Session affinity directs requests from the same client to the same server.
-     A[Client] --Request--> B{<code>cflib</code> cookie set?}
+     A[Client] --Request--> B{<code>__cflb</code> cookie set?}
      B -->|Yes| C[Route to previous server]
      C --> O2
      B ---->|No| E[Follow normal routing]
      E --> O2
-     E --Set <code>cflib</code> cookie--> A
+     E --Set <code>__cflb</code> cookie--> A
      subgraph P1 [Pool 1]
         O1[Origin 1]
         O2[Origin 2]

--- a/content/load-balancing/understand-basics/session-affinity.md
+++ b/content/load-balancing/understand-basics/session-affinity.md
@@ -48,8 +48,8 @@ Enable Session Affinity when you [create or edit a load balancer](/load-balancin
 
 If you enable Session Affinity, choose one of the following options:
 
-- **By Cloudflare cookie only**: Sets a `cflib` cookie to track the associated origin web server.
-- **By Cloudflare cookie and Client IP fallback**: Sets a `cflib` cookie, but also uses the client IP address when no session affinity cookie is provided.
+- **By Cloudflare cookie only**: Sets a `__cflb` cookie to track the associated origin web server.
+- **By Cloudflare cookie and Client IP fallback**: Sets a `__cflb` cookie, but also uses the client IP address when no session affinity cookie is provided.
 - **By HTTP header**.
 
 {{<Aside type="warning" header="Important">}}
@@ -88,7 +88,7 @@ Origin drain is not supported for load balancers in [DNS-only mode (gray cloud)]
 
 ## Zero-Downtime Failover
 
-Zero-Downtime Failover automatically sends traffic to origin servers within a pool during transient network issues. This helps reduce errors shown to your users when issues occur in between active health monitors. 
+Zero-Downtime Failover automatically sends traffic to origin servers within a pool during transient network issues. This helps reduce errors shown to your users when issues occur in between active health monitors.
 
 You can enable one of three options:
 


### PR DESCRIPTION
Current document refers to the session affinity cookie as having the name "cflib"; the cookie is currently named "__cflb" per https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/#__cflb-cookie-for-cloudflare-load-balancer-session-affinity (verified in testing earlier today)