### PR TITLE
Update configure-hardware-connector.md

### DIFF
--- a/content/magic-wan/configuration/connector/configure-hardware-connector.md
+++ b/content/magic-wan/configuration/connector/configure-hardware-connector.md
@@ -83,7 +83,6 @@ Make sure all IPs are part of the same subnet.
 {{<Aside type="note" header="Limitations">}}
 The high availability (HA) feature is being rolled out in phases. The present version has the following limitations:
 - Only node failure is detected as a failure condition to trigger a failover. Other failure conditions, such as link status and tunnel health, are not yet enabled to trigger failovers.
-- When DHCP server is enabled on a LAN interface, the DHCP leases are not yet synced between the active and the standby Connector. For this reason, it is recommended you enable DHCP reservations when using DHCP server.
 - HA is run in preempt mode, which means the primary node always comes up as the active node.
 {{</Aside>}}
 


### PR DESCRIPTION
A new image has been rolled out which syncs DHCP leases across 2 HA nodes.  So, the docs can be updated to remove this constraint.