### PR TITLE
[Docs Site] Bump Hugo to v0.125.6

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 20
       - uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.123.5'
+          hugo-version: '0.125.6'
           extended: true
 
       - name: (env) pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 20
       - uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.123.5'
+          hugo-version: '0.125.6'
           extended: true
 
       - name: (env) pnpm

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ download:
 	tar -xf minify.tar.gz
 
 hugo:
-	curl -L https://github.com/gohugoio/hugo/releases/download/v0.123.5/hugo_extended_0.123.5_Linux-64bit.tar.gz > hugo.tar.gz
+	curl -L https://github.com/gohugoio/hugo/releases/download/v0.125.6/hugo_extended_0.125.6_Linux-64bit.tar.gz > hugo.tar.gz
 	tar -xf hugo.tar.gz
 
 build: download hugo

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You must have [Hugo](https://gohugo.io) installed on your system and available in your `$PATH` as a global binary. Most operating systems are supported – follow the relevant [installation instructions](https://gohugo.io/installation/) for your operating system to get started.
 
-> **Important:** This project is built with version `0.123.5+extended` and is the minimum required version. You may (probably) use a newer version of Hugo, but will be subject to any Hugo changes.
+> **Important:** This project is built with version `0.125.6+extended` and is the minimum required version. You may (probably) use a newer version of Hugo, but will be subject to any Hugo changes.
 
 You must also have a recent version of Node.js (18+) installed. You may use [Volta](https://github.com/volta-cli/volta), a Node version manager, to install the latest version of Node and `npm`, which is a package manager that is included with `node`'s installation.
 


### PR DESCRIPTION
Updates Hugo to [v0.125.6](https://github.com/gohugoio/hugo/releases/tag/v0.125.6).

The main fix we're interested in was actually from [v0.125.4](https://github.com/gohugoio/hugo/releases/tag/v0.125.4) where template rebuilds when using `hugo -w` was fixed. This means that when changing a partial or a shortcode, it will now trigger a rebuild rather than having to stop/start `npm run dev` with every change.

I've built this branch on my fork at https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/

I've checked...

* Build configuration JSON works ([local](http://localhost:5173/pages/configuration/build-configuration/index.json), [pages](https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/pages/configuration/build-configuration/index.json))
* Framework guides pull through the aforementioned data ([local](http://localhost:5173/pages/framework-guides/deploy-a-brunch-site/#deploy-with-cloudflare-pages), [pages](https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/pages/framework-guides/deploy-a-brunch-site/#deploy-with-cloudflare-pages))
* Mermaid diagrams renders ([local](http://localhost:5173/rules/transform/request-header-modification/), [pages](https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/rules/transform/request-header-modification/))
* Tab Switcher works ([local](http://localhost:5173/workers-ai/fine-tunes/loras/#running-inference-with-loras), [pages](https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/workers-ai/fine-tunes/loras/#running-inference-with-loras))
* Shortcode in titles works ([local](http://localhost:5173/email-security/deployment/inline/setup/cisco-cisco-mx/), [pages](https://kian-hugo-125-6.cloudflare-docs-github.pages.dev/email-security/deployment/inline/setup/cisco-cisco-mx/))

cc @kodster28 