### PR TITLE
[Rules] Add changelog

### DIFF
--- a/content/rules/changelog.md
+++ b/content/rules/changelog.md
@@ -1,0 +1,16 @@
+---
+pcx_content_type: changelog
+title: Changelog
+weight: 25
+layout: changelog
+changelog_file_name: [rules]
+outputs:
+    - html
+    - rss
+---
+
+# Changelog
+
+<!-- Actual content lives in /data/changelogs/rules.yaml. Update the file there for new entries to appear here. For more details, refer to https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/#yaml-file -->
+
+{{<product-changelog>}}

--- a/data/changelogs/rules.yaml
+++ b/data/changelogs/rules.yaml
@@ -4,7 +4,7 @@ productName: Rules
 entries:
 
 - publish_date: '2024-03-22'
-  title: New TLS fields in Ruleset Engine
+  title: New TLS fields in rule expressions
   description: |-
     Customers can now use new fields `cf.tls_client_hello_length` (the length of the client hello message sent in a TLS handshake), `cf.tls_client_random` (the value of the 32-byte random value provided by the client in a TLS handshake), and `cf.tls_client_extensions_sha1` (the SHA-1 fingerprint of TLS client extensions) in various products built on Ruleset Engine.
 

--- a/data/changelogs/rules.yaml
+++ b/data/changelogs/rules.yaml
@@ -1,0 +1,15 @@
+---
+link: "/rules/changelog/"
+productName: Rules
+entries:
+
+- publish_date: '2024-03-22'
+  title: New TLS fields in Ruleset Engine
+  description: |-
+    Customers can now use new fields `cf.tls_client_hello_length` (the length of the client hello message sent in a TLS handshake), `cf.tls_client_random` (the value of the 32-byte random value provided by the client in a TLS handshake), and `cf.tls_client_extensions_sha1` (the SHA-1 fingerprint of TLS client extensions) in various products built on Ruleset Engine.
+
+
+- publish_date: '2024-03-20'
+  title: Origin Rules now allow port numbers in Host Header Override
+  description: |-
+    Customers can now use arbitrary port numbers in Host Header Override in Origin Rules. Previously, only hostname was allowed as a value (for example, `example.com`). Now, you can set the value to `hostname:port` (for example, `example.com:1234`) as well.

--- a/data/changelogs/rules.yaml
+++ b/data/changelogs/rules.yaml
@@ -8,7 +8,6 @@ entries:
   description: |-
     Customers can now use new fields `cf.tls_client_hello_length` (the length of the client hello message sent in a TLS handshake), `cf.tls_client_random` (the value of the 32-byte random value provided by the client in a TLS handshake), and `cf.tls_client_extensions_sha1` (the SHA-1 fingerprint of TLS client extensions) in various products built on Ruleset Engine.
 
-
 - publish_date: '2024-03-20'
   title: Origin Rules now allow port numbers in Host Header Override
   description: |-

--- a/layouts/shortcodes/product-changelog.html
+++ b/layouts/shortcodes/product-changelog.html
@@ -22,7 +22,8 @@
 
 {{- end -}}
 
-{{ .description | $.Page.RenderString }}
+{{ $opts := dict "display" "block" }}
+{{ .description | $.Page.RenderString $opts }}
 
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Addresses PCX-10546.

Also fixes the formatting of inline code blocks in individual product changelogs (we were missing `<p>` tags when the changelog only contained one paragraph).

Before:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/3f5f66b2-6711-44b6-974f-842908698694)

After:
![image](https://github.com/cloudflare/cloudflare-docs/assets/680496/8c2be022-b577-4376-a7a6-32b2a39b7eae)

