### PR TITLE
workers: make size limits clearer

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -220,14 +220,14 @@ A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan
 
 You can assess the size of your Worker bundle after compression by performing a dry-run with `wrangler` and reviewing the final compressed (`gzip`) size output by `wrangler`:
 
-```console
+```sh
 $ wrangler deploy --outdir bundled/ --dry-run
 
 # Output will resemble the below:
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
 
-Note that larger Worker bundles, especially those over 1 MB, can impact the start-up time of the Worker, as the Worker needs to be loaded into memory. You should consider removing unnecessary dependencies and/or using [Workers KV](/kv/), a [D1 database](/d1/) or [R2](/r2/) to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code. 
+Note that larger Worker bundles can impact the start-up time of the Worker, as the Worker needs to be loaded into memory. You should consider removing unnecessary dependencies and/or using [Workers KV](/kv/), a [D1 database](/d1/) or [R2](/r2/) to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code. 
 
 {{<render file="_limits_increase.md">}}
 

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -216,7 +216,18 @@ Each environment variable has a size limitation of 5 KB.
 
 ## Worker size
 
-A Worker can be up to 10 MB in size after compression on the Workers Paid plan, and up to 1 MB on the Workers Free plan.
+A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan, and up to 1 MB on the Workers Free plan.
+
+You can assess the size of your Worker bundle after compression by performing a dry-run with `wrangler` and reviewing the final compressed (`gzip`) size output by `wrangler`:
+
+```console
+$ wrangler deploy --outdir bundled/ --dry-run
+
+# Output will resemble the below:
+Total Upload: 259.61 KiB / gzip: 47.23 KiB
+```
+
+Note that larger Worker bundles, especially those over 1 MB, can impact the start-up time of the Worker, as the Worker needs to be loaded into memory. You should consider removing unnecessary dependencies and/or using [Workers KV](/kv/), a [D1 database](/d1/) or [R2](/r2/) to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code. 
 
 {{<render file="_limits_increase.md">}}
 


### PR DESCRIPTION
This PR:

* Makes it clearer that larger Workers bundles can have a negative perf impact
* How to measure the size after compression
* Options for storing config/binary data/etc outside of a Worker bundle