### PR TITLE
[ZT] Add a note on feature availability in _app-launcher.md

### DIFF
--- a/content/cloudflare-one/_partials/access/_app-launcher.md
+++ b/content/cloudflare-one/_partials/access/_app-launcher.md
@@ -55,6 +55,10 @@ If you are having issues specifying a custom logo, check that the image is serve
 
 ## Customize App Launcher appearance
 
+{{<Aside type="note">}}
+Only available on Pay-as-you-go and Enterprise plans.
+{{</Aside>}}
+
 You can display your own branding, messages, and links to users when they open the App Launcher.
 
 To customize the App Launcher appearance:


### PR DESCRIPTION
Add notes to "customise app launcher appearance" section to indicate this feature is only available on Pay-as-you-go and Enterprise plans.

Ref: https://community.cloudflare.com/t/zero-trust-app-launcher-cant-customize/624499/8