### PR TITLE
[R2] Make wording of egress more clear in pricing.md

### DIFF
--- a/content/r2/pricing.md
+++ b/content/r2/pricing.md
@@ -24,7 +24,7 @@ All included usage is on a monthly basis.
 | Class B Operations | 10 million requests / month  | $0.36 / million requests           |
 | Egress (data transfer to Internet) | Free [^1] |
 
-[^1]: Egressing directly from R2, including via the [Workers API](/r2/api/workers/), [S3 API](/r2/api/s3/), and [`r2.dev` domains](/r2/buckets/public-buckets/#enable-managed-public-access) does not incur data transfer (egress) charges and is free. If you connect other, metered services to an R2 bucket, you may be charged by those services.
+[^1]: Egressing directly from R2, including via the [Workers API](/r2/api/workers/), [S3 API](/r2/api/s3/), [custom domains](/r2/buckets/public-buckets/#custom-domains), and [`r2.dev` domains](/r2/buckets/public-buckets/#enable-managed-public-access) does not incur data transfer (egress) charges and is free. If you connect other, metered services to an R2 bucket, you may be charged by those services.
 
 ### Storage usage
 


### PR DESCRIPTION
Currently the R2 docs don't highlight that public R2 buckets with custom domains also do not have egress fees when listing the options that don't incur egress fees. I think it should be mentioned that custom domains can also be used with no egress fees in addition to `r2.dev` domains because `r2.dev` domains aren't recommend for production while custom domains connected to public R2 buckets are.