### PR TITLE
docs:  fix title level

### DIFF
--- a/content/cache/how-to/cache-keys.md
+++ b/content/cache/how-to/cache-keys.md
@@ -134,7 +134,7 @@ Like `query_string` or `header`, `cookie` controls which cookies appear in the C
 
 You cannot include cookies specific to Cloudflare. Cloudflare cookies are prefixed with `__cf`, for example, `__cflb`
 
-#### User features
+### User features
 
 User feature fields add features about the end-user (client) into the Cache Key.
 


### PR DESCRIPTION
"User Features" was mistakenly placed in the "Cookie" section:

<img width="1003" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/1791748/199f794c-81d2-47eb-9292-215865bcf201">
