### PR TITLE
[Chore] Update wrangler changelog logic

### DIFF
--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -41,9 +41,9 @@
     {{ $description = replaceRE `Open external link` "" $description -}}
     {{- with $entry.title -}}
     {{- $title = . -}}
-    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .) -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (anchorize .) -}}
     {{- else -}}
-    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .publish_date) -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (anchorize .publish_date) -}}
     {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
     {{- with $entry.link -}}

--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -36,14 +36,15 @@
     {{- range $index, $entry := $changelogDataEntries -}}
     {{- $link := "" -}}
     {{- $title := "" -}}
+    {{- $rellink := $entry.url -}}
     {{ $description := $entry.description | $.Page.RenderString | htmlUnescape }}
     {{ $description = replaceRE `Open external link` "" $description -}}
     {{- with $entry.title -}}
-    {{- $link = print $permalink "#" (urlize .) -}}
     {{- $title = . -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .) -}}
     {{- else -}}
-    {{- $link = print $permalink "#" (urlize $entry.publish_date) -}}
-    {{- $title = $entry.publish_date -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .publish_date) -}}
+    {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
     {{- with $entry.link -}}
     {{- if ne $product "Wrangler" -}}
@@ -53,13 +54,12 @@
     {{- with $entry.individual_page -}}
     {{- $result := partial "changelog-entry.html" (dict "link" $entry.link) -}}
     {{- $description = $result.content -}}
-    {{- $title = $result.title }}
+    {{- $title = printf "%s - %s" $product $result.title }}
     {{- with $entry.scheduled -}}
     {{- with $entry.scheduled_date -}}
     {{- $title = (printf "%s for %s" $title $entry.scheduled_date) -}}
     {{- end -}}
     {{- end -}}
-    {{- else -}}
     {{- end -}}
     {{- with $productArea -}}
     {{- $title = print $entry.product " - " $title -}}

--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -21,6 +21,9 @@
 
 {{- $permalink := .Permalink -}}
 {{- $atomLink := print $permalink "index.xml" -}}
+{{- if in $permalink "index.xml"}}
+{{- $atomLink = $permalink -}}
+{{- end -}}
 
 {{- $product := default (index (index $changelogDataEntries 0) "product") ($.Params.changelog_name) }}
 {{- $mainTitle := printf "%s · %s" .Title $product -}}

--- a/layouts/_default/changelog.rss.xml
+++ b/layouts/_default/changelog.rss.xml
@@ -47,8 +47,10 @@
     {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
     {{- with $entry.link -}}
-    {{- if ne $product "Wrangler" -}}
+    {{- if ne $entry.product "Wrangler" -}}
     {{ $link = print "https://developers.cloudflare.com" . }}
+    {{- else -}}
+    {{- $link = $entry.link -}}
     {{- end -}}
     {{- end -}}
     {{- with $entry.individual_page -}}

--- a/layouts/_default/home.rss.xml
+++ b/layouts/_default/home.rss.xml
@@ -28,9 +28,9 @@
     {{ $description = replaceRE `Open external link` "" $description -}}
     {{- with $entry.title -}}
     {{ $title = printf "%s - %s" $product . }}
-    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .) -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (anchorize .) -}}
     {{- else -}}
-    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (urlize .publish_date) -}}
+    {{- $link = print "https://developers.cloudflare.com" $rellink "#" (anchorize .publish_date) -}}
     {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
     {{- with $entry.link -}}

--- a/layouts/_default/home.rss.xml
+++ b/layouts/_default/home.rss.xml
@@ -34,8 +34,10 @@
     {{- $title = printf "%s - %s" $product .publish_date -}}
     {{- end -}}
     {{- with $entry.link -}}
-    {{- if ne $product "Wrangler" -}}
+    {{- if ne $entry.product "Wrangler" -}}
     {{ $link = print "https://developers.cloudflare.com" . }}
+    {{- else -}}
+    {{- $link = $entry.link -}}
     {{- end -}}
     {{- end -}}
     {{- with $entry.individual_page -}}

--- a/layouts/partials/wrangler-changelog.html
+++ b/layouts/partials/wrangler-changelog.html
@@ -1,5 +1,6 @@
 {{- $productArea := "Developer platform" -}}
 {{- $productAreaLink := "/workers/platform/changelog/platform/" -}}
+{{- $productChangelogLink := "/workers/platform/changelog/wrangler/" -}}
 
 {{ $localToken := resources.Get "secrets/github_token.txt" }}
 {{ $opts := dict }}
@@ -28,12 +29,13 @@
 {{- if (in $item.tag_name "wrangler@") -}}
 {{- $item_dict := (dict "publish_date" ($item.published_at | time.Format "2006-01-02")
 "title" (replaceRE `wrangler@` "" $item.name) "link" $item.html_url
-"description" (replaceRE `###[^-]+` "" $item.body) "product" "Wrangler") -}}
+"description" (replaceRE `###[^-]+` "" $item.body) "url" $productChangelogLink
+"product" "Wrangler" "productArea" $productArea "productAreaLink" $productAreaLink) -}}
 {{- $results = $results | append $item_dict -}}
 {{- end -}}
 {{- end -}}
 
-{{- $combinedResult := (dict "wrangler" (dict "link" "/workers/platform/changelog/wrangler/" "productName" "Wrangler" "productArea" $productArea
+{{- $combinedResult := (dict "wrangler" (dict "link" $productChangelogLink "productName" "Wrangler" "productArea" $productArea
 "productAreaLink" $productAreaLink "external" true
 "entries" $results))}}
 

--- a/layouts/shortcodes/full-changelog.html
+++ b/layouts/shortcodes/full-changelog.html
@@ -3,6 +3,10 @@
 {{- $productArea := $.Page.Params.changelog_product_area_name -}}
 {{- $changelogData := partial "full-changelog-data.html" -}}
 
+<script>
+  console.log({{$changelogData}})
+</script>
+
 <!-- Define arrays to populate -->
 {{- $changelogRendered := slice -}}
 {{- $products := slice -}}

--- a/layouts/shortcodes/full-changelog.html
+++ b/layouts/shortcodes/full-changelog.html
@@ -3,10 +3,6 @@
 {{- $productArea := $.Page.Params.changelog_product_area_name -}}
 {{- $changelogData := partial "full-changelog-data.html" -}}
 
-<script>
-  console.log({{$changelogData}})
-</script>
-
 <!-- Define arrays to populate -->
 {{- $changelogRendered := slice -}}
 {{- $products := slice -}}


### PR DESCRIPTION
Validation steps:
- On the top-level `/changelog/` page, you can filter to Wrangler and see an RSS feed that leads to a page
- On the `/workers/platform/changelog/wrangler/` page, the content is rendered correct + you can click the RSS icon and go to the correct page.