### PR TITLE
Update early-hints.md

### DIFF
--- a/content/pages/configuration/early-hints.md
+++ b/content/pages/configuration/early-hints.md
@@ -7,11 +7,6 @@ title: Early Hints
 
 [Early Hints](/cache/advanced-configuration/early-hints/) help the browser to load webpages faster. Early Hints is enabled automatically on all `pages.dev` domains and custom domains. 
 
-1. Log in to [Cloudflare dashboard](https://dash.cloudflare.com). 
-2. Select your account and zone.
-3. Go to **Speed** > **Optimization** > **Content Optimization**.
-4. Turn on the **Early Hints** toggle.
-
 Early Hints automatically caches any [`preload`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) and [`preconnect`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preconnect) type [`Link` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) to send as Early Hints to the browser. The hints are sent to the browser before the full response is prepared, and the browser can figure out how to load the webpage faster for the end user. There are two ways to create these `Link` headers in Pages:
 
 ## Configure Early Hints

--- a/content/pages/configuration/early-hints.md
+++ b/content/pages/configuration/early-hints.md
@@ -5,7 +5,7 @@ title: Early Hints
 
 # Early Hints
 
-[Early Hints](/cache/advanced-configuration/early-hints/) help the browser to load webpages faster. Early Hints is enabled automatically on all `pages.dev` domains. [To enable](/cache/advanced-configuration/early-hints/#enable-early-hints) Early Hints for your custom domains:
+[Early Hints](/cache/advanced-configuration/early-hints/) help the browser to load webpages faster. Early Hints is enabled automatically on all `pages.dev` domains and custom domains. 
 
 1. Log in to [Cloudflare dashboard](https://dash.cloudflare.com). 
 2. Select your account and zone.


### PR DESCRIPTION
Custom domains inherit early hints configuration from pages.dev domain