### PR TITLE
Fix binding assignment on Qwik guide

### DIFF
--- a/content/pages/framework-guides/deploy-a-qwik-site.md
+++ b/content/pages/framework-guides/deploy-a-qwik-site.md
@@ -73,7 +73,7 @@ highlight: [4, 5]
 
 export const useGetServerTime = routeLoader$(({ platform }) => {
   // the type `KVNamespace` comes from the @cloudflare/workers-types package
-  const { MY_KV } = (platform as { MY_KV: KVNamespace }));
+  const { MY_KV } = (platform.env as { MY_KV: KVNamespace }));
 
   return {
     // ....


### PR DESCRIPTION
The original produces a type error:

`Conversion of type 'QwikCityPlatform' to type '{ MY_KV: KVNamespace<string>; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.`

Using create-cloudflare-cli and specifying Qwik as the framework, bindings are by default set on platform.env as specified in entry.cloudflare-pages.tsx

```
declare global {
  interface QwikCityPlatform extends PlatformCloudflarePages {
    env: Env
  }
}
```