### PR TITLE
[Docs Site] Lint sh codeblocks

### DIFF
--- a/.github/styles/cloudflare/ShellCodeBlocks.yml
+++ b/.github/styles/cloudflare/ShellCodeBlocks.yml
@@ -1,0 +1,47 @@
+---
+# Warning: cloudflare.ShellCodeBlocks
+#
+# Checks that all `sh` codeblocks contain at least one `$`, to indicate a command.
+#
+# For a list of all options, see https://vale.sh/docs/topics/styles/
+extends: script
+message: "**Warning**: `sh` codeblocks must include a `$` character at the beginning of a command, otherwise it can't be copied. If this is a multi-line codeblock, please use the `bash` language. For more information, refer to [Code block guidelines](https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/)"
+level: warning
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  open := false
+  closed := false
+  dollar := false
+  blockText := []
+
+  reset := func() {
+    open = false
+    closed = false
+    dollar = false
+    blockText = []
+  }
+
+  for line in text.split(scope, "\n") {
+    trimmed := text.trim_space(line)
+
+    if !open && trimmed == "```sh" { open = true }
+
+    if open {
+      blockText = append(blockText, line)
+      if !dollar && text.contains(trimmed, "$ ") { dollar = true }
+      if !closed && trimmed == "```" { closed = true }
+    }
+
+    if open && closed {
+      if !dollar {
+        block := text.join(blockText, "\n")
+        start := text.index(scope, block)
+        matches = append(matches, { begin: start, end: start + len(block) })
+      }
+
+      reset()
+    }
+  }

--- a/content/ai-gateway/tutorials/deploy-aig-worker.md
+++ b/content/ai-gateway/tutorials/deploy-aig-worker.md
@@ -124,7 +124,7 @@ $ npx wrangler secret put OPENAI_API_KEY
 To make this work in local development, create a new file `.dev.vars` in your Worker project and add this line. Make sure to replace `OPENAI_API_KEY` with your own OpenAI API key:
 
 
-```sh
+```txt
 ---
 header: Save your API key locally
 ---

--- a/content/analytics/analytics-engine/sql-api.md
+++ b/content/analytics/analytics-engine/sql-api.md
@@ -36,13 +36,13 @@ Submit the query text in the body of a `POST` request to the API address. The fo
 You can use cURL to test the API as follows, replacing the `<account_id>` with your 32 character account ID (available in the dashboard) and the `<token>` with the token string you generated above.
 
 ```sh
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/<account_id>/analytics_engine/sql" -H "Authorization: Bearer <token>" -d "SELECT 'Hello Workers Analytics Engine' AS message"
+$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/<account_id>/analytics_engine/sql" -H "Authorization: Bearer <token>" -d "SELECT 'Hello Workers Analytics Engine' AS message"
 ```
 
 If you have already published some data, you might try executing the following to confirm that the dataset has been created in the DB.
 
 ```sh
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/<account_id>/analytics_engine/sql" -H "Authorization: Bearer <token>" -d "SHOW TABLES"
+$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/<account_id>/analytics_engine/sql" -H "Authorization: Bearer <token>" -d "SHOW TABLES"
 ```
 
 Refer to the Workers Analytics Engine [SQL reference](/analytics/analytics-engine/sql-reference/), for the full supported query syntax.

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/device-information-only.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/device-information-only.md
@@ -12,7 +12,7 @@ To set up Device Information Only mode:
 
 1. Enable client certificate provisioning for [your zone](/fundamentals/setup/find-account-and-zone-ids/):
 
-   ```sh
+   ```bash
    curl -X PATCH 'https://api.cloudflare.com/client/v4/zones/<ZONE ID>/devices/policy/certificates' \
        -H "X-Auth-Email: <EMAIL>" \
        -H "X-Auth-Key: <API_KEY>" \

