### PR TITLE
[Workers AI] fix: remove `any` type casting for AI examples

### DIFF
--- a/layouts/partials/models/code-examples/automatic-speech-recognition.md
+++ b/layouts/partials/models/code-examples/automatic-speech-recognition.md
@@ -11,7 +11,7 @@ export interface Env {
 
 export default {
   async fetch(request, env): Promise<Response> {
-    const res: any = await fetch(
+    const res = await fetch(
       "https://github.com/Azure-Samples/cognitive-services-speech-sdk/raw/master/samples/cpp/windows/console/samples/enrollment_audio_katie.wav"
     );
     const blob = await res.arrayBuffer();

--- a/layouts/partials/models/code-examples/image-classification.md
+++ b/layouts/partials/models/code-examples/image-classification.md
@@ -11,7 +11,7 @@ export interface Env {
 
 export default {
   async fetch(request, env): Promise<Response> {
-    const res: any = await fetch("https://cataas.com/cat");
+    const res = await fetch("https://cataas.com/cat");
     const blob = await res.arrayBuffer();
 
     const inputs = {

--- a/layouts/partials/models/code-examples/image-to-text.md
+++ b/layouts/partials/models/code-examples/image-to-text.md
@@ -13,7 +13,7 @@ export interface Env {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const res: any = await fetch("https://cataas.com/cat");
+    const res = await fetch("https://cataas.com/cat");
     const blob = await res.arrayBuffer();
     const input = {
       image: [...new Uint8Array(blob)],

--- a/layouts/partials/models/code-examples/object-detection.md
+++ b/layouts/partials/models/code-examples/object-detection.md
@@ -11,7 +11,7 @@ export interface Env {
 
 export default {
   async fetch(request, env): Promise<Response> {
-    const res: any = await fetch("https://cataas.com/cat");
+    const res = await fetch("https://cataas.com/cat");
     const blob = await res.arrayBuffer();
 
     const inputs = {


### PR DESCRIPTION
Type-casting these `Response` objects to `any` serves no functional purpose and just ambiguates things. `fetch` returns a `Response` which has the `arrayBuffer` method available, and `new Uint8Array(...)` will accept this just fine.

This will improve DX for folks who want to do anything else with the `res` object, as they'll now be able to get auto-complete, etc. for commonly accessed properties like `res.ok` to check for non-200s for example.
