### PR TITLE
[Images] Clarify when "quality" and "onerror" is supported

### DIFF
--- a/content/images/_partials/_supported-properties.md
+++ b/content/images/_partials/_supported-properties.md
@@ -479,7 +479,7 @@ cf: {image: {onerror: "redirect"}}
 
 #### `quality`
 
-{{<Aside type="note" header="Note">}}At the moment, this setting only works directly with [image transformations](/images/transform-images/)..{{</Aside>}}
+{{<Aside type="note" header="Note">}}At the moment, this setting only works directly with [image transformations](/images/transform-images/).{{</Aside>}}
 
 Specifies quality for images in JPEG, WebP, and AVIF formats. The quality is in a 1-100 scale, but useful values are between `50` (low quality, small file size) and `90` (high quality, large file size). `85` is the default. When using the PNG format, an explicit quality setting allows use of PNG8 (palette) variant of the format. Example:
 

--- a/content/images/_partials/_supported-properties.md
+++ b/content/images/_partials/_supported-properties.md
@@ -479,7 +479,7 @@ cf: {image: {onerror: "redirect"}}
 
 #### `quality`
 
-{{<Aside type="note" header="Note">}}At the moment, this setting is ignored by Cloudflare Images.{{</Aside>}}
+{{<Aside type="note" header="Note">}}At the moment, this setting only works directly with [image transformations](/images/transform-images/)..{{</Aside>}}
 
 Specifies quality for images in JPEG, WebP, and AVIF formats. The quality is in a 1-100 scale, but useful values are between `50` (low quality, small file size) and `90` (high quality, large file size). `85` is the default. When using the PNG format, an explicit quality setting allows use of PNG8 (palette) variant of the format. Example:
 

--- a/content/images/_partials/_supported-properties.md
+++ b/content/images/_partials/_supported-properties.md
@@ -459,7 +459,7 @@ Options are:
 
 #### `onerror=redirect`
 
-{{<Aside type="note" header="Note">}}At the moment, this setting is ignored by Cloudflare Images.{{</Aside>}}
+{{<Aside type="note" header="Note">}}At the moment, this setting only works directly with [image transformations](/images/transform-images/).{{</Aside>}}
 
 In case of a fatal error that prevents the image from being resized, redirects to the unresized source image URL. This may be useful in case some images require user authentication and cannot be fetched anonymously via Worker. This option should not be used if there is a chance the source image is very large. This option is ignored if the image is from another domain, but you can use it with subdomains. Example:
 


### PR DESCRIPTION
This makes it more in line with the other similar note on the page, and is more specific since Images and Image Resizing merged.