### PR TITLE
Only issue holobytes for external contributors

### DIFF
--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -11,7 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged }}
     steps:
-      - run: gh pr edit "$NUMBER" --add-label "$LABELS"
+      - id: check_if_contributor_is_external
+        name: Check if contributor is external
+        run: 'curl --write-out ''%{http_code}'' --silent --output /dev/null -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ env.GH_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/cloudflare/members/${{ github.event.pull_request.user.login }} | grep -q ''204'' && echo "is_external=false" >> $GITHUB_OUTPUT || echo "is_external=true" >> $GITHUB_OUTPUT'
+        env:
+          GH_TOKEN: ${{ secrets.HOLOPIN_LABELER }}
+      - name: Issue Lava Lamp Holobyte
+        run: gh pr edit "$NUMBER" --add-label "$LABELS"
+        if: steps.check_if_contributor_is_external.outputs.is_external == 'true'
         env:
           GH_TOKEN: ${{ secrets.HOLOPIN_LABELER }}
           GH_REPO: ${{ github.repository }}
@@ -22,7 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'outstanding contribution'
     steps:
-      - run: gh pr edit "$NUMBER" --add-label "$LABELS"
+      - name: Issue Global Contribution badge
+        run: gh pr edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.HOLOPIN_LABELER }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Untested, but I think this will skip issuing a holobyte for Cloudflare org members, which should reduce noise for frequent maintainers.