### PR TITLE
[WAF] Update create-dashboard.md

### DIFF
--- a/content/waf/_partials/_custom-response-blocked-requests.md
+++ b/content/waf/_partials/_custom-response-blocked-requests.md
@@ -3,13 +3,14 @@ _build:
   publishResources: false
   render: never
   list: never
+inputParameters: responseType;;defaultStatusCode
 ---
 
 When you select the _Block_ action in a rule you can optionally define a custom response.
 
 The custom response has three settings:
 
-* **With response type**: Choose a content type or the default block response from the list. The available custom response types are the following:
+* **With response type**: Choose a content type or the default $1 response from the list. The available custom response types are the following:
 
     | Dashboard value | API value |
     |---|---|
@@ -18,5 +19,5 @@ The custom response has three settings:
     | Custom JSON | `"application/json"` |
     | Custom XML | `"text/xml"` |
 
-* **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is 403.
+* **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is $2.
 * **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2 KB.

--- a/content/waf/custom-rules/create-dashboard.md
+++ b/content/waf/custom-rules/create-dashboard.md
@@ -27,18 +27,4 @@ weight: 2
 
 ## Configuring a custom response for blocked requests
 
-When you select the _Block_ action in a custom rule you can optionally define a custom response.
-
-The custom response has three settings:
-
-* **With response type**: Choose a content type or the default WAF block response from the list. The available custom response types are the following:
-
-    | Dashboard value | API value |
-    |---|---|
-    | Custom HTML | `"text/html"` |
-    | Custom Text | `"text/plain"` |
-    | Custom JSON | `"application/json"` |
-    | Custom XML | `"text/xml"` |
-
-* **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is 403.
-* **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2 KB
+{{<render file="_custom-response-blocked-requests.md" withParameters="WAF block;;403">}}

--- a/content/waf/custom-rules/create-dashboard.md
+++ b/content/waf/custom-rules/create-dashboard.md
@@ -41,4 +41,4 @@ The custom response has three settings:
     | Custom XML | `"text/xml"` |
 
 * **With response code**: Choose an HTTP status code for the response, in the range 400-499. The default response code is 403.
-* **Response body**: The body of the response. Configure a valid body according to the response type you selected.
+* **Response body**: The body of the response. Configure a valid body according to the response type you selected. The maximum field size is 2 KB

--- a/content/waf/custom-rules/custom-rulesets/create-dashboard.md
+++ b/content/waf/custom-rules/custom-rulesets/create-dashboard.md
@@ -65,4 +65,4 @@ Deployed custom rulesets will only apply to incoming traffic of Enterprise domai
 
 ## Configuring a custom response for blocked requests
 
-{{<render file="_custom-response-blocked-requests.md">}}
+{{<render file="_custom-response-blocked-requests.md" withParameters="WAF block;;403">}}

--- a/content/waf/rate-limiting-rules/create-account-dashboard.md
+++ b/content/waf/rate-limiting-rules/create-account-dashboard.md
@@ -82,4 +82,4 @@ The **Deployed custom rate limiting rulesets** list will show a rule for each de
 
 ## Configuring a custom response for blocked requests
 
-{{<render file="_custom-response-blocked-requests.md">}}
+{{<render file="_custom-response-blocked-requests.md" withParameters="rate limiting;;429">}}

--- a/content/waf/rate-limiting-rules/create-zone-dashboard.md
+++ b/content/waf/rate-limiting-rules/create-zone-dashboard.md
@@ -41,4 +41,4 @@ meta:
 
 ## Configuring a custom response for blocked requests
 
-{{<render file="_custom-response-blocked-requests.md">}}
+{{<render file="_custom-response-blocked-requests.md" withParameters="rate limiting;;429">}}


### PR DESCRIPTION
SPM-2230

Document the maximum field size of 2048 bytes for Response body in WAF Custom rules.