### PR TITLE
Switch back to `WebSocketHibernationServer`

### DIFF
--- a/content/durable-objects/examples/websocket-hibernation-server.md
+++ b/content/durable-objects/examples/websocket-hibernation-server.md
@@ -40,8 +40,8 @@ export default {
 
       // This example will refer to the same Durable Object instance,
       // since the name "foo" is hardcoded.
-      let id = env.WEBSOCKET_SERVER.idFromName("foo");
-      let stub = env.WEBSOCKET_SERVER.get(id);
+      let id = env.WEBSOCKET_HIBERNATION_SERVER.idFromName("foo");
+      let stub = env.WEBSOCKET_HIBERNATION_SERVER.get(id);
 
       return stub.fetch(request);
     }
@@ -57,7 +57,7 @@ export default {
 };
 
 // Durable Object
-export class WebSocketServer extends DurableObject {
+export class WebSocketHibernationServer extends DurableObject {
 
   async fetch(request) {
     // Creates two ends of a WebSocket connection.
@@ -106,7 +106,7 @@ filename: index.ts
 import { DurableObject } from "cloudflare:workers";
 
 export interface Env {
-  WEBSOCKET_SERVER: DurableObjectNamespace<WebSocketServer>;
+  WEBSOCKET_HIBERNATION_SERVER: DurableObjectNamespace<WebSocketHibernationServer>;
 }
 
 // Worker
@@ -122,8 +122,8 @@ export default {
 
       // This example will refer to the same Durable Object instance,
       // since the name "foo" is hardcoded.
-      let id = env.WEBSOCKET_SERVER.idFromName("foo");
-      let stub = env.WEBSOCKET_SERVER.get(id);
+      let id = env.WEBSOCKET_HIBERNATION_SERVER.idFromName("foo");
+      let stub = env.WEBSOCKET_HIBERNATION_SERVER.get(id);
 
       return stub.fetch(request);
     }
@@ -139,7 +139,7 @@ export default {
 };
 
 // Durable Object
-export class WebSocketServer extends DurableObject {
+export class WebSocketHibernationServer extends DurableObject {
 
   async fetch(request: Request): Promise<Response> {
     // Creates two ends of a WebSocket connection.


### PR DESCRIPTION
The class name needs to be the same across the script and `wrangler.toml`. We could go with `WebSocketServer`, but then it looks too similar to the regular websocket example. If a reader copied both classes (regular and hibernatable) into a single script to test both simultaneously, they would end up seeing an error because of naming conflicts.