### PR TITLE
[Pages] Document changing Direct Upload production branch with the API

### DIFF
--- a/content/pages/get-started/direct-upload.md
+++ b/content/pages/get-started/direct-upload.md
@@ -132,7 +132,6 @@ After you have your project created, select **Create a new deployment** to begin
 
 {{</table-wrap>}}
 
-
 If using the drag and drop method, a red warning symbol will appear next to an asset if too large and thus unsuccessfully uploaded. In this case, you may choose to delete that asset but you cannot replace it. In order to do so, you must reupload the entire project.
 
 {{<Aside type="warning">}}

--- a/content/pages/get-started/direct-upload.md
+++ b/content/pages/get-started/direct-upload.md
@@ -136,10 +136,10 @@ If using the drag and drop method, a red warning symbol will appear next to an a
 
 {{<Aside type="warning">}}
 
-Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard. However, this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
+Pages projects configured with Direct Upload currently cannot have their production branch changed through the Cloudflare dashboard. However, this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
 
 ```sh
-$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \
+$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/{account_id}/pages/projects/{project_name} \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <API_TOKEN>' \
  --data '{ "production_branch": "<PROD_BRANCH_NAME>" }'

--- a/content/pages/get-started/direct-upload.md
+++ b/content/pages/get-started/direct-upload.md
@@ -132,7 +132,21 @@ After you have your project created, select **Create a new deployment** to begin
 
 {{</table-wrap>}}
 
+
 If using the drag and drop method, a red warning symbol will appear next to an asset if too large and thus unsuccessfully uploaded. In this case, you may choose to delete that asset but you cannot replace it. In order to do so, you must reupload the entire project.
+
+{{<Aside type="warning">}}
+
+Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
+
+```sh
+$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \
+ --header 'Content-Type: application/json' \
+ --header 'Authorization: Bearer <API_TOKEN>' \
+ --data '{ "production_branch": "<PROD_BRANCH_NAME>" }'
+```
+
+{{</Aside>}}
 
 ### Functions
 

--- a/content/pages/get-started/direct-upload.md
+++ b/content/pages/get-started/direct-upload.md
@@ -136,7 +136,7 @@ If using the drag and drop method, a red warning symbol will appear next to an a
 
 {{<Aside type="warning">}}
 
-Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
+Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard. However, this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
 
 ```sh
 $ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \

--- a/content/pages/platform/known-issues.md
+++ b/content/pages/platform/known-issues.md
@@ -20,6 +20,15 @@ Here are some known bugs and issues with Cloudflare Pages:
 
 - Commits/PRs from forked repositories will not create a preview. Support for this will come in the future.
 
+- Projects configured for [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare Dashboard, however this can be changed using the [Update project](https://developers.cloudflare.com/api/operations/pages-project-update-project) API endpoint:
+
+```sh
+$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_IDENTIFIER_HERE/pages/projects/<PROJECT_NAME> \
+ --header 'Content-Type: application/json' \
+ --header 'Authorization: Bearer <API_TOKEN>' \
+ --data '{ "production_branch": "<PROD_BRANCH_NAME>" }'
+```
+
 ## Git configuration
 
 - After you have selected a GitHub/GitLab repository for your Pages application, it cannot be changed. Delete your Pages project and create a new one pointing at a different repository if you need to update it.

--- a/content/pages/platform/known-issues.md
+++ b/content/pages/platform/known-issues.md
@@ -23,7 +23,7 @@ Here are some known bugs and issues with Cloudflare Pages:
 - Projects configured for [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare Dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
 
 ```sh
-$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_IDENTIFIER_HERE/pages/projects/<PROJECT_NAME> \
+$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <API_TOKEN>' \
  --data '{ "production_branch": "<PROD_BRANCH_NAME>" }'

--- a/content/pages/platform/known-issues.md
+++ b/content/pages/platform/known-issues.md
@@ -20,15 +20,6 @@ Here are some known bugs and issues with Cloudflare Pages:
 
 - Commits/PRs from forked repositories will not create a preview. Support for this will come in the future.
 
-- Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
-
-```sh
-$ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \
- --header 'Content-Type: application/json' \
- --header 'Authorization: Bearer <API_TOKEN>' \
- --data '{ "production_branch": "<PROD_BRANCH_NAME>" }'
-```
-
 ## Git configuration
 
 - After you have selected a GitHub/GitLab repository for your Pages application, it cannot be changed. Delete your Pages project and create a new one pointing at a different repository if you need to update it.

--- a/content/pages/platform/known-issues.md
+++ b/content/pages/platform/known-issues.md
@@ -20,7 +20,7 @@ Here are some known bugs and issues with Cloudflare Pages:
 
 - Commits/PRs from forked repositories will not create a preview. Support for this will come in the future.
 
-- Projects configured for [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare Dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
+- Projects configured with [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
 
 ```sh
 $ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/<YOUR_ACCOUNT_IDENTIFIER_HERE>/pages/projects/<PROJECT_NAME> \

--- a/content/pages/platform/known-issues.md
+++ b/content/pages/platform/known-issues.md
@@ -20,7 +20,7 @@ Here are some known bugs and issues with Cloudflare Pages:
 
 - Commits/PRs from forked repositories will not create a preview. Support for this will come in the future.
 
-- Projects configured for [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare Dashboard, however this can be changed using the [Update project](https://developers.cloudflare.com/api/operations/pages-project-update-project) API endpoint:
+- Projects configured for [Direct Upload](/pages/get-started/direct-upload/) currently cannot have their production branch changed through the Cloudflare Dashboard, however this can be changed using the [Update project](/api/operations/pages-project-update-project) API endpoint:
 
 ```sh
 $ curl --request PATCH --url https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_IDENTIFIER_HERE/pages/projects/<PROJECT_NAME> \


### PR DESCRIPTION
Frequently comes up in Support tickets, included a working curl example like the ones we share with customers.