### PR TITLE
[Notifications] Add missing redirect for PagerDuty

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -646,6 +646,7 @@
 # notifications
 /fundamentals/notifications/ /notifications/ 301
 /notifications/create-notifications/ /notifications/get-started/ 301
+/notifications/create-pagerduty/ /notifications/get-started/configure-pagerduty/ 301
 /notifications/edit-notifications/ /notifications/get-started/ 301
 /notifications/create-notifications/create-pagerduty/ /notifications/get-started/configure-pagerduty/ 301
 /notifications/edit-notifications/edit-pagerduty/ /notifications/get-started/configure-pagerduty/ 301


### PR DESCRIPTION
Once upon a time, this URL was valid: https://developers.cloudflare.com/notifications/create-pagerduty/
Sometime later, it was moved to https://developers.cloudflare.com/notifications/get-started/configure-pagerduty/

The URL https://support.cloudflare.com/hc/en-us/articles/360047358211 leads to the old path, and it is linked from the Cloudflare PagerDuty integration, so that link currently 404s:

![image](https://github.com/cloudflare/cloudflare-docs/assets/14004943/02ed3542-a9e2-4200-be42-eac26babfd34)

The quickest way to fix this and potentially other instances of the problem is to redirect the old PagerDuty URL to the new one.