### PR TITLE
[Logs]: Render Logpush fields as headers instead of a table

### DIFF
--- a/content/logs/reference/log-fields/account/access_requests.md
+++ b/content/logs/reference/log-fields/account/access_requests.md
@@ -10,24 +10,92 @@ weight: 21
 
 The descriptions below detail the fields available for `access_requests`.
 
-{{<table-wrap>}}
+## Action
 
-| Field | Value | Type |
-| -- | -- | -- |
-| Action | What type of record is this. <em>login</em> \| <em>logout</em>. | string |
-| Allowed | If request was allowed or denied. | bool |
-| AppDomain | The domain of the Application that Access is protecting. | string |
-| AppUUID | Access Application UUID. | string |
-| Connection | Identity provider used for the login. | string |
-| Country | Request's country of origin. | string |
-| CreatedAt | The date and time the corresponding access request was made (for example, '2021-07-27T00:01:07Z'). | int or string |
-| Email | Email of the user who logged in. | string |
-| IPAddress | The IP address of the client. | string |
-| PurposeJustificationPrompt | Message prompted to the client when accessing the application. | string |
-| PurposeJustificationResponse | Justification given by the client when accessing the application. | string |
-| RayID | Identifier of the request. | string |
-| TemporaryAccessApprovers | List of approvers for this access request. | array[string] |
-| TemporaryAccessDuration | Approved duration for this access request. | int |
-| UserUID | The uid of the user who logged in. | string |
+Type: string
 
-{{</table-wrap>}}
+What type of record is this. <em>login</em> \| <em>logout</em>.
+
+## Allowed
+
+Type: bool
+
+If request was allowed or denied.
+
+## AppDomain
+
+Type: string
+
+The domain of the Application that Access is protecting.
+
+## AppUUID
+
+Type: string
+
+Access Application UUID.
+
+## Connection
+
+Type: string
+
+Identity provider used for the login.
+
+## Country
+
+Type: string
+
+Request's country of origin.
+
+## CreatedAt
+
+Type: int or string
+
+The date and time the corresponding access request was made (for example, '2021-07-27T00:01:07Z').
+
+## Email
+
+Type: string
+
+Email of the user who logged in.
+
+## IPAddress
+
+Type: string
+
+The IP address of the client.
+
+## PurposeJustificationPrompt
+
+Type: string
+
+Message prompted to the client when accessing the application.
+
+## PurposeJustificationResponse
+
+Type: string
+
+Justification given by the client when accessing the application.
+
+## RayID
+
+Type: string
+
+Identifier of the request.
+
+## TemporaryAccessApprovers
+
+Type: array[string]
+
+List of approvers for this access request.
+
+## TemporaryAccessDuration
+
+Type: int
+
+Approved duration for this access request.
+
+## UserUID
+
+Type: string
+
+The uid of the user who logged in.

--- a/content/logs/reference/log-fields/account/audit_logs.md
+++ b/content/logs/reference/log-fields/account/audit_logs.md
@@ -10,24 +10,92 @@ weight: 21
 
 The descriptions below detail the fields available for `audit_logs`.
 
-{{<table-wrap>}}
+## ActionResult
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ActionResult | Whether the action was successful. | bool |
-| ActionType | Type of action taken. | string |
-| ActorEmail | Email of the actor. | string |
-| ActorID | Unique identifier of the actor in Cloudflare's system. | string |
-| ActorIP | Physical network address of the actor. | string |
-| ActorType | Type of user that started the audit trail. | string |
-| ID | Unique identifier of an audit log. | string |
-| Interface | Entry point or interface of the audit log. | string |
-| Metadata | Additional audit log-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by ResourceType. | object |
-| NewValue | Contains the new value for the audited item. | object |
-| OldValue | Contains the old value for the audited item. | object |
-| OwnerID | The identifier of the user that was acting or was acted on behalf of. If a user did the action themselves, this value will be the same as the ActorID. | string |
-| ResourceID | Unique identifier of the resource within Cloudflare's system. | string |
-| ResourceType | The type of resource that was changed. | string |
-| When | When the change happened. | int or string |
+Type: bool
 
-{{</table-wrap>}}
+Whether the action was successful.
+
+## ActionType
+
+Type: string
+
+Type of action taken.
+
+## ActorEmail
+
+Type: string
+
+Email of the actor.
+
+## ActorID
+
+Type: string
+
+Unique identifier of the actor in Cloudflare's system.
+
+## ActorIP
+
+Type: string
+
+Physical network address of the actor.
+
+## ActorType
+
+Type: string
+
+Type of user that started the audit trail.
+
+## ID
+
+Type: string
+
+Unique identifier of an audit log.
+
+## Interface
+
+Type: string
+
+Entry point or interface of the audit log.
+
+## Metadata
+
+Type: object
+
+Additional audit log-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by ResourceType.
+
+## NewValue
+
+Type: object
+
+Contains the new value for the audited item.
+
+## OldValue
+
+Type: object
+
+Contains the old value for the audited item.
+
+## OwnerID
+
+Type: string
+
+The identifier of the user that was acting or was acted on behalf of. If a user did the action themselves, this value will be the same as the ActorID.
+
+## ResourceID
+
+Type: string
+
+Unique identifier of the resource within Cloudflare's system.
+
+## ResourceType
+
+Type: string
+
+The type of resource that was changed.
+
+## When
+
+Type: int or string
+
+When the change happened.

--- a/content/logs/reference/log-fields/account/casb_findings.md
+++ b/content/logs/reference/log-fields/account/casb_findings.md
@@ -10,21 +10,74 @@ weight: 21
 
 The descriptions below detail the fields available for `casb_findings`.
 
-{{<table-wrap>}}
+## AssetDisplayName
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AssetDisplayName | Asset display name (for example, 'My File Name.docx'). | string |
-| AssetExternalID | Unique identifier for an asset of this type. Format will vary by policy vendor. | string |
-| AssetLink | URL to the asset. This may not be available for some policy vendors and asset types. | string |
-| AssetMetadata | Metadata associated with the asset. Structure will vary by policy vendor. | object |
-| DetectedTimestamp | Date and time the finding was first identified (for example, '2021-07-27T00:01:07Z'). | int or string |
-| FindingTypeDisplayName | Human-readable name of the finding type (for example, 'File Publicly Accessible Read Only'). | string |
-| FindingTypeID | UUID of the finding type in Cloudflare's system. | string |
-| FindingTypeSeverity | Severity of the finding type (for example, 'High'). | string |
-| InstanceID | UUID of the finding in Cloudflare's system. | string |
-| IntegrationDisplayName | Human-readable name of the integration (for example, 'My Google Workspace Integration'). | string |
-| IntegrationID | UUID of the integration in Cloudflare's system. | string |
-| IntegrationPolicyVendor | Human-readable vendor name of the integration's policy (for example, 'Google Workspace Standard Policy'). | string |
+Type: string
 
-{{</table-wrap>}}
+Asset display name (for example, 'My File Name.docx').
+
+## AssetExternalID
+
+Type: string
+
+Unique identifier for an asset of this type. Format will vary by policy vendor.
+
+## AssetLink
+
+Type: string
+
+URL to the asset. This may not be available for some policy vendors and asset types.
+
+## AssetMetadata
+
+Type: object
+
+Metadata associated with the asset. Structure will vary by policy vendor.
+
+## DetectedTimestamp
+
+Type: int or string
+
+Date and time the finding was first identified (for example, '2021-07-27T00:01:07Z').
+
+## FindingTypeDisplayName
+
+Type: string
+
+Human-readable name of the finding type (for example, 'File Publicly Accessible Read Only').
+
+## FindingTypeID
+
+Type: string
+
+UUID of the finding type in Cloudflare's system.
+
+## FindingTypeSeverity
+
+Type: string
+
+Severity of the finding type (for example, 'High').
+
+## InstanceID
+
+Type: string
+
+UUID of the finding in Cloudflare's system.
+
+## IntegrationDisplayName
+
+Type: string
+
+Human-readable name of the integration (for example, 'My Google Workspace Integration').
+
+## IntegrationID
+
+Type: string
+
+UUID of the integration in Cloudflare's system.
+
+## IntegrationPolicyVendor
+
+Type: string
+
+Human-readable vendor name of the integration's policy (for example, 'Google Workspace Standard Policy').

--- a/content/logs/reference/log-fields/account/device_posture_results.md
+++ b/content/logs/reference/log-fields/account/device_posture_results.md
@@ -10,26 +10,104 @@ weight: 21
 
 The descriptions below detail the fields available for `device_posture_results`.
 
-{{<table-wrap>}}
+## ClientVersion
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ClientVersion | The Zero Trust client version at the time of upload. | string |
-| DeviceID | The device ID that performed the posture upload. | string |
-| DeviceManufacturer | The manufacturer of the device that the Zero Trust client is running on. | string |
-| DeviceModel | The model of the device that the Zero Trust client is running on. | string |
-| DeviceName | The name of the device that the Zero Trust client is running on. | string |
-| DeviceSerialNumber | The serial number of the device that the Zero Trust client is running on. | string |
-| DeviceType | The Zero Trust client operating system type. | string |
-| Email | The email used to register the device with the Zero Trust client. | string |
-| OSVersion | The operating system version at the time of upload. | string |
-| PolicyID | The posture check ID associated with this device posture result. | string |
-| PostureCheckName | The name of the posture check associated with this device posture result. | string |
-| PostureCheckType | The type of the Zero Trust client check or service provider check. | string |
-| PostureEvaluatedResult | Whether this posture upload passes the associated posture check, given the requirements posture check at the time of the timestamp. | bool |
-| PostureExpectedJSON | JSON object of what the posture check expects from the Zero Trust client. | object |
-| PostureReceivedJSON | JSON object of what the Zero Trust client actually uploads. | object |
-| Timestamp | The date and time the corresponding device posture upload was performed (for example, '2021-07-27T00:01:07Z'). | int or string |
-| UserUID | The uid of the user who registered the device. | string |
+Type: string
 
-{{</table-wrap>}}
+The Zero Trust client version at the time of upload.
+
+## DeviceID
+
+Type: string
+
+The device ID that performed the posture upload.
+
+## DeviceManufacturer
+
+Type: string
+
+The manufacturer of the device that the Zero Trust client is running on.
+
+## DeviceModel
+
+Type: string
+
+The model of the device that the Zero Trust client is running on.
+
+## DeviceName
+
+Type: string
+
+The name of the device that the Zero Trust client is running on.
+
+## DeviceSerialNumber
+
+Type: string
+
+The serial number of the device that the Zero Trust client is running on.
+
+## DeviceType
+
+Type: string
+
+The Zero Trust client operating system type.
+
+## Email
+
+Type: string
+
+The email used to register the device with the Zero Trust client.
+
+## OSVersion
+
+Type: string
+
+The operating system version at the time of upload.
+
+## PolicyID
+
+Type: string
+
+The posture check ID associated with this device posture result.
+
+## PostureCheckName
+
+Type: string
+
+The name of the posture check associated with this device posture result.
+
+## PostureCheckType
+
+Type: string
+
+The type of the Zero Trust client check or service provider check.
+
+## PostureEvaluatedResult
+
+Type: bool
+
+Whether this posture upload passes the associated posture check, given the requirements posture check at the time of the timestamp.
+
+## PostureExpectedJSON
+
+Type: object
+
+JSON object of what the posture check expects from the Zero Trust client.
+
+## PostureReceivedJSON
+
+Type: object
+
+JSON object of what the Zero Trust client actually uploads.
+
+## Timestamp
+
+Type: int or string
+
+The date and time the corresponding device posture upload was performed (for example, '2021-07-27T00:01:07Z'). To specify the timestamp format, refer to [Output types](/logs/reference/log-output-options/#output-types).
+
+## UserUID
+
+Type: string
+
+The uid of the user who registered the device.

--- a/content/logs/reference/log-fields/account/dns_firewall_logs.md
+++ b/content/logs/reference/log-fields/account/dns_firewall_logs.md
@@ -10,28 +10,116 @@ weight: 21
 
 The descriptions below detail the fields available for `dns_firewall_logs`.
 
-{{<table-wrap>}}
+## ClientResponseCode
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ClientResponseCode | Integer value of the response code Cloudflare presents to the client. Response code follows [IANA parameters](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6). | int |
-| ClusterID | The ID of the cluster which handled this request. | string |
-| ColoCode | IATA airport code of data center that received the request. | string |
-| EDNSSubnet | IPv4 or IPv6 address information corresponding to the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) forwarded by recursive resolvers. Not all resolvers send this information. | string |
-| EDNSSubnetLength | Size of the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) in bits. For example, if the last octet of an IPv4 address is omitted (`192.0.2.x.`), the subnet length will be 24. | int |
-| QueryDO | Indicates if the client is capable of handling a signed response (DNSSEC answer OK). | bool |
-| QueryName | Name of the query that was sent. | string |
-| QueryRD | Indicates if the client means a recursive query (Recursion Desired). | bool |
-| QuerySize | The size of the query sent from the client in bytes. | int |
-| QueryTCP | Indicates if the query from the client was made via TCP (if false, then UDP). | bool |
-| QueryType | Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4). | int |
-| ResponseCached | Whether the response was cached or not. | bool |
-| ResponseCachedStale | Whether the response was cached stale. In other words, the TTL had expired and the upstream nameserver was not reachable. | bool |
-| ResponseReason | Short descriptions with more context around the final DNS Firewall response. Refer to [response reasons](/dns/dns-firewall/analytics/) for more information. | string |
-| SourceIP | IP address of the client (IPv4 or IPv6). | string |
-| Timestamp | Timestamp at which the query occurred. | int or string |
-| UpstreamIP | IP of the upstream nameserver (IPv4 or IPv6). | string |
-| UpstreamResponseCode | Integer value of the response code from the upstream nameserver. Response code follows [IANA parameters](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6) | int |
-| UpstreamResponseTimeMs | Upstream response time in milliseconds. | int |
+Type: int
 
-{{</table-wrap>}}
+Integer value of the response code Cloudflare presents to the client. Response code follows [IANA parameters](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6).
+
+## ClusterID
+
+Type: string
+
+The ID of the cluster which handled this request.
+
+## ColoCode
+
+Type: string
+
+IATA airport code of data center that received the request.
+
+## EDNSSubnet
+
+Type: string
+
+IPv4 or IPv6 address information corresponding to the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) forwarded by recursive resolvers. Not all resolvers send this information.
+
+## EDNSSubnetLength
+
+Type: int
+
+Size of the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) in bits. For example, if the last octet of an IPv4 address is omitted (`192.0.2.x.`), the subnet length will be 24.
+
+## QueryDO
+
+Type: bool
+
+Indicates if the client is capable of handling a signed response (DNSSEC answer OK).
+
+## QueryName
+
+Type: string
+
+Name of the query that was sent.
+
+## QueryRD
+
+Type: bool
+
+Indicates if the client means a recursive query (Recursion Desired).
+
+## QuerySize
+
+Type: int
+
+The size of the query sent from the client in bytes.
+
+## QueryTCP
+
+Type: bool
+
+Indicates if the query from the client was made via TCP (if false, then UDP).
+
+## QueryType
+
+Type: int
+
+Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+
+## ResponseCached
+
+Type: bool
+
+Whether the response was cached or not.
+
+## ResponseCachedStale
+
+Type: bool
+
+Whether the response was cached stale. In other words, the TTL had expired and the upstream nameserver was not reachable.
+
+## ResponseReason
+
+Type: string
+
+Short descriptions with more context around the final DNS Firewall response. Refer to [response reasons](/dns/dns-firewall/analytics/) for more information.
+
+## SourceIP
+
+Type: string
+
+IP address of the client (IPv4 or IPv6).
+
+## Timestamp
+
+Type: int or string
+
+Timestamp at which the query occurred.
+
+## UpstreamIP
+
+Type: string
+
+IP of the upstream nameserver (IPv4 or IPv6).
+
+## UpstreamResponseCode
+
+Type: int
+
+Integer value of the response code from the upstream nameserver. Response code follows [IANA parameters](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6)
+
+## UpstreamResponseTimeMs
+
+Type: int
+
+Upstream response time in milliseconds.

