### PR TITLE
Fixes to Drizzle + Neon + Hono tutorial for Cloudflare workers

### DIFF
--- a/content/workers/tutorials/serverless-api-with-drizzle-hono-and-neon/index.md
+++ b/content/workers/tutorials/serverless-api-with-drizzle-hono-and-neon/index.md
@@ -170,7 +170,7 @@ In your project’s root directory, create a `migrate.ts` file and add the follo
 
 ```ts
 ---
-filename: package.json
+filename: migrate.ts
 ---
 import { config } from 'dotenv';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';

--- a/content/workers/tutorials/serverless-api-with-drizzle-hono-and-neon/index.md
+++ b/content/workers/tutorials/serverless-api-with-drizzle-hono-and-neon/index.md
@@ -144,6 +144,7 @@ import type { Config } from 'drizzle-kit';
 export default {
   schema: './src/db/schema.ts',
   out: './drizzle',
+  dialect: 'postgresql',
 } satisfies Config;
 ```
 
@@ -157,7 +158,7 @@ filename: package.json
 ---
 "scripts": {
   ...
-  "db:generate": "drizzle-kit generate:pg"
+  "db:generate": "drizzle-kit generate"
 },
 ...
 ```


### PR DESCRIPTION
Fixes #14650

***

The current [tutorial](https://developers.cloudflare.com/workers/tutorials/serverless-api-with-drizzle-hono-and-neon/) for using Drizzle + Neon + Hono on Cloudflare workers has a mislabelled code snippet and uses a deprecated command from drizzle kit. This PR makes the following changes as a correction:

- Update a mislabelled file (was: `package.json`, but is supposed to be `migrate.ts`)
- Replace the deprecated `drizzle-kit generate:pg` command with `drizzle-kit generate`, and specify the dialect inside the `drizzle.config.ts` file.

For screenshots of the issues, refer to #14650