### PR TITLE
Add `Deprecation` page for Roughtime

### DIFF
--- a/content/time-services/roughtime/deprecation.md
+++ b/content/time-services/roughtime/deprecation.md
@@ -1,0 +1,15 @@
+---
+title: Server Deprecation
+pcx_content_type: reference
+weight: 4
+---
+
+# Deprecated servers
+
+Once their deprecation date has passed, both the port and public key associated to a server will become unavailable.
+
+| Server                          | Public Key                                     | Deprecation date |
+|:--------------------------------|:-----------------------------------------------|:-----------------|
+| `roughtime.cloudflare.com:2002` | `gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo=` | 2024-06-30       |
+
+Available servers are [listed in our tutorial](/time-services/roughtime/usage/), and you can follow it on how to configure your Roughtime server.


### PR DESCRIPTION
Make a clear list of deprecated server, their public key, and refers to the tutorial to migrate.