### PR TITLE
[WAF] Update _custom-response-blocked-requests.md

### DIFF
--- a/content/waf/_partials/_custom-response-blocked-requests.md
+++ b/content/waf/_partials/_custom-response-blocked-requests.md
@@ -19,4 +19,4 @@ The custom response has three settings:
     | Custom XML | `"text/xml"` |
 
 * **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is 403.
-* **Response body**: The body of the response. Configure a valid body according to the response type you selected.
+* **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2048 bytes.

--- a/content/waf/_partials/_custom-response-blocked-requests.md
+++ b/content/waf/_partials/_custom-response-blocked-requests.md
@@ -19,4 +19,4 @@ The custom response has three settings:
     | Custom XML | `"text/xml"` |
 
 * **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is 403.
-* **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2048 bytes.
+* **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2 KB.


### PR DESCRIPTION
[SPM-2230] Document the maximum field size of 2048 bytes for Response body in WAF Custom rules.