### PR TITLE
[Pages] Remove bindings dev mode aside from Svelte guide

### DIFF
--- a/content/pages/framework-guides/deploy-a-svelte-site.md
+++ b/content/pages/framework-guides/deploy-a-svelte-site.md
@@ -103,7 +103,7 @@ In addition to the Cloudflare adapter, review other adapters you can use in your
 
 - [`@sveltejs/adapter-auto`](https://www.npmjs.com/package/@sveltejs/adapter-auto)
 
-  SvelteKit's default adapter  automatically chooses the adapter for your current environment. If you use this adapter, [no configuration is needed](https://kit.svelte.dev/docs/adapter-auto). However, the default adapter introduces a few disadvantages for local development because it has no way of knowing what platform the application is going to be deployed to.
+  SvelteKit's default adapter automatically chooses the adapter for your current environment. If you use this adapter, [no configuration is needed](https://kit.svelte.dev/docs/adapter-auto). However, the default adapter introduces a few disadvantages for local development because it has no way of knowing what platform the application is going to be deployed to.
 
 To solve this issue, provide a `CF_PAGES` variable to SvelteKit so that the adapter can detect the Pages platform. For example, when locally building the application: `CF_PAGES=1 vite build`.
 
@@ -155,12 +155,6 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 {{</Aside>}}
 
 ## Functions setup
-
-{{<Aside type="note">}}
-
-It is currently not possible to access [bindings](/pages/functions/bindings/) in dev mode. This feature is being worked on and will be released soon. For now, this limitation is documented in the SvelteKit documentation for both [Workers](https://kit.svelte.dev/docs/adapter-cloudflare-workers#bindings-testing-locally) and [Pages](https://kit.svelte.dev/docs/adapter-cloudflare#bindings-testing-locally). You can track possible workarounds in this [GitHub issue](https://github.com/cloudflare/cloudflare-docs/issues/11025).
-
-{{</Aside>}}
 
 In SvelteKit, functions are written as endpoints. Functions contained in the `/functions` directory at the project's root will not be included in the deployment, which compiles to a single `_worker.js` file.
 


### PR DESCRIPTION
This aside states that bindings is dev mode `is being worked on and will be released soon.`. This feature dropped in `sveltejs/adapter-cloudflare@4.2.0` and is included by default with new Svelte projects created with C3. 