### PR TITLE
[Pages] Add section for disabling zone caching for custom domains

### DIFF
--- a/content/pages/configuration/custom-domains.md
+++ b/content/pages/configuration/custom-domains.md
@@ -87,6 +87,9 @@ To disable access to your project's provided `*.pages.dev` subdomain:
 
 2. Redirect the `*.pages.dev` URL associated with your production Pages project to a custom domain. You can use the account-level [Bulk Redirect](/rules/url-forwarding/bulk-redirects/) feature to redirect your `*.pages.dev` URL to a custom domain.
 
+## Disable zone caching for custom domains using Pages
+For custom domains that are served by Pages, it is recommended to disable any external caching since Pages has its [own independent cache]('/pages/configuration/custom-domains/) which is unique per deploy. When using a custom domain configured through Cloudflare's proxied `CNAME` records, you may find issues with your custom domain using stale data compared to your `*.pages.dev` subdomain. To fix this, you can create a [new cache rule]('/cache/how-to/cache-rules/create-dashboard/#create-a-cache-rule-in-the-dashboard') to "Bypass cache" for all hostnames that use Pages.
+
 ## Known issues
 
 ### CAA records


### PR DESCRIPTION
Hi there!

I recently migrated my project to Cloudflare Pages and was struggling with stale data appearing on my custom domain and couldn't figure out why. However, I discovered that it was likely due to external caching from the custom domain itself from looking at community posts and discord messages. I noticed that this was a somewhat common issue ([1](https://www.answeroverflow.com/m/1158677998329938021)) ([2](https://stackoverflow.com/questions/76874341/cloudflare-page-with-custom-domain-is-cached-after-deploy)) ([3](https://community.cloudflare.com/t/how-can-i-disable-the-cache-from-a-cloudflare-pages/605730)) and figured it might be worth including somewhere in the documentation.

I apologize if this isn't the proper way to bring this suggestion up, I'm relatively new to the open-source community. Thanks!