### PR TITLE
[QUEUES] chore: add hint for context.waitUntil in how-queues-work reference

### DIFF
--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -55,7 +55,7 @@ export default {
 };
 ```
 
-{{<Aside type="note" header="Hint">}}
+{{<Aside type="note">}}
 
 You can also use `[context.waitUntil()]`(/workers/runtime-apis/handlers/fetch/#contextwaituntil) to send the message without blocking the response.
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -57,7 +57,7 @@ export default {
 
 {{<Aside type="note" header="Hint">}}
 
-You can also use (context.waitUntil)[/workers/runtime-apis/handlers/fetch/#contextwaituntil] to send the message without blocking the response.
+You can also use [context.waitUntil](/workers/runtime-apis/handlers/fetch/#contextwaituntil) to send the message without blocking the response.
 
 Note that because `waitUntil` is non-blocking, any errors raised from the `send` or `sendBatch` methods on a queue will be implicitly ignored.
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -57,7 +57,7 @@ export default {
 
 {{<Aside type="note" header="Hint">}}
 
-You can also use [context.waitUntil](/workers/runtime-apis/handlers/fetch/#contextwaituntil) to send the message without blocking the response.
+You can also use `[context.waitUntil()]`(/workers/runtime-apis/handlers/fetch/#contextwaituntil) to send the message without blocking the response.
 
 Note that because `waitUntil` is non-blocking, any errors raised from the `send` or `sendBatch` methods on a queue will be implicitly ignored.
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -59,7 +59,7 @@ export default {
 
 You can also use `[context.waitUntil()]`(/workers/runtime-apis/handlers/fetch/#contextwaituntil) to send the message without blocking the response.
 
-Note that because `waitUntil` is non-blocking, any errors raised from the `send` or `sendBatch` methods on a queue will be implicitly ignored.
+Note that because `waitUntil()` is non-blocking, any errors raised from the `send()` or `sendBatch()` methods on a queue will be implicitly ignored.
 
 {{</Aside>}}
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -43,16 +43,23 @@ type Environment = {
 };
 
 export default {
-  async fetch(req: Request, env: Environment): Promise<Response> {
+  async fetch(req: Request, env: Environment, context: ExecutionContext): Promise<Response> {
     let message = {
       url: req.url,
       method: req.method,
       headers: Object.fromEntries(req.headers),
     };
+
     await env.MY_FIRST_QUEUE.send(message); // This will throw an exception if the send fails for any reason
   },
 };
 ```
+
+{{<Aside type="note" header="Hint">}}
+
+You can also use (`context.waitUntil`)[/workers/runtime-apis/handlers/fetch/#contextwaituntil] to send the message without blocking the response.
+
+{{</Aside>}}
 
 A queue can have multiple producer Workers. For example, you may have multiple producer Workers writing events or logs to a shared queue based on incoming HTTP requests from users. There is no limit to the total number of producer Workers that can write to a single queue.
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -59,6 +59,8 @@ export default {
 
 You can also use (context.waitUntil)[/workers/runtime-apis/handlers/fetch/#contextwaituntil] to send the message without blocking the response.
 
+Note that because `waitUntil` is non-blocking, any errors raised from the `send` or `sendBatch` methods on a queue will be implicitly ignored.
+
 {{</Aside>}}
 
 A queue can have multiple producer Workers. For example, you may have multiple producer Workers writing events or logs to a shared queue based on incoming HTTP requests from users. There is no limit to the total number of producer Workers that can write to a single queue.

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -57,7 +57,7 @@ export default {
 
 {{<Aside type="note" header="Hint">}}
 
-You can also use (`context.waitUntil`)[/workers/runtime-apis/handlers/fetch/#contextwaituntil] to send the message without blocking the response.
+You can also use (context.waitUntil)[/workers/runtime-apis/handlers/fetch/#contextwaituntil] to send the message without blocking the response.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Adds a reference to `context.waitUntil` to advise of the possibility of sending a message without blocking the response. Clarification from Discord conversation.