### PR TITLE
early-hints: Update "any" -> "all"

### DIFF
--- a/content/pages/configuration/early-hints.md
+++ b/content/pages/configuration/early-hints.md
@@ -29,7 +29,7 @@ Pages will attach this `Link: </styles.css>; rel=preload; as=stylesheet` header.
 
 ### 2. Automatic `Link` header generation
 
-In order to make the authoring experience easier, Pages also automatically generates `Link` headers from any `<link>` HTML elements with any of the following attributes:
+In order to make the authoring experience easier, Pages also automatically generates `Link` headers from any `<link>` HTML elements with all of the following attributes:
 
 - `href`
 - `as`

--- a/content/pages/configuration/early-hints.md
+++ b/content/pages/configuration/early-hints.md
@@ -29,11 +29,11 @@ Pages will attach this `Link: </styles.css>; rel=preload; as=stylesheet` header.
 
 ### 2. Automatic `Link` header generation
 
-In order to make the authoring experience easier, Pages also automatically generates `Link` headers from any `<link>` HTML elements with all of the following attributes:
+In order to make the authoring experience easier, Pages also automatically generates `Link` headers from any `<link>` HTML elements with the following attributes:
 
 - `href`
-- `as`
-- `rel` (`preload` or `preconnect`)
+- `as` (optional)
+- `rel` (one of `preconnect`, `preload`, or `modulepreload`)
 
 `<link>` elements which contain any other additional attributes (for example, `fetchpriority`, `crossorigin` or `data-do-not-generate-a-link-header`) will not be used to generate `Link` headers in order to prevent accidentally losing any custom prioritization logic that would otherwise be dropped as an Early Hint.
 


### PR DESCRIPTION
From the context, it would make the most sense for **all** of the attributes to be present, rather than **any**.