### PR TITLE
[Hyperdrive] Update examples to avoid unnecessary cast of port to number

### DIFF
--- a/content/hyperdrive/configuration/connect-to-postgres.md
+++ b/content/hyperdrive/configuration/connect-to-postgres.md
@@ -125,7 +125,7 @@ export default {
 			host: env.HYPERDRIVE.host,
 			user: env.HYPERDRIVE.user,
 			password: env.HYPERDRIVE.password,
-			port: Number(env.HYPERDRIVE.port),
+			port: env.HYPERDRIVE.port,
 			database: env.HYPERDRIVE.database
 		})
 

--- a/content/hyperdrive/get-started.md
+++ b/content/hyperdrive/get-started.md
@@ -218,7 +218,7 @@ export default {
       host: env.HYPERDRIVE.host,
 			user: env.HYPERDRIVE.user,
 			password: env.HYPERDRIVE.password,
-			port: Number(env.HYPERDRIVE.port),
+			port: env.HYPERDRIVE.port,
 			database: env.HYPERDRIVE.database
 		})
 


### PR DESCRIPTION
The port is already a number, it's just that the published types for it were incorrect.

The types will be / have been fixed by https://github.com/cloudflare/workerd/pull/1968

@elithrar (and heads up that I don't appear to have merge privileges here anymore, so please merge at your convenience)