### PR TITLE
workers: python examples

### DIFF
--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -23,11 +23,13 @@ async def on_fetch(request, env):
 
 ```python
 from js import Response, Headers
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 async def on_fetch(request, env):
-    # https://docs.python.org/3/library/urllib.parse.html#module-urllib.parse
+    # Parse the incoming request URL
     url = urlparse(request.url)
+    # Parse the query parameters into a Python dictionary
+    params = parse_qs(url.query)
 
     if url.path == "/favicon.ico":
       return new Response("")

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -82,4 +82,20 @@ async def on_fetch(request):
 
 ### Respond with JSON
 
-TODO
+```python
+from js import Response
+import json
+
+async def on_fetch(request):
+    # Use json.loads to serialize Python objects to JSON strings
+    payload = json.dumps({"c": 0, "b": 0, "a": 0}, sort_keys=True) 
+
+    headers = Headers.new({"content-type": "application/json"}.items())
+    return Response.new(payload, headers=headers)
+```
+
+## Next steps
+
+* If you're new to Workers and Python, refer to the [get started](/workers/languages/python/) guide
+* Learn more about [calling JavaScript methods and accessing JavaScript objects](/workers/languages/python/ffi/) from Python
+* Understand the [supported packages and versions](/workers/languages/python/packages/) currently available to Python Workers.

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -43,7 +43,7 @@ async def on_fetch(request, env):
 
 
     if url.path == "/favicon.ico":
-      return new Response.new("")
+      return Response.new("")
 
     return Response.new("Hello world!")
 ```
@@ -107,6 +107,33 @@ async def on_fetch(request):
 
     headers = Headers.new({"content-type": "application/json"}.items())
     return Response.new(payload, headers=headers)
