### PR TITLE
Update _aop-configure-origin.md

### DIFF
--- a/content/ssl/_partials/_aop-configure-origin.md
+++ b/content/ssl/_partials/_aop-configure-origin.md
@@ -12,27 +12,27 @@ Check the examples below for Apache and NGINX or refer to your origin web server
 
 {{<details header="Apache example">}}
 
-For this example, you would have saved the certificate to `/path/to/origin-pull-ca.pem`.
-
-$1
-
 ```txt
 SSLVerifyDepth 1
 SSLCACertificateFile /path/to/origin-pull-ca.pem
 ```
 
+For this example, you would have saved your certificate to `/path/to/origin-pull-ca.pem`.
+
+$1
+
 {{</details>}}
 
 {{<details header="NGINX example">}}
-
-For this example, you would have saved your certificate to `/etc/nginx/certs/cloudflare.crt`.
-
-$2
 
 ```txt
 ssl_verify_client optional;
 ssl_client_certificate /etc/nginx/certs/cloudflare.crt;
 ```
+
+For this example, you would have saved your certificate to `/etc/nginx/certs/cloudflare.crt`.
+
+$2
 
 {{</details>}}
 

--- a/content/ssl/_partials/_aop-configure-origin.md
+++ b/content/ssl/_partials/_aop-configure-origin.md
@@ -11,7 +11,7 @@ Check the examples below for Apache and NGINX or refer to your origin web server
 
 {{<details header="Apache example">}}
 
-For this example, you would have saved the certificate `/path/to/origin-pull-ca.pem`.
+For this example, you would have downloaded and renamed the `authenticated_origin_pull_ca.pem` certificate file, and uploaded it to `/path/to/origin-pull-ca.pem`.
 
 ```txt
 SSLVerifyDepth 1
@@ -22,7 +22,7 @@ SSLCACertificateFile /path/to/origin-pull-ca.pem
 
 {{<details header="NGINX example">}}
 
-For this example, you would have saved your certificate to `/etc/nginx/certs/cloudflare.crt`.
+For this example, you would have downloaded and renamed the `authenticated_origin_pull_ca.pem` certificate file, and uploaded it to `/etc/nginx/certs/cloudflare.crt`.
 
 ```txt
 ssl_verify_client optional;

--- a/content/ssl/_partials/_aop-configure-origin.md
+++ b/content/ssl/_partials/_aop-configure-origin.md
@@ -3,6 +3,7 @@ _build:
   publishResources: false
   render: never
   list: never
+inputParameters: param1;;param2
 ---
 
 With the certificate installed, set up your origin web server to accept client certificates.
@@ -11,7 +12,9 @@ Check the examples below for Apache and NGINX or refer to your origin web server
 
 {{<details header="Apache example">}}
 
-For this example, you would have downloaded and renamed the `authenticated_origin_pull_ca.pem` certificate file, and uploaded it to `/path/to/origin-pull-ca.pem`.
+For this example, you would have saved the certificate to `/path/to/origin-pull-ca.pem`.
+
+$1
 
 ```txt
 SSLVerifyDepth 1
@@ -22,7 +25,9 @@ SSLCACertificateFile /path/to/origin-pull-ca.pem
 
 {{<details header="NGINX example">}}
 
-For this example, you would have downloaded and renamed the `authenticated_origin_pull_ca.pem` certificate file, and uploaded it to `/etc/nginx/certs/cloudflare.crt`.
+For this example, you would have saved your certificate to `/etc/nginx/certs/cloudflare.crt`.
+
+$2
 
 ```txt
 ssl_verify_client optional;

--- a/content/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname.md
+++ b/content/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname.md
@@ -18,7 +18,7 @@ In the API response, save the certificate `id` since it will be required in step
 
 ## 2. Configure origin to accept client certificates
 
-{{<render file="_aop-configure-origin.md">}}
+{{<render file="_aop-configure-origin.md" withParameters=" ;; ">}}
 
 ## 3. Enable Authenticated Origin Pulls (globally)
 

--- a/content/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.md
+++ b/content/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.md
@@ -32,7 +32,7 @@ Using a custom certificate is required if you need your domain to be [FIPS](http
 
 ## 2. Configure origin to accept client certificates
 
-{{<render file="_aop-configure-origin.md">}}
+{{<render file="_aop-configure-origin.md" withParameters="If using the Cloudflare certificate, you would have downloaded it from [step 1 above](#1-upload-certificate-to-origin), renamed the .PEM file, and uploaded it to `/path/to/origin-pull-ca.pem`;; If using the Cloudflare certificate, you would have downloaded it from [step 1 above](#1-upload-certificate-to-origin), renamed the .PEM file, and uploaded it to `/etc/nginx/certs/cloudflare.crt`">}}
 
 ## 3. Configure Cloudflare to use client certificate
 

--- a/content/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.md
+++ b/content/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.md
@@ -32,7 +32,7 @@ Using a custom certificate is required if you need your domain to be [FIPS](http
 
 ## 2. Configure origin to accept client certificates
 
-{{<render file="_aop-configure-origin.md" withParameters="If using the Cloudflare certificate, you would have downloaded it from [step 1 above](#1-upload-certificate-to-origin), renamed the .PEM file, and uploaded it to `/path/to/origin-pull-ca.pem`;; If using the Cloudflare certificate, you would have downloaded it from [step 1 above](#1-upload-certificate-to-origin), renamed the .PEM file, and uploaded it to `/etc/nginx/certs/cloudflare.crt`">}}
+{{<render file="_aop-configure-origin.md" withParameters="To use the Cloudflare certificate, download it from [step 1 above](#1-upload-certificate-to-origin), rename the .PEM file, and then upload it to `/path/to/origin-pull-ca.pem` before applying the settings.;; To use the Cloudflare certificate, donwload it from [step 1 above](#1-upload-certificate-to-origin), rename the .PEM file, and then upload it to `/etc/nginx/certs/cloudflare.crt` before applying the settings.">}}
 
 ## 3. Configure Cloudflare to use client certificate
 


### PR DESCRIPTION
Improved the description of Apache and Nginx certificate paths when using Authenticated Origin Pulls, so that users are aware they must download, rename, and then upload the .PEM file provided by Cloudflare.