### PR TITLE
queues: document new delay settings in wrangler.toml 

### DIFF
--- a/content/queues/reference/batching-retries.md
+++ b/content/queues/reference/batching-retries.md
@@ -183,7 +183,9 @@ export default {
 };
 ```
 
-You can also choose to set a default retry delay to any messages that are retried due to either implicit failure or when calling `retry()` explicitly. This is set at the consumer level, and is supported in both push-based (Worker) and pull-based (HTTP) consumers:
+You can also choose to set a default retry delay to any messages that are retried due to either implicit failure or when calling `retry()` explicitly. This is set at the consumer level, and is supported in both push-based (Worker) and pull-based (HTTP) consumers.
+
+Delays can be configured via the `wrangler` CLI:
 
 ```sh
 # Push-based consumers
@@ -194,6 +196,24 @@ $ npx wrangler@latest queues consumer worker add $QUEUE_NAME $WORKER_SCRIPT_NAME
 # Delay any messages that are retried by 60 seconds (1 minute) by default.
 $ npx wrangler@latest queues consumer http add $QUEUE_NAME --retry-delay-secs=60
 ```
+
+Delays can also be configured in [`wrangler.toml`](/workers/wrangler/configuration/#queues) with the `delivery_delay` setting for producers (when sending) and/or the `retry_delay` (when retrying) per-consumer:
+
+```toml
+---
+header: wrangler.toml
+---
+[[queues.producers]]
+  binding = "<BINDING_NAME>"
+  queue = "<QUEUE_NAME>"
+  delivery_delay = 60 # delay every message delivery by 1 minute
+
+[[queues.consumers]]
+  queue = "my-queue"
+  retry_delay = 300 # delay any retried message by 5 minutes before re-attempting delivery
+```
+
+Note that if you use both the `wrangler` CLI and `wrangler.toml` to change the settings associated with a queue or a queue consumer, the most recent configuration change will take effect.
 
 Refer to the [Queues REST API documentation](/api/operations/queue-list-queue-consumers) to learn how to configure message delays and retry delays programmatically.
 

--- a/content/queues/reference/batching-retries.md
+++ b/content/queues/reference/batching-retries.md
@@ -213,7 +213,7 @@ header: wrangler.toml
   retry_delay = 300 # delay any retried message by 5 minutes before re-attempting delivery
 ```
 
-Note that if you use both the `wrangler` CLI and `wrangler.toml` to change the settings associated with a queue or a queue consumer, the most recent configuration change will take effect.
+If you use both the `wrangler` CLI and `wrangler.toml` to change the settings associated with a queue or a queue consumer, the most recent configuration change will take effect.
 
 Refer to the [Queues REST API documentation](/api/operations/queue-list-queue-consumers) to learn how to configure message delays and retry delays programmatically.
 

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -1206,4 +1206,4 @@ If you change your environment variables in the Cloudflare dashboard, Wrangler w
 
 If you change your routes in the dashboard, Wrangler will override them in the next deploy with the routes you have set in your `wrangler.toml`. To manage routes via the Cloudflare dashboard only, remove any route and routes keys from your `wrangler.toml` file. Then add `workers_dev = false` to your `wrangler.toml` file. For more information, refer to [Deprecations](/workers/wrangler/deprecations/#other-deprecated-behavior).
 
-Note that Wrangler will not delete your secrets (encrypted environment variables) unless you run `wrangler secret delete <key>`.
+Wrangler will not delete your secrets (encrypted environment variables) unless you run `wrangler secret delete <key>`.

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -713,6 +713,10 @@ To bind Queues to your producer Worker, assign an array of the below object to t
 - `binding` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
   - The binding name used to refer to the queue in your Worker. The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "MY_QUEUE"` or `binding = "productionQueue"` would both be valid names for the binding.
+ 
+- `delivery_delay` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The number of seconds to [delay messages sent to a queue](/queues/reference/batching-retries/#delay-messages) for by default. This can be overridden on a per-message or per-batch basis.
 
 {{</definitions>}}
 
@@ -725,6 +729,7 @@ header: wrangler.toml
 [[queues.producers]]
   binding = "<BINDING_NAME>"
   queue = "<QUEUE_NAME>"
+  delivery_delay = 60 # Delay messages by 60 seconds before they are delivered to a consumer
 ```
 
 To bind Queues to your consumer Worker, assign an array of the below object to the `[[queues.consumers]]` key.
@@ -757,6 +762,10 @@ To bind Queues to your consumer Worker, assign an array of the below object to t
 
   - The maximum number of concurrent consumers allowed to run at once. Leaving this unset will mean that the number of invocations will scale to the [currently supported maximum](/queues/platform/limits/).
   - Refer to [Consumer concurrency](/queues/reference/consumer-concurrency/) for more information on how consumers autoscale, particularly when messages are retried.
+ 
+- `retry_delay` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The number of seconds to [delay retried messages](/queues/reference/batching-retries/#delay-messages) for by default, before they are re-delivered to the consumer. This can be overridden on a per-message or per-batch basis [when retrying messages](/queues/reference/batching-retries/#explicit-acknowledgement-and-retries).
 
 {{</definitions>}}
 
@@ -773,6 +782,7 @@ header: wrangler.toml
   max_retries = 10
   dead_letter_queue = "my-queue-dlq"
   max_concurrency = 5
+  retry_delay = 120 # Delay retried messages by 2 minutes before re-attempting delivery
 ```
 
 ### R2 buckets


### PR DESCRIPTION
cc @pmiguel 

This PR adds the new `delivery_delay` and `retry_delay` features to the `wrangler.toml` definitions for Queues.

- [x] Wait for https://github.com/cloudflare/workers-sdk/pull/5413 to be merged

