### PR TITLE
Fix typo in introduction

### DIFF
--- a/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
+++ b/content/workers/testing/vitest-integration/get-started/write-your-first-test.md
@@ -8,7 +8,7 @@ meta:
 
 # Write your first test
 
-This guide will instruct you through installing and setting up the `@cloudflare/vitest-pool-workers` package. You will help you get started writing tests against your Workers using Vitest. The `@cloudflare/vitest-pool-workers` package works by running code inside a Cloudflare Worker that Vitest would usually run inside a [Node.js worker thread](https://nodejs.org/api/worker_threads.html). For examples of tests using `@cloudflare/vitest-pool-workers`, refer to [Recipes](/workers/testing/vitest-integration/recipes/).
+This guide will instruct you through installing and setting up the `@cloudflare/vitest-pool-workers` package. This will help you get started writing tests against your Workers using Vitest. The `@cloudflare/vitest-pool-workers` package works by running code inside a Cloudflare Worker that Vitest would usually run inside a [Node.js worker thread](https://nodejs.org/api/worker_threads.html). For examples of tests using `@cloudflare/vitest-pool-workers`, refer to [Recipes](/workers/testing/vitest-integration/recipes/).
 
 ## Prerequisites
 


### PR DESCRIPTION
Fix typo: "You will help you get started" -> "This wi…ll help you get started"

This commit corrects a typo in the introduction section of the documentation. The phrase "You will help you get started" has been amended to "This will help you get started" for clarity. This change improves the readability and professionalism of the document.