### PR TITLE
fix: replace deprecated SDK usage with updated methods

### DIFF
--- a/content/r2/examples/aws/aws-sdk-go.md
+++ b/content/r2/examples/aws/aws-sdk-go.md
@@ -29,14 +29,7 @@ func main() {
 	var accessKeyId = "<access_key_id>"
 	var accessKeySecret = "<access_key_secret>"
 
-	r2Resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		return aws.Endpoint{
-			URL: fmt.Sprintf("https://%s.r2.cloudflarestorage.com", accountId),
-		}, nil
-	})
-
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithEndpointResolverWithOptions(r2Resolver),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyId, accessKeySecret, "")),
 		config.WithRegion("auto"),
 	)
@@ -44,7 +37,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client := s3.NewFromConfig(cfg)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(fmt.Sprintf("https://%s.r2.cloudflarestorage.com", accountId))
+	})
 
 	listObjectsOutput, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
 		Bucket: &bucketName,


### PR DESCRIPTION
ref: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/#with-baseendpoint