### PR TITLE
[Workers] Document received WebSocket message size limit

### DIFF
--- a/content/workers/runtime-apis/websockets.md
+++ b/content/workers/runtime-apis/websockets.md
@@ -129,6 +129,12 @@ let [client, server] = Object.values(new WebSocketPair());
 
 {{</definitions>}}
 
+{{<Aside type="note">}}
+
+WebSocket messages received by a Worker have a size limit of 1 MiB (1048576).  If a larger message is sent, the WebSocket will be automatically closed with a `1009` "Message is too large" response.
+
+{{</Aside>}}
+
 ## Types
 
 ### Message


### PR DESCRIPTION
We mention this limit on the Durable Objects limits page, but it's probably not a bad idea to have it in the WebSocket docs, too, since it applies to any Worker using the WebSocket API, and it's an easy detail to miss.

Not sure if it also might warrant a mention on the Workers limits page as well.