### PR TITLE
Revert "[Docs Site] Fix mixed-case + spaces in Tab Switcher labels"

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -130,7 +130,7 @@ export function tabs() {
           const tabId = parts.slice(0, parts.length - 1).join("-");
 
           const defaultTabLabel = wrappers[i].querySelector(
-            `a[data-link="${tabId}"]`
+            `a[data-link=${tabId}]`
           );
 
           (defaultTab as HTMLElement).style.display = "block";

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -86,7 +86,7 @@ JavaScript
 </a>
 
 {{ else }}
-<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{$link}}" data-id="{{lower $unique_id}}">
+<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{lower $link}}" data-id="{{lower $unique_id}}">
 {{$link}}
 </a>
 {{ end }}


### PR DESCRIPTION
Reverts cloudflare/cloudflare-docs#13735.


https://github.com/cloudflare/cloudflare-docs/assets/26727299/b79713ed-7cd3-435f-9872-f56b6144c02d

- https://developers.cloudflare.com/load-balancing/get-started/quickstart/#create-a-monitor
- https://developers.cloudflare.com/data-localization/compatibility/

cc: @craigsdennis / @KianNH... this actually breaks all our existing tabs, so need to temp revert and push another fix.