### PR TITLE
Be explicit about edge runtime in next.js docs

### DIFF
--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -313,7 +313,7 @@ If you are using the Pages router, for page routes, you need to use `'experiment
 
 #### Not found
 
-Next.js generates a not-found route for your application under the hood during the build process. In some circumstances Next.js can detect that the route requires server side logic (particularly if computation is being performed in the root layout component) and it might create a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
+Next.js generates a `not-found` route for your application under the hood during the build process. In some circumstances, Next.js can detect that the route requires server-side logic (particularly if computation is being performed in the root layout component) and Next.js might create a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
 
 To prevent this incompatibility, Cloudflare recommends to always provide a custom `not-found` route which explicitly opts in the edge runtime:
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -299,13 +299,13 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 ### Edge runtime
 
-All the server-side routes in your Next.js project must be configured as "Edge" runtime routes.
+All server-side routes in your Next.js project must be configured as "Edge" runtime routes, when running on Cloudflare Pages. You must add `export const runtime = 'edge';` to each individual server-side route.
 
 In order to do that remember to add `export const runtime = 'edge';` to each individual server-side route.
 
 {{<Aside type="note">}}
 
-If you're using the Pages router, for page routes you need to use `'experimental-edge'` instead of `'edge'`.
+If you are using the Pages router, for page routes, you need to use `'experimental-edge'` instead of `'edge'`.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -298,6 +298,6 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 ### Troubleshooting
 
-- All server-side routes in your Next.js project must be configured as "Edge" runtime routes, by adding `export const runtime = 'edge';` to each individual route. Refer to the [`next-on-pages` docs](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md) for more examples. If you see the error `failed to retrieve the Cloudflare request context` — try adding this to your route.
+- All server-side routes in your Next.js project must be configured as "Edge" runtime routes, by adding `export const runtime = 'edge';` to each individual route. Refer to the [`next-on-pages` docs](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md) for more examples.
 - `next-on-pages` documents other common issues [here](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/gotchas.md).
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -9,7 +9,7 @@ meta:
 
 [Next.js](https://nextjs.org) is an open-source React framework for creating websites and applications. In this guide, you will create a new Next.js application and deploy it using Cloudflare Pages.
 
-This guide will instruct you how to deploy a full-stack Next.js project which uses the [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge).
+This guide will instruct you how to deploy a full-stack Next.js project which uses the [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge), via the [`next-on-pages`](https://github.com/cloudflare/next-on-pages/tree/main/packages/next-on-pages/docs) adapter.
 
 ## Create a new project using the `create-cloudflare` CLI (C3)
 
@@ -200,6 +200,8 @@ highlight: [1, 7]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
 
+export const runtime = 'edge';
+
 // ...
 
 export async function GET(request) {
@@ -222,6 +224,8 @@ filename: app/api/hello/route.ts
 highlight: [1, 7]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
+
+export const runtime = 'edge';
 
 // ...
 
@@ -291,3 +295,9 @@ The [`wrangler pages dev`](/workers/wrangler/commands/#dev-1) command needs to r
 After you have previewed your application locally, you can deploy it to Cloudflare Pages (both via [Direct Uploads](/pages/get-started/direct-upload/) or [Git integration](/pages/configuration/git-integration/)) and iterate over the process to make new changes.
 
 {{<render file="/_framework-guides/_learn-more.md" withParameters="Next.js">}}
+
+### Troubleshooting
+
+- All server-side routes in your Next.js project must be configured as "Edge" runtime routes, by adding `export const runtime = 'edge';` to each individual route. Refer to the [`next-on-pages` docs](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md) for more examples.
+- `next-on-pages` documents other common issues [here](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/gotchas.md).
+

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -315,7 +315,7 @@ If you're using the Pages router, for page routes you need to use `'experimental
 
 Next.js generates a not-found route for your application under the hood during the build process. In some circumstances Next.js can detect that the route requires server side logic (particularly if computation is being performed in the root layout component) and it might create a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
 
