### PR TITLE
add note regarding `getPlatformProxy`'s persist option compared to `--persist-to`

### DIFF
--- a/content/workers/_partials/_ai-local-usage-charges.md
+++ b/content/workers/_partials/_ai-local-usage-charges.md
@@ -7,6 +7,6 @@ _build:
 
 {{<Aside type="note" header="Workers AI local development usage charges">}}
 
-Using Workers AI always accesses your Cloudflare account in order to run AI models, and will incur usage charges even in local development.
+Using Workers AI always accesses your Cloudflare account in order to run AI models and will incur usage charges even in local development.
 
 {{</Aside>}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -25,7 +25,7 @@ By default, `unstable_dev` will perform integration tests against a local server
 
 The `unstable_dev()` function has an `unstable_` prefix because the API may change in the future.
 
-There are no known bugs at the moment and it is safe to use. If you discover any bugs, open a [GitHub Issue](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+`unstable_dev()` no known bugs at the moment and is safe to use. If you discover any bugs, open a [GitHub Issue](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 
 
 {{</Aside>}}

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -25,7 +25,7 @@ By default, `unstable_dev` will perform integration tests against a local server
 
 The `unstable_dev()` function has an `unstable_` prefix because the API may change in the future.
 
-There are no known bugs at the moment and it is safe to use. If you discover any bugs, please open a [GitHub Issue](https://github.com/cloudflare/workers-sdk/issues/new/choose) and we will review the issue.
+There are no known bugs at the moment and it is safe to use. If you discover any bugs, open a [GitHub Issue](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 
 
 {{</Aside>}}
@@ -258,6 +258,7 @@ const platform = await getPlatformProxy(options);
 *   `options` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
     *   Optional options object containing preferences for the bindings:
+
         * `configPath` {{<type>}}string{{</type>}}
 
           The path to the configuration object to use (default `wrangler.toml`).
@@ -269,8 +270,8 @@ const platform = await getPlatformProxy(options);
         * `persist` {{<type>}}boolean | { path: string }{{</type>}}
 
           Indicates if and where to persist the bindings data. If not present or `true`, defaults to the same location used by Wrangler, so data can be shared between it and the caller. If `false`, no data is persisted to or read from the filesystem.
-
-          _Note_: If use `wrangler`'s `--persist-to` option please keep in mind that such option adds a sub directory called `v3` under the hood while `getPlatformProxy`'s `persist` does not. So for example if you run `wrangler dev --persist-to ./my-directory`, in order to reuse the same location using `getPlatformProxy` you'll have to specify: `persist: "./my-directory/v3"`.
+          
+          **Note:** If you use `wrangler`'s `--persist-to` option, note that this option adds a sub directory called `v3` under the hood while `getPlatformProxy`'s `persist` does not. For example, if you run `wrangler dev --persist-to ./my-directory`, to reuse the same location using `getPlatformProxy`, you will have to specify: `persist: "./my-directory/v3"`.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -270,6 +270,8 @@ const platform = await getPlatformProxy(options);
 
           Indicates if and where to persist the bindings data. If not present or `true`, defaults to the same location used by Wrangler, so data can be shared between it and the caller. If `false`, no data is persisted to or read from the filesystem.
 
+          _Note_: If use `wrangler`'s `--persist-to` option please keep in mind that such option adds a sub directory called `v3` under the hood while `getPlatformProxy`'s `persist` does not. So for example if you run `wrangler dev --persist-to ./my-directory`, in order to reuse the same location using `getPlatformProxy` you'll have to specify: `persist: "./my-directory/v3"`.
+
 {{</definitions>}}
 
 ### Return Type


### PR DESCRIPTION
add a note in the `getPlatformProxy` docs clarifying that it does not add a `v3` sub directory as `wrangler` does

___

as suggested here: https://github.com/cloudflare/next-on-pages/issues/603#issuecomment-1873476287