### PR TITLE
[C3] add information on using pnpm in c3.md

### DIFF
--- a/content/pages/get-started/c3.md
+++ b/content/pages/get-started/c3.md
@@ -20,6 +20,8 @@ Running `npm create cloudflare@latest` will prompt you to install the [`create-c
 
 The list of applications includes a variety of Workers templates as well as an option to select a web framework to create a website or web application.
 
+If you select `pnpm` as your package manager, ensure that you are running the latest version. Otherwise, it may incorrectly resolve dependencies which can cause issues.
+
 ## Web frameworks
 
 If you choose to create a new website or application using a web framework, C3 will prompt you to choose one of the following supported frameworks:

--- a/content/workers/_partials/_c3-run-command.md
+++ b/content/workers/_partials/_c3-run-command.md
@@ -5,7 +5,7 @@ _build:
   list: never
 ---
 
-{{<tabs labels="npm | yarn">}}
+{{<tabs labels="npm | yarn | pnpm">}}
 {{<tab label="npm" default="true">}}
 
 ```sh
@@ -21,4 +21,13 @@ $ yarn create cloudflare
 ```
 
 {{</tab>}}
+
+{{<tab label="pnpm">}}
+
+```sh
+$ pnpm create cloudflare
+```
+
+{{</tab>}}
+
 {{</tabs>}}


### PR DESCRIPTION
closes https://github.com/cloudflare/next-on-pages/issues/747

This can happen when using `pnpm` from `corepack` in a recent LTS version of node (`v20.9.0`)