### PR TITLE
Remove un-necessary step - No need to making script executable

### DIFF
--- a/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
+++ b/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
@@ -63,12 +63,7 @@ ___
   done
 ```
 
-3. Add executable commands to the script:
-```js
-  chmod +x add-multiple-zones.sh
-```
-
-4. Open the command line and run:
+3. Open the command line and run:
 ```js
   bash add-multiple-zones.sh
 ```


### PR DESCRIPTION
We don't need executable permission if we are running the script via bash (by specifying the script as a file argument to bash command) as the documentation suggested in 4th step

So i removed the unnecessary step, running script directly is not preferred as on some systems the user might not have sudo access to make the script executable

Even if the script needed to be directly executed, a shebang is needed which the documented did not provide

Reference: https://askubuntu.com/questions/25681/can-scripts-run-even-when-they-are-not-set-as-executable

This works for sh too