### PR TITLE
Update product-compatibility.md - Origin Rules and o2o

### DIFF
--- a/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.md
@@ -38,7 +38,7 @@ This is not an exhaustive list of Cloudflare products and features.
 | [Load Balancing](/load-balancing/) | No | Yes | Customer zones can still use Load Balancing for non-O2O traffic. |
 | [Page Rules](/rules/page-rules/) | Yes* | Yes | Page Rules that match the subdomain used for O2O may block or interfere with the flow of visitors to your website. |
 | [Mirage](/speed/optimization/images/mirage/) | Yes | Yes |
-| [Origin Rules](/rules/origin-rules/) | No | Yes | Origin Rules that match the subdomain used for O2O may block or interfere with the flow of visitors to your website. |
+| [Origin Rules](/rules/origin-rules/) | Yes | Yes | Enterprise zones can configure Origin Rules, by setting the Host Header, and DNS Overrides to direct traffic to a SaaS zone. |
 | [Polish](/images/polish/) | Yes* | Yes | Polish only runs on cached assets. If the customer zone is bypassing cache for SaaS zone destined traffic, then images optimized by Polish will not be loaded from origin. |
 | [Rate Limiting](/waf/rate-limiting-rules/) | Yes* | Yes | Rate Limiting rules that match the subdomain used for O2O may block or interfere with the flow of visitors to your website. |
 | [Security Level](/waf/tools/security-level/) | Yes | Yes |

--- a/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.md
+++ b/content/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/product-compatibility.md
@@ -38,7 +38,7 @@ This is not an exhaustive list of Cloudflare products and features.
 | [Load Balancing](/load-balancing/) | No | Yes | Customer zones can still use Load Balancing for non-O2O traffic. |
 | [Page Rules](/rules/page-rules/) | Yes* | Yes | Page Rules that match the subdomain used for O2O may block or interfere with the flow of visitors to your website. |
 | [Mirage](/speed/optimization/images/mirage/) | Yes | Yes |
-| [Origin Rules](/rules/origin-rules/) | Yes | Yes | Enterprise zones can configure Origin Rules, by setting the Host Header, and DNS Overrides to direct traffic to a SaaS zone. |
+| [Origin Rules](/rules/origin-rules/) | Yes | Yes | Enterprise zones can configure Origin Rules, by setting the Host Header and DNS Overrides to direct traffic to a SaaS zone. |
 | [Polish](/images/polish/) | Yes* | Yes | Polish only runs on cached assets. If the customer zone is bypassing cache for SaaS zone destined traffic, then images optimized by Polish will not be loaded from origin. |
 | [Rate Limiting](/waf/rate-limiting-rules/) | Yes* | Yes | Rate Limiting rules that match the subdomain used for O2O may block or interfere with the flow of visitors to your website. |
 | [Security Level](/waf/tools/security-level/) | Yes | Yes |


### PR DESCRIPTION
Origin Rules can now work on the eyeball zone for Enterprise customers by setting the Host Header and DNS Override to the the value of the SaaS hostname.