### PR TITLE
[Changelog] RuleID shortcode

### DIFF
--- a/content/waf/change-log/2024-01-04.md
+++ b/content/waf/change-log/2024-01-04.md
@@ -24,7 +24,7 @@ layout: wide
   <tbody>
     <tr>
       <td>Cloudflare Specials</td>
-      <td>...53c7ccde</td>
+      <td>{{<rule-id>}}e6e20a02339c42d9a3c3d7a853c7ccde{{</rule-id>}}</td>
       <td>100612</td>
       <td>SnakeYAML - CVE:CVE-2022-1471</td>
       <td>N/A</td>

--- a/content/waf/change-log/scheduled-changes.md
+++ b/content/waf/change-log/scheduled-changes.md
@@ -23,7 +23,7 @@ layout: wide
   </thead>
   <tbody>
     <tr>
-      <td>{{<rule-id>}}s63e03eecddfc4b3fb0cad587d32b798c{{</rule-id>}}</td>
+      <td>N/A</td>
       <td>N/A</td>
       <td>N/A</td>
       <td>N/A</td>

--- a/content/waf/change-log/scheduled-changes.md
+++ b/content/waf/change-log/scheduled-changes.md
@@ -23,7 +23,7 @@ layout: wide
   </thead>
   <tbody>
     <tr>
-      <td>N/A</td>
+      <td>{{<rule-id>}}s63e03eecddfc4b3fb0cad587d32b798c{{</rule-id>}}</td>
       <td>N/A</td>
       <td>N/A</td>
       <td>N/A</td>

--- a/layouts/shortcodes/rule-id.html
+++ b/layouts/shortcodes/rule-id.html
@@ -1,5 +1,5 @@
 {{- $ruleId := .Inner -}}
-{{- $shortenedRuleId := print "..." (substr $ruleId -8) }}
+{{- $shortenedRuleId := print "..." (substr (trim $ruleId " ") -8) }}
 
 <code>
 <span class="ruleID" 

--- a/layouts/shortcodes/rule-id.html
+++ b/layouts/shortcodes/rule-id.html
@@ -1,8 +1,21 @@
 {{- $ruleId := .Inner -}}
 {{- $shortenedRuleId := print "..." (substr $ruleId -8) }}
 
+<code>
 <span class="ruleID" 
         title="Click to copy full rule ID"
         onclick="navigator.clipboard.writeText({{$ruleId}})">
 {{- $shortenedRuleId -}}
+&nbsp;
+<svg
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      style="width: 16px;height: 16px;"
+      class="icon-copy"
+    >
+      <path d="M14 1.5H6l-.5.5v2.5h1v-2h7v7h-2v1H14l.5-.5V2l-.5-.5z"></path>
+      <path d="M2 5.5l-.5.5v8l.5.5h8l.5-.5V6l-.5-.5H2zm7.5 8h-7v-7h7v7z"></path>
+    </svg>
 </span> 
+</code>

--- a/layouts/shortcodes/rule-id.html
+++ b/layouts/shortcodes/rule-id.html
@@ -1,0 +1,8 @@
+{{- $ruleId := .Inner -}}
+{{- $shortenedRuleId := print "..." (substr $ruleId -8) }}
+
+<span class="ruleID" 
+        title="Click to copy full rule ID"
+        onclick="navigator.clipboard.writeText({{$ruleId}})">
+{{- $shortenedRuleId -}}
+</span> 

--- a/layouts/shortcodes/rule-id.html
+++ b/layouts/shortcodes/rule-id.html
@@ -1,7 +1,7 @@
 {{- $ruleId := .Inner -}}
 {{- $shortenedRuleId := print "..." (substr (trim $ruleId " ") -8) }}
 
-<code>
+<code class="ruleID">
 <span class="ruleID" 
         title="Click to copy full rule ID"
         onclick="navigator.clipboard.writeText({{$ruleId}})">
@@ -11,7 +11,7 @@
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"
-      style="width: 16px;height: 16px;"
+      style="width: 16px;height: 18px;"
       class="icon-copy"
     >
       <path d="M14 1.5H6l-.5.5v2.5h1v-2h7v7h-2v1H14l.5-.5V2l-.5-.5z"></path>

--- a/static/style.css
+++ b/static/style.css
@@ -5871,11 +5871,11 @@ span.ruleID {
   display: inline-flex;
 }
 
-span.ruleID:hover {
+code.ruleID:hover {
   background: rgba(var(--orange-rgb), .3)
 }
 
-span.ruleID:active {
+code.ruleID:active {
 background: orange;
 color: white;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -5872,7 +5872,7 @@ span.ruleID {
 }
 
 span.ruleID:hover {
-  background: rgba(var(--orange-rgb), .2)
+  background: rgba(var(--orange-rgb), .3)
 }
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -5864,3 +5864,20 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
   transition: all 0.1s ease 0.1s;
   visibility: visible;
 }
+
+span.ruleID {
+  display: inline-block;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+span.ruleID:hover {
+  background: rgba(var(--orange-rgb), .2)
+}
+
+
+
+span.ruleID:active {
+background: orange;
+color: white;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -5866,18 +5866,17 @@ html #ot-sdk-btn.ot-sdk-show-settings:hover {
 }
 
 span.ruleID {
-  display: inline-block;
   white-space: nowrap;
   cursor: pointer;
+  display: inline-flex;
 }
 
 span.ruleID:hover {
   background: rgba(var(--orange-rgb), .3)
 }
 
-
-
 span.ruleID:active {
 background: orange;
 color: white;
 }
+


### PR DESCRIPTION
There's currently a gap with WAF / other rules changes where you can't see the full rule Id in our docs / changelog entries.

This PR adds a new shortcode to assist with that, while still preserving the current table formatting.