### PR TITLE
Fix disable_flag for Workers RPC

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/rpc.md
+++ b/content/workers/_partials/_platform-compatibility-dates/rpc.md
@@ -8,7 +8,7 @@ name: "Durable Object stubs and Service Bindings support RPC"
 sort_date: "2024-04-03"
 enable_date: "2024-04-03"
 enable_flag: "rpc"
-disable_flag: "rpc"
+disable_flag: "no_rpc"
 ---
 
 With this flag on, [Durable Object](/durable-objects/) stubs and [Service Bindings](/workers/runtime-apis/bindings/service-bindings/) support [RPC](/workers/runtime-apis/rpc/). This means that these objects now appear as if they define every possible method name. Calling any method name sends an RPC to the remote Durable Object or Worker service.


### PR DESCRIPTION
- The disable_flag was incorrectly set to the same value as the enable_flag
- no_rpc is the correct disable_flag value