### PR TITLE
fix missing closing quote in python docs

### DIFF
--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -87,7 +87,7 @@ async def on_fetch(request):
     logger.info("info log from Python!")
 
     # Or just use print()
-    print("print() from Python!)
+    print("print() from Python!")
 
     return Response.new("We're testing logging!")
 ```


### PR DESCRIPTION
Fixes a missing closing quote in the python examples introduced in #13800:

https://developers.cloudflare.com/workers/languages/python/examples/

![image](https://github.com/cloudflare/cloudflare-docs/assets/856748/68275610-6b93-4534-8195-19b53093773c)
