### PR TITLE
Include `nodejs_compat` flag partials

### DIFF
--- a/content/workers/_partials/_platform-compatibility-dates/nodejs-compat.md
+++ b/content/workers/_partials/_platform-compatibility-dates/nodejs-compat.md
@@ -10,4 +10,4 @@ enable_flag: "nodejs_compat"
 disable_flag: "no_nodejs_compat"
 ---
 
-Enables the full set of available Node.js APIs in the Workers Runtime.
+Enables the full set of [available Node.js APIs](/workers/runtime-apis/nodejs/) in the Workers Runtime.

--- a/content/workers/_partials/_platform-compatibility-dates/nodejs-compat.md
+++ b/content/workers/_partials/_platform-compatibility-dates/nodejs-compat.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Node.js compatibility"
+sort_date: "2023-01-15"
+enable_flag: "nodejs_compat"
+disable_flag: "no_nodejs_compat"
+---
+
+Enables the full set of available Node.js APIs in the Workers Runtime.


### PR DESCRIPTION
This PR adds a partial for the `nodejs_compat` and `no_nodejs_compat` flags.

These flags were introduced (renamed) in https://github.com/cloudflare/workerd/pull/247 and released in https://github.com/cloudflare/workerd/releases/tag/v1.20230115.0.