### PR TITLE
Clarified that O2O for WPEngine does not need Enterprise

### DIFF
--- a/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/wpengine.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/wpengine.md
@@ -3,7 +3,7 @@ pcx_content_type: configuration
 title: WP Engine
 meta:
     title: WP Engine | Provider guides
-    description: Learn how to configure your Enterprise zone with WP Engine.
+    description: Learn how to configure your zone with WP Engine.
 ---
 
 # WP Engine
@@ -20,7 +20,7 @@ For more details about how O2O is different than other Cloudflare setups, refer 
 
 ## Enable
 
-You can only enable O2O on the Cloudflare Enterprise plan.
+WPEngine customers can enable O2O on any Cloudflare zone plan.
 
 To enable O2O on your account, [create](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) a `CNAME` DNS record.
 


### PR DESCRIPTION
Clarified that O2O for WPEngine does not need Enterprise.

Closes pcx-9432