### PR TITLE
[Security Center/ZT] Security Center Gateway policy consistency

### DIFF
--- a/content/security-center/indicator-feeds/getting-started/index.md
+++ b/content/security-center/indicator-feeds/getting-started/index.md
@@ -10,35 +10,34 @@ meta:
 
 In the simplest terms, there are providers and subscribers of our threat intelligence data.
 
-A provider is an organization that has a set of data that they are interested in sharing with other Cloudflare organizations. Any organization can be a provider. Examples of current providers are Government Cyber Defense groups. 
+A provider is an organization that has a set of data that they are interested in sharing with other Cloudflare organizations. Any organization can be a provider. Examples of current providers are Government Cyber Defense groups.
 
-Subscribers can be any Cloudflare customer that wants to secure their environment further by creating rules based on provider datasets. Subscribers must be authorized by a provider. Authorization is granted using the [Indicator Feeds permissions endpoint](/api/operations/custom-indicator-feeds-add-permission). 
+Subscribers can be any Cloudflare customer that wants to secure their environment further by creating rules based on provider datasets. Subscribers must be authorized by a provider. Authorization is granted using the [Indicator Feeds permissions endpoint](/api/operations/custom-indicator-feeds-add-permission).
 
 If your organization has interest in becoming a provider or a subscriber, please reach out to your account team, who will help facilitate the required authorization.
 
 ## Get started
 
-Managing a Custom Indicator Feed is only available using the [Indicator API endpoints](/api/operations/custom-indicator-feeds-get-indicator-feeds). 
+Managing a Custom Indicator Feed is only available using the [Indicator API endpoints](/api/operations/custom-indicator-feeds-get-indicator-feeds).
 
 1. The first thing a provider needs to do is create a feed. Feeds are lists of indicators and can be created using the [Create new indicator feed endpoint](/api/operations/custom-indicator-feeds-create-indicator-feeds).
 
-2. After a feed is created, you can upload data to it. Uploading data to a feed is done through the [`Snapshots` API endpoint](/api/operations/custom-indicator-feeds-update-indicator-feed-data). They are called snapshots because if a provider needs to update their feed with new data, they must upload a file containing all previous and new indicators. 
+2. After a feed is created, you can upload data to it. Uploading data to a feed is done through the [`Snapshots` API endpoint](/api/operations/custom-indicator-feeds-update-indicator-feed-data). They are called snapshots because if a provider needs to update their feed with new data, they must upload a file containing all previous and new indicators.
 
-{{<Aside type="note">}} 
-Uploaded indicator data must be in a [`.stix2`](https://oasis-open.github.io/cti-documentation/stix/intro) formatted file.
-{{</Aside>}}
+  {{<Aside type="note">}}
+  Uploaded indicator data must be in a [`.stix2`](https://oasis-open.github.io/cti-documentation/stix/intro) formatted file.
+  {{</Aside>}}
 
-3. Finally, in order to grant access to a subscriber, any administrator of the account that owns the feed must add the subscribers `account_tag` to the feeds allowed subscribers list. This can be done using the [`permissions` API endpoint](/api/operations/custom-indicator-feeds-add-permission). 
+3. Finally, in order to grant access to a subscriber, any administrator of the account that owns the feed must add the subscribers `account_tag` to the feeds allowed subscribers list. This can be done using the [`permissions` API endpoint](/api/operations/custom-indicator-feeds-add-permission).
 
-## Using a feed in Gateway
+## Use a feed in Gateway
 
-Once an account is granted access to a feed, it will be available as a selectable item in Gateway. 
+Once an account is granted access to a feed, it will be available as a selectable item in Gateway.
 
-1. Open your Zero Trust account.
-2. Select **Gateway** > **Firewall Policies** and create a new DNS policy by selecting **Add a policy**.
-3. Name your policy, add a **Traffic Condition** and select the **Indicator Feeds** from the selector dropdown.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Gateway** > **Firewall Policies**. Select **DNS**.
+2. To create a new DNS policy, select **Add a policy**.
+3. Name your policy, add a **Traffic Condition**, and select _Indicator Feeds_ from the **Selector** dropdown.
 
-If your accounty has been granted access to a Custom Indicator Feed, it will listed in the **Value** dropdown.
+If your account has been granted access to a Custom Indicator Feed, Gateway will list the feed in the **Value** dropdown.
 
-![Example of creating a gateway dns policy rule with custom indiciator feeds](/images/security-center/gateway-indicator-feed.png)
-
+![Example of creating a Gateway DNS policy rule with custom indiciator feeds](/images/security-center/gateway-indicator-feed.png)

--- a/content/security-center/indicator-feeds/getting-started/index.md
+++ b/content/security-center/indicator-feeds/getting-started/index.md
@@ -40,4 +40,4 @@ Once an account is granted access to a feed, it will be available as a selectabl
 
 If your account has been granted access to a Custom Indicator Feed, Gateway will list the feed in the **Value** dropdown.
 
-![Example of creating a Gateway DNS policy rule with custom indiciator feeds](/images/security-center/gateway-indicator-feed.png)
+![Example of creating a Gateway DNS policy rule with Custom Indicator Feeds](/images/security-center/gateway-indicator-feed.png)


### PR DESCRIPTION
Make the procedure for adding a Gateway DNS policy in the Security Center docs consistent with our procedures in the Zero Trust docs. Also fixes typos.

Part of work for the Defense-in-Depth implementation guide (PCX-9060).