### PR TITLE
Add warning about wrangler to the Baselime Integration Page

### DIFF
--- a/content/workers/_partials/_wrangler-tail-warning.md
+++ b/content/workers/_partials/_wrangler-tail-warning.md
@@ -1,0 +1,16 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="warning">}}
+
+When updating a Worker with Wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+
+```toml
+tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]
+```
+
+{{</Aside>}}

--- a/content/workers/observability/baselime-integration.md
+++ b/content/workers/observability/baselime-integration.md
@@ -46,7 +46,7 @@ Once installed, the integration will automatically start forwarding events to Ba
 
 {{<Aside type="warning">}}
 
-When updating a worker with wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+When updating a Worker with Wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
 
 ```toml
 tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]

--- a/content/workers/observability/baselime-integration.md
+++ b/content/workers/observability/baselime-integration.md
@@ -44,15 +44,7 @@ To add the Baselime integration to your Worker:
 Once installed, the integration will automatically start forwarding events to Baselime. To learn more about Baselime, refer to [Baselime's official documentation](https://baselime.io/docs/).
 
 
-{{<Aside type="warning">}}
-
-When updating a Worker with Wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
-
-```toml
-tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]
-```
-
-{{</Aside>}}
+{{<render file="_wrangler-tail-warning.md">}}
 
 {{<Aside type="warning">}}
 

--- a/content/workers/observability/baselime-integration.md
+++ b/content/workers/observability/baselime-integration.md
@@ -46,7 +46,7 @@ Once installed, the integration will automatically start forwarding events to Ba
 
 {{<Aside type="warning">}}
 
-When updating a worker with wrangler the [Tail Consumer](https://developers.cloudflare.com/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+When updating a worker with wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
 
 ```toml
 tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]

--- a/content/workers/observability/baselime-integration.md
+++ b/content/workers/observability/baselime-integration.md
@@ -43,6 +43,17 @@ To add the Baselime integration to your Worker:
 
 Once installed, the integration will automatically start forwarding events to Baselime. To learn more about Baselime, refer to [Baselime's official documentation](https://baselime.io/docs/).
 
+
+{{<Aside type="warning">}}
+
+When updating a worker with wrangler the [Tail Worker](https://developers.cloudflare.com/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+
+```toml
+tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]
+```
+
+{{</Aside>}}
+
 {{<Aside type="warning">}}
 
 Note that automatic distributed tracing is not yet supported via the Baselime integration. To add tracing, follow the [Baselime documentation](https://baselime.io/docs/sending-data/platforms/cloudflare/traces/).

--- a/content/workers/observability/baselime-integration.md
+++ b/content/workers/observability/baselime-integration.md
@@ -46,7 +46,7 @@ Once installed, the integration will automatically start forwarding events to Ba
 
 {{<Aside type="warning">}}
 
-When updating a worker with wrangler the [Tail Worker](https://developers.cloudflare.com/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+When updating a worker with wrangler the [Tail Consumer](https://developers.cloudflare.com/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
 
 ```toml
 tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]

--- a/content/workers/observability/sentry-integration.md
+++ b/content/workers/observability/sentry-integration.md
@@ -24,10 +24,10 @@ This integration adds a [Tail Worker](/workers/observability/logging/tail-worker
 This integration supports the following Sentry features:
 - **[Data Handling](https://develop.sentry.dev/sdk/data-handling/)**: As a best practice, do not include PII or other sensitive data in the payload sent to Sentry. HTTP headers (for example, `Authorization` or `Cookie`) can be removed before events are forwarded to Sentry.
 - **[Sampling](https://docs.sentry.io/platforms/javascript/configuration/sampling/#configuring-the-transaction-sample-rate)**: Sampling can be configured to manage the number and type of events sent to Sentry. Sampling rates can be configured based on the HTTP status code returned by the Worker and for uncaught exceptions. Setting the sampling rate to 100% sends all events to Sentry or setting it to 30% sends approximately 30% of events to Sentry.
-- **[Breadcrumbs](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/)**: Breadcrumbs create a trail of events that happened prior to an issue. Breadcrumbs are automatically forwarded to Sentry in the case of an error or exception. These events consist of the `console.log()` from the Worker before the error or exception occurred. 
+- **[Breadcrumbs](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/)**: Breadcrumbs create a trail of events that happened prior to an issue. Breadcrumbs are automatically forwarded to Sentry in the case of an error or exception. These events consist of the `console.log()` from the Worker before the error or exception occurred.
 
 {{<Aside type="note">}}
-If there are more configuration options that you would like to see, leave us feedback on the [Cloudflare Developer Discord](https://discord.cloudflare.com) (channel name: integrations). 
+If there are more configuration options that you would like to see, leave us feedback on the [Cloudflare Developer Discord](https://discord.cloudflare.com) (channel name: integrations).
 {{</Aside>}}
 
 ## Set up an integration with Sentry
@@ -39,20 +39,12 @@ To add the Sentry integration to your Worker:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Select **Workers & Pages**.
 3. In **Overview**, select your Worker.
-4. Select **Integrations** > **Sentry**. 
+4. Select **Integrations** > **Sentry**.
 5. Follow the setup flow.
 
 Once installed, the integration will automatically start forwarding matching events to Sentry. To learn more about Sentry, refer to [Sentry's official documentation](https://docs.sentry.io/).
 
-{{<Aside type="warning">}}
-
-When updating a Worker with Wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
-
-```toml
-tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]
-```
-
-{{</Aside>}}
+{{<render file="_wrangler-tail-warning.md">}}
 
 {{<Aside type="warning">}}
 

--- a/content/workers/observability/sentry-integration.md
+++ b/content/workers/observability/sentry-integration.md
@@ -46,6 +46,16 @@ Once installed, the integration will automatically start forwarding matching eve
 
 {{<Aside type="warning">}}
 
+When updating a Worker with Wrangler the [Tail Consumer](/workers/observability/logging/tail-workers) config will be removed. Please add the tail_consumer config to the top level of your `wrangler.toml`.
+
+```toml
+tail_consumers = [{service = "<TAIL_WORKER_NAME>"}]
+```
+
+{{</Aside>}}
+
+{{<Aside type="warning">}}
+
 Each Cloudflare account can only be linked to one Sentry organization. Use the [Sentry SDK](https://github.com/getsentry/sentry-javascript) in order to send events to projects in more than one Sentry organization.
 
 {{</Aside>}}


### PR DESCRIPTION
Hey Folks,

We ran into a few repeated issues with people struggling to use the Baselime integration due to wrangler removing the tail_consumer config from a worker.

I have added the docs with a warning that will hopefully help these people.

