### PR TITLE
[MWAN] Fortinet phase 2 options

### DIFF
--- a/content/magic-wan/configuration/manually/third-party/fortinet.md
+++ b/content/magic-wan/configuration/manually/third-party/fortinet.md
@@ -167,7 +167,7 @@ fortigate # config vpn ipsec phase2-interface
         set dhgrp 14
         set replay disable
         set keylifeseconds 3600
-         set auto-negotiate enable
+        set auto-negotiate enable
         set keepalive enable
     next
 end

--- a/content/magic-wan/configuration/manually/third-party/fortinet.md
+++ b/content/magic-wan/configuration/manually/third-party/fortinet.md
@@ -158,6 +158,8 @@ fortigate # config vpn ipsec phase2-interface
         set dhgrp 14
         set replay disable
         set keylifeseconds 3600
+        set auto-negotiate enable
+        set keepalive enable
     next
     edit "MWAN_IPsec_Tun2"
         set phase1name "MWAN_IPsec_Tun2"
@@ -165,6 +167,8 @@ fortigate # config vpn ipsec phase2-interface
         set dhgrp 14
         set replay disable
         set keylifeseconds 3600
+         set auto-negotiate enable
+        set keepalive enable
     next
 end
 ```


### PR DESCRIPTION
Added options necessary on the phase 2 IPsec setup for Fortinet Firewall. Replicates Vincent Barida [PR-13513](https://github.com/cloudflare/cloudflare-docs/pull/13513) which I had to close bc the actions were stalled.