### PR TITLE
[Durable Objects] Clean up Durable Objects examples

### DIFF
--- a/content/durable-objects/examples/alarms-api.md
+++ b/content/durable-objects/examples/alarms-api.md
@@ -14,6 +14,7 @@ layout: example
 This example implements an `alarm()` handler that wakes the Durable Object once every 10 seconds to batch requests to a single Durable Object. The `alarm()` handler will delay processing until there is enough work in the queue.
 
 ```js
+// Worker
 export default {
   async fetch(request, env) {
     let id = env.BATCHER.idFromName("foo");
@@ -23,6 +24,7 @@ export default {
 
 const SECONDS = 1000;
 
+// Durable Object
 export class Batcher {
   constructor(state, env) {
     this.state = state;
@@ -32,6 +34,7 @@ export class Batcher {
       this.count = vals.size == 0 ? 0 : parseInt(vals.keys().next().value);
     });
   }
+
   async fetch(request) {
     this.count++;
 
@@ -50,6 +53,7 @@ export class Batcher {
       },
     });
   }
+
   async alarm() {
     let vals = await this.storage.list();
     await fetch("http://example.com/some-upstream-service", {

--- a/content/durable-objects/examples/build-a-counter.md
+++ b/content/durable-objects/examples/build-a-counter.md
@@ -44,16 +44,16 @@ export default {
 
     // Send a request to the Durable Object using RPC methods, then await its response.
     let count = null;
-		switch (url.pathname) {
+    switch (url.pathname) {
       case "/increment":
-				count = await stub.increment();
+        count = await stub.increment();
         break;
-			case "/decrement":
-				count = await stub.decrement();
-				break;
+      case "/decrement":
+        count = await stub.decrement();
+        break;
       case "/":
         // Serves the current value.
-				count = await stub.getCounterValue();
+        count = await stub.getCounterValue();
         break;
       default:
         return new Response("Not found", { status: 404 });
@@ -66,22 +66,22 @@ export default {
 // Durable Object
 export class Counter extends DurableObject {
 
-	async getCounterValue() {
+  async getCounterValue() {
     let value = (await this.ctx.storage.get("value")) || 0;
     return value;
   }
 
-	async increment(amount = 1) {
+  async increment(amount = 1) {
     let value = (await this.ctx.storage.get("value")) || 0;
     value += amount;
-		// You do not have to worry about a concurrent request having modified the value in storage. 
+    // You do not have to worry about a concurrent request having modified the value in storage. 
     // "input gates" will automatically protect against unwanted concurrency. 
     // Read-modify-write is safe. 
     await this.ctx.storage.put("value", value);
     return value;
   }
 
-	async decrement(amount = 1) {
+  async decrement(amount = 1) {
     let value = (await this.ctx.storage.get("value")) || 0;
     value -= amount;
     await this.ctx.storage.put("value", value);
@@ -100,7 +100,7 @@ filename: index.ts
 import { DurableObject } from "cloudflare:workers";
 
 export interface Env {
-	COUNTERS: DurableObjectNamespace<Counter>;
+  COUNTERS: DurableObjectNamespace<Counter>;
 }
 
 // Worker
@@ -125,17 +125,17 @@ export default {
     // A stub is a client Object used to send messages to the Durable Object.
     let stub = env.COUNTERS.get(id);
 
-		let count = null;
-		switch (url.pathname) {
+    let count = null;
+    switch (url.pathname) {
       case "/increment":
-				count = await stub.increment();
+        count = await stub.increment();
         break;
-			case "/decrement":
-				count = await stub.decrement();
-				break;
+      case "/decrement":
+        count = await stub.decrement();
+        break;
       case "/":
         // Serves the current value.
-				count = await stub.getCounterValue();
+        count = await stub.getCounterValue();
         break;
       default:
         return new Response("Not found", { status: 404 });
@@ -148,22 +148,22 @@ export default {
 // Durable Object
 export class Counter extends DurableObject {
 
-	async getCounterValue() {
+  async getCounterValue() {
     let value = (await this.ctx.storage.get("value")) || 0;
     return value;
   }
 
-	async increment(amount = 1) {
+  async increment(amount = 1) {
     let value: number = (await this.ctx.storage.get("value")) || 0;
     value += amount;
-		// You do not have to worry about a concurrent request having modified the value in storage. 
+    // You do not have to worry about a concurrent request having modified the value in storage. 
     // "input gates" will automatically protect against unwanted concurrency. 
     // Read-modify-write is safe. 
     await this.ctx.storage.put("value", value);
     return value;
   }
 
-	async decrement(amount = 1) {
+  async decrement(amount = 1) {
     let value: number = (await this.ctx.storage.get("value")) || 0;
     value -= amount;
     await this.ctx.storage.put("value", value);

--- a/content/durable-objects/examples/durable-object-in-memory-state.md
+++ b/content/durable-objects/examples/durable-object-in-memory-state.md
@@ -13,7 +13,6 @@ This example shows you how Durable Objects are stateful, meaning in-memory state
 
 ```js
 // Worker
