### PR TITLE
Fix `cloudflare/pages-action` version tag

### DIFF
--- a/content/pages/how-to/use-direct-upload-with-continuous-integration.md
+++ b/content/pages/how-to/use-direct-upload-with-continuous-integration.md
@@ -83,7 +83,7 @@ jobs:
       # - name: Build
       #   run: npm install && npm run build
       - name: Publish
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
See [BenjaminEHowe/jekyll-links/.github/workflows/deploy-cloudflare.yaml#L43](https://github.com/BenjaminEHowe/jekyll-links/blob/f84ccb974f83d30159b03009a73458ace84298df/.github/workflows/deploy-cloudflare.yaml#L43) for example usage.

Looks like I'm also adding a newline at the end of the file, as should be the case... But feel free to remove that edit if you want!