### PR TITLE
Comment out optional field

### DIFF
--- a/content/stream/uploading-videos/upload-video-file.md
+++ b/content/stream/uploading-videos/upload-video-file.md
@@ -215,10 +215,10 @@ var options = {
   chunkSize: 50 * 1024 * 1024, // Required a minimum chunk size of 5MB, here we use 50MB.
   retryDelays: [0, 3000, 5000, 10000, 20000], // Indicates to tus-js-client the delays after which it will retry if the upload fails
   metadata: {
-    filename: 'test.mp4',
+    name: 'test.mp4',
     filetype: 'video/mp4',
-    defaulttimestamppct: 0.5,
-    watermark: '<WATERMARK_UID>',
+    // Optional if you want to include a watermark
+    // watermark: '<WATERMARK_UID>',
   },
   uploadSize: size,
   onError: function (error) {


### PR DESCRIPTION
A few proposed changes here!
1. Renaming `filename` to `name` — since we use `name` as the metadata field to display the video title in the dashboard, we should use it here!
2. Deleting `defaulttimestamppct` — I can't seem to [find any information](https://www.google.com/search?q=tus-js-client+%22defaulttimestamppct%22&sa=X&sca_esv=f5f2bc2e5380d47d&biw=3032&bih=1813&sxsrf=ACQVn09kFtDcWFGCghJsUlfJhDFokhfMFg:1708056458516&gbv=2&sei=it_OZZO0Ho-iqtsPyo-pqA0) about what this is supposed to do, and it seems to work without it.
3. Commenting out `watermark` — if a user overlooks this field without deleting it (like I did) and tries to run the code, they will get an error. We should comment it out so folks can still find it easily, but the code will work for everyone.