### PR TITLE
[Frontend] Don't repeat Shift+D if the key is held down

### DIFF
--- a/assets/theme.ts
+++ b/assets/theme.ts
@@ -41,7 +41,7 @@
 
     // Shift+D for toggle
     addEventListener("keydown", (ev) => {
-      if (ev.target !== document.body) return;
+      if (ev.target !== document.body || ev.repeat) return;
       if (ev.which === 68 && ev.shiftKey) {
         ev.preventDefault();
         setter(!btn.checked);


### PR DESCRIPTION
Eliminates potentially seizure-inducing behaviour if Shift+D is held down, where the theme will repeat between dark and light at the key interval rate (which is very fast)

Property used to check: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat