### PR TITLE
d1: raw() vs all() vs run() fixes

### DIFF
--- a/content/d1/build-databases/query-databases.md
+++ b/content/d1/build-databases/query-databases.md
@@ -141,12 +141,15 @@ console.log(results);
 
 ### await stmt.raw()
 
-Returns results as an array of arrays, with each row represented by an array. Column names are not included in the result set.
+Returns results as an array of arrays, with each row represented by an array.
+
+Column names are not included in the result set by default. To include column names as the first row of the result array, set `.raw({columnNames: true})`.
 
 ```js
 const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
 const raw = await stmt.raw();
 console.log(raw);
+
 /*
 [
   [ "John", 42 ],
@@ -154,11 +157,19 @@ console.log(raw);
   [ "Dave", 29 ],
 ]
 */
-console.log(raw.map(row => row.join(',')).join("\n"));
+
+// With columnNames: true
+const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
+const raw = await stmt.raw({columnNames: true});
+console.log(raw);
+
 /*
-John,42
-Anthony,37
-Dave,29
+[
+  [ "name", age ], // The first result array includes the column names
+  [ "John", 42 ],
+  [ "Anthony", 37 ],
+  [ "Dave", 29 ],
+]
 */
 ```
 

--- a/content/d1/build-databases/query-databases.md
+++ b/content/d1/build-databases/query-databases.md
@@ -70,7 +70,7 @@ D1 automatically converts supported JavaScript (including TypeScript) types pass
 
 ## Return object
 
-The methods `stmt.raw()`, `stmt.all()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
+The methods `stmt.all()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
 
 ```js
 {
@@ -113,7 +113,7 @@ The D1 API supports the following query statement methods for querying against a
 
 ### await stmt.all()
 
-Returns all rows as an array of objects, with each result row represented as an object.
+Returns all rows as an array of objects, with each result row represented as an object on the `results` property of the `D1Result` type.
 
 When joining tables with identical column names, only the leftmost column will be included in the row object. Use [`stmt.raw()`](#await-stmtraw) to return all rows as an array of arrays.
 
@@ -141,7 +141,7 @@ console.log(results);
 
 ### await stmt.raw()
 
-Returns results as an array of arrays, with each row represented by an array.
+Returns results as an array of arrays, with each row represented by an array. The return type is an array of arrays, and does not include query metadata.
 
 Column names are not included in the result set by default. To include column names as the first row of the result array, set `.raw({columnNames: true})`.
 

--- a/content/d1/build-databases/query-databases.md
+++ b/content/d1/build-databases/query-databases.md
@@ -147,8 +147,8 @@ Column names are not included in the result set by default. To include column na
 
 ```js
 const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
