### PR TITLE
Add Holopin

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,0 +1,9 @@
+organization: cloudflare
+stickers:
+  - id: cltg4w6r612040fl2r7vweuvv
+    alias: outstanding contribution
+
+holobytes:
+  - evolvingStickerId: cltg4rlqc39020fl51scnguhb
+    alias: contribution
+    in: true

--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -1,0 +1,15 @@
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  issue_lava_lamp_holobyte:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged }}
+    steps:
+      - run: gh pr edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.HOLOPIN_LABELER }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: contribution


### PR DESCRIPTION
Holopin is a recognition and digital badge platform that we will adopt in our cloudflare-docs and workers-sdk repositories to help show appreciation for the excellent docs contributions that we receive.

Every PR that is merged will be automatically labelled with `contribution` and a holobyte for the evolving Lava Lamp badge will be issued:

![image](https://github.com/cloudflare/workers-sdk/assets/8484333/d59567f1-6df5-4b04-bf47-5741b22bff6b)

Maintainers, if you find a contribution that you feel is truly excellent, you can manually add the `outstanding contribution` label and this will issue a special Global Contribution badge immediately:

![image](https://github.com/cloudflare/workers-sdk/assets/8484333/dd6b5e16-f48f-43f6-841a-05b8ab8e5718)

This PR adds the necessary configuration, but we still need the `HOLOPIN_LABELER` secret (a PAT — I want to use @workers-devprod) and we also still need to install the GitHub bot (cc. @rita3ko).