### PR TITLE
Update _service-binding-rpc-example.md

### DIFF
--- a/content/workers/_partials/_service-binding-rpc-example.md
+++ b/content/workers/_partials/_service-binding-rpc-example.md
@@ -11,6 +11,7 @@ For example, if Worker B implements the public method `add(a, b)`:
 ---
 filename: wrangler.toml
 ---
+compatibility_date = "2024-03-20"
 name = "worker_b"
 main = "./src/workerB.js"
 ```
@@ -34,6 +35,7 @@ Worker A can declare a [binding](/workers/runtime-apis/bindings) to Worker B:
 ---
 filename: wrangler.toml
 ---
+compatibility_date = "2024-03-20"
 name = "worker_a"
 main = "./src/workerA.js"
 services = [


### PR DESCRIPTION
Update _service-binding-rpc-example.md to reflect the fact that newer compatibility dates break the example in the docs. 

Alternatively workers could be fixed to not produce the following error with the current example, or the example changed.

```
 ⛅️ wrangler 3.61.0
-------------------

▲ [WARNING] The entrypoint src/index.js has exports like an ES Module, but hasn't defined a default export like a module worker normally would. Building the worker using "service-worker" format...


⎔ Starting local server...
[wrangler:inf] Ready on http://localhost:8787
✘ [ERROR] MiniflareCoreError [ERR_RUNTIME_FAILURE]: The Workers runtime failed to start. There is likely additional logging output above.


✘ [ERROR] service core:user:service-test: Uncaught Error: Dynamic require of "cloudflare:workers" is not supported

    at null.<anonymous> (core:user:service-test:7:11)
    at null.<anonymous> (core:user:service-test:273:35)
    at null.<anonymous> (core:user:service-test:279:3)```