### PR TITLE
[Docs] Update regex to include query strings

### DIFF
--- a/content/images/transform-images/serve-images-custom-paths.md
+++ b/content/images/transform-images/serve-images-custom-paths.md
@@ -101,7 +101,7 @@ header: Text in Expression Editor
 header: Text in Path > Rewrite to... > Dynamic
 ---
 regex_replace(
-  http.request.uri.path,
+  http.request.uri,
   "^/(.*)\\?width=([0-9]+)&height=([0-9]+)$",
   "/cdn-cgi/image/width=${2},height=${3}/${1}"
 )


### PR DESCRIPTION
The regex `http.request.uri.path` under the **Modify existing URLS to be compatible with transformations in Images** section did not include the query string needed to rewrite the `width` and `height` params accordingly.

Changed to `http.request.uri`.