### PR TITLE
[QUEUES] Queues use JSON content type by default

### DIFF
--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -58,6 +58,49 @@ A queue can have multiple producer Workers. For example, you may have multiple p
 
 Additionally, multiple queues can be bound to a single Worker. That single Worker can decide which queue to write to (or write to multiple) based on any logic you define in your code.
 
+### Content types
+
+Messages published to a queue can be published in different formats, depending on what interoperability is needed with your consumer. The default content type is `json`, which means that any object that can be passed to `JSON.stringify()` will be accepted. 
+
+To explicitly set the content type or specify an alternative content type, pass the `contentType` option to the `send()` method of your queue:
+
+```ts
+type Environment = {
+  readonly MY_FIRST_QUEUE: Queue;
+};
+
+export default {
+  async fetch(req: Request, env: Environment): Promise<Response> {
+    let message = {
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers),
+    };
+    try {
+      await env.MY_FIRST_QUEUE.send(message, { contentType: "json" }); // "json" is the default
+    } catch (e) {
+      // Catch cases where send fails, including due to a mismatched content type
+      console.log(e)
+      return Response.json({"msg": e}, { status: 500 })
+    }
+  },
+};
+```
+
+To only accept simple strings when writing to a queue, set `{ contentType: "string" }` instead:
+
+```ts
+    try {
+      // This will throw an exception (error) if you write to pass a non-string to the queue, such as a
+      // native JavaScript object or ArrayBuffer.
+      await env.MY_FIRST_QUEUE.send("hello there", { contentType: "string" }); // explicitly set 'string'
+    } catch (e) {
+      console.log(e)
+      return Response.json({"msg": e}, { status: 500 })
+```
+
+The [`QueuesContentType`](/queues/reference/javascript-apis/#queuescontenttype) API documentation describes how each format is serialized to a queue.
+
 ## Consumers
 
 ### Create a consumer

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -60,7 +60,7 @@ Additionally, multiple queues can be bound to a single Worker. That single Worke
 
 ### Content types
 
-Messages published to a queue can be published in different formats, depending on what interoperability is needed with your consumer. The default content type is `json`, which means that any object that can be passed to `JSON.stringify()` will be accepted. 
+Messages published to a queue can be published in different formats, depending on what interoperability is needed with your consumer. The default content type is `json`, which means that any object that can be passed to `JSON.stringify()` will be accepted.
 
 To explicitly set the content type or specify an alternative content type, pass the `contentType` option to the `send()` method of your queue:
 
@@ -87,13 +87,13 @@ export default {
 };
 ```
 
-To only accept simple strings when writing to a queue, set `{ contentType: "string" }` instead:
+To only accept simple strings when writing to a queue, set `{ contentType: "text" }` instead:
 
 ```ts
     try {
       // This will throw an exception (error) if you write to pass a non-string to the queue, such as a
       // native JavaScript object or ArrayBuffer.
-      await env.MY_FIRST_QUEUE.send("hello there", { contentType: "string" }); // explicitly set 'string'
+      await env.MY_FIRST_QUEUE.send("hello there", { contentType: "text" }); // explicitly set 'text'
     } catch (e) {
       console.log(e)
       return Response.json({"msg": e}, { status: 500 })

--- a/content/queues/reference/javascript-apis.md
+++ b/content/queues/reference/javascript-apis.md
@@ -87,7 +87,7 @@ type MessageSendRequest<Body = unknown> = {
 
 {{<definitions>}}
 
-- {{<code>}}body{{</code>}} {{<type>}}unknown{{</type>}} 
+- {{<code>}}body{{</code>}} {{<type>}}unknown{{</type>}}
 
   - The body of the message.
   - The body can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
@@ -116,7 +116,7 @@ type QueuesContentType = "text" | "bytes" | "json" | "v8";
 
 {{<Aside type="note">}}
 
-The default content type for Queues changed to `json` (from `v8`) to improve compatibility with pull-based consumers for any Workers with a [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) after `2024-03-04`.
+The default content type for Queues changed to `json` (from `v8`) to improve compatibility with pull-based consumers for any Workers with a [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) after `2024-03-18`.
 
 {{</Aside>}}
 
@@ -138,7 +138,7 @@ If the `queue()` function throws, or the promise returned by it or any of the pr
 
 {{<Aside type="note">}}
 
-`waitUntil()` is the only supported method to run tasks (such as logging or metrics calls) that resolve after a queue handler has completed. Promises that have not resolved by the time the queue handler returns may not complete and will not block completion of execution. 
+`waitUntil()` is the only supported method to run tasks (such as logging or metrics calls) that resolve after a queue handler has completed. Promises that have not resolved by the time the queue handler returns may not complete and will not block completion of execution.
 
 {{</Aside>}}
 
@@ -199,7 +199,7 @@ interface MessageBatch<Body = unknown> {
 
 - {{<code>}}ackAll(){{</code>}} {{<type>}}void{{</type>}}
 
-  - Marks every message as successfully delivered, regardless of whether your `queue()` consumer handler returns successfully or not. 
+  - Marks every message as successfully delivered, regardless of whether your `queue()` consumer handler returns successfully or not.
 
 - {{<code>}}retryAll(){{</code>}} {{<type>}}void{{</type>}}
 
@@ -231,14 +231,14 @@ interface Message<Body = unknown> {
 
   - A timestamp when the message was sent.
 
-- {{<code>}}body{{</code>}} {{<type>}}unknown{{</type>}} 
+- {{<code>}}body{{</code>}} {{<type>}}unknown{{</type>}}
 
   - The body of the message.
   - The body can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
 
 - {{<code>}}ack(){{</code>}} {{<type>}}void{{</type>}}
 
-  - Marks a message as successfully delivered, regardless of whether your `queue()` consumer handler returns successfully or not. 
+  - Marks a message as successfully delivered, regardless of whether your `queue()` consumer handler returns successfully or not.
 
 - {{<code>}}retry(){{</code>}} {{<type>}}void{{</type>}}
 

--- a/content/queues/reference/javascript-apis.md
+++ b/content/queues/reference/javascript-apis.md
@@ -105,13 +105,20 @@ type MessageSendRequest<Body = unknown> = {
 A union type containing valid message content types.
 
 ```ts
+// Default: json
 type QueuesContentType = "text" | "bytes" | "json" | "v8";
 ```
 
+- Use `"json"` to send a JavaScript object that can be JSON-serialized. This content type can be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com). The `json` content type is the default.
 - Use `"text"` to send a `String`. This content type can be previewed with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature.
-- Use `"json"` to send a JavaScript object that can be JSON-serialized. This content type can be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com).
 - Use `"bytes"` to send an `ArrayBuffer`. This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded.
-- Use `"v8"` to send a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (for example `Date` and `Map`). This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded. `"v8"` is the default content type.
+- Use `"v8"` to send a JavaScript object that cannot be JSON-serialized but is supported by [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) (for example `Date` and `Map`). This content type cannot be previewed from the [Cloudflare dashboard](https://dash.cloudflare.com) and will display as Base64-encoded.
+
+{{<Aside type="note">}}
+
+The default content type for Queues changed to `json` (from `v8`) to improve compatibility with pull-based consumers for any Workers with a [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) after `2024-03-04`.
+
+{{</Aside>}}
 
 If you specify an invalid content type, or if your specified content type does not match the message content's type, the send operation will fail with an error.
 

--- a/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
+++ b/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
@@ -1,0 +1,14 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Queues send messages in `JSON` format"
+sort_date: "2024-03-04"
+enable_date: "2024-03-04"
+enable_flag: "queues_json_messages"
+disable_flag: "no_queues_json_messages"
+---
+
+With the `queues_json_messages` flag set, Queue bindings will serialize values passed to `send()` or `sendBatch()` into JSON format by default (when no specific `contentType` is provided).

--- a/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
+++ b/content/workers/_partials/_platform-compatibility-dates/queues-json-messages.md
@@ -5,8 +5,8 @@ _build:
   list: never
 
 name: "Queues send messages in `JSON` format"
-sort_date: "2024-03-04"
-enable_date: "2024-03-04"
+sort_date: "2024-03-18"
+enable_date: "2024-03-18"
 enable_flag: "queues_json_messages"
 disable_flag: "no_queues_json_messages"
 ---

--- a/data/changelogs/queues.yaml
+++ b/data/changelogs/queues.yaml
@@ -2,13 +2,18 @@
 link: "/queues/platform/changelog/"
 productName: Queues
 entries:
+- publish_date: '2024-03-04'
+  title: Default content type now set to JSON
+  description: |-
+    The default [content type](/queues/reference/javascript-apis/#queuescontenttype) for messages published to a queue is now `json`, which improves compatibility with the upcoming pull-based queues.
+    
+    Any Workers created on or after the [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) of `2024-03-04`, or that explicitly set the `queues_json_messages` compatibility flag, will use the new default behaviour. Existing Workers with a compatibility date prior will continue to use `v8` as the default content type for published messages.
 - publish_date: '2024-02-24'
   title: Explicit retries no longer impact consumer concurrency/scaling.
   description: |-
     Calling `retry()` or `retryAll()` on a message or message batch will no longer have an impact on how Queues scales [consumer concurrency](/queues/reference/consumer-concurrency/).
 
     Previously, using [explicit retries](/queues/reference/batching-retries/#retries) via `retry()` or `retryAll()` would count as an error and could result in Queues scaling down the number of concurrent consumers.
-
 - publish_date: '2023-10-07'
   title: More queues per account - up to 10,000
   description: |-

--- a/data/changelogs/queues.yaml
+++ b/data/changelogs/queues.yaml
@@ -2,12 +2,12 @@
 link: "/queues/platform/changelog/"
 productName: Queues
 entries:
-- publish_date: '2024-03-04'
+- publish_date: '2024-03-18'
   title: Default content type now set to JSON
   description: |-
     The default [content type](/queues/reference/javascript-apis/#queuescontenttype) for messages published to a queue is now `json`, which improves compatibility with the upcoming pull-based queues.
-    
-    Any Workers created on or after the [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) of `2024-03-04`, or that explicitly set the `queues_json_messages` compatibility flag, will use the new default behaviour. Existing Workers with a compatibility date prior will continue to use `v8` as the default content type for published messages.
+
+    Any Workers created on or after the [compatibility date](/workers/configuration/compatibility-dates/#queues_json_messages) of `2024-03-18`, or that explicitly set the `queues_json_messages` compatibility flag, will use the new default behaviour. Existing Workers with a compatibility date prior will continue to use `v8` as the default content type for published messages.
 - publish_date: '2024-02-24'
   title: Explicit retries no longer impact consumer concurrency/scaling.
   description: |-
@@ -18,7 +18,7 @@ entries:
   title: More queues per account - up to 10,000
   description: |-
     Developers building on Queues can now create up to 10,000 queues per account, enabling easier per-user, per-job and sharding use-cases.
-  
+
     Refer to [Limits](/queues/platform/limits) to learn more about Queues' current limits.
 - publish_date: '2023-10-05'
   title: Higher consumer concurrency limits
@@ -26,7 +26,7 @@ entries:
     [Queue consumers](/queues/reference/consumer-concurrency/) can now scale to 20 concurrent invocations (per queue), up from 10. This allows you to scale out and process higher throughput queues more quickly.
 
     Queues with [no explicit limit specified](/queues/reference/consumer-concurrency/#limit-concurrency) will automatically scale to the new maximum.
-  
+
     This limit will continue to grow during the Queues beta.
 - publish_date: '2023-03-28'
   title: Consumer concurrency (enabled)


### PR DESCRIPTION
We recently reverted these changes in https://github.com/cloudflare/cloudflare-docs/pull/13269 as they went live too early.

This PR re-adds the changes, with corrected dates about when the feature goes live.

CC: @elithrar 

