### PR TITLE
Update AutoTrain colab link

### DIFF
--- a/content/workers-ai/tutorials/fine-tune-models-with-autotrain.md
+++ b/content/workers-ai/tutorials/fine-tune-models-with-autotrain.md
@@ -43,7 +43,7 @@ Different models, like Mistral, will provide a specific [chat template/instructi
 
 ## 2. Configure the HuggingFace Autotrain Advanced Notebook
 
-Open the [HuggingFace Autotrain Advanced Notebook](https://colab.research.google.com/github/huggingface/autotrain-advanced/blob/main/colabs/AutoTrain_LLM.ipynb)
+Open the [HuggingFace Autotrain Advanced Notebook](https://colab.research.google.com/github/huggingface/autotrain-advanced/blob/main/colabs/AutoTrain.ipynb)
 
 In order to give your AutoTrain ample memory, you will need to need to choose a different Runtime. From the menu at the top of the Notebook choose Runtime > Change Runtime Type. Choose A100.
 
@@ -70,7 +70,7 @@ Although not required to use AutoTrain, creating a [HuggingFace account](https:/
 
 If you do not perform the HuggingFace setup you can still download your files from the Notebook.
 
-Follow the instructions [in the notebook](https://colab.research.google.com/github/huggingface/autotrain-advanced/blob/main/colabs/AutoTrain_LLM.ipynb) to create an account and token if necessary.
+Follow the instructions [in the notebook](https://colab.research.google.com/github/huggingface/autotrain-advanced/blob/main/colabs/AutoTrain.ipynb) to create an account and token if necessary.
 
 ### Section: Hyperparameters
 


### PR DESCRIPTION
The colab link points to old, deprecated notebook and thus needs update in the tutorial.