### PR TITLE
Clarify dedicated egress IP plan availability

### DIFF
--- a/content/cloudflare-one/policies/gateway/egress-policies/dedicated-egress-ips.md
+++ b/content/cloudflare-one/policies/gateway/egress-policies/dedicated-egress-ips.md
@@ -7,7 +7,7 @@ weight: 1
 # Dedicated egress IPs
 
 {{<Aside type="note">}}
-Only available on Enterprise plans.
+Only available as an add-on to Zero Trust Enterprise plans.
 {{</Aside>}}
 
 Dedicated egress IPs are static IP addresses that can be used to allowlist traffic from your organization. These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare’s network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities.


### PR DESCRIPTION
Changed the availability aside to make it clear that dedicated egress IPs will require an additional purchase.