### PR TITLE
Fix cd: no such file or directory: 01-hello

### DIFF
--- a/content/workers/languages/python/_index.md
+++ b/content/workers/languages/python/_index.md
@@ -29,7 +29,7 @@ We'd love your feedback. Join the #python-workers channel in the [Cloudflare Dev
 
 ```bash
 git clone https://github.com/cloudflare/python-workers-examples
-cd 01-hello
+cd python-workers-examples/01-hello
 npx wrangler@latest dev
 ```
 


### PR DESCRIPTION
When the current instructions to clone `python-workers-examples` and navigate to `01-hello` are followed, they could result in `cd: no such file or directory: 01-hello`.

This PR ensures the correct instructions are added.