### PR TITLE
Python: fix typo in example

### DIFF
--- a/content/workers/languages/python/examples.md
+++ b/content/workers/languages/python/examples.md
@@ -87,7 +87,7 @@ async def on_fetch(request):
     logger.info("info log from Python!")
 
     # Or just use print()
-    print("print() from Python!)
+    print("print() from Python!")
 
     return Response.new("We're testing logging!")
 ```


### PR DESCRIPTION
Fix a missing quote.