### PR TITLE
 pages: add sections about local support for bindings in wrangler.toml

### DIFF
--- a/content/pages/_partials/_pages_local_bindings_warning.md
+++ b/content/pages/_partials/_pages_local_bindings_warning.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="note">}}
+
+`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely. In order to use bindings for production and preview deployments, you will need to set them up in the Cloudflare dashboard.
+
+{{</Aside>}}

--- a/content/pages/functions/bindings.md
+++ b/content/pages/functions/bindings.md
@@ -57,11 +57,7 @@ While developing locally, interact with your KV namespace by adding `-k <BINDING
 
 Alternatively, you can interact with a KV namespace locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#kv-namespaces) for more information.
 
-{{<Aside type="note">}}
-
-`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
-
-{{</Aside>}}
+{{<render file="_pages_local_bindings_warning.md">}}
 
 ## Durable Object namespaces
 
@@ -165,11 +161,7 @@ If your bucket is bound to `BUCKET`, access this bucket in local dev by running 
 
 Alternatively, you can interact with an R2 bucket locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#r2-buckets) for more information.
 
-{{<Aside type="note">}}
-
-`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
-
-{{</Aside>}}
+{{<render file="_pages_local_bindings_warning.md">}}
 
 ## D1 databases
 
@@ -231,11 +223,7 @@ Refer to the [D1 client API documentation](/d1/how-to/query-databases/) for the 
 
 Alternatively, you can interact with a D1 database locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#d1-databases) for more information.
 
-{{<Aside type="note">}}
-
-`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
-
-{{</Aside>}}
+{{<render file="_pages_local_bindings_warning.md">}}
 
 ## Workers AI
 [Workers AI](/workers-ai/) allows you to run powerful AI models. To bind Workers AI to your Pages Function:
@@ -338,11 +326,7 @@ To interact with a [service binding](/workers/configuration/bindings/about-servi
 
 Alternatively, you can interact with a service binding locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#service-bindings) for more information.
 
-{{<Aside type="note">}}
-
-`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
-
-{{</Aside>}}
+{{<render file="_pages_local_bindings_warning.md">}}
 
 ## Queue Producers
 

--- a/content/pages/functions/bindings.md
+++ b/content/pages/functions/bindings.md
@@ -55,7 +55,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 While developing locally, interact with your KV namespace by adding `-k <BINDING_NAME>` or `--kv=<BINDING_NAME>` to your run command. For example, if your namespace is bound to `TODO_LIST`, access the KV namespace in your local dev by running `npx wrangler pages dev <OUTPUT_DIR> --kv=TODO_LIST`. The data from this namespace can be accessed using `context.env.TODO_LIST`.
 
-Alternatively, you can interact with a KV namespace locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#kv-namespaces) for more information.
+Alternatively, you can interact with a KV namespace locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#kv-namespaces) for more information.
 
 {{<Aside type="note">}}
 
