### PR TITLE
Remove the outdated note of early hints

### DIFF
--- a/content/workers/examples/103-early-hints.md
+++ b/content/workers/examples/103-early-hints.md
@@ -22,12 +22,6 @@ To ensure Early Hints are enabled on your zone:
 2. Go to **Speed** > **Optimization** > **Content Optimization**.
 3. Enable the **Early Hints** toggle to on.
 
-{{<Aside type="note">}}
-
-Currently, `103 Early Hints` are only supported in Chrome 103 or later. To view up-to-date information on which browsers support Early Hints, refer to [caniuse.com](https://caniuse.com/mdn-http_status_103).
-
-{{</Aside>}}
-
 You can return `Link` headers from a Worker running on your zone to speed up your page load times.
 
 {{<tabs labels="js | ts | py">}}


### PR DESCRIPTION
Early hints are now widely supported: https://caniuse.com/mdn-http_status_103

Remove the note to prevent users to underestimate the value of  early hints.