### PR TITLE
[D1] Add NuxtHub to D1 community projects

### DIFF
--- a/content/d1/reference/community-projects.md
+++ b/content/d1/reference/community-projects.md
@@ -89,7 +89,7 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 
 ### NuxtHub
 
-`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindinds into your Nuxt application with zero configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with D1, KV and R2 with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`). It also provide a way to use your remote D1 database in development using the `nuxi dev --remote` command.
+`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindings into your Nuxt application with no configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with [D1](/d1/), [KV](/kv/) and [R2](/r2/) with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`). `NuxtHub` also provides a way to use your remote D1 database in development using the `nuxi dev --remote` command.
 
 * [GitHub](https://github.com/nuxt-hub/core)
 * [Documentation](https://hub.nuxt.com)

--- a/content/d1/reference/community-projects.md
+++ b/content/d1/reference/community-projects.md
@@ -89,7 +89,7 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 
 ### NuxtHub
 
-`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindinds into your Nuxt application with zero configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with D1, KV and R2 with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`).
+`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindinds into your Nuxt application with zero configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with D1, KV and R2 with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`). It also provide a way to use your remote D1 database in development using the `nuxi dev --remote` command.
 
 * [GitHub](https://github.com/nuxt-hub/core)
 * [Documentation](https://hub.nuxt.com)

--- a/content/d1/reference/community-projects.md
+++ b/content/d1/reference/community-projects.md
@@ -87,6 +87,13 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 * [GitHub](https://github.com/lauragift21/staff-directory)
 * [D1 functionality](https://github.com/lauragift21/staff-directory/blob/main/app/db.ts)
 
+### NuxtHub
+
+`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindinds into your Nuxt application with zero configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with D1, KV and R2 with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`).
+
+* [GitHub](https://github.com/nuxt-hub/core)
+* [Documentation](https://hub.nuxt.com)
+
 ## Feedback
 
 To report a bug or file feature requests for these community projects, create an issue directly on the project's repository.

--- a/content/d1/reference/community-projects.md
+++ b/content/d1/reference/community-projects.md
@@ -89,7 +89,9 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 
 ### NuxtHub
 
-`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindings into your Nuxt application with no configuration. It leverages [Cloudflare Wrangler Plaform Proxy](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with [D1](/d1/), [KV](/kv/) and [R2](/r2/) with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`). `NuxtHub` also provides a way to use your remote D1 database in development using the `nuxi dev --remote` command.
+`NuxtHub` is a Nuxt module that brings Cloudflare Worker bindings into your Nuxt application with no configuration. It leverages the [Wrangler Platform Proxy](/workers/wrangler/api/#getplatformproxy) in development and direct binding in production to interact with [D1](/d1/), [KV](/kv/) and [R2](/r2/) with server composables (`hubDatabase()`, `hubKV()` and `hubBlob()`).
+
+`NuxtHub` also provides a way to use your remote D1 database in development using the `npx nuxt dev --remote` command.
 
 * [GitHub](https://github.com/nuxt-hub/core)
 * [Documentation](https://hub.nuxt.com)

--- a/content/d1/reference/community-projects.md
+++ b/content/d1/reference/community-projects.md
@@ -93,6 +93,7 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 
 * [GitHub](https://github.com/nuxt-hub/core)
 * [Documentation](https://hub.nuxt.com)
+* [Example](https://github.com/Atinux/nuxt-todos-edge)
 
 ## Feedback
 


### PR DESCRIPTION
I believe this open source and community project needs to be showcased as it gives a zero-config experience between Cloudflare and Nuxt.