### PR TITLE
[R2] Add links to all presigned URL examples

### DIFF
--- a/content/r2/api/s3/presigned-urls.md
+++ b/content/r2/api/s3/presigned-urls.md
@@ -56,11 +56,7 @@ R2 currently supports the following methods when generating a presigned URL:
 
 Generate a presigned URL by referring to the following examples:
 
-- [AWS SDK for Go](/r2/examples/aws/aws-sdk-go/#generate-presigned-urls)
-- [AWS SDK for JS v3](/r2/examples/aws/aws-sdk-js-v3/#generate-presigned-urls)
-- [AWS SDK for JS](/r2/examples/aws/aws-sdk-js/#generate-presigned-urls)
-- [AWS SDK for PHP](/r2/examples/aws/aws-sdk-php/#generate-presigned-urls)
-- [AWS CLI](/r2/examples/aws/aws-cli/#generate-presigned-urls)
+{{<resource-by-tag tags="r2-presigned-url" resource_type="configuration">}}
 
 ## Presigned URL alternative with Workers
 

--- a/content/r2/buckets/cors.md
+++ b/content/r2/buckets/cors.md
@@ -73,6 +73,12 @@ Test the presigned URL by uploading an object using cURL. The example below woul
 $ curl -X PUT <URL> -H "Content-Type: text/plain" -d "123"
 ```
 
+### Generating presigned URLs with other languages and tools
+
+Take a look at our other examples for generating presigned URLs.
+
+{{<resource-by-tag tags="r2-presigned-url" resource_type="configuration">}}
+
 ## Add CORS policies from the dashboard
 
 1. From the Cloudflare dashboard, select **R2**.

--- a/content/r2/examples/aws/aws-cli.md
+++ b/content/r2/examples/aws/aws-cli.md
@@ -1,6 +1,7 @@
 ---
 title: aws CLI
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws` CLI for R2

--- a/content/r2/examples/aws/aws-sdk-go.md
+++ b/content/r2/examples/aws/aws-sdk-go.md
@@ -1,6 +1,7 @@
 ---
 title: aws-sdk-go
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws-sdk-go` for R2 

--- a/content/r2/examples/aws/aws-sdk-js-v3.md
+++ b/content/r2/examples/aws/aws-sdk-js-v3.md
@@ -1,6 +1,7 @@
 ---
 title: aws-sdk-js-v3
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws-sdk-js-v3` for R2 

--- a/content/r2/examples/aws/aws-sdk-js.md
+++ b/content/r2/examples/aws/aws-sdk-js.md
@@ -1,6 +1,7 @@
 ---
 title: aws-sdk-js
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws-sdk-js` for R2

--- a/content/r2/examples/aws/aws-sdk-net.md
+++ b/content/r2/examples/aws/aws-sdk-net.md
@@ -1,6 +1,7 @@
 ---
 title: aws-sdk-net
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws-sdk-net` for R2
@@ -110,6 +111,9 @@ static async Task GetObject()
 The [GetPreSignedURL](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/MIS3GetPreSignedURLGetPreSignedUrlRequest.html) method allows you to sign ahead of time, giving temporary access to a specific operation. In this case, presigning a `PutObject` request for `sdk-example/file.txt`.
 
 ```csharp
+---
+highlight: [3]
+---
 static string? GeneratePresignedUrl()
 {
 	AWSConfigsS3.UseSignatureVersion4 = true;

--- a/content/r2/examples/aws/aws-sdk-php.md
+++ b/content/r2/examples/aws/aws-sdk-php.md
@@ -2,6 +2,7 @@
 title: aws-sdk-php
 summary: Example of how to configure `aws-sdk-php` to use R2.
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `aws-sdk-php` for R2

--- a/content/r2/examples/rclone.md
+++ b/content/r2/examples/rclone.md
@@ -1,6 +1,7 @@
 ---
 title: rclone
 pcx_content_type: configuration
+tags: [r2-presigned-url]
 ---
 
 # Configure `rclone` for R2

--- a/content/use-cases/ai.md
+++ b/content/use-cases/ai.md
@@ -16,7 +16,7 @@ Build and deploy ambitious AI applications to Cloudflare's global network.
 
 Diagrams, design patterns, and detailed best practices to help you generate solutions with Cloudflare products.
 
-{{<resource-by-tag tags="AI" resource_type="reference-architecture,design-guide,reference-architecture-diagram">}}
+{{<resource-by-tag tags="AI" resource_type="reference-architecture,design-guide,reference-architecture-diagram" showDescriptions="true">}}
 
 ## Demo apps
 
@@ -26,7 +26,7 @@ Diagrams, design patterns, and detailed best practices to help you generate solu
 
 Step-by-step guides to help you build and learn.
 
-{{<resource-by-tag tags="AI" resource_type="tutorial">}}
+{{<resource-by-tag tags="AI" resource_type="tutorial" showDescriptions="true">}}
 
 ## Customer spotlights
 
@@ -36,7 +36,7 @@ Explore case studies on [AI companies building on Cloudflare](https://workers.cl
 
 Examples ready to copy and paste.
 
-{{<resource-by-tag tags="AI" resource_type="example">}}
+{{<resource-by-tag tags="AI" resource_type="example" showDescriptions="true">}}
 
 {{<Aside type="note">}}
 

--- a/layouts/shortcodes/resource-by-tag.html
+++ b/layouts/shortcodes/resource-by-tag.html
@@ -1,15 +1,19 @@
 {{- $tags := split (lower (.Get "tags")) "," -}}
 {{- $resource_type := split (.Get "resource_type") "," -}}
+{{- $showDescriptions := default false (.Get "showDescriptions") -}}
 
 <ul>
-  {{ range $index, $siteTag := .Site.Taxonomies.tags }}
-  {{ if in $tags $index -}}
-  {{ range $siteTag }}
-  {{ if in $resource_type .Params.pcx_content_type}}
-  {{ $string := printf "[%s](%s): %s" .Title .RelPermalink (partial "seo-meta-description.html" (dict "content" .Content "params" .Params "truncate" 500 "plainify" true ))| $.Page.RenderString}}
-  <li>{{$string}}</li>
-  {{ end }}
-  {{ end }}
-  {{ end }}
-  {{ end }}
+{{- range $index, $siteTag := .Site.Taxonomies.tags -}}
+  {{- if in $tags $index -}}
+    {{- range $siteTag -}}
+      {{- if in $resource_type .Params.pcx_content_type -}}
+        {{- $string := printf "[%s](%s)" .Title .RelPermalink -}}
+        {{- if $showDescriptions -}}
+          {{- $string = printf "%s: %s" $string (partial "seo-meta-description.html" (dict "content" .Content "params" .Params "truncate" 500 "plainify" true )) -}}
+        {{- end -}}
+        <li>{{- $string | $.Page.RenderString -}}</li>
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 </ul>


### PR DESCRIPTION
Adds links to all of the examples that contain a presigned URL section based on Discord feedback (we have some SDK-specific instructions on their examples page but don't lead users to them).

![image](https://github.com/cloudflare/cloudflare-docs/assets/94662631/07848174-3253-4eb7-b0cc-15a3e0ad0d1a)

cc @kodster28 for shortcode changes