### PR TITLE
[DNS] Clarify Multi-signer as the only DNSSEC option for outgoing zone transfers

### DIFF
--- a/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/_index.md
+++ b/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/_index.md
@@ -23,3 +23,5 @@ Outgoing zone transfers are available to Enterprise customers who are currently 
 ## Notes
 
 If you use [Cloudflare Load Balancing](/load-balancing/), only proxied Load Balancer DNS records will be transferred.
+
+If you wish to use [DNSSEC](/dns/dnssec/) with outgoing zone transfers, you will need to set up [Multi-signer DNSSEC](/dns/dnssec/multi-signer-dnssec/).


### PR DESCRIPTION
Currently the docs do not state which DNSSEC options are compatible with outgoing zone transfers. 