### PR TITLE
[Docs] Add NTS link to RFC 8915

### DIFF
--- a/content/time-services/nts.md
+++ b/content/time-services/nts.md
@@ -6,7 +6,7 @@ weight: 3
 
 # Network Time Security
 
-Network Time Security (NTS) provides cryptographic security for the client-server mode of the Network Time Protocol (NTP). This allows users to obtain time in an authenticated manner.
+[Network Time Security](https://datatracker.ietf.org/doc/html/rfc8915) (NTS) provides cryptographic security for the client-server mode of the Network Time Protocol (NTP). This allows users to obtain time in an authenticated manner.
 
 ## Background
 


### PR DESCRIPTION
Add a link at the start of the documentation page, to match the link provided on [NTP page](./content/time-services/ntp/_index.md).