### PR TITLE
[Durable Objects] Reference branch was updated so point to master

### DIFF
--- a/content/durable-objects/examples/websocket-hibernation-server.md
+++ b/content/durable-objects/examples/websocket-hibernation-server.md
@@ -219,4 +219,4 @@ new_classes = ["WebSocketHibernationServer"]
 ```
 ### Related resources
 
-- [Durable Objects: Edge Chat Demo with Hibernation](https://github.com/cloudflare/workers-chat-demo/tree/hibernation).
+- [Durable Objects: Edge Chat Demo with Hibernation](https://github.com/cloudflare/workers-chat-demo/).


### PR DESCRIPTION
We merged the `hibernation` branch, and it's actually a bit behind `master` now so we should just point to that.