### PR TITLE
Added useful info when using WARP on a tightly-firewalled corporate network

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/deployment/firewall.md
@@ -10,15 +10,21 @@ If your organization uses a firewall or other policies to restrict or intercept 
 
 ## Client orchestration API
 
-The WARP client talks with our edge via a standard HTTPS connection outside the tunnel for operations like registration or settings changes. To perform these operations, you must allow `zero-trust-client.cloudflareclient.com` which will lookup the following IP addresses:
+Prior to connection, the WARP client talks with our edge via a standard HTTPS connection **outside the tunnel** for operations like registration and settings changes.
+
+Connections to the API will honour the system proxy settings (if configured), however it is recommended that the connections bypass any proxy and are allowed to be made directly. In this case you must allow `zero-trust-client.cloudflareclient.com` which will resolve to the following IP addresses:
 
 {{<render file="warp/_client-orchestration-ips.md">}}
+
+Once the tunnel has been established, communication with the API will take place **inside the tunnel**, unless a proxy configuration (e.g. PAC file) says otherwise.
 
 ## DoH IP
 
 All DNS requests through WARP are sent outside the tunnel via DoH (DNS over HTTPS). The following IP addresses must be reachable for DNS to work correctly.
 
 {{<render file="warp/_doh-ips.md">}}
+
+DoH requests are always sent directly and will not use a proxy server, even if one is configured for the system.
 
 ### Android devices
 
@@ -56,9 +62,9 @@ The following domains are used as part of our captive portal check:
 
 ## Connectivity check
 
-As part of establishing the WARP connection, the client will check the following URLs to validate a successful connection:
+As part of establishing the WARP connection, the client will check the following HTTPS URLs to validate a successful connection:
 
-- `engage.cloudflareclient.com` verifies general Internet connectivity outside of the WARP tunnel.
+- `engage.cloudflareclient.com` verifies general Internet connectivity outside of the WARP tunnel. These requests are always sent directly and will not use a proxy server, even if one is configured for the system. Resolves to `162.159.192.1` and `2606:4700:d0::a29f:c001`.
 - `connectivity.cloudflareclient.com` verifies connectivity inside of the WARP tunnel. Because this check happens inside of the tunnel, you do not need to add `connectivity.cloudflareclient.com` to your firewall allowlist.
 
 ## NEL reporting
@@ -74,7 +80,12 @@ If your organization does not currently allow inbound/outbound communication ove
 - macOS: `/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP`
 
 ### Optional scopes
-To run [Digital Experience Monitoring tests](/cloudflare-one/insights/dex/tests/), you will also need to allow the `warp-dex` process to generate network traffic to your target destinations:
+To run [Digital Experience Monitoring tests](/cloudflare-one/insights/dex/tests/), you will need to allow the `warp-dex` process to generate network traffic to your target destinations:
 
 - Windows: `C:\Program Files\Cloudflare\Cloudflare WARP\warp-dex.exe`
 - macOS: `/Applications/Cloudflare WARP.app/Contents/Resources/warp-dex`
+
+In order to allow the network connectivity tests within the WARP GUI to function reliably, you will also need to allow the userspace GUI to generate network traffic:
+
+- Windows: `C:\Program Files\Cloudflare\Cloudflare WARP\Cloudflare WARP.exe`
+- macOS: `/Applications/Cloudflare WARP.app`


### PR DESCRIPTION
Added useful info learned from hours of debugging and reverse-engineering when setting up WARP on a tightly-firewalled corporate network.