### PR TITLE
[Docs Site] add `EditorConfig.EditorConfig` to recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "mhutchie.git-graph"
+        "mhutchie.git-graph",
+        "EditorConfig.EditorConfig"
     ]
 }


### PR DESCRIPTION
It's pretty common to see PRs that trim whitespace at the end of files when making other changes in VSCode.

By adding [`EditorConfig.EditorConfig`](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) to the recommended extensions, if folks then install these, it'll make the [`.editorconfig`](https://github.com/cloudflare/cloudflare-docs/blob/607d9ffe84fdcc879d1b076901fd4b5cda669d96/.editorconfig) read by VSCode and hopefully reduce the amount of trailing whitespace at the end of files moving forward (as well as LF line endings + remove final new line), so these don't pollute git diffs in other PRs.