### PR TITLE
[Workers] Update docs to mention the timestamp

### DIFF
--- a/content/workers/runtime-apis/bindings/version-metadata.md
+++ b/content/workers/runtime-apis/bindings/version-metadata.md
@@ -9,7 +9,7 @@ meta:
 
 The version metadata binding can be used to access metadata associated with a [version](/workers/configuration/versions-and-deployments/#versions) from inside the Workers runtime.
 
-Worker version ID and version tag are available through the version metadata binding. They can be used in events sent to [Workers Analytics Engine](/analytics/analytics-engine/) or to any third-party analytics/metrics service in order to aggregate by Worker version.
+Worker version ID, version tag and timestamp of when the version was created are available through the version metadata binding. They can be used in events sent to [Workers Analytics Engine](/analytics/analytics-engine/) or to any third-party analytics/metrics service in order to aggregate by Worker version.
 
 To use the version metadata binding, update your Worker's `wrangler.toml` file:
 
@@ -31,10 +31,10 @@ An example of how to access the version ID and version tag from within a Worker 
 ```js
 export default {
   async fetch(request, env, ctx) {
-    const { id: versionId, tag: versionTag } = env.CF_VERSION_METADATA;
+    const { id: versionId, tag: versionTag, timestamp: versionTimestamp } = env.CF_VERSION_METADATA;
     env.WAE.writeDataPoint({
       indexes: [versionId],
-      blobs: [versionTag],
+      blobs: [versionTag, versionTimestamp],
       //...
     });
     //...


### PR DESCRIPTION
We're adding a `timestamp` field to the version_metadata binding so this docs that.

(Bit weird to include the timestamp in AE but wanted to keep inline with the rest and show a usage)