### PR TITLE
[Cache/CDN] fix typo in `cache-everything-ignore-query-strings.md`

### DIFF
--- a/content/cache/troubleshooting/cache-everything-ignore-query-strings.md
+++ b/content/cache/troubleshooting/cache-everything-ignore-query-strings.md
@@ -53,7 +53,7 @@ addEventListener('fetch', event => {
      event.respondWith(fetchAndApply(event.request))
 })
 
-asyncfunction fetchAndApply(request) {
+async function fetchAndApply(request) {
      let url = new URL(request.url)
 
      // Only use the path for the cache key, removing query strings


### PR DESCRIPTION
Just a boring old typo 🙂

I hope I followed the [guidelines](https://github.com/cloudflare/cloudflare-docs/blob/acf494f3598e80dc531a82ae7fc6ae71b8a1d493/CONTRIBUTING.md) correctly. Using my private email, let me know if I should use my Cloudflare address instead.