### PR TITLE
[Docs Site] Pin cytoscape to fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
     "vue-tsc": "^1.0.12",
     "wrangler": "3.28.0"
   },
+  "overrides": {
+    "mermaid": {
+      "cytoscape": "3.28.1"
+    }
+  },
   "volta": {
     "node": "18.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
       "cytoscape": "3.28.1"
     }
   },
+  "pnpm": {
+    "overrides": {
+      "cytoscape": "3.28.1"
+    }
+  },
   "volta": {
     "node": "18.10.0"
   },


### PR DESCRIPTION
Pins the `cytoscape` dependency of `mermaid` to fix a build issue (https://github.com/cloudflare/cloudflare-docs/actions/runs/8726706847/job/23942576800?pr=14034#step:7:3627).

Mermaid has a patch for `cytoscape@3.28.1` to add the export for `./dist/cytoscape.umd.js`, but they do not pin to `3.28.1` exactly but rather `^3.28.1` meaning the release of `3.29.0` 2 hours ago has caused a breakage.

This is just a hot-fix for the time being.