### PR TITLE
Update the one-liner for Workers Analytics Engine

### DIFF
--- a/content/analytics/_index.md
+++ b/content/analytics/_index.md
@@ -16,7 +16,7 @@ Cloudflare visualizes the metadata collected by our products in the Cloudflare d
 ## Features
 
 {{<feature header="Workers Analytics Engine" href="/analytics/analytics-engine/">}}
-Provides analytics about anything using Cloudflare Workers.
+Provides a queryable analytics engine for custom events emitted from Cloudflare Workers.
 {{</feature>}}
 
 {{<feature header="Cloudflare Web Analytics" href="/analytics/web-analytics/">}}


### PR DESCRIPTION
I was trying to understand the analytics options within Cloudflare (there are many! https://developers.cloudflare.com/analytics/). I think the one-liner for Workers Analytics Engine today is confusing, and propose this change to improve it.

**Today, the one-liner for Workers Analytics Engine is:** "[Workers Analytics Engine] Provides analytics about anything using Cloudflare Workers." 

This is confusing because it reads as follows: _"[Workers Analytics Engine] (Provides analytics about (anything using Cloudflare Workers))."_

 **Here is the issue with this one-liner:**
* Workers Analytics Engine itself does not provide built-in analytics. It is an engine to which events can be emitted, but does not provide analytics about something out of the box. 
* "anything using Cloudflare Workers" is confusing. What is using Cloudflare Workers? What is anything?

**I propose that we update the one-liner for Workers Analytics Engine to:** Provides a queryable analytics engine for custom events emitted from Cloudflare Workers.

**Here are the advantages with this proposed one-liner:**
* Clearly indicates that this allows custom events emitted from Cloudflare Workers
* Clearly indicates that the analytics engine can be a sink for events, and can be queried
* Better differentiated against all other analytics options within Cloudflare