### PR TITLE
[Docs Site] Fix mixed-case + spaces in Tab Switcher labels

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -130,7 +130,7 @@ export function tabs() {
           const tabId = parts.slice(0, parts.length - 1).join("-");
 
           const defaultTabLabel = wrappers[i].querySelector(
-            `a[data-link=${tabId}]`
+            `a[data-link="${tabId}"]`
           );
 
           (defaultTab as HTMLElement).style.display = "block";

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -86,7 +86,7 @@ JavaScript
 </a>
 
 {{ else }}
-<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{lower $link}}" data-id="{{lower $unique_id}}">
+<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{$link}}" data-id="{{lower $unique_id}}">
 {{$link}}
 </a>
 {{ end }}


### PR DESCRIPTION
Fixes the tab switcher usage on https://developers.cloudflare.com/workers-ai/fine-tunes/loras/ taking you to the top of the page since it caused exceptions in the JS that handles `click` events.

1) we called `lower` on non-JS/TS labels but the JS didn't search with a lower-cased selector

<img width="880" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/0e4332b5-9bd8-49b8-ac58-62b8f59516f0">

2) we didn't wrap the label in quotes meaning labels with spaces (like "Workers AI SDK") wasn't a valid selector

<img width="522" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/5b5c5b1e-b17f-4aed-bac7-c3f0439c3ad0">
