### PR TITLE
[Docs Site] Make tabs scrollable when overflowing

### DIFF
--- a/static/codeBlock.css
+++ b/static/codeBlock.css
@@ -85,7 +85,6 @@
 .CodeBlock-scrolls-horizontally > code {
   word-break: normal;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .CodeBlock-scrolls-horizontally > code {

--- a/static/home.css
+++ b/static/home.css
@@ -3251,7 +3251,6 @@ blockquote .DocsMarkdown--header-anchor-positioner {
     padding: .25em 0;
     border-radius: .3125em;
     overflow-x: auto;
-    -webkit-overflow-scrolling: touch
 }
 
 .DocsMarkdown--table-wrap:not(:last-child) {

--- a/static/plans.css
+++ b/static/plans.css
@@ -54,7 +54,6 @@
     padding: 0.25em 0;
     border-radius: 0.3125em;
     overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
   
   .DocsMarkdown--table-wrap:not(:last-child) {

--- a/static/style.css
+++ b/static/style.css
@@ -2008,7 +2008,6 @@ html[is-docs-page] body {
   flex-direction: column;
   flex: 1 1;
   overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: rgba(var(--color-rgb), 0.1) transparent;
 }
@@ -2477,7 +2476,6 @@ html[is-docs-page] body {
   width: calc(100% + 1em);
   max-height: 100vh;
   overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
   padding: 1em 0 0 1em;
   margin: -1em;
   transition: opacity 0.3s ease;
@@ -3450,7 +3448,6 @@ blockquote .DocsMarkdown--header-anchor-positioner {
   padding: 0.25em 0;
   border-radius: 0.3125em;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .DocsMarkdown--table-wrap:not(:last-child) {
@@ -4611,7 +4608,6 @@ pre {
   position: relative;
   margin-top: 1rem;
   box-shadow: 0 1px rgba(var(--shadow-color-rgb), 0.12);
-  height: 2.4rem;
   border-radius: 0.5em 0.5em 0 0;
   overflow: hidden;
 }
@@ -4627,6 +4623,29 @@ pre {
   display: flex;
   width: 100%;
   background-color: #d9d9d9;
+  overflow-x: auto;
+}
+
+.tabs > ul::-webkit-scrollbar {
+  height: 12px;
+}
+
+.tabs > ul::-webkit-scrollbar-track-piece {
+  background: transparent;
+  border-radius: var(--border-radius);
+}
+
+.tabs > ul::-webkit-scrollbar-thumb {
+  border-radius: var(--border-radius);
+  box-shadow: inset 0 1px 1px rgba(var(--background-color-rgb), 0.1);
+  background-color: var(--code-block-scrollbar-color);
+  background-clip: padding-box;
+  border: 4px solid transparent;
+  border-radius: calc(var(--border-radius) * 20);
+}
+
+[theme="dark"] .tabs > ul::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 1px 1px rgba(var(--color-rgb), 0.1);
 }
 
 [theme="dark"] .tabs > ul {
@@ -4687,12 +4706,6 @@ pre {
 .tab-label > svg {
   width: 15px;
   margin-right: 0.25rem;
-}
-
-@media (max-width: 500px) {
-  .tabs > ul {
-    flex-wrap: wrap;
-  }
 }
 
 .tab {


### PR DESCRIPTION
Changes:

1) Makes the tabs scrollable when they overflow (currently they just cut-off)
2) Adds a scrollbar when they are overflowing, as a visual indication to the user that there is content off-screen
3) Removes `-webkit-overflow-scrolling` usage as a general clean-up, no current browsers actually support it: https://caniuse.com/?search=webkit-overflow-scrolling

Before (can't scroll, off-screen tab):
<img width="303" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/b4ee0d7b-d64c-4d5b-9174-e2f9e28d118a">


After (can scroll, indicated to user):
<img width="299" alt="image" src="https://github.com/cloudflare/cloudflare-docs/assets/94662631/8881cd40-207d-4ac2-ab0d-a8eca4d8baef">
