### PR TITLE
[Vale] Add "namespace" to spelling exceptions

### DIFF
--- a/.github/styles/cloudflare/spelling-exceptions.txt
+++ b/.github/styles/cloudflare/spelling-exceptions.txt
@@ -2,4 +2,5 @@ akamai
 geo
 nameserver
 nameservers
+namespace
 subnet


### PR DESCRIPTION
Example PR where it causes issues: https://github.com/cloudflare/cloudflare-docs/pull/12568

Namespace is used a lot, i.e KV

@kodster28 