### PR TITLE
Update move-domain.md with 'transferring a domain between cloudflare registrar accounts' notice

### DIFF
--- a/content/fundamentals/setup/manage-domains/move-domain.md
+++ b/content/fundamentals/setup/manage-domains/move-domain.md
@@ -26,7 +26,7 @@ If you have [two-factor authentication (2FA)](/fundamentals/account-and-billing/
 
 To transfer a domain from one Cloudflare account to another, you will need:
 
-* Access to your domain registrar. If your domain is using Cloudflare Registrar, you will need to transfer your domain [to another registrar](/registrar/account-options/transfer-out-from-cloudflare/). We do not currently support transferring Cloudflare Registrar domains between Cloudflare accounts. We are looking to add this in the future, see the [feature request](https://community.cloudflare.com/t/feature-request-registrar-transfer-between-cloudflare-accounts/540582).
+* Access to your domain registrar. If your domain is using Cloudflare Registrar, you will need to transfer your domain [to another registrar](/registrar/account-options/transfer-out-from-cloudflare/) because we not currently support transferring Cloudflare Registrar domains between Cloudflare accounts. We are looking to add this in the future, refer to this [feature request](https://community.cloudflare.com/t/feature-request-registrar-transfer-between-cloudflare-accounts/540582).
 * At least one Cloudflare account associated with the domain.
 
 ## Transfer your domain

--- a/content/fundamentals/setup/manage-domains/move-domain.md
+++ b/content/fundamentals/setup/manage-domains/move-domain.md
@@ -26,7 +26,7 @@ If you have [two-factor authentication (2FA)](/fundamentals/account-and-billing/
 
 To transfer a domain from one Cloudflare account to another, you will need:
 
-* Access to your domain registrar. If your domain is using Cloudflare Registrar, you will need to transfer your domain [to another registrar](/registrar/account-options/transfer-out-from-cloudflare/).
+* Access to your domain registrar. If your domain is using Cloudflare Registrar, you will need to transfer your domain [to another registrar](/registrar/account-options/transfer-out-from-cloudflare/). We do not currently support transferring Cloudflare Registrar domains between Cloudflare accounts. We are looking to add this in the future, see the [feature request](https://community.cloudflare.com/t/feature-request-registrar-transfer-between-cloudflare-accounts/540582).
 * At least one Cloudflare account associated with the domain.
 
 ## Transfer your domain


### PR DESCRIPTION
Cloudflare doesn't actually support transferring Cloudflare Registrar domains between Cloudflare accounts, updated the documentation to reflect this.

It wasn't until I wasted a bunch of time on this thinking it was possible, eventually stumbling upon the support information shown below. Which really should be included in the documentation for "Move a domain between Cloudflare accounts". Hence this PR.

![cloudflare](https://github.com/cloudflare/cloudflare-docs/assets/31993698/8ce1f14a-613e-4dcd-877c-3b9df9ab3c2a)