### PR TITLE
Update language-support-and-tools.md

### DIFF
--- a/content/pages/configuration/language-support-and-tools.md
+++ b/content/pages/configuration/language-support-and-tools.md
@@ -46,6 +46,8 @@ Many common tools have been preinstalled in the Cloudflare Pages build environme
 
 If you want to set a specific version of a framework your Cloudflare Pages project is using, note that Pages will respect your package manager of choice during your build process. For example, if you use Gatsby, your `package.json` should indicate a version of the `gatsby` npm package, which will be installed using `npm install` as your project builds on Cloudflare Pages.
 
+Please note that the presence of `package.json` or `package-lock.json` would cause `npm install` to be ran. If you don't want `npm install` run automatically, you should consider removing  `package.json` and `package-lock.json`. 
+
 ## Build environment
 
 Cloudflare Pages builds are run in a [gVisor](https://gvisor.dev/docs/) container.


### PR DESCRIPTION
added this:

```
Please note that the presence of `package.json` or `package-lock.json` would cause `npm install` to be ran. If you don't want `npm install` run automatically, you should consider removing  `package.json` and `package-lock.json`. 
```

Mainly I got a customer asking why git integration is trying to run npm install and build routines even though they have specified python version and mkdocs build commands and scoped directories to only the mkdocs directory. Found out that they have package.json and package-lock.json there for something that has nothing to do with cloudflare pages or the mkdocs build process. mkdocs reads other parts of their shared code to build documentation.