### PR TITLE
[R2] Add example on migrating from Cloudflare Images to R2

### DIFF
--- a/content/r2/data-migration/_index.md
+++ b/content/r2/data-migration/_index.md
@@ -20,6 +20,19 @@ Quickly and easily migrate data from other cloud providers to R2. Explore each o
     </th>
     <tr>
       <td colspan="5" rowspan="1">
+        <a href="/r2/data-migration/cloudflare-images/">Cloudflare Images</a>
+      </td>
+      <td colspan="5" rowspan="1">
+        Migrate all images from Cloudflare Images to an R2 bucket.
+      </td>
+      <td colspan="5" rowspan="1">
+        <ul>
+            <li>For one-time, comprehensive transfers.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="5" rowspan="1">
         <a href="/r2/data-migration/super-slurper/">Super Slurper</a>
       </td>
       <td colspan="5" rowspan="1">

--- a/content/r2/data-migration/cloudflare-images.md
+++ b/content/r2/data-migration/cloudflare-images.md
@@ -91,6 +91,7 @@ async function getImagesList(env: Env, continuationToken: string | null = null) 
 }
 
 async function getImageResponse(env: Env, imageId: string) {
+  // Replace with your custom domain to work around rate limits
 	const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${env.IMAGES_ACCOUNT_ID}/images/v1/${imageId}/blob`, {
 		headers: {
 			"Authorization": `Bearer ${env.IMAGES_API_TOKEN}`

--- a/content/r2/data-migration/cloudflare-images.md
+++ b/content/r2/data-migration/cloudflare-images.md
@@ -1,0 +1,106 @@
+---
+title: Cloudflare Images
+pcx_content_type: how-to
+weight: 2
+---
+
+# Cloudflare Images
+
+Images hosted in Cloudflare Images can be migrated to an R2 bucket by using the [list images operation](/api/operations/cloudflare-images-list-images-v2) and the [base image operation](https://developers.cloudflare.com/api/operations/cloudflare-images-base-image).
+
+## Migrating to R2 via a Worker
+
+To use the example, an API token is needed with read permissions for images. [Read how to create an API token.](/fundamentals/api/get-started/create-token/)
+
+Below is an example Worker that exports all images from Cloudflare Images to an R2 bucket.
+
+Add your account identifier and API token to your environment variables when running the example worker. [Read how to add secrets.](/workers/configuration/secrets/#add-secrets-to-your-project)
+
+```ts
+export interface Env {
+	MY_BUCKET: R2Bucket;
+	IMAGES_ACCOUNT_ID: string;
+	IMAGES_API_TOKEN: string;
+}
+
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+		await exportImagesBatch(env, null);
+
+		return new Response("");
+	},
+};
+
+async function exportImagesBatch(env: Env, continuationToken: string | null, imagesCount: number = 0): Promise<null> {
+	const imagesList = await getImagesList(env, continuationToken);
+
+	if(!imagesList.result.images.length) {
+		console.debug("Reached the end of the image list.");
+
+		return null;
+	}
+
+	await Promise.all(imagesList.result.images.map(async (image) => {
+		const imageResponse = await getImageResponse(env, image.id);
+
+		console.debug(`Uploading image ${image.id} to bucket.`);
+
+		await env.MY_BUCKET.put(image.id, await imageResponse.arrayBuffer(), {
+			customMetadata: image.meta,
+			httpMetadata: imageResponse.headers
+		});
+	}));
+
+	return await exportImagesBatch(env, imagesList.result.continuation_token, imagesCount + imagesList.result.images.length);
+}
+
+type ListImagesResult = {
+	result: {
+		images: {
+			id: string;
+			filename: string;
+			meta: Record<string, string>;
+			requireSignedURLs: boolean;
+			uploaded: string;
+			variants: string[];
+		}[];
+		continuation_token: string;
+	}
+};
+
+async function getImagesList(env: Env, continuationToken: string | null = null) {
+	const url = new URL(`https://api.cloudflare.com/client/v4/accounts/${env.IMAGES_ACCOUNT_ID}/images/v2`);
+
+	if(continuationToken) {
+		url.searchParams.set("continuation_token", continuationToken);
+	}
+
+	url.searchParams.set("per_page", "10");
+
+	const response = await fetch(url, {
+		headers: {
+			"Authorization": `Bearer ${env.IMAGES_API_TOKEN}`,
+		}
+	});
+
+	if(!response.ok) {
+		throw new Error("List images response was unsuccessful.");
+	}
+
+	return await response.json<ListImagesResult>();
+}
+
+async function getImageResponse(env: Env, imageId: string) {
+	const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${env.IMAGES_ACCOUNT_ID}/images/v1/${imageId}/blob`, {
+		headers: {
+			"Authorization": `Bearer ${env.IMAGES_API_TOKEN}`
+		}
+	});
+
+	if(!response.ok) {
+		throw new Error("Image response was unsuccessful.");
+	}
+
+	return response;
+}
+```

--- a/content/r2/data-migration/cloudflare-images.md
+++ b/content/r2/data-migration/cloudflare-images.md
@@ -25,13 +25,13 @@ export interface Env {
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		const uploadedImges = await exportImagesBatch(env, null);
+		const uploadedImages = await exportImagesBatch(env, null);
 
 		return new Response(`${uploadedImages} images was uploaded.`);
 	},
 };
 
-async function exportImagesBatch(env: Env, continuationToken: string | null, imagesCount: number = 0): Promise<null> {
+async function exportImagesBatch(env: Env, continuationToken: string | null, imagesCount: number = 0): Promise<number> {
 	const imagesList = await getImagesList(env, continuationToken);
 
 	if(!imagesList.result.images.length) {

--- a/content/r2/data-migration/cloudflare-images.md
+++ b/content/r2/data-migration/cloudflare-images.md
@@ -25,9 +25,9 @@ export interface Env {
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		await exportImagesBatch(env, null);
+		const uploadedImges = await exportImagesBatch(env, null);
 
-		return new Response("");
+		return new Response(`${uploadedImages} images was uploaded.`);
 	},
 };
 
@@ -37,7 +37,7 @@ async function exportImagesBatch(env: Env, continuationToken: string | null, ima
 	if(!imagesList.result.images.length) {
 		console.debug("Reached the end of the image list.");
 
-		return null;
+		return imagesCount;
 	}
 
 	await Promise.all(imagesList.result.images.map(async (image) => {


### PR DESCRIPTION
Added an example of migrating from Cloudflare Images to an R2 bucket via a Worker. Based on my gist @ https://gist.github.com/nora-soderlund/0b30a7edbcf739bc0f6fe421c8d7a6b4. 