### PR TITLE
add compatibility_date to wfp metadata example

### DIFF
--- a/content/cloudflare-for-platforms/workers-for-platforms/reference/metadata.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/reference/metadata.md
@@ -80,6 +80,9 @@ At a minimum, the `main_module` key is required to publish a user Worker.
 
   - The path to the module entry point of the user Worker that will be executed. For example, `main.js`.
 
+- `compatibility_date` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - A date in the form yyyy-mm-dd, which will be used to determine which version of the Workers runtime is used for the user Worker. Refer to (Compatibility dates)[https://developers.cloudflare.com/workers/configuration/compatibility-dates/].
 
 - `bindings` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 

--- a/content/cloudflare-for-platforms/workers-for-platforms/reference/metadata.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/reference/metadata.md
@@ -82,7 +82,7 @@ At a minimum, the `main_module` key is required to publish a user Worker.
 
 - `compatibility_date` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - A date in the form yyyy-mm-dd, which will be used to determine which version of the Workers runtime is used for the user Worker. Refer to (Compatibility dates)[https://developers.cloudflare.com/workers/configuration/compatibility-dates/].
+  - A date in the form yyyy-mm-dd, which will be used to determine which version of the Workers runtime is used for the user Worker. Refer to [Compatibility dates](https://developers.cloudflare.com/workers/configuration/compatibility-dates/).
 
 - `bindings` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 


### PR DESCRIPTION
Currently compatibility_date is missing as a configuration option in the Workers for Platforms documentation.  Adds it below the json example as an optional attribute.

This caused me issues when trying to use `ReadableStream()`.  Even though my `compatibility_date` was set for my WFP codebase, I was not setting it for the user workers (and it is not a required metadata property), so that feature was not working, and I spent a long time trying to figure out how I could even set that attribute.

Uses the same description for `compatibility_date` found here:
https://developers.cloudflare.com/workers/wrangler/configuration/#inheritable-keys