### PR TITLE
Remove compatibility checkmark for Microsoft Endpoint Manager & Linux

### DIFF
--- a/content/cloudflare-one/identity/devices/service-providers/_index.md
+++ b/content/cloudflare-one/identity/devices/service-providers/_index.md
@@ -15,7 +15,7 @@ Service-to-service integrations allow the WARP client to get device posture data
 | ---------------------| ----- | ------- | ----- | --- | ---------------- |
 | [Crowdstrike](/cloudflare-one/identity/devices/service-providers/crowdstrike/) | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [Kolide](/cloudflare-one/identity/devices/service-providers/kolide/) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| [Microsoft Endpoint Manager](/cloudflare-one/identity/devices/service-providers/microsoft/) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| [Microsoft Endpoint Manager](/cloudflare-one/identity/devices/service-providers/microsoft/) | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [SentinelOne](/cloudflare-one/identity/devices/service-providers/sentinelone/) | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [Uptycs](/cloudflare-one/identity/devices/service-providers/uptycs/) | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [Workspace ONE](/cloudflare-one/identity/devices/service-providers/workspace-one/) | ✅ | ✅ | ✅ | ❌ | ❌ |


### PR DESCRIPTION
PCX-9936

Due to a limitation on Microsoft's end, the Microsoft Endpoint Manager S2S integration isn't compatible with Linux devices.