### PR TITLE
Document compat flag: fetcher_no_get_put_delete

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
+++ b/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
@@ -11,7 +11,7 @@ enable_flag: "fetcher_no_get_put_delete"
 disable_flag: "fetcher_has_get_put_delete"
 ---
 
-Some objects in the Workers API implement a method `fetch()` which behaves similarly to the global `fetch()` method, but the requests are sent to the destination represented by the object, rather than being routed based on the hostname. In particular, [Durable Object](https://developers.cloudflare.com/durable-objects/) stubs and [Service Bindings](https://developers.cloudflare.com/workers/configuration/bindings/about-service-bindings/) both have such `fetch()` methods.
+Some objects in the Workers API implement a method `fetch()` which behaves similarly to the global `fetch()` method, but the requests are sent to the destination represented by the object, rather than being routed based on the URL. In particular, [Durable Object](/durable-objects/) stubs and [Service Bindings](/workers/configuration/bindings/about-service-bindings/) both have such `fetch()` methods.
 
 Historically, API objects that had such a `fetch()` method also had methods `get()`, `put()`, and `delete()`. These methods were thin wrappers around `fetch()` which would perform the corresponding HTTP method and automatically handle writing/reading the request/response bodies as needed.
 

--- a/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
+++ b/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
@@ -11,10 +11,11 @@ enable_flag: "fetcher_no_get_put_delete"
 disable_flag: "fetcher_has_get_put_delete"
 ---
 
-Some objects in the Workers API implement a method `fetch()` which behaves similarly to the global `fetch()` method, but the requests are sent to the destination represented by the object, rather than being routed based on the URL. In particular, [Durable Object](/durable-objects/) stubs and [Service Bindings](/workers/configuration/bindings/about-service-bindings/) both have such `fetch()` methods.
+[Durable Object](/durable-objects/) stubs and [Service Bindings](/workers/configuration/bindings/about-service-bindings/) both implement a `fetch()` method which behaves similarly to the global `fetch()` method, but requests are instead sent to the destination represented by the object, rather than being routed based on the URL.
 
 Historically, API objects that had such a `fetch()` method also had methods `get()`, `put()`, and `delete()`. These methods were thin wrappers around `fetch()` which would perform the corresponding HTTP method and automatically handle writing/reading the request/response bodies as needed.
 
-These methods were thought to be a neat idea but were never actually documented. In retrospect, they don't seem so great anymore. Moreover, they may soon get in the way: we would like for applications to define their own methods on these types, and applications may be surprised if they cannot define `get`, `put`, and `delete` due to conflicting with these helpers.
+These methods were a very early idea from many years ago, but were never actually documented, and therefore rarely (if ever) used. Enabling the `fetcher_no_get_put_delete`, or setting a compatibility date on or after `2024-03-26` disables these methods for your Worker.
 
-Therefore, these methods are being removed. Since they were never documented, it's unlikely anyone relies on them.
+This change paves a future path for you to be able to define your own custom methods using these names. Without this change, you would be unable to define your own `get`, `put`, and `delete` methods, since they would conflict with these built-in helper methods.
+

--- a/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
+++ b/content/workers/_partials/_platform-compatibility-dates/fetcher-no-get-put-delete.md
@@ -1,0 +1,20 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Fetchers no longer have get/put/delete helper methods"
+sort_date: "2024-03-26"
+enable_date: "2024-03-26"
+enable_flag: "fetcher_no_get_put_delete"
+disable_flag: "fetcher_has_get_put_delete"
+---
+
+Some objects in the Workers API implement a method `fetch()` which behaves similarly to the global `fetch()` method, but the requests are sent to the destination represented by the object, rather than being routed based on the hostname. In particular, [Durable Object](https://developers.cloudflare.com/durable-objects/) stubs and [Service Bindings](https://developers.cloudflare.com/workers/configuration/bindings/about-service-bindings/) both have such `fetch()` methods.
+
+Historically, API objects that had such a `fetch()` method also had methods `get()`, `put()`, and `delete()`. These methods were thin wrappers around `fetch()` which would perform the corresponding HTTP method and automatically handle writing/reading the request/response bodies as needed.
+
+These methods were thought to be a neat idea but were never actually documented. In retrospect, they don't seem so great anymore. Moreover, they may soon get in the way: we would like for applications to define their own methods on these types, and applications may be surprised if they cannot define `get`, `put`, and `delete` due to conflicting with these helpers.
+
+Therefore, these methods are being removed. Since they were never documented, it's unlikely anyone relies on them.


### PR DESCRIPTION
As implemented in: https://github.com/cloudflare/workerd/pull/1770

Preview: https://kenton-fetcher-no-get-put-de.cloudflare-docs-7ou.pages.dev/workers/configuration/compatibility-dates/#fetchers-no-longer-have-getputdelete-helper-methods