### PR TITLE
amend `DocsMarkdown--table-wrap table` incorrect `min-width`

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3462,19 +3462,13 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 }
 
 .DocsMarkdown--table-wrap table {
-  min-width: calc(
-    var(--docs-body-width) - var(--docs-content-gap) * 2 -
-      var(--table-border-width) * 2
-  );
+  min-width: 100%;
   margin: 0;
 }
 
 @media (max-width: 768px) {
   .DocsMarkdown--table-wrap table {
-    min-width: calc(
-      100vw - var(--docs-content-horizontal-padding) * 2 -
-        var(--table-border-width) * 2
-    );
+    min-width: 100%;
   }
 }
 


### PR DESCRIPTION
#14631 mistakenly removed the `--table-border-width` css variable without updating some css rules that made use of it causing some `min-width` values to be no longer correctly set:
![Screenshot 2024-05-27 at 18 05 36](https://github.com/cloudflare/cloudflare-docs/assets/61631103/f0d4b053-a264-440c-9497-d3f559301789)

This PR amends the issue by, instead or restoring the css variable, by setting the `min-width` to `100%` (I think this is better than the previous solution as that seemed unnecessarily complicated and it also caused the table to overflow slightly)

This fixes a virtual bug we have in some tables (for example see the [nuxt deployment table](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nuxt-site/))

| Before | After |
|--------|--------|
| ![Screenshot 2024-05-27 at 18 03 56](https://github.com/cloudflare/cloudflare-docs/assets/61631103/dbd3df7a-2d81-4bba-b7b3-a266e92e0918) | ![Screenshot 2024-05-27 at 18 04 18](https://github.com/cloudflare/cloudflare-docs/assets/61631103/ee60248d-e68a-4987-9f24-0cf5c9e6fc88) | 