--- a/content/logs/reference/log-fields/account/gateway_dns.md
+++ b/content/logs/reference/log-fields/account/gateway_dns.md
@@ -10,51 +10,254 @@ weight: 21
 
 The descriptions below detail the fields available for `gateway_dns`.
 
-{{<table-wrap>}}
+## ApplicationID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ApplicationID | ID of the application the domain belongs to (for example, 1, 2). Set to 0 when no ApplicationID is matched. | int |
-| ColoCode | The name of the colo that received the DNS query (for example, 'SJC', 'MIA', 'IAD'). | string |
-| ColoID | The ID of the colo that received the DNS query (for example, 46, 72, 397). | int |
-| CustomResolveDurationMs | The time it took for the custom resolver to respond. | int |
-| CustomResolverAddress | IP and port combo used to resolve the custom dns resolver query, if any. | string |
-| CustomResolverPolicyID | Custom resolver policy UUID, if matched. | string |
-| CustomResolverPolicyName | Custom resolver policy name, if matched. | string |
-| CustomResolverResponse | Status of the custom resolver response. | string |
-| Datetime | The date and time the corresponding DNS request was made (for example, '2021-07-27T00:01:07Z'). | int or string |
-| DeviceID | UUID of the device where the HTTP request originated from (for example, 'dad71818-0429-11ec-a0dc-000000000000'). | string |
-| DeviceName | The name of the device where the HTTP request originated from (for example, 'Laptop MB810'). | string |
-| DstIP | The destination IP address the DNS query was made to (for example, '104.16.132.2290'). | string |
-| DstPort | The destination port used at the edge. The port changes based on the protocol used by the DNS query (for example, 0). | int |
-| Email | Email used to authenticate the client (for example, 'user@test.com'). | string |
-| IsResponseCached | Response comes from cache or not. | bool |
-| Location | Name of the location the DNS request is coming from. Location is created by the customer (for example, 'Office NYC'). | string |
-| LocationID | UUID of the location the DNS request is coming from. Location is created by the customer (for example, '7bdc7a9c-81d3-4816-8e56-000000000000'). | string |
-| MatchedCategoryIDs | ID or IDs of category that the domain was matched with the policy (for example, [7,12,28,122,129,163]). | array[int] |
-| MatchedCategoryNames | Name or names of category that the domain was matched with the policy (for example, ['Photography', 'Weather']). | array[string] |
-| MatchedIndicatorFeedIDs | ID or IDs of indicator feed(s) that the domain was matched with the policy (for example, [7,12]). | array[int] |
-| MatchedIndicatorFeedNames | Name or names of indicator feed(s) that the domain was matched with the policy (for example, ['Vendor Malware Feed', 'Vendor CoC Feed']). | array[string] |
-| Policy | Name of the policy that was applied (if any) (for example, '7bdc7a9c-81d3-4816-8e56-de1acad3dec5'). | string |
-| PolicyID | ID of the policy/rule that was applied (if any). | string |
-| Protocol | The protocol used for the DNS query by the client (for example, 'udp'). | string |
-| QueryCategoryIDs | ID or IDs of category that the domain belongs to (for example, [7,12,28,122,129,163]). | array[int] |
-| QueryCategoryNames | Name or names of category that the domain belongs to (for example, ['Photography', 'Weather']). | array[string] |
-| QueryIndicatorFeedIDs | ID or IDs of indicator feed(s) that the domain belongs to (for example, [7,12,28]). | array[int] |
-| QueryIndicatorFeedNames | Name or names of indicator feed(s) that the domain belongs to (for example, ['Vendor Malware Feed', 'Vendor CoC Feed', 'Vendor Phishing Feed']). | array[string] |
-| QueryName | The query name (for example, 'example.com'). | string |
-| QueryNameReversed | Query name in reverse (for example, 'com.example'). | string |
-| QuerySize | The size of the DNS request in bytes (for example, 151). | int |
-| QueryType | The type of DNS query (for example, '1', '28', '15', or '16'). | string |
-| QueryTypeName | The type of DNS query (for example, 'A', 'AAAA', 'MX', or 'TXT'). | string |
-| RCode | The return code sent back by the DNS resolver. | int |
-| RData | The rdata objects (for example, {"type":"5","data":"dns-packet-placeholder..."}). | array[object] |
-| ResolvedIPs | The resolved IPs in the response, if any (for example ['203.0.113.1', '203.0.113.2']). | array[string] |
-| ResolverDecision | Result of the DNS query (for example, 'overrideForSafeSearch'). | string |
-| SrcIP | The source IP address making the DNS query (for example, '104.16.132.229'). | string |
-| SrcPort | The port used by the client when they sent the DNS request (for example, 0). | int |
-| TimeZone | Time zone used to calculate the current time, if a matched rule was scheduled with it. | string |
-| TimeZoneInferredMethod | Method used to pick the time zone for the schedule (from rule/ from user ip/ from local time). | string |
-| UserID | User identity where the HTTP request originated from (for example, '00000000-0000-0000-0000-000000000000'). | string |
+Type: int
 
-{{</table-wrap>}}
+ID of the application the domain belongs to (for example, 1, 2). Set to 0 when no ApplicationID is matched.
+
+## ColoCode
+
+Type: string
+
+The name of the colo that received the DNS query (for example, 'SJC', 'MIA', 'IAD').
+
+## ColoID
+
+Type: int
+
+The ID of the colo that received the DNS query (for example, 46, 72, 397).
+
+## CustomResolveDurationMs
+
+Type: int
+
+The time it took for the custom resolver to respond.
+
+## CustomResolverAddress
+
+Type: string
+
+IP and port combo used to resolve the custom dns resolver query, if any.
+
+## CustomResolverPolicyID
+
+Type: string
+
+Custom resolver policy UUID, if matched.
+
+## CustomResolverPolicyName
+
+Type: string
+
+Custom resolver policy name, if matched.
+
+## CustomResolverResponse
+
+Type: string
+
+Status of the custom resolver response.
+
+## Datetime
+
+Type: int or string
+
+The date and time the corresponding DNS request was made (for example, '2021-07-27T00:01:07Z').
+
+## DeviceID
+
+Type: string
+
+UUID of the device where the HTTP request originated from (for example, 'dad71818-0429-11ec-a0dc-000000000000').
+
+## DeviceName
+
+Type: string
+
+The name of the device where the HTTP request originated from (for example, 'Laptop MB810').
+
+## DstIP
+
+Type: string
+
+The destination IP address the DNS query was made to (for example, '104.16.132.2290').
+
+## DstPort
+
+Type: int
+
+The destination port used at the edge. The port changes based on the protocol used by the DNS query (for example, 0).
+
+## Email
+
+Type: string
+
+Email used to authenticate the client (for example, 'user@test.com').
+
+## IsResponseCached
+
+Type: bool
+
+Response comes from cache or not.
+
+## Location
+
+Type: string
+
+Name of the location the DNS request is coming from. Location is created by the customer (for example, 'Office NYC').
+
+## LocationID
+
+Type: string
+
+UUID of the location the DNS request is coming from. Location is created by the customer (for example, '7bdc7a9c-81d3-4816-8e56-000000000000').
+
+## MatchedCategoryIDs
+
+Type: array[int]
+
+ID or IDs of category that the domain was matched with the policy (for example, [7,12,28,122,129,163]).
+
+## MatchedCategoryNames
+
+Type: array[string]
+
+Name or names of category that the domain was matched with the policy (for example, ['Photography', 'Weather']).
+
+## MatchedIndicatorFeedIDs
+
+Type: array[int]
+
+ID or IDs of indicator feed(s) that the domain was matched with the policy (for example, [7,12]).
+
+## MatchedIndicatorFeedNames
+
+Type: array[string]
+
+Name or names of indicator feed(s) that the domain was matched with the policy (for example, ['Vendor Malware Feed', 'Vendor CoC Feed']).
+
+## Policy
+
+Type: string
+
+Name of the policy that was applied (if any) (for example, '7bdc7a9c-81d3-4816-8e56-de1acad3dec5').
+
+## PolicyID
+
+Type: string
+
+ID of the policy/rule that was applied (if any).
+
+## Protocol
+
+Type: string
+
+The protocol used for the DNS query by the client (for example, 'udp').
+
+## QueryCategoryIDs
+
+Type: array[int]
+
+ID or IDs of category that the domain belongs to (for example, [7,12,28,122,129,163]).
+
+## QueryCategoryNames
+
+Type: array[string]
+
+Name or names of category that the domain belongs to (for example, ['Photography', 'Weather']).
+
+## QueryIndicatorFeedIDs
+
+Type: array[int]
+
+ID or IDs of indicator feed(s) that the domain belongs to (for example, [7,12,28]).
+
+## QueryIndicatorFeedNames
+
+Type: array[string]
+
+Name or names of indicator feed(s) that the domain belongs to (for example, ['Vendor Malware Feed', 'Vendor CoC Feed', 'Vendor Phishing Feed']).
+
+## QueryName
+
+Type: string
+
+The query name (for example, 'example.com'). Cloudflare will surface '.' for root server queries in your logs.
+
+## QueryNameReversed
+
+Type: string
+
+Query name in reverse (for example, 'com.example'). Cloudflare will surface '.' for root server queries in your logs.
+
+## QuerySize
+
+Type: int
+
+The size of the DNS request in bytes (for example, 151).
+
+## QueryType
+
+Type: int
+
+The type of DNS query (for example, 1, 28, 15, or 16).
+
+## QueryTypeName
+
+Type: string
+
+The type of DNS query (for example, 'A', 'AAAA', 'MX', or 'TXT').
+
+## RCode
+
+Type: int
+
+The return code sent back by the DNS resolver.
+
+## RData
+
+Type: array[object]
+
+The rdata objects (for example, {"type":"5","data":"dns-packet-placeholder..."}).
+
+## ResolvedIPs
+
+Type: array[string]
+
+The resolved IPs in the response, if any (for example ['203.0.113.1', '203.0.113.2']).
+
+## ResolverDecision
+
+Type: string
+
+Result of the DNS query (for example, 'overrideForSafeSearch').
+
+## SrcIP
+
+Type: string
+
+The source IP address making the DNS query (for example, '104.16.132.229').
+
+## SrcPort
+
+Type: int
+
+The port used by the client when they sent the DNS request (for example, 0).
+
+## TimeZone
+
+Type: string
+
+Time zone used to calculate the current time, if a matched rule was scheduled with it.
+
+## TimeZoneInferredMethod
+
+Type: string
+
+Method used to pick the time zone for the schedule (from rule/ from user ip/ from local time).
+
+## UserID
+
+Type: string
+
+User identity where the HTTP request originated from (for example, '00000000-0000-0000-0000-000000000000').

--- a/content/logs/reference/log-fields/account/gateway_http.md
+++ b/content/logs/reference/log-fields/account/gateway_http.md
@@ -10,46 +10,224 @@ weight: 21
 
 The descriptions below detail the fields available for `gateway_http`.
 
-{{<table-wrap>}}
+## AccountID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AccountID | Cloudflare account tag. | string |
-| Action | Action performed by gateway on the HTTP request. | string |
-| BlockedFileHash | Hash of the file blocked in the response, if any. | string |
-| BlockedFileName | File name blocked in the request, if any. | string |
-| BlockedFileReason | Reason file was blocked in the response, if any. | string |
-| BlockedFileSize | File size(bytes) blocked in the response, if any. | string |
-| BlockedFileType | File type blocked in the response eg. exe, bin, if any. | string |
-| Datetime | The date and time the corresponding HTTP request was made. | int or string |
-| DestinationIP | Destination ip of the request. | string |
-| DestinationPort | Destination port of the request. | string |
-| DeviceID | UUID of the device where the HTTP request originated from. | string |
-| DeviceName | The name of the device where the HTTP request originated from (for example, 'Laptop MB810'). | string |
-| DownloadMatchedDlpProfileEntries | List of matched DLP entries in the HTTP request. | array[string] |
-| DownloadMatchedDlpProfiles | List of matched DLP profiles in the HTTP request. | array[string] |
-| DownloadedFileNames | List of files downloaded in the HTTP request. | array[string] |
-| Email | Email used to authenticate the client. | string |
-| FileInfo | Information about files detected within the HTTP request. | object |
-| HTTPHost | Content of the host header in the HTTP request. | string |
-| HTTPMethod | HTTP request method. | string |
-| HTTPStatusCode | HTTP status code gateway returned to the user. Zero if nothing was returned (for example, client disconnected). | int |
-| HTTPVersion | Version name for the HTTP request. | string |
-| IsIsolated | If the requested was isolated with Cloudflare Browser Isolation or not. | bool |
-| PolicyID | The gateway policy UUID applied to the request, if any. | string |
-| PolicyName | The name of the gateway policy applied to the request, if any. | string |
-| Referer | Contents of the referer header in the HTTP request. | string |
-| RequestID | Cloudflare request ID. This might be empty on bypass action. | string |
-| SessionID | Network session ID. | string |
-| SourceIP | Source ip of the request. | string |
-| SourceInternalIP | Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp. | string |
-| SourcePort | Source port of the request. | string |
-| URL | HTTP request URL. | string |
-| UntrustedCertificateAction | Action taken when an untrusted origin certificate error occurs (for example, expired certificate, mismatched common name, invalid certificate chain, signed by non-public CA). One of <em>none</em> \| <em>block</em> \| <em>error</em> \| <em>passThrough</em>. | string |
-| UploadMatchedDlpProfileEntries | List of matched DLP entries in the HTTP request. | array[string] |
-| UploadMatchedDlpProfiles | List of matched DLP profiles in the HTTP request. | array[string] |
-| UploadedFileNames | List of files uploaded in the HTTP request. | array[string] |
-| UserAgent | Contents of the user agent header in the HTTP request. | string |
-| UserID | User identity where the HTTP request originated from. | string |
+Type: string
 
