### PR TITLE
[QUEUES] Fix typos under `content/queues`

### DIFF
--- a/content/queues/configuration/batching-retries.md
+++ b/content/queues/configuration/batching-retries.md
@@ -113,7 +113,7 @@ Retrying messages with `.retry()` or calling `.retryAll()` on a batch will cause
 
 ## Delay messages
 
-When publishing messages to a queue, or when [marking a messsage or batch for retry](#explicit-acknowledgement-and-retries), you can choose to delay messages from being processed for a period of time.
+When publishing messages to a queue, or when [marking a message or batch for retry](#explicit-acknowledgement-and-retries), you can choose to delay messages from being processed for a period of time.
 
 Delaying messages allows you to defer tasks until later, and/or respond to backpressure when consuming from a queue. For example, if an upstream API you are calling to returns a `HTTP 429: Too Many Requests`, you can delay messages to slow down how quickly you are consuming them before they are re-processed.
 

--- a/content/queues/configuration/pull-consumers.md
+++ b/content/queues/configuration/pull-consumers.md
@@ -15,7 +15,7 @@ A pull-based consumer allows you to pull from a queue over HTTP from any environ
 Deciding whether to configure a push-based consumer or a pull-based consumer will depend on how you are using your queues, as well as the configuration of infrastructure upstream from your queue consumer.
 
 - **Starting with a [push-based consumer](/queues/reference/how-queues-works/#consumers) is the easiest way to get started and consume from a queue**. A push-based consumer runs on Workers, and by default, will automatically scale up and consume messages as they are written to the queue.
-- Use a pull-based consumer if you need to consume messages from existing infrastucture outside of Cloudflare Workers, and/or where you need to carefully control how fast messages are consumed. A pull-based consumer must explicitly make a call to pull (and then acknowledge) messages from the queue, only when it is ready to do so.
+- Use a pull-based consumer if you need to consume messages from existing infrastructure outside of Cloudflare Workers, and/or where you need to carefully control how fast messages are consumed. A pull-based consumer must explicitly make a call to pull (and then acknowledge) messages from the queue, only when it is ready to do so.
 
 You can remove and attach a new consumer on a queue at any time, allowing you to change from a pull-based to a push-based consumer if your requirements change.
 

--- a/content/queues/reference/how-queues-works.md
+++ b/content/queues/reference/how-queues-works.md
@@ -196,5 +196,5 @@ A message is the object you are producing to and consuming from a queue.
 
 Any JSON serializable object can be published to a queue. For most developers, this means either simple strings or JSON objects. You can explicitly [set the content type](#content-types) when sending a message.
 
-Messages themselves can be [batched when delivered to a consumer](/queues/configuration/batching-retries/). By default, messages within a batch are treated as all or nothing when determining retries. If the last message in a batch fails to be processed, the entire batch will be retried. You can also choose to [explictly acknowledge](/queues/configuration/batching-retries/) messages as they are successfully processed, and/or mark individual messages to be retried.
+Messages themselves can be [batched when delivered to a consumer](/queues/configuration/batching-retries/). By default, messages within a batch are treated as all or nothing when determining retries. If the last message in a batch fails to be processed, the entire batch will be retried. You can also choose to [explicitly acknowledge](/queues/configuration/batching-retries/) messages as they are successfully processed, and/or mark individual messages to be retried.
 


### PR DESCRIPTION
Hi, it's me again I've previously submitted PRs for typos:🤣
* https://github.com/cloudflare/cloudflare-docs/pull/14263
* https://github.com/cloudflare/cloudflare-docs/pull/14311
* https://github.com/cloudflare/cloudflare-docs/pull/14312

This PR aims to fix some typos under `content/queues` directory.