### PR TITLE
Add alternative WARP download links

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/download-warp/_index.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/download-warp/_index.md
@@ -18,6 +18,8 @@ Alternatively, download the client from one of the following links after checkin
 
 **[Windows Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-windows/distribution_groups/beta)**
 
+**[Alternate download link](https://one.one.one.one)**
+
 ## macOS
 
 {{<render file="warp/system-requirements/_macOS.md">}}
@@ -25,6 +27,8 @@ Alternatively, download the client from one of the following links after checkin
 **[macOS Release Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-macos-1/distribution_groups/release)**
 
 **[macOS Beta Builds](https://install.appcenter.ms/orgs/cloudflare/apps/1.1.1.1-macos/distribution_groups/beta)**
+
+**[Alternate download link](https://one.one.one.one)**
 
 ## Linux
 


### PR DESCRIPTION
Microsoft AppCenter is down, so add alternative WARP download links from one.one.one.one 