### PR TITLE
[Durable Objects] WebSocket Hibernation Pricing + drive-by fix

### DIFF
--- a/content/durable-objects/platform/pricing.md
+++ b/content/durable-objects/platform/pricing.md
@@ -26,7 +26,10 @@ This example represents a simple Durable Object used as a co-ordination service 
 
 In this scenario, the estimated monthly cost would be calculated as:
 
+Requests:
 - (1.5 million requests - included 1 million requests) x $0.15 / 1,000,000 = $0.075
+
+Compute Duration:
 - 1,000,000 seconds \* 128 MB / 1 GB = 128,000 GB-s
 - (128,000 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $0.00
 
@@ -41,14 +44,17 @@ This example represents a moderately trafficked Durable Objects based applicatio
 
 In this scenario, the estimated monthly cost would be calculated as:
 
-- 50 requests to establish the WebSockets.
-- 50 messages per minute \* 100 Durable Objects \* 60 minutes \* 8 hours \* 30 days = 72,000,000 requests.
-- (72 million requests - included 1 million requests) x $0.15 / 1,000,000 = $10.65.
-- 100 Durable Objects \* 60 seconds \* 60 minutes \* 8 hours \* 30 days / 2 = 43,200,000 seconds.
-- 43,200,000 seconds \* 128 MB / 1 GB = 5,529,600 GB-s.
-- (5,529,600 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $64.12.
+Requests:
+- 50 requests to each of the 100 Durable Objects to establish the WebSockets (5,000 connections created each day, total 150,000 connection requests).
+- 50 messages per minute \* 100 Durable Objects \* 60 minutes \* 8 hours \* 30 days = 72,000,000 requests + 150,000 connection requests.
+- (~72 million requests - included 1 million requests) x $0.15 / 1,000,000 = $10.65.
 
-**Estimated total**: $10.65 (requests) + $64.12 (compute duration) = $74.77 per month.
+Compute Duration
+- 100 Durable Objects \* 60 seconds \* 60 minutes \* 8 hours \* 30 days = 86,400,000 seconds.
+- 86,400,000 seconds \* 128 MB / 1 GB = 11,059,200 GB-s.
+- (11,059,200 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $133.24.
+
+**Estimated total**: $10.65 (requests) + $133.24 (compute duration) + minimum $5/mo usage = $148.89 per month.
 
 ### Example 3
 
@@ -59,9 +65,12 @@ This example represents a horizontally scaled Durable Objects based application 
 
 In this scenario, the estimated monthly cost would be calculated as:
 
+Requests:
 - 100 requests to establish the WebSockets.
 - 1 message per second \* 100 connections \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 requests
 - (259.2 million requests - included 1 million requests) x $0.15 / 1,000,000 = $38.73
+
+Compute Duration:
 - 100 Durable Objects \* 60 seconds \* 60 minutes \* 24 hours \* 30 days = 259,200,000 seconds
 - 259,200,000 seconds \* 128 MB / 1 GB = 33,177,600 GB-s
 - (33,177,600 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $409.72
@@ -77,9 +86,12 @@ This example represents a moderately trafficked Durable Objects based applicatio
 
 In this scenario, the estimated monthly cost would be calculated as:
 
+Requests:
 - 100 requests to each of the 100 Durable Objects to establish the WebSockets (10,000 initial connections).
 - 100 messages per minute<sup>1</sup> \* 100 Durable Objects \* 60 minutes \* 24 hours \* 30 days = 432,000,000 requests
 - (432 million requests - included 1 million requests) x $0.15 / 1,000,000 = $64.65
+
+Compute Duration:
 - 100 Durable Objects \* 1 second<sup>2</sup> \* 60 minutes \* 24 hours \* 30 days = 4,320,000 seconds
 - 4,320,000 seconds \* 128 MB / 1 GB = 552,960 GB-s
 - (552,960 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $1.91

--- a/content/durable-objects/platform/pricing.md
+++ b/content/durable-objects/platform/pricing.md
@@ -68,6 +68,28 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 **Estimated total**: $38.73 (requests) + $409.72 (compute duration) = $453.45 per month
 
+### Example 4
+
+This example represents a moderately trafficked Durable Objects based application using WebSocket Hibernation to broadcast game, chat or real-time user state across connected clients:
+
+* 100 Durable Objects each have 100 Hibernatable WebSocket connections established to each of them.
+* Clients send one message per minute, and it takes 10ms to process a single message in the `webSocketMessage` handler. Since each Durable Object handles 100 WebSockets, cumulatively each Durable Object will be actively executing JS for 1 second each minute (100 WebSockets * 10ms).
+
+In this scenario, the estimated monthly cost would be calculated as:
+
+- 100 requests to each of the 100 Durable Objects to establish the WebSockets (10,000 initial connections).
+- 100 messages per minute<sup>1</sup> \* 100 Durable Objects \* 60 minutes \* 24 hours \* 30 days = 432,000,000 requests
+- (432 million requests - included 1 million requests) x $0.15 / 1,000,000 = $64.65
+- 100 Durable Objects \* 1 second<sup>2</sup> \* 60 minutes \* 24 hours \* 30 days = 4,320,000 seconds
+- 4,320,000 seconds \* 128 MB / 1 GB = 552,960 GB-s
+- (552,960 GB-s - included 400,000 GB-s) x $12.50 / 1,000,000 = $1.91
+
+**Estimated total**: $64.65 (requests) + $1.91 (compute duration) + Minimum $5/mo usage = $71.56 per month
+
+<sup>1</sup> 100 messages per minute comes from the fact that 100 clients connect to each DO, and each sends 1 message per minute.
+
+<sup>2</sup> we use 1 second here because each Durable Object is active for 1 second per minute. This can also be thought of as 432 million requests that each take 10ms to execute (4,320,000 seconds).
+
 ## Transactional Storage API billing
 
 {{<render file="_transactional_storage_api_pricing.md" productFolder="workers">}}

--- a/content/durable-objects/platform/pricing.md
+++ b/content/durable-objects/platform/pricing.md
@@ -82,7 +82,7 @@ Compute Duration:
 This example represents a moderately trafficked Durable Objects based application using WebSocket Hibernation to broadcast game, chat or real-time user state across connected clients:
 
 * 100 Durable Objects each have 100 Hibernatable WebSocket connections established to each of them.
-* Clients send one message per minute, and it takes 10ms to process a single message in the `webSocketMessage` handler. Since each Durable Object handles 100 WebSockets, cumulatively each Durable Object will be actively executing JS for 1 second each minute (100 WebSockets * 10ms).
+* Clients send one message per minute, and it takes 10ms to process a single message in the `webSocketMessage()` handler. Since each Durable Object handles 100 WebSockets, cumulatively each Durable Object will be actively executing JS for 1 second each minute (100 WebSockets * 10ms).
 
 In this scenario, the estimated monthly cost would be calculated as:
 

--- a/content/durable-objects/platform/pricing.md
+++ b/content/durable-objects/platform/pricing.md
@@ -100,7 +100,7 @@ Compute Duration:
 
 <sup>1</sup> 100 messages per minute comes from the fact that 100 clients connect to each DO, and each sends 1 message per minute.
 
-<sup>2</sup> we use 1 second here because each Durable Object is active for 1 second per minute. This can also be thought of as 432 million requests that each take 10ms to execute (4,320,000 seconds).
+<sup>2</sup> The example uses 1 second because each Durable Object is active for 1 second per minute. This can also be thought of as 432 million requests that each take 10 ms to execute (4,320,000 seconds).
 
 ## Transactional Storage API billing
 


### PR DESCRIPTION
Should we also do an example where there's 1 WS per DO, and then _a ton_ of DOs?

I'm not sure how the recent pricing changes to IO affect things so just sticking with this for now.