### PR TITLE
adds `--show-interactive-dev-session` flag to `dev` options

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -732,6 +732,8 @@ As of Wrangler v3.2.0, `wrangler dev` is supported by any Linux distributions pr
 - `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets to be served.
   - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --assets dist/ --latest`.
+- `--show-interactive-dev-session` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(default: true){{</prop-meta>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Show interactive dev session (defaults to true if the terminal supports interactivity)
 - `--site` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets for Workers Sites.
 - `--site-include` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}


### PR DESCRIPTION
I was very happy to find [this](https://github.com/cloudflare/workers-sdk/pull/5099) (I'm also using Turbo repo and the interactive prompt reduces the signal:noise), so I figured others might also be grateful for the option.