### PR TITLE
[Style guide] clarify purpose and usage of IA plan

### DIFF
--- a/content/style-guide/documentation-content-strategy/information-architecture.md
+++ b/content/style-guide/documentation-content-strategy/information-architecture.md
@@ -9,14 +9,14 @@ weight: 4
 
 The information architecture (IA) of the Cloudflare developer documentation follows a consistent pattern. Product documentation always includes an [Overview](/style-guide/documentation-content-strategy/content-types/overview/) and [Get started](/style-guide/documentation-content-strategy/content-types/get-started/) page. Including other content types depends on the product, how it is used, and what content users need to be successful.
 
-## Developer platform information architecture
+## Developer Platform information architecture
 
-At launch, developer platform products should include the following high-level sections. As products mature, the IA may grow out of this structure based on what you can do with the product. For an example of a more mature product that differs from this IA, refer to the [Cloudflare Stream documentation](/stream/).
+At launch, Cloudflare Developer Platform products are recommended to include the following high-level sections. The following is a recommended guideline based on standard user journey flow (Learn, Get started, Configure, Test, Deploy, Asses, Maintain, etc.) and is intended to serve as a helpful reference to the documentation writer. As products mature, the IA may grow out of this structure based on what you can do with the product. For an example of a more mature product that differs from this IA, refer to the [Cloudflare Stream documentation](/stream/).
 
 * [Overview](/style-guide/documentation-content-strategy/content-types/overview/)
 * [Get started](/style-guide/documentation-content-strategy/content-types/get-started/)
-* [Configuration](/style-guide/documentation-content-strategy/content-types/configuration/) - Steps that come after getting started, or the delta between getting started and your desired state. As a product matures, content in **Configuration** might expand into its own section.
-* Observability - Information about testing, metrics, analytics, local development, etc
+* [Configuration](/style-guide/documentation-content-strategy/content-types/configuration/) - Steps that come after getting started, including features (like Cron Triggers and Smart Placement for Workers) or the delta between getting started and your desired state. As a product matures, content in **Configuration** might expand into its own top-level sections.
+* Observability - Information about testing, metrics, analytics, local development, etc. Alternative title: **Testing & Observability**.
 * [Reference](/style-guide/documentation-content-strategy/content-types/reference/)
 * [Concepts](/style-guide/documentation-content-strategy/content-types/concept/)
-* Platform - Section unique to developer platform products that includes Pricing, Limits, Storage options, Changelog, Betas, and Known issues pages
+* Platform - Section unique to Developer Platform products that includes Pricing, Limits, Storage options, Changelog, Betas, and Known issues pages.

--- a/content/style-guide/documentation-content-strategy/information-architecture.md
+++ b/content/style-guide/documentation-content-strategy/information-architecture.md
@@ -11,7 +11,7 @@ The information architecture (IA) of the Cloudflare developer documentation foll
 
 ## Developer Platform information architecture
 
-At launch, Cloudflare Developer Platform products are recommended to include the following high-level sections. The following is a recommended guideline based on standard user journey flow (Learn, Get started, Configure, Test, Deploy, Asses, Maintain, etc.) and is intended to serve as a helpful reference to the documentation writer. As products mature, the IA may grow out of this structure based on what you can do with the product. For an example of a more mature product that differs from this IA, refer to the [Cloudflare Stream documentation](/stream/).
+At launch, Cloudflare Developer Platform products are recommended to include the following high-level sections. The following is a recommended guideline based on standard user journey flow (Learn, Get started, Configure, Test, Deploy, Asses, Maintain, etc.) and is intended to serve as a helpful reference to the documentation writer and collaborators. Depending on the product and as products mature, the IA may grow out of this structure or differ from this structure based on what you can do with the product. For an example of a more mature product that differs from this IA, refer to the [Cloudflare Stream documentation](/stream/).
 
 * [Overview](/style-guide/documentation-content-strategy/content-types/overview/)
 * [Get started](/style-guide/documentation-content-strategy/content-types/get-started/)


### PR DESCRIPTION
This plan originally stemmed from user research and organization for the Workers docs. Clarifying that this is a reference/suggestion/guideline, and not a mandatory structure.