### PR TITLE
[Pages] Sourcemaps support for Pages

### DIFF
--- a/content/pages/functions/debugging-and-logging.md
+++ b/content/pages/functions/debugging-and-logging.md
@@ -60,7 +60,14 @@ The output of each `wrangler pages deployment tail` log is a structured JSON obj
 {
   "outcome": "ok",
   "scriptName": null,
-  "exceptions": [],
+  "exceptions": [
+    {
+      "stack": "    at src/routes/index.tsx17:4\n    at new Promise (<anonymous>)\n",
+      "name": "Error",
+      "message": "An error has occurred",
+      "timestamp": 1668542036110
+    }
+  ],
   "logs": [],
   "eventTimestamp": 1668542036104,
   "event": {
@@ -98,3 +105,15 @@ The following limits apply to Functions logs:
 * Logs will not display if the Function’s requests per second are over 100 for the last five minutes.
 * Logs from any [Durable Objects](/pages/functions/bindings/#durable-objects) your Functions bind to will show up in the Cloudflare dashboard.
 * A maximum of 10 clients can view a deployment’s logs at one time. This can be a combination of either dashboard sessions or `wrangler pages deployment tail` calls.
+
+## Sourcemaps
+
+If you're debugging an uncaught exception, you might find that the [stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) in your logs contain line numbers to generated JavaScript files. Using Pages' support for [source maps](https://web.dev/articles/source-maps) you can get stack traces that match with the line numbers and symbols of your original source code.
+
+{{<Aside type="note">}}
+
+When developing full stack applications, many build tools (including wrangler for Pages Functions and most fullstack frameworks) will generate source maps for both the client and server, ensure your build step is configured to only emit server sourcemaps or use an additional build step to remove the client source maps. Public source maps might expose the source code of your application to the user.
+
+{{</Aside>}}
+
+Refer to [Source maps and stack traces](/pages/functions/source-maps/) for an in-depth explanation.

--- a/content/pages/functions/debugging-and-logging.md
+++ b/content/pages/functions/debugging-and-logging.md
@@ -112,7 +112,7 @@ If you're debugging an uncaught exception, you might find that the [stack traces
 
 {{<Aside type="note">}}
 
-When developing full stack applications, many build tools (including wrangler for Pages Functions and most fullstack frameworks) will generate source maps for both the client and server, ensure your build step is configured to only emit server sourcemaps or use an additional build step to remove the client source maps. Public source maps might expose the source code of your application to the user.
+When developing fullstack applications, many build tools (including wrangler for Pages Functions and most fullstack frameworks) will generate source maps for both the client and server, ensure your build step is configured to only emit server sourcemaps or use an additional build step to remove the client source maps. Public source maps might expose the source code of your application to the user.
 
 {{</Aside>}}
 

--- a/content/pages/functions/source-maps.md
+++ b/content/pages/functions/source-maps.md
@@ -1,0 +1,41 @@
+---
+pcx_content_type: configuration
+title: Source maps and stack traces
+meta:
+  description: Adding source maps and generating stack traces for Pages. 
+---
+{{<heading-pill style="beta">}}Source maps and stack traces{{</heading-pill>}}
+
+{{<render file="_source-maps.md" productFolder="workers">}}
+
+{{<Aside type="warning">}}
+
+Support for uploading source maps for Pages is available now in open beta. Minimum required Wrangler version: 3.60.0. 
+
+{{</Aside>}}
+
+## Source Maps
+
+To enable source maps, provide the `--upload-source-maps` flag to [`wrangler pages deploy`](/workers/wrangler/commands/#deploy-1) or add the following to your Pages application's [`wrangler.toml`](/pages/functions/wrangler-configuration/) file if you are using the Pages build environment:
+
+```toml
+upload_source_maps = true 
+```
+
+When uploading source maps is enabled, Wrangler will automatically generate and upload source map files when you run [`wrangler pages deploy`](/workers/wrangler/commands/#deploy-1).
+
+## Stack traces
+​​
+When your application throws an uncaught exception, we fetch the source map and use it to map the stack trace of the exception back to lines of your application’s original source code. 
+
+You can then view the stack trace when streaming [real-time logs]/pages/functions/debugging-and-logging/).
+
+{{<Aside type="note">}}
+
+The source map is retrieved after your Pages Function invocation completes — it's an asynchronous process that does not impact your applications's CPU utilization or performance. Source maps are not accessible inside the application at runtime, if you `console.log()` the [stack property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack), you will not get a deobfuscated stack trace. 
+
+{{</Aside>}}
+
+## Related resources
+
+* [Real-time logs](/pages/functions/debugging-and-logging/) - Learn how to capture Pages logs in real-time.

--- a/content/pages/functions/source-maps.md
+++ b/content/pages/functions/source-maps.md
@@ -28,7 +28,7 @@ When uploading source maps is enabled, Wrangler will automatically generate and 
 ​​
 When your application throws an uncaught exception, we fetch the source map and use it to map the stack trace of the exception back to lines of your application’s original source code. 
 
-You can then view the stack trace when streaming [real-time logs]/pages/functions/debugging-and-logging/).
+You can then view the stack trace when streaming [real-time logs](/pages/functions/debugging-and-logging/).
 
 {{<Aside type="note">}}
 

--- a/content/pages/functions/wrangler-configuration.md
+++ b/content/pages/functions/wrangler-configuration.md
@@ -330,6 +330,9 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 
   - Specify how Pages Functions should be located to minimize round-trip time. Refer to [Smart Placement](/workers/configuration/smart-placement/).
 
+- `upload_source_maps` {{<type>}}boolean{{</type>}}
+
+  - When `upload_source_maps` is set to `true`, Wrangler will upload any server-side source maps part of your Pages project to give corrected stack traces in logs.
 {{</definitions>}}
 
 ## Non-inheritable keys

--- a/content/workers/_partials/_source-maps.md
+++ b/content/workers/_partials/_source-maps.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+[Stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) help with debugging your code when your application encounters an unhandled exception. Stack traces show you the specific functions that were called, in what order, from which line and file, and with what arguments.
+
+Most JavaScript code is first bundled, often transpiled, and then minified before being deployed to production. This process creates smaller bundles to optimize performance and converts code from Typescript to Javascript if needed.
+
+Source maps translate compiled and minified code back to the original code that you wrote. Source maps are combined with the stack trace returned by the JavaScript runtime to present you with a stack trace.

--- a/content/workers/observability/source-maps.md
+++ b/content/workers/observability/source-maps.md
@@ -6,11 +6,7 @@ meta:
 ---
 {{<heading-pill style="beta">}}Source maps and stack traces{{</heading-pill>}}
 
-[Stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) help with debugging your code when the Worker encounters an unhandled exception. Stack traces show you the specific functions that were called, in what order, from which line and file, and with what arguments.
-
-Most JavaScript code – not just on Workers, but across platforms – is first bundled, often transpiled, and then minified before being deployed to production. This process creates smaller bundles to optimize performance and converts code from Typescript to Javascript if needed.
-
-Source maps translate compiled and minified code back to the original code that you wrote. Source maps are combined with the stack trace returned by the JavaScript runtime to present you with a stack trace.
+{{<render file="_source-maps.md" productFolder="workers">}}
 
 {{<Aside type="warning">}}
 


### PR DESCRIPTION
- Documents new sourcemap functionality for pages
- Copies the Worker-specific sourcemap explanation to Pages with updates to keep consistent with the differences between support with Workers/Pages.