### PR TITLE
Add HTTP/3 QUIC not supported for regional services

### DIFF
--- a/content/data-localization/_index.md
+++ b/content/data-localization/_index.md
@@ -53,6 +53,7 @@ Overview by product-behavior is summarized in the following table. Below you can
 | Caching/CDN | ✅ | ✅ | ✅ |
 | Cache Reserve | ⚫️ | 🚧{{<fnref num="29">}} | ✅ |
 | DNS | ⚫️ | ⚫️ | 🚧{{<fnref num="1">}} |
+| HTTP/3 (with QUIC)  | ⚫️ | ✘ | ⚫️ |
 | Image Resizing | ✅ | ✘ | 🚧{{<fnref num="1">}} |
 | Load Balancing | ✅ | ✅ | 🚧{{<fnref num="1">}} |
 | Onion Routing | ✘ | ✘ | ✘ |


### PR DESCRIPTION
Regional services currently don't support HTTP/3 QUIC.