### PR TITLE
add Docusaurus to build-caching documentation

### DIFF
--- a/content/pages/configuration/build-caching.md
+++ b/content/pages/configuration/build-caching.md
@@ -49,13 +49,14 @@ Package manager caches are automatically saved to the build cache to speed up de
 
 Caching the build output from frameworks can speed up subsequent build times. The build cache supports the following frameworks:
 
-| Framework | Directories cached         |
-| --------- | -------------------------- |
-| Gatsby    | `.cache`, `public`         |
-| Next.js   | `.next/cache`              |
-| Astro     | `node_modules/.astro`      |
-| Nuxt      | `node_modules/.cache/nuxt` |
-| Eleventy  | `.cache`                   |
+| Framework  | Directories cached                            |
+| ---------- | --------------------------------------------- |
+| Gatsby     | `.cache`, `public`                            |
+| Next.js    | `.next/cache`                                 |
+| Astro      | `node_modules/.astro`                         |
+| Nuxt       | `node_modules/.cache/nuxt`                    |
+| Eleventy   | `.cache`                                      |
+| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build` |
 
 ## Limits
 

--- a/content/pages/configuration/build-caching.md
+++ b/content/pages/configuration/build-caching.md
@@ -51,12 +51,12 @@ Caching the build output from frameworks can speed up subsequent build times. Th
 
 | Framework  | Directories cached                            |
 | ---------- | --------------------------------------------- |
+| Astro      | `node_modules/.astro`                         |
+| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build` |
+| Eleventy   | `.cache`                                      |
 | Gatsby     | `.cache`, `public`                            |
 | Next.js    | `.next/cache`                                 |
-| Astro      | `node_modules/.astro`                         |
 | Nuxt       | `node_modules/.cache/nuxt`                    |
-| Eleventy   | `.cache`                                      |
-| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build` |
 
 ## Limits
 


### PR DESCRIPTION
###### DEVDASH-60

> [!WARNING]
> This PR should not be merged until the build caching for Docusaurus has actually been released