### PR TITLE
chore: Do not restrict search on product section

### DIFF
--- a/assets/search.ts
+++ b/assets/search.ts
@@ -8,11 +8,8 @@
 
   let {
     apikey: apiKey,
-    product,
     index: indexName,
   } = algoliaConfig
-
-  const facetFilters = product ? [`product:${product}`] : []
 
   function loaded() {
     window.docsearch({
@@ -32,9 +29,6 @@
       },
       getMissingResultsUrl({ query }) {
         return `/search/?q=${query}`;
-      },
-      searchParameters: {
-        optionalFilters: facetFilters
       },
       transformItems: items => {
         return items.filter(item => {


### PR DESCRIPTION
**🔖 Summary**

Following some recent improvements we made for the documentation's search, this commit is a suggestion to remove an odd feature: currently, when the search feature is triggered from a specific product section, the search results which belong to that section are surfaced first, even though they are less relevant.

From my experience, and according to others, this is rather confusing, and this change is about preventing that behavior, effectively surfacing the most relevant results, no matter which page the user is currently browsing.

**🚧 Changes**

- Remove the Algolia [`optionalFilters`](https://www.algolia.com/doc/guides/managing-results/rules/merchandising-and-promoting/how-to/how-to-promote-with-optional-filters/) which were responsible for promoting lesser relevant search results from the currently browsed page.

**✅ Testing plan**

- Ran the documentation locally using `npm run dev` and looked at the before/after XHR requests going to Algolia to make sure the `optionalFilters` are not present anymore (also see the before/after screenshots showing what the search results look like).

**Before**
<img width="1407" alt="before" src="https://github.com/cloudflare/cloudflare-docs/assets/3115191/879a9924-df37-4c59-975d-10bad76000f2">

**After**
<img width="1389" alt="after" src="https://github.com/cloudflare/cloudflare-docs/assets/3115191/887fa794-f7a0-4e69-93f6-a86316617c69">

