### PR TITLE
replace link to archived kv-asset-handler repo

### DIFF
--- a/content/workers/configuration/sites/start-from-worker.md
+++ b/content/workers/configuration/sites/start-from-worker.md
@@ -87,7 +87,7 @@ async function handleEvent(event) {
 {{</tab>}}
 {{</tabs>}}
 
-   For more information on the configurable options of `getAssetFromKV()` refer to [kv-asset-handler docs](https://github.com/cloudflare/kv-asset-handler).
+   For more information on the configurable options of `getAssetFromKV()` refer to [kv-asset-handler docs](https://github.com/cloudflare/workers-sdk/tree/main/packages/kv-asset-handler).
 
 5.  Run `wrangler dev` or `npx wrangler deploy` as you would normally with your Worker project.
     Wrangler will automatically upload the assets found in the configured directory.


### PR DESCRIPTION
the [kv-asset-handler repo](https://github.com/cloudflare/kv-asset-handler) has been moved to [workers-sdk](https://github.com/cloudflare/workers-sdk/) but the link in the docs was not updated and still points to the archived repo