### PR TITLE
remove useless '\' in '\ ' which cause regex101 error, and add kaios

### DIFF
--- a/content/automatic-platform-optimization/reference/cache-device-type.md
+++ b/content/automatic-platform-optimization/reference/cache-device-type.md
@@ -8,7 +8,7 @@ weight: 13
 
 APO cache by device type provides all of the same benefits of Cloudflare's cache while targeting visitors with content appropriate to their device. Cloudflare evaluates the `User-Agent` header in the HTTP request to identify the device type. Cloudflare then identifies each device type with a case insensitive match to the regex below:
 
-- **Mobile**: `(?:phone|windows\s+phone|ipod|blackberry|(?:android|bb\d+|meego|silk|googlebot) .+? mobile|palm|windows\s+ce|opera\ mini|avantgo|mobilesafari|docomo)`
+- **Mobile**: `(?:phone|windows\s+phone|ipod|blackberry|(?:android|bb\d+|meego|silk|googlebot) .+? mobile|palm|windows\s+ce|opera mini|avantgo|mobilesafari|docomo|kaios)`
 - **Tablet**: `(?:ipad|playbook|(?:android|bb\d+|meego|silk)(?! .+? mobile))`
 - **Desktop**: Everything else not matched above.
 

--- a/content/cache/how-to/edge-browser-cache-ttl/create-page-rules.md
+++ b/content/cache/how-to/edge-browser-cache-ttl/create-page-rules.md
@@ -97,7 +97,7 @@ We do not support non-ASCII characters (for example, punycode/unicode domain) in
 
 Enterprise domains can cache content by device type to target visitors with content appropriate to their device. Cloudflare evaluates the User-Agent header in the HTTP request to identify the device type and identifies each device type with a case insensitive match to the regex below:
 
-- Mobile: `(?:phone|windows\s+phone|ipod|blackberry|(?:android|bb\d+|meego|silk|googlebot) .+? mobile|palm|windows\s+ce|opera\ mini|avantgo|mobilesafari|docomo|KAIOS)`
+- Mobile: `(?:phone|windows\s+phone|ipod|blackberry|(?:android|bb\d+|meego|silk|googlebot) .+? mobile|palm|windows\s+ce|opera mini|avantgo|mobilesafari|docomo|kaios)`
 - Tablet: `(?:ipad|playbook|(?:android|bb\d+|meego|silk)(?! .+? mobile))`
 - Desktop: Everything else not matched above.
 


### PR DESCRIPTION
- `\ ` has no special meaning, and regex101 mark it as error.
- add `kaios` and converted into lowercase.

This PR makes the user-agent mobile regex same.
 