### PR TITLE
[Durable Objects] Syntax fixes in use-kv-from-durable-objects.md

### DIFF
--- a/content/durable-objects/examples/use-kv-from-durable-objects.md
+++ b/content/durable-objects/examples/use-kv-from-durable-objects.md
@@ -73,11 +73,10 @@ export default {
 
 export class YourDurableObject implements DurableObject {
   constructor(public state: DurableObjectState, env: Env) {
-      this.state = state;
-      // Ensure you pass your bindings and environmental variables into
-      // each Durable Object when it is initialized
-      this.env = env;
-    }
+    this.state = state;
+    // Ensure you pass your bindings and environmental variables into
+    // each Durable Object when it is initialized
+    this.env = env;
   }
 
   async fetch(request: Request) {
@@ -90,6 +89,6 @@ export class YourDurableObject implements DurableObject {
 
     return Response.json(val)
   }
+}
 ```
-
 

--- a/content/durable-objects/examples/use-kv-from-durable-objects.md
+++ b/content/durable-objects/examples/use-kv-from-durable-objects.md
@@ -48,8 +48,8 @@ export default {
     // Assume each Durable Object is mapped to a roomId in a query parameter
     // In a production application, this will likely be a roomId defined by your application
     // that you validate (and/or authenticate) first.
-    let url = new URL(req.url)
-    let roomIdParam = url.searchParams.get("roomId")
+    let url = new URL(req.url);
+    let roomIdParam = url.searchParams.get("roomId");
 
     if (roomIdParam) {
       // Create (or get) a Durable Object based on that roomId.
@@ -87,7 +87,7 @@ export class YourDurableObject implements DurableObject {
     // Fetch from KV
     let val = await this.env.YOUR_KV_NAMESPACE.get("some-other-key");
 
-    return Response.json(val)
+    return Response.json(val);
   }
 }
 ```


### PR DESCRIPTION
This fixes an incorrect class definition: `fetch` should be a method of
`DurableObject`, not a free function.

Also fixes some missing semicolons I noticed while making the main change.
