### PR TITLE
[QUEUES] Document queues_json_messages runtime compatibility flag

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
+++ b/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
@@ -1,0 +1,14 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Queues send messages in `JSON` format"
+sort_date: "2024-03-04"
+enable_date: "2024-03-04"
+enable_flag: "queues_json_messages"
+disable_flag: "no_queues_json_messages"
+---
+
+With the `queues_json_messages` flag set, Queue bindings will serialize values passed to `send()` or `sendBatch()` into JSON format by default (when no specific `contentType` is provided).


### PR DESCRIPTION
**Note**: Merge only on or after `2024-03-04`

Adds docs for the new compatibility flag and behavior change for Queues messages.