### PR TITLE
Update tunnel-run-parameters.md

### DIFF
--- a/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
+++ b/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
@@ -14,7 +14,9 @@ This page lists general-purpose configuration options for a Cloudflare Tunnel. Y
 | ----------------- | ------- |
 | `cloudflared tunnel --autoupdate-freq <FREQ> run <UUID or NAME>`  | `24h`   |
 
-Configures autoupdate frequency. See also: [`no-autoupdate`](#no-autoupdate).
+Configures the frequency of `cloudflared` updates.
+
+By default, `cloudflared` will periodically check for updates and restart with the new version. Restarts are performed by spawning a new process that connects to the Cloudflare global network. On successful connection, the old process will gracefully shut down after handling all outstanding requests. See also: [`no-autoupdate`](#no-autoupdate). 
 
 ## `config`
 
@@ -84,13 +86,11 @@ Exposes a Prometheus endpoint on the specified IP address/port, which you can th
 
 ## `no-autoupdate`
 
-| Syntax          | Default | Environment Variable |
-| --------------- | ------- | -------------------- |
-| `cloudflared tunnel --no-autoupdate run <UUID or NAME>`  | `false` | `NO_AUTOUPDATE`      |
+| Syntax          | Environment Variable |
+| --------------- | -------------------- |
+| `cloudflared tunnel --no-autoupdate run <UUID or NAME>`  | `NO_AUTOUPDATE`  |
 
-When the parameter `--no-autoupdate` is not present, `cloudflared` will periodically check for updates and restart with the new version. See also: [`autoupdate-freq`](#autoupdate-freq). Restarts are performed by spawning a new process that connects to the Cloudflare global network. On successful connection, the old process will gracefully shut down after handling all outstanding requests.
-
-When `--no-autoupdate` is provided as an argument, automatic updates are disabled.
+Disables automatic `cloudflared` updates. See also: [`autoupdate-freq`](#autoupdate-freq). 
 
 ## `origincert`
 

--- a/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
+++ b/content/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters.md
@@ -86,11 +86,11 @@ Exposes a Prometheus endpoint on the specified IP address/port, which you can th
 
 | Syntax          | Default | Environment Variable |
 | --------------- | ------- | -------------------- |
-| `cloudflared tunnel --no-autoupdate <BOOLEAN> run <UUID or NAME>`  | `false` | `NO_AUTOUPDATE`      |
+| `cloudflared tunnel --no-autoupdate run <UUID or NAME>`  | `false` | `NO_AUTOUPDATE`      |
 
-When `false`, `cloudflared` will periodically check for updates and restart with the new version. See also: [`autoupdate-freq`](#autoupdate-freq). Restarts are performed by spawning a new process that connects to the Cloudflare global network. On successful connection, the old process will gracefully shut down after handling all outstanding requests.
+When the parameter `--no-autoupdate` is not present, `cloudflared` will periodically check for updates and restart with the new version. See also: [`autoupdate-freq`](#autoupdate-freq). Restarts are performed by spawning a new process that connects to the Cloudflare global network. On successful connection, the old process will gracefully shut down after handling all outstanding requests.
 
-When `true`, automatic updates are disabled.
+When `--no-autoupdate` is provided as an argument, automatic updates are disabled.
 
 ## `origincert`
 


### PR DESCRIPTION
The cloudflared parameter --no-autoupdate doesn't take a boolean value.  When the parameter is provided it disables auto updates, when it's missing, auto updates are enabled.