### PR TITLE
[Chore] Fix datetime format for RSS feeds

### DIFF
--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -25,7 +25,7 @@
     <description>Updates to Cloudflare's {{$product}} product.</description>
     <language>en-us</language>
     <atom:link href="{{$atomLink}}" rel="self" />
-    <lastBuildDate>{{- index (index $changelogDataEntries 0) "publish_date" | time.Format "Monday, Jan 2, 2006" -}}</lastBuildDate>
+    <lastBuildDate>{{- index (index $changelogDataEntries 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST" -}}</lastBuildDate>
     {{- range $changelogDataEntries -}}
     {{- $entry := . -}}
     {{- $link := "" -}}
@@ -53,7 +53,7 @@
     <title>{{- $title -}}</title>
     <link>{{- $link -}}</link>
     <description>{{- $description -}}</description>
-    <pubDate>{{- .publish_date | time.Format "Monday, Jan 2, 2006" -}}</pubDate>
+    <pubDate>{{- .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST -}}</pubDate>
     </item>
     {{- end -}}
   </channel>

--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -53,7 +53,7 @@
     <title>{{- $title -}}</title>
     <link>{{- $link -}}</link>
     <description>{{- $description -}}</description>
-    <pubDate>{{- .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST -}}</pubDate>
+    <pubDate>{{- .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST" -}}</pubDate>
     </item>
     {{- end -}}
   </channel>

--- a/layouts/_default/home.rss.xml
+++ b/layouts/_default/home.rss.xml
@@ -18,7 +18,7 @@
     <description>View updates to various Cloudflare products.</description>
     <language>en-us</language>
     <atom:link href="{{$atomLink}}" rel="self" />
-    <lastBuildDate>{{- index (index $changelogRendered 0) "publish_date" | time.Format "Monday, Jan 2, 2006" -}}</lastBuildDate>
+    <lastBuildDate>{{- index (index $changelogRendered 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST -}}</lastBuildDate>
     {{- range $changelogRendered -}}
     {{- $entry := . -}}
     {{- $link := "" -}}
@@ -48,7 +48,7 @@
     <title>{{- $title -}}</title>
     <link>{{ $link }}</link>
     <description>{{- $description -}}</description>
-    <pubDate>{{ .publish_date | time.Format "Monday, Jan 2, 2006" }}</pubDate>
+    <pubDate>{{ .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST }}</pubDate>
     <product>{{- $product -}}</product>
     </item>
     {{- end -}}

--- a/layouts/_default/home.rss.xml
+++ b/layouts/_default/home.rss.xml
@@ -18,7 +18,7 @@
     <description>View updates to various Cloudflare products.</description>
     <language>en-us</language>
     <atom:link href="{{$atomLink}}" rel="self" />
-    <lastBuildDate>{{- index (index $changelogRendered 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST -}}</lastBuildDate>
+    <lastBuildDate>{{- index (index $changelogRendered 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST" -}}</lastBuildDate>
     {{- range $changelogRendered -}}
     {{- $entry := . -}}
     {{- $link := "" -}}
@@ -48,7 +48,7 @@
     <title>{{- $title -}}</title>
     <link>{{ $link }}</link>
     <description>{{- $description -}}</description>
-    <pubDate>{{ .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST }}</pubDate>
+    <pubDate>{{ .publish_date | time.Format "Mon, 02 Jan 2006 08:00:00 EST" }}</pubDate>
     <product>{{- $product -}}</product>
     </item>
     {{- end -}}


### PR DESCRIPTION
Solves the date issue brought up in PCX-10277, as shown by [RSS validator](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fchangelog-date-validation.cloudflare-docs-7ou.pages.dev%2Fr2%2Freference%2Fchangelog%2Findex.xml).

_Technically_, we're still violating the spec with the top-level changelog and having a `<product>` attribute... but can live with that atm.