### PR TITLE
Issue with Configure CORS JSON example

### DIFF
--- a/content/r2/buckets/cors.md
+++ b/content/r2/buckets/cors.md
@@ -109,7 +109,7 @@ The `AllowedOrigins` specify the web server being used, and `localhost:3000` is 
        "http://localhost:3000" 
     ],  
     "AllowedMethods": [
-       "GET",
+       "GET"
     ]
   }
 ]


### PR DESCRIPTION
The comma that caused the invalid JSON error has been deleted and the example JSON is now valid