### PR TITLE
[Chore] Update workers playground link tracking

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -285,6 +285,7 @@ export function zarazTrackDocEvents() {
   const links = document.getElementsByClassName("DocsMarkdown--link");
   const dropdowns = document.getElementsByTagName("details")
   const glossaryTooltips = document.getElementsByClassName("glossary-tooltip")
+  const playgroundLinks = document.getElementsByClassName("playground-link")
   addEventListener("DOMContentLoaded", () => {
     if (links.length > 0) {
       for (const link of links as any) {  // Type cast to any for iteration
@@ -322,6 +323,13 @@ export function zarazTrackDocEvents() {
       });
   }
 }
+  if (playgroundLinks.length > 0) {
+    for (const playgroundLink of playgroundLinks as any) { 
+      playgroundLink.addEventListener("click", () => {
+        $zarazLinkEvent('playground link click', playgroundLink);
+      });
+  }
+  }
   });
 }
 


### PR DESCRIPTION
Need to adjust the tracking to account for the links w/in a code block, b/c they aren't rendered like the links we were previously tracking.

<img width="970" alt="Screenshot 2024-01-12 at 1 20 10 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/26727299/b2248720-c036-4c97-8a75-bd3d5184a0e4">
