### PR TITLE
Update CODEOWNERS for pages framework guides

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@
 /content/workers/reference/migrate-to-module-workers/ @irvinebroque @cloudflare/pcx-technical-writing
 /content/workers/reference/security-model/ @irvinebroque @cloudflare/pcx-technical-writing
 /content/workers/_partials/_platform-compatibility-dates/ @irvinebroque @kflansburg @cloudflare/pcx-technical-writing
+/content/pages/framework-guides/ @igorminar @dario-piotrowicz @cloudflare/pcx-technical-writing
 
 # Firewall Rules & WAF
 /content/firewall/ @cloudflare/firewall @cloudflare/pcx-technical-writing


### PR DESCRIPTION
Adds @IgorMinar and @dario-piotrowicz as codeowners. Ensures we can get docs changes out fast. If we need to create a team in the Github org for this we can.

refs https://github.com/cloudflare/cloudflare-docs/pull/13141