### PR TITLE
[Workers] Change wording around wrangler global flags

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -42,17 +42,17 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 
 {{<Aside type="note">}}
 
-The following global flags work on every command.
+The following global flags work on every command, with some exceptions for `pages` commands.
 
 {{<definitions>}}
 
-- `--config` {{<type>}}string{{</type>}}
-  - Path to `.toml` configuration file.
 - `--help` {{<type>}}boolean{{</type>}}
   - Show help.
 - `--version` {{<type>}}boolean{{</type>}}
   - Show version number.
-- `--experimental-json-config` {{<type>}}boolean{{</type>}}
+- `--config` {{<type>}}string{{</type>}} {{<prop-meta>}}(not supported by Pages){{</prop-meta>}}
+  - Path to `.toml` configuration file.
+- `--experimental-json-config` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(not supported by Pages){{</prop-meta>}}
   - ⚠️ This is an experimental command. Read configuration from a `wrangler.json` file, instead of `wrangler.toml`. `wrangler.json` is a [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) file.
 
 {{</definitions>}}


### PR DESCRIPTION
`wrangler` suports several global flags that supposedly apply to all `wrangler` commands, such as `--version` or `--help`. However, some of these flags are not
supported by Pages yet, and listing them as global is causing confusion for our users.

This commit adjusts the wording around wrangler global flags, to clarify which of these flags are not supported by Pages.

<img width="807" alt="Screenshot 2024-05-15 at 19 58 54" src="https://github.com/cloudflare/cloudflare-docs/assets/4638332/98effc16-923c-449b-a2df-c0101098420e">
