### PR TITLE
Workers AI — Add playground link to text generation models

### DIFF
--- a/layouts/partials/models/header.md
+++ b/layouts/partials/models/header.md
@@ -29,6 +29,16 @@
   {{ end -}}
 {{- end -}}
 
+{{if eq $params.model.task.name "Text Generation" }}
+## Use the Playground
+
+Try out this model with Workers AI Model Playground. It does not require any setup or authentication and an instant way to preview and test a model directly in the browser.
+
+<a class="Button Button-is-docs-primary DocsMarkdown--link-content" href="https://playground.ai.cloudflare.com/?model={{$params.model.name}}" target="_blank">
+  Launch the Model Playground
+</a>
+{{end}}
+
 {{ .Scratch.Set "conditional-name" "code-examples" }}
 {{ partial "models/conditionally.md" . | markdownify}}
 


### PR DESCRIPTION
This PR adds links to the new LLM Playground for our Text Generation models.

![Screenshot 2024-04-02 at 14 44 31](https://github.com/cloudflare/cloudflare-docs/assets/65447/a2a1402c-d8bd-4c8e-98fb-d43fb8c22ca9)
