### PR TITLE
Clarify ResponseInit options

### DIFF
--- a/content/workers/runtime-apis/response.md
+++ b/content/workers/runtime-apis/response.md
@@ -39,16 +39,19 @@ let response = new Response(body, init);
 
 Valid options for the `options` object include: {{<definitions>}}
 
-- `status` {{<type>}}int{{</type>}}
-
-  - The status code for the response, such as `200`.
-
-- `statusText` {{<type>}}string{{</type>}}
-
-  - The status message associated with the status code, such as, `OK`.
-
+<!-- Does `cf` do anything in a Response? -->
+- `cf` {{<type>}}any | null{{</type>}}
+  - An object that contains Cloudflare-specific information. This object is not part of the Fetch API standard and is only available in Cloudflare Workers.
+- `encodeBody` {{<type>}}string{{</type>}}
+  - Workers have to compress data according to the `content-encoding` header when transmitting, to serve data that is already compressed, this property has to be set to `"manual"`, otherwise the default is `"automatic"`.
 - `headers` {{<type-link href="/runtime-apis/request#parameters">}}Headers{{</type-link>}} | {{<type-link href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">}}ByteString{{</type-link>}}
   - Any headers to add to your response that are contained within a [`Headers`](/workers/runtime-apis/request/#parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) key-value pairs.
+- `status` {{<type>}}int{{</type>}}
+  - The status code for the response, such as `200`.
+- `statusText` {{<type>}}string{{</type>}}
+  - The status message associated with the status code, such as, `OK`.
+- `webSocket` {{<type>}}WebSocket | null{{</type>}}
+  - This is present in successful WebSocket handshake responses. For example, if a client sends a WebSocket upgrade request to an origin and a Worker intercepts the request and then forwards it to the origin and the origin replies with a successful WebSocket upgrade response, the Worker sees `response.webSocket`. This establishes a WebSocket connection proxied through a Worker. Note that you cannot intercept data flowing over a WebSocket connection.
 
 {{</definitions>}}
 
@@ -60,8 +63,6 @@ Valid options for the `options` object include: {{<definitions>}}
   - A getter to get the body contents.
 - `response.bodyUsed` {{<type>}}boolean{{</type>}}
   - A boolean indicating if the body was used in the response.
-- `response.encodeBody` {{<type>}}string{{</type>}}
-  - Workers have to compress data according to the `content-encoding` header when transmitting, to serve data that is already compressed, this property has to be set to `"manual"`, otherwise the default is `"automatic"`.
 - `response.headers` {{<type-link href="/runtime-apis/request#parameters">}}Headers{{</type-link>}}
   - The headers for the response.
 - `response.ok` {{<type>}}boolean{{</type>}}
@@ -74,10 +75,7 @@ Valid options for the `options` object include: {{<definitions>}}
   - The status message corresponding to the status code (for example, `OK` for `200`).
 - `response.url` {{<type>}}string{{</type>}}
   - The URL of the response. The value is the final URL obtained after any redirects.
-
-<!-- What type is this? WebSocket? -->
-
-- `response.webSocket`
+- `response.webSocket` {{<type>}}WebSocket?{{</type>}}
   - This is present in successful WebSocket handshake responses. For example, if a client sends a WebSocket upgrade request to an origin and a Worker intercepts the request and then forwards it to the origin and the origin replies with a successful WebSocket upgrade response, the Worker sees `response.webSocket`. This establishes a WebSocket connection proxied through a Worker. Note that you cannot intercept data flowing over a WebSocket connection.
 
 {{</definitions>}}

--- a/content/workers/runtime-apis/response.md
+++ b/content/workers/runtime-apis/response.md
@@ -39,9 +39,8 @@ let response = new Response(body, init);
 
 Valid options for the `options` object include: {{<definitions>}}
 
-<!-- Does `cf` do anything in a Response? -->
 - `cf` {{<type>}}any | null{{</type>}}
-  - An object that contains Cloudflare-specific information. This object is not part of the Fetch API standard and is only available in Cloudflare Workers.
+  - An object that contains Cloudflare-specific information. This object is not part of the Fetch API standard and is only available in Cloudflare Workers. This field is only used by consumers of the Response for informational purposes and does not have any impact on Workers behavior.
 - `encodeBody` {{<type>}}string{{</type>}}
   - Workers have to compress data according to the `content-encoding` header when transmitting, to serve data that is already compressed, this property has to be set to `"manual"`, otherwise the default is `"automatic"`.
 - `headers` {{<type-link href="/runtime-apis/request#parameters">}}Headers{{</type-link>}} | {{<type-link href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">}}ByteString{{</type-link>}}


### PR DESCRIPTION
In https://github.com/cloudflare/workers-rs/issues/567 it was noted that our docs do not show all of the possible options for `ResponseInit`. This updates our docs to reflect what is in `worker-types`. 