### PR TITLE
queues: link to event notifications

### DIFF
--- a/content/queues/reference/event-notifications.md
+++ b/content/queues/reference/event-notifications.md
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: R2 Event Notifications
+
+external_link: /r2/buckets/event-notifications/
+weight: 29
+_build:
+  publishResources: false
+  render: never
+---


### PR DESCRIPTION
Cross link to https://developers.cloudflare.com/r2/buckets/event-notifications/ from Queues docs for discovery.