### PR TITLE
[RPC] documentation update on fully consuming Response streams before use

### DIFF
--- a/content/workers/runtime-apis/rpc/_index.md
+++ b/content/workers/runtime-apis/rpc/_index.md
@@ -218,9 +218,9 @@ Only [byte-oriented streams](https://developer.mozilla.org/en-US/docs/Web/API/St
 
 In all cases, ownership of the stream is transferred to the recipient. The sender can no longer read/write the stream after sending it. If the sender wishes to keep its own copy, it can use the [`tee()` method of `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee) or the [`clone()` method of `Request` or `Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone). Keep in mind that doing this may force the system to buffer bytes and lose the benefits of flow control.
 
-### Note:
-
+{{<Aside type="note" description="Fully consume response objects">}}
 When handling `Response` objects, fully consume the response using `.text()`, `.json()`, or `.blob()` before logging or utilizing it further. This ensures the stream is not closed prematurely in asynchronous contexts like queue processing.
+{{</Aside>}}
 
 ## Forwarding RPC stubs
 

--- a/content/workers/runtime-apis/rpc/_index.md
+++ b/content/workers/runtime-apis/rpc/_index.md
@@ -218,6 +218,10 @@ Only [byte-oriented streams](https://developer.mozilla.org/en-US/docs/Web/API/St
 
 In all cases, ownership of the stream is transferred to the recipient. The sender can no longer read/write the stream after sending it. If the sender wishes to keep its own copy, it can use the [`tee()` method of `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee) or the [`clone()` method of `Request` or `Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone). Keep in mind that doing this may force the system to buffer bytes and lose the benefits of flow control.
 
+### Note:
+
+When handling `Response` objects, fully consume the response using `.text()`, `.json()`, or `.blob()` before logging or utilizing it further. This ensures the stream is not closed prematurely in asynchronous contexts like queue processing.
+
 ## Forwarding RPC stubs
 
 A stub received over RPC from one Worker can be forwarded over RPC to another Worker.


### PR DESCRIPTION
I have added a note to the documentation emphasizing the importance of fully consuming Response objects using methods like .text(), .json(), or .blob() before logging or further utilization. This ensures the response stream is not closed prematurely, particularly in asynchronous contexts such as queue processing.

issue: https://discord.com/channels/595317990191398933/1247472256267980811

tested: https://github.com/draphy/cloudflare-rpc-test
