### PR TITLE
Add Developer Spotlight details to fundamentals

### DIFF
--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -24,7 +24,7 @@ Your tutorial must be:
 1. Easy for anyone to follow.
 2. Technically accurate.
 3. Entirely original, written only by you.
-Written following Cloudflare’s documentation style guide. For more information, please visit our [style guide documentation](https://developers.cloudflare.com/style-guide/) and our [tutorial style guide documentation](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/tutorial/)
+Written following Cloudflare’s documentation style guide. For more information, please visit our [style guide documentation](style-guide/) and our [tutorial style guide documentation](style-guide/documentation-content-strategy/content-types/tutorial/)
 4. About using Cloudflare's Developer Platform products.
 5. Complete, not an unfinished draft.
 

--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -32,7 +32,7 @@ Written following Cloudflare’s documentation style guide. For more information
 
 ## FAQ
 
-- How many tutorial topic ideas can I submit?
+### How many tutorial topic ideas can I submit?
 
 You may submit as many tutorial topics ideas as you like in your application
 
@@ -41,17 +41,17 @@ You may submit as many tutorial topics ideas as you like in your application
 We will add the account credits to your Cloudflare account after your tutorial has been approved and published under the Developer Spotlight program.
 
 
-- If my tutorial is accepted and published on Cloudflare's Developer Voices page, can I republish it elsewhere?
+### If my tutorial is accepted and published on Cloudflare's Developer Voices page, can I republish it elsewhere?
 
 We ask that you do not republish any tutorials that have been published under the Cloudflare Developer Voices page.
 
 
-- Will I be credited for my work?
+### Will I be credited for my work?
 
 You will be credited as the author of any tutorial you submit that is successfully published to the Cloudflare Developer Voices program. We will add your details to your work after it has been approved.
 
 
-- What happens If my topic of choice gets accepted but the tutorial submission gets rejected?
+### What happens If my topic of choice gets accepted but the tutorial submission gets rejected?
 
 Our team will do our best to help you edit your tutorial's pull request to be ready for submission, however in the unlikely chance that your tutorial's pull request is rejected you are still free to publish your work elsewhere.
 

--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -7,7 +7,7 @@ title: Developer Spotlight Program
 
 If you use Cloudflare's developer products and would like to share your expertise then Cloudflare's Developer Spotlight program is for you! Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
 
-The Developer Spotlight Program is not currently open for applicants. Please keep an eye on our official Discord channel for future anouncements.
+The Developer Spotlight program is not currently open for applicants. Please keep an eye on our official Discord channel for future anouncements.
 
 ## Who can apply?
 

--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -24,7 +24,7 @@ Your tutorial must be:
 1. Easy for anyone to follow.
 2. Technically accurate.
 3. Entirely original, written only by you.
-Written following Cloudflare’s documentation style guide. For more information, please visit our [style guide documentation](style-guide/) and our [tutorial style guide documentation](style-guide/documentation-content-strategy/content-types/tutorial/)
+Written following Cloudflare’s documentation style guide. For more information, please visit our [style guide documentation](/style-guide/) and our [tutorial style guide documentation](/style-guide/documentation-content-strategy/content-types/tutorial/)
 4. About using Cloudflare's Developer Platform products.
 5. Complete, not an unfinished draft.
 

--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -1,0 +1,59 @@
+---
+pcx_content_type: reference
+title: Developer Spotlight Program
+---
+
+# Developer Spotlight Program
+
+If you use Cloudflare's developer products and would like to share your expertise then Cloudflare's Developer Spotlight program is for you! Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
+
+The Developer Spotlight Program is not currently open for applicants. Please keep an eye on our official Discord channel for future anouncements.
+
+## Who can apply?
+
+Anybody who is not currently a Cloudflare employee and regularly uses our Developer platform products can apply.
+
+## Submission process
+
+Those who apply will be asked to provide a title and details for a tutorial they would like to write for the Developer Spotlight program. Selected applicants will be contacted by the email and will be asked to write and submit their completed tutorial to [Cloudflare's documentation GitHub](https://github.com/cloudflare/cloudflare-docs). Once your tutorial has been submitted as a PR, reviewed for both technical and content accuracy, approved and merged into Cloudflare's documentation, you will be awarded 350 account credits to your Cloudflare account and your name will be added to the header of your tutorial.
+
+## Submission rules
+
+Your tutorial must be:
+
+1. Easy for anyone to follow.
+2. Technically accurate.
+3. Entirely original, written only by you.
+Written following Cloudflare’s documentation style guide. For more information, please visit our [style guide documentation](https://developers.cloudflare.com/style-guide/) and our [tutorial style guide documentation](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/tutorial/)
+4. About using Cloudflare's Developer Platform products.
+5. Complete, not an unfinished draft.
+
+---
+
+## FAQ
+
+- How many tutorial topic ideas can I submit?
+
+You may submit as many tutorial topics ideas as you like in your application
+
+- When will I be compensated for my tutorial?
+
+We will add the account credits to your Cloudflare account after your tutorial has been approved and published under the Developer Spotlight program.
+
+
+- If my tutorial is accepted and published on Cloudflare's Developer Voices page, can I republish it elsewhere?
+
+We ask that you do not republish any tutorials that have been published under the Cloudflare Developer Voices page.
+
+
+- Will I be credited for my work?
+
+You will be credited as the author of any tutorial you submit that is successfully published to the Cloudflare Developer Voices program. We will add your details to your work after it has been approved.
+
+
+- What happens If my topic of choice gets accepted but the tutorial submission gets rejected?
+
+Our team will do our best to help you edit your tutorial's pull request to be ready for submission, however in the unlikely chance that your tutorial's pull request is rejected you are still free to publish your work elsewhere.
+
+
+

--- a/content/fundamentals/reference/developer-spotlight.md
+++ b/content/fundamentals/reference/developer-spotlight.md
@@ -36,7 +36,7 @@ Written following Cloudflare’s documentation style guide. For more information
 
 You may submit as many tutorial topics ideas as you like in your application
 
-- When will I be compensated for my tutorial?
+### When will I be compensated for my tutorial?
 
 We will add the account credits to your Cloudflare account after your tutorial has been approved and published under the Developer Spotlight program.
 


### PR DESCRIPTION
Adding Dev Spotlight description, submission details and FAQ to the Cloudflare fundamentals page.