-To prevent such problem we recommend to always provide a custom not-found route which explicitly opts in the edge runtime:
+To prevent this incompatibility, Cloudflare recommends to always provide a custom `not-found` route which explicitly opts in the edge runtime:
 
 ```ts
 ---
@@ -334,13 +334,13 @@ export default async function NotFound() {
 
 {{<Aside type="note">}}
 
-Projects created with C3 have a default custom not-found page already created for them.
+Projects created with C3 have a default custom `not-found` page already created for them.
 
 {{</Aside>}}
 
 #### `generateStaticParams`
 
-When doing static site generation (SSG) in the app directory and using the [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) utility, Next.js by default tries to handle requests for non statically generated routes on-demand. It does so by creating a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
+When doing static site generation (SSG) in the [`/app` directory](https://nextjs.org/docs/getting-started/project-structure) and using the [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) function, Next.js by default tries to handle requests for non statically generated routes on-demand. It does so by creating a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
 
 In such cases you need to instruct Next.js not to do so by specifying a `false` [`dynamicParams`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams):
 
@@ -357,9 +357,9 @@ filename: app/my-example-page/[slug]/page.jsx
 
 #### `getStaticPaths`
 
-When doing static site generation (SSG) in the pages directory and using the [`getStaticPaths`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths) utility, Next.js by default tries to handle requests for non statically generated routes on-demand. It does so by creating a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
+When doing static site generation (SSG) in the [`/pages`](https://nextjs.org/docs/getting-started/project-structure) directory and using the [`getStaticPaths`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths) function, Next.js by default tries to handle requests for non statically generated routes on-demand. It does so by creating a Node.js serverless function (which, as such, is incompatible with `@cloudflare/next-on-pages`).
 
-In such cases you need to instruct Next.js not to do so by specifying a [false `fallback`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-false):
+In such cases, you need to instruct Next.js not to do so by specifying a [false `fallback`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-false):
 
 ```diff
 ---
@@ -379,7 +379,7 @@ export async function getStaticPaths() {
 
 {{<Aside type="warning">}}
 
-Note that the `paths` array cannot be empty as that causes Next.js to ignore the provided `fallback` value, so make sure that at build time at least one entry is present in the array
+The `paths` array cannot be empty. An empty `paths` array causes Next.js to ignore the provided `fallback` value. At build time, make sure that at least one entry is present in the array.
 
 {{</Aside>}}
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -294,9 +294,8 @@ The [`wrangler pages dev`](/workers/wrangler/commands/#dev-1) command needs to r
 
 After you have previewed your application locally, you can deploy it to Cloudflare Pages (both via [Direct Uploads](/pages/get-started/direct-upload/) or [Git integration](/pages/configuration/git-integration/)) and iterate over the process to make new changes.
 
-## Gotchas
+## Debugging
 
-Let's explore some common pitfalls that you can encounter why developing a Next.js fullstack application for Cloudflare Pages.
 
 ### Edge runtime
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -301,7 +301,6 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 All server-side routes in your Next.js project must be configured as "Edge" runtime routes, when running on Cloudflare Pages. You must add `export const runtime = 'edge';` to each individual server-side route.
 
-In order to do that remember to add `export const runtime = 'edge';` to each individual server-side route.
 
 {{<Aside type="note">}}
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -298,6 +298,6 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 ### Troubleshooting
 
-- All server-side routes in your Next.js project must be configured as "Edge" runtime routes, by adding `export const runtime = 'edge';` to each individual route. Refer to the [`next-on-pages` docs](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md) for more examples.
+- All server-side routes in your Next.js project must be configured as "Edge" runtime routes, by adding `export const runtime = 'edge';` to each individual route. Refer to the [`next-on-pages` docs](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/examples.md) for more examples. If you see the error `failed to retrieve the Cloudflare request context` — try adding this to your route.
 - `next-on-pages` documents other common issues [here](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/gotchas.md).
 


### PR DESCRIPTION
refs PAGES-3514

- Adds `export const runtime = 'edge` back into example code
- Links explicitly to `next-on-pages` docs at top of these docs, to make `next-on-pages` documentation discoverable
- Adds Troubleshooting section that explicitly calls out need to include `export const runtime = 'edge'`