### PR TITLE
adds missing import from TypeScript cookie example

### DIFF
--- a/content/workers/examples/extract-cookie-value.md
+++ b/content/workers/examples/extract-cookie-value.md
@@ -33,6 +33,7 @@ export default {
 {{<tab label="ts">}}
 
 ```ts
+import { parse } from "cookie";
 export default {
   async fetch(request) {
     // The name of the cookie


### PR DESCRIPTION
the TS example was missing the import, and I was confused where `parse` was coming from 