### PR TITLE
[Speed] Update compression diagrams

### DIFF
--- a/content/speed/optimization/content/brotli/content-compression.md
+++ b/content/speed/optimization/content/brotli/content-compression.md
@@ -26,9 +26,11 @@ C[(Origin server)]
 A == "Request" ==> B -.-> C
 C -.-> B == "Response<br>(Gzip / Brotli / No compression)" ==> A
 
-style A stroke-width: 3px
-style B stroke: orange,fill: orange
+style A stroke-width: 2px
+style B stroke: orange,fill: orange,color: black
 style C stroke-dasharray: 5 5
+linkStyle 0,3 stroke-width: 2px
+linkStyle 1,2 stroke-width: 1px
 ```
 
 If supported by visitors' web browsers, Cloudflare will return Gzip or Brotli-encoded responses for the following content types:
@@ -122,8 +124,10 @@ A -.-> B == "Request<br>Accept-Encoding: gzip, br" ==> C
 C == "Response<br>Accept-Encoding: (Gzip / Brotli / No compression)" ==> B -.-> A
 
 style A stroke-dasharray: 5 5
-style B stroke: orange,fill: orange
-style C stroke-width: 3px
+style B stroke: orange,fill: orange,color: black
+style C stroke-width: 2px
+linkStyle 1,2 stroke-width: 2px
+linkStyle 0,3 stroke-width: 1px
 ```
 
 If your origin server responds to a Cloudflare request using Gzip/Brotli compression, we will keep the same compression in the response sent to the website visitor if:


### PR DESCRIPTION
- Force text color to black when using orange background (improves readability in dark mode). 
- Adjust stroke widths (makes arrowheads more visible).

Before:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/8683a4fe-c138-4331-ac10-b01bcc76afdb)

After:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/44664541-b318-4e91-ad52-206aa109ab0c)
