### PR TITLE
Add double quotes around values in _secrets-in-dev.md

### DIFF
--- a/content/workers/_partials/_secrets-in-dev.md
+++ b/content/workers/_partials/_secrets-in-dev.md
@@ -7,12 +7,12 @@ _build:
 
 When developing your Worker or Pages Function, create a `.dev.vars` file in the root of your project to define secrets that will be used when running `wrangler dev` or `wrangler pages dev`, as opposed to using [environment variables in `wrangler.toml`](/workers/configuration/environment-variables/#compare-secrets-and-environment-variables). This works both in local and remote development modes.
 
-The `.dev.vars` file should be formatted like a `dotenv` file, such as `KEY=VALUE`:
+The `.dev.vars` file should be formatted like a `dotenv` file, such as `KEY="VALUE"`:
 
 ```bash
 ---
 header: .dev.vars 
 ---
-SECRET_KEY=value
-API_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+SECRET_KEY="value"
+API_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 ```


### PR DESCRIPTION
Not using double quotes causes problems when the # character is part of the secret, chars after it are cut off. Repro: Add SECRET=123#456 , when read, it will return "123", SECRET="123#456" however is fine. Dotdev, which is referenced above, also uses double quotes in their docs: https://github.com/motdotla/dotenv?tab=readme-ov-file#%EF%B8%8F-usage