### PR TITLE
[wrangler] Update configuration.md to be clearer on DO binding's script_name

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -442,7 +442,7 @@ To bind Durable Objects to your Worker, assign an array of the below object to t
 
 - `script_name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The Worker script where the Durable Object is defined, if it is external to this Worker. When using this option a local instance of the Durable Object will not be created, and instead a remote binding is used.
+  - The name of the Worker where the Durable Object is defined, if it is external to this Worker. When using this option a local instance of the Durable Object will not be created, and instead a remote binding is used.
 
 - `environment` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -442,7 +442,7 @@ To bind Durable Objects to your Worker, assign an array of the below object to t
 
 - `script_name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - The Worker script where the Durable Object is defined, if it is external to this Worker.
+  - The Worker script where the Durable Object is defined, if it is external to this Worker. When using this option a local instance of the Durable Object will not be created, and instead a remote binding is used.
 
 - `environment` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 


### PR DESCRIPTION
The Durable Object documentation mentions the script_name configuration option, but doesn't mention that if used the durable object will be considered remote by wrangler. This commit makes that clear.