### PR TITLE
Hyperdrive: local development docs

### DIFF
--- a/content/hyperdrive/configuration/local-development.md
+++ b/content/hyperdrive/configuration/local-development.md
@@ -20,55 +20,57 @@ Users new to Hyperdrive and/or Cloudflare Workers should visit the [Hyperdrive t
 
 To specify a database to connect to when developing locally, you can:
 
-* **Recommended** Create a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable with the connection string of your database. This allows you to avoid committing potentially sensitive credentials to source control in your `wrangler.toml`, if your test/development database is not ephemeral.
+* **Recommended** Create a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environmental variable with the connection string of your database. `<BINDING_NAME>` is the name of the binding assigned to your Hyperdrive in your `wrangler.toml` or Pages configuration. This allows you to avoid committing potentially sensitive credentials to source control in your `wrangler.toml`, if your test/development database is not ephemeral. If you have configured multiple Hyperdrive bindings, replace `<BINDING_NAME>` with the unique binding name for each.
 * Set `localConnectionString` in `wrangler.toml`.
 
-If both the `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable and `localConnectionString` in `wrangler.toml` are set, `wrangler dev` will use the environmental variable instead. Use `unset HYPERDRIVE_LOCAL_CONNECTION_STRING` to unset any existing environmental variables.
+If both the `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environmental variable and `localConnectionString` in `wrangler.toml` are set, `wrangler dev` will use the environmental variable instead. Use `unset WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` to unset any existing environmental variables. 
 
 For example, to use the environmental variable, export the environmental variable before running `wrangler dev`:
 
 ```sh
-$ export HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/databasename"
-$ wrangler dev
+# Our configured Hyperdrive binding is "TEST_DB" 
+$ export WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB="postgres://user:password@localhost:5432/databasename"
+# Start a local development session referencing this local instance
+$ npx wrangler dev
 ```
 
 To configure a `localConnectionString` in `wrangler.toml`, ensure your Hyperdrive bindings have a `localConnectionString` property set:
 
 ```toml
 [[hyperdrive]]
-binding = "HYPERDRIVE"
+binding = "TEST_DB"
 id = "c020574a-5623-407b-be0c-cd192bab9545"
 localConnectionString = "postgres://user:password@localhost:5432/databasename"
 
 ## Example
 
-The following shows how to check your wrangler version, set a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable, and run a `wrangler dev` session:
+The following shows how to check your wrangler version, set a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB` environmental variable, and run a `wrangler dev` session:
 
 ```sh
 # Confirm we are using wrangler v3.0+
-$ wrangler --version
+$ npx wrangler --version
 ⛅️ wrangler 3.27.0
 
-# Set our environmental variable
-export HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/databasename"
+# Set our environmental variable: our configured Hyperdrive binding is "TEST_DB".
+export WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB="postgres://user:password@localhost:5432/databasename"
 
 # Start a local dev session:
-$ wrangler dev
+$ npx wrangler dev
 
 # Outputs:
 ------------------
-Found a non-empty HYPERDRIVE_LOCAL_CONNECTION_STRING variable. Hyperdrive will connect to this database
+Found a non-empty WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB variable. Hyperdrive will connect to this database
 during local development.
 
 wrangler dev now uses local mode by default, powered by 🔥 Miniflare and 👷 workerd.
 To run an edge preview session for your Worker, use wrangler dev --remote
 Your worker has access to the following bindings:
 - Hyperdrive configs:
-  - HYPERDRIVE: c020574a-5623-407b-be0c-cd192bab9545
+  - TEST_DB: c020574a-5623-407b-be0c-cd192bab9545
 ⎔ Starting local server...
 
 [mf:inf] Ready on http://127.0.0.1:8787/
-[b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                 │
+[b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit
 ```
 
 Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) Hyperdrive configuration, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.

--- a/content/hyperdrive/configuration/local-development.md
+++ b/content/hyperdrive/configuration/local-development.md
@@ -6,7 +6,7 @@ pcx_content_type: concept
 
 # Develop locally
 
