### PR TITLE
Add edgeworker release notes for release 2024.2.400

### DIFF
--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -2,6 +2,10 @@
 link: "/workers/platform/changelog/"
 productName: Workers
 entries:
+- publish_date: '2024-02-23'
+  description: |-
+    - Sockets now support an [`opened`](/workers/runtime-apis/tcp-sockets/#socket) attribute.
+    - [Durable Object alarm handlers](/durable-objects/api/alarms/#alarm) now impose a maximum wall time of 15 minutes.
 - publish_date: '2023-12-04'
   description: |-
     - The Web Platform standard [`navigator.sendBeacon(...)` API](/workers/runtime-apis/web-standards#navigatorsendbeaconurl-data) is now provided by the Workers runtime.

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -5,7 +5,7 @@ entries:
 - publish_date: '2024-02-23'
   description: |-
     - Sockets now support an [`opened`](/workers/runtime-apis/tcp-sockets/#socket) attribute.
-    - [Durable Object alarm handlers](/durable-objects/api/alarms/#alarm) now impose a maximum wall-clock time of 15 minutes.
+    - [Durable Object alarm handlers](/durable-objects/api/alarms/#alarm) now impose a maximum wall time of 15 minutes.
 - publish_date: '2023-12-04'
   description: |-
     - The Web Platform standard [`navigator.sendBeacon(...)` API](/workers/runtime-apis/web-standards#navigatorsendbeaconurl-data) is now provided by the Workers runtime.

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -5,7 +5,7 @@ entries:
 - publish_date: '2024-02-23'
   description: |-
     - Sockets now support an [`opened`](/workers/runtime-apis/tcp-sockets/#socket) attribute.
-    - [Durable Object alarm handlers](/durable-objects/api/alarms/#alarm) now impose a maximum wall time of 15 minutes.
+    - [Durable Object alarm handlers](/durable-objects/api/alarms/#alarm) now impose a maximum wall-clock time of 15 minutes.
 - publish_date: '2023-12-04'
   description: |-
     - The Web Platform standard [`navigator.sendBeacon(...)` API](/workers/runtime-apis/web-standards#navigatorsendbeaconurl-data) is now provided by the Workers runtime.


### PR DESCRIPTION
Opening this up now to get eyes on it and amend the release notes.

We shouldn't merge until edgeworker-debug has been released.