### PR TITLE
[Chore] Remove duplicate redirect

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1171,7 +1171,6 @@
 /workers/runtime-apis/websockets/use-websockets/ /workers/examples/websockets/ 301
 /workers/runtime-apis/websockets/websockets/ /workers/runtime-apis/websockets/ 301
 /workers/learning/continuous-integration/ /workers/configuration/continuous-integration/ 301
-/workers/learning/continuous-integration/ /workers/configuration/continuous-integration/ 301
 /workers/learning/security-model/ /workers/reference/security-model/ 301
 
 # workers ai


### PR DESCRIPTION
Fixes the following warning in the Cloudflare Pages deployment logs:

```
Found invalid redirect lines:
  - #1183: /workers/learning/continuous-integration/ /workers/configuration/continuous-integration/ 301
    Ignoring duplicate rule for path /workers/learning/continuous-integration/.
```