-Hyperdrive can be used when developing and testing your Workers locally, by connecting to any local database instance running on your machine directly. Local development uses [Wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
+Hyperdrive can be used when developing and testing your Workers locally by connecting to any local database instance running on your machine directly. Local development uses [Wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
 
 ## Start a local development session
 
@@ -14,7 +14,7 @@ Hyperdrive can be used when developing and testing your Workers locally, by conn
 
 This guide assumes you are using `wrangler` version `3.27.0` or later.
 
-Users new to Hyperdrive and/or Cloudflare Workers should visit the [Hyperdrive tutorial](/hyperdrive/get-started/) to install `wrangler` and deploy their first database.
+If you are new to Hyperdrive and/or Cloudflare Workers, refer to [Hyperdrive tutorial](/hyperdrive/get-started/) to install `wrangler` and deploy their first database.
 
 {{</Aside>}}
 
@@ -28,7 +28,7 @@ If both the `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environ
 For example, to use the environmental variable, export the environmental variable before running `wrangler dev`:
 
 ```sh
-# Our configured Hyperdrive binding is "TEST_DB" 
+# Your configured Hyperdrive binding is "TEST_DB" 
 $ export WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB="postgres://user:password@localhost:5432/databasename"
 # Start a local development session referencing this local instance
 $ npx wrangler dev
@@ -44,14 +44,14 @@ localConnectionString = "postgres://user:password@localhost:5432/databasename"
 
 ## Example
 
-The following shows how to check your wrangler version, set a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB` environmental variable, and run a `wrangler dev` session:
+The following example shows you how to check your wrangler version, set a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB` environmental variable, and run a `wrangler dev` session:
 
 ```sh
-# Confirm we are using wrangler v3.0+
+# Confirm you are using wrangler v3.0+
 $ npx wrangler --version
 ⛅️ wrangler 3.27.0
 
-# Set our environmental variable: our configured Hyperdrive binding is "TEST_DB".
+# Set your environmental variable: your configured Hyperdrive binding is "TEST_DB".
 export WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_TEST_DB="postgres://user:password@localhost:5432/databasename"
 
 # Start a local dev session:
@@ -73,7 +73,7 @@ Your worker has access to the following bindings:
 [b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit
 ```
 
-Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) Hyperdrive configuration, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
+`wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) Hyperdrive configuration, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
 
 Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
 

--- a/content/hyperdrive/configuration/local-development.md
+++ b/content/hyperdrive/configuration/local-development.md
@@ -1,0 +1,73 @@
+---
+title: Local development
+weight: 6
+pcx_content_type: concept
+---
+
+# Develop locally
+
+Hyperdrive can be used when developing and testing your Workers locally, by connecting to any local database instance running on your machine directly. Local development uses [Wrangler](/workers/wrangler/install-and-update/), the command-line interface for Workers, to manage local development sessions and state.
+
+## Start a local development session
+
+{{<Aside type="note">}}
+
+This guide assumes you are using [Wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
+
+Users new to Hyperdrive and/or Cloudflare Workers should visit the [Hyperdrive tutorial](/hyperdrive/get-started/) to install `wrangler` and deploy their first database.
+
+{{</Aside>}}
+
+To specify a database to connect to when developing locally:
+
+* Create a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable with the connection string of your database.
+* Set `localConnectionString` in `wrangler.toml`
+
+```sh
+HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/postgres"
+```
+
+If both the `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable and `localConnectionString` in `wrangler.toml` are set, `wrangler dev` will use the environmental variable. 
+
+
+```sh
+# Confirm we are using wrangler v3.0+
+$ wrangler --version
+⛅️ wrangler 3.0.0
+
+# Start a local dev session:
+$ wrangler dev
+
+# Outputs:
+------------------
+wrangler dev now uses local mode by default, powered by 🔥 Miniflare and 👷 workerd.
+To run an edge preview session for your Worker, use wrangler dev --remote
+Your worker has access to the following bindings:
+- Hyperdrive:
+  - HYPERDRIVE: test-db (c020574a-5623-407b-be0c-cd192bab9545)
+⎔ Starting local server...
+
+[mf:inf] Ready on http://127.0.0.1:8787/
+[b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                 │
+```
+
+In this example, the Hyperdrive binding in your Worker will connect directly to the database specified The corresponding D1 binding in your `wrangler.toml` configuration file would resemble the following:
+
+```toml
+---
+header: wrangler.toml
+---
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "99eb9a44966446a19476c8d54be9a0bf"
+```
+
+Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) database, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
+
+Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
+
+## Related resources
+
+* Use [`wrangler dev`](/workers/wrangler/commands/#dev) to run your Worker and Hyperdrive locally and debug issues before deploying.
+* Learn [how Hyperdrive works](/hyperdrive/configuration/how-hyperdrive-works/).
+* Understand how to [configure query caching in Hyperdrive](/hyperdrive/configuration/query-caching/).

--- a/content/hyperdrive/configuration/local-development.md
+++ b/content/hyperdrive/configuration/local-development.md
@@ -12,57 +12,66 @@ Hyperdrive can be used when developing and testing your Workers locally, by conn
 
 {{<Aside type="note">}}
 
-This guide assumes you are using [Wrangler v3.0](https://blog.cloudflare.com/wrangler3/) or later.
+This guide assumes you are using `wrangler` version `3.27.0` or later.
 
 Users new to Hyperdrive and/or Cloudflare Workers should visit the [Hyperdrive tutorial](/hyperdrive/get-started/) to install `wrangler` and deploy their first database.
 
 {{</Aside>}}
 
-To specify a database to connect to when developing locally:
+To specify a database to connect to when developing locally, you can:
 
-* Create a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable with the connection string of your database.
-* Set `localConnectionString` in `wrangler.toml`
+* **Recommended** Create a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable with the connection string of your database. This allows you to avoid committing potentially sensitive credentials to source control in your `wrangler.toml`, if your test/development database is not ephemeral.
+* Set `localConnectionString` in `wrangler.toml`.
+
+If both the `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable and `localConnectionString` in `wrangler.toml` are set, `wrangler dev` will use the environmental variable instead. Use `unset HYPERDRIVE_LOCAL_CONNECTION_STRING` to unset any existing environmental variables.
+
+For example, to use the environmental variable, export the environmental variable before running `wrangler dev`:
 
 ```sh
-HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/postgres"
+$ export HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/databasename"
+$ wrangler dev
 ```
 
-If both the `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable and `localConnectionString` in `wrangler.toml` are set, `wrangler dev` will use the environmental variable. 
+To configure a `localConnectionString` in `wrangler.toml`, ensure your Hyperdrive bindings have a `localConnectionString` property set:
 
+```toml
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "c020574a-5623-407b-be0c-cd192bab9545"
+localConnectionString = "postgres://user:password@localhost:5432/databasename"
+
+## Example
+
+The following shows how to check your wrangler version, set a `HYPERDRIVE_LOCAL_CONNECTION_STRING` environmental variable, and run a `wrangler dev` session:
 
 ```sh
 # Confirm we are using wrangler v3.0+
 $ wrangler --version
-⛅️ wrangler 3.0.0
+⛅️ wrangler 3.27.0
+
+# Set our environmental variable
+export HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@localhost:5432/databasename"
 
 # Start a local dev session:
 $ wrangler dev
 
 # Outputs:
 ------------------
+Found a non-empty HYPERDRIVE_LOCAL_CONNECTION_STRING variable. Hyperdrive will connect to this database
+during local development.
+
 wrangler dev now uses local mode by default, powered by 🔥 Miniflare and 👷 workerd.
 To run an edge preview session for your Worker, use wrangler dev --remote
 Your worker has access to the following bindings:
-- Hyperdrive:
-  - HYPERDRIVE: test-db (c020574a-5623-407b-be0c-cd192bab9545)
+- Hyperdrive configs:
+  - HYPERDRIVE: c020574a-5623-407b-be0c-cd192bab9545
 ⎔ Starting local server...
 
 [mf:inf] Ready on http://127.0.0.1:8787/
 [b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                 │
 ```
 
-In this example, the Hyperdrive binding in your Worker will connect directly to the database specified The corresponding D1 binding in your `wrangler.toml` configuration file would resemble the following:
-
-```toml
----
-header: wrangler.toml
----
-[[hyperdrive]]
-binding = "HYPERDRIVE"
-id = "99eb9a44966446a19476c8d54be9a0bf"
-```
-
-Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) database, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
+Note that `wrangler dev` separates local and production (remote) data. A local session does not have access to your production data by default. To access your production (remote) Hyperdrive configuration, pass the `--remote` flag when calling `wrangler dev`. Any changes you make when running in `--remote` mode cannot be undone.
 
 Refer to the [`wrangler dev` documentation](/workers/wrangler/commands/#dev) to learn more about how to configure a local development session.
 

--- a/content/workers/wrangler/system-environment-variables.md
+++ b/content/workers/wrangler/system-environment-variables.md
@@ -43,7 +43,7 @@ Wrangler supports the following environment variables:
 
 - `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/) - for example, if the binding for your Hyperdrive is named `PROD_DB`, this would be `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_PROD_DB="postgres://user:password@127.0.0.1:5432/testdb"`. Each Hyperdrive is uniquely distinguished by the binding name.
+  - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/). For example, if the binding for your Hyperdrive is named `PROD_DB`, this would be `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_PROD_DB="postgres://user:password@127.0.0.1:5432/testdb"`. Each Hyperdrive is uniquely distinguished by the binding name.
 
 - `CLOUDFLARE_API_BASE_URL` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/workers/wrangler/system-environment-variables.md
+++ b/content/workers/wrangler/system-environment-variables.md
@@ -41,9 +41,9 @@ Wrangler supports the following environment variables:
 
   - Options for this are `true` and `false`, the default behavior is `false`.
 
-- `HYPERDRIVE_LOCAL_CONNECTION_STRING` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+- `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/) - for example, `HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@127.0.0.1:5432/testdb"`
+  - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/) - for example, if the binding for your Hyperdrive is named `PROD_DB`, this would be `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_PROD_DB="postgres://user:password@127.0.0.1:5432/testdb"`. Each Hyperdrive is uniquely distinguished by the binding name.
 
 - `CLOUDFLARE_API_BASE_URL` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/workers/wrangler/system-environment-variables.md
