### PR TITLE
[Workers] Remove Cache API per-request storage limit

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -94,7 +94,7 @@ On the Unbound billing model, scheduled Workers ([Cron Triggers](/workers/config
 
 | Feature                       | Workers Free  | [Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model) | [Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model) and [Standard](/workers/platform/pricing/#example-pricing-standard-usage-model) |
 | ----------------------------- | ------------- | ------- | ------- |
-| [Max object size](#cache-api-limits) | 512 MB | 512 MB  | 512 MB  |
+| [Maximum object size](#cache-api-limits) | 512 MB | 512 MB  | 512 MB  |
 | [Calls/request](#cache-api-limits)   | 50     | 50      | 1,000   |
 
 {{</table-wrap>}}

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -92,17 +92,14 @@ On the Unbound billing model, scheduled Workers ([Cron Triggers](/workers/config
 
 {{<table-wrap>}}
 
-| Feature                       | Workers Free  | [Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model) | [Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model) | [Standard](/workers/platform/pricing/#example-pricing-standard-usage-model)  |
-| ----------------------------- | ------------- | ------- | ------- | ------- |
-| [Max object size](#cache-api-limits) | 512 MB | 512 MB  | 512 MB  | 512 MB  |
-| [Calls/request](#cache-api-limits)   | 50     | 50      | 1,000   | 1,000   |
-| [Storage/request](#cache-api-limits) | 5 GB   | 5 GB    | 5 GB    | 5 GB    |
+| Feature                       | Workers Free  | [Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model) | [Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model) and [Standard](/workers/platform/pricing/#example-pricing-standard-usage-model) |
+| ----------------------------- | ------------- | ------- | ------- |
+| [Max object size](#cache-api-limits) | 512 MB | 512 MB  | 512 MB  |
+| [Calls/request](#cache-api-limits)   | 50     | 50      | 1,000   |
 
 {{</table-wrap>}}
 
 - 50 total `put()`, `match()`, or `delete()` calls per-request, using the same quota as `fetch()`.
-
-- 5 GB total `put()` per request.
 
 {{<Aside type="note">}}
 


### PR DESCRIPTION
This has been removed in https://github.com/cloudflare/workerd/pull/1863, which has been deployed to production since.
Also updates the table formatting to list the unbound and standard models together – currently the Standard column can't be seen without scrolling to the right which is confusing (https://developers.cloudflare.com/workers/platform/limits/#cache-api-limits), putting them together also matches the approach used for the table above.