### PR TITLE
[WAF] Adjust page title

### DIFF
--- a/content/waf/change-log/2024-04-16---emergency-release.md
+++ b/content/waf/change-log/2024-04-16---emergency-release.md
@@ -6,7 +6,7 @@ weight: 830
 layout: wide
 ---
 
-# 2024-04-16
+# 2024-04-16 - Emergency Release
 
 {{<table-wrap>}}
 <table style="width: 100%">


### PR DESCRIPTION
Makes the changelog page title consistent with the title of past emergency releases.

Cc @vs-mg 