### PR TITLE
Update bandwidth-measurement.md

### DIFF
--- a/content/magic-transit/reference/bandwidth-measurement.md
+++ b/content/magic-transit/reference/bandwidth-measurement.md
@@ -8,3 +8,5 @@ title: Bandwidth measurement
 Cloudflare measures Magic Transit usage based on the 95th percentile of clean bandwidth for your network. "Clean bandwidth" refers to the egress traffic routed to your network after all DDoS mitigation and firewall functions are applied. The usage measurement explicitly excludes attack traffic blocked at Cloudflare's global network.
 
 To measure 95th percentile bandwidth, Cloudflare records clean bandwidth leaving our global network at five minute intervals, sorts these measurements in descending order, and discards the top 5% of recorded measurements. The highest remaining value constitutes the 95th percentile bandwidth measurement for that time period.
+
+Note: when using [Magic Transit with Egress option](/reference-architecture/architectures/magic-transit/#magic-transit-with-egress-option-enabled), Cloudflare will also measure the 95th percentile of the egress traffic from your network to Cloudflare.


### PR DESCRIPTION
Clarify that 95th percentile calculations include customer egress traffic when using the Egress option.