### PR TITLE
[queues] correct `DurableObject` to `DurableObjectNamespace` & remove constructor block

### DIFF
--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -48,7 +48,7 @@ filename: src/index.ts
 ---
 interface Env {
   YOUR_QUEUE: Queue;
-  YOUR_DO_CLASS: DurableObject;
+  YOUR_DO_CLASS: DurableObjectNamespace;
 }
 
 export default {

--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -79,7 +79,7 @@ export default {
 }
 
 export class YourDurableObject implements DurableObject {
-  constructor(public state: DurableObjectState, public env: Env) {}
+  constructor(private state: DurableObjectState, private env: Env) {}
 
   async fetch(request: Request) {
     // Error handling elided for brevity.

--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -78,13 +78,7 @@ export default {
 }
 
 export class YourDurableObject implements DurableObject {
-  constructor(public state: DurableObjectState, env: Env) {
-      this.state = state;
-      // Ensure you pass your bindings and environment variables into
-      // each Durable Object when it is initialized
-      this.env = env;
-    }
-  }
+  constructor(public state: DurableObjectState, public env: Env) {}
 
   async fetch(request: Request) {
     // Error handling elided for brevity.

--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -74,6 +74,7 @@ export default {
       // This would return "wrote to queue", but you could return any response.
       return response;
     }
+		return new Response("userId must be provided", { status: 400 });
   }
 }
 


### PR DESCRIPTION
In the `Env` declaration for the [Use Queues with Durable Objects](https://developers.cloudflare.com/queues/examples/use-queues-with-durable-objects/) example, the `YOUR_DO_CLASS` binding should be an instance of `DurableObjectNamespace` instead of `DurableObject`.

Constructor block for the `YourDurableObject` class contained an extra `}`, causing the `fetch()` to not be recognized. This block has been removed entirely, and the `env` been made `public` to match `state`