### PR TITLE
[Pages] Update type argument in c3 usage docs

### DIFF
--- a/content/pages/get-started/c3.md
+++ b/content/pages/get-started/c3.md
@@ -16,7 +16,6 @@ To get started, open a terminal window and run:
 
 {{<render file="/_c3-run-command.md" productFolder="/workers/" >}}
 
-
 Running `npm create cloudflare@latest` will prompt you to install the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) package, and lead you through a setup wizard. After you have entered the setup wizard, you will be asked which type of application you would like to create.
 
 The list of applications includes a variety of Workers templates as well as an option to select a web framework to create a website or web application.
@@ -74,11 +73,12 @@ $ npm create cloudflare@latest [--] [<DIRECTORY>] [OPTIONS] [-- <NESTED ARGS...>
 - `NESTED ARGS..` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - CLI arguments to pass to eventual third party CLIs C3 might invoke (in the case of full-stack applications).
 - `--type` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
   - The type of application that should be created.
 
   - The possible values for this option are:
 
-    - `webFramework`: A website or web application.
+    - `web-framework`: A website or web application.
     - `hello-world`: A basic "Hello World" Cloudflare Worker.
     - `common`: A Cloudflare Worker which implements a common example of routing/proxying functionalities.
     - `scheduled`: A scheduled Cloudflare Worker (triggered via [Cron Triggers](/workers/configuration/cron-triggers/)).
@@ -87,6 +87,7 @@ $ npm create cloudflare@latest [--] [<DIRECTORY>] [OPTIONS] [-- <NESTED ARGS...>
     - `openapi`: A Worker implementing an OpenAPI REST endpoint.
 
 - `--framework` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
   - The type of framework to use to create a web application (when using this option, `--type` is ignored).
 
   - The possible values for this option are:

--- a/content/pages/get-started/c3.md
+++ b/content/pages/get-started/c3.md
@@ -83,7 +83,6 @@ $ npm create cloudflare@latest [--] [<DIRECTORY>] [OPTIONS] [-- <NESTED ARGS...>
     - `common`: A Cloudflare Worker which implements a common example of routing/proxying functionalities.
     - `scheduled`: A scheduled Cloudflare Worker (triggered via [Cron Triggers](/workers/configuration/cron-triggers/)).
     - `queues`: A Cloudflare Worker which is both a consumer and produced of [Queues](/queues/).
-    - `chatgptPlugin`: A ChatGPT plugin.
     - `openapi`: A Worker implementing an OpenAPI REST endpoint.
 
 - `--framework` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}


### PR DESCRIPTION
The `webFramework` --type argument is being renamed to `web-framework`.