### PR TITLE
[Workers AI] TOC revision + storage options name change in Platform sections

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1270,6 +1270,7 @@
 /workers-ai/models/openchat_3.5-awq/ /workers-ai/models/ 301
 /workers-ai/platform/workers-pages-sdk/ /workers-ai/configuration/workers-pages-sdk/ 301
 /workers-ai/platform/bindings/ /workers-ai/configuration/bindings/ 301
+/workers-ai/platform/rest-api/ /workers-ai/rest-api/ 301
 
 
 # workers KV

--- a/content/_redirects
+++ b/content/_redirects
@@ -1268,6 +1268,8 @@
 /workers-ai/models/image-classification/ /workers-ai/models/#image-classification 301
 /workers-ai/models/codellama-7b-instruct-awq/ /workers-ai/models/ 301
 /workers-ai/models/openchat_3.5-awq/ /workers-ai/models/ 301
+/workers-ai/platform/workers-pages-sdk/ /workers-ai/configuration/workers-pages-sdk/ 301
+/workers-ai/platform/bindings/ /workers-ai/configuration/bindings/ 301
 
 
 # workers KV

--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -34,7 +34,7 @@ Many of these limits will increase during D1's [public beta](/workers/platform/b
 
 If you would like to explore other storage solutions for your application, Cloudflare also offers [Workers KV](/kv/api/), [Durable Objects](/durable-objects/), and [R2](/r2/get-started/). 
 
-Refer to the [Storage options guide](/workers/platform/storage-options/) to review which storage option is right for your use case.
+Refer to the [Choose a data or storage product](/workers/platform/storage-options/) to review which storage option is right for your use case.
 
 {{</Aside>}}
 

--- a/content/d1/platform/storage-options.md
+++ b/content/d1/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 3

--- a/content/durable-objects/platform/storage-options.md
+++ b/content/durable-objects/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 3

--- a/content/hyperdrive/platform/storage-options.md
+++ b/content/hyperdrive/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 3

--- a/content/learning-paths/workers/devplat/intro-to-devplat.md
+++ b/content/learning-paths/workers/devplat/intro-to-devplat.md
@@ -44,7 +44,7 @@ Some Cloudflare Developer storage products include:
 * [Durable Objects](/durable-objects/): Globally distributed coordination API with strongly consistent storage.
 * [D1](/d1/): Cloudflare’s native serverless database.
 
-To understand which storage option is right for you, refer to the [Storage options guide](/workers/platform/storage-options/).
+To understand which storage option is right for you, refer to the [Choose a data or storage product](/workers/platform/storage-options/).
 
 To explore possible database integrations, refer to [Databases](/workers/databases/) in the Workers documentation.
 

--- a/content/pages/platform/storage-options.md
+++ b/content/pages/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 2

--- a/content/queues/platform/storage-options.md
+++ b/content/queues/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 3

--- a/content/r2/reference/storage-options.md
+++ b/content/r2/reference/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 
 external_link: /workers/platform/storage-options/
 weight: 1

--- a/content/vectorize/platform/storage-options.md
+++ b/content/vectorize/platform/storage-options.md
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Storage Options guide
+title: Choose a data or storage product
 weight: 3
 external_link: /workers/platform/storage-options/
 _build:

--- a/content/workers-ai/configuration/_index.md
+++ b/content/workers-ai/configuration/_index.md
@@ -1,0 +1,9 @@
+---
+pcx_content_type: navigation
+title: Configuration
+weight: 3
+---
+
+# Get started
+
+{{<directory-listing>}}

--- a/content/workers-ai/configuration/bindings.md
+++ b/content/workers-ai/configuration/bindings.md
@@ -1,7 +1,8 @@
 ---
 pcx_content_type: configuration
 title: Bindings
-weight: 6
+meta:
+    description:
 ---
 
 # Bindings

--- a/content/workers-ai/configuration/workers-pages-sdk.md
+++ b/content/workers-ai/configuration/workers-pages-sdk.md
@@ -1,18 +1,19 @@
 ---
 pcx_content_type: configuration
-title: Workers + Pages SDK
-weight: 1
+title: Workers & Pages SDK
+meta:
+    description: An SDK that provides an interface between a [Worker](/workers/) or [Pages Function](/pages/functions/).
 ---
 
-# Workers + Pages SDK
+# Workers & Pages SDK
 
-This SDK provides an interface between a Worker or Pages function and Workers AI.
+The Workers & Pages SDK provides an interface between a [Worker](/workers/) or [Pages Function](/pages/functions/) and Workers AI.
 
 ```javascript
 import { run } from "@cloudflare/ai";
 ```
 
-## Ai class
+## `Ai` class
 
 Workers AI requires an `Ai` instance before you can run a model.
 
@@ -26,9 +27,9 @@ export type Ai = {
 };
 ```
 
-### Ai methods
+### `Ai` methods
 
-#### new Ai()
+#### new `Ai()`
 
 To create a new `Ai` instance:
 
@@ -38,7 +39,7 @@ import { Ai } from "@cloudflare/ai";
 const ai = new Ai(env.AI);
 ```
 
