### PR TITLE
Fixed formatting error on Update tokens.md

### DIFF
--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -39,7 +39,7 @@ Buckets created with jurisdictions must be accessed via jurisdiction-specific `e
 
 {{<Aside type="warning">}}
 
-Jurisdictional buckets can only be accessed via the corresponding jurisdictional endpoint. Most S3 clients will not let you configure multiple `endpoint`s, so you'll generally have to initialize one client per jurisdiction.
+Jurisdictional buckets can only be accessed via the corresponding jurisdictional endpoint. Most S3 clients will not let you configure multiple `endpoints`, so you'll generally have to initialize one client per jurisdiction.
 
 {{</Aside>}}
 


### PR DESCRIPTION
I fixed a formatting error on the "Jurisdictional buckets" warning. The waring incorrectly formatted [`endpoint`s ] when it should have been [`endpoints`].