### PR TITLE
[Docs Site] Fix <p> tags on asides

### DIFF
--- a/layouts/shortcodes/Aside.html
+++ b/layouts/shortcodes/Aside.html
@@ -1,8 +1,8 @@
 {{- $type := default "note" (.Get "type") -}}
 <aside class="DocsMarkdown--aside" role="note" data-type="{{ $type }}">
   {{- with .Get "header" }}
-  <div class="DocsMarkdown--aside-header">{{- safeHTML . -}}</div>
+    <div class="DocsMarkdown--aside-header">{{- safeHTML . -}}</div>
   {{- end -}}
 
-  {{- .Page.RenderString .Inner -}}
+  {{- .Inner | .Page.RenderString (dict "display" "block") -}}
 </aside>


### PR DESCRIPTION
> display (string) Specify either inline or block. If inline, removes surrounding p tags from short snippets. Default is inline.

https://gohugo.io/methods/page/renderstring/

The move from Hugo 0.110.0 to 0.123.5 removed the `<p>` tags - I suspect it's related to https://github.com/gohugoio/hugo/pull/11700, but this fixes it anyhow.

cc @kodster28 