### PR TITLE
[Front-end] Adjust pill margins

### DIFF
--- a/layouts/shortcodes/heading-pill.html
+++ b/layouts/shortcodes/heading-pill.html
@@ -12,7 +12,7 @@
         </span>
         <span>{{- .Page.RenderString .Inner -}}</span>
         {{- printf "</%s>" $heading | safeHTML -}}
-        <div class="DocsMarkdown--pill DocsMarkdown--pill-{{$style}} DocsMarkdown-pill-{{printf "%s" $heading}}">{{(replace $style "-" " ") | title}}</div>
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-{{$style}} DocsMarkdown--pill-{{printf "%s" $heading}}">{{(replace $style "-" " ") | title}}</div>
     <!-- Otherwise render as <h1> -->
     {{- else -}}
         <h1 id="{{- $ID -}}">{{- .Page.RenderString .Inner -}}</h1>

--- a/layouts/shortcodes/heading-pill.html
+++ b/layouts/shortcodes/heading-pill.html
@@ -12,7 +12,7 @@
         </span>
         <span>{{- .Page.RenderString .Inner -}}</span>
         {{- printf "</%s>" $heading | safeHTML -}}
-        <div class="DocsMarkdown--pill DocsMarkdown--pill-{{$style}} DocsMarkdown-pill-lower">{{(replace $style "-" " ") | title}}</div>
+        <div class="DocsMarkdown--pill DocsMarkdown--pill-{{$style}} DocsMarkdown-pill-{{printf "%s" $heading}}">{{(replace $style "-" " ") | title}}</div>
     <!-- Otherwise render as <h1> -->
     {{- else -}}
         <h1 id="{{- $ID -}}">{{- .Page.RenderString .Inner -}}</h1>

--- a/static/style.css
+++ b/static/style.css
@@ -5193,9 +5193,23 @@ pre {
 }
 
 /* Pills on levels lower than H1 */
+
 .DocsMarkdown-pill-lower {
   margin-bottom: initial;
   margin-top: 2.25em;
+}
+
+.DocsMarkdown-pill-h2 {
+  margin-bottom: initial;
+  margin-top: 2.6em;
+}
+.DocsMarkdown-pill-h3 {
+  margin-bottom: initial;
+  margin-top: 2.75em;
+}
+.DocsMarkdown-pill-h4 {
+  margin-bottom: initial;
+  margin-top: 1.75em;
 }
 
 .DocsMarkdown--pill-tab {

--- a/static/style.css
+++ b/static/style.css
@@ -5224,19 +5224,16 @@ pre {
 }
 
 .DocsMarkdown--pill-beta {
-  width: 42px;
   background: var(--orange-8);
   color: var(--orange-1);
 }
 
 .DocsMarkdown--pill-deprecated {
-  width: 79px;
   background: var(--red-8);
   color: var(--red-0);
 }
 
 [theme="dark"] .DocsMarkdown--pill-deprecated {
-  width: 79px;
   background: var(--red-6);
   color: var(--red-0);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -5194,20 +5194,21 @@ pre {
 
 /* Pills on levels lower than H1 */
 
+/* '-lower' unused? */
 .DocsMarkdown-pill-lower {
   margin-bottom: initial;
   margin-top: 2.25em;
 }
 
-.DocsMarkdown-pill-h2 {
+.DocsMarkdown--pill-h2 {
   margin-bottom: initial;
   margin-top: 2.6em;
 }
-.DocsMarkdown-pill-h3 {
+.DocsMarkdown--pill-h3 {
   margin-bottom: initial;
   margin-top: 2.75em;
 }
-.DocsMarkdown-pill-h4 {
+.DocsMarkdown--pill-h4 {
   margin-bottom: initial;
   margin-top: 1.75em;
 }


### PR DESCRIPTION
Adjust pill shortcode and `style.css` to create CSS classes for `h2`, `h3`, and `h4`.

Because there's no magic number to keep pills proportionally aligned to their headings, the shortcode now assigns a CSS class corresponding to the heading level (e.g. `.DocsMarkdown--pill-h3`) and uses a unique `margin-top` value to refine alignment.

Also removes unnecessary pixel size values for pills.

**Test cases**:
- `h1`: https://max-docs-pill-sizing.cloudflare-docs-7ou.pages.dev/ai-gateway/
- `h2`: https://max-docs-pill-sizing.cloudflare-docs-7ou.pages.dev/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-sessions/#configure-warp-sessions-in-access
- `h3`: https://max-docs-pill-sizing.cloudflare-docs-7ou.pages.dev/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#override-local-interface-ip
- `h4`: https://max-docs-pill-sizing.cloudflare-docs-7ou.pages.dev/cloudflare-one/policies/gateway/dns-policies/#warp-client-block-notifications