### PR TITLE
Link to Workers for Platforms from Workers docs

### DIFF
--- a/content/workers/platform/workers-for-platforms.md
+++ b/content/workers/platform/workers-for-platforms.md
@@ -1,0 +1,14 @@
+---
+pcx_content_type: navigation
+title: Workers for Platforms
+weight: 10
+
+external_link: /cloudflare-for-platforms/workers-for-platforms/
+_build:
+  publishResources: false
+  render: never
+
+meta:
+  description: Deploy custom code on behalf of your users or let your users directly deploy their own code to your platform, managing infrastructure.
+---
+Deploy custom code on behalf of your users or let your users directly deploy their own code to your platform, managing infrastructure.


### PR DESCRIPTION
Could consider linking to Workers for Platforms from top-level, but for now, think this is appropriate place for top-level link?