-* **env.AI** is the project [binding](/workers-ai/platform/bindings/) defined in your `wrangler.toml` configuration.
+* **env.AI** is the project [binding](/workers-ai/configuration/bindings/) defined in your `wrangler.toml` configuration.
 
 #### async ai.run()
 

--- a/content/workers-ai/models/_index.md
+++ b/content/workers-ai/models/_index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: Models
-weight: 3
+weight: 4
 hideChildren: true
 ---
 

--- a/content/workers-ai/platform/limits.md
+++ b/content/workers-ai/platform/limits.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: configuration
 title: Limits
-weight: 4
+weight: 2
 ---
 
 # Limits
@@ -10,13 +10,13 @@ During the open beta, the following limits are in place:
 
 **Inference requests per minute (per model)**
 
-- [@cf/meta/llama-2-7b-chat-int8](/workers-ai/models/#text-generation) - 50 reqs/min
-- [@cf/openai/whisper](/workers-ai/models/#automatic-speech-recognition) - 4000 reqs/min
-- [@cf/meta/m2m100-1.2b](/workers-ai/models/#translation) - 4000 reqs/min
-- [@cf/huggingface/distilbert-sst-2-int8](/workers-ai/models/#text-classification) - 6000 reqs/min
-- [@cf/microsoft/resnet-50](/workers-ai/models/#image-classification) - 6000 reqs/min
-- [@cf/baai/bge-base-en-v1.5](/workers-ai/models/#text-embeddings) - 6000 reqs/min
+- [@cf/meta/llama-2-7b-chat-int8](/workers-ai/models/#text-generation) - 50 requests/minute.
+- [@cf/openai/whisper](/workers-ai/models/#automatic-speech-recognition) - 4,000 requests/minute.
+- [@cf/meta/m2m100-1.2b](/workers-ai/models/#translation) - 4,000 reqs/min
+- [@cf/huggingface/distilbert-sst-2-int8](/workers-ai/models/#text-classification) - 6,000 requests/minute.
+- [@cf/microsoft/resnet-50](/workers-ai/models/#image-classification) - 6,000 requests/minute.
+- [@cf/baai/bge-base-en-v1.5](/workers-ai/models/#text-embeddings) - 6,000 requests/minute.
 
-Note that these limits are estimates, subject to change, and will vary by location while in Open Beta.
+Note that these limits are estimates, subject to change, and will vary by location while in open beta.
 
 Model inferences in local mode using Wrangler will also count towards these limits.

--- a/content/workers-ai/platform/pricing.md
+++ b/content/workers-ai/platform/pricing.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Pricing
-weight: 3
+weight: 1
 ---
 
 # Pricing

--- a/content/workers-ai/platform/storage-options.md
+++ b/content/workers-ai/platform/storage-options.md
@@ -1,8 +1,9 @@
 ---
 pcx_content_type: navigation
+title: Choose a data or storage product
+
+external_link: /workers/platform/storage-options/
 weight: 3
-title: REST API
-external_link: /api/operations/workers-ai-post-run-model
 _build:
   publishResources: false
   render: never

--- a/content/workers-ai/rest-api.md
+++ b/content/workers-ai/rest-api.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 weight: 6
-title: REST API
+title: Workers AI API
 external_link: /api/operations/workers-ai-post-run-model
 _build:
   publishResources: false

--- a/content/workers-ai/rest-api.md
+++ b/content/workers-ai/rest-api.md
@@ -1,0 +1,9 @@
+---
+pcx_content_type: navigation
+weight: 6
+title: REST API
+external_link: /api/operations/workers-ai-post-run-model
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/workers/platform/storage-options.md
+++ b/content/workers/platform/storage-options.md
@@ -1,5 +1,5 @@
 ---
-title: Choosing a data or storage product
+title: Choose a data or storage product
 pcx_content_type: concept
 weight: 3
 meta:
@@ -7,7 +7,7 @@ meta:
   description: Storage and database options available on Cloudflare's developer platform.
 ---
 
-# Choosing a data or storage product for your use-case
+# Choose a data or storage product for your use-case
 
 Cloudflare Workers support a range of storage and database options for persisting different types of data across different use-cases, from key-value stores (like [Workers KV](/kv/)) through to SQL databases (such as [D1](/d1/)). This guide describes the use-cases suited to each storage option, as well as their performance and consistency properties.
 


### PR DESCRIPTION
PCX-10034

Two tasks in one PR:
1. All Dev Plat products "Storage options guide" has been changed to the new "Choose a storage or data product" title following Matt's PR.
2. WAI Platform section has been updated according to content strategy.

Regarding task 2, review the following resources to understand the purpose of this change before commenting:

PCX-9882
PCX Developer Platform Information Architecture (IA) in wiki
https://developers.cloudflare.com/style-guide/documentation-content-strategy/information-architecture/
