### PR TITLE
[Durable Objects] Initial DO JS RPC docs

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -310,9 +310,11 @@
 /durable-objects/learning/durable-objects-migrations/ /durable-objects/reference/durable-objects-migrations/ 301
 /durable-objects/learning/websockets/ /durable-objects/reference/websockets/ 301
 /durable-objects/examples/durable-object-location-example/ /durable-objects/examples/durable-object-in-memory-state/ 301
-/durable-objects/how-to/ /durable-objects/configuration/ 301
-/durable-objects/how-to/access-durable-object-from-a-worker/ /durable-objects/configuration/access-durable-object-from-a-worker/ 301
-/durable-objects/how-to/create-durable-object-stubs/ /durable-objects/configuration/create-durable-object-stubs/ 301
+/durable-objects/how-to/ /durable-objects/best-practices/ 301
+/durable-objects/how-to/access-durable-object-from-a-worker/ /durable-objects/best-practices/access-durable-objects-from-a-worker/ 301
+/durable-objects/how-to/create-durable-object-stubs/ /durable-objects/best-practices/create-durable-object-stubs-and-send-requests/ 301
+/durable-objects/configuration/access-durable-object-from-a-worker/ /durable-objects/best-practices/access-durable-objects-from-a-worker/ 301
+/durable-objects/configuration/create-durable-object-stubs/ /durable-objects/best-practices/create-durable-object-stubs-and-send-requests/ 301
 
 # email-routing
 /email-routing/enable-email-routing/ /email-routing/get-started/enable-email-routing/ 301

--- a/content/durable-objects/api/_index.md
+++ b/content/durable-objects/api/_index.md
@@ -1,7 +1,7 @@
 ---
 title: API
 pcx_content_type: navigation
-weight: 3
+weight: 2
 ---
 
 # API

--- a/content/durable-objects/best-practices/_index.md
+++ b/content/durable-objects/best-practices/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Configuration
+title: Best practices
 pcx_content_type: navigation
-weight: 4
+weight: 1
 ---
 
-# Configuration
+# Best Practices
 
 {{<directory-listing>}}

--- a/content/durable-objects/best-practices/access-durable-objects-from-a-worker.md
+++ b/content/durable-objects/best-practices/access-durable-objects-from-a-worker.md
@@ -1,10 +1,10 @@
 ---
 title: Access a Durable Object from a Worker
 pcx_content_type: concept
-weight: 16
+weight: 1
 ---
 
