### PR TITLE
Cloudflare for Saas - List more Limitations

### DIFF
--- a/content/cloudflare-for-platforms/cloudflare-for-saas/_index.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/_index.md
@@ -31,6 +31,8 @@ If your customers already have their applications on Cloudflare, they cannot con
 *   Page Shield
 *   Spectrum
 *   Wildcard DNS
+*   Page Rules
+*   Redirect Rules
 
 ## How it works
 


### PR DESCRIPTION
Page rules and redirect rules (on the client zone) also won't work on custom hostnames.