### PR TITLE
[Durable Objects] DO Transactional Storage - transaction method

### DIFF
--- a/content/durable-objects/api/transactional-storage-api.md
+++ b/content/durable-objects/api/transactional-storage-api.md
@@ -170,6 +170,8 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   - Same as the option to `get()`, above.
 
+### transaction
+
 - {{<code>}}transaction(closure{{<param-type>}}Function(txn){{</param-type>}}){{</code>}} : {{<type>}}Promise{{</type>}}
 
   - Runs the sequence of storage operations called on `txn` in a single transaction that either commits successfully or aborts.


### PR DESCRIPTION
The `transaction` method is documented under the `sync` method when it should be under it's own section.