### PR TITLE
turnstile: fix refresh timed-out heading

### DIFF
--- a/content/turnstile/get-started/client-side-rendering.md
+++ b/content/turnstile/get-started/client-side-rendering.md
@@ -182,7 +182,7 @@ The visitor can also be instructed to manually obtain a new token by setting the
 
 Additionally, specifying `never` will not result in a regeneration of a token, and the application using Turnstile will be responsible for obtaining a novel Turnstile token.
 
-# Refresh a timed-out widget
+## Refresh a timed-out widget
 
 When managed mode is chosen, Turnstile may present the visitor with an interactive challenge at times. If this interactive challenge is presented but was not solved within a given time period, it will time out and Turnstile's challenge process will need to be restarted.
 


### PR DESCRIPTION
The heading is currently a h1 instead of a h2.
This causes the heading to not appear in the navbar and is just plain wrong.

https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#refresh-a-timed-out-widget