### PR TITLE
[Workers KV] Normalized KV docs and improved structure

### DIFF
--- a/content/kv/api/_index.md
+++ b/content/kv/api/_index.md
@@ -6,4 +6,19 @@ weight: 3
 
 # API
 
+All of the actions available in the Javascript API:
+
 {{<directory-listing>}}
+
+To use the API, you need to use the {{<glossary-tooltip term_id="KV namespace">}}KV namespace{{</glossary-tooltip>}} like this:
+
+```js
+export default {
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.list();
+    // ...
+  },
+};
+```
+
+Read the [Get Started](https://developers.cloudflare.com/kv/get-started/) guide to know how ot set up the KV namespace.

--- a/content/kv/api/delete-key-value-pairs.md
+++ b/content/kv/api/delete-key-value-pairs.md
@@ -6,14 +6,39 @@ weight: 7
 
 # Delete key-value pairs
 
-To delete a key-value pair, call the `delete()` method on any {{<glossary-tooltip term_id="KV namespace">}}KV namespace{{</glossary-tooltip>}} you have bound to your Worker code:
+To delete a key-value pair call the `delete()` method:
 
 ```js
 await env.NAMESPACE.delete(key);
 ```
 
-Calling the `delete()` method will remove the key and value from your KV namespace. As with any operations, it may take some time for the key to be deleted from various points in the Cloudflare global network.
+If the key is not found, the promise will resolve and nothing will happen.
 
-This method returns a promise that you should `await` on to verify successful deletion.
+```js
+export default {
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.delete('first-key');
+    // ...
+  },
+};
+```
 
 You can also [delete key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#delete) or [via the API](/api/operations/workers-kv-namespace-delete-key-value-pair).
+
+{{<Aside type="note">}} 
+Changes might take up to 60 seconds to [propagate throught the Cloudflare Network](/kv/reference/how-kv-works/), but will be consistent within the same location after `await` completes.
+{{</Aside>}}
+
+## Parameters
+
+```js
+.delete(key)
+```
+
+{{<definitions>}}
+
+- `key` {{<type>}}string{{</type>}}
+
+  - The key to associate with the value. A key cannot be empty, have a `.` or `..`. All other keys are valid. Keys have a maximum length of 512 bytes.
+
+{{</definitions>}}

--- a/content/kv/api/list-keys.md
+++ b/content/kv/api/list-keys.md
@@ -6,37 +6,68 @@ weight: 7
 
 # List keys
 
-Use a list operation to view all the keys that live in a given KV namespace.
+To get the list of the keys call the `list()` method:
 
-An example:
+```js
+const results = await env.NAMESPACE.list(options?);
+```
 
 ```js
 export default {
   async fetch(request, env, ctx) {
     const value = await env.NAMESPACE.list();
-
-    return new Response(value.keys);
+    // ...
   },
 };
 ```
 
 You can also [list keys on the command line with Wrangler](/kv/reference/kv-commands/#list) or [via the API](/api/operations/workers-kv-namespace-list-a-namespace'-s-keys).
 
-Changes may take up to 60 seconds to be reflected on the application calling the method on the KV namespace.
+{{<Aside type="note">}} 
+This method may return stale values, since changes in any location might take up to 60 seconds to [propagate throught the Cloudflare Network](/kv/reference/how-kv-works/).
+{{</Aside>}}
 
-## `list()` method
+## Parameters
 
-The `list()` method has this signature:
-
-```ts
-NAMESPACE.list({prefix?: string, limit?: number, cursor?: string})
+```js
+.list({ prefix, limit, cursor })
 ```
 
-All arguments are optional:
+{{<definitions>}}
 
-- `prefix` is a `string` that represents a prefix you can use to filter all keys.
-- `limit` is the maximum number of keys returned. The default is 1,000, which is the maximum. It is unlikely that you will want to change this default but it is included for completeness.
-- `cursor` is a `string` used for paginating responses.
+- `prefix` {{<type>}}string{{</type>}}
+
+  - Represents a filter that will find all of the keys that start with the given "prefix". It cannot have a `.` or `..`. All other keys are valid. Keys have a maximum length of 512 bytes.
+
+- `limit` {{<type>}}number{{</type>}}
+
+  - The maximum amount of keys to return. The default is 1,000, which is also the maximum. It is unlikely that you will want to change this default but it is included for completeness.
+
+- `cursor` {{<type>}}string{{</type>}}
+
+  - Used for pagination purposes, give the cursor and the results returned will start from that record.
+
+{{</definitions>}}
+
+### Prefix
+
+List all the keys starting with a particular prefix. 
+
+For example, you may have structured your keys with a user, a user ID, and key names, separated by colons (such as `user:1:<key>`). You could get the keys for user number one by using the following code:
+
+```js
+export default {
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.list({ prefix: "user:1:" });
+    return new Response(value.keys);
+  },
+};
+```
+
+This will return all keys starting with the `"user:1:"` prefix.
+
+
+## Output
 
 The `list()` method returns a promise which resolves with an object that looks like the following:
 
@@ -60,30 +91,13 @@ The `name` is a `string`, the `expiration` value is a number, and `metadata` is 
 
 If `list_complete` is `false`, there are more keys to fetch, even if the `keys` array is empty. You will use the `cursor` property to get more keys. Refer to [Pagination](#pagination) for more details.
 
-Consider storing your values in metadata if your values fit in the [metadata-size limit](/kv/platform/limits/). Storing values in metadata is more efficient than a `list()` followed by a `get()` per key. When using `put()`, leave the `value` parameter empty and instead include a property in the metadata object:
+Consider storing your values [in metadata](/kv/api/write-key-value-pairs/#metadata) if your values fit in the [metadata-size limit](/kv/platform/limits/). Storing values in metadata is more efficient than a `list()` followed by a `get()` per key. When using `put()`, leave the `value` parameter empty and instead include a property in the metadata object:
 
 ```js
-await NAMESPACE.put(key, "", {
+await env.NAMESPACE.put(key, "", {
   metadata: { value: value },
 });
 ```
-
-## List by prefix
-
-List all the keys starting with a particular prefix. 
-
-For example, you may have structured your keys with a user, a user ID, and key names, separated by colons (such as `user:1:<key>`). You could get the keys for user number one by using the following code:
-
-```js
-export default {
-  async fetch(request, env, ctx) {
-    const value = await env.NAMESPACE.list({ prefix: "user:1:" });
-    return new Response(value.keys);
-  },
-};
-```
-
-This will return all keys starting with the `"user:1:"` prefix.
 
 ## Ordering
 
@@ -94,11 +108,11 @@ Keys are always returned in lexicographically sorted order according to their UT
 If there are more keys to fetch, the `list_complete` key will be set to `false` and a `cursor` will also be returned. In this case, you can call `list()` again with the `cursor` value to get the next batch of keys:
 
 ```js
-const value = await NAMESPACE.list();
+const value = await env.NAMESPACE.list();
 
 const cursor = value.cursor;
 
-const next_value = await NAMESPACE.list({ cursor: cursor });
+const next_value = await env.NAMESPACE.list({ cursor: cursor });
 ```
 
 Checking for an empty array in `keys` is not sufficient to determine whether there are more keys to fetch. Instead, use `list_complete`. 

--- a/content/kv/api/write-key-value-pairs.md
+++ b/content/kv/api/write-key-value-pairs.md
@@ -6,15 +6,32 @@ weight: 7
 
 # Write key-value pairs
 
-To create a new key-value pair, or to update the value for a particular key, call the `put()` method on any KV namespace you have bound to your Worker code. 
-
-The basic form of the method  `put()` looks like this:
+To create or update a key-value pair call the `put()` method:
 
 ```js
-await env.NAMESPACE.put(key, value);
+await env.NAMESPACE.put(key, value, options?);
 ```
 
+```js
+export default {
+  async fetch(request, env, ctx) {
+    const value = await env.NAMESPACE.put('first-key', 'my value');
+    // ...
+  },
+};
+```
+
+You can also [write key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#create) and [write data via the API](/api/operations/workers-kv-namespace-write-key-value-pair-with-metadata).
+
+{{<Aside type="note">}} 
+Changes might take up to 60 seconds to [propagate throught the Cloudflare Network](/kv/reference/how-kv-works/), but will be consistent within the same location after `await` completes.
+{{</Aside>}}
+
 ## Parameters
+
+```js
+.put(key, value, { expiration, expirationTtl, metadata })
+```
 
 {{<definitions>}}
 
@@ -23,33 +40,24 @@ await env.NAMESPACE.put(key, value);
   - The key to associate with the value. A key cannot be empty, have a `.` or `..`. All other keys are valid. Keys have a maximum length of 512 bytes.
 
 - `value` {{<type>}}string{{</type>}} | {{<type>}}ReadableStream{{</type>}} | {{<type>}}ArrayBuffer{{</type>}}
-  - The value to store. The type is inferred.
+
+  - The value to store. The type is inferred. The maximum size is 25 MiB.
+
+- `expiration` {{<type>}}number{{</type>}}
+
+  - Set a key’s expiration using an absolute time specified in a number of seconds since the UNIX epoch.
+
+- `expirationTtl` {{<type>}}number{{</type>}}
+
+  - Set a key’s expiration time to live (TTL) using a relative number of seconds from the current time.
+
+- `metadata` {{<type>}}JSON Object{{</type>}}
+
+  - Any arbitrary object (must serialize to JSON) to associate with a key-value pair.
 
 {{</definitions>}}
 
-The `put()` method returns a `Promise` that you should `await` on to verify a successful update.
-
-The maximum size of a value is 25 MiB.
-
-You can also [write key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#create) and [write data via the API](/api/operations/workers-kv-namespace-write-key-value-pair-with-metadata).
-
-{{<Aside type="note">}} 
-Due to the eventually consistent nature of KV, concurrent writes can end up overwriting one another. It is a common pattern to write data from a single process via Wrangler or the API. This avoids competing concurrent writes because of the single stream. All data is still readily available within all Workers bound to the namespace. 
-
-Writes are immediately visible to other requests in the same global network location, but can take up to 60 seconds to be visible in other parts of the world. 
-
-Refer to [How KV works](/kv/reference/how-kv-works/) for more information on this topic.
-{{</Aside>}}
-
-## Write data in bulk
-
-Write more than one key-value pair at a time with Wrangler or [via the API](/api/operations/workers-kv-namespace-write-multiple-key-value-pairs). 
-
-The bulk API can accept up to 10,000 KV pairs at once.
-
-A `key` and a `value` are required for each KV pair. The entire request size must be less than 100 megabytes. As of January 2022, Cloudflare does not support bulk writes from within a Worker.
-
-## Expiring keys
+### Expiring keys
 
 KV offers the ability to create keys that automatically expire. You may configure expiration to occur either at a particular point in time, or after a certain amount of time has passed since the key was last modified.
 
@@ -71,9 +79,7 @@ Use both options when writing a key inside a Worker or when writing keys using t
 
 As of January 2022, expiration targets that are less than 60 seconds into the future are not supported. This is true for both expiration methods.
 
-### Create expiring keys
-
-The `put()` method has an optional third parameter. 
+#### Create expiring keys
 
 The `put()` method accepts an object with optional fields that allow you to customize the behavior of the `put()` method. You can set `expiration` or `expirationTtl`, depending on how you want to specify the key’s expiration time. 
 
@@ -81,9 +87,9 @@ To use `expiration` or `expirationTtl`, run one of the two commands below to set
 
 {{<definitions>}}
 
-- `NAMESPACE.put(key, value, {expiration: secondsSinceEpoch})` {{<type>}}Promise{{</type>}}
+- `.put(key, value, { expiration: secondsSinceEpoch })` {{<type>}}Promise{{</type>}}
 
-- `NAMESPACE.put(key, value, {expirationTtl: secondsFromNow})` {{<type>}}Promise{{</type>}}
+- `.put(key, value, { expirationTtl: secondsFromNow })` {{<type>}}Promise{{</type>}}
 
 {{</definitions>}}
 
@@ -91,7 +97,7 @@ These assume that `secondsSinceEpoch` and `secondsFromNow` are variables defined
 
 You can also [write with an expiration on the command line via Wrangler](/kv/reference/kv-namespaces/) or [via the API](/api/operations/workers-kv-namespace-write-key-value-pair-with-metadata).
 
-## Metadata
+### Metadata
 
 To associate some {{<glossary-tooltip term_id="metadata">}}metadata{{</glossary-tooltip>}} with a key-value pair, set `metadata` to any arbitrary object (must serialize to JSON) in the `put()` options object on a `put()` call. 
 
@@ -104,3 +110,12 @@ await env.NAMESPACE.put(key, value, {
 ```
 
 The serialized JSON representation of the metadata object must be no more than 1024 bytes in length.
+
+
+## Write data in bulk
+
+Write more than one key-value pair at a time with Wrangler or [via the API](/api/operations/workers-kv-namespace-write-multiple-key-value-pairs). 
+
+The bulk API can accept up to 10,000 KV pairs at once.
+
+A `key` and a `value` are required for each KV pair. The entire request size must be less than 100 megabytes. As of January 2022, Cloudflare does not support bulk writes from within a Worker.


### PR DESCRIPTION
Greatly clean up the documentation:

- Normalize to follow a similar structure on all pages. Before, some pages started by a code example, some with the API, some with a list of descriptions, etc. Now all pages have: 1. Small usage example, 2. An more complete example, 3. Description, (opt) 4. Warnings, 5. Other sections like description about "", etc.
- Normalize the way parameters are described
- Normalized the warning about consistency, since each page was saying something different, which might lead to confusion.
- No information should have been deleted; this is mainly reordering information and making pages consistent among each other. Some times redundant information _has_ been removed from a single page in favour of a link to the more complete description, like in the previous point.