### PR TITLE
Update unicode-interoperability.md to indicate macOS file names are case insensitive

### DIFF
--- a/content/r2/reference/unicode-interoperability.md
+++ b/content/r2/reference/unicode-interoperability.md
@@ -13,7 +13,7 @@ R2 preserves the encoding for display though. When you list the objects, you wil
 
 There are still some platform-specific differences to consider:
 
-* Windows filenames are case-insensitive while R2, Linux, and macOS are not.
+* Windows and macOS filenames are case-insensitive while R2 and Linux are not.
 * Windows console support for Unicode can be error-prone. Make sure to run `chcp 65001` before using command-line tools or use Cygwin if your object names appear to be incorrect.
 * Linux allows distinct files that are unicode-equivalent because filenames are byte streams. Unicode-equivalent filenames on Linux will point to the same R2 object.
 


### PR DESCRIPTION
Noticed a minor issue while reading the docs, it lists macOS as a case-sensitive file system but by default it's not. You can see this in a terminal:

<img width="257" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/1830497/fc19c2b1-7e82-4f74-ae6c-d142eab07575">
