### PR TITLE
Clarify that direct upload of Functions is not supported only from the dashboard

### DIFF
--- a/content/pages/functions/get-started.md
+++ b/content/pages/functions/get-started.md
@@ -64,7 +64,7 @@ After you have set up your Function, deploy your Pages project. Deploy your proj
 * Using [Wrangler](/workers/wrangler/commands/#pages) from the command line.
 
 {{<Aside type="warning">}}
-[Direct Upload](/pages/get-started/direct-upload/) is currently not supported with Functions.
+[Direct Upload](/pages/get-started/direct-upload/) from the Cloudflare dashboard is currently not supported with Functions.
 {{</Aside>}}
 
 ## Related resources


### PR DESCRIPTION
Our warning states that direct upload does not support Pages Functions, this is not correct as Pages Functions are supported. What we don't support if the direct upload of them from the dashboard, so here I'm amending this (as it can lead to user's confusion as in https://github.com/cloudflare/workers-sdk/issues/5216).