### PR TITLE
Add rollback notice; format as callout

### DIFF
--- a/content/pages/configuration/rollbacks.md
+++ b/content/pages/configuration/rollbacks.md
@@ -7,7 +7,11 @@ title: Rollbacks
 
 Rollbacks allow you to instantly revert your project to a previous production deployment.
 
-Any production deployment that has been successfully built is a valid rollback target. When your project has rolled back to a previous deployment, you may still rollback to deployments that are newer than your current version. Note that preview deployments are not valid rollback targets.
+Any production deployment that has been successfully built is a valid rollback target. When your project has rolled back to a previous deployment, you may still rollback to deployments that are newer than your current version.
+
+{{<Aside type="warning">}}
+Preview deployments are not valid rollback targets. Additionally, a deployment must have at least two versions in order for rollbacks to be made accessible from the UI.
+{{</Aside>}}
 
 In order to perform a rollback, go to **Deployments** in your Pages project. Browse the **All deployments** list and select the three dotted actions menu for the desired target. Select **Rollback to this deployment** for a confirmation window to appear. When confirmed, your project's production deployment will change instantly.
 

--- a/content/pages/configuration/rollbacks.md
+++ b/content/pages/configuration/rollbacks.md
@@ -10,7 +10,7 @@ Rollbacks allow you to instantly revert your project to a previous production de
 Any production deployment that has been successfully built is a valid rollback target. When your project has rolled back to a previous deployment, you may still rollback to deployments that are newer than your current version.
 
 {{<Aside type="warning">}}
-Preview deployments are not valid rollback targets. Additionally, a deployment must have at least two versions in order for rollbacks to be made accessible from the UI.
+Preview deployments are not valid rollback targets. Additionally, a deployment brnach must have at least two commits in order for rollbacks to be made accessible from the UI. Otherwise, the **Rollback to this deployment** option will not be presented.
 {{</Aside>}}
 
 In order to perform a rollback, go to **Deployments** in your Pages project. Browse the **All deployments** list and select the three dotted actions menu for the desired target. Select **Rollback to this deployment** for a confirmation window to appear. When confirmed, your project's production deployment will change instantly.


### PR DESCRIPTION
During our initial buildout of a Cloudflare deployment, our team noticed that we could not see the "Rollback" option in the drop-down menu when the deployment only had one version (one pushed/merged commit on the branch). Thought it might be worthy to add here, and also to format it and the other note in a callout.