### PR TITLE
[D1] Fix Docs for D1 Miniflare example

### DIFF
--- a/content/d1/learning/local-development.md
+++ b/content/d1/learning/local-development.md
@@ -120,7 +120,9 @@ database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 ```js
 const mf = new Miniflare({
-  d1Databases: ["DB"],
+  d1Databases: {
+    DB: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  },
 });
 ```
 


### PR DESCRIPTION
Because in this example the `binding` and `database_id` are different, the binding needs to be expressed as `Record<string, string>`

[https://github.com/cloudflare/workers-sdk/tree/4a925629238c9244d0fcf058301f46fc8fb64da2/packages/miniflare#d1](https://github.com/cloudflare/workers-sdk/tree/4a925629238c9244d0fcf058301f46fc8fb64da2/packages/miniflare#d1)

_Identical PR for the [miniflare.dev](https://miniflare.dev/storage/d1) docs: https://github.com/cloudflare/miniflare/pull/754_