### PR TITLE
[Docs Site]: minor TS improvements to assets

### DIFF
--- a/assets/contents.ts
+++ b/assets/contents.ts
@@ -7,13 +7,13 @@ export function toc() {
   let target = document.querySelector('ul.DocsTableOfContents');
   let article = target && document.querySelector('article.DocsMarkdown');
 
-  if (article) {
+  if (article && target) {
     let headers = article.querySelectorAll('h2,h3,h4');
-    
-    let i = 0,
-      tmp: Element,
-      last: ListItem,
-      container = target;
+
+    let i = 0;
+    let tmp;
+    let last;
+    let container = target;
     if (!headers.length) return; // exit & leave hidden
 
     for (; i < headers.length; i++) {
@@ -24,16 +24,16 @@ export function toc() {
         // eg; "H4" > "H2" ==> true
         container = last.appendChild(document.createElement('ul'));
       } else if (last && tmp.nodeName < last.h) {
-        container = container.parentElement || target;
+        container = container?.parentElement || target;
       }
 
       last = document.createElement('li') as ListItem;
       let a = document.createElement('a');
       a.classList.add('DocsTableOfContents-link');
       a.href = '#' + tmp.id;
-      a.textContent = tmp.lastElementChild.textContent.trim();
+      a.textContent = tmp?.lastElementChild?.textContent?.trim() ?? '';
       last.append(a);
-      container.appendChild(last);
+      container?.appendChild(last);
       last.h = tmp.nodeName;
     }
 
@@ -81,7 +81,7 @@ export function toc() {
         }
         return;
       }
-      const topMostVisibleLink = [...tocLinks][topVisibleIndex];
+      const topMostVisibleLink = [...tocLinks][topVisibleIndex ?? 0];
 
       // find a new link to highlight
       const highlightLink = [...tocLinks].find(

--- a/assets/events.ts
+++ b/assets/events.ts
@@ -35,7 +35,7 @@ export function $tabbable(links: NodeListOf<Element>, bool: boolean) {
 // but only on load if `#hash` in URL
 export function load() {
   let hash = location.hash.substring(1);
-  let item = hash && document.getElementById(hash.toLowerCase());
+  let item = hash && document.querySelector(`#${hash.toLowerCase()}`);
   let timer =
     item &&
     setInterval(() => {
@@ -94,20 +94,20 @@ function $tab(ev: MouseEvent) {
     .closest("[data-id]")
     ?.getAttribute("data-id");
 
-  let tabs = document.querySelectorAll(
+  let tabs = document.querySelectorAll<HTMLElement>(
     `div[tab-wrapper-id="${tabBlockId}"] > .tab`
   );
 
   for (let i = 0; i < tabs.length; i++) {
-    (tabs[i] as HTMLElement).style.display = "none";
+    tabs[i].style.display = "none";
   }
 
   let link = (ev.target as HTMLElement)
     .closest("[data-link]")
     ?.getAttribute("data-link");
 
-  document.getElementById(`${link}-${tabBlockId}`).style.display = "block";
-  zaraz.track("tab click", {selected_option: ev.target.innerText})
+  document.querySelector<HTMLElement>(`#${link}-${tabBlockId}`).style.display = "block";
+  zaraz.track("tab click", {selected_option: (ev.target as HTMLElement).innerText})
 }
 
 export function tabs() {
@@ -116,9 +116,9 @@ export function tabs() {
 
   addEventListener("DOMContentLoaded", () => {
     for (let i = 0; i < wrappers.length; i++) {
-      const labels = wrappers[i].querySelectorAll(".tab-label");
-      const tabs = wrappers[i].querySelectorAll(".tab");
-      const defaultTab = wrappers[i].querySelector(".tab.tab-default");
+      const labels = wrappers[i].querySelectorAll<HTMLElement>(".tab-label");
+      const tabs = wrappers[i].querySelectorAll<HTMLElement>(".tab");
+      const defaultTab = wrappers[i].querySelector<HTMLElement>(".tab.tab-default");
 
       if (tabs.length > 0) {
         // if a tab has been specified as default, set that
@@ -133,11 +133,11 @@ export function tabs() {
             `a[data-link="${tabId}"]`
           );
 
-          (defaultTab as HTMLElement).style.display = "block";
-          (defaultTabLabel as HTMLElement).classList.add("active");
+          defaultTab.style.display = "block";
+          defaultTabLabel.classList.add("active");
         } else {
-          (tabs[0] as HTMLElement).style.display = "block";
-          (labels[0] as HTMLElement).classList.add("active");
+          tabs[0].style.display = "block";
+          labels[0].classList.add("active");
         }
 
         for (let i = 0; i < labels.length; i++)
@@ -148,14 +148,14 @@ export function tabs() {
 }
 
 export function activeTab() {
-  const blocks = document.getElementsByClassName("tab-active");
+  const blocks = document.querySelectorAll(".tab-active");
   if (blocks) {
     for (const block of blocks) {
       const blockId = block.getAttribute("block-id");
 
-      var tabs = block.querySelectorAll(`.tab-label`);
+      var tabs = block.querySelectorAll<HTMLElement>(`.tab-label`);
       for (var i = 0; i < tabs.length; i++) {
-        (tabs[i] as HTMLElement).addEventListener("click", function name() {
+        tabs[i].addEventListener("click", function name() {
           let current = block.querySelector(`.active`);
           current.classList.remove("active");
           this.classList.add("active");
@@ -236,7 +236,7 @@ export function dropdowns() {
 }
 
 export function toggleSidebar() {
-  const toggleButton = document.getElementsByClassName("toggleSidebar");
+  const toggleButton = document.querySelectorAll(".toggleSidebar");
   if (toggleButton.length > 0) {
     let div = document.querySelector(".DocsSidebar--sections .toggleSidebar");
     let btn = div.querySelector("button");
@@ -270,7 +270,7 @@ export function toggleSidebar() {
         item.toggleAttribute(attr, !isHidden);
       });
 
-      let moduleCounters = document.getElementsByClassName("moduleCounter")
+      let moduleCounters = document.querySelectorAll(".moduleCounter")
       if (moduleCounters) {
         for (const counter of moduleCounters) {
           let isHidden2 = counter.hasAttribute(attr);
@@ -282,15 +282,15 @@ export function toggleSidebar() {
 }
 
 export function zarazTrackDocEvents() {
-  const links = document.getElementsByClassName("DocsMarkdown--link");
-  const dropdowns = document.getElementsByTagName("details")
-  const glossaryTooltips = document.getElementsByClassName("glossary-tooltip")
-  const playgroundLinks = document.getElementsByClassName("playground-link")
-  const copyCodeBlockButtons = document.getElementsByClassName("copyCode-button")
+  const links = document.querySelectorAll<HTMLAnchorElement>(".DocsMarkdown--link");
+  const dropdowns = document.querySelectorAll("details")
+  const glossaryTooltips = document.querySelectorAll(".glossary-tooltip")
+  const playgroundLinks = document.querySelectorAll<HTMLAnchorElement>(".playground-link")
+  const copyCodeBlockButtons = document.querySelectorAll(".copyCode-button")
   addEventListener("DOMContentLoaded", () => {
     if (links.length > 0) {
-      for (const link of links as any) {  // Type cast to any for iteration
-        const linkURL = new URL(link)
+      for (const link of links) {
+        const linkURL = new URL(link.href)
         const cfSubdomainRegex = new RegExp(`^[^.]+?\.cloudflare\.com`)
         if (linkURL.hostname !== "developers.cloudflare.com") {
           if (linkURL.hostname === "workers.cloudflare.com" && linkURL.pathname.startsWith("/playground#")) {
@@ -310,14 +310,14 @@ export function zarazTrackDocEvents() {
       }
     }
     if (dropdowns.length > 0) {
-      for (const dropdown of dropdowns as any) {
+      for (const dropdown of dropdowns) {
         dropdown.addEventListener("click", () => {
-          $zarazDropdownEvent(dropdown.getElementsByTagName("summary")[0]);
+          $zarazDropdownEvent(dropdown.querySelectorAll("summary")[0]);
         });
     }
   }
   if (glossaryTooltips.length > 0) {
-    for (const tooltip of glossaryTooltips as any) {
+    for (const tooltip of glossaryTooltips) {
       tooltip.addEventListener("pointerleave", () => {
         $zarazGlossaryTooltipEvent(tooltip.getAttribute('aria-label'))
       });
@@ -327,14 +327,14 @@ export function zarazTrackDocEvents() {
   }
 }
   if (playgroundLinks.length > 0) {
-    for (const playgroundLink of playgroundLinks as any) {
+    for (const playgroundLink of playgroundLinks) {
       playgroundLink.addEventListener("click", () => {
         $zarazLinkEvent('playground link click', playgroundLink);
       });
   }
   }
   if (copyCodeBlockButtons.length > 0) {
-    for (const copyButton of copyCodeBlockButtons as any) {
+    for (const copyButton of copyCodeBlockButtons) {
       copyButton.addEventListener("click", () => {
         const codeBlockElement = copyButton.parentElement.parentElement.firstElementChild;
         zaraz.track('copy button link click', {
@@ -346,11 +346,11 @@ export function zarazTrackDocEvents() {
   });
 }
 
-function $zarazLinkEvent(type: string, link: Element) {
+function $zarazLinkEvent(type: string, link: HTMLAnchorElement) {
   zaraz.track(type, {href: link.href, hostname: link.hostname})
 }
 
-function $zarazDropdownEvent(summary: string) {
+function $zarazDropdownEvent(summary: HTMLElement) {
   zaraz.track('dropdown click', {text: summary.innerText})
 }
 
@@ -359,26 +359,26 @@ function $zarazGlossaryTooltipEvent(term: string) {
 }
 
 export function zarazTrackHomepageLinks() {
-  const links = document.getElementsByClassName("DocsMarkdown--link");
-  const playgroundLinks = document.getElementsByClassName("playground-link")
-  const copyCodeBlockButtons = document.getElementsByClassName("copyCode-button")
+  const links = document.querySelectorAll<HTMLAnchorElement>(".DocsMarkdown--link");
+  const playgroundLinks = document.querySelectorAll<HTMLAnchorElement>(".playground-link")
+  const copyCodeBlockButtons = document.querySelectorAll<HTMLButtonElement>(".copyCode-button")
   addEventListener("DOMContentLoaded", () => {
     if (links.length > 0) {
-      for (const link of links as any) {  // Type cast to any for iteration
+      for (const link of links) {
         link.addEventListener("click", () => {
           zaraz.track('homepage link click', {href: link.href})
         });
       }
     }
     if (playgroundLinks.length > 0) {
-      for (const playgroundLink of playgroundLinks as any) {
+      for (const playgroundLink of playgroundLinks) {
         playgroundLink.addEventListener("click", () => {
           $zarazLinkEvent('playground link click', playgroundLink);
         });
     }
     }
     if (copyCodeBlockButtons.length > 0) {
-      for (const copyButton of copyCodeBlockButtons as any) {
+      for (const copyButton of copyCodeBlockButtons) {
         copyButton.addEventListener("click", () => {
           const codeBlockElement = copyButton.parentElement.parentElement.firstElementChild;
           zaraz.track('copy button link click', {

--- a/assets/events.ts
+++ b/assets/events.ts
@@ -15,6 +15,7 @@ export function $focus(elem: HTMLElement, bool: boolean) {
   if (SEARCH_ID && SEARCH_ID.test(elem.id)) {
     SEARCH_INPUT = elem;
 
+    if(!elem.parentElement || !elem.parentElement.parentElement) return;
     elem.parentElement.parentElement.toggleAttribute("is-focused", bool);
     elem.setAttribute("aria-expanded", "" + bool);
 
@@ -40,7 +41,9 @@ export function load() {
     item &&
     setInterval(() => {
       if (document.readyState !== "complete") return;
-      clearInterval(timer);
+      if(timer){
+        clearInterval(timer);
+      }
       setTimeout(() => {
         item.scrollIntoView({ behavior: "smooth" });
       }, 250);
@@ -59,9 +62,9 @@ export function mobile() {
     });
 
   // clicking on mobile search icon
-  let input: HTMLInputElement =
-    document.querySelector("#DocsSearch--input") ||
-    document.querySelector("#SiteSearch--input");
+  let input =
+    document.querySelector<HTMLInputElement>("#DocsSearch--input") ||
+    document.querySelector<HTMLInputElement>("#SiteSearch--input");
 
   // register init handler
   if (input)
@@ -106,7 +109,10 @@ function $tab(ev: MouseEvent) {
     .closest("[data-link]")
     ?.getAttribute("data-link");
 
-  document.querySelector<HTMLElement>(`#${link}-${tabBlockId}`).style.display = "block";
+  const linkElement = document.querySelector<HTMLElement>(`#${link}-${tabBlockId}`);
+  if(linkElement){
+    linkElement.style.display = "block";
+  }
   zaraz.track("tab click", {selected_option: (ev.target as HTMLElement).innerText})
 }
 
@@ -134,7 +140,9 @@ export function tabs() {
           );
 
           defaultTab.style.display = "block";
-          defaultTabLabel.classList.add("active");
+          if(defaultTabLabel){
+            defaultTabLabel.classList.add("active");
+          }
         } else {
           tabs[0].style.display = "block";
           labels[0].classList.add("active");
@@ -157,7 +165,9 @@ export function activeTab() {
       for (var i = 0; i < tabs.length; i++) {
         tabs[i].addEventListener("click", function name() {
           let current = block.querySelector(`.active`);
-          current.classList.remove("active");
+          if(current){
+            current.classList.remove("active");
+          }
           this.classList.add("active");
         });
       }
@@ -175,7 +185,8 @@ export function dropdowns() {
     let focused = 0; // index
 
     if (btn && links.length > 0) {
-      let arrows: EventListener = (ev: KeyboardEvent) => {
+      let arrows: EventListener = (rawEv: Event) => {
+        const ev = rawEv as KeyboardEvent;
         let key = ev.which;
         let isTAB = key === 9;
 
@@ -239,7 +250,9 @@ export function toggleSidebar() {
   const toggleButton = document.querySelectorAll(".toggleSidebar");
   if (toggleButton.length > 0) {
     let div = document.querySelector(".DocsSidebar--sections .toggleSidebar");
+    if(!div) return;
     let btn = div.querySelector("button");
+    if(!btn) return;
     btn.addEventListener("click", () => {
       let classToggleList = [
         ".DocsSidebar",
@@ -253,6 +266,7 @@ export function toggleSidebar() {
 
       classToggleList.forEach(function (querySelector) {
         let item = document.querySelector(querySelector);
+        if(!item) return;
         item.classList.toggle("collapsed");
       });
 
@@ -266,6 +280,7 @@ export function toggleSidebar() {
 
       attrToggleList.forEach(function (querySelector) {
         let item = document.querySelector(querySelector);
+        if(!item) return;
         let isHidden = item.hasAttribute(attr);
         item.toggleAttribute(attr, !isHidden);
       });
@@ -336,10 +351,10 @@ export function zarazTrackDocEvents() {
   if (copyCodeBlockButtons.length > 0) {
     for (const copyButton of copyCodeBlockButtons) {
       copyButton.addEventListener("click", () => {
-        const codeBlockElement = copyButton.parentElement.parentElement.firstElementChild;
+        const codeBlockElement = copyButton?.parentElement?.parentElement?.firstElementChild;
         zaraz.track('copy button link click', {
-          title: codeBlockElement.getAttribute('title') ?? 'title not set',
-          language: codeBlockElement.getAttribute('language') ?? 'language not set',});
+          title: codeBlockElement?.getAttribute('title') ?? 'title not set',
+          language: codeBlockElement?.getAttribute('language') ?? 'language not set',});
       });
     }
   }
@@ -354,7 +369,7 @@ function $zarazDropdownEvent(summary: HTMLElement) {
   zaraz.track('dropdown click', {text: summary.innerText})
 }
 
-function $zarazGlossaryTooltipEvent(term: string) {
+function $zarazGlossaryTooltipEvent(term: string | null) {
   zaraz.track('glossary tooltip view', {term: term})
 }
 
@@ -380,10 +395,10 @@ export function zarazTrackHomepageLinks() {
     if (copyCodeBlockButtons.length > 0) {
       for (const copyButton of copyCodeBlockButtons) {
         copyButton.addEventListener("click", () => {
-          const codeBlockElement = copyButton.parentElement.parentElement.firstElementChild;
+          const codeBlockElement = copyButton?.parentElement?.parentElement?.firstElementChild;
           zaraz.track('copy button link click', {
-            title: codeBlockElement.getAttribute('title') ?? 'title not set',
-            language: codeBlockElement.getAttribute('language') ?? 'language not set',});
+            title: codeBlockElement?.getAttribute('title') ?? 'title not set',
+            language: codeBlockElement?.getAttribute('language') ?? 'language not set',});
         });
       }
     }

--- a/assets/json-collector.ts
+++ b/assets/json-collector.ts
@@ -9,7 +9,17 @@ import * as cybersafe from "data/learning-paths/cybersafe.json";
 import * as zero_trust_web_access from "data/learning-paths/zero-trust-web-access.json";
 import * as secure_internet_traffic from "data/learning-paths/secure-internet-traffic.json";
 
-let learning_paths = [
+export type LearningPath = {
+  title: string;
+  path: string;
+  priority: number;
+  description: string;
+  products: string[];
+  product_group: string;
+  additional_groups?: string[];
+}
+
+let learning_paths: LearningPath[] = [
   get_started_free,
   load_balancing,
   prevent_ddos_attacks,

--- a/assets/learning-paths.ts
+++ b/assets/learning-paths.ts
@@ -57,10 +57,6 @@ function filterResults() {
           passed = paths;
         } else {
           passed = paths.filter((currentPath) => {
-            console.log('do filter', {
-              currentPath,
-              selectedOptions,
-            })
             let keepItem = true;
             for (const [filterName, filterValue] of Object.entries(
               selectedOptions

--- a/assets/learning-paths.ts
+++ b/assets/learning-paths.ts
@@ -1,7 +1,7 @@
 import { learning_paths as paths, type LearningPath } from "./json-collector";
 
 function buildHtml(destination: HTMLElement, array: LearningPath[]) {
-  const numTrails = document.getElementById("numTrails");
+  const numTrails = document.querySelector<HTMLElement>("#numTrails");
   if(!numTrails) return;
 
   destination.innerHTML = "";
@@ -30,10 +30,10 @@ type Filterable = 'product_group' | 'products';
 type FilterableObj = {
   [key in Filterable]?: string;
 }
-function getSelectValues(selectElementCollection: HTMLCollectionOf<Element>) {
+function getSelectValues(selectElementCollection: NodeListOf<HTMLSelectElement>) {
   let selectedValues: FilterableObj = {};
   for (const htmlElement of selectElementCollection) {
-    let selectElement = htmlElement as HTMLSelectElement;
+    let selectElement = htmlElement;
     let selectedValue =
       selectElement.options[selectElement.selectedIndex].value;
     selectedValues[selectElement.id as Filterable] = selectedValue;
@@ -42,9 +42,9 @@ function getSelectValues(selectElementCollection: HTMLCollectionOf<Element>) {
 }
 
 function filterResults() {
-  const pathGrid = document.getElementById("pathGrid");
+  const pathGrid = document.querySelector<HTMLElement>("#pathGrid");
   if (pathGrid) {
-    const selectorDropdowns = document.getElementsByClassName("selectorFilter");
+    const selectorDropdowns = document.querySelectorAll<HTMLSelectElement>(".selectorFilter");
     let passed = [];
     for (const dropdown of selectorDropdowns) {
       dropdown.addEventListener("change", () => {

--- a/assets/learning-paths.ts
+++ b/assets/learning-paths.ts
@@ -1,7 +1,9 @@
-import { learning_paths as paths } from "./json-collector";
+import { learning_paths as paths, type LearningPath } from "./json-collector";
 
-function buildHtml(destination, array) {
+function buildHtml(destination: HTMLElement, array: LearningPath[]) {
   const numTrails = document.getElementById("numTrails");
+  if(!numTrails) return;
+
   destination.innerHTML = "";
   if (array.length === 0) {
     numTrails.innerText = "0 results";
@@ -24,13 +26,17 @@ function buildHtml(destination, array) {
   }
 }
 
+type Filterable = 'product_group' | 'products';
+type FilterableObj = {
+  [key in Filterable]?: string;
+}
 function getSelectValues(selectElementCollection: HTMLCollectionOf<Element>) {
-  let selectedValues: Record<string, string> = {};
+  let selectedValues: FilterableObj = {};
   for (const htmlElement of selectElementCollection) {
     let selectElement = htmlElement as HTMLSelectElement;
     let selectedValue =
       selectElement.options[selectElement.selectedIndex].value;
-    selectedValues[selectElement.id] = selectedValue;
+    selectedValues[selectElement.id as Filterable] = selectedValue;
   }
   return selectedValues;
 }
@@ -51,6 +57,10 @@ function filterResults() {
           passed = paths;
         } else {
           passed = paths.filter((currentPath) => {
+            console.log('do filter', {
+              currentPath,
+              selectedOptions,
+            })
             let keepItem = true;
             for (const [filterName, filterValue] of Object.entries(
               selectedOptions
@@ -60,7 +70,7 @@ function filterResults() {
               } else if (currentPath["additional_groups"] && filterName === "product_group" && currentPath["additional_groups"].includes(filterValue)) {
                 continue;
               }
-              else if (!currentPath[filterName].includes(filterValue) ) {
+              else if (!currentPath[filterName as Filterable]?.includes(filterValue) ) {
                 keepItem = false;
                 break;
               }

--- a/assets/main.ts
+++ b/assets/main.ts
@@ -7,6 +7,7 @@ declare global {
   interface Window {
     docsearch: any;
     Coveo?: any;
+    zaraz: any;
   }
 }
 

--- a/assets/navlinks.ts
+++ b/assets/navlinks.ts
@@ -8,7 +8,8 @@ export function init() {
     .querySelectorAll<HTMLButtonElement>('.DocsSidebar--nav-expand-collapse-button')
     .forEach(btn => {
       let item = btn.parentNode; // .DocsSidebar--nav-item
-      if (item) btn.addEventListener('click', toggle);
+      if (!item) return;
+      btn.addEventListener('click', toggle);
 
       let div = item.querySelector('div'); // .DocsSidebar--nav-item-collapse-container
       if (div && div.hasAttribute('is-expanded')) div.style.height = 'auto';
@@ -16,14 +17,14 @@ export function init() {
 }
 
 type ListItem = HTMLLIElement & {
-  timer?: NodeJS.Timeout | void;
+  timer?: ReturnType<typeof setTimeout>
 };
 
 function toggle(ev: Event) {
   let attr = 'is-expanded';
 
   let item: ListItem = (ev.target as HTMLLIElement).closest('li')!;
-  if (item.timer) item.timer = clearTimeout(item.timer);
+  if (item.timer) clearTimeout(item.timer);
 
   let isExpanded = item.hasAttribute(attr);
   let aria = item.querySelector('span[is-visually-hidden]');

--- a/assets/search.ts
+++ b/assets/search.ts
@@ -30,7 +30,7 @@
         }
       }
       },
-      getMissingResultsUrl({ query }) {
+      getMissingResultsUrl({ query }: {query: string}) {
         return `/search/?q=${query}`;
       },
       searchParameters: {

--- a/assets/search.ts
+++ b/assets/search.ts
@@ -68,7 +68,8 @@
     let button = $('#MobileSearch')
     if (button) {
       button.addEventListener('click', () => {
-        document.querySelector(".DocSearch.DocSearch-Button").click()
+        const docsSearchButton = document.querySelector<HTMLButtonElement>('.DocSearch.DocSearch-Button')
+        docsSearchButton?.click()
       });
     }
   }

--- a/assets/theme.ts
+++ b/assets/theme.ts
@@ -1,7 +1,7 @@
 (function () {
   let tooEarly = false;
   let btn: HTMLInputElement;
-  let media: MediaQueryList | void;
+  let media;
 
   if (document.readyState !== "loading") init();
   else addEventListener("DOMContentLoaded", init);
@@ -26,11 +26,13 @@
       // security error
     }
     // set tooltip text
+    const themeToggleTooltip = document.getElementById("ThemeToggle--tooltip");
+    if(!themeToggleTooltip) return;
     if (isDark) {
-      document.getElementById("ThemeToggle--tooltip").textContent =
+      themeToggleTooltip.textContent =
         "Set theme to light (⇧+D)";
     } else {
-      document.getElementById("ThemeToggle--tooltip").textContent =
+      themeToggleTooltip.textContent =
         "Set theme to dark (⇧+D)";
     }
   }

--- a/assets/theme.ts
+++ b/assets/theme.ts
@@ -26,7 +26,7 @@
       // security error
     }
     // set tooltip text
-    const themeToggleTooltip = document.getElementById("ThemeToggle--tooltip");
+    const themeToggleTooltip = document.querySelector<HTMLElement>("#ThemeToggle--tooltip");
     if(!themeToggleTooltip) return;
     if (isDark) {
       themeToggleTooltip.textContent =

--- a/assets/timeago.ts
+++ b/assets/timeago.ts
@@ -1,8 +1,8 @@
 import fromnow from 'fromnow';
 
 export function init() {
-  let i = 0,
-    tmp: string;
+  let i = 0;
+  let tmp: string | null;
   let arr = document.querySelectorAll('time.relative');
   for (; i < arr.length; i++) {
     tmp = arr[i].getAttribute('datetime');

--- a/assets/tutorial-coveo.ts
+++ b/assets/tutorial-coveo.ts
@@ -11,7 +11,7 @@
 
     // Initialize the framework by targeting the root in the interface.
     // It does not have to be the document body.
-    const root = document.getElementById("searchresults");
+    const root = document.querySelector("#searchresults");
     coveo.init(root);
 
     coveo.SearchEndpoint.configureCloudV2Endpoint(org, token);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "assets/*.ts"
   ],
   "compilerOptions": {
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext", "dom", "dom.iterable"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./components/*"],


### PR DESCRIPTION
This PR makes the following minor improvements to many of the the `assets/*.ts` files:

- Transitions to more modern `querySelector` and `querySelectorAll` APIs
- With above, types the elements being queried more accurately
- Removes a bunch of unnecessary `as any` (etc.) type casting
- Better handles nullish elements when query selectors might fail

There should be no functional changes - just types improvements. This reduces the number of TypeScript errors reported (via `npx tsc --noEmit`) from ~63 to ~17.