### PR TITLE
[Pages] Clarify redirects documentation

### DIFF
--- a/content/pages/configuration/redirects.md
+++ b/content/pages/configuration/redirects.md
@@ -89,7 +89,7 @@ Cloudflare currently offers limited support for advanced redirects. More support
 | ----------------------------------- | ------- | --------------------------------------------------------------- | --------------------------------------- |
 | Redirects (301, 302, 303, 307, 308) | Yes     | `/home / 301`                                                   | 302 is used as the default status code. |
 | Rewrites (other status codes)       | No      | `/blog/* /blog/404.html 404`                                    |                                         |
-| Splats                              | Yes     | `/blog/* /blog/:splat`                                          | Refer to [Splats](#splats).             |
+| Splats                              | Yes     | `/blog/* /posts/:splat`                                         | Refer to [Splats](#splats).             |
 | Placeholders                        | Yes     | `/blog/:year/:month/:date/:slug /news/:year/:month/:date/:slug` | Refer to [Placeholders](#placeholders). |
 | Query Parameters                    | No      | `/shop id=:id /blog/:id 301`                                    |                                         |
 | Proxying                            | Yes     | `/blog/* /news/:splat 200`                                      | Refer to [Proxying](#proxying).         |


### PR DESCRIPTION
The documentation for redirects has a section for [Advanced redirects](https://developers.cloudflare.com/pages/configuration/redirects/#advanced-redirects). 

The example for [splats](https://developers.cloudflare.com/pages/configuration/redirects/#splats) shows a redirect from `/blog/*` to `/blog/:splat`.

This doesn't seem to make sense, as the `*` greedily matches all characters and the `:splat` adds them back to the partial URL. This results in a redirect of `/blog/foo` to `/blog/foo` - the same place.

I think it would be clearer if the table under advanced redirects showed an example which redirects to another directory, e.g. `/blog/foo` to `/posts/foo`. This is a common pattern where splats seem to be useful.