-{{</table-wrap>}}
+Cloudflare account tag.
+
+## Action
+
+Type: string
+
+Action performed by gateway on the HTTP request.
+
+## BlockedFileHash
+
+Type: string
+
+Hash of the file blocked in the response, if any.
+
+## BlockedFileName
+
+Type: string
+
+File name blocked in the request, if any.
+
+## BlockedFileReason
+
+Type: string
+
+Reason file was blocked in the response, if any.
+
+## BlockedFileSize
+
+Type: string
+
+File size(bytes) blocked in the response, if any.
+
+## BlockedFileType
+
+Type: string
+
+File type blocked in the response eg. exe, bin, if any.
+
+## Datetime
+
+Type: int or string
+
+The date and time the corresponding HTTP request was made.
+
+## DestinationIP
+
+Type: string
+
+Destination ip of the request.
+
+## DestinationPort
+
+Type: string
+
+Destination port of the request.
+
+## DeviceID
+
+Type: string
+
+UUID of the device where the HTTP request originated from.
+
+## DeviceName
+
+Type: string
+
+The name of the device where the HTTP request originated from (for example, 'Laptop MB810').
+
+## DownloadMatchedDlpProfileEntries
+
+Type: array[string]
+
+List of matched DLP entries in the HTTP request.
+
+## DownloadMatchedDlpProfiles
+
+Type: array[string]
+
+List of matched DLP profiles in the HTTP request.
+
+## DownloadedFileNames
+
+Type: array[string]
+
+List of files downloaded in the HTTP request.
+
+## Email
+
+Type: string
+
+Email used to authenticate the client.
+
+## FileInfo
+
+Type: object
+
+Information about files detected within the HTTP request.
+
+## HTTPHost
+
+Type: string
+
+Content of the host header in the HTTP request.
+
+## HTTPMethod
+
+Type: string
+
+HTTP request method.
+
+## HTTPStatusCode
+
+Type: int
+
+HTTP status code gateway returned to the user. Zero if nothing was returned (for example, client disconnected).
+
+## HTTPVersion
+
+Type: string
+
+Version name for the HTTP request.
+
+## IsIsolated
+
+Type: bool
+
+If the requested was isolated with Cloudflare Browser Isolation or not.
+
+## PolicyID
+
+Type: string
+
+The gateway policy UUID applied to the request, if any.
+
+## PolicyName
+
+Type: string
+
+The name of the gateway policy applied to the request, if any.
+
+## Referer
+
+Type: string
+
+Contents of the referer header in the HTTP request.
+
+## RequestID
+
+Type: string
+
+Cloudflare request ID. This might be empty on bypass action.
+
+## SessionID
+
+Type: string
+
+Network session ID.
+
+## SourceIP
+
+Type: string
+
+Source ip of the request.
+
+## SourceInternalIP
+
+Type: string
+
+Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+
+## SourcePort
+
+Type: string
+
+Source port of the request.
+
+## URL
+
+Type: string
+
+HTTP request URL.
+
+## UntrustedCertificateAction
+
+Type: string
+
+Action taken when an untrusted origin certificate error occurs (for example, expired certificate, mismatched common name, invalid certificate chain, signed by non-public CA). One of <em>none</em> \| <em>block</em> \| <em>error</em> \| <em>passThrough</em>.
+
+## UploadMatchedDlpProfileEntries
+
+Type: array[string]
+
+List of matched DLP entries in the HTTP request.
+
+## UploadMatchedDlpProfiles
+
+Type: array[string]
+
+List of matched DLP profiles in the HTTP request.
+
+## UploadedFileNames
+
+Type: array[string]
+
+List of files uploaded in the HTTP request.
+
+## UserAgent
+
+Type: string
+
+Contents of the user agent header in the HTTP request.
+
+## UserID
+
+Type: string
+
+User identity where the HTTP request originated from.

--- a/content/logs/reference/log-fields/account/gateway_network.md
+++ b/content/logs/reference/log-fields/account/gateway_network.md
@@ -10,29 +10,122 @@ weight: 21
 
 The descriptions below detail the fields available for `gateway_network`.
 
-{{<table-wrap>}}
+## AccountID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AccountID | Cloudflare account tag. | string |
-| Action | Action performed by gateway on the session. | string |
-| Datetime | The date and time the corresponding network session was made (for example, '2021-07-27T00:01:07Z'). | int or string |
-| DestinationIP | Destination IP of the network session. | string |
-| DestinationPort | Destination port of the network session. | int |
-| DetectedProtocol | Detected traffic protocol of the network session. | string |
-| DeviceID | UUID of the device where the network session originated from. | string |
-| DeviceName | The name of the device where the HTTP request originated from (for example, 'Laptop MB810'). | string |
-| Email | Email associated with the user identity where the network session originated from. | string |
-| OverrideIP | Overridden IP of the network session, if any. | string |
-| OverridePort | Overridden port of the network session, if any. | int |
-| PolicyID | Identifier of the policy/rule that was applied, if any. | string |
-| PolicyName | The name of the gateway policy applied to the request, if any. | string |
-| SNI | Content of the SNI for the TLS network session, if any. | string |
-| SessionID | The session identifier of this network session. | string |
-| SourceIP | Source IP of the network session. | string |
-| SourceInternalIP | Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp. | string |
-| SourcePort | Source port of the network session. | int |
-| Transport | Transport protocol used for this session. <br />Possible values are <em>tcp</em> \| <em>quic</em> \| <em>udp</em>. | string |
-| UserID | User identity where the network session originated from. | string |
+Type: string
 
-{{</table-wrap>}}
+Cloudflare account tag.
+
+## Action
+
+Type: string
+
+Action performed by gateway on the session.
+
+## Datetime
+
+Type: int or string
+
+The date and time the corresponding network session was made (for example, '2021-07-27T00:01:07Z').
+
+## DestinationIP
+
+Type: string
+
+Destination IP of the network session.
+
+## DestinationPort
+
+Type: int
+
+Destination port of the network session.
+
+## DetectedProtocol
+
+Type: string
+
+Detected traffic protocol of the network session.
+
+## DeviceID
+
+Type: string
+
+UUID of the device where the network session originated from.
+
+## DeviceName
+
+Type: string
+
+The name of the device where the HTTP request originated from (for example, 'Laptop MB810').
+
+## Email
+
+Type: string
+
+Email associated with the user identity where the network session originated from.
+
+## OverrideIP
+
+Type: string
+
+Overridden IP of the network session, if any.
+
+## OverridePort
+
+Type: int
+
+Overridden port of the network session, if any.
+
+## PolicyID
+
+Type: string
+
+Identifier of the policy/rule that was applied, if any.
+
+## PolicyName
+
+Type: string
+
+The name of the gateway policy applied to the request, if any.
+
+## SNI
+
+Type: string
+
+Content of the SNI for the TLS network session, if any.
+
+## SessionID
+
+Type: string
+
+The session identifier of this network session.
+
+## SourceIP
+
+Type: string
+
+Source IP of the network session.
+
+## SourceInternalIP
+
+Type: string
+
+Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+
+## SourcePort
+
+Type: int
+
+Source port of the network session.
+
+## Transport
+
+Type: string
+
+Transport protocol used for this session. <br />Possible values are <em>tcp</em> \| <em>quic</em> \| <em>udp</em>.
+
+## UserID
+
+Type: string
+
+User identity where the network session originated from.

--- a/content/logs/reference/log-fields/account/magic_ids_detections.md
+++ b/content/logs/reference/log-fields/account/magic_ids_detections.md
@@ -10,21 +10,74 @@ weight: 21
 
 The descriptions below detail the fields available for `magic_ids_detections`.
 
-{{<table-wrap>}}
+## Action
 
-| Field | Value | Type |
-| -- | -- | -- |
-| Action | What action was taken on the packet. Possible values are <em>pass</em> \| <em>block</em>. | string |
-| ColoCity | The city where the detection occurred. | string |
-| ColoCode | The IATA airport code corresponding to where the detection occurred. | string |
-| DestinationIP | The destination IP of the packet which triggered the detection. | string |
-| DestinationPort | The destination port of the packet which triggered the detection. It is set to 0 if the protocol field is set to <em>any</em>. | int |
-| Protocol | The layer 4 protocol of the packet which triggered the detection. Possible values are <em>tcp</em> \| <em>udp</em> \| <em>any</em>. Variant <em>any</em> means a detection occurred at a lower layer (such as IP). | string |
-| SignatureID | The signature ID of the detection. | int |
-| SignatureMessage | The signature message of the detection. Describes what the packet is attempting to do. | string |
-| SignatureRevision | The signature revision of the detection. | int |
-| SourceIP | The source IP of packet which triggered the detection. | string |
-| SourcePort | The source port of the packet which triggered the detection. It is set to 0 if the protocol field is set to <em>any</em>. | int |
-| Timestamp | A timestamp of when the detection occurred. | int or string |
+Type: string
 
-{{</table-wrap>}}
+What action was taken on the packet. Possible values are <em>pass</em> \| <em>block</em>.
+
+## ColoCity
+
+Type: string
+
+The city where the detection occurred.
+
+## ColoCode
+
+Type: string
+
+The IATA airport code corresponding to where the detection occurred.
+
+## DestinationIP
+
+Type: string
+
+The destination IP of the packet which triggered the detection.
+
+## DestinationPort
+
+Type: int
+
+The destination port of the packet which triggered the detection. It is set to 0 if the protocol field is set to <em>any</em>.
+
+## Protocol
+
+Type: string
+
+The layer 4 protocol of the packet which triggered the detection. Possible values are <em>tcp</em> \| <em>udp</em> \| <em>any</em>. Variant <em>any</em> means a detection occurred at a lower layer (such as IP).
+
+## SignatureID
+
+Type: int
+
+The signature ID of the detection.
+
+## SignatureMessage
+
+Type: string
+
+The signature message of the detection. Describes what the packet is attempting to do.
+
+## SignatureRevision
+
+Type: int
+
+The signature revision of the detection.
+
+## SourceIP
+
+Type: string
+
+The source IP of packet which triggered the detection.
+
+## SourcePort
+
+Type: int
+
+The source port of the packet which triggered the detection. It is set to 0 if the protocol field is set to <em>any</em>.
+
+## Timestamp
+
+Type: int or string
+
+A timestamp of when the detection occurred.

--- a/content/logs/reference/log-fields/account/network_analytics_logs.md
+++ b/content/logs/reference/log-fields/account/network_analytics_logs.md
@@ -10,90 +10,488 @@ weight: 21
 
 The descriptions below detail the fields available for `network_analytics_logs`.
 
-{{<table-wrap>}}
+## AttackCampaignID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AttackCampaignID | Unique identifier of the attack campaign that this packet was a part of, if any. | string |
-| AttackID | Unique identifier of the mitigation that matched the packet, if any. | string |
-| AttackVector | Descriptive name of the type of attack that this packet was a part of, if any. Only for packets matching rules contained within the Cloudflare L3/4 managed ruleset. | string |
-| ColoCity | The city where the Cloudflare datacenter that received the packet is located. | string |
-| ColoCode | The Cloudflare datacenter that received the packet (nearest IATA airport code). | string |
-| ColoCountry | The country where the Cloudflare datacenter that received the packet is located (ISO 3166-1 alpha-2). | string |
-| ColoGeoHash | The latitude and longitude where the colo that received the packet is located (Geohash encoding). | string |
-| ColoName | The unique site identifier of the Cloudflare datacenter that received the packet (for example, 'ams01', 'sjc01', 'lhr01'). | string |
-| Datetime | The date and time the event occurred at the edge. | int or string |
-| DestinationASN | The ASN associated with the destination IP of the packet. | int |
-| DestinationASNName | The name of the ASN associated with the destination IP of the packet. | string |
-| DestinationCountry | The country where the destination IP of the packet is located (ISO 3166-1 alpha-2). | string |
-| DestinationGeoHash | The latitude and longitude where the destination IP of the packet is located (Geohash encoding). | string |
-| DestinationPort | Value of the Destination Port header field in the TCP or UDP packet. | int |
-| Direction | The direction in relation to customer network. <br />Possible values are <em>ingress</em> \| <em>egress</em>. | string |
-| GREChecksum | Value of the Checksum header field in the GRE packet. | int |
-| GREEtherType | Value of the EtherType header field in the GRE packet. | int |
-| GREHeaderLength | Length of the GRE packet header, in bytes. | int |
-| GREKey | Value of the Key header field in the GRE packet. | int |
-| GRESequenceNumber | Value of the Sequence Number header field in the GRE packet. | int |
-| GREVersion | Value of the Version header field in the GRE packet. | int |
-| ICMPChecksum | Value of the Checksum header field in the ICMP packet. | int |
-| ICMPCode | Value of the Code header field in the ICMP packet. | int |
-| ICMPType | Value of the Type header field in the ICMP packet. | int |
-| IPDestinationAddress | Value of the Destination Address header field in the IPv4 or IPv6 packet. | string |
-| IPDestinationSubnet | Computed subnet of the Destination Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6). | string |
-| IPFragmentOffset | Value of the Fragment Offset header field in the IPv4 or IPv6 packet. | int |
-| IPHeaderLength | Length of the IPv4 or IPv6 packet header, in bytes. | int |
-| IPMoreFragments | Value of the More Fragments header field in the IPv4 or IPv6 packet. | int |
-| IPProtocol | Value of the Protocol header field in the IPv4 or IPv6 packet. | int |
-| IPProtocolName | Name of the protocol specified by the Protocol header field in the IPv4 or IPv6 packet. | string |
-| IPSourceAddress | Value of the Source Address header field in the IPv4 or IPv6 packet. | string |
-| IPSourceSubnet | Computed subnet of the Source Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6). | string |
-| IPTTL | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet. | int |
-| IPTTLBuckets | Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet, with the last digit truncated. | int |
-| IPTotalLength | Total length of the IPv4 or IPv6 packet, in bytes. | int |
-| IPTotalLengthBuckets | Total length of the IPv4 or IPv6 packet, in bytes, with the last two digits truncated. | int |
-| IPv4Checksum | Value of the Checksum header field in the IPv4 packet. | int |
-| IPv4DSCP | Value of the Differentiated Services Code Point header field in the IPv4 packet. | int |
-| IPv4DontFragment | Value of the Don't Fragment header field in the IPv4 packet. | int |
-| IPv4ECN | Value of the Explicit Congestion Notification header field in the IPv4 packet. | int |
-| IPv4Identification | Value of the Identification header field in the IPv4 packet. | int |
-| IPv4Options | List of Options numbers included in the IPv4 packet header. | string |
-| IPv6DSCP | Value of the Differentiated Services Code Point header field in the IPv6 packet. | int |
-| IPv6ECN | Value of the Explicit Congestion Notification header field in the IPv6 packet. | int |
-| IPv6ExtensionHeaders | List of Extension Header numbers included in the IPv6 packet header. | string |
-| IPv6FlowLabel | Value of the Flow Label header field in the IPv6 packet. | int |
-| IPv6Identification | Value of the Identification extension header field in the IPv6 packet. | int |
-| MitigationReason | Reason for applying a mitigation to the packet, if any. <br />Possible values are <em>BLOCKED</em> \| <em>RATE_LIMITED</em> \|<em>UNEXPECTED</em> \| <em>CHALLENGE_NEEDED</em> \| <em>CHALLENGE_PASSED</em> \| <em>NOT_FOUND</em> \| <em>OUT_OF_SEQUENCE</em> \| <em>ALREADY_CLOSED</em>. | string |
-| MitigationScope | Whether the packet matched a local or global mitigation, if any. <br />Possible values are <em>local</em> \| <em>global</em>. | string |
-| MitigationSystem | Which Cloudflare system sampled the packet. <br />Possible values are <em>dosd</em> \| <em>flowtrackd</em> \| <em>magic-firewall</em>. | string |
-| Outcome | The action that Cloudflare systems took on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>. | string |
-| ProtocolState | State of the packet in the context of the protocol, if any. <br />Possible values are <em>OPEN</em> \| <em>NEW</em> \| <em>CLOSING</em> \| <em>CLOSED</em>. | string |
-| RuleID | Unique identifier of the rule contained within the Cloudflare L3/4 managed ruleset that this packet matched, if any. | string |
-| RuleName | Human-readable name of the rule contained within the Cloudflare L3/4 managed ruleset that this packet matched, if any. | string |
-| RulesetID | Unique identifier of the Cloudflare L3/4 managed ruleset containing the rule that this packet matched, if any. <br />Possible values are <em>3b64149bfa6e4220bbbc2bd6db589552</em>. | string |
-| RulesetOverrideID | Unique identifier of the rule within the accounts root ddos_l4 phase ruleset which resulted in an override of the default sensitivity or action being applied/evaluated, if any. | string |
-| SampleInterval | The sample interval is the inverse of the sample rate. For example, a sample interval of 1000 means that this packet was randomly sampled from 1 in 1000 packets. Sample rates are dynamic and based on the volume of traffic. | int |
-| SourceASN | The ASN associated with the source IP of the packet. | int |
-| SourceASNName | The name of the ASN associated with the source IP of the packet. | string |
-| SourceCountry | The country where the source IP of the packet is located (ISO 3166-1 alpha-2). | string |
-| SourceGeoHash | The latitude and longitude where the source IP of the packet is located (Geohash encoding). | string |
-| SourcePort | Value of the Source Port header field in the TCP or UDP packet. | int |
-| TCPAcknowledgementNumber | Value of the Acknowledgement Number header field in the TCP packet. | int |
-| TCPChecksum | Value of the Checksum header field in the TCP packet. | int |
-| TCPDataOffset | Value of the Data Offset header field in the TCP packet. | int |
-| TCPFlags | Value of the Flags header field in the TCP packet. | int |
-| TCPFlagsString | Human-readable string representation of the Flags header field in the TCP packet. | string |
-| TCPMSS | Value of the MSS option header field in the TCP packet. | int |
-| TCPOptions | List of Options numbers included in the TCP packet header. | string |
-| TCPSACKBlocks | List of the SACK Blocks option header in the TCP packet. | string |
-| TCPSACKPermitted | Value of the SACK Permitted option header in the TCP packet. | int |
-| TCPSequenceNumber | Value of the Sequence Number header field in the TCP packet. | int |
-| TCPTimestampECR | Value of the Timestamp Echo Reply option header in the TCP packet. | int |
-| TCPTimestampValue | Value of the Timestamp option header in the TCP packet. | int |
-| TCPUrgentPointer | Value of the Urgent Pointer header field in the TCP packet. | int |
-| TCPWindowScale | Value of the Window Scale option header in the TCP packet. | int |
-| TCPWindowSize | Value of the Window Size header field in the TCP packet. | int |
-| UDPChecksum | Value of the Checksum header field in the UDP packet. | int |
-| UDPPayloadLength | Value of the Payload Length header field in the UDP packet. | int |
-| Verdict | The action that Cloudflare systems think should be taken on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>. | string |
+Type: string
 
