### PR TITLE
[Chore] Update page layouts

### DIFF
--- a/content/ddos-protection/change-log/http/_index.md
+++ b/content/ddos-protection/change-log/http/_index.md
@@ -4,6 +4,7 @@ pcx_content_type: concept
 weight: 2
 meta:
   title: Changelog for the HTTP DDoS managed ruleset
+sidebar_toc: true
 layout: changelog
 changelog_file_name: [ddos-http]
 outputs:

--- a/content/ddos-protection/change-log/network/_index.md
+++ b/content/ddos-protection/change-log/network/_index.md
@@ -4,6 +4,7 @@ pcx_content_type: concept
 weight: 1
 meta:
   title: Changelog for the Network-layer DDoS managed ruleset
+sidebar_toc: true
 layout: changelog
 changelog_file_name: [ddos-network]
 outputs:

--- a/content/waf/change-log/_index.md
+++ b/content/waf/change-log/_index.md
@@ -4,6 +4,7 @@ pcx_content_type: concept
 weight: 20
 meta:
   title: Changelog for managed rulesets
+sidebar_toc: true
 layout: changelog
 changelog_file_name: [waf]
 outputs:

--- a/content/waf/managed-rules/_index.md
+++ b/content/waf/managed-rules/_index.md
@@ -4,6 +4,7 @@ title: Managed rules
 weight: 7
 meta:
   title: WAF Managed Rules
+layout: list
 ---
 
 # WAF Managed Rules


### PR DESCRIPTION
Use a less wide layout for changelog pages (by enabling sidebar_toc). 
Add explicit layout to WAF Managed Rules page (list), which is currently the default for section list pages.