### PR TITLE
[Roughtime] Update install instruction for getroughtime

### DIFF
--- a/content/time-services/roughtime/usage.md
+++ b/content/time-services/roughtime/usage.md
@@ -18,8 +18,7 @@ You just need the server's address and public key to run the protocol:
 To get started, download and run Cloudflare's [Go client](https://github.com/cloudflare/roughtime):
 
 ```go
-go get -u github.com/cloudflare/roughtime
-go install github.com/cloudflare/roughtime...
+go install github.com/cloudflare/roughtime/cmd/getroughtime@latest
 getroughtime -ping roughtime.cloudflare.com:2003 -pubkey 0GD7c3yP8xEc4Zl2zeuN2SlLvDVVocjsPSL8/Rl/7zg=
 ```
 


### PR DESCRIPTION
`go get` doesn't work outside of a go module. 

For a hello world example, it might help to keep the step simple by installing the `getroughtime` client (without setting up a module).

This PR updates the instruction to do that.