-{{</table-wrap>}}
+Unique identifier of the attack campaign that this packet was a part of, if any.
+
+## AttackID
+
+Type: string
+
+Unique identifier of the mitigation that matched the packet, if any.
+
+## AttackVector
+
+Type: string
+
+Descriptive name of the type of attack that this packet was a part of, if any. Only for packets matching rules contained within the Cloudflare L3/4 managed ruleset.
+
+## ColoCity
+
+Type: string
+
+The city where the Cloudflare datacenter that received the packet is located.
+
+## ColoCode
+
+Type: string
+
+The Cloudflare datacenter that received the packet (nearest IATA airport code).
+
+## ColoCountry
+
+Type: string
+
+The country where the Cloudflare datacenter that received the packet is located (ISO 3166-1 alpha-2).
+
+## ColoGeoHash
+
+Type: string
+
+The latitude and longitude where the colo that received the packet is located (Geohash encoding).
+
+## ColoName
+
+Type: string
+
+The unique site identifier of the Cloudflare datacenter that received the packet (for example, 'ams01', 'sjc01', 'lhr01').
+
+## Datetime
+
+Type: int or string
+
+The date and time the event occurred at the edge.
+
+## DestinationASN
+
+Type: int
+
+The ASN associated with the destination IP of the packet.
+
+## DestinationASNName
+
+Type: string
+
+The name of the ASN associated with the destination IP of the packet.
+
+## DestinationCountry
+
+Type: string
+
+The country where the destination IP of the packet is located (ISO 3166-1 alpha-2).
+
+## DestinationGeoHash
+
+Type: string
+
+The latitude and longitude where the destination IP of the packet is located (Geohash encoding).
+
+## DestinationPort
+
+Type: int
+
+Value of the Destination Port header field in the TCP or UDP packet.
+
+## Direction
+
+Type: string
+
+The direction in relation to customer network. <br />Possible values are <em>ingress</em> \| <em>egress</em>.
+
+## GREChecksum
+
+Type: int
+
+Value of the Checksum header field in the GRE packet.
+
+## GREEtherType
+
+Type: int
+
+Value of the EtherType header field in the GRE packet.
+
+## GREHeaderLength
+
+Type: int
+
+Length of the GRE packet header, in bytes.
+
+## GREKey
+
+Type: int
+
+Value of the Key header field in the GRE packet.
+
+## GRESequenceNumber
+
+Type: int
+
+Value of the Sequence Number header field in the GRE packet.
+
+## GREVersion
+
+Type: int
+
+Value of the Version header field in the GRE packet.
+
+## ICMPChecksum
+
+Type: int
+
+Value of the Checksum header field in the ICMP packet.
+
+## ICMPCode
+
+Type: int
+
+Value of the Code header field in the ICMP packet.
+
+## ICMPType
+
+Type: int
+
+Value of the Type header field in the ICMP packet.
+
+## IPDestinationAddress
+
+Type: string
+
+Value of the Destination Address header field in the IPv4 or IPv6 packet.
+
+## IPDestinationSubnet
+
+Type: string
+
+Computed subnet of the Destination Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6).
+
+## IPFragmentOffset
+
+Type: int
+
+Value of the Fragment Offset header field in the IPv4 or IPv6 packet.
+
+## IPHeaderLength
+
+Type: int
+
+Length of the IPv4 or IPv6 packet header, in bytes.
+
+## IPMoreFragments
+
+Type: int
+
+Value of the More Fragments header field in the IPv4 or IPv6 packet.
+
+## IPProtocol
+
+Type: int
+
+Value of the Protocol header field in the IPv4 or IPv6 packet.
+
+## IPProtocolName
+
+Type: string
+
+Name of the protocol specified by the Protocol header field in the IPv4 or IPv6 packet.
+
+## IPSourceAddress
+
+Type: string
+
+Value of the Source Address header field in the IPv4 or IPv6 packet.
+
+## IPSourceSubnet
+
+Type: string
+
+Computed subnet of the Source Address header field in the IPv4 or IPv6 packet (/24 for IPv4; /64 for IPv6).
+
+## IPTTL
+
+Type: int
+
+Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet.
+
+## IPTTLBuckets
+
+Type: int
+
+Value of the TTL header field in the IPv4 packet or the Hop Limit header field in the IPv6 packet, with the last digit truncated.
+
+## IPTotalLength
+
+Type: int
+
+Total length of the IPv4 or IPv6 packet, in bytes.
+
+## IPTotalLengthBuckets
+
+Type: int
+
+Total length of the IPv4 or IPv6 packet, in bytes, with the last two digits truncated.
+
+## IPv4Checksum
+
+Type: int
+
+Value of the Checksum header field in the IPv4 packet.
+
+## IPv4DSCP
+
+Type: int
+
+Value of the Differentiated Services Code Point header field in the IPv4 packet.
+
+## IPv4DontFragment
+
+Type: int
+
+Value of the Don't Fragment header field in the IPv4 packet.
+
+## IPv4ECN
+
+Type: int
+
+Value of the Explicit Congestion Notification header field in the IPv4 packet.
+
+## IPv4Identification
+
+Type: int
+
+Value of the Identification header field in the IPv4 packet.
+
+## IPv4Options
+
+Type: string
+
+List of Options numbers included in the IPv4 packet header.
+
+## IPv6DSCP
+
+Type: int
+
+Value of the Differentiated Services Code Point header field in the IPv6 packet.
+
+## IPv6ECN
+
+Type: int
+
+Value of the Explicit Congestion Notification header field in the IPv6 packet.
+
+## IPv6ExtensionHeaders
+
+Type: string
+
+List of Extension Header numbers included in the IPv6 packet header.
+
+## IPv6FlowLabel
+
+Type: int
+
+Value of the Flow Label header field in the IPv6 packet.
+
+## IPv6Identification
+
+Type: int
+
+Value of the Identification extension header field in the IPv6 packet.
+
+## MitigationReason
+
+Type: string
+
+Reason for applying a mitigation to the packet, if any. <br />Possible values are <em>BLOCKED</em> \| <em>RATE_LIMITED</em> \|<em>UNEXPECTED</em> \| <em>CHALLENGE_NEEDED</em> \| <em>CHALLENGE_PASSED</em> \| <em>NOT_FOUND</em> \| <em>OUT_OF_SEQUENCE</em> \| <em>ALREADY_CLOSED</em>.
+
+## MitigationScope
+
+Type: string
+
+Whether the packet matched a local or global mitigation, if any. <br />Possible values are <em>local</em> \| <em>global</em>.
+
+## MitigationSystem
+
+Type: string
+
+Which Cloudflare system sampled the packet. <br />Possible values are <em>dosd</em> \| <em>flowtrackd</em> \| <em>magic-firewall</em>.
+
+## Outcome
+
+Type: string
+
+The action that Cloudflare systems took on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>.
+
+## ProtocolState
+
+Type: string
+
+State of the packet in the context of the protocol, if any. <br />Possible values are <em>OPEN</em> \| <em>NEW</em> \| <em>CLOSING</em> \| <em>CLOSED</em>.
+
+## RuleID
+
+Type: string
+
+Unique identifier of the rule contained within the Cloudflare L3/4 managed ruleset that this packet matched, if any.
+
+## RuleName
+
+Type: string
+
+Human-readable name of the rule contained within the Cloudflare L3/4 managed ruleset that this packet matched, if any.
+
+## RulesetID
+
+Type: string
+
+Unique identifier of the Cloudflare L3/4 managed ruleset containing the rule that this packet matched, if any. <br />Possible values are <em>3b64149bfa6e4220bbbc2bd6db589552</em>.
+
+## RulesetOverrideID
+
+Type: string
+
+Unique identifier of the rule within the accounts root ddos_l4 phase ruleset which resulted in an override of the default sensitivity or action being applied/evaluated, if any.
+
+## SampleInterval
+
+Type: int
+
+The sample interval is the inverse of the sample rate. For example, a sample interval of 1000 means that this packet was randomly sampled from 1 in 1000 packets. Sample rates are dynamic and based on the volume of traffic.
+
+## SourceASN
+
+Type: int
+
+The ASN associated with the source IP of the packet.
+
+## SourceASNName
+
+Type: string
+
+The name of the ASN associated with the source IP of the packet.
+
+## SourceCountry
+
+Type: string
+
+The country where the source IP of the packet is located (ISO 3166-1 alpha-2).
+
+## SourceGeoHash
+
+Type: string
+
+The latitude and longitude where the source IP of the packet is located (Geohash encoding).
+
+## SourcePort
+
+Type: int
+
+Value of the Source Port header field in the TCP or UDP packet.
+
+## TCPAcknowledgementNumber
+
+Type: int
+
+Value of the Acknowledgement Number header field in the TCP packet.
+
+## TCPChecksum
+
+Type: int
+
+Value of the Checksum header field in the TCP packet.
+
+## TCPDataOffset
+
+Type: int
+
+Value of the Data Offset header field in the TCP packet.
+
+## TCPFlags
+
+Type: int
+
+Value of the Flags header field in the TCP packet.
+
+## TCPFlagsString
+
+Type: string
+
+Human-readable string representation of the Flags header field in the TCP packet.
+
+## TCPMSS
+
+Type: int
+
+Value of the MSS option header field in the TCP packet.
+
+## TCPOptions
+
+Type: string
+
+List of Options numbers included in the TCP packet header.
+
+## TCPSACKBlocks
+
+Type: string
+
+List of the SACK Blocks option header in the TCP packet.
+
+## TCPSACKPermitted
+
+Type: int
+
+Value of the SACK Permitted option header in the TCP packet.
+
+## TCPSequenceNumber
+
+Type: int
+
+Value of the Sequence Number header field in the TCP packet.
+
+## TCPTimestampECR
+
+Type: int
+
+Value of the Timestamp Echo Reply option header in the TCP packet.
+
+## TCPTimestampValue
+
+Type: int
+
+Value of the Timestamp option header in the TCP packet.
+
+## TCPUrgentPointer
+
+Type: int
+
+Value of the Urgent Pointer header field in the TCP packet.
+
+## TCPWindowScale
+
+Type: int
+
+Value of the Window Scale option header in the TCP packet.
+
+## TCPWindowSize
+
+Type: int
+
+Value of the Window Size header field in the TCP packet.
+
+## UDPChecksum
+
+Type: int
+
+Value of the Checksum header field in the UDP packet.
+
+## UDPPayloadLength
+
+Type: int
+
+Value of the Payload Length header field in the UDP packet.
+
+## Verdict
+
+Type: string
+
+The action that Cloudflare systems think should be taken on the packet. <br />Possible values are <em>pass</em> \| <em>drop</em>.

--- a/content/logs/reference/log-fields/account/sinkhole_http_logs.md
+++ b/content/logs/reference/log-fields/account/sinkhole_http_logs.md
@@ -10,26 +10,104 @@ weight: 21
 
 The descriptions below detail the fields available for `sinkhole_http_logs`.
 
-{{<table-wrap>}}
+## AccountID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AccountID | The Account ID. | string |
-| Body | The request body. | string |
-| BodyLength | The length of request body. | int |
-| DestAddr | The destination IP address of the request. | string |
-| Headers | The request headers. If a header has multiple values, the values are comma separated. Each header is separated by the escaped newline character (\n). | string |
-| Host | The host the request was sent to. | string |
-| Method | The request method. | string |
-| Password | The request password. | string |
-| R2Path | The path to the object within the R2 bucket linked to this sinkhole that stores overflow body and header data. Blank if neither headers nor body was larger than 256 bytes. | string |
-| Referrer | The referrer of the request. | string |
-| SinkholeID | The ID of the Sinkhole that logged the HTTP Request. | string |
-| SrcAddr | The sender's IP address. | string |
-| Timestamp | The date and time the sinkhole HTTP request was logged. | int or string |
-| URI | The request Uniform Resource Identifier. | string |
-| URL | The request Uniform Resource Locator. | string |
-| UserAgent | The request user agent. | string |
-| Username | The request username. | string |
+Type: string
 
-{{</table-wrap>}}
+The Account ID.
+
+## Body
+
+Type: string
+
+The request body.
+
+## BodyLength
+
+Type: int
+
+The length of request body.
+
+## DestAddr
+
+Type: string
+
+The destination IP address of the request.
+
+## Headers
+
+Type: string
+
+The request headers. If a header has multiple values, the values are comma separated. Each header is separated by the escaped newline character (\n).
+
+## Host
+
+Type: string
+
+The host the request was sent to.
+
+## Method
+
+Type: string
+
+The request method.
+
+## Password
+
+Type: string
+
+The request password.
+
+## R2Path
+
+Type: string
+
+The path to the object within the R2 bucket linked to this sinkhole that stores overflow body and header data. Blank if neither headers nor body was larger than 256 bytes.
+
+## Referrer
+
+Type: string
+
+The referrer of the request.
+
+## SinkholeID
+
+Type: string
+
+The ID of the Sinkhole that logged the HTTP Request.
+
+## SrcAddr
+
+Type: string
+
+The sender's IP address.
+
+## Timestamp
+
+Type: int or string
+
+The date and time the sinkhole HTTP request was logged.
+
+## URI
+
+Type: string
+
+The request Uniform Resource Identifier.
+
+## URL
+
+Type: string
+
+The request Uniform Resource Locator.
+
+## UserAgent
+
+Type: string
+
+The request user agent.
+
+## Username
+
+Type: string
+
+The request username.

