### PR TITLE
Update the web analytics path provided to Pages users

### DIFF
--- a/content/pages/_partials/_web-analytics-setup.md
+++ b/content/pages/_partials/_web-analytics-setup.md
@@ -8,6 +8,6 @@ _build:
 1. Log in to [Cloudflare dashboard](https://dash.cloudflare.com/login).
 2. From Account Home, select **Workers & Pages**.
 3. In **Overview**, select your Pages project.
-4. Go to **Settings** > **General** > and select **Enable Web Analytics**. 
+4. Go to **Manage** > **Web Analytics** > and select **Enable Web Analytics**.
 
 Cloudflare will automatically add the JavaScript snippet to your Pages site on the next deployment.


### PR DESCRIPTION
The path in the dashboard seems to have been updated but the update hasn't been made in our docs:
![Screenshot 2024-03-12 at 18 07 14](https://github.com/cloudflare/cloudflare-docs/assets/61631103/71d39d53-ddb2-45ef-93a3-78a893d700b0)
