### PR TITLE
Add filename for JavaScript example on tutorial archetype

### DIFF
--- a/archetypes/tutorial.md
+++ b/archetypes/tutorial.md
@@ -51,7 +51,7 @@ Once you run the command, set up a basic Worker by selecting the following optio
 
 ```js
 ---
-filename: src/testJavaScriptFile.js
+filename: src/index.js
 ---
 export default {
   async fetch(request, env, ctx) {

--- a/archetypes/tutorial.md
+++ b/archetypes/tutorial.md
@@ -50,6 +50,9 @@ Once you run the command, set up a basic Worker by selecting the following optio
 (JavaScript example)
 
 ```js
+---
+filename: src/testJavaScriptFile.js
+---
 export default {
   async fetch(request, env, ctx) {
     return new Response("Hello World!");

--- a/archetypes/tutorial.md
+++ b/archetypes/tutorial.md
@@ -6,7 +6,7 @@ updated: '{{ time.Now.Format "2006-01-02" }}'
 title: '{{ replace .File.ContentBaseName `-` ` ` | title }}'
 ---
 
-# Tutorial title. Second-person imperative verb phrase that reflects user goal or job-to-be-done
+# # Tutorial title. Second-person imperative verb phrase that reflects user goal or job-to-be-done. For example, 'Create a Worker' or 'Build a Pages application'.
 
 {{<tutorial-date-info>}}
 


### PR DESCRIPTION
The tutorial archetype doesn't currently include the filename for code blocks. Adding this in for the Developer Spotlight program.