### PR TITLE
[Docs Site] Stop command output being copied to clipboard

### DIFF
--- a/bin/prism.config.ts
+++ b/bin/prism.config.ts
@@ -55,6 +55,11 @@ Prism.languages.sh = {
       },
     },
   },
+
+  output: {
+    pattern: /.(?:.*(?:[\r\n]|.$))*/,
+    alias: "unselectable"
+  }
 };
 
 const originalGrammar = Prism.languages.powershell;

--- a/components/CodeCopy.vue
+++ b/components/CodeCopy.vue
@@ -26,8 +26,12 @@ function copyCode(e: MouseEvent) {
     lines.forEach((line) =>
       textLines.push((line as HTMLElement).innerText.trimEnd())
     );
-    const text = textLines.join("\n");
+    let text = textLines.join("\n");
     if (text) {
+      // Remove extraneous newlines at the end of shell
+      // codeblocks, that persist after removing comment/output
+      // lines.
+      text = text.replaceAll(/\n{1,}$/g, "");
       try {
         //copy to clipboard
         navigator.clipboard.writeText(text);

--- a/static/codeBlock.css
+++ b/static/codeBlock.css
@@ -509,11 +509,11 @@
   color: var(--code-green);
 }
 
-[language="sh"] .CodeBlock--token-plain {
+[language="sh"] .CodeBlock--token-output {
   color: var(--code-gray);
 }
 
-[language="sh"] .CodeBlock--token-plain,
+[language="sh"] .CodeBlock--token-output,
 [language="sh"] .CodeBlock--token-unselectable,
 [language="powershell"] .CodeBlock--token-plain,
 [language="powershell"] .CodeBlock--token-unselectable {

--- a/static/codeBlock.css
+++ b/static/codeBlock.css
@@ -509,10 +509,12 @@
   color: var(--code-green);
 }
 
+[language="sh"] .CodeBlock--token-plain,
 [language="sh"] .CodeBlock--token-output {
   color: var(--code-gray);
 }
 
+[language="sh"] .CodeBlock--token-plain,
 [language="sh"] .CodeBlock--token-output,
 [language="sh"] .CodeBlock--token-unselectable,
 [language="powershell"] .CodeBlock--token-plain,


### PR DESCRIPTION
Improves the 'Copy to clipboard' functionality on `sh`/`shell` codeblocks.

These codeblocks do not allow the user to select comments, and command output, like so:

<img width="586" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/fc2756e6-bf27-43c2-805c-997bd0e1b6f2">

However, clicking the 'Copy to clipboard' button would include that text:

```
npx wrangler vectorize create tutorial-index --dimensions=3 --metric=cosine

✅ Successfully created index 'tutorial-index'

[[vectorize]]
binding = "VECTORIZE_INDEX"
index_name = "tutorial-index"
```

Now, it will only copy the command to the clipboard:

```
npx wrangler vectorize create tutorial-index --dimensions=3 --metric=cosine
```
