### PR TITLE
[Workers] bump vitest version

### DIFF
--- a/content/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.md
+++ b/content/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.md
@@ -29,7 +29,7 @@ First, you will need to uninstall the old environment and install the new pool. 
 
 ```sh
 $ npm uninstall vitest-environment-miniflare
-$ npm install --save-dev --save-exact vitest@1.3.0
+$ npm install --save-dev --save-exact vitest@1.4.0
 $ npm install --save-dev @cloudflare/vitest-pool-workers
 ```
 

--- a/content/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.md
+++ b/content/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.md
@@ -29,7 +29,7 @@ First, you will need to uninstall the old environment and install the new pool. 
 
 ```sh
 $ npm uninstall vitest-environment-miniflare
-$ npm install --save-dev --save-exact vitest@1.4.0
+$ npm install --save-dev --save-exact vitest@1.5.0
 $ npm install --save-dev @cloudflare/vitest-pool-workers
 ```
 

--- a/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
+++ b/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
@@ -23,7 +23,7 @@ This guide will instruct you through installing and setting up the `@cloudflare/
 Open a terminal window and make sure you are in your project's root directory. Once you have confirmed that, run:
 
 ```sh
-$ npm install vitest@1.3.0 --save-dev --save-exact
+$ npm install vitest@1.4.0 --save-dev --save-exact
 $ npm install @cloudflare/vitest-pool-workers --save-dev
 ```
 
@@ -31,7 +31,7 @@ The above commands will add the packages to your `package.json` file and install
 
 {{<Aside type="note">}}
 
-Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 1.3.0.
+Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 1.4.0.
 
 {{</Aside>}}
 

--- a/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
+++ b/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
@@ -23,7 +23,7 @@ This guide will instruct you through installing and setting up the `@cloudflare/
 Open a terminal window and make sure you are in your project's root directory. Once you have confirmed that, run:
 
 ```sh
-$ npm install vitest@1.4.0 --save-dev --save-exact
+$ npm install vitest@1.5.0 --save-dev --save-exact
 $ npm install @cloudflare/vitest-pool-workers --save-dev
 ```
 
@@ -31,7 +31,7 @@ The above commands will add the packages to your `package.json` file and install
 
 {{<Aside type="note">}}
 
-Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 1.4.0.
+Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 1.5.0.
 
 {{</Aside>}}
 


### PR DESCRIPTION
Bumps the vitest version from `1.3.0` to `1.5.0`.

Do not merge until https://github.com/cloudflare/workers-sdk/pull/5458 is merged and released.