### PR TITLE
[Vale] Lint "sh" codeblocks

### DIFF
--- a/.github/styles/cloudflare/ShellCodeBlocks.yml
+++ b/.github/styles/cloudflare/ShellCodeBlocks.yml
@@ -1,0 +1,47 @@
+---
+# Warning: cloudflare.ShellCodeBlocks
+#
+# Checks that all `sh` codeblocks contain at least one `$`, to indicate a command.
+#
+# For a list of all options, see https://vale.sh/docs/topics/styles/
+extends: script
+message: "**Warning**: `sh` codeblocks must include a `$` character at the beginning of a command, otherwise it will be unselectable. For more information, refer to [Code block guidelines](https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/)"
+level: warning
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  open := false
+  closed := false
+  dollar := false
+  blockText := []
+
+  reset := func() {
+    open = false
+    closed = false
+    dollar = false
+    blockText = []
+  }
+
+  for line in text.split(scope, "\n") {
+    trimmed := text.trim_space(line)
+
+    if !open && trimmed == "```sh" { open = true }
+
+    if open {
+      blockText = append(blockText, line)
+      if !dollar && text.contains(trimmed, "$") { dollar = true }
+      if !closed && trimmed == "```" { closed = true }
+    }
+
+    if open && closed {
+      if !dollar {
+        block := text.join(blockText, "\n")
+        start := text.index(scope, block)
+        matches = append(matches, { begin: start, end: start + len(block) })
+      }
+
+      reset()
+    }
+  }


### PR DESCRIPTION
A draft PR whilst PCX can discuss if scenarios where the command and output are separated by prose, like [this](https://developers.cloudflare.com/workers/tutorials/connect-to-turso-using-workers/#use-wrangler-to-create-a-workers-project), are proper usage of `sh` code blocks.

If they are, then the lint is going to have a lot of false positives since the output block has no command in it. 

In any case, I thought I'd throw up the draft. The script is [Tengo](https://github.com/d5/tengo) which is a Go-like scripting language which Vale embeds, so it isn't quite Go and therefore some things can't be cleaned up (like instantiating all the `false` variables on one line).