### PR TITLE
[ZT] Move ref arch down in sidenav

### DIFF
--- a/content/cloudflare-one/account-limits.md
+++ b/content/cloudflare-one/account-limits.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: reference
 title: Account limits
-weight: 11
+weight: 12
 ---
 
 # Account limits

--- a/content/cloudflare-one/changelog/_index.md
+++ b/content/cloudflare-one/changelog/_index.md
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Changelog
 meta:
     description: Review recent changes to Cloudflare Access.
-weight: 14
+weight: 15
 ---
 
 # Changelog

--- a/content/cloudflare-one/faq/_index.md
+++ b/content/cloudflare-one/faq/_index.md
@@ -3,7 +3,7 @@ type: overview
 pcx_content_type: navigation
 hideChildren: true
 title: FAQ
-weight: 14
+weight: 16
 layout: wide
 ---
 

--- a/content/cloudflare-one/glossary/index.md
+++ b/content/cloudflare-one/glossary/index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: reference
 title: Glossary
-weight: 13
+weight: 14
 layout: wide
 ---
 

--- a/content/cloudflare-one/reference-architecture.md
+++ b/content/cloudflare-one/reference-architecture.md
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Reference architecture
 external_link: /reference-architecture/architectures/sase/
-weight: 2
+weight: 10
 _build:
   publishResources: false
   render: never

--- a/content/cloudflare-one/roles-permissions.md
+++ b/content/cloudflare-one/roles-permissions.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: reference
 title: Roles and permissions
-weight: 12
+weight: 13
 ---
 
 # Roles and permissions
@@ -11,7 +11,6 @@ When creating a Cloudflare Zero Trust account, you will be given the Super Admin
 To check the list of members in your account, or to manage roles and permissions, refer to our [Account setup](/fundamentals/setup/manage-members/) documentation.
 
 ## Zero Trust roles
-
 
 Only Super Administrators will be able to assign or remove the following roles from users in their account. Scroll to the right to see a full list of permissions for each role.
 

--- a/content/cloudflare-one/tutorials/_index.md
+++ b/content/cloudflare-one/tutorials/_index.md
@@ -3,7 +3,7 @@ type: overview
 hideChildren: true
 pcx_content_type: navigation
 title: Tutorials
-weight: 10
+weight: 11
 layout: table
 column_text: Category
 column_param: category


### PR DESCRIPTION
Move **Reference architecture** link down to better fit between **API and Terraform** and **Tutorials**.

PCX-10103