--- a/content/logs/reference/log-fields/account/workers_trace_events.md
+++ b/content/logs/reference/log-fields/account/workers_trace_events.md
@@ -10,20 +10,68 @@ weight: 21
 
 The descriptions below detail the fields available for `workers_trace_events`.
 
-{{<table-wrap>}}
+## DispatchNamespace
 
-| Field | Value | Type |
-| -- | -- | -- |
-| DispatchNamespace | The Cloudflare Worker dispatch namespace. | string |
-| Entrypoint | The name of the entrypoint class in which the Worker began execution. | string |
-| Event | Details about the source event. | object |
-| EventTimestampMs | The timestamp of when the event was received, in milliseconds. | int |
-| EventType | The event type that triggered the invocation. <br />Possible values are <em>fetch</em>. | string |
-| Exceptions | List of uncaught exceptions during the invocation. | array[object] |
-| Logs | List of console messages emitted during the invocation. | array[object] |
-| Outcome | The outcome of the worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em>. | string |
-| ScriptName | The Cloudflare Worker script name. | string |
-| ScriptTags | A list of user-defined tags used to categorize the Worker. | array[string] |
-| ScriptVersion | The version of the script that was executed. | object |
+Type: string
 
-{{</table-wrap>}}
+The Cloudflare Worker dispatch namespace.
+
+## Entrypoint
+
+Type: string
+
+The name of the entrypoint class in which the Worker began execution.
+
+## Event
+
+Type: object
+
+Details about the source event.
+
+## EventTimestampMs
+
+Type: int
+
+The timestamp of when the event was received, in milliseconds.
+
+## EventType
+
+Type: string
+
+The event type that triggered the invocation. <br />Possible values are <em>fetch</em>.
+
+## Exceptions
+
+Type: array[object]
+
+List of uncaught exceptions during the invocation.
+
+## Logs
+
+Type: array[object]
+
+List of console messages emitted during the invocation.
+
+## Outcome
+
+Type: string
+
+The outcome of the worker script invocation. <br />Possible values are <em>ok</em> \| <em>exception</em>.
+
+## ScriptName
+
+Type: string
+
+The Cloudflare Worker script name.
+
+## ScriptTags
+
+Type: array[string]
+
+A list of user-defined tags used to categorize the Worker.
+
+## ScriptVersion
+
+Type: object
+
+The version of the script that was invoked.

--- a/content/logs/reference/log-fields/account/zero_trust_network_sessions.md
+++ b/content/logs/reference/log-fields/account/zero_trust_network_sessions.md
@@ -10,47 +10,230 @@ weight: 21
 
 The descriptions below detail the fields available for `zero_trust_network_sessions`.
 
-{{<table-wrap>}}
+## AccountID
 
-| Field | Value | Type |
-| -- | -- | -- |
-| AccountID | Cloudflare account ID. | string |
-| BytesReceived | The number of bytes sent from the origin to the client during the network session. | int |
-| BytesSent | The number of bytes sent from the client to the origin during the network session. | int |
-| ClientTCPHandshakeDurationMs | Duration of handshaking the TCP connection between the client and Cloudflare in milliseconds. | int |
-| ClientTLSCipher | TLS cipher suite used in the connection between the client and Cloudflare. | string |
-| ClientTLSHandshakeDurationMs | Duration of handshaking the TLS connection between the client and Cloudflare in milliseconds. | int |
-| ClientTLSVersion | TLS protocol version used in the connection between the client and Cloudflare. | string |
-| ConnectionCloseReason | The reason for closing the connection, only applicable for TCP. <br />Possible values are <em>CLIENT_CLOSED</em> \| <em>CLIENT_IDLE_TIMEOUT</em> \| <em>CLIENT_TLS_ERROR</em> \| <em>CLIENT_ERROR</em> \| <em>ORIGIN_CLOSED</em> \| <em>ORIGIN_TLS_ERROR</em> \| <em>ORIGIN_ERROR</em> \| <em>ORIGIN_UNREACHABLE</em> \| <em>PROXY_CONN_REFUSED</em> \| <em>UNKNOWN</em> \| <em>MISMATCHED_IP_VERSIONS</em>. | string |
-| ConnectionReuse | Whether the TCP connection was reused for multiple HTTP requests. | bool |
-| DestinationTunnelID | Identifier of the Cloudflare One connector to which the network session was routed to, if any, such as Cloudflare Tunnel or WARP device. | string |
-| DetectedProtocol | Detected traffic protocol of the network session. | string |
-| DeviceID | Identifier of the client device which initiated the network session, if applicable, (for example, WARP Device ID). | string |
-| DeviceName | Name of the client device which initiated the network session, if applicable, (for example, WARP Device ID). | string |
-| EgressColoName | The name of the Cloudflare colo from which traffic egressed to the origin. | string |
-| EgressIP | Source IP used when egressing traffic from Cloudflare to the origin. | string |
-| EgressPort | Source port used when egressing traffic from Cloudflare to the origin. | int |
-| EgressRuleID | Identifier of the egress rule that was applied by the Secure Web Gateway, if any. | string |
-| EgressRuleName | The name of the egress rule that was applied by the Secure Web Gateway, if any. | string |
-| Email | Email address associated with the user identity which initiated the network session. | string |
-| IngressColoName | The name of the Cloudflare colo to which traffic ingressed. | string |
-| Offramp | The type of destination to which the network session was routed. <br />Possible values are <em>INTERNET</em> \| <em>MAGIC</em> \| <em>CFD_TUNNEL</em> \| <em>WARP</em>. | string |
-| OriginIP | The IP of the destination ("origin") for the network session. | string |
-| OriginPort | The port of the destination origin for the network session. | int |
-| OriginTLSCertificateIssuer | The issuer of the origin TLS certificate. | string |
-| OriginTLSCertificateValidationResult | The result of validating the TLS certificate of the origin. <br />Possible values are <em>VALID</em> \| <em>EXPIRED</em> \| <em>REVOKED</em> \| <em>HOSTNAME_MISMATCH</em> \| <em>NONE</em> \| <em>UNKNOWN</em>. | string |
-| OriginTLSCipher | TLS cipher suite used in the connection between Cloudflare and the origin. | string |
-| OriginTLSHandshakeDurationMs | Duration of handshaking the TLS connection between Cloudflare and the origin in milliseconds. | int |
-| OriginTLSVersion | TLS protocol version used in the connection between Cloudflare and the origin. | string |
-| Protocol | Network protocol used for this network session. <br />Possible values are <em>TCP</em> \| <em>UDP</em> \| <em>ICMP</em> \| <em>ICMPV6</em>. | string |
-| RuleEvaluationDurationMs | The duration taken by Secure Web Gateway applying applicable Network, HTTP, and Egress rules to the network session in milliseconds. | int |
-| SessionEndTime | The network session end timestamp with nanosecond precision. | int or string |
-| SessionID | The identifier of this network session. | string |
-| SessionStartTime | The network session start timestamp with nanosecond precision. | int or string |
-| SourceIP | Source IP of the network session. | string |
-| SourceInternalIP | Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp. | string |
-| SourcePort | Source port of the network session. | int |
-| UserID | User identity where the network session originated from. Only applicable for WARP device clients. | string |
-| VirtualNetworkID | Identifier of the virtual network configured for the client. | string |
+Type: string
 
-{{</table-wrap>}}
+Cloudflare account ID.
+
+## BytesReceived
+
+Type: int
+
+The number of bytes sent from the origin to the client during the network session.
+
+## BytesSent
+
+Type: int
+
+The number of bytes sent from the client to the origin during the network session.
+
+## ClientTCPHandshakeDurationMs
+
+Type: int
+
+Duration of handshaking the TCP connection between the client and Cloudflare in milliseconds.
+
+## ClientTLSCipher
+
+Type: string
+
+TLS cipher suite used in the connection between the client and Cloudflare.
+
+## ClientTLSHandshakeDurationMs
+
+Type: int
+
+Duration of handshaking the TLS connection between the client and Cloudflare in milliseconds.
+
+## ClientTLSVersion
+
+Type: string
+
+TLS protocol version used in the connection between the client and Cloudflare.
+
+## ConnectionCloseReason
+
+Type: string
+
+The reason for closing the connection, only applicable for TCP. <br />Possible values are <em>CLIENT_CLOSED</em> \| <em>CLIENT_IDLE_TIMEOUT</em> \| <em>CLIENT_TLS_ERROR</em> \| <em>CLIENT_ERROR</em> \| <em>ORIGIN_CLOSED</em> \| <em>ORIGIN_TLS_ERROR</em> \| <em>ORIGIN_ERROR</em> \| <em>ORIGIN_UNREACHABLE</em> \| <em>PROXY_CONN_REFUSED</em> \| <em>UNKNOWN</em> \| <em>MISMATCHED_IP_VERSIONS</em>.
+
+## ConnectionReuse
+
+Type: bool
+
+Whether the TCP connection was reused for multiple HTTP requests.
+
+## DestinationTunnelID
+
+Type: string
+
+Identifier of the Cloudflare One connector to which the network session was routed to, if any, such as Cloudflare Tunnel or WARP device.
+
+## DetectedProtocol
+
+Type: string
+
+Detected traffic protocol of the network session.
+
+## DeviceID
+
+Type: string
+
+Identifier of the client device which initiated the network session, if applicable, (for example, WARP Device ID).
+
+## DeviceName
+
+Type: string
+
+Name of the client device which initiated the network session, if applicable, (for example, WARP Device ID).
+
+## EgressColoName
+
+Type: string
+
+The name of the Cloudflare colo from which traffic egressed to the origin.
+
+## EgressIP
+
+Type: string
+
+Source IP used when egressing traffic from Cloudflare to the origin.
+
+## EgressPort
+
+Type: int
+
+Source port used when egressing traffic from Cloudflare to the origin.
+
+## EgressRuleID
+
+Type: string
+
+Identifier of the egress rule that was applied by the Secure Web Gateway, if any.
+
+## EgressRuleName
+
+Type: string
+
+The name of the egress rule that was applied by the Secure Web Gateway, if any.
+
+## Email
+
+Type: string
+
+Email address associated with the user identity which initiated the network session.
+
+## IngressColoName
+
+Type: string
+
+The name of the Cloudflare colo to which traffic ingressed.
+
+## Offramp
+
+Type: string
+
+The type of destination to which the network session was routed. <br />Possible values are <em>INTERNET</em> \| <em>MAGIC</em> \| <em>CFD_TUNNEL</em> \| <em>WARP</em>.
+
+## OriginIP
+
+Type: string
+
+The IP of the destination ("origin") for the network session.
+
+## OriginPort
+
+Type: int
+
+The port of the destination origin for the network session.
+
+## OriginTLSCertificateIssuer
+
+Type: string
+
+The issuer of the origin TLS certificate.
+
+## OriginTLSCertificateValidationResult
+
+Type: string
+
+The result of validating the TLS certificate of the origin. <br />Possible values are <em>VALID</em> \| <em>EXPIRED</em> \| <em>REVOKED</em> \| <em>HOSTNAME_MISMATCH</em> \| <em>NONE</em> \| <em>UNKNOWN</em>.
+
+## OriginTLSCipher
+
+Type: string
+
+TLS cipher suite used in the connection between Cloudflare and the origin.
+
+## OriginTLSHandshakeDurationMs
+
+Type: int
+
+Duration of handshaking the TLS connection between Cloudflare and the origin in milliseconds.
+
+## OriginTLSVersion
+
+Type: string
+
+TLS protocol version used in the connection between Cloudflare and the origin.
+
+## Protocol
+
+Type: string
+
+Network protocol used for this network session. <br />Possible values are <em>TCP</em> \| <em>UDP</em> \| <em>ICMP</em> \| <em>ICMPV6</em>.
+
+## RuleEvaluationDurationMs
+
+Type: int
+
+The duration taken by Secure Web Gateway applying applicable Network, HTTP, and Egress rules to the network session in milliseconds.
+
+## SessionEndTime
+
+Type: int or string
+
+The network session end timestamp with nanosecond precision.
+
+## SessionID
+
+Type: string
+
+The identifier of this network session.
+
+## SessionStartTime
+
+Type: int or string
+
+The network session start timestamp with nanosecond precision.
+
+## SourceIP
+
+Type: string
+
+Source IP of the network session.
+
+## SourceInternalIP
+
+Type: string
+
+Local LAN IP of the device. Only available when connected via a GRE/IPsec tunnel on-ramp.
+
+## SourcePort
+
+Type: int
+
+Source port of the network session.
+
+## UserID
+
+Type: string
+
+User identity where the network session originated from. Only applicable for WARP device clients.
+
+## VirtualNetworkID
+
+Type: string
+
+Identifier of the virtual network configured for the client.

--- a/content/logs/reference/log-fields/zone/dns_logs.md
+++ b/content/logs/reference/log-fields/zone/dns_logs.md
@@ -10,18 +10,56 @@ weight: 21
 
 The descriptions below detail the fields available for `dns_logs`.
 
-{{<table-wrap>}}
+## ColoCode
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ColoCode | IATA airport code of data center that received the request. | string |
-| EDNSSubnet | IPv4 or IPv6 address information corresponding to the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) forwarded by recursive resolvers. Not all resolvers send this information. | string |
-| EDNSSubnetLength | Size of the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) in bits. For example, if the last octet of an IPv4 address is omitted (`192.0.2.x.`), the subnet length will be 24. | int |
-| QueryName | Name of the query that was sent. | string |
-| QueryType | Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4). | int |
-| ResponseCached | Whether the response was cached or not. | bool |
-| ResponseCode | Integer value of response code. For more information refer to  [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6). | int |
-| SourceIP | IP address of the client (IPv4 or IPv6). | string |
-| Timestamp | Timestamp at which the query occurred. | int or string |
+Type: string
 
