### PR TITLE
[Stream] Fix asides in Stream Player API

### DIFF
--- a/content/stream/viewing-videos/using-the-stream-player/using-the-player-api.md
+++ b/content/stream/viewing-videos/using-the-stream-player/using-the-player-api.md
@@ -60,11 +60,11 @@ To use this SDK, add an additional `<script>` tag to your website:
 
   - Sets or returns whether the autoplay attribute was set, allowing video playback to start upon load.
 
-    {{<Aside>}}
+{{<Aside>}}
 
 Some browsers prevent videos with audio from playing automatically. You may add the `mute` attribute to allow your videos to autoplay. For more information, review the [iOS video policies](https://webkit.org/blog/6784/new-video-policies-for-ios/).
 
-    {{</Aside>}}
+{{</Aside>}}
 
 - `buffered` {{<type-link href="https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges">}}TimeRanges{{</type-link>}} {{<prop-meta>}}readonly{{</prop-meta>}}
 
@@ -82,11 +82,11 @@ Some browsers prevent videos with audio from playing automatically. You may add 
 
   - Will initialize the player with the specified language code's text track enabled. The value should be the BCP-47 language code that was used to [upload the text track](/stream/edit-videos/adding-captions/). If the specified language code has no captions available, the player will behave as though no language code had been provided.
 
-    {{<Aside>}}
+{{<Aside>}}
 
 This will _only_ work once during initialization. Beyond that point the user has full control over their text track settings.
 
-      {{</Aside>}}
+{{</Aside>}}
 
 - `duration` {{<type>}}integer{{</type>}} {{<prop-meta>}}readonly{{</prop-meta>}}
 
@@ -120,11 +120,11 @@ This will _only_ work once during initialization. Beyond that point the user has
 
   - Sets or returns whether the video should be preloaded upon element load.
 
-    {{<Aside>}}
+{{<Aside>}}
 
 The `<video>` element does not force the browser to follow the value of this attribute; it is a mere hint. Even though the `preload="none"` option is a valid HTML5 attribute, Stream player will always load some metadata to initialize the player. The amount of data loaded in this case is negligible.
 
-    {{</Aside>}}
+{{</Aside>}}
 
 - `primaryColor` {{<type>}}string{{</type>}}
 


### PR DESCRIPTION
Fixes bad rendering due to indentation quirks

Before:
<img width="723" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/0db751d4-c960-4981-a724-fed7826dfc58">

After:
<img width="720" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/488c983a-7562-4f52-b698-77b90d1843a0">
