### PR TITLE
clarify that `getPlatformProxy` cannot run in the Workers runtime

### DIFF
--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -239,7 +239,7 @@ The `getPlatformProxy` function provides a way to obtain an object containing pr
 
 {{<Aside type="warning">}}
 
-Note that `getPlatformProxy` is, by design, to be used exclusively in Node.js applications. It cannot be run inside a worker (i.e. in the `workerd` runtime).
+`getPlatformProxy` is, by design, to be used exclusively in Node.js applications. `getPlatformProxy` cannot be run inside a Worker (that is, in the `workerd` runtime).
 
 {{</Aside>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -239,7 +239,7 @@ The `getPlatformProxy` function provides a way to obtain an object containing pr
 
 {{<Aside type="warning">}}
 
-`getPlatformProxy` is, by design, to be used exclusively in Node.js applications. `getPlatformProxy` cannot be run inside a Worker (that is, in the `workerd` runtime).
+`getPlatformProxy` is, by design, to be used exclusively in Node.js applications. `getPlatformProxy` cannot be run inside the Workers runtime.
 
 {{</Aside>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -237,6 +237,12 @@ describe("multi-worker testing", () => {
 
 The `getPlatformProxy` function provides a way to obtain an object containing proxies (to **local** `workerd` bindings) and emulations of Cloudflare Workers specific values, allowing the emulation of such in a Node.js process.
 
+{{<Aside type="warning">}}
+
+Note that `getPlatformProxy` is, by design, to be used exclusively in Node.js applications. It cannot be run inside a worker (i.e. in the `workerd` runtime).
+
+{{</Aside>}}
+
 One general use case for getting a platform proxy is for emulating bindings in applications targeting Workers, but running outside the Workers runtime (for example, framework local development servers running in Node.js), or for testing purposes (for example, ensuring code properly interacts with a type of binding).
 
 {{<Aside type="note">}}


### PR DESCRIPTION
Add a warning aside to help clarify that `getPlatformProxy` is a utility designed to run exclusively in Node.js and not `workerd`

___

I'm adding this warning as it could be beneficial for users based on [this conversation](https://discord.com/channels/595317990191398933/1203415576366682162) in our discord.