### PR TITLE
Update `wrangler types` documentation with new customization options

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2334,7 +2334,7 @@ wrangler types [<PATH>] [OPTIONS]
 
 - `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `worker-configuration.d.ts`){{</prop-meta>}}
   - The path to where the declaration file for your Worker will be written.
-  - Since it is a declaration file, it needs to have a `d.ts` extension.
+  - The path to the declaration file must have a `d.ts` extension.
 
 - `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}
   - The name of the interface to generate for the environment object.

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2338,7 +2338,7 @@ wrangler types [<PATH>] [OPTIONS]
 
 - `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}
   - The name of the interface to generate for the environment object.
-  - _Ignored if the worker uses the Service Worker syntax._
+  - _Not valid if the worker uses the Service Worker syntax._
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2338,7 +2338,7 @@ wrangler types [<PATH>] [OPTIONS]
 
 - `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}
   - The name of the interface to generate for the environment object.
-  - _Not valid if the worker uses the Service Worker syntax._
+  - Not valid if the Worker uses the Service Worker syntax.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2333,7 +2333,7 @@ wrangler types [<PATH>] [OPTIONS]
 {{<definitions>}}
 
 - `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `worker-configuration.d.ts`){{</prop-meta>}}
-  - The path to where to write the resulting types n entry point for your Worker.
+  - The path to where the declaration file for your Worker will be written.
   - Since it is a declaration file, it needs to have a `d.ts` extension.
 
 - `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2327,10 +2327,14 @@ Deleted certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d successfully
 Generate types from bindings and module rules in configuration.
 
 ```sh
-wrangler types [OPTIONS]
+wrangler types [<PATH>] [OPTIONS]
 ```
 
 {{<definitions>}}
+
+- `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `worker-configuration.d.ts`){{</prop-meta>}}
+  - The path to where to write the resulting types n entry point for your Worker.
+  - Since it is a declaration file, it needs to have a `d.ts` extension.
 
 - `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}
   - The name of the interface to generate for the environment object.

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2326,8 +2326,17 @@ Deleted certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d successfully
 
 Generate types from bindings and module rules in configuration.
 
-```txt
-wrangler types
+```sh
+wrangler types [OPTIONS]
 ```
+
+{{<definitions>}}
+
+- `--env-interface` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `Env`){{</prop-meta>}}
+  - The name of the interface to generate for the environment object.
+  - _Ignored if the worker uses the Service Worker syntax._
+
+{{</definitions>}}
+
 
 <!--TODO Add examples of DTS generated output -->


### PR DESCRIPTION
update the `wrangler types` documentation to add the new `path` positional parameter and `--env-interface` flag
