### PR TITLE
Clarify cross-zone a little better for cf-worker-ip

### DIFF
--- a/content/fundamentals/reference/http-request-headers.md
+++ b/content/fundamentals/reference/http-request-headers.md
@@ -31,7 +31,7 @@ Alternatively, if you do not wish to receive the `CF-Connecting-IP` header or an
 
 In same-zone Worker subrequests, the value of `CF-Connecting-IP` reflects the value of `x-real-ip` (the client’s IP). `x-real-ip` can be altered by the user in their Worker script.
 
-In cross-zone subrequests from one Cloudflare customer zone to another Cloudflare customer zone, the `CF-Connecting-IP` value will be set to the Worker client IP address `'2a06:98c0:3600::103'` for security reasons.
+In cross-zone subrequests from one Cloudflare zone to another Cloudflare zone, the `CF-Connecting-IP` value will be set to the Worker client IP address `'2a06:98c0:3600::103'` for security reasons.
 
 For Worker subrequests destined for a non-Cloudflare customer zone, the `CF-Connecting-IP` and `x-real-ip` headers will both reflect the client's IP address, with only the `x-real-ip` header able to be altered.
 


### PR DESCRIPTION
The word "customer" makes it sound like cross-account rather than just cross-zone and has caused confusion. Let's just clarify this a little more and drop that word