### PR TITLE
Update load-custom-managed-component.md to include the worker prefix

### DIFF
--- a/content/zaraz/advanced/load-custom-managed-component.md
+++ b/content/zaraz/advanced/load-custom-managed-component.md
@@ -47,7 +47,7 @@ export default async function (manager) {
 ## Deploy a Managed Component to Cloudflare
 
 1. Open a terminal in your Managed Component’s root directory.
-2. From there, run `npx managed-component-to-cloudflare-worker ./index.js my-new-counter-mc`, which will deploy the Managed Component to a specialized Cloudflare Worker. Change the path to your `index.js`. You can also rename the Component if you choose.
+2. From there, run `npx managed-component-to-cloudflare-worker ./index.js my-new-counter-mc`, which will deploy the Managed Component to a specialized Cloudflare Worker. Change the path to your `index.js`. You can also rename the Component.
 3. Your Managed Component should now be [visible on your account](https://dash.cloudflare.com/redirect?account=/workers-and-pages) as a Cloudflare Worker prefixed with `custom-mc-`.
 
 ## Configure a Managed Component in Cloudflare

--- a/content/zaraz/advanced/load-custom-managed-component.md
+++ b/content/zaraz/advanced/load-custom-managed-component.md
@@ -59,7 +59,7 @@ As with regular tools, it is recommended that you [create the triggers](/zaraz/g
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
 2. Select **Zaraz** > **Tools Configuration** > [**Third-party tools**](https://dash.cloudflare.com/?to=/:account/:zone/zaraz/tools-config/tools/catalog).
 3. Select **Add new tool** and choose **Custom Managed Component** from the tools library page. Select **Continue** to confirm your selection.
-4. In **Select Custom MC**, choose a Custom Managed Component that you have deployed to your account, such as `my-new-counter-mc`. Select **Continue**.
+4. In **Select Custom MC**, choose a Custom Managed Component that you have deployed to your account, such as `custom-mc-my-new-counter-mc`. Select **Continue**.
 5. In **Permissions**, select the permissions you want to grant the Custom Managed Component. If you run an untrusted Managed Component, pay close attention to what permissions you are granting. Select **Continue**.
 6. In **Set up**, configure the settings for your new tool. The information you need to enter will depend on the code of the Managed Component. You can add settings and default fields, as well as use [variables you have previously set up](/zaraz/get-started/create-variables/).
 7. Select **Save**.

--- a/content/zaraz/advanced/load-custom-managed-component.md
+++ b/content/zaraz/advanced/load-custom-managed-component.md
@@ -48,7 +48,7 @@ export default async function (manager) {
 
 1. Open a terminal in your Managed Component’s root directory.
 2. From there, run `npx managed-component-to-cloudflare-worker ./index.js my-new-counter-mc`, which will deploy the Managed Component to a specialized Cloudflare Worker. Change the path to your `index.js`. You can also rename the Component if you choose.
-3. Your Managed Component should now be [visible on your account](https://dash.cloudflare.com/redirect?account=/workers-and-pages) as a Cloudflare Worker prefixed with `custom-mc`.
+3. Your Managed Component should now be [visible on your account](https://dash.cloudflare.com/redirect?account=/workers-and-pages) as a Cloudflare Worker prefixed with `custom-mc-`.
 
 ## Configure a Managed Component in Cloudflare
 


### PR DESCRIPTION
The name of Zaraz MC workers must always begin with `custom-mc-`. The docs do not reflect that [here](https://developers.cloudflare.com/zaraz/advanced/load-custom-managed-component/#:~:text=account%2C%20such%20as-,my%2Dnew%2Dcounter%2Dmc,-.%20Select%20Continue.) and it is missing the "-" [here](https://developers.cloudflare.com/zaraz/advanced/load-custom-managed-component/#:~:text=Worker%20prefixed%20with-,custom%2Dmc,-.).

- [See mc to worker script](https://github.com/cloudflare/managed-component-to-cloudflare-worker/blob/ca82f92d4231241febdae0b1b814d67347c8cc30/bin/managed-component-to-cloudflare-worker.js#L249)
- [See in docs](https://developers.cloudflare.com/zaraz/advanced/load-custom-managed-component/#:~:text=Worker%20prefixed%20with-,custom%2Dmc,-.)