@@ -163,7 +163,7 @@ By default, `wrangler dev` automatically persists data.
 
 If your bucket is bound to `BUCKET`, access this bucket in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --r2=BUCKET`. Interact with this binding by using `context.env` (for example, `context.env.BUCKET`).
 
-Alternatively, you can interact with an R2 bucket locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#r2-buckets) for more information.
+Alternatively, you can interact with an R2 bucket locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#r2-buckets) for more information.
 
 {{<Aside type="note">}}
 
@@ -229,7 +229,7 @@ Specifically:
 
 Refer to the [D1 client API documentation](/d1/how-to/query-databases/) for the API methods available on your D1 binding.
 
-Alternatively, you can interact with a D1 database locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#d1-databases) for more information.
+Alternatively, you can interact with a D1 database locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#d1-databases) for more information.
 
 {{<Aside type="note">}}
 
@@ -336,7 +336,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 To interact with a [service binding](/workers/configuration/bindings/about-service-bindings/) while developing locally, run the Worker you want to bind to via `wrangler dev` and in parallel, run `wrangler pages dev` with `--service <BINDING_NAME>=<SCRIPT_NAME>` where `SCRIPT_NAME` indicates the name of the Worker. For example, if your Worker is called `my-worker`, connect with this Worker by running it via `npx wrangler dev` (in the Worker's directory) alongside `npx wrangler pages dev <OUTPUT_DIR> --service MY_SERVICE=my-worker` (in the Pages' directory). Interact with this binding by using `context.env` (for example, `context.env.MY_SERVICE`).
 
-Alternatively, you can interact with a service binding locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#service-bindings) for more information.
+Alternatively, you can interact with a service binding locally via a `wrangler.toml` file. Refer to [Wrangler configuration](/workers/wrangler/configuration/#service-bindings) for more information.
 
 {{<Aside type="note">}}
 

--- a/content/pages/functions/bindings.md
+++ b/content/pages/functions/bindings.md
@@ -55,6 +55,14 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 While developing locally, interact with your KV namespace by adding `-k <BINDING_NAME>` or `--kv=<BINDING_NAME>` to your run command. For example, if your namespace is bound to `TODO_LIST`, access the KV namespace in your local dev by running `npx wrangler pages dev <OUTPUT_DIR> --kv=TODO_LIST`. The data from this namespace can be accessed using `context.env.TODO_LIST`.
 
+Alternatively, you can interact with a KV namespace locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#kv-namespaces) for more information.
+
+{{<Aside type="note">}}
+
+`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
+
+{{</Aside>}}
+
 ## Durable Object namespaces
 
 [Durable Objects](/durable-objects/) (DO) are Cloudflare's strongly consistent data store that power capabilities such as connecting WebSockets and handling state. To bind your DO namespace to your Pages Function:
@@ -147,7 +155,21 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 ### Interact with your R2 buckets locally
 
-While developing locally, interact with an R2 bucket by adding `--r2=<BINDING_NAME>` to your run command. For example, if your bucket is bound to `BUCKET`, access this bucket in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --r2=BUCKET`. Interact with this binding by using `context.env` (for example, `context.env.BUCKET`).
+While developing locally, interact with an R2 bucket by adding `--r2=<BINDING_NAME>` to your run command.
+
+{{<Aside type="note">}}
+By default, `wrangler dev` automatically persists data.
+{{</Aside>}}
+
+If your bucket is bound to `BUCKET`, access this bucket in local dev by running `npx wrangler pages dev <OUTPUT_DIR> --r2=BUCKET`. Interact with this binding by using `context.env` (for example, `context.env.BUCKET`).
+
+Alternatively, you can interact with an R2 bucket locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#r2-buckets) for more information.
+
+{{<Aside type="note">}}
+
+`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
+
+{{</Aside>}}
 
 ## D1 databases
 
@@ -206,6 +228,14 @@ Specifically:
 * Interact with this binding by using `context.env` - for example, `context.env.NORTHWIND_DB`
 
 Refer to the [D1 client API documentation](/d1/how-to/query-databases/) for the API methods available on your D1 binding.
+
+Alternatively, you can interact with a D1 database locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#d1-databases) for more information.
+
+{{<Aside type="note">}}
+
+`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
+
+{{</Aside>}}
 
 ## Workers AI
 [Workers AI](/workers-ai/) allows you to run powerful AI models. To bind Workers AI to your Pages Function:
@@ -305,6 +335,14 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 ### Interact with your service bindings locally
 
 To interact with a [service binding](/workers/configuration/bindings/about-service-bindings/) while developing locally, run the Worker you want to bind to via `wrangler dev` and in parallel, run `wrangler pages dev` with `--service <BINDING_NAME>=<SCRIPT_NAME>` where `SCRIPT_NAME` indicates the name of the Worker. For example, if your Worker is called `my-worker`, connect with this Worker by running it via `npx wrangler dev` (in the Worker's directory) alongside `npx wrangler pages dev <OUTPUT_DIR> --service MY_SERVICE=my-worker` (in the Pages' directory). Interact with this binding by using `context.env` (for example, `context.env.MY_SERVICE`).
+
+Alternatively, you can interact with a service binding locally via a `wrangler.toml` file. See [Wrangler configuration](/workers/wrangler/configuration/#service-bindings) for more information.
+
+{{<Aside type="note">}}
+
+`wrangler.toml` is currently **only** used for local development. Bindings specified in it are not available remotely.
+
+{{</Aside>}}
 
 ## Queue Producers
 


### PR DESCRIPTION
Updated local bindings sections for: kv, r2, d1, and service bindings since those are currently supported.