### PR TITLE
Update known-limitations.md - Comcast IPs to include IPv6 addresses

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/troubleshooting/known-limitations.md
@@ -50,11 +50,14 @@ Because of how the WARP client instantiates the local DNS Proxy, it is incompati
 
 ## Comcast DNS servers
 
-Comcast DNS traffic to `75.75.75.75` and `75.75.76.76` cannot be proxied through WARP. This is because Comcast rejects DNS traffic that is not sent directly from the user's device.
+Comcast DNS traffic (to the IPs below) cannot be proxied through WARP. This is because Comcast rejects DNS traffic that is not sent directly from the user's device.
+
+- IPv4 Addresses: `75.75.75.75` and `75.75.76.76`
+- IPv6 Addresses: `2001:558:feed::1` and `2001:558:feed::2`
 
 To work around the issue, you can either:
 
-- Create a [Split Tunnel rule](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) that excludes `75.75.75.75/32` and `75.75.76.76/32` from WARP.
+- Create a [Split Tunnel rule](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/) that excludes the above IPs from WARP.
 - Configure your device or router to use a public DNS server such as [`1.1.1.1`](https://1.1.1.1/dns/).
 
 ## Cox DNS servers


### PR DESCRIPTION
I added the IPv6 Comcast Addresses to the suggested excluded IPs for Users on Comcast using the default configuration. 

For formatting  I copied it from the WARP with firewall, where we list multiple IPs.