### PR TITLE
[Hugo] Add # surfaced to list-examples component

### DIFF
--- a/layouts/shortcodes/list-examples.html
+++ b/layouts/shortcodes/list-examples.html
@@ -1,4 +1,5 @@
 {{- $filters := split (.Get "filters") "," -}}
+{{- $examplePages := slice -}}
 
 {{- $target := printf "%sexamples/" .Page.FirstSection.RelPermalink -}}
 {{- $pages := (where .Site.Pages "Section" .Page.Section) -}}
@@ -6,6 +7,18 @@
 {{- with .Get "directory" -}}
 {{- $target = . -}}
 {{- end -}}
+
+<!-- Get the list of examples -->
+
+{{- range $index, $page := $pages.ByWeight -}}
+  {{- $x := $page.RelPermalink -}}
+  {{- $isExample := (strings.HasPrefix $x $target) -}}
+  {{- if and (ne $x $target) $isExample -}}
+  {{- $examplePages = $examplePages | append . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $examplesLength := len $examplePages }}
 
 <!-- Build out the filters dynamically -->
 {{ if ne (index $filters 0) "" }}
@@ -34,12 +47,11 @@
 </div>
 {{ end }}
 
+<p id="totalExamples">{{$examplesLength}} examples</p>
+
 <!-- Add list of examples, with optional filterable properties -->
 <ul class="DocsCodeExamplesOverview" style="list-style: none">
-  {{- range $index, $page := $pages.ByWeight -}}
-  {{- $x := $page.RelPermalink -}}
-  {{- $isExample := (strings.HasPrefix $x $target) -}}
-  {{- if and (ne $x $target) $isExample -}}
+  {{- range $index, $page := $examplePages -}}
   <li class="DocsCodeExamplesOverview--example" {{ if ne (index $filters 0) "" }} {{ range $index2, $filter := $filters
     }} {{ with (index $page.Params $filter) }} data-{{$filter}}="{{ delimit (.) "|" }}" {{ end }} {{ end }} {{ end }}>
     <div class="DocsCodeExamplesOverview--example-title">
@@ -51,13 +63,14 @@
     </div>
   </li>
   {{- end -}}
-  {{- end -}}
 </ul>
 
 <script>
   // Grab persistent items from DOM
   const selectorDropdowns = document.getElementsByClassName("selectorFilter");
   const examples = document.getElementsByClassName("DocsCodeExamplesOverview--example")
+  const numExamplesText = document.getElementById("totalExamples")
+  let numExamples = 0
 
   // Add listener for filtering by search params
   document.addEventListener('DOMContentLoaded', () => {
@@ -95,6 +108,7 @@
   }
 
   function filterList() {
+    numExamples = 0
     let selectedOptions = getSelectValues(selectorDropdowns);
     for (const example of examples) {
 
@@ -106,6 +120,7 @@
       }
       if (keepValue) {
         example.style.display = "";
+        numExamples += 1;
       } else {
         example.style.display = "none";
       }
@@ -117,6 +132,7 @@
       newUrl.searchParams.set(option, selectedOptions[option])
     }
     history.pushState({}, '', newUrl.toString());
+    numExamplesText.textContent = `${numExamples} examples`
   }
 
   // Add listeners for tracking events

--- a/static/style.css
+++ b/static/style.css
@@ -4409,6 +4409,20 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   }
 }
 
+p#totalExamples {
+  margin-top: 1em;
+  font-size: 1.1em;
+  padding-left: .5em;
+  width: 7em;
+  font-weight: 400;
+  border-radius: 5px;
+  background: #FCC373;
+}
+
+[theme="dark"] p#totalExamples {
+  background: #0051c3;
+}
+
 .DocsTutorials {
   margin: 2em 0;
   width: 53em;


### PR DESCRIPTION
For behavior, refer to `/workers/examples/`.

- Does the # of examples text adjust correctly when you're adding / removing filters?
- Any other CSS weirdness?