-const raw = await stmt.raw();
-console.log(raw);
+const rows = await stmt.raw();
+console.log(rows);
 
 /*
 [
@@ -160,16 +160,11 @@ console.log(raw);
 
 // With columnNames: true
 const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
-const raw = await stmt.raw({columnNames: true});
-console.log(raw);
+const [columns, ...rows] = await stmt.raw({columnNames: true});
+console.log(columns);
 
 /*
-[
-  [ "name", age ], // The first result array includes the column names
-  [ "John", 42 ],
-  [ "Anthony", 37 ],
-  [ "Dave", 29 ],
-]
+[ "name", age ], // The first result array includes the column names
 */
 ```
 

--- a/content/d1/build-databases/query-databases.md
+++ b/content/d1/build-databases/query-databases.md
@@ -70,7 +70,7 @@ D1 automatically converts supported JavaScript (including TypeScript) types pass
 
 ## Return object
 
-The methods `stmt.run()`, `stmt.all()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
+The methods `stmt.raw()`, `stmt.all()`, `stmt.first()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
 
 ```js
 {
@@ -104,8 +104,8 @@ The `db.exec()` method returns a `D1ExecResult` object:
 
 The D1 API supports the following query statement methods:
 
-* [`await stmt.first( [column] )`](/d1/build-databases/query-databases/#await-stmtfirstcolumn)
 * [`await stmt.all()`](/d1/build-databases/query-databases/#await-stmtall)
+* [`await stmt.first( [column] )`](/d1/build-databases/query-databases/#await-stmtfirstcolumn)
 * [`await stmt.raw()`](/d1/build-databases/query-databases/#await-stmtraw)
 * [`await stmt.run()`](/d1/build-databases/query-databases/#await-stmtrun)
 * [`await db.dump()`](/d1/build-databases/query-databases/#await-dbdump)

--- a/content/d1/build-databases/query-databases.md
+++ b/content/d1/build-databases/query-databases.md
@@ -70,7 +70,7 @@ D1 automatically converts supported JavaScript (including TypeScript) types pass
 
 ## Return object
 
-The methods `stmt.raw()`, `stmt.all()`, `stmt.first()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
+The methods `stmt.raw()`, `stmt.all()` and `db.batch()` return a typed `D1Result` object that contains the results (if applicable), the success status, and a meta object with the internal duration of the operation in milliseconds.
 
 ```js
 {
@@ -102,14 +102,65 @@ The `db.exec()` method returns a `D1ExecResult` object:
 
 ## Query statement methods
 
-The D1 API supports the following query statement methods:
+The D1 API supports the following query statement methods for querying against a D1 database.
 
 * [`await stmt.all()`](/d1/build-databases/query-databases/#await-stmtall)
-* [`await stmt.first( [column] )`](/d1/build-databases/query-databases/#await-stmtfirstcolumn)
 * [`await stmt.raw()`](/d1/build-databases/query-databases/#await-stmtraw)
+* [`await stmt.first( [column] )`](/d1/build-databases/query-databases/#await-stmtfirstcolumn)
 * [`await stmt.run()`](/d1/build-databases/query-databases/#await-stmtrun)
 * [`await db.dump()`](/d1/build-databases/query-databases/#await-dbdump)
 * [`await db.exec()`](/d1/build-databases/query-databases/#await-dbexec)
+
+### await stmt.all()
+
+Returns all rows as an array of objects, with each result row represented as an object.
+
+When joining tables with identical column names, only the leftmost column will be included in the row object. Use [`stmt.raw()`](#await-stmtraw) to return all rows as an array of arrays.
+
+```js
+const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
+const { results } = await stmt.all();
+console.log(results);
+/*
+[
+  {
+     name: "John",
+     age: 42,
+  },
+   {
+     name: "Anthony",
+     age: 37,
+  },
+    {
+     name: "Dave",
+     age: 29,
+  },
+ ]
+*/
+```
+
+### await stmt.raw()
+
+Returns results as an array of arrays, with each row represented by an array. Column names are not included in the result set.
+
+```js
+const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
+const raw = await stmt.raw();
+console.log(raw);
+/*
+[
+  [ "John", 42 ],
+  [ "Anthony", 37 ],
+  [ "Dave", 29 ],
+]
+*/
+console.log(raw.map(row => row.join(',')).join("\n"));
+/*
+John,42
+Anthony,37
+Dave,29
+*/
+```
 
 ### await stmt.first([column])
 
@@ -136,59 +187,6 @@ If the query returns rows, but `column` does not exist, then `first()` will thro
 
 `stmt.first()` does not alter the SQL query. To improve performance, consider appending `LIMIT 1` to your statement.
 
-### await stmt.all()
-
-Returns all rows and metadata.
-
-```js
-const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
-const { results } = await stmt.all();
-console.log(results);
-/*
-[
-  {
-     name: "John",
-     age: 42,
-  },
-   {
-     name: "Anthony",
-     age: 37,
-  },
-    {
-     name: "Dave",
-     age: 29,
-  },
- ]
-*/
-```
-
-
-
-### await stmt.raw()
-
-Same as [`stmt.all()`](/d1/build-databases/query-databases/#await-stmtall), but returns an array of rows instead of objects.
-
-```js
-const stmt = db.prepare('SELECT name, age FROM users LIMIT 3');
-const raw = await stmt.raw();
-console.log(raw);
-/*
-[
-  [ "John", 42 ],
-  [ "Anthony", 37 ],
-  [ "Dave", 29 ],
-]
-*/
-console.log(raw.map(row => row.join(',')).join("\n"));
-/*
-John,42
-Anthony,37
-Dave,29
-*/
-```
-
-
-
 ### await stmt.run()
 
 Runs the query (or queries), but returns no results. Instead, `run()` returns the metrics only. Useful for write operations like UPDATE, DELETE or INSERT.
@@ -209,12 +207,12 @@ console.log(info);
 */
 ```
 
-
-
 ### await db.dump()
 
 {{<Aside type="warning">}}
+
 This API only works on databases created during D1's alpha period. Check which version your database uses with `wrangler d1 info <DATABASE_NAME>`.
+
 {{</Aside>}}
 
 Dumps the entire D1 database to an SQLite compatible file inside an ArrayBuffer.
@@ -228,7 +226,6 @@ return new Response(dump, {
     }
 });
 ```
-
 
 ### await db.exec()
 
@@ -246,6 +243,26 @@ console.log(out);
   duration: 76
 }
 */
+```
+
+## TypeScript support
+
+D1's query API is fully-typed via the `@cloudflare/workers-types` package, and also supports [generic types](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-types) as part of its TypeScript API. A generic type allows you to provide an optional _type parameter_ so that a function understands the type of the data it is handling.
+
+When using the [query statement methods](#query-statement-methods) `stmt.all()`, `stmt.raw()` and `stmt.first()`, you can provide a type representing each database row. D1's API will [return the result object](#return-object) with the correct type.
+
+For example, providing an `OrderRow` type as a type parameter to `stmt.all()` will return a typed `Array<OrderRow>` object instead of the default `Record<string, unknown>` type:
+
+```ts
+// Row definition
+type OrderRow {
+  Id: string;
+  CustomerName: string;
+  OrderDate: number;
+}
+
+// Elsewhere in your application
+const result = await env.MY_DB.prepare("SELECT Id, CustomerName, OrderDate FROM [Order] ORDER BY ShippedDate DESC LIMIT 100").all<OrderRow>();
 ```
 
 ## Reuse prepared statements

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -2,6 +2,19 @@
 link: "/d1/platform/changelog/"
 productName: D1
 entries:
+  - publish_date: "2024-02-13"
+    title: API changes to `.raw()`, `.all()` and `.run()`
+    description: |-
+      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour.
+      
+      `.raw()` now correctly returns results an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects.
+      
+      `.run()` no longer incorrectly returns a `D1Result` and instead returns a [`D1ExecResult`](/d1/build-databases/query-databases/#return-object) as originally intended and documented.
+      
+      This may be a breaking change for some applications that expected `.raw()` to return an array of objects.
+
+    Visit the [query databases documentation](/d1/build-databases/query-databases/) to review D1's query methods, return types and TypeScript support in detail.
+
   - publish_date: "2024-01-18"
     title: Support for LIMIT on UPDATE and DELETE statements
     description: |-

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,9 +5,9 @@ entries:
   - publish_date: "2024-02-13"
     title: API changes to `.raw()`, `.all()` and `.run()`
     description: |-
-      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour and improving compatibility with ORMs.
+      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour and improve compatibility with ORMs libraries.
       
-      `.raw()` now correctly returns results an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects. To include an array of column names in the results when using `.raw()`, use `.raw({columnNames: true})`.
+      `.raw()` now correctly returns results as an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects. To include an array of column names in the results when using `.raw()`, use `.raw({columnNames: true})`.
       
       `.run()` no longer incorrectly returns a `D1Result` and instead returns a [`D1ExecResult`](/d1/build-databases/query-databases/#return-object) as originally intended and documented.
       

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,9 +5,9 @@ entries:
   - publish_date: "2024-02-13"
     title: API changes to `.raw()`, `.all()` and `.run()`
     description: |-
-      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour.
+      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour and improving compatibility with ORMs.
       
-      `.raw()` now correctly returns results an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects.
+      `.raw()` now correctly returns results an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects. To include an array of column names in the results when using `.raw()`, use `.raw({columnNames: true})`.
       
       `.run()` no longer incorrectly returns a `D1Result` and instead returns a [`D1ExecResult`](/d1/build-databases/query-databases/#return-object) as originally intended and documented.
       

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,9 +5,9 @@ entries:
   - publish_date: "2024-02-13"
     title: API changes to `.raw()`, `.all()` and `.run()`
     description: |-
-      D1's `.raw()`, `.all()` and `.run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour and improve compatibility with ORMs libraries.
+      D1's `raw()`, `all()` and `run()` [query statement methods](/d1/build-databases/query-databases/#query-statement-methods) have been updated to reflect their intended behaviour and improve compatibility with ORMs libraries.
       
-      `.raw()` now correctly returns results as an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `.all()`, which is unchanged and returns an array of objects. To include an array of column names in the results when using `.raw()`, use `.raw({columnNames: true})`.
+      `raw()` now correctly returns results as an array of arrays, allowing the correct handling of duplicate column names (such as when joining tables), as compared to `all()`, which is unchanged and returns an array of objects. To include an array of column names in the results when using `raw()`, use `raw({columnNames: true})`.
       
       `.run()` no longer incorrectly returns a `D1Result` and instead returns a [`D1ExecResult`](/d1/build-databases/query-databases/#return-object) as originally intended and documented.
       

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -13,7 +13,7 @@ entries:
       
       This may be a breaking change for some applications that expected `.raw()` to return an array of objects.
 
-    Visit the [query databases documentation](/d1/build-databases/query-databases/) to review D1's query methods, return types and TypeScript support in detail.
+      Visit the [query databases documentation](/d1/build-databases/query-databases/) to review D1's query methods, return types and TypeScript support in detail.
 
   - publish_date: "2024-01-18"
     title: Support for LIMIT on UPDATE and DELETE statements


### PR DESCRIPTION
This PR:

- [x] Adds a changelog for the breaking change (and fix) made to `raw()`
- [x] Updates the /query-databases/ docs to better describe `raw()` vs. `all()` behaviour
- [x] Documents how to use generic type params
- [x] Fixes docs for `first()`