### PR TITLE
Access env via cloudflare object in Remix starter example

### DIFF
--- a/content/d1/examples/d1-and-remix.md
+++ b/content/d1/examples/d1-and-remix.md
@@ -39,7 +39,7 @@ interface Env {
 }
 
 export const loader: LoaderFunction = async ({ context, params }) => {
-  let env = context.env as Env;
+  let env = context.cloudflare.env as Env;
 
   let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").all();
   return json(results);


### PR DESCRIPTION
- I went through `npm create cloudflare`
- Created a new Remix app
- Followed the docs here: https://developers.cloudflare.com/d1/examples/d1-and-remix/
- `env` is undefined
- Fixed by accessing `env` via `cloudflare.env`

https://github.com/irvinebroque/remix-d1/blob/main/app/routes/_index.tsx#L10
