### PR TITLE
Document same zone worker-to-worker limitation

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -168,6 +168,12 @@ Use the [TransformStream API](/workers/runtime-apis/streams/transformstream/) to
 
 A subrequest is any request that a Worker makes to another Internet resource using the [Fetch API](/workers/runtime-apis/fetch/).
 
+### Can I make subrequests from my Worker to another Worker on my account?
+
+To make subrequests from your Worker to another Worker on your account, use [Service Bindings](/workers/configuration/bindings/about-service-bindings/). Service bindings allow you to send HTTP requests to another Worker without those requests going over the Internet.
+
+If you attempt to use global `fetch()` to make a subrequest to another Worker on your account that runs on the same [zone](https://developers.cloudflare.com/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
+
 ### How many subrequests can I make?
 
 The limit for subrequests a Worker can make is 50 per request on the Bundled usage model or 1,000 per request on the Unbound usage model. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -174,6 +174,7 @@ To make subrequests from your Worker to another Worker on your account, use [Ser
 
 If you attempt to use global [`fetch()`](/workers/runtime-apis/fetch/) to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
 
+If you make a subrequest from your Worker to a target Worker that runs on a [Custom Domain](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/#worker-to-worker-communication) rather than a route, the request will be allowed.
 ### How many subrequests can I make?
 
 The limit for subrequests a Worker can make is 50 per request on the Bundled usage model or 1,000 per request on the Unbound usage model. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -172,7 +172,7 @@ A subrequest is any request that a Worker makes to another Internet resource usi
 
 To make subrequests from your Worker to another Worker on your account, use [Service Bindings](/workers/configuration/bindings/about-service-bindings/). Service bindings allow you to send HTTP requests to another Worker without those requests going over the Internet.
 
-If you attempt to use global `fetch()` to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
+If you attempt to use global [`fetch()`](/workers/runtime-apis/fetch/) to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
 
 ### How many subrequests can I make?
 

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -172,7 +172,7 @@ A subrequest is any request that a Worker makes to another Internet resource usi
 
 To make subrequests from your Worker to another Worker on your account, use [Service Bindings](/workers/configuration/bindings/about-service-bindings/). Service bindings allow you to send HTTP requests to another Worker without those requests going over the Internet.
 
-If you attempt to use global `fetch()` to make a subrequest to another Worker on your account that runs on the same [zone](https://developers.cloudflare.com/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
+If you attempt to use global `fetch()` to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
 
 ### How many subrequests can I make?
 

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -168,13 +168,14 @@ Use the [TransformStream API](/workers/runtime-apis/streams/transformstream/) to
 
 A subrequest is any request that a Worker makes to another Internet resource using the [Fetch API](/workers/runtime-apis/fetch/).
 
-### Can I make subrequests from my Worker to another Worker on my account?
+### Worker-to-Worker subrequests
 
 To make subrequests from your Worker to another Worker on your account, use [Service Bindings](/workers/configuration/bindings/about-service-bindings/). Service bindings allow you to send HTTP requests to another Worker without those requests going over the Internet.
 
-If you attempt to use global [`fetch()`](/workers/runtime-apis/fetch/) to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
+If you attempt to use global [`fetch()`](/workers/runtime-apis/fetch/) to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without service bindings, the request will fail.
 
 If you make a subrequest from your Worker to a target Worker that runs on a [Custom Domain](/workers/configuration/routing/custom-domains/#worker-to-worker-communication) rather than a route, the request will be allowed.
+
 ### How many subrequests can I make?
 
 The limit for subrequests a Worker can make is 50 per request on the Bundled usage model or 1,000 per request on the Unbound usage model. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -174,7 +174,7 @@ To make subrequests from your Worker to another Worker on your account, use [Ser
 
 If you attempt to use global [`fetch()`](/workers/runtime-apis/fetch/) to make a subrequest to another Worker on your account that runs on the same [zone](/fundamentals/setup/accounts-and-zones/#zones), without Service Bindings, the request will fail.
 
-If you make a subrequest from your Worker to a target Worker that runs on a [Custom Domain](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/#worker-to-worker-communication) rather than a route, the request will be allowed.
+If you make a subrequest from your Worker to a target Worker that runs on a [Custom Domain](/workers/configuration/routing/custom-domains/#worker-to-worker-communication) rather than a route, the request will be allowed.
 ### How many subrequests can I make?
 
 The limit for subrequests a Worker can make is 50 per request on the Bundled usage model or 1,000 per request on the Unbound usage model. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.


### PR DESCRIPTION
Some of this is already documented on the Custom Domains docs page. But needs to be discoverable in some form on the limits page, since this is where people expect to find it.