### PR TITLE
Update _create-hyperdrive-config.md to document variable in bash script

### DIFF
--- a/content/hyperdrive/_partials/_create-hyperdrive-config.md
+++ b/content/hyperdrive/_partials/_create-hyperdrive-config.md
@@ -20,10 +20,10 @@ postgres://USERNAME:PASSWORD@HOSTNAME_OR_IP_ADDRESS:PORT/database_name
 
 Most database providers will provide a connection string you can directly copy-and-paste directly into Hyperdrive.
 
-To create a Hyperdrive configuration with the [Wrangler CLI](/workers/wrangler/install-and-update/), open your terminal and run the following command, pasting the connection string provided from your database host, or replacing `user`, `password`, `HOSTNAME_OR_IP_ADDRESS`, `port`, and `database_name` placeholders with those specific to your database:
+To create a Hyperdrive configuration with the [Wrangler CLI](/workers/wrangler/install-and-update/), open your terminal and run the following command. Replace <NAME_OF_HYPERDRIVE_CONFIG> with a name for your Hyperdrive configuration and paste the connection string provided from your database host, or replace `user`, `password`, `HOSTNAME_OR_IP_ADDRESS`, `port`, and `database_name` placeholders with those specific to your database:
 
 ```sh
-$ npx wrangler hyperdrive create $NAME --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
+$ npx wrangler hyperdrive create <NAME_OF_HYPERDRIVE_CONFIG> --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
 ```
 
 {{<Aside type="note">}}
@@ -44,7 +44,7 @@ compatibility_date = "2023-09-11"
 
 node_compat = true # required for database drivers to function
 
-# Pasted from the output of `wrangler hyperdrive create $NAME --connection-string=[...]` above.
+# Pasted from the output of `wrangler hyperdrive create <NAME_OF_HYPERDRIVE_CONFIG> --connection-string=[...]` above.
 [[hyperdrive]]
 binding = "HYPERDRIVE"
 id = ""


### PR DESCRIPTION
We should document the variable $NAME currently used in our scripts in Hyperdrive docs. When following the tutorial, it's not written that this variable needs to be replaced with a desired name for the Hyperdrive configuration, only that the connection string should be replaced. As a result, you end up with an error in your script and have to debug/read the error to figure out what to change. Noting down the need to replace $NAME (which I propose renaming to <NAME_OF_HYPERDRIVE_CONFIG> in the absence of env var setting) would help avoid errors in the tutorial flow.

<img width="735" alt="Screenshot 2024-06-04 at 12 39 33 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/35609369/c2eb3ca2-9d8f-437d-b30a-dc34776f233e">

I am open to setting $NAME as a variable but that opens us up to the split behavior of setting env vars in Windows vs MacOS. 