### PR TITLE
[Workers] Document Brotli compatibility flag, Fetch API compression and passthrough support

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/brotli-content-encoding.md
+++ b/content/workers/_partials/_platform-compatibility-dates/brotli-content-encoding.md
@@ -1,0 +1,14 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Brotli Content-Encoding support"
+sort_date: "2024-04-29"
+enable_date: "2024-04-29"
+enable_flag: "brotli_content_encoding"
+disable_flag: "no_brotli_content_encoding"
+---
+
+When the `brotli_content_encoding` compatibility flag is enabled, Workers supports the `br` content encoding and can request and respond with data encoded using the [Brotli](https://developer.mozilla.org/en-US/docs/Glossary/Brotli_compression) compression algorithm. This reduces the amount of data that needs to be fetched and can be used to pass through the original compressed data to the client. See the Fetch API [documentation](/workers/runtime-apis/fetch/#how-the-accept-encoding-header-is-handled) for details.

--- a/content/workers/runtime-apis/fetch.md
+++ b/content/workers/runtime-apis/fetch.md
@@ -79,6 +79,42 @@ async function eventHandler(event) {
 
 {{</definitions>}}
 
+---
+
+## How the `Accept-Encoding` header is handled
+
+When making a subrequest with the `fetch()` API, you can specify which forms of compression to prefer that the server will respond with (if the server supports it) by including the [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header.
+
+Workers supports both the gzip and brotli compression algorithms. Usually it is not necessary to specify `Accept-Encoding` or `Content-Encoding` headers in the Workers Runtime production environment – brotli or gzip compression is automatically requested when fetching from an origin and applied to the response when returning data to the client, depending on the capabilities of the client and origin server.
+
+To support requesting brotli from the origin, you must enable the [`brotli_content_encoding`](/workers/configuration/compatibility-dates/#brotli-content-encoding-support) compatibility flag in your Worker. Soon, this compatibility flag will be enabled by default for all Workers past an upcoming compatibility date.
+
+### Passthrough behavior
+
+One scenario where the Accept-Encoding header is useful is for passing through compressed data from a server to the client, where the Accept-Encoding allows the worker to directly receive the compressed data stream from the server without it being decompressed beforehand. As long as you do not read the body of the compressed response prior to returning it to the client and keep the `Content-Encoding` header intact, it will "pass through" without being decompressed and then recompressed again. This can be helpful when using Workers in front of origin servers or when fetching compressed media assets, to ensure that the same compression used by the origin server is used in the response that your Worker returns.
+
+In addition to a change in the content encoding, recompression is also needed when a response uses an encoding not supported by the client. As an example, when a Worker requests either brotli or gzip as the encoding but the client only supports gzip, recompression will still be needed if the server returns brotli-encoded data to the server (and will be applied automatically). Note that this behavior may also vary based on the [compression rules](/rules/compression-rules/), which can be used to configure what compression should be applied for different types of data on the server side.
+
+```typescript
+export default {
+  async fetch(request) {
+    // Accept brotli or gzip compression
+    const headers = new Headers({
+      'Accept-Encoding': "br, gzip"
+    });
+    let response = await fetch("https://developers.cloudflare.com", {method: "GET", headers});
+
+    // As long as the original response body is returned and the Content-Encoding header is
+    // preserved, the same encoded data will be returned without needing to be compressed again.
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+}
+```
+
 ## Related resources
 
 - [Example: use `fetch` to respond with another site](/workers/examples/respond-with-another-site/)

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -2,6 +2,9 @@
 link: "/workers/platform/changelog/"
 productName: Workers
 entries:
+- publish_date: '2024-04-03'
+  description: |-
+    - When the [`brotli_content_encoding`](/workers/configuration/compatibility-dates/#brotli-content-encoding-support) compatibility flag is enabled, the Workers runtime now supports compressing and decompressing request bodies encoded using the [Brotli](https://developer.mozilla.org/en-US/docs/Glossary/Brotli_compression) compression algorithm. Refer to [this docs section](/workers/runtime-apis/fetch/#how-the-accept-encoding-header-is-handled) for more detail.
 - publish_date: '2024-04-01'
   description: |-
     - The new [`unwrap_custom_thenables` compatibility flag](/workers/configuration/compatibility-dates/#support-for-accepting-custom-thenables-in-internal-apis) enables workers to accept custom thenables in internal APIs that expect a promise (for instance, the `ctx.waitUntil(...)` method).


### PR DESCRIPTION
This flag will have a default compatibility date once https://github.com/cloudflare/workerd/pull/708 has been deployed. Adds documentation for the flag and describes the role of the Accept-Encoding header in the Fetch API, as well as how compressed data passthrough can be achieved.