### PR TITLE
docs(update): clarify wrangler-configuration.md

### DIFF
--- a/content/pages/functions/wrangler-configuration.md
+++ b/content/pages/functions/wrangler-configuration.md
@@ -8,7 +8,7 @@ weight: 6
 
 {{<Aside type="warning">}}
 
-If your project contains an existing `wrangler.toml` file that you [previously used for local development](/pages/functions/local-development/), make sure you verify that it matches your project settings in the Cloudflare dashboard before opting-in to deploy your Pages project with `wrangler.toml`. Instead of writing your `wrangler.toml` file by hand, Cloudflare recommends using `npx wrangler pages download config` to download your current project settings into a `wrangler.toml` file.
+If your project contains an existing `wrangler.toml` file that you [previously used for local development](/pages/functions/local-development/), make sure you verify that it matches your project settings in the Cloudflare dashboard before opting-in to deploy your Pages project with `wrangler.toml`. Instead of writing your `wrangler.toml` file by hand, Cloudflare recommends using `npx wrangler pages download config <project name>` to download your current project settings into a `wrangler.toml` file. Note that the `wrangler.toml` file may contain access tokens like for GitHub.
 
 {{</Aside>}}
 


### PR DESCRIPTION
When running the command `npx wrangler pages download config` the user may be surprised that the `wrangler.toml` file that is generated contains sensitive access credentials, like for GitHub. Add a note stating this explicitly.