### PR TITLE
[Docs Site] Style triple-quoted strings properly

### DIFF
--- a/static/codeBlock.css
+++ b/static/codeBlock.css
@@ -334,7 +334,8 @@
 .CodeBlock--token-object-property,
 .CodeBlock--token-regex,
 .CodeBlock--token-string,
-.CodeBlock--token-template-string {
+.CodeBlock--token-template-string,
+.CodeBlock--token-triple-quoted-string {
   color: var(--code-gold);
 }
 


### PR DESCRIPTION
Improves styling of triple-quoted strings, i.e in one of our Python examples:

Before:
![image](https://github.com/cloudflare/cloudflare-docs/assets/94662631/af0429fd-8b42-4229-8f58-0489ba6bffb4)

After:
![image](https://github.com/cloudflare/cloudflare-docs/assets/94662631/dd27f156-4c63-4795-9676-78c5a907929a)
