### PR TITLE
[Pages] Update Astro guide for new adapter

### DIFF
--- a/content/pages/framework-guides/deploy-an-astro-site.md
+++ b/content/pages/framework-guides/deploy-an-astro-site.md
@@ -78,21 +78,9 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 
 {{</Aside>}}
 
-### Modes
+### Local runtime
 
-There are currently two modes supported when using Pages Functions with the [`@astrojs/cloudflare`](https://github.com/withastro/adapters/tree/main/packages/cloudflare#readme) adapter.
-
-1. [**Advanced**](/pages/functions/advanced-mode/) mode: This mode is used when you want to run your Function in `advanced` mode. This mode picks up the `_worker.js` in `dist`, or a directory mode where Pages will compile the Worker out of a Functions folder in the project root.
-
-{{<Aside type="note">}}
-
-If no mode is set, the default is `"advanced"`.
-
-{{</Aside>}}
-
-2. **Directory** mode: This mode is used when you want to run your Pages Function in `directory` mode. In this mode, the adapter will compile the client-side part of your application the same way, but it will move the Worker into a `functions` folder in the project root. The adapter will allow you to access your Pages Functions from your `functions` folder. This allows you to add [Pages Plugins](/pages/functions/plugins/) and [Middleware](/pages/functions/middleware/) which can be checked into version control.
-
-To use `directory` mode, modify your `astro.config.mjs` file to add `mode: "directory"` to the adapter configuration:
+Local runtime support is configured via the platformProxy option:
 
 ```js
 ---
@@ -103,8 +91,11 @@ import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 
 export default defineConfig({
-  output: 'server',
-  adapter: cloudflare({ mode: "directory" }),
+  adapter: cloudflare({
+    platformProxy: {
+      enabled: true,
+    },
+  }),
 });
 ```
 
@@ -112,7 +103,7 @@ export default defineConfig({
 
 A [binding](/pages/functions/bindings/) allows your application to interact with Cloudflare developer products, such as [KV](/kv/reference/how-kv-works/), [Durable Object](/durable-objects/), [R2](/r2/), and [D1](https://blog.cloudflare.com/introducing-d1/).
 
-Use bindings in Astro components and API routes by using `context.local` from [Astro Middleware](https://docs.astro.build/en/guides/middleware/) to access the Cloudflare runtime which amongst other fields contains the Cloudflare's environment and consecutively any bindings set for your application.
+Use bindings in Astro components and API routes by using `context.locals` from [Astro Middleware](https://docs.astro.build/en/guides/middleware/) to access the Cloudflare runtime which amongst other fields contains the Cloudflare's environment and consecutively any bindings set for your application.
 
 Refer to the following example of how to access a KV namespace with TypeScript.
 
@@ -130,10 +121,7 @@ type ENV = {
   MY_KV: KVNamespace;
 };
 
-// Depending on your adapter mode
-// use `AdvancedRuntime<ENV>` for advance runtime mode
-// use `DirectoryRuntime<ENV>` for directory runtime mode
-type Runtime = import("@astrojs/cloudflare").AdvancedRuntime<ENV>;
+type Runtime = import("@astrojs/cloudflare").Runtime<ENV>;
 declare namespace App {
   interface Locals extends Runtime {}
 }

--- a/content/pages/framework-guides/deploy-an-astro-site.md
+++ b/content/pages/framework-guides/deploy-an-astro-site.md
@@ -80,7 +80,7 @@ For the complete guide to deploying your first site to Cloudflare Pages, refer t
 
 ### Local runtime
 
-Local runtime support is configured via the platformProxy option:
+Local runtime support is configured via the `platformProxy` option:
 
 ```js
 ---

--- a/content/pages/framework-guides/deploy-an-astro-site.md
+++ b/content/pages/framework-guides/deploy-an-astro-site.md
@@ -121,6 +121,7 @@ type ENV = {
   MY_KV: KVNamespace;
 };
 
+// use a default runtime configuration (advanced mode).
 type Runtime = import("@astrojs/cloudflare").Runtime<ENV>;
 declare namespace App {
   interface Locals extends Runtime {}


### PR DESCRIPTION
This pull request updates the deployment documentation for Astro projects on Cloudflare Pages to align with the recent v10 changes in the @astrojs/cloudflare adapter.

Changes:
- Removal of Mode Options
- Introduction of Local Runtime and PlatformProxy
- Minor text adjustment