### PR TITLE
Update on "Page Load" component

### DIFF
--- a/content/analytics/web-analytics/understanding-web-analytics/page-load-time-summary.md
+++ b/content/analytics/web-analytics/understanding-web-analytics/page-load-time-summary.md
@@ -13,7 +13,7 @@ Page load time summary gives you an overview of how long your web page takes to 
 
 Below is a list of all the components you can inspect:
 
-- **Page load**: The total amount of time required to load the page.
+- **Page load**: The total amount of time required to load the page. (NOTE: In order to streamline the presented values, the formula we use for this component includes elements that are not listed. Pre-domain-lookup time, gaps between timing metrics, and percentile aggregations will cause an expected discrepancy between the sum of all timings metrics when compared with the Page Load value.)
 - **DNS** (`domainLookupEnd` - `domainLookupStart`): How long a DNS query takes. This could appear as zero for reused connections or content stored in the local cache (memory or disk).
 - **TCP** (`connectEnd` - `connectStart`): How long it takes to establish a TCP connection with the server. If using HTTPS, this process includes TLS negotiation time.
 - **Request** (`responseStart` - `requestStart`): The time elapsed between making an HTTP request and receiving the first byte of the response.


### PR DESCRIPTION
(PCX-10085)

Customers will observe an expected discrepancy regarding the Page Load value.

- QUESTION: _Why doesn't the Page Load metric reflect the total of the other metrics?_ Meaning: if we sum up the remaining metrics (DNS+TCP+request+response+processing+), the total does not add up to the Page load value.

When inquired about this discrepancy, the respective Engineering team investigated and concluded the following:

> all our data comes from the browser timings API - https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
> 
> We looked into both individual requests and aggregated data, and also grouped the data by additional dimensions (such as browser, os) to find factors that could affect the mismatch.
> 
> The following diagram describes what has been causing the difference between the sum of timings metrics and the Page Load Time:
> 

![image](https://github.com/cloudflare/cloudflare-docs/assets/90766559/831d56a4-fe9b-414a-a5a1-e3d7b81dd22c)


> - Pre-domain-lookup time: Omitted from the RUM metrics provided which causes the difference between the Sum of timings metrics and the Page Load Time
> - The gaps between timings metrics: Gaps between DNS and TCP, TCP and Request, Response and Processing, and Processing and Load Event can also cause the difference between the Sum of timings metrics and the Page Load Time
> - The aggregation by Percentiles: Sum of Percentiles differs from Percentile of the Sum, as we prioritize the Median (50th percentile) in our dash UI.

We may or may not add missing elements and gaps mentioned here to the dashboard UI, since adding too many elements could overwhelm the users by being overly informative.