### PR TITLE
rules/snippets: subrequests limit

### DIFF
--- a/content/rules/snippets/_index.md
+++ b/content/rules/snippets/_index.md
@@ -58,6 +58,7 @@ Description                | All plans
 Maximum execution time     | 5 ms
 Maximum memory             | 2 MB
 Maximum total package size | 32 KB
+Subrequests                | 1
 
 ## Execution order
 


### PR DESCRIPTION
Snippets allow only 1 subrequest (subsequent `fetch` calls result in error code `1202`).