### PR TITLE
Remove TCP sockets from beta list

### DIFF
--- a/content/workers/platform/betas.md
+++ b/content/workers/platform/betas.md
@@ -20,5 +20,4 @@ These are the current alphas and betas relevant to the Cloudflare Workers platfo
 | Green Compute                 |              | ✅          |[Blog](https://blog.cloudflare.com/earth-day-2022-green-compute-open-beta/) |
 | Pub/Sub                       | ✅           |             |[Docs](/pub-sub)                                                            |
 | Queues                        |              | ✅          |[Docs](/queues)                                                             |
-| [TCP Sockets](/workers/runtime-apis/tcp-sockets/)           | ✅          |             |[Docs](/workers/runtime-apis/tcp-sockets) |
 | Workers Analytics Engine      |              | ✅          |[Docs](/analytics/analytics-engine/)               |


### PR DESCRIPTION
Hey!

Someone pointed out on [Discord](https://discord.com/channels/595317990191398933/1148642604238524558/1201123582705668207) that TCP sockets are still listed as private beta on the docs site. This is [no longer true](https://blog.cloudflare.com/workers-tcp-socket-api-connect-databases). As I was unable to find any mention of them being beta outside of this page, I removed them from this page altogether.