-
 export default {
   async fetch(request, env) {
     return await handleRequest(request, env);

--- a/content/durable-objects/examples/testing-with-durable-objects.md
+++ b/content/durable-objects/examples/testing-with-durable-objects.md
@@ -15,119 +15,119 @@ import type { UnstableDevWorker } from "wrangler"
 import { describe, expect, it, beforeAll, afterAll } from "vitest"
 
 describe("Worker", () => {
-	let worker: UnstableDevWorker
+  let worker: UnstableDevWorker
 
-	beforeAll(async () => {
-		worker = await unstable_dev("src/index.ts", {
-			experimental: { disableExperimentalWarning: true },
-		});
-	});
+  beforeAll(async () => {
+    worker = await unstable_dev("src/index.ts", {
+      experimental: { disableExperimentalWarning: true },
+    });
+  });
 
-	afterAll(async () => {
-		await worker.stop()
-	})
+  afterAll(async () => {
+    await worker.stop()
+  })
 
-	it("should deny request for short paths", async () => {
-		const cases = {
-			failures: ["/", "/foo", "/foo/", "/%2F"],
-		}
-		for (const path of cases.failures) {
-			const resp = await worker.fetch(`http://example.com${path}`)
-			if (resp) {
-				const text = await resp.text()
-				expect(text).toMatchInlineSnapshot('"path must be at least 5 characters"')
-			}
-		}
-	})
+  it("should deny request for short paths", async () => {
+    const cases = {
+      failures: ["/", "/foo", "/foo/", "/%2F"],
+    }
+    for (const path of cases.failures) {
+      const resp = await worker.fetch(`http://example.com${path}`)
+      if (resp) {
+        const text = await resp.text()
+        expect(text).toMatchInlineSnapshot('"path must be at least 5 characters"')
+      }
+    }
+  })
 
-	describe("durable object", () => {
-		it("Should send text from a POST to a matching GET", async () => {
-			const path = "/stuff1"
-			const url = `http://example.com${path}`
+  describe("durable object", () => {
+    it("Should send text from a POST to a matching GET", async () => {
+      const path = "/stuff1"
+      const url = `http://example.com${path}`
 
-			// The get request should wait for the post request to complete
-			const getResponsePromise = worker.fetch(url)
+      // The get request should wait for the post request to complete
+      const getResponsePromise = worker.fetch(url)
 
-			// The post request to the same path should receive a response that the text was consumed
-			const postResponse = await worker.fetch(url, { method: "POST", body: "Hello World 12345" })
-			expect(postResponse.status).toBe(200)
-			const postText = await postResponse.text()
-			expect(postText).toBe("The text was consumed!")
+      // The post request to the same path should receive a response that the text was consumed
+      const postResponse = await worker.fetch(url, { method: "POST", body: "Hello World 12345" })
+      expect(postResponse.status).toBe(200)
+      const postText = await postResponse.text()
+      expect(postText).toBe("The text was consumed!")
 
-			// The get request should now receive the text
-			const getResponse = await getResponsePromise
-			expect(getResponse.status).toBe(200)
-			const text = await getResponse.text()
-			expect(text).toBe("Hello World 12345")
-		})
+      // The get request should now receive the text
+      const getResponse = await getResponsePromise
+      expect(getResponse.status).toBe(200)
+      const text = await getResponse.text()
+      expect(text).toBe("Hello World 12345")
+    })
 
-		it("Shouldn't send text from a POST to a different GET", async () => {
-			const path1 = "/stuff1"
-			const path2 = "/stuff2"
-			const url = (p: string) => `http://example.com${p}`
+    it("Shouldn't send text from a POST to a different GET", async () => {
+      const path1 = "/stuff1"
+      const path2 = "/stuff2"
+      const url = (p: string) => `http://example.com${p}`
 
-			// The get request should wait for the post request to complete
-			const getResponsePromise1 = worker.fetch(url(path1))
-			const getResponsePromise2 = worker.fetch(url(path2))
+      // The get request should wait for the post request to complete
+      const getResponsePromise1 = worker.fetch(url(path1))
+      const getResponsePromise2 = worker.fetch(url(path2))
 
-			// The post request to the same path should receive a response that the text was consumed
-			const postResponse1 = await worker.fetch(url(path1), { method: "POST", body: "Hello World 12345" })
-			expect(postResponse1.status).toBe(200)
-			const postText1 = await postResponse1.text()
-			expect(postText1).toBe("The text was consumed!")
+      // The post request to the same path should receive a response that the text was consumed
+      const postResponse1 = await worker.fetch(url(path1), { method: "POST", body: "Hello World 12345" })
+      expect(postResponse1.status).toBe(200)
+      const postText1 = await postResponse1.text()
+      expect(postText1).toBe("The text was consumed!")
 
-			const postResponse2 = await worker.fetch(url(path2), { method: "POST", body: "Hello World 789" })
-			expect(postResponse2.status).toBe(200)
-			const postText2 = await postResponse2.text()
-			expect(postText2).toBe("The text was consumed!")
+      const postResponse2 = await worker.fetch(url(path2), { method: "POST", body: "Hello World 789" })
+      expect(postResponse2.status).toBe(200)
+      const postText2 = await postResponse2.text()
+      expect(postText2).toBe("The text was consumed!")
 
-			// The get request should now receive the text
-			const getResponse1 = await getResponsePromise1
-			expect(getResponse1.status).toBe(200)
-			const text1 = await getResponse1.text()
-			expect(text1).toBe("Hello World 12345")
+      // The get request should now receive the text
+      const getResponse1 = await getResponsePromise1
+      expect(getResponse1.status).toBe(200)
+      const text1 = await getResponse1.text()
+      expect(text1).toBe("Hello World 12345")
 
-			const getResponse2 = await getResponsePromise2
-			expect(getResponse2.status).toBe(200)
-			const text2 = await getResponse2.text()
-			expect(text2).toBe("Hello World 789")
-		})
+      const getResponse2 = await getResponsePromise2
+      expect(getResponse2.status).toBe(200)
+      const text2 = await getResponse2.text()
+      expect(text2).toBe("Hello World 789")
+    })
 
-		it("Should not send the same POST twice", async () => {
-			const path = "/stuff1"
-			const url = (p: string) => `http://example.com${p}`
+    it("Should not send the same POST twice", async () => {
+      const path = "/stuff1"
+      const url = (p: string) => `http://example.com${p}`
 
-			// The get request should wait for the post request to complete
-			const getResponsePromise1 = worker.fetch(url(path))
+      // The get request should wait for the post request to complete
+      const getResponsePromise1 = worker.fetch(url(path))
 
-			// The post request to the same path should receive a response that the text was consumed
-			const postResponse1 = await worker.fetch(url(path), { method: "POST", body: "Hello World 12345" })
-			expect(postResponse1.status).toBe(200)
-			const postText1 = await postResponse1.text()
-			expect(postText1).toBe("The text was consumed!")
+      // The post request to the same path should receive a response that the text was consumed
+      const postResponse1 = await worker.fetch(url(path), { method: "POST", body: "Hello World 12345" })
+      expect(postResponse1.status).toBe(200)
+      const postText1 = await postResponse1.text()
+      expect(postText1).toBe("The text was consumed!")
 
-			// The get request should now receive the text
-			const getResponse1 = await getResponsePromise1
-			expect(getResponse1.status).toBe(200)
-			const text1 = await getResponse1.text()
-			expect(text1).toBe("Hello World 12345")
+      // The get request should now receive the text
+      const getResponse1 = await getResponsePromise1
+      expect(getResponse1.status).toBe(200)
+      const text1 = await getResponse1.text()
+      expect(text1).toBe("Hello World 12345")
 
-			// The next get request should wait for the next post request to complete
-			const getResponsePromise2 = worker.fetch(url(path))
+      // The next get request should wait for the next post request to complete
+      const getResponsePromise2 = worker.fetch(url(path))
 
-			// Send a new POST with different text
-			const postResponse2 = await worker.fetch(url(path), { method: "POST", body: "Hello World 789" })
-			expect(postResponse2.status).toBe(200)
-			const postText2 = await postResponse2.text()
-			expect(postText2).toBe("The text was consumed!")
-			
-			// The get request should receive the new text, not the old text
-			const getResponse2 = await getResponsePromise2
-			expect(getResponse2.status).toBe(200)
-			const text2 = await getResponse2.text()
-			expect(text2).toBe("Hello World 789")
-		})
-	})
+      // Send a new POST with different text
+      const postResponse2 = await worker.fetch(url(path), { method: "POST", body: "Hello World 789" })
+      expect(postResponse2.status).toBe(200)
+      const postText2 = await postResponse2.text()
+      expect(postText2).toBe("The text was consumed!")
+      
+      // The get request should receive the new text, not the old text
+      const getResponse2 = await getResponsePromise2
+      expect(getResponse2.status).toBe(200)
+      const text2 = await getResponse2.text()
+      expect(text2).toBe("Hello World 789")
+    })
+  })
 })
 ```
 


### PR DESCRIPTION
Summary of changes:
- Simplify WebSocket example
- Fix indentation 
- Use RPC instead of fetch where appropriate
- Apply uniform comment style