--- a/content/cloudflare-one/connections/connect-networks/do-more-with-tunnels/migrate-legacy-tunnels.md
+++ b/content/cloudflare-one/connections/connect-networks/do-more-with-tunnels/migrate-legacy-tunnels.md
@@ -36,7 +36,7 @@ To migrate your legacy tunnels to the named tunnels architecture:
 3. [Create a tunnel](/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/#3-create-a-tunnel-and-give-it-a-name).
 
     ```sh
-    cloudflared tunnel create <TUNNEL-NAME>
+    $ loudflared tunnel create <TUNNEL-NAME>
     ```
 
 4. [Route traffic](/cloudflare-one/connections/connect-networks/routing-to-tunnel/) to your tunnel to create routes that your tunnel will serve.
@@ -44,13 +44,13 @@ To migrate your legacy tunnels to the named tunnels architecture:
     - If your legacy tunnel was serving `tunnel.example.com`, run this command to configure your named tunnel to also serve `tunnel.example.com`. For more information, refer to the [DNS Record routing](/cloudflare-one/connections/connect-networks/routing-to-tunnel/dns/) section.
 
       ```sh
-      cloudflared tunnel route dns <TUNNEL-NAME> tunnel.example.com
+      $ cloudflared tunnel route dns <TUNNEL-NAME> tunnel.example.com
       ```
 
     - If you used to run your legacy tunnel with the `--lb-pool` flag, run this command to set up your named tunnel as a load balancer origin. For more information, refer to the [Load Balancers routing](/cloudflare-one/connections/connect-networks/routing-to-tunnel/lb/) section.
 
       ```sh
-      cloudflared tunnel route lb <TUNNEL-NAME> <LOAD-BALANCER-NAME> <LOAD-BALANCER-POOL>
+      $ cloudflared tunnel route lb <TUNNEL-NAME> <LOAD-BALANCER-NAME> <LOAD-BALANCER-POOL>
       ```
 
 5. Next, create a [configuration file](/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/) with ingress rules. The ingress rules describe how to dispatch requests to your origins based on hostname and path. For example, if in the past you used to run `cloudflared tunnel --hostname tunnel.example.com --url https://localhost:3000`, you should add an equivalent ingress rule to your configuration file:

--- a/content/cloudflare-one/connections/connect-networks/do-more-with-tunnels/migrate-legacy-tunnels.md
+++ b/content/cloudflare-one/connections/connect-networks/do-more-with-tunnels/migrate-legacy-tunnels.md
@@ -36,7 +36,7 @@ To migrate your legacy tunnels to the named tunnels architecture:
 3. [Create a tunnel](/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/#3-create-a-tunnel-and-give-it-a-name).
 
     ```sh
-    $ loudflared tunnel create <TUNNEL-NAME>
+    $ cloudflared tunnel create <TUNNEL-NAME>
     ```
 
 4. [Route traffic](/cloudflare-one/connections/connect-networks/routing-to-tunnel/) to your tunnel to create routes that your tunnel will serve.

--- a/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/private-dns.md
+++ b/content/cloudflare-one/connections/connect-networks/private-net/cloudflared/private-dns.md
@@ -33,13 +33,13 @@ The WARP client will now resolve requests through the internal DNS server you se
 For testing, run a `dig` command for the internal DNS service:
 
 ```sh
-dig AAAA www.myorg.privatecorp
+$ dig AAAA www.myorg.privatecorp
 ```
 
 The `dig` command will work because `myorg.privatecorp` was configured above as a fallback domain. If you skip that step, you can still force `dig` to use your private DNS resolver:
 
 ```sh
-dig @10.0.0.25 AAAA www.myorg.privatecorp
+$ dig @10.0.0.25 AAAA www.myorg.privatecorp
 ```
 
 Both `dig` commands will fail if the WARP client is disabled on your end user's device.

--- a/content/d1/build-with-d1/import-export-data.md
+++ b/content/d1/build-with-d1/import-export-data.md
@@ -111,22 +111,22 @@ In addition to importing existing SQLite databases, you might want to export a D
 
 To export full D1 database schema and data:
 ```sh
-npx wrangler d1 export <database_name> --remote --output=./database.sql
+$ npx wrangler d1 export <database_name> --remote --output=./database.sql
 ```
 
 To export single table schema and data:
 ```sh
-npx wrangler d1 export <database_name> --remote --table=<table_name> --output=./table.sql
+$ npx wrangler d1 export <database_name> --remote --table=<table_name> --output=./table.sql
 ```
 
 To export only D1 database schema:
 ```sh
-npx wrangler d1 export <database_name> --remote --output=./schema.sql --no-data=true
+$ npx wrangler d1 export <database_name> --remote --output=./schema.sql --no-data=true
 ```
 
 To export only D1 table schema:
 ```sh
-npx wrangler d1 export <database_name> --remote --table=<table_name> --output=./schema.sql --no-data=true
+$ npx wrangler d1 export <database_name> --remote --table=<table_name> --output=./schema.sql --no-data=true
 ```
 
 ### Known limitations

--- a/content/d1/build-with-d1/query-json.md
+++ b/content/d1/build-with-d1/query-json.md
@@ -67,7 +67,8 @@ In the following example, calling `json_extract` over a string (not valid JSON) 
 SELECT json_extract('not valid JSON: just a string', '$')
 ```
 This will return an error:
-```sh
+
+```txt
 ERROR 9015: SQL engine error: query error: Error code 1: SQL error or missing database (malformed
   JSON)`
 ```

--- a/content/d1/build-with-d1/use-indexes.md
+++ b/content/d1/build-with-d1/use-indexes.md
@@ -70,7 +70,7 @@ SELECT name, type, sql FROM sqlite_schema WHERE type IN ('index');
 
 This will return output resembling the below:
 
-```sh
+```txt
 ┌──────────────────────────────────┬───────┬────────────────────────────────────────┐
 │ name                             │ type  │ sql                                    │
 ├──────────────────────────────────┼───────┼────────────────────────────────────────┤

--- a/content/d1/get-started.md
+++ b/content/d1/get-started.md
@@ -160,7 +160,7 @@ $ npx wrangler d1 execute prod-d1-tutorial --local --command="SELECT * FROM Cust
 
 You should see the following output:
 
-```sh
+```txt
 🌀 Mapping SQL input into an array of statements
 🌀 Executing on local database production-db-backend (5f092302-3fbd-4247-a873-bf1afc5150b) from .wrangler/state/v3/d1:
 ┌────────────┬─────────────────────┬───────────────────┐

--- a/content/d1/tutorials/build-a-staff-directory-app/index.md
+++ b/content/d1/tutorials/build-a-staff-directory-app/index.md
@@ -444,7 +444,7 @@ With your application ready for deployment, you can use Wrangler to build and de
 
 After successful login, confirm that your `wrangler.toml` file is configured similarly to the code block below:
 
-```sh
+```toml
 name = "staff-directory"
 compatibility_date = "2023-12-01"
 

--- a/content/dns/dns-firewall/random-prefix-attacks/setup.md
+++ b/content/dns/dns-firewall/random-prefix-attacks/setup.md
@@ -13,7 +13,7 @@ In order to enable automatic mitigation of [random prefix attacks](/dns/dns-fire
 1. Set up [DNS Firewall](/dns/dns-firewall/setup/).
 2. Send a [`PATCH` request](/api/operations/dns-firewall-update-dns-firewall-cluster) to update your DNS Firewall cluster.
 
-   ```sh
+   ```bash
    curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/dns_firewall/<CLUSTER_TAG>" \
     -H "Authorization: Bearer <token>" \
     -H "Content-Type: application/json" \

--- a/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
+++ b/content/fundamentals/setup/manage-domains/add-multiple-sites-automation.md
@@ -85,7 +85,7 @@ After adding a domain, it will be in a [`Pending Nameserver Update`](/dns/zone-s
 This tool is a requirement to complete any `Additional options` steps in this tutorial.
 
 ```sh
-  echo '{"foo":{"bar":"foo","testing":"hello"}}' | jq .
+$ echo '{"foo":{"bar":"foo","testing":"hello"}}' | jq .
 ```
 
 Refer to `jq` [documentation](https://jqlang.github.io/jq/manual/#basic-filters) for more information.

--- a/content/hyperdrive/_partials/_create-hyperdrive-config.md
+++ b/content/hyperdrive/_partials/_create-hyperdrive-config.md
@@ -14,7 +14,7 @@ To configure Hyperdrive, you will need:
 
 Hyperdrive accepts the combination of these parameters in the common connection string format used by database drivers:
 
-```sh
+```txt
 postgres://USERNAME:PASSWORD@HOSTNAME_OR_IP_ADDRESS:PORT/database_name
 ```
 

--- a/content/hyperdrive/examples/timescale.md
+++ b/content/hyperdrive/examples/timescale.md
@@ -34,7 +34,7 @@ If you do not have your password stored, you will need to select **Forgot your p
 
 You will end up with a connection string resembling the below:
 
-```sh
+```txt
 postgres://tsdbadmin:YOUR_PASSWORD_HERE@pn79dztyy0.xzhhbfensb.tsdb.cloud.timescale.com:31358/tsdb
 ```
 

--- a/content/hyperdrive/get-started.md
+++ b/content/hyperdrive/get-started.md
@@ -121,7 +121,7 @@ To create your first Hyperdrive, you will need:
 
 Hyperdrive accepts the combination of these parameters in the common connection string format used by database drivers:
 
-```sh
+```txt
 postgres://USERNAME:PASSWORD@HOSTNAME_OR_IP_ADDRESS:PORT/database_name
 ```
 

--- a/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
+++ b/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
@@ -83,7 +83,7 @@ You should ensure that you do not break any existing clients if when you reset t
 
 Insert your password into the **Service URL** as follows (leaving the portion after the @ untouched):
 
-```sh
+```txt
 postgres://tsdbadmin:YOURPASSWORD@...
 ```
 

--- a/content/pages/framework-guides/deploy-an-mkdocs-site.md
+++ b/content/pages/framework-guides/deploy-an-mkdocs-site.md
@@ -26,7 +26,7 @@ $ mkdocs new <PROJECT_NAME>
 Then `cd` into your project, take MkDocs and its dependencies and put them into a `requirements.txt` file:
 
 ```sh
-pip freeze > requirements.txt
+$ pip freeze > requirements.txt
 ```
 
 {{<render file="_tutorials-before-you-start.md">}}

--- a/content/pub-sub/examples/connect-javascript.md
+++ b/content/pub-sub/examples/connect-javascript.md
@@ -19,7 +19,7 @@ Before running the example, make sure to install the MQTT library:
 
 ```sh
 # Pre-requisite: install MQTT.js
-npm install mqtt --save
+$ npm install mqtt --save
 ```
 
 Copy the following example as `example.js` and run it with `node example.js`. 

--- a/content/pulumi/tutorial/hello-world.md
+++ b/content/pulumi/tutorial/hello-world.md
@@ -112,7 +112,7 @@ You have not yet created any Cloudflare resources but have defined a variable, `
 
 Example:
 
-```sh
+```bash
 View in Browser (Ctrl+O):
 https://app.pulumi.com/diana-pulumi-corp/serverless-cloudflare/dev/updates/1
 ```

--- a/content/support/Troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.md
+++ b/content/support/Troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites.md
@@ -423,13 +423,13 @@ For Windows users, see [WinMTR](https://github.com/White-Tiger/WinMTR/releases).
 Generally, we'd use MTR as the following:
 
 ```sh
-mtr -rw <dest_hostname> e.g.: mtr -rw one.one.one.one
+$ mtr -rw <dest_hostname> e.g.: mtr -rw one.one.one.one
 ```
 
 or with destination IP:
 
 ```sh
-mtr -rw <dest_IP> e.g.: mtr -rw 1.1.1.1
+$ mtr -rw <dest_IP> e.g.: mtr -rw 1.1.1.1
 ```
 
 Please refer to this documentation, which explains more about analysing MTR: [How to read MTR](https://www.cloudflare.com/en-gb/learning/network-layer/what-is-mtr/).[](https://www.cloudflare.com/en-gb/learning/network-layer/what-is-mtr/)

--- a/content/workers-ai/fine-tunes/loras.md
+++ b/content/workers-ai/fine-tunes/loras.md
@@ -141,7 +141,7 @@ curl -X GET https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/finetu
 {{</tab>}}
 {{<tab label="json output" no-code="true">}}
 
-```sh
+```json
 ---
 header: Example JSON output
 ---

--- a/content/workers/configuration/integrations/apis.md
+++ b/content/workers/configuration/integrations/apis.md
@@ -34,7 +34,7 @@ async function handleRequest(request) {
 If your API requires authentication, use Wrangler secrets to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:
 
 ```sh
-wrangler secret put SECRET_NAME
+$ wrangler secret put SECRET_NAME
 ```
 
 Then, retrieve the secret value in your code using the following code snippet:

--- a/content/workers/configuration/integrations/external-services.md
+++ b/content/workers/configuration/integrations/external-services.md
@@ -12,7 +12,7 @@ Many external services provide libraries and SDKs to interact with their APIs. W
 If your service requires authentication, use Wrangler secrets to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:
 
 ```sh
-wrangler secret put SECRET_NAME
+$ wrangler secret put SECRET_NAME
 ```
 
 Then, retrieve the secret value in your code using the following code snippet:

--- a/content/workers/configuration/versions-and-deployments/gradual-deployments.md
+++ b/content/workers/configuration/versions-and-deployments/gradual-deployments.md
@@ -76,7 +76,7 @@ $ npx wrangler versions deploy --experimental-versions
 
 Run a cURL command on your Worker to test the split deployment.
 
-```sh
+```bash
 for j in {0..10}
 do
     curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
@@ -102,7 +102,7 @@ $ npx wrangler versions deploy --experimental-versions
 6. Create a new deployment that splits traffic between the two versions created in step 3 and 5 by going to **Deployments** and selecting **Deploy Version**.
 7. cURL your Worker to test the split deployment.
 
-```sh
+```bash
 for j in {0..10}
 do
     curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
@@ -119,7 +119,7 @@ You may want requests associated with a particular identifier (such as user, ses
 You can do this by setting the `Cloudflare-Workers-Version-Key` header on the incoming request to your Worker. For example:
 
 ```sh
-curl -s https://$SCRIPT_NAME.$SUBDOMAIN.workers.dev -H 'Cloudflare-Workers-Version-Key: foo'
+$ curl -s https://$SCRIPT_NAME.$SUBDOMAIN.workers.dev -H 'Cloudflare-Workers-Version-Key: foo'
 ```
 
 For a given [deployment](/workers/configuration/versions-and-deployments/#deployments), all requests with a version key set to `foo` will be handled by the same version of your Worker. The specific version of your Worker that the version key `foo` corresponds to is determined by the percentages you have configured for each Worker version in your deployment.
@@ -194,7 +194,7 @@ When using gradual deployments, you may want to attribute Workers invocations to
 
 A new `ScriptVersion` object is available in [Workers Logpush](/workers/observability/logging/logpush/). `ScriptVersion` can only be added through the [Logpush API](/api/operations/post-accounts-account_identifier-logpush-jobs) right now. Sample API call:
 
-```sh
+```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/logpush/jobs' \
 -H 'Authorization: Bearer <TOKEN>' \
 -H 'Content-Type: application/json' \
@@ -209,7 +209,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/logpush
 
 `ScriptVersion` is an object with the following structure:
 
-```sh
+```json
 scriptVersion: {
     id: "<UUID>",
     message: "<MESSAGE>",

--- a/content/workers/databases/connecting-to-databases.md
+++ b/content/workers/databases/connecting-to-databases.md
@@ -53,7 +53,7 @@ There are four ways to connect to a database from a Worker:
 If your database requires authentication, use Wrangler secrets to securely store your credentials. To do this, create a secret in your Cloudflare Workers project using the following [`wrangler secret`](/workers/wrangler/commands/#secret) command:
 
 ```sh
-wrangler secret put <SECRET_NAME>
+$ wrangler secret put <SECRET_NAME>
 ```
 
 Then, retrieve the secret value in your code using the following code snippet:

--- a/content/workers/databases/native-integrations/neon.md
+++ b/content/workers/databases/native-integrations/neon.md
@@ -54,7 +54,7 @@ To set up an integration with Neon:
 5. In your Worker, install the `@neondatabase/serverless` driver to connect to your database and start manipulating data:
 
     ```sh
-    npm install @neondatabase/serverless
+    $ npm install @neondatabase/serverless
     ```
 
 6. The following example shows how to make a query to your Neon database in a Worker. The credentials needed to connect to Neon have been automatically added as secrets to your Worker through the integration.

--- a/content/workers/databases/native-integrations/planetscale.md
+++ b/content/workers/databases/native-integrations/planetscale.md
@@ -45,7 +45,7 @@ To set up an integration with PlanetScale:
 5. In your Worker, install the `@planetscale/database` driver to connect to your PlanetScale database and start manipulating data:
 
     ```sh
-    npm install @planetscale/database
+    $ npm install @planetscale/database
     ```
 
 6. The following example shows how to make a query to your PlanetScale database in a Worker. The credentials needed to connect to PlanetScale have been automatically added as secrets to your Worker through the integration. 

--- a/content/workers/databases/native-integrations/supabase.md
+++ b/content/workers/databases/native-integrations/supabase.md
@@ -45,7 +45,7 @@ To set up an integration with Supabase:
 5. In your Worker, install the `@supabase/supabase-js`  driver to connect to your database and start manipulating data:
 
     ```sh
-    npm install @supabase/supabase-js
+    $ npm install @supabase/supabase-js
     ```
 
 6. The following example shows how to make a query to your Supabase database in a Worker. The credentials needed to connect to Supabase have been automatically added as secrets to your Worker through the integration.

--- a/content/workers/databases/native-integrations/upstash.md
+++ b/content/workers/databases/native-integrations/upstash.md
@@ -19,11 +19,11 @@ To set up an integration with Upstash:
     - Use the CLI directly from your Upstash console.
     - Alternatively, install [redis-cli](https://redis.io/docs/getting-started/installation/) locally and run the following commands. 
     ```sh
-    ➜ set GB "Ey up?"
+    $ set GB "Ey up?"
     OK
-    ➜ set US "Yo, what’s up?"
+    $ set US "Yo, what’s up?"
     OK
-    ➜ set NL "Hoi, hoe gaat het?"
+    $ set NL "Hoi, hoe gaat het?"
     OK
     ```
 3. Add the Upstash Redis integration to your Worker:

--- a/content/workers/platform/pricing.md
+++ b/content/workers/platform/pricing.md
@@ -6,12 +6,6 @@ meta:
   description: Workers plans and pricing information.
 ---
 
-<style>
-  .DocsMarkdown--table-wrap tr > :first-child {
-    word-break: normal;
-  }
-</style>
-
 # Pricing
 
 {{<Aside type="warning">}}
@@ -45,13 +39,11 @@ Users on the Workers Paid plan only have access to the Standard usage model.
 Workers Enterprise accounts are billed based on the usage model specified in their contract. To switch to the Standard usage model, reach out to your CSM. Some Workers Enterprise customers maintain the ability to change usage models.
 
 
-{{<table-wrap>}}
 |             |  Requests<sup>1</sup>                                                                                                | Duration                | CPU time                                                   |
 | ----------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------- | ---------------------------------------------------------- |
 | **Free**    |  100,000 per day                                                    | No charge for duration                                                                    | 10 milliseconds of CPU time per invocation                 |
 | **Standard** |  10 million included per month <br /> +$0.30 per additional million | No charge or limit for duration  | 30 million CPU milliseconds included per month<br /> +$0.02 per additional million CPU milliseconds<br /><br/> Max of 30 seconds of CPU time per invocation <br /> Max of 15 minutes of CPU time per [Cron Trigger](/workers/configuration/cron-triggers/) or [Queue Consumer](/queues/configuration/javascript-apis/#consumer) invocation                    |
 
-{{</table-wrap>}}
 <sup>1</sup>  Inbound requests to your Worker. Cloudflare does not bill for [subrequests](/workers/platform/limits/#subrequests) you make from your Worker.
 
 ### Example pricing: Standard Usage Model

--- a/content/workers/runtime-apis/rpc/lifecycle.md
+++ b/content/workers/runtime-apis/rpc/lifecycle.md
@@ -50,7 +50,7 @@ function sendEmail(id, message) {
 Because it has not yet landed in V8, the `using` keyword is not yet available directly in the Workers runtime. To use it in your code, you must use a prerelease version of the [Wrangler CLI](/workers/wrangler/) to run and deploy your Worker:
 
 ```sh
-npx wrangler@using-keyword-experimental dev
+$ npx wrangler@using-keyword-experimental dev
 ```
 
 This version of Wrangler will transpile `using` into direct calls to `Symbol.dispose()`, before running your code or deploying it to Cloudflare.

--- a/content/workers/tutorials/connect-to-turso-using-workers/index.md
+++ b/content/workers/tutorials/connect-to-turso-using-workers/index.md
@@ -100,7 +100,7 @@ $ npx wrangler init worker-turso-ts
 
 In your terminal, you will be asked a series of questions related to your project. Choose the following options to use TypeScript to write a `fetch` handler:
 
-```sh
+```txt
 ✔ Would you like to use git to manage this Worker? … no
 ✔ No package.json found. Would you like to create one? … yes
 ✔ Would you like to use TypeScript? … yes
@@ -308,7 +308,7 @@ $ npx wrangler dev
 
 You should be able to review output similar to the following:
 
-```sh
+```txt
 Your worker has access to the following bindings:
 - Vars:
   - LIBSQL_DB_URL: "your-url"
@@ -363,7 +363,7 @@ The first time you run this command, it will launch a browser, ask you to sign i
 
 The `deploy` command will output the following:
 
-```sh
+```txt
 Your worker has access to the following bindings:
 - Vars:
   - LIBSQL_DB_URL: "your-url"

--- a/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
+++ b/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
@@ -47,7 +47,7 @@ Replace `<PROJECT_NAME>` with your desired project name.
 
 In your terminal, you will be asked a series of questions related to your project. Choose the following options:
 
-```sh
+```txt
 What type of application do you want to create? … "Hello World" Worker
 Do you want to use TypeScript? … Yes
 Do you want to use git for version control? … Yes

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2655,7 +2655,7 @@ Deleted certificate 99f5fef1-6cc1-46b8-bd79-44a0d5082b8d successfully
 
 Generate types from bindings and module rules in configuration.
 
-```sh
+```txt
 wrangler types [<PATH>] [OPTIONS]
 ```
 


### PR DESCRIPTION
Adds a Vale lint to spot invalid `sh` codeblocks (if they don't contain a `$ ` then the entire block is unselectable/uncopyable).