### PR TITLE
Update use-queues-with-durable-objects.md

### DIFF
--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -32,6 +32,10 @@ name = "my-worker"
 bindings = [
   { name = "YOUR_DO_CLASS", class_name = "YourDurableObject" }
 ]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["YourDurableObject"]
 ```
 
 The following Worker script:

--- a/content/queues/examples/use-queues-with-durable-objects.md
+++ b/content/queues/examples/use-queues-with-durable-objects.md
@@ -85,7 +85,7 @@ export class YourDurableObject implements DurableObject {
     // Error handling elided for brevity.
     // Publish to your queue
     await this.env.YOUR_QUEUE.send({
-      id: this.state.id // Write the ID of the Durable Object to your queue
+      id: this.state.id.toString() // Write the ID of the Durable Object to your queue
       // Write any other properties to your queue
     });
 


### PR DESCRIPTION
ID doesn't marshal to JSON directly. Use `.toString()` to convert before.