### PR TITLE
[Workers] Add a section to Wrangler configuration for top-level only keys

### DIFF
--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -52,6 +52,28 @@ These are defined under `[env.name]` keys, such as `[env.staging]` which you can
 
 The majority of keys are inheritable, meaning that top-level configuration can be used in environments. [Bindings](/workers/runtime-apis/bindings/), such as `vars` or `kv_namespaces`, are not inheritable and need to be defined explicitly.
 
+Further, there are a few keys that can *only* appear at the top-level.
+
+## Top-level only keys
+
+Top-level keys apply to the Worker as a whole (and therefore all environments). They cannot be defined within named environments.
+
+{{<definitions>}}
+
+- `keep_vars` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - Whether Wrangler should keep variables configured in the dashboard on deploy. Refer to [source of truth](#source-of-truth).
+
+- `send_metrics` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - Whether Wrangler should send usage metrics to Cloudflare for this project.
+
+- `site` {{<type>}}object{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - See the [Workers Sites](#workers-sites) section below for more information. Cloudflare Pages is preferred over this approach.
+
+{{</definitions>}}
+
 ## Inheritable keys
 
 Inheritable keys are configurable at the top-level, and can be inherited (or overridden) by environment-specific configuration.
@@ -127,14 +149,6 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
   - Determines whether Wrangler will preserve the file names of additional modules bundled with the Worker.
     The default is to prepend filenames with a content hash.
     For example, `34de60b44167af5c5a709e62a4e20c4f18c9e3b6-favicon.ico`.
-
-- `send_metrics` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-
-  - Whether Wrangler should send usage metrics to Cloudflare for this project.
-
-- `keep_vars` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-
-  - Whether Wrangler should keep variables configured in the dashboard on deploy. Refer to [source of truth](#source-of-truth).
 
 - `logpush` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 


### PR DESCRIPTION
Some keys in the inheritable section are not actually inheritable.