### PR TITLE
Remove un-necessary step - No need to making script executable

### DIFF
--- a/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
+++ b/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
@@ -63,12 +63,7 @@ ___
   done
 ```
 
-3. Add executable commands to the script:
-```js
-  chmod +x add-multiple-zones.sh
-```
-
-4. Open the command line and run:
+3. Open the command line and run:
 ```js
   bash add-multiple-zones.sh
 ```


### PR DESCRIPTION
The bash file doesn't need to be made executable by changing file permissions as in the next step we are passing it as an argument to bash and not executing it directly

This change will also help remove the need of *sudo* in the step so non root users can run the procedure.

Reference: https://askubuntu.com/questions/25681/can-scripts-run-even-when-they-are-not-set-as-executable