### PR TITLE
[Fundamental] Clarify Roles and their Capabilities (Administrator, Billing, billing-edit, subscriptions-edit)

### DIFF
--- a/content/fundamentals/setup/manage-members/roles.md
+++ b/content/fundamentals/setup/manage-members/roles.md
@@ -16,7 +16,7 @@ If you are adding members whose [role scope](/fundamentals/setup/manage-members/
 
 | Role | Description |
 | --- | --- |
-| Administrator | Can access the full account including subscriptions, except for membership management and billing. |
+| Administrator | Can access the full account and edit subscriptions. Cannot manage memberships nor billing profile. |
 | Super Administrator - All Privileges | Can edit any Cloudflare setting, make purchases, update billing, and manage memberships. Super Administrators can revoke the access of other Super Administrators. |
 | Administrator Read Only | Can access the full account in read-only mode. |
 | Analytics | Can read Analytics. |


### PR DESCRIPTION
This change attempts to mitigate the misunderstanding stemming from "billing" and "subscriptions" capabilities vs the roles "Billing" and "Administrator". 

In short, billing capabilities and subscription capabilities are independent, neither implies the other, and a role can have both, one of them, or neither.

"billing" capability :a  role with this capability can manage a billing profile (info related with payment card, etc.).
"subscription" capability: a role with this capability can manage (e.g. upgrade) existing subscriptions
The Administrator role: among others, it has subscription capability, but not billing capability (i.e. billing profile management)
The Billing role: has both billing and subscription capabilities. 