### PR TITLE
Small improvements/fixes in the AI getting started doc

### DIFF
--- a/content/workers-ai/get-started/workers-wrangler.md
+++ b/content/workers-ai/get-started/workers-wrangler.md
@@ -127,11 +127,17 @@ After configuring your Worker, you can test your project locally before you depl
 
 ## 5. Develop locally with Wrangler
 
-While in your project directory, test Workers AI locally by running. Note, you will be prompted to login at this time:
+While in your project directory, test Workers AI locally by running the following command: 
 
 ```sh
 $ npx wrangler dev --remote
 ```
+
+{{<Aside type="note">}}
+
+Note, you will be prompted to login at this time.
+
+{{</Aside>}}
 
 {{<Aside type="warning">}}
 Be sure to include the `--remote`. This proxies Workers AI requests to the Cloudflare network as the dev environment is not currently capable of running them locally.

--- a/content/workers-ai/get-started/workers-wrangler.md
+++ b/content/workers-ai/get-started/workers-wrangler.md
@@ -130,7 +130,7 @@ After configuring your Worker, you can test your project locally before you depl
 While in your project directory, test Workers AI locally by running the following command: 
 
 ```sh
-$ npx wrangler dev --remote
+$ npx wrangler dev
 ```
 
 {{<Aside type="note">}}
@@ -139,9 +139,7 @@ Note, you will be prompted to login at this time.
 
 {{</Aside>}}
 
-{{<Aside type="warning">}}
-Be sure to include the `--remote`. This proxies Workers AI requests to the Cloudflare network as the dev environment is not currently capable of running them locally.
-{{</Aside>}}
+{{<render file="_ai-local-usage-charges.md" productFolder="workers">}}
 
 When you run `npx wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you visit the URL Wrangler provides, you will see this message:
 


### PR DESCRIPTION
- fix the broken sentence: `test Workers AI locally by running.`
- remove `--remote` flag requirement (as it is no longer necessary)
