### PR TITLE
[Chore] Hugo config referencing wrong term

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -7,7 +7,7 @@ disableHugoGeneratorInject = true
 enableRobotsTXT = false
 summaryLength = 30
 disableAliases = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy", "term"]
 timeout = "120s"
 
 enableEmoji = true


### PR DESCRIPTION
Feedback from #12713, we're currently generating `tag` pages b/c I specified the wrong value (outdated) for disabling those sorts of pages.

`taxonomyTerm` !== `term`
https://gohugo.io/templates/section-templates/#page-kinds