### PR TITLE
[Durable Objects] Update alarms.md to fix `this.storage = state.storage;` 

### DIFF
--- a/content/durable-objects/api/alarms.md
+++ b/content/durable-objects/api/alarms.md
@@ -97,7 +97,7 @@ const SECONDS = 1000;
 export class AlarmExample {
   constructor(ctx, env) {
     this.ctx = ctx;
-    this.storage = state.storage;
+    this.storage = ctx.storage;
   }
   async fetch(request) {
     // If there is no alarm currently set, set one for 10 seconds from now


### PR DESCRIPTION
I think  ...

`this.storage = state.storage;`

... should be ...

`this.storage = ctx.storage;`

Since `state` is not defined.