### PR TITLE
Update rate-limit.md

### DIFF
--- a/content/workers/runtime-apis/bindings/rate-limit.md
+++ b/content/workers/runtime-apis/bindings/rate-limit.md
@@ -22,7 +22,8 @@ The Rate Limiting API is backed by the same infrastructure that serves the [Rate
 
 - You must use version 3.45.0 or later of the [Wrangler CLI](/workers/wrangler)
 
-We want your feedback. Tell us what you'd like to see in the #rate-limiting-beta channel of the [Cloudflare Developers Discord](https://discord.cloudflare.com/)
+We want your feedback. Tell us what you'd like to see in the [#workers-discussions](https://discord.com/channels/595317990191398933/779390076219686943) or [#workers-help](https://discord.com/channels/595317990191398933/1052656806058528849) channels of the [Cloudflare Developers Discord](https://discord.cloudflare.com/). You can find the an archive of the previous discussion in [#rate-limiting-beta](https://discord.com/channels/595317990191398933/1225429769219211436)
+
 {{</Aside>}}
 
 ## Get started


### PR DESCRIPTION
The rate-limiting-beta channel was archived yesterday (see screenshot below), I'm redirecting users accordingly, while still pointing to the archived channel for historical reference

![Screenshot from 2024-05-16 09-32-27](https://github.com/cloudflare/cloudflare-docs/assets/3818427/385ae9c1-ad46-4d20-904a-678ab1164161)
