### PR TITLE
Adding R2 temporary credentials documentation

### DIFF
--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -52,9 +52,9 @@ Jurisdictional buckets can only be accessed via the corresponding jurisdictional
 | Object Read & Write | Allows the ability to read, write, and list objects in specific buckets. |
 | Object Read only | Allows the ability to read and list objects in specific buckets. |
 
-# Temporary Access Credentials
+## Temporary access credentials
 
-If you need to create temporary credentials for a bucket or a prefix/object within a bucket, you can use the [temp-access-credentials endpoint](https://developers.cloudflare.com/api/operations/r2-create-temp-access-credentials) in the api. You will need an existing R2 token to pass in as the parent access key id. You can use the credentials from the api result for an S3-compatible request by setting the credential variables like so:
+If you need to create temporary credentials for a bucket or a prefix/object within a bucket, you can use the [temp-access-credentials endpoint](/api/operations/r2-create-temp-access-credentials) in the API. You will need an existing R2 token to pass in as the parent access key id. You can use the credentials from the API result for an S3-compatible request by setting the credential variables like so:
 
 ```
 AWS_ACCESS_KEY_ID = <accessKeyId>

--- a/content/r2/api/s3/tokens.md
+++ b/content/r2/api/s3/tokens.md
@@ -51,3 +51,19 @@ Jurisdictional buckets can only be accessed via the corresponding jurisdictional
 | Admin Read only | Allows the ability to list buckets and view bucket configuration in addition to list and read object access. |
 | Object Read & Write | Allows the ability to read, write, and list objects in specific buckets. |
 | Object Read only | Allows the ability to read and list objects in specific buckets. |
+
+# Temporary Access Credentials
+
+If you need to create temporary credentials for a bucket or a prefix/object within a bucket, you can use the [temp-access-credentials endpoint](https://developers.cloudflare.com/api/operations/r2-create-temp-access-credentials) in the api. You will need an existing R2 token to pass in as the parent access key id. You can use the credentials from the api result for an S3-compatible request by setting the credential variables like so:
+
+```
+AWS_ACCESS_KEY_ID = <accessKeyId>
+AWS_SECRET_ACCESS_KEY = <secretAccessKey>
+AWS_SESSION_TOKEN = <sessionToken>
+```
+
+{{<Aside type="note">}}
+
+The temporary access key cannot have a permission that is higher than the parent access key. e.g. if the parent key is set to `Object Read Write`, the temporary access key could only have `Object Read Write` or `Object Read Only` permissions.
+
+{{</Aside>}}


### PR DESCRIPTION
Adding documentation for a new R2 endpoint for generating temporary access credentials.

Related openapi docs can be found here: https://developers.cloudflare.com/api/operations/r2-create-temp-access-credentials