### PR TITLE
[Speed] Update mobile-redirect.md

### DIFF
--- a/content/speed/optimization/other/mobile-redirect.md
+++ b/content/speed/optimization/other/mobile-redirect.md
@@ -8,7 +8,7 @@ weight: 4
 {{<heading-pill style="deprecated">}} Mobile Redirect {{</heading-pill>}}
 
 {{<Aside type="warning" header="Deprecation notice">}}
-Mobile Redirect is deprecated and will be removed on 2024-06-30. After this date, Mobile Redirect will no longer be available via the Cloudflare dashboard, API, or Terraform.
+Mobile Redirect is deprecated and will be removed on 2024-06-15. After this date, Mobile Redirect will no longer be available via the Cloudflare dashboard, API, or Terraform.
 
 You should configure [Single Redirects](/rules/url-forwarding/single-redirects/) instead of using Mobile Redirect. Refer to [Perform mobile redirects](/rules/url-forwarding/single-redirects/examples/#perform-mobile-redirects) for examples of performing mobile redirects with Single Redirects.
 {{</Aside>}}


### PR DESCRIPTION
Hello team, per email sent to customers on April 19th:

"This message is to inform you that Cloudflare will deprecate and remove the Mobile Redirects product on June 15, 2024. To preserve the current functionality, you will need to migrate your Mobile Redirect configuration to Redirect Rules prior to June 15, 2024 or visitors will not be redirected to the preferred subdomain as per your existing Mobile Redirect configuration."

Thanks!