### PR TITLE
[D1] feat: add missing d1 `meta` object properties

### DIFF
--- a/content/d1/build-with-d1/d1-client-api.md
+++ b/content/d1/build-with-d1/d1-client-api.md
@@ -79,7 +79,11 @@ The methods `stmt.all()` and `db.batch()` return a typed `D1Result` object that 
   meta: {
     duration: number, // duration of the operation in milliseconds
     rows_read: number, // the number of rows read (scanned) by this query
-    rows_written: number // the number of rows written by this query
+    rows_written: number, // the number of rows (including extra indices) written by this query
+    changes: number, // the number of data rows (excluding extra indices) changed by this query
+    changed_db: boolean, // whether the db was changed by this query
+    size_after: number, // the db size after executing this query
+    last_row_id: number // ToDo
   }
 }
 ```


### PR DESCRIPTION
Hi,
this adds docs about the missing properties to the `meta` object returned by `stmt.all()` and `db.batch()` d1 methods.
I'm not sure what `last_row_id` is exactly, can anyone help with that?

I think the information added here has quite some value - I did make a [pretty weird pr](https://github.com/prisma/prisma-engines/pull/4832) to another project because I did not know how to get the number of changed rows excluding indices (since there were no docs on that). Turns out - [it's pretty simple](https://github.com/prisma/prisma/pull/24083/commits/366b71dc3b891e9df2cd94b6a5d2278102373451#diff-27a4d9f7fa5e200bd36aa2ec1041e786e3e0c7ae705df17bbb0c474b60326f9c) 😅

Thanks for looking into this!