### PR TITLE
Update the Next.js Pages guide to use the latest tooling

### DIFF
--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -87,7 +87,7 @@ Projects created with C3 have bindings for local development set up by default.
 
 {{</Aside>}}
 
-To set up bindings for use in local development, you will use the `setupDevPlatform` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/tree/main/internal-packages/next-dev). This function, tries to read the project's [`wrangler.toml`](/workers/wrangler/configuration/) file and based on it sets up a platform emulation that your Next.js application can make use of locally.
+To set up bindings for use in local development, you will use the `setupDevPlatform` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/tree/main/internal-packages/next-dev). `setupDevPlatform` sets up a platform emulation based on your project's [`wrangler.toml`](/workers/wrangler/configuration/) file that your Next.js application can make use of locally.
 
 For example, to work with a KV binding locally, open the Next.js configuration file and add:
 
@@ -101,7 +101,7 @@ highlight: [1-7]
 ---
 import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev'
 
-// note: the if statement is present because we
+// note: the if statement is present because you
 //       only need to use the function during development
 if (process.env.NODE_ENV === 'development') {
   await setupDevPlatform()
@@ -121,7 +121,7 @@ export default nextConfig
 filename: next.config.js / next.config.cjs
 highlight: [1-6]
 ---
-// note: the if statement is present because we
+// note: the if statement is present because you
 //       only need to use the function during development
 if (process.env.NODE_ENV === "development") {
   const { setupDevPlatform } = require("@cloudflare/next-on-pages/next-dev")
@@ -137,7 +137,7 @@ module.exports = nextConfig
 {{</tab>}}
 {{</tabs>}}
 
-Also make sure to have a `wrangler.toml` file at the root of your project with a declaration for a KV binding named `MY_KV`:
+Make sure to have a `wrangler.toml` file at the root of your project with a declaration for a KV binding named `MY_KV`:
 
 ```toml
 ---
@@ -150,7 +150,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [[kv_namespaces]]
 binding = "MY_KV"
-id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+id = "<YOUR_KV_NAMESPACE_ID>"
 ```
 
 ### Set up bindings for a deployed application
@@ -159,14 +159,13 @@ To access bindings in a deployed application, you will need to [configure](/page
 
 ### Add bindings to Typescript projects
 
-If your project is using typescript you will want to set up proper type support so that you can access
-your bindings in a type safe and convenient manner.
+If your project is using TypeScript, you will want to set up proper type support so you can access your bindings in a type-safe and convenient manner.
 
 To get proper type support, you need to create a new `env.d.ts` file in your project and extend the `CloudflareEnv` (used by `getRequestContext`) interface with your [bindings](/pages/functions/bindings/).
 
 {{<Aside type="note">}}
 
-Note: Projects created with C3 have a default `env.d.ts` file.
+Projects created with C3 have a default `env.d.ts` file.
 
 {{</Aside>}}
 
@@ -282,7 +281,7 @@ $ npx wrangler pages dev .vercel/output/static
 
 {{<Aside type="note">}}
 
-The `wrangler pages dev` command needs to run the application using the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) compatibility flag, that can be either specified in the `wrangler.toml` file or provided to the command as an inline argument: `--compatibility-flag=nodejs_compat`.
+The [`wrangler pages dev`](/workers/wrangler/commands/#dev-1) command needs to run the application using the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) compatibility flag. The `nodejs_compat` flag can be specified in either your project's `wrangler.toml` file or provided to the command as an inline argument: `--compatibility-flag=nodejs_compat`.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -37,7 +37,7 @@ The initial deployment created via C3 is referred to as a [Direct Upload](/pages
 
 ## Configure and deploy a project without C3
 
-If you already have a Next.js project or wish to manually create and deploy one without using C3, Cloudflare recommends that you use `@cloudflare/next-on-pages` and refer to its [README](https://github.com/cloudflare/next-on-pages/blob/3846730c4a0d12/packages/next-on-pages#cloudflarenext-on-pages) for instructions and additional information to help you develop and deploy your project.
+If you already have a Next.js project or wish to manually create and deploy one without using C3, Cloudflare recommends that you use `@cloudflare/next-on-pages` and refer to its [README](https://github.com/cloudflare/next-on-pages/tree/main/packages/next-on-pages) for instructions and additional information to help you develop and deploy your project.
 
 {{<render file="/_framework-guides/_git-integration.md">}}
 
@@ -87,7 +87,7 @@ Projects created with C3 have bindings for local development set up by default.
 
 {{</Aside>}}
 
-To set up bindings for use in local development, you will use the `setupDevPlatform` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/blob/3846730c4a0d12/internal-packages/next-dev). This function, tries to read the project's [`wrangler.toml`](/workers/wrangler/configuration/) file and based on it sets up a platform emulation that your Next.js application can make use of locally.
+To set up bindings for use in local development, you will use the `setupDevPlatform` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/tree/main/internal-packages/next-dev). This function, tries to read the project's [`wrangler.toml`](/workers/wrangler/configuration/) file and based on it sets up a platform emulation that your Next.js application can make use of locally.
 
 For example, to work with a KV binding locally, open the Next.js configuration file and add:
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -101,8 +101,8 @@ highlight: [1-7]
 ---
 import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev'
 
-// note: the if statement is because we only need to use the function
-// during development (the check is recommended but completely optional)
+// note: the if statement is present because we
+//       only need to use the function during development
 if (process.env.NODE_ENV === 'development') {
   await setupDevPlatform()
 }
@@ -121,8 +121,8 @@ export default nextConfig
 filename: next.config.js / next.config.cjs
 highlight: [1-6]
 ---
-// note: the if statement is because we only need to use the function
-// during development (the check is recommended but completely optional)
+// note: the if statement is present because we
+//       only need to use the function during development
 if (process.env.NODE_ENV === "development") {
   const { setupDevPlatform } = require("@cloudflare/next-on-pages/next-dev")
   setupDevPlatform()

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -37,7 +37,7 @@ The initial deployment created via C3 is referred to as a [Direct Upload](/pages
 
 ## Configure and deploy a project without C3
 
-If you already have a Next.js project or wish to manually create and deploy one without using C3, Cloudflare recommends that you use `@cloudflare/next-on-pages` and refer to its [README](https://github.com/cloudflare/next-on-pages/tree/main/packages/next-on-pages#cloudflarenext-on-pages) for instructions and additional information to help you develop and deploy your project.
+If you already have a Next.js project or wish to manually create and deploy one without using C3, Cloudflare recommends that you use `@cloudflare/next-on-pages` and refer to its [README](https://github.com/cloudflare/next-on-pages/blob/3846730c4a0d12/packages/next-on-pages#cloudflarenext-on-pages) for instructions and additional information to help you develop and deploy your project.
 
 {{<render file="/_framework-guides/_git-integration.md">}}
 
@@ -87,7 +87,7 @@ Projects created with C3 have bindings for local development set up by default.
 
 {{</Aside>}}
 
-To set up bindings for use in local development, you will use the `setupDevBindings` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/tree/main/internal-packages/next-dev). This function allows you to specify bindings that work locally, and are accessed the same way remote bindings are.
+To set up bindings for use in local development, you will use the `setupDevPlatform` function provided by [`@cloudflare/next-on-pages/next-dev`](https://github.com/cloudflare/next-on-pages/blob/3846730c4a0d12/internal-packages/next-dev). This function, tries to read the project's [`wrangler.toml`](/workers/wrangler/configuration/) file and based on it sets up a platform emulation that your Next.js application can make use of locally.
 
 For example, to work with a KV binding locally, open the Next.js configuration file and add:
 
@@ -97,26 +97,18 @@ For example, to work with a KV binding locally, open the Next.js configuration f
 ```js
 ---
 filename: next.config.mjs
-highlight: [1, 6-18]
+highlight: [1-7]
 ---
-import { setupDevBindings } from '@cloudflare/next-on-pages/next-dev'
+import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev'
+
+// note: the if statement is because we only need to use the function
+// during development (the check is recommended but completely optional)
+if (process.env.NODE_ENV === 'development') {
+  await setupDevPlatform()
+}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
-
-// we only need to use the function during development so Cloudflare can check `NODE_ENV`
-// (note: this check is recommended but completely optional)
-if (process.env.NODE_ENV === 'development') {
-  // call the function with the bindings you want to have access to
-  await setupDevBindings({
-    bindings: {
-      MY_KV: {
-        type: "kv",
-        id: "MY_KV",
-      },
-    },
-  })
-}
 
 export default nextConfig
 ```
@@ -127,26 +119,17 @@ export default nextConfig
 ```js
 ---
 filename: next.config.js / next.config.cjs
-highlight: [4-18]
+highlight: [1-6]
 ---
+// note: the if statement is because we only need to use the function
+// during development (the check is recommended but completely optional)
+if (process.env.NODE_ENV === "development") {
+  const { setupDevPlatform } = require("@cloudflare/next-on-pages/next-dev")
+  setupDevPlatform()
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
-
-// we only need to use the function during development so we can check NODE_ENV
-// (note: this check is recommended but completely optional)
-if (process.env.NODE_ENV === "development") {
-  const { setupDevBindings } = require("@cloudflare/next-on-pages/next-dev")
-
-  // call the function with the bindings you want to have access to
-  setupDevBindings({
-    bindings: {
-      MY_KV: {
-        type: "kv",
-        id: "MY_KV",
-      },
-    },
-  })
-}
 
 module.exports = nextConfig
 ```
@@ -154,13 +137,59 @@ module.exports = nextConfig
 {{</tab>}}
 {{</tabs>}}
 
+Also make sure to have a `wrangler.toml` file at the root of your project with a declaration for a KV binding named `MY_KV`:
+
+```toml
+---
+filename: wrangler.toml
+highlight: [5-7]
+---
+name = "my-next-app"
+
+compatibility_flags = ["nodejs_compat"]
+
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
 ### Set up bindings for a deployed application
 
 To access bindings in a deployed application, you will need to [configure](/pages/functions/bindings/) any necessary bindings and connect them to your project via your project's settings page in the Cloudflare dashboard.
 
+### Add bindings to Typescript projects
+
+If your project is using typescript you will want to set up proper type support so that you can access
+your bindings in a type safe and convenient manner.
+
+To get proper type support, you need to create a new `env.d.ts` file in your project and extend the `CloudflareEnv` (used by `getRequestContext`) interface with your [bindings](/pages/functions/bindings/).
+
+{{<Aside type="note">}}
+
+Note: Projects created with C3 have a default `env.d.ts` file.
+
+{{</Aside>}}
+
+The following is an example of how to add a `KVNamespace` binding:
+
+```ts
+---
+filename: env.d.ts
+highlight: [7]
+---
+interface CloudflareEnv {
+  // The KV Namespace binding type used here comes
+  // from `@cloudflare/workers-types`. To use it in such
+  // a way make sure that you have installed the package
+  // as a dev dependency and you have added it to your
+  //`tsconfig.json` file under `compilerOptions.types`.
+  MY_KV: KVNamespace
+}
+```
+
 ### Access bindings in the application
 
-Local and remote bindings can be accessed directly from `process.env`. The following code example shows how to access them in a `hello` API route of an App Router application.
+Local and remote bindings can be accessed using the [`getRequestContext` function](https://github.com/cloudflare/next-on-pages/blob/3846730c4a0d12/packages/next-on-pages/README.md#cloudflare-platform-integration) exposed by `@cloudflare/next-on-pages`. The following code example shows how to access them in a `hello` API route of an App Router application.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
@@ -168,14 +197,18 @@ Local and remote bindings can be accessed directly from `process.env`. The follo
 ```js
 ---
 filename: app/api/hello/route.js
-highlight: [3]
+highlight: [1, 7]
 ---
+import { getRequestContext } from '@cloudflare/next-on-pages'
+
+// ...
+
 export async function GET(request) {
-  // this is the KV binding you defined in the config file
-  const myKv = process.env.MY_KV;
+  // this is the KV binding you defined in the wrangler.toml file
+  const myKv = getRequestContext().env.MY_KV
 
   // get a value from the namespace
-  const kvValue = await myKv.get(`kvTest`) || false;
+  const kvValue = await myKv.get(`kvTest`) || false
 
   return new Response(`The value of kvTest in MY_KV is: ${kvValue}`)
 }
@@ -187,14 +220,18 @@ export async function GET(request) {
 ```ts
 ---
 filename: app/api/hello/route.ts
-highlight: [3]
+highlight: [1, 7]
 ---
+import { getRequestContext } from '@cloudflare/next-on-pages'
+
+// ...
+
 export async function GET(request: NextRequest) {
-  // this is the KV binding you defined in the config file
-  const myKv = process.env.MY_KV;
+  // this is the KV binding you defined in the wrangler.toml file
+  const myKv = getRequestContext().env.MY_KV
 
   // get a value from the namespace
-  const kvValue = await myKv.get(`kvTest`) || false;
+  const kvValue = await myKv.get(`kvTest`) || false
 
   return new Response(`The value of kvTest in MY_KV is: ${kvValue}`)
 }
@@ -202,40 +239,6 @@ export async function GET(request: NextRequest) {
 
 {{</tab>}}
 {{</tabs>}}
-
-### Add bindings to TypeScript projects
-
-{{<Aside type="note">}}
-
-Projects created with C3 have a default `env.d.ts` file.
-
-{{</Aside>}}
-
-To get proper type support, you need to create a new `env.d.ts` file in your project and declare a [binding](/pages/functions/bindings/).
-
-The following is an example of adding a `KVNamespace` binding:
-
-```ts
----
-filename: env.d.ts
-highlight: [4-10]
----
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      // The KV Namespace binding type used here comes
-      // from `@cloudflare/workers-types`. To
-      // use it like so, make sure that you have installed
-      // the package as a dev dependency and you have added
-      // it to your `tsconfig.json` file under
-      // `compilerOptions.types`.
-      MY_KV: KVNamespace;
-    }
-  }
-}
-
-export {};
-```
 
 ## `Image` component
 
@@ -262,7 +265,7 @@ To ensure that your application is being built in a manner that is fully compati
 If you have created your project with C3, do this by running:
 
 ```sh
-$ npm run pages:build && npm run pages:dev
+$ npm run preview
 ```
 
 If you have created your project without C3, run:
@@ -274,8 +277,15 @@ $ npx @cloudflare/next-on-pages@1
 And preview your project by running:
 
 ```sh
-$ npx wrangler pages dev .vercel/output/static --compatibility-flag=nodejs_compat
+$ npx wrangler pages dev .vercel/output/static
 ```
+
+{{<Aside type="note">}}
+
+The `wrangler pages dev` command needs to run the application using the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) compatibility flag, that can be either specified in the `wrangler.toml` file or provided to the command as an inline argument: `--compatibility-flag=nodejs_compat`.
+
+{{</Aside>}}
+
 
 ### Deploy your application and iterate
 


### PR DESCRIPTION

update the Next.js Pages guide to use the latest tooling consistently to the changes made in C3: https://github.com/cloudflare/workers-sdk/pull/5009

Such changes include:
 - renaming `setupDevBindings` with `setupDevPlatform`
 - updating the bindings access to use `getRequestContext`
 - update the C3 scaffolded script names
 - update the `env.d.ts` file content
 
 ___
 
 resolves #12972