### PR TITLE
Add known limitation IDP initiated login

### DIFF
--- a/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
+++ b/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
@@ -18,7 +18,10 @@ All users in your email domain must exist as a member in your Cloudflare account
 
 {{<Aside>}}
 
-Cloudflare dashboard SSO does not support users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
+Cloudflare dashboard SSO does not support:
+
+1. Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
+2. IDP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URl in your IDP to assist users. 
 
 {{</Aside>}}
 

--- a/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
+++ b/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
@@ -21,7 +21,7 @@ All users in your email domain must exist as a member in your Cloudflare account
 Cloudflare dashboard SSO does not support:
 
 1. Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
-2. IDP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IDP to assist users. 
+2. IdP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IdP to assist users. 
 
 {{</Aside>}}
 

--- a/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
+++ b/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
@@ -20,8 +20,8 @@ All users in your email domain must exist as a member in your Cloudflare account
 
 Cloudflare dashboard SSO does not support:
 
-1. Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
-2. IdP initiated logins (such as a tile in Okta). All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IdP to assist users. 
+- Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
+- IdP initiated logins (such as a tile in Okta). All login attempts must originate from `https://dash.cloudflare.com`. You can create a bookmark for this URL in your IdP to assist users. 
 
 {{</Aside>}}
 

--- a/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
+++ b/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
@@ -21,7 +21,7 @@ All users in your email domain must exist as a member in your Cloudflare account
 Cloudflare dashboard SSO does not support:
 
 1. Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
-2. IDP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URl in your IDP to assist users. 
+2. IDP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IDP to assist users. 
 
 {{</Aside>}}
 

--- a/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
+++ b/content/cloudflare-one/applications/configure-apps/dash-sso-apps.md
@@ -21,7 +21,7 @@ All users in your email domain must exist as a member in your Cloudflare account
 Cloudflare dashboard SSO does not support:
 
 1. Users with plus-addressed emails, such as `example+2@domain.com`. If you have users like this added to your Cloudflare organization, they will be unable to login with SSO.
-2. IdP initiated logins such as a tile in Okta. All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IdP to assist users. 
+2. IdP initiated logins (such as a tile in Okta). All login attempts must originate from https://dash.cloudflare.com. You can create a bookmark for this URL in your IdP to assist users. 
 
 {{</Aside>}}
 


### PR DESCRIPTION
Users often create tickets or chats when they receive the error: 

"Invalid login session. Please try going to the URL of your application.""

This is a known limitation but not clearly documented as such

