### PR TITLE
[Workers AI] Remove model id from overview

### DIFF
--- a/layouts/shortcodes/models-grouped-by-task.md
+++ b/layouts/shortcodes/models-grouped-by-task.md
@@ -5,8 +5,9 @@
 
 {{ $firstPage.Params.model.task.description }}
 
-| Model | Description |
-| ----- | ----------- |
+| Model                    | Description        |
+| ------------------------ | ------------------ |
+| <div style="width:10em"> | <div style="flex"> |
 
 {{- $pages := .Pages -}}
 {{- range sort $pages "Params.weight" "desc" -}}
@@ -17,6 +18,6 @@
 {{- $betaFlag = true }}
 {{- end }}
 {{- end }}
-| [{{ $params.model_display_name }}{{ if $betaFlag }} <div class="DocsMarkdown--pill DocsMarkdown--pill-beta">Beta</div>{{ end }}]({{ .RelPermalink }}) | {{ $params.model.description }} |
+| [{{ $params.model_display_name }}{{ if $betaFlag }} <div class="DocsMarkdown--pill DocsMarkdown--pill-beta" style="width: max-content">Beta</div>{{ end }}]({{ .RelPermalink }}) | {{ $params.model.description }} |
 {{- end -}}
 {{- end -}}

--- a/layouts/shortcodes/models-grouped-by-task.md
+++ b/layouts/shortcodes/models-grouped-by-task.md
@@ -5,9 +5,14 @@
 
 {{ $firstPage.Params.model.task.description }}
 
-| Model                    | Description        |
-| ------------------------ | ------------------ |
-| <div style="width:10em"> | <div style="flex"> |
+<style>
+table th:first-of-type {
+    width: 10em;
+}
+</style>
+
+| Model | Description |
+| ----- | ----------- |
 
 {{- $pages := .Pages -}}
 {{- range sort $pages "Params.weight" "desc" -}}

--- a/layouts/shortcodes/models-grouped-by-task.md
+++ b/layouts/shortcodes/models-grouped-by-task.md
@@ -5,8 +5,8 @@
 
 {{ $firstPage.Params.model.task.description }}
 
-| Model | Model ID | Description |
-| ----- | -------- | ----------- |
+| Model | Description |
+| ----- | ----------- |
 
 {{- $pages := .Pages -}}
 {{- range sort $pages "Params.weight" "desc" -}}
@@ -17,6 +17,6 @@
 {{- $betaFlag = true }}
 {{- end }}
 {{- end }}
-| [{{ $params.model_display_name }}{{ if $betaFlag }} <div class="DocsMarkdown--pill DocsMarkdown--pill-beta">Beta</div>{{ end }}]({{ .RelPermalink }}) | `{{$params.model.name}}` | {{ $params.model.description }} |
+| [{{ $params.model_display_name }}{{ if $betaFlag }} <div class="DocsMarkdown--pill DocsMarkdown--pill-beta">Beta</div>{{ end }}]({{ .RelPermalink }}) | {{ $params.model.description }} |
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This:
- removes the modelId from the model overview page
- makes the model name column wider
- fixes too long beta tags