+++ b/content/workers/wrangler/system-environment-variables.md
@@ -41,6 +41,10 @@ Wrangler supports the following environment variables:
 
   - Options for this are `true` and `false`, the default behavior is `false`.
 
+- `HYPERDRIVE_LOCAL_CONNECTION_STRING` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/) - for example, `HYPERDRIVE_LOCAL_CONNECTION_STRING="postgres://user:password@127.0.0.1:5432/testdb"`
+
 - `CLOUDFLARE_API_BASE_URL` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
   - The default value is `"https://api.cloudflare.com/client/v4"`.

--- a/data/changelogs/hyperdrive.yaml
+++ b/data/changelogs/hyperdrive.yaml
@@ -2,6 +2,12 @@
 link: "/hyperdrive/platform/changelog/"
 productName: Hyperdrive
 entries:
+  - publish_date: "2024-03-19"
+    title: Improved local development configuration
+    description: |-
+      Hyperdrive now supports a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environmental variable for configuring local development to use a test/non-production database, in addition to the `localConnectionString` configuration in `wrangler.toml`. 
+
+      Refer to the [local development documentation](/hyperdrive/configuration/local-development/) for instructions on how to configure Hyperdrive for local development.
   - publish_date: "2023-09-28"
     title: Hyperdrive now available
     description: |-

--- a/data/changelogs/hyperdrive.yaml
+++ b/data/changelogs/hyperdrive.yaml
@@ -7,7 +7,7 @@ entries:
     description: |-
       Hyperdrive now supports a `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environmental variable for configuring local development to use a test/non-production database, in addition to the `localConnectionString` configuration in `wrangler.toml`. 
 
-      Refer to the [local development documentation](/hyperdrive/configuration/local-development/) for instructions on how to configure Hyperdrive for local development.
+      Refer to [Local development](/hyperdrive/configuration/local-development/) for instructions on how to configure Hyperdrive locally.
   - publish_date: "2023-09-28"
     title: Hyperdrive now available
     description: |-


### PR DESCRIPTION
Blocks on https://github.com/cloudflare/workers-sdk/pull/4900

This PR:

- [x] Documents the new `HYPERDRIVE_LOCAL_CONNECTION_STRING` in the wrangler docs
- [x] Adds a new `/hyperdrive/configuration/local-development/` page to document how to test and use Hyperdrive in local dev
- [x] Documents the precedence over `localConnectionString` in `wrangler.toml`