### PR TITLE
add caching and data revalidation section to the Next.js troubleshooting documentation

### DIFF
--- a/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
+++ b/content/pages/framework-guides/nextjs/deploy-a-nextjs-site.md
@@ -310,6 +310,10 @@ If you are using the Pages router, for page routes, you need to use `'experiment
 
 {{</Aside>}}
 
+### Caching and Data Revalidation
+
+`@cloudflare/next-on-pages` provides an out-of-the-box solution for caching as close as possible to the default one that Next.js provides. In case you run into troubles with caching and data revalidation or want to see the possible caching storage options please refer to the [`next-on-pages caching documentation`](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/caching.md).
+
 ### App router
 
 #### Not found


### PR DESCRIPTION
This should help with the lack of visibility of the caching documentation mentioned in https://github.com/cloudflare/next-on-pages/issues/794

closes #14231 