### PR TITLE
[Workers] Missing compat dates

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/no-cfbotmanagement-default.md
+++ b/content/workers/_partials/_platform-compatibility-dates/no-cfbotmanagement-default.md
@@ -1,0 +1,19 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Bot Management data"
+sort_date: "2023-08-01"
+enable_date: "2023-08-01"
+experimental: false
+enable_flag: "no_cf_botmanagement_default"
+disable_flag: "cf_botmanagement_default"
+---
+
+This flag streamlines Workers requests by reducing unnecessary properties in the `request.cf` object.
+
+With the flag enabled - either by default after 2023-08-01 or by setting the `no_cf_botmanagement_default` flag - Cloudflare will only include the [Bot Management object](/bots/reference/bot-management-variables/#bot-management-variables) in a Worker's `request.cf` if the account has access to Bot Management.
+
+With the flag disabled, Cloudflare will include a default Bot Management object, regardless of whether the account is entitled to Bot Management.

--- a/content/workers/_partials/_platform-compatibility-dates/urlsearchparams-deletehasvalue.md
+++ b/content/workers/_partials/_platform-compatibility-dates/urlsearchparams-deletehasvalue.md
@@ -1,0 +1,35 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "URLSearchParams delete() and has() value argument"
+sort_date: "2023-07-01"
+enable_date: "2023-07-01"
+experimental: false
+enable_flag: "urlsearchparams_delete_has_value_arg"
+disable_flag: "no_urlsearchparams_delete_has_value_arg"
+---
+
+The WHATWG introduced additional optional arguments to the `URLSearchParams` object [`delete()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/delete) and [`has()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/has) methods that allow for more precise control over the removal of query parameters. Because
+the arguments are optional and change the behavior of the methods when present there is a risk of
+breaking existing code. If your compatibility date is set to July 1, 2023 or after, this compatibility flag will be enabled by default.
+
+For an example of how this change could break existing code, consider code that uses the `Array` `forEach()` method to iterate through a number of parameters to delete:
+
+```js
+const usp = new URLSearchParams();
+// ...
+['abc', 'xyz'].forEach(usp.delete.bind(usp));
+```
+
+The `forEach()` automatically passes multiple parameters to the function that is passed in. Prior to the addition of the new standard parameters, these extra arguments would have been ignored.
+
+Now, however, the additional arguments have meaning and change the behavior of the function. With this flag, the example above would need to be changed to:
+
+```js
+const usp = new URLSearchParams();
+// ...
+['abc', 'xyz'].forEach((key) => usp.delete(key));
+```


### PR DESCRIPTION
closes #10586.

- This continues the work started in #9235 (the `http_headers_getsetcookie` was already documented)
- Am I telling lies on the Bot Management flag?
- Do we also need docs around the experimental flags that aren't yet documented + aren't mentioned as being WIP / not available / deprecated?
    - [`service_binding_extra_handler`](https://github.com/cloudflare/workerd/blob/c6c5445358cb6e34387dcd5cb3015b9d5c2e44c8/src/workerd/io/compatibility-date.capnp#L291)
    - [`rtti_api`](https://github.com/cloudflare/workerd/blob/c6c5445358cb6e34387dcd5cb3015b9d5c2e44c8/src/workerd/io/compatibility-date.capnp#L340)
    - [`webgpu`](https://github.com/cloudflare/workerd/blob/c6c5445358cb6e34387dcd5cb3015b9d5c2e44c8/src/workerd/io/compatibility-date.capnp#L345)


cc: @jasnell / @irvinebroque / @GregBrimble 