### PR TITLE
[Docs Site] Tab Switcher bug fixes

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -130,7 +130,7 @@ export function tabs() {
           const tabId = parts.slice(0, parts.length - 1).join("-");
 
           const defaultTabLabel = wrappers[i].querySelector(
-            `a[data-link=${tabId}]`
+            `a[data-link="${tabId}"]`
           );
 
           (defaultTab as HTMLElement).style.display = "block";

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -2,4 +2,4 @@
 {{- $default := .Get "default" -}}
 {{- $noCode := .Get "no-code" -}}
 
-<div class="tab {{ if eq $default "true" }}tab-default{{ end }} {{ if eq $noCode "true" }}noCodeTab{{ end }}" id="tab-{{ $label }}-UNIQUE_ID">{{ $.Inner | $.Page.RenderString }}</div>
+<div class="tab {{ if eq $default "true" }}tab-default{{ end }} {{ if eq $noCode "true" }}noCodeTab{{ end }}" id="tab-{{ (lower $label) }}-UNIQUE_ID">{{ $.Inner | $.Page.RenderString }}</div>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,13 +1,16 @@
-{{- $text := .Get "labels" -}} {{- $labels := split $text " | " -}}
-{{ $unique_id := substr (md5 .Inner) 0 16 }}
+{{- $text := .Get "labels" -}}
+{{- $labels := split $text " | " -}}
+{{- $unique_id := lower (substr (md5 .Inner) 0 16) -}}
 
 <div class="tabs-wrapper" tab-wrapper-id="{{$unique_id}}">
 <nav role="navigation" class="tabs">
 <ul class="tab-active" block-id="{{$unique_id}}">
-{{ range $idx, $txt := $labels }} {{- $link := replace $txt "/" "-"}}
+{{ range $idx, $txt := $labels }}
+{{- $link := replace $txt "/" "-" -}}
+{{- $dataLink := printf "tab-%s" (lower $link) }}
 <li class="tab-label-wrapper">
 {{ if (eq $link "js") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
     xmlns="http://www.w3.org/2000/svg">
 <path
@@ -19,7 +22,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "js-sw") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
         xmlns="http://www.w3.org/2000/svg">
     <title>JavaScript</title>
@@ -32,7 +35,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -45,7 +48,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts-sw") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +62,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "py") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
     <path d="M253.806,1.783c-20.678,0.098-40.426,1.859-57.803,4.935c-51.187,9.044-60.48,27.97-60.48,62.877v46.103
           h120.963v15.366H135.522H90.126c-35.155,0-65.937,21.13-75.563,61.325c-11.107,46.075-11.603,74.83,0,122.939
@@ -79,7 +82,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "js-esm") }}
-<a class="tab-label " href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label " href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
         xmlns="http://www.w3.org/2000/svg">
     <title>JavaScript</title>
@@ -92,7 +95,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts-esm") }}
-<a class="tab-label" href="#" data-link="tab-{{$link}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -106,7 +109,7 @@ JavaScript
 </a>
 
 {{ else }}
-<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="tab-{{lower $link}}" data-id="{{lower $unique_id}}">
+<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
 {{$link}}
 </a>
 {{ end }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -109,7 +109,7 @@ JavaScript
 </a>
 
 {{ else }}
-<a class="tab-label noCodeLabel {{ if eq $idx 0 }}active{{ end }}" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label noCodeLabel" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
 {{$link}}
 </a>
 {{ end }}


### PR DESCRIPTION
Fixes:
  * issue when `default` tabs contained a space since we wasn't wrapping the selector in quotes
  * issue when the `label` on a `tab` wasn't lower-cased (we `lower`'d the labels in `tabs` but not in `tab`, meaning the IDs were different case)
  * issue with `no-code` labels adding an `active` class (we handle this in client-side JS)
  
Tested on:
  * [js-ts-py labels](https://kian-pcx-11272.cloudflare-docs-7ou.pages.dev/workers/examples/return-html/)
  * [no-code labels](https://kian-pcx-11272.cloudflare-docs-7ou.pages.dev/ai-gateway/configuration/caching/)
  * [spaces + punctuation in labels](https://kian-pcx-11272.cloudflare-docs-7ou.pages.dev/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations#switch-organizations-in-warp)
  * [tabs set as explicit default](https://kian-pcx-11272.cloudflare-docs-7ou.pages.dev/hyperdrive/configuration/connect-to-postgres/#postgresjs)
  
  