### PR TITLE
[Workers] fix numbered list index in guide.md

### DIFF
--- a/content/workers/get-started/guide.md
+++ b/content/workers/get-started/guide.md
@@ -125,7 +125,7 @@ This [`fetch()` handler](/workers/runtime-apis/handlers/fetch/) will be called w
 
 The `fetch` handler will always be passed three parameters: [`request`, `env` and `context`](/workers/runtime-apis/handlers/fetch/).
 
-1. The `Response` object: `return new Response("Hello World!");`
+4. The `Response` object: `return new Response("Hello World!");`
 
 The Workers runtime expects `fetch` handlers to return a `Response` object or a Promise which resolves with a `Response` object. In this example, you will return a new `Response` with the string `"Hello World!"`.
 


### PR DESCRIPTION
At L114 https://github.com/cloudflare/cloudflare-docs/blob/3c741f2c5413d3cd3cba887d480eb50ec93c8edf/content/workers/get-started/guide.md?plain=1#L114 the documentation mentions four parts, but the numbered list that follows was `1, 2, 3, 1`.

This PR fixes the index of the last element of that list, changing it to `4`.