### PR TITLE
[Docs Site] Make non-wrapped tables overflow

### DIFF
--- a/static/home.css
+++ b/static/home.css
@@ -3084,11 +3084,12 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 }
 
 .DocsMarkdown table {
-    word-break: break-word;
     border-collapse: collapse;
     border-spacing: 0;
     border: 0;
-    --border-color: rgba(var(--color-rgb), .1)
+    --border-color: rgba(var(--color-rgb), .1);
+    display: block;
+    overflow-x: auto;
 }
 
 .DocsMarkdown th {

--- a/static/style.css
+++ b/static/style.css
@@ -3242,11 +3242,12 @@ blockquote .DocsMarkdown--header-anchor-positioner {
 }
 
 .DocsMarkdown table {
-  word-break: break-word;
   border-collapse: collapse;
   border-spacing: 0;
   border: 0;
   --border-color: rgba(var(--color-rgb), 0.1);
+  display: block;
+  overflow-x: auto;
 }
 
 .DocsMarkdown table.Small {


### PR DESCRIPTION
Stops normal (non-`{{<table-wrap>}}`) tables from having `word-break`, and make them overflow off the page with scroll.