### PR TITLE
Correct delegated DCV Setup for Custom Hostnames

### DIFF
--- a/content/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.md
@@ -34,7 +34,7 @@ DCV Delegation requires your customers to place a one-time record at their autho
 
 To set up Delegated DCV:
 
-1. Order a [custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates/) for your zone. You can choose any **Certificate validation method**.
+1. Add a [custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates/) for your zone. You can choose any **Certificate validation method**.
 2. On **SSL/TLS** > **Custom Hostnames**, go to **DCV Delegation for Custom Hostnames**.
 3. Copy the hostname value.
 4. For each hostname, the domain owner needs to place a `CNAME` record at their authoritative DNS. In this example, the SaaS zone is `example.com`.

--- a/content/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.md
@@ -34,7 +34,7 @@ DCV Delegation requires your customers to place a one-time record at their autho
 
 To set up Delegated DCV:
 
-1. Add a [custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates/) for your zone. You can choose any **Certificate validation method**.
+1. Add a [custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/create-custom-hostnames/) for your zone. You can choose any **Certificate validation method**.
 2. On **SSL/TLS** > **Custom Hostnames**, go to **DCV Delegation for Custom Hostnames**.
 3. Copy the hostname value.
 4. For each hostname, the domain owner needs to place a `CNAME` record at their authoritative DNS. In this example, the SaaS zone is `example.com`.


### PR DESCRIPTION
SaaS customers do not ["Order a custom certificate"](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/#setup) to implement Delegated DCV.
Rather, they "Add a custom hostname":

![image](https://github.com/cloudflare/cloudflare-docs/assets/90766559/a2645209-97a2-4601-90b8-108bb65e64ce)

....and then afterwards they can indeed choose any Certificate validation method.