### PR TITLE
[Durable Objects] websockets.md: serializeAttachment() is a socket method, not state

### DIFF
--- a/content/durable-objects/api/websockets.md
+++ b/content/durable-objects/api/websockets.md
@@ -114,7 +114,7 @@ For more information beyond the API reference, refer to [Use WebSockets in Durab
 - {{<code>}}deserializeAttachment(){{</code>}} : {{<type>}}any{{</type>}}
   - This method is part of the [Hibernatable WebSockets API](/durable-objects/reference/websockets/#websocket-hibernation).
 
-  - Retrieves the most recent value passed to `state.serializeAttachment()`, or `null` if none exists.
+  - Retrieves the most recent value passed to `ws.serializeAttachment()`, or `null` if none exists.
 
 {{</definitions>}}
 


### PR DESCRIPTION
Changed `state.serializeAttachment()` to `ws.serializeAttachment()`