+```
+
+### Publish to a Queue
+
+```python
+---
+filename: src/entry.py
+---
+from js import Response, Object
+from pyodide.ffi import to_js as _to_js
+
+# to_js converts between Python dictionaries and JavaScript Objects
+def to_js(obj):
+   return _to_js(obj, dict_converter=Object.fromEntries)
+
+async def on_fetch(request, env):
+    # Bindings are available on the 'env' parameter
+    # https://developers.cloudflare.com/queues/ 
+
+    # The default contentType is "json"
+    # We can also pass plain text strings
+    await env.QUEUE.send("hello", contentType="text")
+    # Send a JSON payload
+    await env.QUEUE.send(to_js({"hello": "world"}))
+
+    # Return a response
+    return Response.json(to_js({"write": "success"}))
 ```
 
 ## Next steps

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -62,7 +62,12 @@ async def on_fetch(request):
 
     # Alternatively, use the native Python logger
     logger = logging.getLogger(__name__)
-    logger.info("logger.info from Python!")
+
+    # The default level is warning. We can change that to info.
+    logging.basicConfig(level=logging.INFO)
+
+    logger.error("error from Python!")
+    logger.info("info log from Python!")
 
     # Or just use print()
     print("print() from Python!)

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -1,0 +1,76 @@
+---
+pcx_content_type: content
+title: Examples
+meta:
+  title: Python Worker Examples
+---
+
+# Examples
+
+### Return a custom status code and/or response headers
+
+```python
+from js import Response, Headers
+
+async def on_fetch(request, env):
+  # Create a Headers object
+  headers = Headers.new({"x-hello-from": "python-workers"}.items())
+  # Return a response object with a status code and headers
+  return Response.new("Hello world!", status=404, headers=headers)
+```
+
+### Parse an incoming request URL
+
+```python
+from js import Response, Headers
+from urllib.parse import urlparse
+
+async def on_fetch(request, env):
+    # https://docs.python.org/3/library/urllib.parse.html#module-urllib.parse
+    url = urlparse(request.url)
+
+    if url.path == "/favicon.ico":
+      return new Response("")
+
+    return new Response("Hello world!")
+```
+
+### Parse JSON from the incoming request
+
+What about `json.loads` as an alternative here?
+
+```python
+from js import Response
+
+async def on_fetch(request):
+    name = (await request.json()).name
+    return Response.new("Hello, {name}".format(name=name))
+```
+
+### Emit logs from your Python Worker
+
+```python
+# To use the JavaScript console APIs
+from js import console
+# To use the native Python logging
+import logging
+
+async def on_fetch(request):
+    # Use the console APIs from JavaScript
+    # https://developer.mozilla.org/en-US/docs/Web/API/console
+    console.log("console.log from Python!")
+
+    # Alternatively, use the native Python logger
+    logger = logging.getLogger(__name__)
+    logger.info("logger.info from Python!")
+
+    # Or just use print()
+    print("print() from Python!)
+
+    return Response.new("We're testing logging!")
+```
+
+
+### Respond with JSON
+
+TODO

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -31,15 +31,18 @@ async def on_fetch(request, env):
     # Parse the query parameters into a Python dictionary
     params = parse_qs(url.query)
 
-    if url.path == "/favicon.ico":
-      return new Response("")
+    if "name" in params:
+        greeting = "Hello there, {name}".format(name=params["name"][0])
+        return Response.new(greeting)
 
-    return new Response("Hello world!")
+
+    if url.path == "/favicon.ico":
+      return new Response.new("")
+
+    return Response.new("Hello world!")
 ```
 
 ### Parse JSON from the incoming request
-
-What about `json.loads` as an alternative here?
 
 ```python
 from js import Response
@@ -76,7 +79,6 @@ async def on_fetch(request):
 
     return Response.new("We're testing logging!")
 ```
-
 
 ### Respond with JSON
 

--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -10,6 +10,9 @@ meta:
 ### Return a custom status code and/or response headers
 
 ```python
+---
+filename: src/entry.py
+---
 from js import Response, Headers
 
 async def on_fetch(request, env):
@@ -22,6 +25,9 @@ async def on_fetch(request, env):
 ### Parse an incoming request URL
 
 ```python
+---
+filename: src/entry.py
+---
 from js import Response, Headers
 from urllib.parse import urlparse, parse_qs
 
@@ -45,6 +51,9 @@ async def on_fetch(request, env):
 ### Parse JSON from the incoming request
 
 ```python
+---
+filename: src/entry.py
+---
 from js import Response
 
 async def on_fetch(request):
@@ -55,6 +64,9 @@ async def on_fetch(request):
 ### Emit logs from your Python Worker
 
 ```python
+---
+filename: src/entry.py
+---
 # To use the JavaScript console APIs
 from js import console
 # To use the native Python logging
@@ -83,6 +95,9 @@ async def on_fetch(request):
 ### Respond with JSON
 
 ```python
+---
+filename: src/entry.py
+---
 from js import Response
 import json
 

--- a/content/workers/languages/python/ffi.md
+++ b/content/workers/languages/python/ffi.md
@@ -60,3 +60,5 @@ from js import Response
 def on_fetch(request):
     return Response.new("Hello World!")
 ```
+
+Refer to the [Python examples](/workers/languages/python/examples/) to learn how to call into JavaScript functions from Python, including `console.log` and logging, providing options to `Response`, and parsing JSON.

--- a/content/workers/languages/python/how-python-workers-work.md
+++ b/content/workers/languages/python/how-python-workers-work.md
@@ -43,6 +43,8 @@ When you run `npx wrangler@latest dev` in local dev, the Workers runtime will:
 
 There no extra toolchain or precompilation steps needed. The Python execution environment is provided directly by the Workers runtime, mirroring how Workers written in JavaScript work.
 
+Refer to the [Python examples](/workers/languages/python/examples/) to learn how to use Python within Workers.
+
 ## Deployment Lifecycle
 
 To reduce cold start times, when you deploy a Python Worker, Cloudflare performs as much of the expensive work as possible upfront, at deploy time. When you run npx `wrangler@latest deploy`, the following happens:


### PR DESCRIPTION
This PR adds examples for common Python Workers use-cases.

- [x] Returning headers
- [x] Parsing a URL + query params
- [x] Logging
- [x] Parsing incoming request JSON bodies
- [x] Returning JSON back to a client

Should this live within the Python docs, or in the general examples?