### PR TITLE
[Changelog] Make schedule dates clearer in titles

### DIFF
--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -166,10 +166,10 @@ link: "/waf/change-log/"
 productName: WAF
 entries:
 - publish_date: '2023-09-18'
+  scheduled_date: '2023-09-25'
   individual_page: true
   scheduled: true
   link: '/waf/change-log/scheduled-changes/'
-  scheduled_date: '2023-09-25`
 - publish_date: '2023-09-18'
   individual_page: true
   link: '/waf/change-log/2023-09-18/'

--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -195,7 +195,7 @@ entries:
 
 - `scheduled_date` {{<type>}}date{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
-   - Should be included for scheduled pages. Helps render the date of the upcoming change in the title, which provides more actionable information to folks scanning titles or the associated RSS feeds.
+   - Should be included for pages with scheduled changes. Helps render the date of the upcoming change in the title, which provides more actionable information to folks scanning titles or the associated RSS feeds.
 
 {{</definitions>}}
 

--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -199,12 +199,6 @@ entries:
 
 {{</definitions>}}
 
-{{<Aside type="warning">}}
-
-If there are no currently scheduled changes, remove the entry marked as scheduled. Otherwise, customers will still see an entry for scheduled changes and might get confused.
-
-{{</Aside>}}
-
 ## Examples
 
 - [Stream Changelog](/stream/changelog/)

--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -179,7 +179,7 @@ entries:
 {{<definitions>}}
 - `publish_date` {{<type>}}date{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 
-    - Date of scheduled change, formatted as `YYYY-MM-DD`.
+    - Date when the page was published, formatted as `YYYY-MM-DD`. For pages with scheduled changes, you should update this field when adding/updating entries, so that the changelog item gets placed at the top of the changelog list (and feed). You should _not_ update this date when clearing all scheduled changes due to a release, since this change is not as relevant.
 
 - `individual_page` {{<type>}}boolean{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
 

--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: Changelog
-
 ---
 
 # Changelog
@@ -170,6 +169,7 @@ entries:
   individual_page: true
   scheduled: true
   link: '/waf/change-log/scheduled-changes/'
+  scheduled_date: '2023-09-25`
 - publish_date: '2023-09-18'
   individual_page: true
   link: '/waf/change-log/2023-09-18/'
@@ -193,7 +193,17 @@ entries:
 
    - Should be included for scheduled pages. Because this component renders content on the underlying page, you should only have a) one scheduled entry per scheduled entry page and b) only a scheduled entry when the scheduled entry page has content.
 
+- `scheduled_date` {{<type>}}date{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+   - Should be included for scheduled pages. Helps render the date of the upcoming change in the title, which provides more actionable information to folks scanning titles or the associated RSS feeds.
+
 {{</definitions>}}
+
+{{<Aside type="warning">}}
+
+If there are no currently scheduled changes, remove the entry marked as scheduled. Otherwise, customers will still see an entry for scheduled changes and might get confused.
+
+{{</Aside>}}
 
 ## Examples
 

--- a/content/style-guide/documentation-content-strategy/content-types/changelog.md
+++ b/content/style-guide/documentation-content-strategy/content-types/changelog.md
@@ -199,6 +199,12 @@ entries:
 
 {{</definitions>}}
 
+{{<Aside type="note">}}
+
+If the scheduled date gets pushed for a change, update the `publish_date` and `scheduled_date` fields of the changelog entry. This process makes sure customers will receive notifications via their RSS feeds.
+
+{{</Aside>}}
+
 ## Examples
 
 - [Stream Changelog](/stream/changelog/)

--- a/data/changelogs/ddos-http.yaml
+++ b/data/changelogs/ddos-http.yaml
@@ -5,7 +5,7 @@ subCategoryName: HTTP
 topLevelLink: "/ddos-protection/change-log/"
 entries:
 - publish_date: '2024-03-12'
-  scheduled_date: "2024-04-15"
+  scheduled_date: "2024-04-04"
   scheduled: true
   individual_page: true
   link: '/ddos-protection/change-log/http/scheduled-changes/'

--- a/data/changelogs/ddos-http.yaml
+++ b/data/changelogs/ddos-http.yaml
@@ -5,9 +5,9 @@ subCategoryName: HTTP
 topLevelLink: "/ddos-protection/change-log/"
 entries:
 - publish_date: '2024-03-12'
+  scheduled_date: "2024-04-15"
   scheduled: true
   individual_page: true
-  scheduled_date: "2024-04-15"
   link: '/ddos-protection/change-log/http/scheduled-changes/'
 - publish_date: '2024-04-04'
   individual_page: true

--- a/data/changelogs/ddos-http.yaml
+++ b/data/changelogs/ddos-http.yaml
@@ -7,6 +7,7 @@ entries:
 - publish_date: '2024-03-12'
   scheduled: true
   individual_page: true
+  scheduled_date: "2024-04-15"
   link: '/ddos-protection/change-log/http/scheduled-changes/'
 - publish_date: '2024-04-04'
   individual_page: true

--- a/data/changelogs/waf.yaml
+++ b/data/changelogs/waf.yaml
@@ -3,7 +3,7 @@ link: "/waf/change-log/"
 productName: WAF
 entries:
 - publish_date: '2024-04-08'
-  scheduled_date: '2024-04-15'
+  scheduled_date: '2024-04-08'
   individual_page: true
   scheduled: true
   link: '/waf/change-log/scheduled-changes/'

--- a/data/changelogs/waf.yaml
+++ b/data/changelogs/waf.yaml
@@ -2,7 +2,7 @@
 link: "/waf/change-log/"
 productName: WAF
 entries:
-- publish_date: '2024-04-08'
+- publish_date: '2024-04-02'
   scheduled_date: '2024-04-08'
   individual_page: true
   scheduled: true

--- a/data/changelogs/waf.yaml
+++ b/data/changelogs/waf.yaml
@@ -3,6 +3,7 @@ link: "/waf/change-log/"
 productName: WAF
 entries:
 - publish_date: '2024-04-08'
+  scheduled_date: '2024-04-15'
   individual_page: true
   scheduled: true
   link: '/waf/change-log/scheduled-changes/'

--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -26,28 +26,32 @@
     <language>en-us</language>
     <atom:link href="{{$atomLink}}" rel="self" />
     <lastBuildDate>{{- index (index $changelogDataEntries 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST" -}}</lastBuildDate>
-    {{- range $changelogDataEntries -}}
-    {{- $entry := . -}}
+    {{- range $index, $entry := $changelogDataEntries -}}
     {{- $link := "" -}}
     {{- $title := "" -}}
-    {{ $description := .description | $.Page.RenderString | htmlUnescape }}
+    {{ $description := $entry.description | $.Page.RenderString | htmlUnescape }}
     {{ $description = replaceRE `Open external link` "" $description -}}
-    {{- with .title -}}
+    {{- with $entry.title -}}
     {{- $link = print $permalink "#" (urlize .) -}}
     {{- $title = . -}}
     {{- else -}}
-    {{- $link = print $permalink "#" (urlize .publish_date) -}}
-    {{- $title = .publish_date -}}
+    {{- $link = print $permalink "#" (urlize $entry.publish_date) -}}
+    {{- $title = $entry.publish_date -}}
     {{- end -}}
-    {{- with .link -}}
+    {{- with $entry.link -}}
     {{- if ne $product "Wrangler" -}}
     {{ $link = print "https://developers.cloudflare.com" . }}
     {{- end -}}
     {{- end -}}
-    {{- with .individual_page -}}
+    {{- with $entry.individual_page -}}
     {{- $result := partial "changelog-entry.html" (dict "link" $entry.link) -}}
     {{- $description = $result.content -}}
     {{- $title = $result.title }}
+    {{- with $entry.scheduled -}}
+    {{- with $entry.scheduled_date -}}
+    {{- $title = (printf "%s for %s" $title $entry.scheduled_date) -}}
+    {{- end -}}
+    {{- end -}}
     {{- end -}}
     <item>
     <title>{{- $title -}}</title>

--- a/layouts/_default/home.rss.xml
+++ b/layouts/_default/home.rss.xml
@@ -19,30 +19,34 @@
     <language>en-us</language>
     <atom:link href="{{$atomLink}}" rel="self" />
     <lastBuildDate>{{- index (index $changelogRendered 0) "publish_date" | time.Format "Mon, 02 Jan 2006 08:00:00 EST" -}}</lastBuildDate>
-    {{- range $changelogRendered -}}
-    {{- $entry := . -}}
+    {{- range $index, $entry := $changelogRendered -}}
     {{- $link := "" -}}
     {{- $title := "" -}}
-    {{- $rellink := .url -}}
-    {{- $product := .product -}}
-    {{ $description := .description | $.Page.RenderString | htmlUnescape }}
+    {{- $rellink := $entry.url -}}
+    {{- $product := $entry.product -}}
+    {{ $description := $entry.description | $.Page.RenderString | htmlUnescape }}
     {{ $description = replaceRE `Open external link` "" $description -}}
-    {{- with .title -}}
+    {{- with $entry.title -}}
     {{ $title = printf "%s - %s" $product . }}
     {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .) -}}
     {{- else -}}
     {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .publish_date) -}}
     {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
-    {{- with .link -}}
+    {{- with $entry.link -}}
     {{- if ne $product "Wrangler" -}}
     {{ $link = print "https://developers.cloudflare.com" . }}
     {{- end -}}
     {{- end -}}
-    {{- with .individual_page -}}
+    {{- with $entry.individual_page -}}
     {{- $result := partial "changelog-entry.html" (dict "link" $entry.link) -}}
     {{- $description = $result.content -}}
     {{- $title = printf "%s - %s" $product $result.title }}
+    {{- with $entry.scheduled -}}
+    {{- with $entry.scheduled_date -}}
+    {{- $title = (printf "%s for %s" $title $entry.scheduled_date) -}}
+    {{- end -}}
+    {{- end -}}
     {{- end -}}
     <item>
     <title>{{- $title -}}</title>

--- a/layouts/shortcodes/full-changelog.html
+++ b/layouts/shortcodes/full-changelog.html
@@ -17,6 +17,11 @@
 {{- end -}}
 {{- end -}}
 {{ $description := printf "For more details, refer to the dedicated page for [%s](%s)." $title $item.link -}}
+{{- with $item.scheduled -}}
+{{- with $item.scheduled_date -}}
+{{- $title = (printf "%s for %s" $title $item.scheduled_date) -}}
+{{- end -}}
+{{- end -}}
 {{- $placeholderDict = merge $placeholderDict (dict "title" $title "description" $description) -}}
 {{- end -}}
 {{- $changelogRendered = $changelogRendered 


### PR DESCRIPTION
Testing with values added to the scheduled_changes WAF / DDoS entries.

Setting as draft b/c don't want to merge accidentally with the dates (as those are fake).

New behavior:
- On the main changelog page, added dates for scheduled changes to the titles (if included)
<img width="807" alt="Screenshot 2024-04-10 at 12 15 38 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/26727299/b4fc5dca-ac80-458f-b3b6-17b8e95fbdc8">

- On the per-product and Cloudflare changelog RSS feeds, added dates for scheduled changes to the titles
<img width="807" alt="Screenshot 2024-04-10 at 12 16 15 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/26727299/9017f8d7-a004-4d93-9276-385547972058">


