### PR TITLE
[Wrangler] mention which bindings are not supported locally

### DIFF
--- a/content/workers/testing/local-development.md
+++ b/content/workers/testing/local-development.md
@@ -36,18 +36,19 @@ Resources such as KV, Durable Objects, D1, and R2 will be stored and persisted l
 
 | Product                                   | Local Dev Supported | Remote Dev Supported |
 | ----------------------------------------- | ------------------- | -------------------- |
-| R2                                        | ✅                  | ✅                   |
-| KV                                        | ✅                  | ✅                   |
+| AI                                        | ✅[^1]              | ✅                   |
+| Analytics Engine                          | ❌                  | ✅                   |
+| Browser Rendering                         | ❌                  | ✅                   |
 | D1                                        | ✅                  | ✅                   |
 | Durable Objects                           | ✅                  | ✅                   |
-| Queues                                    | ✅                  | ❌                   |
-| Service Bindings (multiple workers)       | ✅                  | ✅                   |
-| AI                                        | ✅[^1]              | ✅                   |
+| Email Bindings                            | ❌                  | ✅                   |
 | Hyperdrive                                | ✅                  | ✅                   |
-| Rate Limiting                             | ✅                  | ✅                   |
+| KV                                        | ✅                  | ✅                   |
 | mTLS                                      | ❌                  | ✅                   |
-| Browser Rendering                         | ❌                  | ✅                   |
-| Analytics Engine                          | ❌                  | ✅                   |
+| Queues                                    | ✅                  | ❌                   |
+| R2                                        | ✅                  | ✅                   |
+| Rate Limiting                             | ✅                  | ✅                   |
+| Service Bindings (multiple workers)       | ✅                  | ✅                   |
 | Vectorize                                 | ❌                  | ✅                   |
 
 With any bindings that are not supported locally, you will need to use the `--remote` command in wrangler, such as `wrangler dev --remote`.

--- a/content/workers/testing/local-development.md
+++ b/content/workers/testing/local-development.md
@@ -28,22 +28,29 @@ Wrangler provides a [`dev`](/workers/wrangler/commands/#dev) command that starts
 $ npx wrangler dev
 ```
 
-`wrangler dev` will run the preview of the Worker directly on your local machine. `wrangler dev` uses a combination of `workerd` and [Miniflare](https://github.com/cloudflare/workers-sdk/tree/main/packages/miniflare), a simulator that allows you to test your Worker against additional resources like KV, Durable Objects, WebSockets, and more. 
+`wrangler dev` will run the preview of the Worker directly on your local machine. `wrangler dev` uses a combination of `workerd` and [Miniflare](https://github.com/cloudflare/workers-sdk/tree/main/packages/miniflare), a simulator that allows you to test your Worker against additional resources like KV, Durable Objects, WebSockets, and more.
 
 Resources such as KV, Durable Objects, D1, and R2 will be stored and persisted locally and not affect live production or preview data. Wrangler will automatically create local versions of bindings found in `wrangler.toml`. These will not have data in them initially, so you will need to add data manually.
 
-### Supported resource bindings in local development
+### Supported resource bindings in different environments
 
-| Product                                   | Supported |
-| ----------------------------------------- | --------- |
-| R2                                        | ✅        |
-| KV                                        | ✅        |
-| D1                                        | ✅        |
-| Durable Objects                           | ✅        |
-| Queues                                    | ✅        |
-| Service Bindings (multiple workers)       | ✅        |
-| AI                                        | ✅[^1]    |
-| Hyperdrive                                | ✅        |
+| Product                                   | Local Dev Supported | Remote Dev Supported |
+| ----------------------------------------- | ------------------- | -------------------- |
+| R2                                        | ✅                  | ✅                   |
+| KV                                        | ✅                  | ✅                   |
+| D1                                        | ✅                  | ✅                   |
+| Durable Objects                           | ✅                  | ✅                   |
+| Queues                                    | ✅                  | ❌                   |
+| Service Bindings (multiple workers)       | ✅                  | ✅                   |
+| AI                                        | ✅[^1]              | ✅                   |
+| Hyperdrive                                | ✅                  | ✅                   |
+| Rate Limiting                             | ✅                  | ✅                   |
+| mTLS                                      | ❌                  | ✅                   |
+| Browser Rendering                         | ❌                  | ✅                   |
+| Analytics Engine                          | ❌                  | ✅                   |
+| Vectorize                                 | ❌                  | ✅                   |
+
+With any bindings that are not supported locally, you will need to use the `--remote` command in wrangler, such as `wrangler dev --remote`.
 
 [^1]: Using Workers AI always accesses your Cloudflare account in order to run AI models and will incur usage charges even in local development.
 


### PR DESCRIPTION
People are often confused about which bindings are supported locally, or not. This updates this table to be explicit about which bindings are not supported.

It also adds Rate Limiting as being supported locally.

A more concerning thing here is that if your worker is using one of the bindings that doesn't support local development, so therefore requires you to run with `--remote`, if that worker also uses Queues, there's essentially no way to test it without deploying straight to production. Any worker with Queues that you try to run with `--remote` just breaks entirely.