### PR TITLE
sdks: add curl vs SDK examples

### DIFF
--- a/content/fundamentals/api/how-to/make-api-calls.md
+++ b/content/fundamentals/api/how-to/make-api-calls.md
@@ -32,7 +32,7 @@ For specific guidance on making API calls, refer to the following resources:
 
 *   The product's [Developer Docs section](/products/) for how-to guides.
 *   [API schema docs](/api/) for request and response payloads for each endpoint.
-*   If you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/cloudflare/terraform-provider-cloudflare), use our first-party libraries to integrate with Cloudflare's API.
+*   The first-party libraries for[Go](https://github.com/cloudflare/cloudflare-go), [Typescript](https://github.com/cloudflare/cloudflare-typescript), [Python](https://github.com/cloudflare/cloudflare-python), or [Hashicorp's Terraform](https://github.com/cloudflare/terraform-provider-cloudflare).
 
 ## Pagination
 

--- a/content/fundamentals/api/how-to/make-api-calls.md
+++ b/content/fundamentals/api/how-to/make-api-calls.md
@@ -32,7 +32,7 @@ For specific guidance on making API calls, refer to the following resources:
 
 *   The product's [Developer Docs section](/products/) for how-to guides.
 *   [API schema docs](/api/) for request and response payloads for each endpoint.
-*   The first-party libraries for[Go](https://github.com/cloudflare/cloudflare-go), [Typescript](https://github.com/cloudflare/cloudflare-typescript), [Python](https://github.com/cloudflare/cloudflare-python), or [Hashicorp's Terraform](https://github.com/cloudflare/terraform-provider-cloudflare).
+*   The first-party libraries for [Go](https://github.com/cloudflare/cloudflare-go), [Typescript](https://github.com/cloudflare/cloudflare-typescript), [Python](https://github.com/cloudflare/cloudflare-python), or [Hashicorp's Terraform](https://github.com/cloudflare/terraform-provider-cloudflare).
 
 ## Pagination
 

--- a/content/fundamentals/api/reference/sdks.md
+++ b/content/fundamentals/api/reference/sdks.md
@@ -25,7 +25,7 @@ There is no definite answer on which you should use. Instead, consider your use 
 | Usage from within an existing application or framework      | ❌   | ✅   |
 | More complex usage where you need to chain together outputs | ❌   | ✅   |
 
-\* You can use SDKs in CI with a few additional validation steps.
+\* It is possible, although not straight forward, to use the SDKs within bash scripts or CI environments with additional runtime dependencies and setup.
 
 ## Example
 

--- a/content/fundamentals/api/reference/sdks.md
+++ b/content/fundamentals/api/reference/sdks.md
@@ -25,7 +25,7 @@ There is no definite answer on which you should use. Instead, consider your use 
 | Usage from within an existing application or framework      | ❌   | ✅   |
 | More complex usage where you need to chain together outputs | ❌   | ✅   |
 
-\* You can use SDKs in CI with a few additional steps.
+\* You can use SDKs in CI with a few additional validation steps.
 
 ## Example
 

--- a/content/fundamentals/api/reference/sdks.md
+++ b/content/fundamentals/api/reference/sdks.md
@@ -1,24 +1,22 @@
 ---
-pcx_content_type: how-to
+pcx_content_type: reference
 title: SDKs
 weight: 5
 ---
 
 # SDKs
 
-Despite many examples using `curl` to demonstrate usage of the Cloudflare API,
-there are also language SDKs (software development kits) available. These
-libraries provide the ability to interact with the Cloudflare API in language
-specific syntax and integrate with your existing application.
+Cloudflare offers language software development kits (SDKs) as well as `curl` examples to demonstrate how to use the Cloudflare API. The SDK libraries allow you to interact with the Cloudflare API in language-specific syntax and more easily integrate with your existing applications.
+
+Cloudflare currently offers the following SDKs:
 
 - [Go](https://github.com/cloudflare/cloudflare-go)
 - [Typescript](https://github.com/cloudflare/cloudflare-typescript)
 - [Python](https://github.com/cloudflare/cloudflare-python)
 
-## curl vs SDK
+## When to use curl vs SDK
 
-There is no definite answer on which you should use. Instead, you should consider
-your use case and determine which is the best fit.
+There is no definite answer on which you should use. Instead, consider your use case and determine whether curl or an SDK is the best fit.
 
 | Use case                                                    | curl | SDK  |
 | ----------------------------------------------------------- | ---- | ---- |
@@ -27,21 +25,20 @@ your use case and determine which is the best fit.
 | Usage from within an existing application or framework      | ❌   | ✅   |
 | More complex usage where you need to chain together outputs | ❌   | ✅   |
 
-\* You can use SDKs in CI however, it requires installing and additional steps to get working.
+\* You can use SDKs in CI with a few additional steps.
 
 ## Example
 
-Consider the scenario where you need to query all the Cloudflare zones you have
-access to. Here is a small comparison of the two approaches:
+The following are examples of how you would query all of the Cloudflare zones you have access to.
 
-With curl:
+### With curl:
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/zones" \
 -H "Authorization: Bearer <API_TOKEN>"
 ```
 
-With the Typescript SDK:
+### With the Typescript SDK:
 
 ```js
 const client = new Cloudflare({

--- a/content/fundamentals/api/sdks.md
+++ b/content/fundamentals/api/sdks.md
@@ -1,0 +1,54 @@
+---
+pcx_content_type: how-to
+title: SDKs
+weight: 5
+---
+
+# SDKs
+
+Despite many examples using `curl` to demonstrate usage of the Cloudflare API,
+there are also language SDKs (software development kits) available. These
+libraries provide the ability to interact with the Cloudflare API in language
+specific syntax and integrate with your existing application.
+
+- [Go](https://github.com/cloudflare/cloudflare-go)
+- [Typescript](https://github.com/cloudflare/cloudflare-typescript)
+- [Python](https://github.com/cloudflare/cloudflare-python)
+
+## curl vs SDK
+
+There is no definite answer on which you should use. Instead, you should consider
+your use case and determine which is the best fit.
+
+| Use case                                                    | curl | SDK  |
+| ----------------------------------------------------------- | ---- | ---- |
+| Quick testing within the CLI                                | ✅   | ❌   |
+| Use within bash scripts or CI                               | ✅   | ❌\* |
+| Usage from within an existing application or framework      | ❌   | ✅   |
+| More complex usage where you need to chain together outputs | ❌   | ✅   |
+
+\* You can use SDKs in CI however, it requires installing and additional steps to get working.
+
+## Example
+
+Consider the scenario where you need to query all the Cloudflare zones you have
+access to. Here is a small comparison of the two approaches:
+
+With curl:
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones" \
+-H "Authorization: Bearer <API_TOKEN>"
+```
+
+With the Typescript SDK:
+
+```js
+const client = new Cloudflare({
+  apiToken: process.env["CLOUDFLARE_API_TOKEN"],
+});
+
+const zones = await client.zones.list();
+
+console.log(zones);
+```

--- a/content/fundamentals/basic-tasks/interact-with-cloudflare.md
+++ b/content/fundamentals/basic-tasks/interact-with-cloudflare.md
@@ -21,8 +21,10 @@ If your domain was added to Cloudflare by a hosting partner, manage your DNS rec
 
 For those who prefer to interact with Cloudflare programmatically, you can use several methods:
 
-| Resource | Docs | Description
-| --- | --- | --- |
-| [Cloudflare API](/fundamentals/api/) | [API docs](/api/) | RESTful API based on HTTPS requests and JSON responses. |
-| [Terraform](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) | [Terraform docs](/terraform/) | Configure Cloudflare using HashiCorp’s Infrastructure as Code tool, Terraform. |
-| [Cloudflare Go](https://github.com/cloudflare/cloudflare-go) | [README](https://github.com/cloudflare/cloudflare-go#readme) | A Go library for interacting with Cloudflare's API v4. |
+| Resource                                                                               | Docs                                                                 | Description                                                                    |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [Cloudflare API](/fundamentals/api/)                                                   | [API docs](/api/)                                                    | RESTful API based on HTTPS requests and JSON responses.                        |
+| [Terraform](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) | [Terraform docs](/terraform/)                                        | Configure Cloudflare using HashiCorp’s Infrastructure as Code tool, Terraform. |
+| [cloudflare-go](https://github.com/cloudflare/cloudflare-go)                           | [README](https://github.com/cloudflare/cloudflare-go#readme)         | The official Go library for the Cloudflare API.                                |
+| [cloudflare-typescript](https://github.com/cloudflare/cloudflare-typescript)           | [README](https://github.com/cloudflare/cloudflare-typescript#readme) | The official Typescript library for the Cloudflare API.                        |
+| [cloudflare-python](https://github.com/cloudflare/cloudflare-python)                   | [README](https://github.com/cloudflare/cloudflare-python#readme)     | The official Python library for the Cloudflare API.                            |


### PR DESCRIPTION
Introduces a page for mentioning the existence of the SDKs but also how it compares to `curl`.