-{{</table-wrap>}}
+IATA airport code of data center that received the request.
+
+## EDNSSubnet
+
+Type: string
+
+IPv4 or IPv6 address information corresponding to the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) forwarded by recursive resolvers. Not all resolvers send this information.
+
+## EDNSSubnetLength
+
+Type: int
+
+Size of the [EDNS Client Subnet (ECS)](/glossary/?term=ecs) in bits. For example, if the last octet of an IPv4 address is omitted (`192.0.2.x.`), the subnet length will be 24.
+
+## QueryName
+
+Type: string
+
+Name of the query that was sent.
+
+## QueryType
+
+Type: int
+
+Integer value of query type. For more information refer to [Query type](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+
+## ResponseCached
+
+Type: bool
+
+Whether the response was cached or not.
+
+## ResponseCode
+
+Type: int
+
+Integer value of response code. For more information refer to  [Response code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6).
+
+## SourceIP
+
+Type: string
+
+IP address of the client (IPv4 or IPv6).
+
+## Timestamp
+
+Type: int or string
+
+Timestamp at which the query occurred.

--- a/content/logs/reference/log-fields/zone/firewall_events.md
+++ b/content/logs/reference/log-fields/zone/firewall_events.md
@@ -10,40 +10,206 @@ weight: 21
 
 The descriptions below detail the fields available for `firewall_events`.
 
-{{<table-wrap>}}
+## Action
 
-| Field | Value | Type |
-| -- | -- | -- |
-| Action | The code of the first-class action the Cloudflare Firewall took on this request. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionclose</em> \| <em>challengesolved</em> \| <em>challengefailed</em> \| <em>challengebypassed</em> \| <em>jschallengesolved</em> \| <em>jschallengefailed</em> \| <em>jschallengebypassed</em> \| <em>bypass</em> \| <em>managedchallenge</em> \| <em>managedchallengeskipped</em> \| <em>managedchallengenoninteractivesolved</em> \| <em>managedchallengeinteractivesolved</em> \| <em>managedchallengebypassed</em>. | string |
-| ClientASN | The ASN number of the visitor. | int |
-| ClientASNDescription | The ASN of the visitor as string. | string |
-| ClientCountry | Country from which request originated. | string |
-| ClientIP | The visitor's IP address (IPv4 or IPv6). | string |
-| ClientIPClass | The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>. | string |
-| ClientRefererHost | The referer host. | string |
-| ClientRefererPath | The referer path requested by visitor. | string |
-| ClientRefererQuery | The referer query-string was requested by the visitor. | string |
-| ClientRefererScheme | The referer URL scheme requested by the visitor. | string |
-| ClientRequestHost | The HTTP hostname requested by the visitor. | string |
-| ClientRequestMethod | The HTTP method used by the visitor. | string |
-| ClientRequestPath | The path requested by visitor. | string |
-| ClientRequestProtocol | The version of HTTP protocol requested by the visitor. | string |
-| ClientRequestQuery | The query-string was requested by the visitor. | string |
-| ClientRequestScheme | The URL scheme requested by the visitor. | string |
-| ClientRequestUserAgent | Visitor's user-agent string. | string |
-| Datetime | The date and time the event occurred at the edge. | int or string |
-| Description | The description of the rule triggered by this request. | string |
-| EdgeColoCode | The airport code of the Cloudflare datacenter that served this request. | string |
-| EdgeResponseStatus | HTTP response status code returned to browser. | int |
-| Kind | The kind of event, currently only possible values are: <em>firewall</em>. | string |
-| LeakedCredentialCheckResult | Result of the check for leaked credentials. | string |
-| MatchIndex | Rules match index in the chain. The last matching rule will have MatchIndex <em>0</em>. If another rule matched before the last one, it will have MatchIndex <em>1</em>. The same applies to any other matching rules, which will have a MatchIndex value of <em>2</em>, <em>3</em>, and so on. | int |
-| Metadata | Additional product-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by Cloudflare security product and can change over time. | object |
-| OriginResponseStatus | HTTP origin response status code returned to browser. | int |
-| OriginatorRayID | The RayID of the request that issued the challenge/jschallenge. | string |
-| RayID | The RayID of the request. | string |
-| Ref | The user-defined identifier for the rule triggered by this request. Use refs to label your rules individually alongside the Cloudflare-provided RuleID. You can set refs via the [Rulesets API](/ruleset-engine/rulesets-api/) for some security products. | string |
-| RuleID | The Cloudflare security product-specific RuleID triggered by this request. | string |
-| Source | The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> \| <em>apishieldschemavalidation</em> \| <em>apishieldtokenvalidation</em> \| <em>apishieldsequencemitigation</em>. | string |
+Type: string
 
-{{</table-wrap>}}
+The code of the first-class action the Cloudflare Firewall took on this request. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionclose</em> \| <em>challengesolved</em> \| <em>challengefailed</em> \| <em>challengebypassed</em> \| <em>jschallengesolved</em> \| <em>jschallengefailed</em> \| <em>jschallengebypassed</em> \| <em>bypass</em> \| <em>managedchallenge</em> \| <em>managedchallengeskipped</em> \| <em>managedchallengenoninteractivesolved</em> \| <em>managedchallengeinteractivesolved</em> \| <em>managedchallengebypassed</em>.
+
+## ClientASN
+
+Type: int
+
+The ASN number of the visitor.
+
+## ClientASNDescription
+
+Type: string
+
+The ASN of the visitor as string.
+
+## ClientCountry
+
+Type: string
+
+Country from which request originated.
+
+## ClientIP
+
+Type: string
+
+The visitor's IP address (IPv4 or IPv6).
+
+## ClientIPClass
+
+Type: string
+
+The classification of the visitor's IP address, possible values are: <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>.
+
+## ClientRefererHost
+
+Type: string
+
+The referer host.
+
+## ClientRefererPath
+
+Type: string
+
+The referer path requested by visitor.
+
+## ClientRefererQuery
+
+Type: string
+
+The referer query-string was requested by the visitor.
+
+## ClientRefererScheme
+
+Type: string
+
+The referer URL scheme requested by the visitor.
+
+## ClientRequestHost
+
+Type: string
+
+The HTTP hostname requested by the visitor.
+
+## ClientRequestMethod
+
+Type: string
+
+The HTTP method used by the visitor.
+
+## ClientRequestPath
+
+Type: string
+
+The path requested by visitor.
+
+## ClientRequestProtocol
+
+Type: string
+
+The version of HTTP protocol requested by the visitor.
+
+## ClientRequestQuery
+
+Type: string
+
+The query-string was requested by the visitor.
+
+## ClientRequestScheme
+
+Type: string
+
+The URL scheme requested by the visitor.
+
+## ClientRequestUserAgent
+
+Type: string
+
+Visitor's user-agent string.
+
+## ContentScanObjResults
+
+Type: array[string]
+
+List of content scan results.
+
+## ContentScanObjSizes
+
+Type: array[int]
+
+List of content object sizes.
+
+## ContentScanObjTypes
+
+Type: array[string]
+
+List of content types.
+
+## Datetime
+
+Type: int or string
+
+The date and time the event occurred at the edge.
+
+## Description
+
+Type: string
+
+The description of the rule triggered by this request.
+
+## EdgeColoCode
+
+Type: string
+
+The airport code of the Cloudflare datacenter that served this request.
+
+## EdgeResponseStatus
+
+Type: int
+
+HTTP response status code returned to browser.
+
+## Kind
+
+Type: string
+
+The kind of event, currently only possible values are: <em>firewall</em>.
+
+## LeakedCredentialCheckResult
+
+Type: string
+
+Result of the check for leaked credentials.
+
+## MatchIndex
+
+Type: int
+
+Rules match index in the chain. The last matching rule will have MatchIndex <em>0</em>. If another rule matched before the last one, it will have MatchIndex <em>1</em>. The same applies to any other matching rules, which will have a MatchIndex value of <em>2</em>, <em>3</em>, and so on.
+
+## Metadata
+
+Type: object
+
+Additional product-specific information. Metadata is organized in key:value pairs. Key and Value formats can vary by Cloudflare security product and can change over time.
+
+## OriginResponseStatus
+
+Type: int
+
+HTTP origin response status code returned to browser.
+
+## OriginatorRayID
+
+Type: string
+
+The RayID of the request that issued the challenge/jschallenge.
+
+## RayID
+
+Type: string
+
+The RayID of the request.
+
+## Ref
+
+Type: string
+
+The user-defined identifier for the rule triggered by this request. Use refs to label your rules individually alongside the Cloudflare-provided RuleID. You can set refs via the [Rulesets API](/ruleset-engine/rulesets-api/) for some security products.
+
+## RuleID
+
+Type: string
+
+The Cloudflare security product-specific RuleID triggered by this request.
+
+## Source
+
+Type: string
+
+The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> \| <em>apishieldschemavalidation</em> \| <em>apishieldtokenvalidation</em> \| <em>apishieldsequencemitigation</em>.

--- a/content/logs/reference/log-fields/zone/http_requests.md
+++ b/content/logs/reference/log-fields/zone/http_requests.md
@@ -10,99 +10,560 @@ weight: 21
 
 The descriptions below detail the fields available for `http_requests`.
 
-{{<table-wrap>}}
+## BotDetectionIDs
 
-| Field | Value | Type |
-| -- | -- | -- |
-| BotDetectionIDs | List of IDs that correlate to the Bot Management Heuristic detections made on a request. Available only for Bot Management customers. To enable this feature, contact your account team. | array[int] |
-| BotScore | Cloudflare Bot Score. Scores below 30 are commonly associated with automated traffic. Available only for Bot Management customers. To enable this feature, contact your account team. | int |
-| BotScoreSrc | Detection engine responsible for generating the Bot Score. <br />Possible values are <em>Not Computed</em> \| <em>Heuristics</em> \| <em>Machine Learning</em> \| <em>Behavioral Analysis</em> \| <em>Verified Bot</em> \| <em>JS Fingerprinting</em> \| <em>Cloudflare Service</em>. Available only for Bot Management customers. To enable this feature, contact your account team. | string |
-| BotTags | Type of bot traffic (if available). Refer to [Bot Tags](/bots/concepts/cloudflare-bot-tags/) for the list of potential values. Available only for Bot Management customers. To enable this feature, contact your account team. | array[string] |
-| CacheCacheStatus | Cache status. <br />Possible values are <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> <br />"dynamic" means that a request is not eligible for cache. This can mean, for example that it was blocked by the firewall. Refer to [Cloudflare cache responses](/cache/concepts/cache-responses/) for more details. | string |
-| CacheReserveUsed | Cache Reserve was used to serve this request. | bool |
-| CacheResponseBytes | Number of bytes returned by the cache. | int |
-| CacheResponseStatus (deprecated) | HTTP status code returned by the cache to the edge. All requests (including non-cacheable ones) go through the cache. Refer also to CacheCacheStatus field. | int |
-| CacheTieredFill | Tiered Cache was used to serve this request. | bool |
-| ClientASN | Client AS number. | int |
-| ClientCountry | 2-letter ISO-3166 country code of the client IP address. | string |
-| ClientDeviceType | Client device type. | string |
-| ClientIP | IP address of the client. | string |
-| ClientIPClass | Client IP class. <br />Possible values are <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>. | string |
-| ClientMTLSAuthCertFingerprint | The SHA256 fingerprint of the certificate presented by the client during mTLS authentication. Only populated on the first request on an mTLS connection. | string |
-| ClientMTLSAuthStatus | The status of mTLS authentication. Only populated on the first request on an mTLS connection. <br />Possible values are <em>unknown</em> \| <em>ok</em> \| <em>absent</em> \| <em>untrusted</em> \| <em>notyetvalid</em> \| <em>expired</em>. | string |
-| ClientRegionCode | The ISO-3166-2 region code of the client IP address. | string |
-| ClientRequestBytes | Number of bytes in the client request. | int |
-| ClientRequestHost | Host requested by the client. | string |
-| ClientRequestMethod | HTTP method of client request. | string |
-| ClientRequestPath | URI path requested by the client. | string |
-| ClientRequestProtocol | HTTP protocol of client request. | string |
-| ClientRequestReferer | HTTP request referrer. | string |
-| ClientRequestScheme | The URL scheme requested by the visitor. | string |
-| ClientRequestSource | Identifies requests as coming from an external source or another service within Cloudflare. Refer to [ClientRequestSource field](/logs/reference/clientrequestsource/) for the list of potential values. | string |
-| ClientRequestURI | URI requested by the client. | string |
-| ClientRequestUserAgent | User agent reported by the client. | string |
-| ClientSSLCipher | Client SSL cipher. | string |
-| ClientSSLProtocol | Client SSL (TLS) protocol. The value "none" means that SSL was not used. | string |
-| ClientSrcPort | Client source port. | int |
-| ClientTCPRTTMs | The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received. | int |
-| ClientXRequestedWith | X-Requested-With HTTP header. | string |
-| ContentScanObjResults | List of content scan results. | array[string] |
-| ContentScanObjTypes | List of content types. | array[string] |
-| Cookies | String key-value pairs for Cookies. | object |
-| EdgeCFConnectingO2O | True if the request looped through multiple zones on the Cloudflare edge. This is considered an orange to orange (o2o) request. | bool |
-| EdgeColoCode | IATA airport code of data center that received the request. | string |
-| EdgeColoID | Cloudflare edge colo id. | int |
-| EdgeEndTimestamp | Timestamp at which the edge finished sending response to the client. | int or string |
-| EdgePathingOp | Indicates what type of response was issued for this request (unknown = no specific action). | string |
-| EdgePathingSrc | Details how the request was classified based on security checks (unknown = no specific classification). | string |
-| EdgePathingStatus | Indicates what data was used to determine the handling of this request (unknown = no data). | string |
-| EdgeRequestHost | Host header on the request from the edge to the origin. | string |
-| EdgeResponseBodyBytes | Size of the HTTP response body returned to clients. | int |
-| EdgeResponseBytes | Number of bytes returned by the edge to the client. | int |
-| EdgeResponseCompressionRatio | The edge response compression ratio is calculated as the ratio between the sizes of the original and compressed responses. | float |
-| EdgeResponseContentType | Edge response Content-Type header value. | string |
-| EdgeResponseStatus | HTTP status code returned by Cloudflare to the client. | int |
-| EdgeServerIP | IP of the edge server making a request to the origin. Possible responses are string in IPv4 or IPv6 format, or empty string. Empty string means that there was no request made to the origin server. | string |
-| EdgeStartTimestamp | Timestamp at which the edge received request from the client. | int or string |
-| EdgeTimeToFirstByteMs | Total view of Time To First Byte as measured at Cloudflare's edge. Starts after a TCP connection is established and ends when Cloudflare begins returning the first byte of a response to eyeballs. Includes TLS handshake time (for new connections) and origin response time. | int |
-| JA3Hash | The MD5 hash of the JA3 fingerprint used to profile SSL/TLS clients. Available only for Bot Management customers. To enable this feature, contact your account team. | string |
-| LeakedCredentialCheckResult | Result of the check for leaked credentials. | string |
-| OriginDNSResponseTimeMs | Time taken to receive a DNS response for an origin name. Usually takes a few milliseconds, but may be longer if a CNAME record is used. | int |
-| OriginIP | IP of the origin server. | string |
-| OriginRequestHeaderSendDurationMs | Time taken to send request headers to origin after establishing a connection. Note that this value is usually 0. | int |
-| OriginResponseBytes (deprecated) | Number of bytes returned by the origin server. | int |
-| OriginResponseDurationMs | Upstream response time, measured from the first datacenter that receives a request. Includes time taken by Argo Smart Routing and Tiered Cache, plus time to connect and receive a response from origin servers. This field replaces OriginResponseTime. | int |
-| OriginResponseHTTPExpires | Value of the origin 'expires' header in RFC1123 format. | string |
-| OriginResponseHTTPLastModified | Value of the origin 'last-modified' header in RFC1123 format. | string |
-| OriginResponseHeaderReceiveDurationMs | Time taken for origin to return response headers after Cloudflare finishes sending request headers. | int |
-| OriginResponseStatus | Status returned by the upstream server. The value 0 means that there was no request made to the origin server and the response was served by Cloudflare's Edge. However, if the zone has a Worker running on it, the value 0 could be the result of a Workers subrequest made to the origin. | int |
-| OriginResponseTime (deprecated) | Number of nanoseconds it took the origin to return the response to edge. | int |
-| OriginSSLProtocol | SSL (TLS) protocol used to connect to the origin. | string |
-| OriginTCPHandshakeDurationMs | Time taken to complete TCP handshake with origin. This will be 0 if an origin connection is reused. | int |
-| OriginTLSHandshakeDurationMs | Time taken to complete TLS handshake with origin. This will be 0 if an origin connection is reused. | int |
-| ParentRayID | Ray ID of the parent request if this request was made using a Worker script. | string |
-| RayID | ID of the request. | string |
-| RequestHeaders | String key-value pairs for RequestHeaders. | object |
-| ResponseHeaders | String key-value pairs for ResponseHeaders. | object |
-| SecurityAction | Action of the security rule that triggered a terminating action, if any. | string |
-| SecurityActions | Array of actions the Cloudflare security products performed on this request. The individual security products associated with this action be found in SecuritySources and their respective rule Ids can be found in SecurityRuleIDs. The length of the array is the same as SecurityRuleIDs and SecuritySources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionClose</em> \| <em>challengeSolved</em> \| <em>challengeFailed</em> \| <em>challengeBypassed</em> \| <em>jschallengeSolved</em> \| <em>jschallengeFailed</em> \| <em>jschallengeBypassed</em> \| <em>bypass</em> \| <em>managedChallenge</em> \| <em>managedChallengeSkipped</em> \| <em>managedChallengeNonInteractiveSolved</em> \| <em>managedChallengeInteractiveSolved</em> \| <em>managedChallengeBypassed</em> \| <em>rewrite</em> \| <em>forceConnectionClose</em> \| <em>skip</em> \| <em>managedChallengeFailed</em>. | array[string] |
-| SecurityRuleDescription | Description of the security rule that triggered a terminating action, if any. | string |
-| SecurityRuleID | Rule ID of the security rule that triggered a terminating action, if any. | string |
-| SecurityRuleIDs | Array of rule IDs of the security product that matched the request. The security product associated with the rule ID can be found in SecuritySources. The length of the array is the same as SecurityActions and SecuritySources. | array[string] |
-| SecuritySources | Array of security products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The rule IDs can be found in SecurityRuleIDs, and the actions can be found in SecurityActions. The length of the array is the same as SecurityRuleIDs and SecurityActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>ipRange</em> \| <em>securityLevel</em> \| <em>zoneLockdown</em> \| <em>waf</em> \| <em>firewallRules</em> \| <em>uaBlock</em> \| <em>rateLimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botFight</em> \| <em>apiShield</em> \| <em>botManagement</em> \| <em>dlp</em> \| <em>firewallManaged</em> \| <em>firewallCustom</em> \| <em>apiShieldSchemaValidation</em> \| <em>apiShieldTokenValidation</em> \| <em>apiShieldSequenceMitigation</em>. | array[string] |
-| SmartRouteColoID | The Cloudflare datacenter used to connect to the origin server if Argo Smart Routing is used. | int |
-| UpperTierColoID | The "upper tier" datacenter that was checked for a cached copy if Tiered Cache is used. | int |
-| WAFAttackScore | Overall request score generated by the WAF detection module. | int |
-| WAFFlags (deprecated) | Additional configuration flags: <em>simulate (0x1)</em> \| <em>null</em>. | string |
-| WAFMatchedVar (deprecated) | The full name of the most-recently matched variable. | string |
-| WAFRCEAttackScore | WAF score for an RCE attack. | int |
-| WAFSQLiAttackScore | WAF score for an SQLi attack. | int |
-| WAFXSSAttackScore | WAF score for an XSS attack. | int |
-| WorkerCPUTime | Amount of time in microseconds spent executing a worker, if any. | int |
-| WorkerStatus | Status returned from worker daemon. | string |
-| WorkerSubrequest | Whether or not this request was a worker subrequest. | bool |
-| WorkerSubrequestCount | Number of subrequests issued by a worker when handling this request. | int |
-| WorkerWallTimeUs | The elapsed time in microseconds between the start of a Worker invocation, and when the Workers Runtime determines that no more JavaScript needs to run. Specifically, this measures the wall-clock time that the JavaScript context remained open. For example, when returning a response with a large body, the Workers runtime can, in some cases, determine that no more JavaScript needs to run, and closes the JS context before all the bytes have passed through and been sent. Alternatively, if you use the `waitUntil()` API to perform work without blocking the return of a response, this work may continue executing after the response has been returned, and will be included in `WorkerWallTimeUs`. | int |
-| ZoneName | The human-readable name of the zone (e.g. 'cloudflare.com'). | string |
+Type: array[int]
 
-{{</table-wrap>}}
+List of IDs that correlate to the Bot Management Heuristic detections made on a request. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## BotScore
+
+Type: int
+
+Cloudflare Bot Score. Scores below 30 are commonly associated with automated traffic. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## BotScoreSrc
+
+Type: string
+
+Detection engine responsible for generating the Bot Score. <br />Possible values are <em>Not Computed</em> \| <em>Heuristics</em> \| <em>Machine Learning</em> \| <em>Behavioral Analysis</em> \| <em>Verified Bot</em> \| <em>JS Fingerprinting</em> \| <em>Cloudflare Service</em>. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## BotTags
+
+Type: array[string]
+
+Type of bot traffic (if available). Refer to [Bot Tags](/bots/concepts/cloudflare-bot-tags/) for the list of potential values. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## CacheCacheStatus
+
+Type: string
+
+Cache status. <br />Possible values are <em>unknown</em> \| <em>miss</em> \| <em>expired</em> \| <em>updating</em> \| <em>stale</em> \| <em>hit</em> \| <em>ignored</em> \| <em>bypass</em> \| <em>revalidated</em> \| <em>dynamic</em> \| <em>stream_hit</em> \| <em>deferred</em> <br />"dynamic" means that a request is not eligible for cache. This can mean, for example that it was blocked by the firewall. Refer to [Cloudflare cache responses](/cache/concepts/cache-responses/) for more details.
+
+## CacheReserveUsed
+
+Type: bool
+
+Cache Reserve was used to serve this request.
+
+## CacheResponseBytes
+
+Type: int
+
+Number of bytes returned by the cache.
+
+## CacheResponseStatus (deprecated)
+
+Type: int
+
+HTTP status code returned by the cache to the edge. All requests (including non-cacheable ones) go through the cache. Refer also to CacheCacheStatus field.
+
+## CacheTieredFill
+
+Type: bool
+
+Tiered Cache was used to serve this request.
+
+## ClientASN
+
+Type: int
+
+Client AS number.
+
+## ClientCountry
+
+Type: string
+
+2-letter ISO-3166 country code of the client IP address.
+
+## ClientDeviceType
+
+Type: string
+
+Client device type.
+
+## ClientIP
+
+Type: string
+
+IP address of the client.
+
+## ClientIPClass
+
+Type: string
+
+Client IP class. <br />Possible values are <em>unknown</em> \| <em>badHost</em> \| <em>searchEngine</em> \| <em>allowlist</em> \| <em>monitoringService</em> \| <em>noRecord</em> \| <em>scan</em> \| <em>tor</em>.
+
+## ClientMTLSAuthCertFingerprint
+
+Type: string
+
+The SHA256 fingerprint of the certificate presented by the client during mTLS authentication. Only populated on the first request on an mTLS connection.
+
+## ClientMTLSAuthStatus
+
+Type: string
+
+The status of mTLS authentication. Only populated on the first request on an mTLS connection. <br />Possible values are <em>unknown</em> \| <em>ok</em> \| <em>absent</em> \| <em>untrusted</em> \| <em>notyetvalid</em> \| <em>expired</em>.
+
+## ClientRegionCode
+
+Type: string
+
+The ISO-3166-2 region code of the client IP address.
+
+## ClientRequestBytes
+
+Type: int
+
+Number of bytes in the client request.
+
+## ClientRequestHost
+
+Type: string
+
+Host requested by the client.
+
+## ClientRequestMethod
+
+Type: string
+
+HTTP method of client request.
+
+## ClientRequestPath
+
+Type: string
+
+URI path requested by the client.
+
+## ClientRequestProtocol
+
+Type: string
+
+HTTP protocol of client request.
+
+## ClientRequestReferer
+
+Type: string
+
+HTTP request referrer.
+
+## ClientRequestScheme
+
+Type: string
+
+The URL scheme requested by the visitor.
+
+## ClientRequestSource
+
+Type: string
+
+Identifies requests as coming from an external source or another service within Cloudflare. Refer to [ClientRequestSource field](/logs/reference/clientrequestsource/) for the list of potential values.
+
+## ClientRequestURI
+
+Type: string
+
+URI requested by the client.
+
+## ClientRequestUserAgent
+
+Type: string
+
+User agent reported by the client.
+
+## ClientSSLCipher
+
+Type: string
+
+Client SSL cipher.
+
+## ClientSSLProtocol
+
+Type: string
+
+Client SSL (TLS) protocol. The value "none" means that SSL was not used.
+
+## ClientSrcPort
+
+Type: int
+
+Client source port.
+
+## ClientTCPRTTMs
+
+Type: int
+
+The smoothed average of TCP round-trip time (SRTT). For the initial request on a connection, this is measured only during connection setup. For a subsequent request on the same connection, it is measured over the entire connection lifetime up until the time that request is received.
+
+## ClientXRequestedWith
+
+Type: string
+
+X-Requested-With HTTP header.
+
+## ContentScanObjResults
+
+Type: array[string]
+
+List of content scan results.
+
+## ContentScanObjSizes
+
+Type: array[int]
+
+List of content object sizes.
+
+## ContentScanObjTypes
+
+Type: array[string]
+
+List of content types.
+
+## Cookies
+
+Type: object
+
+String key-value pairs for Cookies.
+
+## EdgeCFConnectingO2O
+
+Type: bool
+
+True if the request looped through multiple zones on the Cloudflare edge. This is considered an orange to orange (o2o) request.
+
+## EdgeColoCode
+
+Type: string
+
+IATA airport code of data center that received the request.
+
+## EdgeColoID
+
+Type: int
+
+Cloudflare edge colo id.
+
+## EdgeEndTimestamp
+
+Type: int or string
+
+Timestamp at which the edge finished sending response to the client.
+
+## EdgePathingOp
+
+Type: string
+
+Indicates what type of response was issued for this request (unknown = no specific action).
+
+## EdgePathingSrc
+
+Type: string
+
+Details how the request was classified based on security checks (unknown = no specific classification).
+
+## EdgePathingStatus
+
+Type: string
+
+Indicates what data was used to determine the handling of this request (unknown = no data).
+
+## EdgeRequestHost
+
+Type: string
+
+Host header on the request from the edge to the origin.
+
+## EdgeResponseBodyBytes
+
+Type: int
+
+Size of the HTTP response body returned to clients.
+
+## EdgeResponseBytes
+
+Type: int
+
+Number of bytes returned by the edge to the client.
+
+## EdgeResponseCompressionRatio
+
+Type: float
+
+The edge response compression ratio is calculated as the ratio between the sizes of the original and compressed responses.
+
+## EdgeResponseContentType
+
+Type: string
+
+Edge response Content-Type header value.
+
+## EdgeResponseStatus
+
+Type: int
+
+HTTP status code returned by Cloudflare to the client.
+
+## EdgeServerIP
+
+Type: string
+
+IP of the edge server making a request to the origin. Possible responses are string in IPv4 or IPv6 format, or empty string. Empty string means that there was no request made to the origin server.
+
+## EdgeStartTimestamp
+
+Type: int or string
+
+Timestamp at which the edge received request from the client.
+
+## EdgeTimeToFirstByteMs
+
+Type: int
+
+Total view of Time To First Byte as measured at Cloudflare's edge. Starts after a TCP connection is established and ends when Cloudflare begins returning the first byte of a response to eyeballs. Includes TLS handshake time (for new connections) and origin response time.
+
+## JA3Hash
+
+Type: string
+
+The MD5 hash of the JA3 fingerprint used to profile SSL/TLS clients. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## JA4
+
+Type: string
+
+The JA4 fingerprint used to profile SSL/TLS clients. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## JA4Signals
+
+Type: object
+
+Inter-request statistics computed for this JA4 fingerprint. JA4Signals field is organized in key:value pairs, where values are numbers. Available only for Bot Management customers. To enable this feature, contact your account team.
+
+## LeakedCredentialCheckResult
+
+Type: string
+
+Result of the check for leaked credentials.
+
+## OriginDNSResponseTimeMs
+
+Type: int
+
+Time taken to receive a DNS response for an origin name. Usually takes a few milliseconds, but may be longer if a CNAME record is used.
+
+## OriginIP
+
+Type: string
+
+IP of the origin server.
+
+## OriginRequestHeaderSendDurationMs
+
+Type: int
+
+Time taken to send request headers to origin after establishing a connection. Note that this value is usually 0.
+
+## OriginResponseBytes (deprecated)
+
+Type: int
+
+Number of bytes returned by the origin server.
+
+## OriginResponseDurationMs
+
+Type: int
+
+Upstream response time, measured from the first datacenter that receives a request. Includes time taken by Argo Smart Routing and Tiered Cache, plus time to connect and receive a response from origin servers. This field replaces OriginResponseTime.
+
+## OriginResponseHTTPExpires
+
+Type: string
+
+Value of the origin 'expires' header in RFC1123 format.
+
+## OriginResponseHTTPLastModified
+
+Type: string
+
+Value of the origin 'last-modified' header in RFC1123 format.
+
+## OriginResponseHeaderReceiveDurationMs
+
+Type: int
+
+Time taken for origin to return response headers after Cloudflare finishes sending request headers.
+
+## OriginResponseStatus
+
+Type: int
+
+Status returned by the upstream server. The value 0 means that there was no request made to the origin server and the response was served by Cloudflare's Edge. However, if the zone has a Worker running on it, the value 0 could be the result of a Workers subrequest made to the origin.
+
+## OriginResponseTime (deprecated)
+
+Type: int
+
+Number of nanoseconds it took the origin to return the response to edge.
+
+## OriginSSLProtocol
+
+Type: string
+
+SSL (TLS) protocol used to connect to the origin.
+
+## OriginTCPHandshakeDurationMs
+
+Type: int
+
+Time taken to complete TCP handshake with origin. This will be 0 if an origin connection is reused.
+
+## OriginTLSHandshakeDurationMs
+
+Type: int
+
+Time taken to complete TLS handshake with origin. This will be 0 if an origin connection is reused.
+
+## ParentRayID
+
+Type: string
+
+Ray ID of the parent request if this request was made using a Worker script.
+
+## RayID
+
+Type: string
+
+ID of the request.
+
+## RequestHeaders
+
+Type: object
+
+String key-value pairs for RequestHeaders.
+
+## ResponseHeaders
+
+Type: object
+
+String key-value pairs for ResponseHeaders.
+
+## SecurityAction
+
+Type: string
+
+Action of the security rule that triggered a terminating action, if any.
+
+## SecurityActions
+
+Type: array[string]
+
+Array of actions the Cloudflare security products performed on this request. The individual security products associated with this action be found in SecuritySources and their respective rule Ids can be found in SecurityRuleIDs. The length of the array is the same as SecurityRuleIDs and SecuritySources. <br />Possible actions are <em>unknown</em> \| <em>allow</em> \| <em>block</em> \| <em>challenge</em> \| <em>jschallenge</em> \| <em>log</em> \| <em>connectionClose</em> \| <em>challengeSolved</em> \| <em>challengeFailed</em> \| <em>challengeBypassed</em> \| <em>jschallengeSolved</em> \| <em>jschallengeFailed</em> \| <em>jschallengeBypassed</em> \| <em>bypass</em> \| <em>managedChallenge</em> \| <em>managedChallengeSkipped</em> \| <em>managedChallengeNonInteractiveSolved</em> \| <em>managedChallengeInteractiveSolved</em> \| <em>managedChallengeBypassed</em> \| <em>rewrite</em> \| <em>forceConnectionClose</em> \| <em>skip</em> \| <em>managedChallengeFailed</em>.
+
+## SecurityRuleDescription
+
+Type: string
+
+Description of the security rule that triggered a terminating action, if any.
+
+## SecurityRuleID
+
+Type: string
+
+Rule ID of the security rule that triggered a terminating action, if any.
+
+## SecurityRuleIDs
+
+Type: array[string]
+
+Array of rule IDs of the security product that matched the request. The security product associated with the rule ID can be found in SecuritySources. The length of the array is the same as SecurityActions and SecuritySources.
+
+## SecuritySources
+
+Type: array[string]
+
+Array of security products that matched the request. The same product can appear multiple times, which indicates different rules or actions that were activated. The rule IDs can be found in SecurityRuleIDs, and the actions can be found in SecurityActions. The length of the array is the same as SecurityRuleIDs and SecurityActions. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>ipRange</em> \| <em>securityLevel</em> \| <em>zoneLockdown</em> \| <em>waf</em> \| <em>firewallRules</em> \| <em>uaBlock</em> \| <em>rateLimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botFight</em> \| <em>apiShield</em> \| <em>botManagement</em> \| <em>dlp</em> \| <em>firewallManaged</em> \| <em>firewallCustom</em> \| <em>apiShieldSchemaValidation</em> \| <em>apiShieldTokenValidation</em> \| <em>apiShieldSequenceMitigation</em>.
+
+## SmartRouteColoID
+
+Type: int
+
+The Cloudflare datacenter used to connect to the origin server if Argo Smart Routing is used.
+
+## UpperTierColoID
+
+Type: int
+
+The "upper tier" datacenter that was checked for a cached copy if Tiered Cache is used.
+
+## WAFAttackScore
+
+Type: int
+
+Overall request score generated by the WAF detection module.
+
+## WAFFlags (deprecated)
+
+Type: string
+
+Additional configuration flags: <em>simulate (0x1)</em> \| <em>null</em>.
+
+## WAFMatchedVar (deprecated)
+
+Type: string
+
+The full name of the most-recently matched variable.
+
+## WAFRCEAttackScore
+
+Type: int
+
+WAF score for an RCE attack.
+
+## WAFSQLiAttackScore
+
+Type: int
+
+WAF score for an SQLi attack.
+
+## WAFXSSAttackScore
+
+Type: int
+
+WAF score for an XSS attack.
+
+## WorkerCPUTime
+
+Type: int
+
+Amount of time in microseconds spent executing a worker, if any.
+
+## WorkerStatus
+
+Type: string
+
+Status returned from worker daemon.
+
+## WorkerSubrequest
+
+Type: bool
+
+Whether or not this request was a worker subrequest.
+
+## WorkerSubrequestCount
+
+Type: int
+
+Number of subrequests issued by a worker when handling this request.
+
+## WorkerWallTimeUs
+
+Type: int
+
+The elapsed time in microseconds between the start of a Worker invocation, and when the Workers Runtime determines that no more JavaScript needs to run. Specifically, this measures the wall-clock time that the JavaScript context remained open. For example, when returning a response with a large body, the Workers runtime can, in some cases, determine that no more JavaScript needs to run, and closes the JS context before all the bytes have passed through and been sent. Alternatively, if you use the `waitUntil()` API to perform work without blocking the return of a response, this work may continue executing after the response has been returned, and will be included in `WorkerWallTimeUs`.
+
+## ZoneName
+
+Type: string
+
+The human-readable name of the zone (e.g. 'cloudflare.com').

--- a/content/logs/reference/log-fields/zone/nel_reports.md
+++ b/content/logs/reference/log-fields/zone/nel_reports.md
@@ -10,16 +10,44 @@ weight: 21
 
 The descriptions below detail the fields available for `nel_reports`.
 
-{{<table-wrap>}}
+## ClientIPASN
 
-| Field | Value | Type |
-| -- | -- | -- |
-| ClientIPASN | Client ASN. | int |
-| ClientIPASNDescription | Client ASN description. | string |
-| ClientIPCountry | Client country. | string |
-| LastKnownGoodColoCode | IATA airport code of colo client connected to. | string |
-| Phase | The phase of connection the error occurred in; <em>dns</em> \| <em>connection</em> \| <em>application</em> \| <em>unknown</em>. | string |
-| Timestamp | Timestamp for error report. | int or string |
-| Type | The type of error in the phase. | string |
+Type: int
 
-{{</table-wrap>}}
+Client ASN.
+
+## ClientIPASNDescription
+
+Type: string
+
+Client ASN description.
+
+## ClientIPCountry
+
+Type: string
+
+Client country.
+
+## LastKnownGoodColoCode
+
+Type: string
+
+IATA airport code of colo client connected to.
+
+## Phase
+
+Type: string
+
+The phase of connection the error occurred in; <em>dns</em> \| <em>connection</em> \| <em>application</em> \| <em>unknown</em>.
+
+## Timestamp
+
+Type: int or string
+
+Timestamp for error report.
+
+## Type
+
+Type: string
+
+The type of error in the phase.

--- a/content/logs/reference/log-fields/zone/page_shield_events.md
+++ b/content/logs/reference/log-fields/zone/page_shield_events.md
@@ -10,17 +10,50 @@ weight: 21
 
 The descriptions below detail the fields available for `page_shield_events`.
 
-{{<table-wrap>}}
+## Action
 
-| Field | Value | Type |
-| -- | -- | -- |
-| Action | The action which was taken against the violation. <br />Possible values are <em>log</em> \| <em>allow</em>. | string |
-| Host | The host where the resource was seen on. | string |
-| PageURL | The page URL the violation was seen on. | string |
-| PolicyID | The ID of the policy which was violated. | string |
-| Timestamp | The timestamp of when the report was received. | int or string |
-| URL | The resource URL. | string |
-| URLContainsCDNCGIPath | Whether the resource URL contains the CDN-CGI path. | bool |
-| URLHost | The domain host of the URL. | string |
+Type: string
 
-{{</table-wrap>}}
+The action which was taken against the violation. <br />Possible values are <em>log</em> \| <em>allow</em>.
+
+## Host
+
+Type: string
+
+The host where the resource was seen on.
+
+## PageURL
+
+Type: string
+
+The page URL the violation was seen on.
+
+## PolicyID
+
+Type: string
+
+The ID of the policy which was violated.
+
+## Timestamp
+
+Type: int or string
+
+The timestamp of when the report was received.
+
+## URL
+
+Type: string
+
+The resource URL.
+
+## URLContainsCDNCGIPath
+
+Type: bool
+
+Whether the resource URL contains the CDN-CGI path.
+
+## URLHost
+
+Type: string
+
+The domain host of the URL.

--- a/content/logs/reference/log-fields/zone/spectrum_events.md
+++ b/content/logs/reference/log-fields/zone/spectrum_events.md
@@ -10,40 +10,188 @@ weight: 21
 
 The descriptions below detail the fields available for `spectrum_events`.
 
-{{<table-wrap>}}
+## Application
 
-| Field | Value | Type |
-| -- | -- | -- |
-| Application | The unique public ID of the application on which the event occurred. | string |
-| ClientAsn | Client AS number. | int |
-| ClientBytes | The number of bytes read from the client by the Spectrum service. | int |
-| ClientCountry | Country of the client IP address. | string |
-| ClientIP | Client IP address. | string |
-| ClientMatchedIpFirewall | Whether the connection matched any IP Firewall rules. UNKNOWN = No match or Firewall not enabled for spectrum; <em>UNKNOWN</em> \| <em>ALLOW</em> \| <em>BLOCK_ERROR</em> \| <em>BLOCK_IP</em> \| <em>BLOCK_COUNTRY</em> \| <em>BLOCK_ASN</em> \| <em>WHITELIST_IP</em> \| <em>WHITELIST_COUNTRY</em> \| <em>WHITELIST_ASN</em>. | string |
-| ClientPort | Client port. | int |
-| ClientProto | Transport protocol used by client; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>. | string |
-| ClientTcpRtt | The TCP round-trip time in nanoseconds between the client and Spectrum. | int |
-| ClientTlsCipher | The cipher negotiated between the client and Spectrum. An unknown cipher is returned as "UNK." | string |
-| ClientTlsClientHelloServerName | The server name in the Client Hello message from client to Spectrum. | string |
-| ClientTlsProtocol | The TLS version negotiated between the client and Spectrum; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>. | string |
-| ClientTlsStatus | Indicates state of TLS session from the client to Spectrum; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>. | string |
-| ColoCode | IATA airport code of data center that received the request. | string |
-| ConnectTimestamp | Timestamp at which both legs of the connection (client/edge, edge/origin or nexthop) were established. | int or string |
-| DisconnectTimestamp | Timestamp at which the connection was closed. | int or string |
-| Event | <em>connect</em> \| <em>disconnect</em> \| <em>clientFiltered</em> \| <em>tlsError</em> \| <em>resolveOrigin</em> \| <em>originError</em>. | string |
-| IpFirewall | Whether IP Firewall was enabled at time of connection. | bool |
-| OriginBytes | The number of bytes read from the origin by Spectrum. | int |
-| OriginIP | Origin IP address. | string |
-| OriginPort | Origin port. | int |
-| OriginProto | Transport protocol used by origin; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>. | string |
-| OriginTcpRtt | The TCP round-trip time in nanoseconds between Spectrum and the origin. | int |
-| OriginTlsCipher | The cipher negotiated between Spectrum and the origin. An unknown cipher is returned as "UNK." | string |
-| OriginTlsFingerprint | SHA256 hash of origin certificate. An unknown SHA256 hash is returned as an empty string. | string |
-| OriginTlsMode | If and how the upstream connection is encrypted; <em>unknown</em> \| <em>off</em> \| <em>flexible</em> \| <em>full</em> \| <em>strict</em>. | string |
-| OriginTlsProtocol | The TLS version negotiated between Spectrum and the origin; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>. | string |
-| OriginTlsStatus | The state of the TLS session from Spectrum to the origin; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>. | string |
-| ProxyProtocol | Which form of proxy protocol is applied to the given connection; <em>off</em> \| <em>v1</em> \| <em>v2</em> \| <em>simple</em>. | string |
-| Status | A code indicating reason for connection closure. | int |
-| Timestamp | Timestamp at which the event took place. | int or string |
+Type: string
 
-{{</table-wrap>}}
+The unique public ID of the application on which the event occurred.
+
+## ClientAsn
+
+Type: int
+
+Client AS number.
+
+## ClientBytes
+
+Type: int
+
+The number of bytes read from the client by the Spectrum service.
+
+## ClientCountry
+
+Type: string
+
+Country of the client IP address.
+
+## ClientIP
+
+Type: string
+
+Client IP address.
+
+## ClientMatchedIpFirewall
+
+Type: string
+
+Whether the connection matched any IP Firewall rules. UNKNOWN = No match or Firewall not enabled for spectrum; <em>UNKNOWN</em> \| <em>ALLOW</em> \| <em>BLOCK_ERROR</em> \| <em>BLOCK_IP</em> \| <em>BLOCK_COUNTRY</em> \| <em>BLOCK_ASN</em> \| <em>WHITELIST_IP</em> \| <em>WHITELIST_COUNTRY</em> \| <em>WHITELIST_ASN</em>.
+
+## ClientPort
+
+Type: int
+
+Client port.
+
+## ClientProto
+
+Type: string
+
+Transport protocol used by client; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>.
+
+## ClientTcpRtt
+
+Type: int
+
+The TCP round-trip time in nanoseconds between the client and Spectrum.
+
+## ClientTlsCipher
+
+Type: string
+
+The cipher negotiated between the client and Spectrum. An unknown cipher is returned as "UNK."
+
+## ClientTlsClientHelloServerName
+
+Type: string
+
+The server name in the Client Hello message from client to Spectrum.
+
+## ClientTlsProtocol
+
+Type: string
+
+The TLS version negotiated between the client and Spectrum; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>.
+
+## ClientTlsStatus
+
+Type: string
+
+Indicates state of TLS session from the client to Spectrum; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>.
+
+## ColoCode
+
+Type: string
+
+IATA airport code of data center that received the request.
+
+## ConnectTimestamp
+
+Type: int or string
+
+Timestamp at which both legs of the connection (client/edge, edge/origin or nexthop) were established.
+
+## DisconnectTimestamp
+
+Type: int or string
+
+Timestamp at which the connection was closed.
+
+## Event
+
+Type: string
+
+<em>connect</em> \| <em>disconnect</em> \| <em>clientFiltered</em> \| <em>tlsError</em> \| <em>resolveOrigin</em> \| <em>originError</em>.
+
+## IpFirewall
+
+Type: bool
+
+Whether IP Firewall was enabled at time of connection.
+
+## OriginBytes
+
+Type: int
+
+The number of bytes read from the origin by Spectrum.
+
+## OriginIP
+
+Type: string
+
+Origin IP address.
+
+## OriginPort
+
+Type: int
+
+Origin port.
+
+## OriginProto
+
+Type: string
+
+Transport protocol used by origin; <em>tcp</em> \| <em>udp</em> \| <em>unix</em>.
+
+## OriginTcpRtt
+
+Type: int
+
+The TCP round-trip time in nanoseconds between Spectrum and the origin.
+
+## OriginTlsCipher
+
+Type: string
+
+The cipher negotiated between Spectrum and the origin. An unknown cipher is returned as "UNK."
+
+## OriginTlsFingerprint
+
+Type: string
+
+SHA256 hash of origin certificate. An unknown SHA256 hash is returned as an empty string.
+
+## OriginTlsMode
+
+Type: string
+
+If and how the upstream connection is encrypted; <em>unknown</em> \| <em>off</em> \| <em>flexible</em> \| <em>full</em> \| <em>strict</em>.
+
+## OriginTlsProtocol
+
+Type: string
+
+The TLS version negotiated between Spectrum and the origin; <em>unknown</em> \| <em>none</em> \| <em>SSLv3</em> \| <em>TLSv1</em> \| <em>TLSv1.1</em> \| <em>TLSv1.2</em> \| <em>TLSv1.3</em>.
+
+## OriginTlsStatus
+
+Type: string
+
+The state of the TLS session from Spectrum to the origin; <em>UNKNOWN</em> \| <em>OK</em> \| <em>INTERNAL_ERROR</em> \| <em>INVALID_CONFIG</em> \| <em>INVALID_SNI</em> \| <em>HANDSHAKE_FAILED</em> \| <em>KEYLESS_RPC</em>.
+
+## ProxyProtocol
+
+Type: string
+
+Which form of proxy protocol is applied to the given connection; <em>off</em> \| <em>v1</em> \| <em>v2</em> \| <em>simple</em>.
+
+## Status
+
+Type: int
+
+A code indicating reason for connection closure.
+
+## Timestamp
+
+Type: int or string
+
+Timestamp at which the event took place.


### PR DESCRIPTION
This should hopefully fix any issues we were having with the table layouts as well as enabling users to now link directly to a specific field using HTML anchor tags.

![Screenshot 2024-05-31 at 8 44 57 AM](https://github.com/cloudflare/cloudflare-docs/assets/10947617/7088c0b9-fe87-4623-a1b6-58c14daf2e7f)
