### PR TITLE
[Pages] Improve redirect example for URL fragments

### DIFF
--- a/content/pages/configuration/redirects.md
+++ b/content/pages/configuration/redirects.md
@@ -58,7 +58,7 @@ filename: _redirects
 /twitch https://twitch.tv
 /trailing /trailing/ 301
 /notrailing/ /nottrailing 301
-/page/ /page/#fragment 301
+/page/ /page2/#fragment 301
 /blog/* https://blog.my.domain/:splat
 /products/:code/:name /products?code=:code&name=:name
 ```


### PR DESCRIPTION
`/page/ /page/#fragment 301` is a poor example since the resulting `#fragment` won't be sent to the server and it will result in an infinite loop.
Making the paths be different improves the example and still demonstrates the same point.

https://discord.com/channels/595317990191398933/789155108529111069/1209416499299618856