### PR TITLE
docs: clarify `persist` values

### DIFF
--- a/content/workers/wrangler/api.md
+++ b/content/workers/wrangler/api.md
@@ -278,7 +278,7 @@ const platform = await getPlatformProxy(options);
 
         * `persist` {{<type>}}boolean | { path: string }{{</type>}}
 
-          Indicates if and where to persist the bindings data. If not present or `true`, defaults to the same location used by Wrangler, so data can be shared between it and the caller. If `false`, no data is persisted to or read from the filesystem.
+          Indicates if and where to persist the bindings data. If `true` or `undefined`, defaults to the same location used by Wrangler, so data can be shared between it and the caller. If `false`, no data is persisted to or read from the filesystem.
 
           **Note:** If you use `wrangler`'s `--persist-to` option, note that this option adds a sub directory called `v3` under the hood while `getPlatformProxy`'s `persist` does not. For example, if you run `wrangler dev --persist-to ./my-directory`, to reuse the same location using `getPlatformProxy`, you will have to specify: `persist: "./my-directory/v3"`.
 


### PR DESCRIPTION
"not present or true" is confusing because I don't know if "not" applies only to "present" or also to "true"