### PR TITLE
[Docs Site] Fix typo and punctuation.

### DIFF
--- a/content/calls/calls-vs-sfus.md
+++ b/content/calls/calls-vs-sfus.md
@@ -6,7 +6,7 @@ weight: 4
 
 ## Cloudflare Calls vs. Traditional SFUs
 
-Cloudflare Calls represents a paradigm shift in building real-time applications by leveraging a distributed real-time data plane. It creates a seamless experience in real-time communication, transcending traditional geographical limitations and scalability concerns. Calls is designed for developers looking to integrate WebRTC funcintionalities in a server-client architecture without delving deep into the complexities of regional scaling or server management.
+Cloudflare Calls represents a paradigm shift in building real-time applications by leveraging a distributed real-time data plane. It creates a seamless experience in real-time communication, transcending traditional geographical limitations and scalability concerns. Calls is designed for developers looking to integrate WebRTC functionalities in a server-client architecture without delving deep into the complexities of regional scaling or server management.
 
 ### The Limitations of Centralized SFUs
 
@@ -16,7 +16,7 @@ Selective Forwarding Units (SFUs) play a critical role in managing WebRTC connec
 
 - **Scalability Concerns:** Scaling a centralized SFU to meet global demand can be challenging and inefficient, often requiring additional infrastructure and complexity.
 
-### How is Cloudflare Calls different
+### How is Cloudflare Calls different?
 
 Cloudflare Calls addresses these limitations by leveraging Cloudflare's global network infrastructure:
 


### PR DESCRIPTION
**Changes**
- Fixes mispelling
- If a heading is phrased as a question, it should have a question mark.

**Sidenote** - The title of this page should probably use Title Case. But, the other pages in the Calls API do not do this, so I left the title as is.