### PR TITLE
[Docs] Add support for per-page OpenGraph images

### DIFF
--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -9,7 +9,7 @@
 
   {{- $availableContentTypes := slice
     "changelog" "concept" "configuration" "faq" "get-started" "glossary"
-    "how-to" "integration-guide" "learning-path" "learning-unit" "migration" 
+    "how-to" "integration-guide" "learning-path" "learning-unit" "migration"
     "navigation" "overview" "reference" "reference-architecture" "troubleshooting"
     "tutorial"
     -}}
@@ -67,7 +67,7 @@
   {{- else -}}
     {{- $titleAddition = printf " · %s" (index .Context.Ancestors 0).Title -}}
   {{- end -}}
-  
+
   {{- $title = print .Context.Title $titleAddition " · Learning paths" -}}
 
   {{- else -}}
@@ -123,7 +123,7 @@
   {{- $diffMod := now.Sub $lastMod -}}
   {{- $lastModifiedDays := math.Round (div $diffMod.Hours 24) -}}
   <meta name="pcx_last_modified" content="{{- $lastModifiedDays -}}">
-  
+
   {{- with .Context.Params.updated -}}
   {{- $lastReview := . | time -}}
   {{- $diffReview := now.Sub $lastReview -}}
@@ -147,7 +147,7 @@
 
   <!--Add rss feed if specified via output -->
   {{ with $.Context.OutputFormats.Get "rss" }}
-  
+
   {{ $rssFeedURL := print $.Context.Permalink "index.xml" -}}
 
   {{- if ne $product "" -}}

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -44,8 +44,8 @@
   "Cloudflare One" "/zt-preview.png"
   "Developer platform" "/dev-products-preview.png"
   "Network security" "/core-services-preview.png"
-  "Performance" "/core-services-preview.png"
-  "Security" "/core-services-preview.png"
+  "Application performance" "/core-services-preview.png"
+  "Application security" "/core-services-preview.png"
   -}}
 
   {{- range $key, $value := $imageDict -}}

--- a/layouts/partials/head.meta.html
+++ b/layouts/partials/head.meta.html
@@ -54,6 +54,11 @@
   {{- end -}}
   {{- end -}}
 
+  <!-- Individual pages can override the opengraph (share) image in frontmatter in meta > image -->
+  {{- with .Context.Params.meta.image -}}
+  {{- $imagePlaceholder = . | absURL -}}
+  {{- end -}}
+
   {{- $pt := default .Context.Title .Context.Params.meta.title -}}
   {{- if or (eq .Context.Params.layout "learning-module") (eq .Context.Params.layout "learning-unit") -}}
   {{- $titleAddition := "" -}}


### PR DESCRIPTION
How it would work:

1. Add image for social media sharing to `/static/` folder (ideally to a sub-folder like `/static/share_images/`).
2. Add a `meta > image` entry in the front-matter of the Markdown file:

    ```md
    ---
    title: Demo
    meta:
      image: /share_images/cdn_hero.png
    ---
    ```

Note: Images in the `static` folder are not accounted for when checking for unused images! These images have to be manually maintained (e.g., manually deleted when they're no longer needed).