### PR TITLE
[R2] Update public-buckets.md with Zone Hold advisory

### DIFF
--- a/content/r2/buckets/public-buckets.md
+++ b/content/r2/buckets/public-buckets.md
@@ -61,7 +61,7 @@ To view the added DNS record, select *...* next to the connected domain and sele
 
 {{<Aside type="note">}}
 
-If the zone is on the Enterprise plan, make sure that you [release the zone hold](/fundamentals/setup/account/account-security/zone-holds/#release-zone-holds) before adding the custom domain. A zone hold would prevent the custom subdomain from activating.
+If the zone is on an Enterprise plan, make sure that you [release the zone hold](/fundamentals/setup/account/account-security/zone-holds/#release-zone-holds) before adding the custom domain. A zone hold would prevent the custom subdomain from activating.
 
 {{</Aside>}}
 

--- a/content/r2/buckets/public-buckets.md
+++ b/content/r2/buckets/public-buckets.md
@@ -59,6 +59,12 @@ Your domain is now connected. The status takes a few minutes to change from **In
 
 To view the added DNS record, select *...* next to the connected domain and select **Manage DNS**.
 
+{{<Aside type="note">}}
+
+If the zone is on the Enterprise plan, make sure that you [release the zone hold](/fundamentals/setup/account/account-security/zone-holds/#release-zone-holds) before adding the custom domain. A zone hold would prevent the custom subdomain from activating.
+
+{{</Aside>}}
+
 ### Restrictions
 
 There are a few restrictions when using custom domains to access R2 buckets.


### PR DESCRIPTION
Enterprise zones would have Zone Hold enabled by default. This would prevent the activation of the Custom Domain.