### PR TITLE
Use proper XML indentation for multi-org configuration

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations.md
@@ -21,26 +21,26 @@ An MDM file supports a maximum of 25 configurations. The following is an example
 
 ```xml
 <array>
-<dict>
-    <key>organization</key>
-    <string>mycompany</string>
-    <key>display_name</key>
-    <string>Production environment</string>
-</dict>
-<dict>
-    <key>organization</key>
-    <string>mycompany</string>
-    <key>override_warp_endpoint</key>
-    <string>203.0.113.0:500</string>
-    <key>display_name</key>
-    <string>Cloudflare China network</string>
-</dict>
-<dict>
-    <key>organization</key>
-    <string>test-org</string>
-    <key>display_name</key>
-    <string>Test environment</string>
-</dict>
+  <dict>
+      <key>organization</key>
+      <string>mycompany</string>
+      <key>display_name</key>
+      <string>Production environment</string>
+  </dict>
+  <dict>
+      <key>organization</key>
+      <string>mycompany</string>
+      <key>override_warp_endpoint</key>
+      <string>203.0.113.0:500</string>
+      <key>display_name</key>
+      <string>Cloudflare China network</string>
+  </dict>
+  <dict>
+      <key>organization</key>
+      <string>test-org</string>
+      <key>display_name</key>
+      <string>Test environment</string>
+  </dict>
 </array>
 ```
 


### PR DESCRIPTION
Small change to use the correct XML indentation levels for the inline configuration example