### PR TITLE
Clarify Turnstile support for desktop mode

### DIFF
--- a/content/waf/reference/cloudflare-challenges.md
+++ b/content/waf/reference/cloudflare-challenges.md
@@ -82,6 +82,10 @@ This behavior commonly occurs because an extension modifies your browser's defau
 
 {{</Aside>}}
 
+### Mobile device emulation
+
+Challenges are not supported when device emulation is enabled on a browser, for example, using the browser's developer tools.
+
 ---
 
 ## Resolve a challenge

--- a/content/waf/reference/cloudflare-challenges.md
+++ b/content/waf/reference/cloudflare-challenges.md
@@ -82,10 +82,6 @@ This behavior commonly occurs because an extension modifies your browser's defau
 
 {{</Aside>}}
 
-### Mobile browsers
-
-Challenges are not supported for desktop mode on mobile browsers or mobile mode on desktop browsers.
-
 ---
 
 ## Resolve a challenge


### PR DESCRIPTION
Turnstile and challenge pages now support `desktop mode` on mobile browsers.