### PR TITLE
[Rules] Add advice about troubleshooting request header modification rules

### DIFF
--- a/content/rules/transform/troubleshooting.md
+++ b/content/rules/transform/troubleshooting.md
@@ -14,8 +14,8 @@ For more information on runtime errors related to Transform Rules configuration,
 
 ## Why do I not see my request header modifications?
 
-Request header modification Transform Rules affect the HTTP headers that are sent by Cloudflare's network to your origin server. As these are sent to your origin by Cloudflare, you will not see them reflected in your browser request or response data, which can make it difficult to tell if the rule is taking effect.
+Transform Rules performing request header modifications affect the HTTP headers sent by Cloudflare's network to your origin server. You will not find these headers in your browser request or response data, which can make it difficult to tell if the rule is working as intended.
 
-To check whether a request header modification is taking effect, you can check the logs on your origin server or use [Cloudflare Trace](/fundamentals/basic-tasks/trace-request/) to check that the rule is matching traffic correctly.
+To check if a request header modification is taking effect, you can check the logs on your origin server or use [Cloudflare Trace](/fundamentals/basic-tasks/trace-request/) to check that the rule is matching traffic correctly.
 
-If you intennded for the headers to be used in the browser, you have to [modify the response headers](/rules/transform/response-header-modification/) instead.
+To add HTTP headers that website visitors will receive in their browsers, you must [modify the response headers](/rules/transform/response-header-modification/) instead.

--- a/content/rules/transform/troubleshooting.md
+++ b/content/rules/transform/troubleshooting.md
@@ -11,3 +11,11 @@ meta:
 When troubleshooting a rule configuration, review the [Transform Rules evaluation](/rules/transform/#transform-rules-evaluation) section to understand how and when your Transform Rule is evaluated for each request.
 
 For more information on runtime errors related to Transform Rules configuration, refer to [Troubleshooting Cloudflare 1XXX errors](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/).
+
+## Why do I not see my request header modifications?
+
+Request header modification Transform Rules affect the HTTP headers that are sent by Cloudflare's network to your origin server. As these are sent to your origin by Cloudflare, you will not see them reflected in your browser request or response data, which can make it difficult to tell if the rule is taking effect.
+
+To check whether a request header modification is taking effect, you can check the logs on your origin server or use [Cloudflare Trace](/fundamentals/basic-tasks/trace-request/) to check that the rule is matching traffic correctly.
+
+If you intennded for the headers to be used in the browser, you have to [modify the response headers(/rules/transform/response-header-modification/) instead.

--- a/content/rules/transform/troubleshooting.md
+++ b/content/rules/transform/troubleshooting.md
@@ -18,4 +18,4 @@ Request header modification Transform Rules affect the HTTP headers that are sen
 
 To check whether a request header modification is taking effect, you can check the logs on your origin server or use [Cloudflare Trace](/fundamentals/basic-tasks/trace-request/) to check that the rule is matching traffic correctly.
 
-If you intennded for the headers to be used in the browser, you have to [modify the response headers(/rules/transform/response-header-modification/) instead.
+If you intennded for the headers to be used in the browser, you have to [modify the response headers](/rules/transform/response-header-modification/) instead.


### PR DESCRIPTION
PCX, please do correct my grammar and language as needed.

Context: Customer Support get a lot of cases where customers try to troubleshoot request header modification rules using their browser, which does not logically make sense since request header rules apply to Edge->Origin and not involved in the browser.

This aims to fix that. I am aware this troubleshooting section is not supposed to be an FAQ but it felt like the best place to put this. Feel free to reword the heading if it doesn't make sense.