### PR TITLE
Unescaped unintentionally escaped HTML

### DIFF
--- a/content/waf/_index.md
+++ b/content/waf/_index.md
@@ -37,7 +37,7 @@ Review mitigated requests (rule matches) using an intuitive interface. Tailor yo
 {{</feature>}}
 
 {{<feature header="Security Analytics" href="/waf/analytics/security-analytics/" cta="Explore Security Analytics">}}
-{{<plan type="business">}}
+{{</*plan type="business"*/>}}
 Displays information about all incoming HTTP requests, including those not affected by security measures.
 {{</feature>}}
 


### PR DESCRIPTION
Corrected a small mistake that made it display incorrectly as you see in the following image due to HTML getting escaped

![image](https://github.com/cloudflare/cloudflare-docs/assets/30863082/fd871209-044d-4dc5-b0c1-2aadb5cf4871)

Instead of how it was intended to be

![image](https://github.com/cloudflare/cloudflare-docs/assets/30863082/f4134a22-1b41-4ddb-8719-d140d6d5902c)
