### PR TITLE
[Chore] Add hostname and punycode to spelling exceptions

### DIFF
--- a/.github/styles/cloudflare/spelling-exceptions.txt
+++ b/.github/styles/cloudflare/spelling-exceptions.txt
@@ -3,3 +3,6 @@ geo
 nameserver
 nameservers
 subnet
+hostname
+hostnames
+punycode


### PR DESCRIPTION
Add `hostname` and `punycode` to spelling exceptions for new Vale spellcheck.