### PR TITLE
Update Delegated DCV dev docs with a recurring caveat

### DIFF
--- a/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
+++ b/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
@@ -66,16 +66,12 @@ _acme-challenge.sub.example.com CNAME sub.example.com.<COPIED_VALIDATION_URL>.
 
 {{</example>}}
 
-{{<Aside type="note" header="Ensure to remove any previous TXT records">}}
-If you have any previous DCV TXT records in place, such as the following:
-
-{{<example>}}
+{{<Aside type="warning" header="Remove previous TXT records">}}
+Existing TXT records for `_acme-challenge` will conflict with the delegated DCV CNAME record. Make sure to check and remove records such as the following:
 
 ```txt
 _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 ```
-
-These will need to be removed, or else they will conflict with the delegated DCV CNAME record and prevent successful validation.
 {{</Aside>}}
 
 Once this is complete, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.

--- a/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
+++ b/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
@@ -74,7 +74,7 @@ _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 ```
 {{</Aside>}}
 
-Once the 'CNAME' records are in place, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.
+Once the `CNAME` records are in place, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.
 
 Because DCV happens regularly, do not remove the `CNAME` record(s) at your authoritative DNS provider. Otherwise, Cloudflare will not be able to perform DCV on your behalf and your certificate will not be issued.
 

--- a/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
+++ b/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
@@ -66,6 +66,18 @@ _acme-challenge.sub.example.com CNAME sub.example.com.<COPIED_VALIDATION_URL>.
 
 {{</example>}}
 
+{{<Aside type="note" header="Ensure to remove any previous TXT records">}}
+If you have any previous DCV TXT records in place, such as the following:
+
+{{<example>}}
+
+```txt
+_acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
+```
+
+These will need to be removed, or else they will conflict with the delegated DCV CNAME record and prevent successful validation.
+{{</Aside>}}
+
 Once this is complete, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.
 
 Because DCV happens regularly, do not remove the `CNAME` record(s) at your authoritative DNS provider. Otherwise, Cloudflare will not be able to perform DCV on your behalf and your certificate will not be issued.

--- a/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
+++ b/content/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.md
@@ -74,7 +74,7 @@ _acme-challenge.example.com TXT <CERTIFICATE_VALIDATION_VALUE>
 ```
 {{</Aside>}}
 
-Once this is complete, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.
+Once the 'CNAME' records are in place, Cloudflare will add TXT DCV tokens for every hostname on the Advanced certificate that has a DCV delegation record in place, as long as the zone is [active](/dns/zone-setups/reference/domain-status/) on Cloudflare.
 
 Because DCV happens regularly, do not remove the `CNAME` record(s) at your authoritative DNS provider. Otherwise, Cloudflare will not be able to perform DCV on your behalf and your certificate will not be issued.
 


### PR DESCRIPTION
We're seeing multiple customer having issues with delegated DCV because any pre-existing DCV TXT values will inevitably conflict with the delegated DCV Cname and prevent Delegated DCV from actually working.