-# Access a Durable Object from a Worker
+# Access Durable Objects from a Worker
 
 To access a Durable Object from a Worker, you must first create a [Durable Object binding](/workers/configuration/bindings/#durable-object-bindings) in your Worker project's [`wrangler.toml`](/workers/wrangler/configuration/#durable-objects) file. The binding is configured to use a particular class and controls access to instances of that class.
 

--- a/content/durable-objects/examples/build-a-counter.md
+++ b/content/durable-objects/examples/build-a-counter.md
@@ -1,6 +1,6 @@
 ---
 type: example
-summary: Build a counter using Durable Objects and Workers.
+summary: Build a counter using Durable Objects and Workers with RPC methods.
 tags:
   - Durable Objects
 pcx_content_type: configuration
@@ -9,7 +9,7 @@ weight: 3
 layout: example
 ---
 
-This example shows how to build a counter using Durable Objects and Workers that can print, increment, and decrement a `name` provided by the URL query string parameter, for example, `?name=A`.
+This example shows how to build a counter using Durable Objects and Workers with [RPC methods](/workers/runtime-apis/rpc) that can print, increment, and decrement a `name` provided by the URL query string parameter, for example, `?name=A`.
 
 {{<tabs labels="js | ts">}}
 {{<tab label="js" default="true">}}
@@ -18,8 +18,9 @@ This example shows how to build a counter using Durable Objects and Workers that
 ---
 filename: index.js
 ---
-// Worker
+import { DurableObject } from "cloudflare:workers";
 
+// Worker
 export default {
   async fetch(request, env) {
     let url = new URL(request.url);
@@ -35,57 +36,56 @@ export default {
     // has its own state. `idFromName()` always returns the same ID when given the
     // same string as input (and called on the same class), but never the same
     // ID for two different strings (or for different classes).
-    let id = env.COUNTER.idFromName(name);
+    let id = env.COUNTERS.idFromName(name);
 
     // Construct the stub for the Durable Object using the ID. 
     // A stub is a client Object used to send messages to the Durable Object.
-    let obj = env.COUNTER.get(id);
+    let stub = env.COUNTERS.get(id);
 
-    // Send a request to the Durable Object, then await its response.
-    let resp = await obj.fetch(request.url);
-    let count = await resp.text();
+    // Send a request to the Durable Object using RPC methods, then await its response.
+    let count = null;
+		switch (url.pathname) {
+      case "/increment":
+				count = await stub.increment();
+        break;
+			case "/decrement":
+				count = await stub.decrement();
+				break;
+      case "/":
+        // Serves the current value.
+				count = await stub.getCounterValue();
+        break;
+      default:
+        return new Response("Not found", { status: 404 });
+    }
 
     return new Response(`Durable Object '${name}' count: ${count}`);
   }
 };
 
 // Durable Object
+export class Counter extends DurableObject {
 
-export class Counter {
-  constructor(state, env) {
-    this.state = state;
+	async getCounterValue() {
+    let value = (await this.ctx.storage.get("value")) || 0;
+    return value;
   }
 
-  // Handle HTTP requests from clients.
-  async fetch(request) {
-    // Apply requested action.
-    let url = new URL(request.url);
-
-    // Durable Object storage is automatically cached in-memory, so reading the
-    // same key every request is fast. 
-    // You could also store the value in a class member if you prefer.
-    let value = (await this.state.storage.get("value")) || 0;
-
-    switch (url.pathname) {
-      case "/increment":
-        ++value;
-        break;
-      case "/decrement":
-        --value;
-        break;
-      case "/":
-        // Serves the current value.
-        break;
-      default:
-        return new Response("Not found", { status: 404 });
-    }
-
-    // You do not have to worry about a concurrent request having modified the value in storage. 
+	async increment(amount = 1) {
+    let value = (await this.ctx.storage.get("value")) || 0;
+    value += amount;
+		// You do not have to worry about a concurrent request having modified the value in storage. 
     // "input gates" will automatically protect against unwanted concurrency. 
     // Read-modify-write is safe. 
-    await this.state.storage.put("value", value);
+    await this.ctx.storage.put("value", value);
+    return value;
+  }
 
-    return new Response(value);
+	async decrement(amount = 1) {
+    let value = (await this.ctx.storage.get("value")) || 0;
+    value -= amount;
+    await this.ctx.storage.put("value", value);
+    return value;
   }
 }
 ```
@@ -97,12 +97,13 @@ export class Counter {
 ---
 filename: index.ts
 ---
+import { DurableObject } from "cloudflare:workers";
+
 export interface Env {
-  COUNTER: DurableObjectNamespace;
+	COUNTERS: DurableObjectNamespace<Counter>;
 }
 
 // Worker
-
 export default {
   async fetch(request: Request, env: Env) {
     let url = new URL(request.url);
@@ -118,59 +119,55 @@ export default {
     // has its own state. `idFromName()` always returns the same ID when given the
     // same string as input (and called on the same class), but never the same
     // ID for two different strings (or for different classes).
-    let id = env.COUNTER.idFromName(name);
+    let id = env.COUNTERS.idFromName(name);
 
     // Construct the stub for the Durable Object using the ID. 
     // A stub is a client Object used to send messages to the Durable Object.
-    let obj = env.COUNTER.get(id);
+    let stub = env.COUNTERS.get(id);
 
-    // Send a request to the Durable Object, then await its response.
-    let resp = await obj.fetch(request.url);
-    let count = await resp.text();
+		let count = null;
+		switch (url.pathname) {
+      case "/increment":
+				count = await stub.increment();
+        break;
+			case "/decrement":
+				count = await stub.decrement();
+				break;
+      case "/":
+        // Serves the current value.
+				count = await stub.getCounterValue();
+        break;
+      default:
+        return new Response("Not found", { status: 404 });
+    }
 
     return new Response(`Durable Object '${name}' count: ${count}`);
   }
 };
 
 // Durable Object
+export class Counter extends DurableObject {
 
-export class Counter {
-  state: DurableObjectState;
-
-  constructor(state: DurableObjectState, env: Env) {
-    this.state = state;
+	async getCounterValue() {
+    let value = (await this.ctx.storage.get("value")) || 0;
+    return value;
   }
 
-  // Handle HTTP requests from clients.
-  async fetch(request: Request) {
-    // Apply requested action.
-    let url = new URL(request.url);
-
-    // Durable Object storage is automatically cached in-memory, so reading the
-    // same key every request is fast. 
-    // You could also store the value in a class member if you prefer.
-    let value: number = (await this.state.storage.get("value")) || 0;
-
-    switch (url.pathname) {
-      case "/increment":
-        ++value;
-        break;
-      case "/decrement":
-        --value;
-        break;
-      case "/":
-        // Serves the current value.
-        break;
-      default:
-        return new Response("Not found", { status: 404 });
-    }
-
-    // You do not have to worry about a concurrent request having modified the value in storage. 
+	async increment(amount = 1) {
+    let value: number = (await this.ctx.storage.get("value")) || 0;
+    value += amount;
+		// You do not have to worry about a concurrent request having modified the value in storage. 
     // "input gates" will automatically protect against unwanted concurrency. 
     // Read-modify-write is safe. 
-    this.state.storage.put("value", value);
+    await this.ctx.storage.put("value", value);
+    return value;
+  }
 
-    return new Response(value.toString());
+	async decrement(amount = 1) {
+    let value: number = (await this.ctx.storage.get("value")) || 0;
+    value -= amount;
+    await this.ctx.storage.put("value", value);
+    return value;
   }
 }
 ```
@@ -187,7 +184,7 @@ filename: wrangler.toml
 name = "my-counter"
 
 [[durable_objects.bindings]]
-name = "COUNTER"
+name = "COUNTERS"
 class_name = "Counter"
 
 [[migrations]]
@@ -196,4 +193,5 @@ new_classes = ["Counter"]
 ```
 ### Related resources
 
+- [Workers RPC](/workers/runtime-apis/rpc/)
 - [Durable Objects: Easy, Fast, Correct — Choose three](https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/).

--- a/content/durable-objects/get-started.md
+++ b/content/durable-objects/get-started.md
@@ -197,13 +197,13 @@ export default {
 In the code above, you have:
 
 1. Exported your Worker's main event handlers, such as the `fetch()` handler for receiving HTTP requests.
-2. Passed `env` into the `fetch()` handler. Bindings are delivered as a property of the environment object passed as the second parameter when an event handler or class constructor is invoked. By calling the `idFromName()` function on the binding, you use a string-derived object ID. You can also ask the system to [generate random unique IDs](/durable-objects/configuration/access-durable-object-from-a-worker/#generate-ids-randomly). System-generated unique IDs have better performance characteristics, but require you to store the ID somewhere to access the Object again later. 
+2. Passed `env` into the `fetch()` handler. Bindings are delivered as a property of the environment object passed as the second parameter when an event handler or class constructor is invoked. By calling the `idFromName()` function on the binding, you use a string-derived object ID. You can also ask the system to [generate random unique IDs](/durable-objects/best-practices/access-durable-objects-from-a-worker/#generate-ids-randomly). System-generated unique IDs have better performance characteristics, but require you to store the ID somewhere to access the Object again later. 
 3. Derived an object ID from the URL path. `MY_DURABLE_OBJECT.idFromName()` always returns the same ID when given the same string as input (and called on the same class), but never the same ID for two different strings (or for different classes). In this case, you are creating a new object for each unique path. 
 4. Constructed the stub for the Durable Object using the ID. A stub is a client object used to send messages to the Durable Object.
 5. Forwarded the request to the Durable Object. `stub.fetch()` has the same signature as the global `fetch()` function, except that the request is always sent to the object, regardless of the request's URL.  The first time you send a request to a new object, the object will be created for us. If you do not store durable state in the object, it will automatically be deleted later (and recreated if you request it again). If you store durable state, then the object may be evicted from memory but its durable state will be kept  permanently.
 6. Received an HTTP response back to the client with `return response`.
 
-Refer to [Access a Durable Object from a Worker](/durable-objects/configuration/access-durable-object-from-a-worker/) to learn more about communicating to a Durable Object.
+Refer to [Access a Durable Object from a Worker](/durable-objects/best-practices/access-durable-objects-from-a-worker/) to learn more about communicating to a Durable Object.
 
 ## 5. Configure Durable Object bindings
 
@@ -275,6 +275,6 @@ Preview your Durable Object Worker at `<YOUR_WORKER>.<YOUR_SUBDOMAIN>.workers.de
 
 By finishing this tutorial, you have successfully created, tested and deployed a Durable Object.
 ### Related resources
-- [Access a Durable Object from a Worker](/durable-objects/configuration/access-durable-object-from-a-worker/)
-- [Create Durable Object stubs](/durable-objects/configuration/create-durable-object-stubs/)
+- [Access a Durable Object from a Worker](/durable-objects/best-practices/access-durable-objects-from-a-worker/)
+- [Create Durable Object stubs](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/)
 - [Miniflare](https://github.com/cloudflare/workers-sdk/tree/main/packages/miniflare) - Helpful tools for mocking and testing your Durable Objects.

--- a/content/durable-objects/reference/error-handling.md
+++ b/content/durable-objects/reference/error-handling.md
@@ -19,7 +19,7 @@ Refer to [Troubleshooting](/durable-objects/reference/troubleshooting/) to revie
 
 ## Understanding stubs
 
-A Durable Object stub is a client Object used to send requests to a remote Durable Object. To learn more about how to make requests to a Durable Object, refer to [Create Durable Objects stubs](/durable-objects/configuration/create-durable-object-stubs/) and [Access a Durable Objects from a Worker](/durable-objects/configuration/access-durable-object-from-a-worker/).
+A Durable Object stub is a client Object used to send requests to a remote Durable Object. To learn more about how to make requests to a Durable Object, refer to [Create Durable Objects stubs](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) and [Access a Durable Objects from a Worker](/durable-objects/best-practices/access-durable-objects-from-a-worker/).
 
 ## Example
 

--- a/content/durable-objects/reference/troubleshooting.md
+++ b/content/durable-objects/reference/troubleshooting.md
@@ -35,7 +35,7 @@ To solve this error, you can either do less work per request, or send fewer requ
 
 ### Your account is generating too much load on Durable Objects. Please back off and try again later.
 
-There is a limit on how quickly you can [create new Durable Objects or lookup different existing Durable Objects](/durable-objects/configuration/create-durable-object-stubs/). Those lookups are usually cached, meaning attempts for the same set of recently accessed Durable Objects should be successful, so catching this error and retrying after a short wait is safe. If possible, also consider spreading those lookups across multiple requests.
+There is a limit on how quickly you can [create new Durable Objects or lookup different existing Durable Objects](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/). Those lookups are usually cached, meaning attempts for the same set of recently accessed Durable Objects should be successful, so catching this error and retrying after a short wait is safe. If possible, also consider spreading those lookups across multiple requests.
 
 ### Durable Object reset because its code was updated.
 

--- a/content/durable-objects/reference/websockets.md
+++ b/content/durable-objects/reference/websockets.md
@@ -14,7 +14,7 @@ Durable Objects provide a single-point-of-coordination for [Cloudflare Workers](
 
 While there are other use cases for using Workers exclusively with WebSockets, WebSockets are most useful when combined with Durable Objects.
 
-When a client connects to your application using a WebSocket, you need a way for server-generated messages to be sent using the existing socket connection. Multiple clients can establish a WebSocket connection with a specific Durable Object addressed by its [unique ID](/durable-objects/configuration/access-durable-object-from-a-worker/#1-create-durable-object-ids). The Durable Object can then send messages to each client over the WebSocket connection.
+When a client connects to your application using a WebSocket, you need a way for server-generated messages to be sent using the existing socket connection. Multiple clients can establish a WebSocket connection with a specific Durable Object addressed by its [unique ID](/durable-objects/best-practices/access-durable-objects-from-a-worker/#1-create-durable-object-ids). The Durable Object can then send messages to each client over the WebSocket connection.
 
 Durable Objects can use the web standard APIs described in [WebSockets API](/durable-objects/api/websockets/). Refer to [Cloudflare Edge Chat Demo](https://github.com/cloudflare/workers-chat-demo) for an example of using Durable Objects with WebSockets.
 

--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -40,7 +40,7 @@ The following Worker script:
 2. Passes request data to the Durable Object.
 3. Publishes to a queue from within the Durable Object.
 
-The `constructor()` in the Durable Object makes your `Environment` available (in scope) on `this.env` to the [`fetch()` handler](/durable-objects/configuration/access-durable-object-from-a-worker/#3-use-fetch-handler-method) in the Durable Object.
+The `constructor()` in the Durable Object makes your `Environment` available (in scope) on `this.env` to the [`fetch()` handler](/durable-objects/best-practices/access-durable-objects-from-a-worker/#3-use-fetch-handler-method/) in the Durable Object.
 
 ```ts
 ---

--- a/content/workers/_partials/_durable_objects_pricing.md
+++ b/content/workers/_partials/_durable_objects_pricing.md
@@ -11,18 +11,26 @@ _build:
 
 |          | Paid plan                                         |
 | -------- | ------------------------------------------------- |
-| HTTP requests<sup>1</sup>               | 1 million, + $0.15/million                        |
-| Establish WebSocket connection requests | 1 million, + $0.15/million                        |
-| Incoming WebSocket messages             | 1 million, + $0.15/million                        |
-| Alarm invocations                       | 1 million, + $0.15/million                        |
-| Duration<sup>2</sup>                    | 400,000 GB-s, + $12.50/million GB-s<sup>3,4</sup> |
+| Requests               | 1 million, + $0.15/million<br> Includes HTTP requests, RPC sessions, WebSocket messages<sup>2</sup>, and alarm invocations                      |
+| Duration<sup>3</sup>                    | 400,000 GB-s, + $12.50/million GB-s<sup>4,5</sup> |
 
 {{</table-wrap>}}
 
-<sup>1</sup> Requests include all incoming HTTP requests, WebSocket messages, and alarm invocations. A request is needed to create a WebSocket connection. There is no charge for outgoing WebSocket messages, nor for incoming [WebSocket protocol pings](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2). Billing-only applies a 20:1 ratio to incoming WebSocket messages to factor in smaller messages for real-time communication. For example, 100 WebSocket incoming messages would be charged as 5 requests for billing purposes. The 20:1 ratio does not affect Durable Object metrics and analytics, which reflect actual usage.
+<sup>1</sup> Each [RPC session](/workers/runtime-apis/rpc/lifecycle/) is billed as one request to your Durable Object. Every [RPC method call](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/#call-rpc-methods) on a [Durable Objects stub](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/#get-a-durable-object-stub) is its own RPC session and therefore a single billed request.
 
-<sup>2</sup> Application level auto-response messages handled by [`state.setWebSocketAutoResponse()`](/durable-objects/api/websockets/) will not incur additional wall-clock time, and so they will not be charged.
+RPC method calls can return objects (stubs) extending [`RpcTarget`](/workers/runtime-apis/rpc/lifecycle/#lifetimes-memory-and-resource-management) and invoke calls on those stubs. Subsequent calls on the returned stub are part of the same RPC session and are not billed as separate requests. For example:
 
-<sup>3</sup> Duration is billed in wall-clock time as long as the Object is active, but is shared across all requests active on an Object at once. Once your Object finishes responding to all requests, it will stop incurring duration charges. Calling `accept()` on a WebSocket in an Object will incur duration charges for the entire time the WebSocket is connected. If you prefer, use [`state.acceptWebSocket()`](/durable-objects/api/websockets/#state-methods-for-websockets) instead, which will stop incurring duration charges once all event handlers finish running.
+```js
+let durableObjectStub = OBJECT_NAMESPACE.get(id); // retrieve Durable Object stub
+using foo = await durableObjectStub.bar(); // billed as a request
+await foo.baz(); // treated as part of the same RPC session created by calling bar(), not billed as a request
+await durableObjectStub.cat(); // billed as a request
+```
 
-<sup>4</sup> Duration billing charges for the 128 MB of memory your Durable Object is allocated, regardless of actual usage. If your account creates many instances of a single Durable Object class, Durable Objects may run in the same isolate on the same physical machine and share the 128 MB of memory. These Durable Objects are still billed as if they are allocated a full 128 MB of memory.
+<sup>2</sup> A request is needed to create a WebSocket connection. There is no charge for outgoing WebSocket messages, nor for incoming [WebSocket protocol pings](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2). For compute requests billing-only, a 20:1 ratio is applied to incoming WebSocket messages to factor in smaller messages for real-time communication. For example, 100 WebSocket incoming messages would be charged as 5 requests for billing purposes. The 20:1 ratio does not affect Durable Object metrics and analytics, which reflect actual usage.
+
+<sup>3</sup> Application level auto-response messages handled by [`state.setWebSocketAutoResponse()`](/durable-objects/api/websockets/) will not incur additional wall-clock time, and so they will not be charged.
+
+<sup>4</sup> Duration is billed in wall-clock time as long as the Object is active, but is shared across all requests active on an Object at once. Once your Object finishes responding to all requests, it will stop incurring duration charges. Calling `accept()` on a WebSocket in an Object will incur duration charges for the entire time the WebSocket is connected. If you prefer, use [`state.acceptWebSocket()`](/durable-objects/api/websockets/#state-methods-for-websockets) instead, which will stop incurring duration charges once all event handlers finish running.
+
+<sup>5</sup> Duration billing charges for the 128 MB of memory your Durable Object is allocated, regardless of actual usage. If your account creates many instances of a single Durable Object class, Durable Objects may run in the same isolate on the same physical machine and share the 128 MB of memory. These Durable Objects are still billed as if they are allocated a full 128 MB of memory.

--- a/content/workers/configuration/bindings/_index.md
+++ b/content/workers/configuration/bindings/_index.md
@@ -38,7 +38,7 @@ KV namespace bindings allow for communication between a Worker and a KV namespac
 
 Durable Object bindings for communication between a Worker and a Durable Object.
 
-* Learn more about [Durable Object bindings](/durable-objects/configuration/access-durable-object-from-a-worker/).
+* Learn more about [Durable Object bindings](/durable-objects/best-practices/access-durable-objects-from-a-worker/).
 * Configure Durable Object bindings via your [`wrangler.toml` file](/workers/wrangler/configuration/#durable-objects).
 
 ### R2 bucket bindings


### PR DESCRIPTION
TODO: 

- [x] Use RPC in counter example
- [x] Rename `Configuration` section, add `Send requests to a Durable Object`
- [x] Update pricing to add RPC methods: https://github.com/cloudflare/cloudflare-docs/pull/13235/

Must merge after https://github.com/cloudflare/cloudflare-docs/pull/13252 which has Workers RPC links

DEFER to next PR:

- [ ] Change all occurrences of `state` to `ctx`
- [ ] Update `Get started` tutorial to RPC (maybe let JS RPC bake for a bit?)