### PR TITLE
Missing arrow in documentation code bash snippet for the placeholder ACCOUNT_ID

### DIFF
--- a/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
+++ b/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
@@ -54,7 +54,7 @@ ___
       -H 'X-Auth-Key: <CLOUDFLARE_API_KEY>' \
       --data '{
       "account": {
-        "id":"<ACCOUNT_ID" 
+        "id":"<ACCOUNT_ID>" 
       },
       "name": "'"$domain"'",
       "type": "full"


### PR DESCRIPTION
The page assumed all token placeholder in code are represented using < > arrows, in the API key placeholder for the first code snippet the ending arrow is missing, I have added that for the placeholder ACCOUNT_ID
This is needed for consistency in documentation