### PR TITLE
[Docs Site] pin deps in api-links-crawl workflow

### DIFF
--- a/.github/workflows/api-links-crawl.yml
+++ b/.github/workflows/api-links-crawl.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/api-links-crawl.yml
+++ b/.github/workflows/api-links-crawl.yml
@@ -21,8 +21,21 @@ jobs:
         with:
           node-version: 20
 
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install dependencies
-        run: npm install @actions/core puppeteer
+        run: npm install @actions/core@1 puppeteer@22
 
       - name: Run API docs link checker
         id: check-api-links


### PR DESCRIPTION
These dependencies not being pinned are a ticking time bomb for a breaking change. By pinning these to at least a major version, we add much more reproducible builds, reduce risk of breaking changes, and with the addition of the npm cache step (similar to #15265), should be faster too.