### PR TITLE
Fix documentation - transform images dynamic rewrite path - Update serve-images-custo…

### DIFF
--- a/content/images/transform-images/serve-images-custom-paths.md
+++ b/content/images/transform-images/serve-images-custom-paths.md
@@ -50,7 +50,7 @@ header: Text in Expression Editor
 ---
 header: Text in Path > Rewrite to... > Dynamic
 ---
-concat("/cdn-cgi/images", substring(http.request.uri.path, 7))
+concat("/cdn-cgi/image", substring(http.request.uri.path, 7))
 ```
 
 ### Advanced version


### PR DESCRIPTION
As per the [transform images documentation](https://developers.cloudflare.com/images/transform-images/transform-via-url/) the correct path is `/cdn-cgi/image/` and not `/cdn-cgi/images/`. I tried with `image` and it works fine for me. It does not work with `images`.