### PR TITLE
[Docs Site] Add flexbox to /plans/

### DIFF
--- a/content/plans.html
+++ b/content/plans.html
@@ -22,7 +22,9 @@ meta:
         <span>Account</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="account" additional_plans="true">}}
+    </div>
 
 
     <h2 id="analytics">
@@ -32,7 +34,9 @@ meta:
         <span>Analytics</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="analytics" additional_plans="true">}}
+    </div>
 
     <h2 id="cache">
       <span class="DocsMarkdown--header-anchor-positioner">
@@ -41,8 +45,9 @@ meta:
       <span>Cache</span>
     </h2>
 
-  {{<product-features id="cache" additional_plans="true">}}
-
+    <div class="DocsMarkdown--plans-flexbox">
+    {{<product-features id="cache" additional_plans="true">}}
+    </div>
 
     <h2 id="dns">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -51,8 +56,9 @@ meta:
         <span>DNS</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="dns" additional_plans="true">}}
-
+    </div>
 
     <h2 id="email">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -61,8 +67,9 @@ meta:
         <span>Email</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="email" additional_plans="true">}}
-
+    </div>
 
     <h2 id="global-configurations">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -71,7 +78,9 @@ meta:
         <span>Global configurations</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="global_configurations" additional_plans="true">}}
+    </div>
 
     <h2 id="network">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -80,7 +89,9 @@ meta:
         <span>Network</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="network" additional_plans="true">}}
+    </div>
 
     <h2 id="rules">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -89,8 +100,9 @@ meta:
         <span>Rules</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="rules" additional_plans="true">}}
-
+    </div>
 
     <h2 id="scrapeshield">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -99,8 +111,9 @@ meta:
         <span>Scrape Shield</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="scrape_shield" additional_plans="true">}}
-
+    </div>
 
     <h2 id="security">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -109,7 +122,9 @@ meta:
         <span>Security</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="security" additional_plans="true">}}
+    </div>
 
     <h2 id="spectrum">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -118,7 +133,9 @@ meta:
         <span>Spectrum</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="spectrum" additional_plans="true">}}
+    </div>
 
     <h2 id="speed">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -127,8 +144,9 @@ meta:
         <span>Speed</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="speed" additional_plans="true">}}
-
+    </div>
 
     <h2 id="ssl">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -137,7 +155,9 @@ meta:
         <span>SSL/TLS</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="ssl" additional_plans="true">}}
+    </div>
 
     <h2 id="support">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -146,7 +166,9 @@ meta:
         <span>Support</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="support" additional_plans="true">}}
+    </div>
 
     <h2 id="traffic">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -155,7 +177,9 @@ meta:
         <span>Traffic</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="traffic" additional_plans="true">}}
+    </div>
 
     <h2 id="web3">
         <span class="DocsMarkdown--header-anchor-positioner">
@@ -164,8 +188,9 @@ meta:
         <span>Web3</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="web3" additional_plans="true">}}
-
+    </div>
     <h2 id="zaraz">
         <span class="DocsMarkdown--header-anchor-positioner">
         <a class="DocsMarkdown--header-anchor Link Link-without-underline" href="#zaraz" aria-hidden="true">​</a>
@@ -173,8 +198,9 @@ meta:
         <span>Zaraz</span>
     </h2>
 
+    <div class="DocsMarkdown--plans-flexbox">
     {{<product-features id="zaraz" additional_plans="true">}}
-
+    </div>
 
 <span style="font-size:1.25em;text-align:center">
     <h2 id="missing-features">

--- a/layouts/shortcodes/product-features.html
+++ b/layouts/shortcodes/product-features.html
@@ -14,6 +14,7 @@
 
 <!-- Render heading and link of the feature name -->
 
+<div>
 {{- $titleString := print "### " $title | $.Page.RenderString -}}
 {{- $titleString -}}
 {{- with $link -}}
@@ -73,5 +74,6 @@
 </ul>
 {{ end }}
 {{ end }}
+</div>
 {{ end }}
 {{ end }}

--- a/static/plans.css
+++ b/static/plans.css
@@ -100,3 +100,24 @@
   .DocsMarkdown--table-wrap tr > :last-child {
     padding-right: 1em;
   }
+
+  .DocsMarkdown--plans-flexbox {
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 20px;
+    display: flex;
+  }
+
+  @media only screen and (max-width: 600px) {
+    .DocsMarkdown--plans-flexbox {
+      flex-direction: column;
+    }
+  }
+
+  .DocsMarkdown--plans-flexbox > div {
+    flex: 1 1 calc(33.333% - 20px);
+  }
+
+  .DocsMarkdown--plans-flexbox > div > h3 {
+    margin-top: 0 !important;
+  }


### PR DESCRIPTION
Adds a flexbox to the items on https://developers.cloudflare.com/plans/ 

https://github.com/cloudflare/cloudflare-docs/assets/94662631/2fa710a3-477e-4382-8ced-a3d125de1427

