### PR TITLE
Improvements to Next.js guide

### DIFF
--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -221,8 +221,9 @@ export async function GET(request) {
 ```ts
 ---
 filename: app/api/hello/route.ts
-highlight: [1, 9]
+highlight: [2, 10]
 ---
+import type { NextRequest } from 'next/server'
 import { getRequestContext } from '@cloudflare/next-on-pages'
 
 export const runtime = 'edge'

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -297,11 +297,11 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 ## Troubleshooting
 
-The following section presents a common mistakes and issues that developer might encounter when developing a Next.js application using `next-on-pages`.
+Review common mistakes and issues that you might encounter when developing a Next.js application using `next-on-pages`.
 
 ### Edge runtime
 
-All server-side routes in your Next.js project must be configured as "Edge" runtime routes when running on Cloudflare Pages. You must add `export const runtime = 'edge'` to each individual server-side route.
+All server-side routes in your Next.js project must be configured as Edge runtime routes when running on Cloudflare Pages. You must add `export const runtime = 'edge'` to each individual server-side route.
 
 
 {{<Aside type="note">}}
@@ -354,13 +354,13 @@ filename: app/my-example-page/[slug]/page.jsx
 // ...
 ```
 
-#### Top Level `getRequestContext`
+#### Top-level `getRequestContext`
 
-The `getRequestContext` function can't be called at the top level of a route file or in any manner that triggers the function call as part of the file's initialization.
+The `getRequestContext` function cannot be called at the top level of a route file or in any manner that triggers the function call as part of the file's initialization.
 
-In other words `getRequestContext` must be called inside the request handling process logic and not in a global/unconditional manner that gets triggered as soon as the file is imported.
+`getRequestContext` must be called inside the request handling process logic and not in a global/unconditional manner that gets triggered as soon as the file is imported.
 
-For example the following represents an erroneous usage of `getRequestContext`:
+For example, the following is an incorrect usage of `getRequestContext`:
 
 ```js
 ---
@@ -378,7 +378,7 @@ export async function GET(request) {
 }
 ```
 
-which can be fixed for example in the following way:
+The above example can be fixed in the following way:
 
 ```js
 ---

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -200,7 +200,7 @@ highlight: [1, 7]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
 
-export const runtime = 'edge';
+export const runtime = 'edge'
 
 // ...
 
@@ -225,7 +225,7 @@ highlight: [1, 7]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
 
-export const runtime = 'edge';
+export const runtime = 'edge'
 
 // ...
 
@@ -299,7 +299,7 @@ After you have previewed your application locally, you can deploy it to Cloudfla
 
 ### Edge runtime
 
-All server-side routes in your Next.js project must be configured as "Edge" runtime routes, when running on Cloudflare Pages. You must add `export const runtime = 'edge';` to each individual server-side route.
+All server-side routes in your Next.js project must be configured as "Edge" runtime routes, when running on Cloudflare Pages. You must add `export const runtime = 'edge'` to each individual server-side route.
 
 
 {{<Aside type="note">}}
@@ -321,13 +321,13 @@ To prevent this incompatibility, Cloudflare recommends to always provide a custo
 filename: (src/)app/not-found.(jsx|tsx)
 ---
 
-export const runtime = 'edge';
+export const runtime = 'edge'
 
 export default async function NotFound() {
     // ...
     return (
         // ...
-    );
+    )
 }
 ```
 
@@ -347,7 +347,7 @@ In such cases you need to instruct Next.js not to do so by specifying a `false` 
 ---
 filename: app/my-example-page/[slug]/page.jsx
 ---
-+ export const dynamicParams = false;
++ export const dynamicParams = false
 
 // ...
 ```
@@ -413,7 +413,7 @@ export async function getStaticPaths() {
     return {
         paths,
 +       fallback: false,
-	};
+	}
 }
 ```
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -196,7 +196,7 @@ Local and remote bindings can be accessed using the [`getRequestContext` functio
 ```js
 ---
 filename: app/api/hello/route.js
-highlight: [1, 7]
+highlight: [1, 9]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
 
@@ -221,7 +221,7 @@ export async function GET(request) {
 ```ts
 ---
 filename: app/api/hello/route.ts
-highlight: [1, 7]
+highlight: [1, 9]
 ---
 import { getRequestContext } from '@cloudflare/next-on-pages'
 

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -301,7 +301,7 @@ The following section presents a common mistakes and issues that developer might
 
 ### Edge runtime
 
-All server-side routes in your Next.js project must be configured as "Edge" runtime routes, when running on Cloudflare Pages. You must add `export const runtime = 'edge'` to each individual server-side route.
+All server-side routes in your Next.js project must be configured as "Edge" runtime routes when running on Cloudflare Pages. You must add `export const runtime = 'edge'` to each individual server-side route.
 
 
 {{<Aside type="note">}}

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -352,6 +352,47 @@ filename: app/my-example-page/[slug]/page.jsx
 // ...
 ```
 
+#### Top Level `getRequestContext`
+
+The `getRequestContext` function can't be called at the top level of a route file or in any manner that triggers the function call as part of the file's initialization.
+
+In other words `getRequestContext` must be called inside the request handling process logic and not in a global/unconditional manner that gets triggered as soon as the file is imported.
+
+For example the following represents an erroneous usage of `getRequestContext`:
+
+```js
+---
+filename: app/api/myvar/route.js
+highlight: [5]
+---
+import { getRequestContext } from '@cloudflare/next-on-pages'
+
+export const runtime = 'edge'
+
+const myVariable = getRequestContext().env.MY_VARIABLE
+
+export async function GET(request) {
+  return new Response(myVariable)
+}
+```
+
+which can be fixed for example in the following way:
+
+```js
+---
+filename: app/api/myvar/route.js
+highlight: [6]
+---
+import { getRequestContext } from '@cloudflare/next-on-pages'
+
+export const runtime = 'edge'
+
+export async function GET(request) {
+  const myVariable = getRequestContext().env.MY_VARIABLE
+  return new Response(myVariable)
+}
+```
+
 ### Pages router
 
 #### `getStaticPaths`

--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -295,8 +295,9 @@ The [`wrangler pages dev`](/workers/wrangler/commands/#dev-1) command needs to r
 
 After you have previewed your application locally, you can deploy it to Cloudflare Pages (both via [Direct Uploads](/pages/get-started/direct-upload/) or [Git integration](/pages/configuration/git-integration/)) and iterate over the process to make new changes.
 
-## Debugging
+## Troubleshooting
 
+The following section presents a common mistakes and issues that developer might encounter when developing a Next.js application using `next-on-pages`.
 
 ### Edge runtime
 


### PR DESCRIPTION

This PR improves the Next.js guide by:
 - adding a debugging/troubleshooting section for the top-level usage of `getRequestContext`
 - removing semicolons from code snippets (for consistency)
 - fixing wrong code snippets contents and hightlights
 - making the debugging section (hopefully) more clear and renaming it to troubleshooting
  