### PR TITLE
[Stream] Document upper bound on scheduled deletion timestamps

### DIFF
--- a/content/stream/stream-live/start-stream-live.md
+++ b/content/stream/stream-live/start-stream-live.md
@@ -37,7 +37,7 @@ header: Request
 ---
 curl -X POST \
 -H "Authorization: Bearer <API_TOKEN>" \
--D '{"meta": {"name":"test stream"},"recording": { "mode": "automatic" }}' \
+-d '{"meta": {"name":"test stream"},"recording": { "mode": "automatic" }}' \
 https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs
 ```
 
@@ -89,7 +89,7 @@ header: Response
 
 - `deleteRecordingAfterDays` {{<type>}}integer{{</type>}} {{<prop-meta>}}default: `null` (any){{</prop-meta>}}
 
-  - Specifies a date and time when the recording, not the input, will be deleted. This property applies from the time the recording is made available and ready to stream. After the recording is deleted, it is no longer viewable and no longer counts towards storage for billing. Minimum value is `30`.
+  - Specifies a date and time when the recording, not the input, will be deleted. This property applies from the time the recording is made available and ready to stream. After the recording is deleted, it is no longer viewable and no longer counts towards storage for billing. Minimum value is `30`, maximum value is `1096`.
 
     When the stream ends, a `scheduledDeletion` timestamp is calculated using the `deleteRecordingAfterDays` value if present.
 
@@ -111,7 +111,7 @@ header: Request
 ---
 $ curl -X PUT \
 -H "Authorization: Bearer <API_TOKEN>" \
--D '{"meta": {"name":"test stream 1"},"recording": { "mode": "automatic", "timeoutSeconds": 10 }}' \
+-d '{"meta": {"name":"test stream 1"},"recording": { "mode": "automatic", "timeoutSeconds": 10 }}' \
 https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/stream/live_inputs/:input_id
 ```
 

--- a/content/stream/uploading-videos/upload-video-file.md
+++ b/content/stream/uploading-videos/upload-video-file.md
@@ -73,7 +73,7 @@ Setting arbitrary metadata values in the `Upload-Metadata` header sets values th
 
 - `scheduleddeletion`
 
-  - Specifies a date and time when a video will be deleted. After a video is deleted, it is no longer viewable and no longer counts towards storage for billing. The specified date and time cannot be earlier than 30 days from the video's created timestamp.
+  - Specifies a date and time when a video will be deleted. After a video is deleted, it is no longer viewable and no longer counts towards storage for billing. The specified date and time cannot be earlier than 30 days or later than 1096 days from the video's created timestamp.
 
 - `allowedorigins`
 


### PR DESCRIPTION
* Updates documentation for Stream API to include upper bound of 1096 days for scheduled deletion.