### PR TITLE
[Access] fix broken link in spectrum configuration-options.md

### DIFF
--- a/content/spectrum/reference/configuration-options.md
+++ b/content/spectrum/reference/configuration-options.md
@@ -22,7 +22,7 @@ The application type determines the protocol by which data travels from the edge
 
 When a Spectrum application is created, it is assigned a unique IPv4 and IPv6 address, or you can provision the application to be IPv6 only. The addresses are not static, and they may change over time. The best way to look up the current addresses is by using DNS. The DNS name of the Spectrum application will always return the IPs currently dedicated to the application.
 
-The addresses are Anycasted from all Cloudflare data centers, with the exception of data centers in China. Spectrum is not available in China, but users have the option to use Cloudflare's partner JD Cloud's solution [Starshield](https://www.jdcloud.com/cn/products/starshield.).
+The addresses are Anycasted from all Cloudflare data centers, with the exception of data centers in China. Spectrum is not available in China, but users have the option to use Cloudflare's partner JD Cloud's solution [Starshield](https://www.jdcloud.com/cn/products/starshield).
 
 ## SMTP
 


### PR DESCRIPTION
There is a dot at the end of the href attribute that redirects to a 404 page (https://www.jdcloud.com/cn/pages/end). Removing this dot directs to the correct page for JD Cloud StarShield products.