### PR TITLE
Change 'Script' to 'Worker' in Workers metrics and analytics doc

### DIFF
--- a/content/workers/observability/metrics-and-analytics.md
+++ b/content/workers/observability/metrics-and-analytics.md
@@ -73,7 +73,7 @@ Worker invocation statuses indicate whether a Worker executed successfully or fa
 | ---------------------- | ---------------------------------------------------------------------------- | ------------------ | ---------------------- |
 | Success                | Worker executed successfully                                                 |                    | `success`              |
 | Client disconnected    | HTTP client (that is, the browser) disconnected before the request completed |                    | `clientDisconnected`   |
-| Script threw exception | Worker threw an unhandled JavaScript exception                               | 1101               | `scriptThrewException` |
+| Worker threw exception | Worker threw an unhandled JavaScript exception                               | 1101               | `scriptThrewException` |
 | Exceeded resources¹    | Worker exceeded runtime limits                                               | 1102, 1027         | `exceededResources`    |
 | Internal error²        | Workers runtime encountered an error                                         |                    | `internalError`        |
 


### PR DESCRIPTION
Dashboard has been updated to refer to Scripts as Workers, including this error message. Making this change in docs to reflect changes on the dash.