### PR TITLE
[Chore] Remove workers tablewrap where appropriate

### DIFF
--- a/content/pages/configuration/headers.md
+++ b/content/pages/configuration/headers.md
@@ -46,8 +46,6 @@ https://myproject.pages.dev/*
 
 An incoming request which matches multiple rules' URL patterns will inherit all rules' headers. Using the previous `_headers` file, the following requests will have the following headers applied:
 
-{{<table-wrap>}}
-
 | Request URL                                     | Headers                                                                                                                               |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `https://custom.domain/secure/page`             | `X-Frame-Options: DENY` <br /> `X-Content-Type-Options: nosniff ` <br /> `Referrer-Policy: no-referrer`                               |
@@ -55,8 +53,6 @@ An incoming request which matches multiple rules' URL patterns will inherit all 
 | `https://myproject.pages.dev/home`              | `X-Robots-Tag: noindex`                                                                                                               |
 | `https://myproject.pages.dev/secure/page`       | `X-Frame-Options: DENY` <br /> `X-Content-Type-Options: nosniff` <br /> `Referrer-Policy: no-referrer` <br /> `X-Robots-Tag: noindex` |
 | `https://myproject.pages.dev/static/styles.css` | `Access-Control-Allow-Origin: *` <br /> `X-Robots-Tag: nosnippet, noindex`                                                            |
-
-{{</table-wrap>}}
 
 A project is limited to 100 header rules. Each line in the `_headers` file has a 2,000 character limit. The entire line, including spacing, header name, and value, counts towards this limit.
 

--- a/content/pages/get-started/direct-upload.md
+++ b/content/pages/get-started/direct-upload.md
@@ -16,13 +16,13 @@ Before you deploy your project with Direct Upload, run the appropriate [build co
 
 ## Upload methods
 
-After you have your prebuilt assets ready, there are two ways to begin uploading: 
+After you have your prebuilt assets ready, there are two ways to begin uploading:
 
 * [Wrangler](/pages/get-started/direct-upload/#wrangler-cli).
 * [Drag and drop](/pages/get-started/direct-upload/#drag-and-drop).
 
 {{<Aside type= "note">}}
-  
+
 Within a Direct Upload project, you can switch between creating deployments with either Wrangler or drag and drop. However, you cannot create deployments with Direct Upload on a project that you created through Git integration on the dashboard. Only projects created with Direct Upload can be updated with Direct Upload.
 
 {{</Aside>}}
@@ -33,7 +33,7 @@ Below is the supported file types for each Direct Upload options:
 * Wrangler: A single folder of assets. (Zip files are not supported.)
 * Drag and drop: A zip file or single folder of assets.
 
-## Wrangler CLI 
+## Wrangler CLI
 
 ### Set up Wrangler
 
@@ -47,7 +47,7 @@ Log in to Wrangler with the [`wrangler login` command](/workers/wrangler/command
 $ npx wrangler pages project create
 ```
 
-You will then be prompted to specify the project name. Your project will be served at `<PROJECT_NAME>.pages.dev` (or your project name plus a few random characters if your project name is already taken). You will also be prompted to specify your production branch. 
+You will then be prompted to specify the project name. Your project will be served at `<PROJECT_NAME>.pages.dev` (or your project name plus a few random characters if your project name is already taken). You will also be prompted to specify your production branch.
 
 Subsequent deployments will reuse both of these values (saved in your `node_modules/.cache/wrangler` folder).
 
@@ -62,20 +62,20 @@ $ npx wrangler pages deploy <BUILD_OUTPUT_DIRECTORY>
 Find the appropriate build output directory for your project in [Build directory under Framework presets](/pages/configuration/build-configuration/#framework-presets).
 
 Your production deployment will be available at `<PROJECT_NAME>.pages.dev`.
- 
+
 {{<Aside type= "note">}}
 
-Before using the `wrangler pages deploy` command, you will need to make sure you are inside the project. If not, you can also pass in the project path. 
+Before using the `wrangler pages deploy` command, you will need to make sure you are inside the project. If not, you can also pass in the project path.
 
 {{</Aside>}}
- 
-To deploy assets to a preview environment, run: 
+
+To deploy assets to a preview environment, run:
 
 ```sh
 $ npx wrangler pages deploy <OUTPUT_DIRECTORY> --branch=<BRANCH_NAME>
 ```
 
-For every branch you create, a branch alias will be available to you at `<BRANCH_NAME>.<PROJECT_NAME>.pages.dev`. 
+For every branch you create, a branch alias will be available to you at `<BRANCH_NAME>.<PROJECT_NAME>.pages.dev`.
 
 {{<Aside type= "note">}}
 
@@ -83,7 +83,7 @@ If you are in a Git workspace, Wrangler will automatically pull the branch infor
 
 {{</Aside>}}
 
-If you would like to streamline the project creation and asset deployment steps, you can also use the deploy command to both create and deploy assets at the same time. If you execute this command first, you will still be prompted to specify your project name and production branch. These values will still be cached for subsequent deployments as stated above. If the cache already exists and you would like to create a new project, you will need to run the [`create` command](#create-your-project). 
+If you would like to streamline the project creation and asset deployment steps, you can also use the deploy command to both create and deploy assets at the same time. If you execute this command first, you will still be prompted to specify your project name and production branch. These values will still be cached for subsequent deployments as stated above. If the cache already exists and you would like to create a new project, you will need to run the [`create` command](#create-your-project).
 
 #### Other useful commands
 
@@ -99,7 +99,7 @@ If you would like to use Wrangler to obtain a list of all unique preview URLs fo
 $ npx wrangler pages deployment list
 ```
 
-For step-by-step directions on how to use Wrangler and continuous integration tools like GitHub Actions, Circle CI, and Travis CI together for continuous deployment, refer to [Use Direct Upload with continuous integration](/pages/how-to/use-direct-upload-with-continuous-integration/). 
+For step-by-step directions on how to use Wrangler and continuous integration tools like GitHub Actions, Circle CI, and Travis CI together for continuous deployment, refer to [Use Direct Upload with continuous integration](/pages/how-to/use-direct-upload-with-continuous-integration/).
 
 ## Drag and drop
 
@@ -113,24 +113,20 @@ To deploy with drag and drop:
 4. Enter your project name in the provided field and drag and drop your assets.
 5. Select **Deploy**.
 
-Your project will be served from `<PROJECT_NAME>.pages.dev`. Next drag and drop your build output directory into the uploading frame. Once your files have been successfully uploaded, select **Save and Deploy** and continue to your newly deployed project. 
+Your project will be served from `<PROJECT_NAME>.pages.dev`. Next drag and drop your build output directory into the uploading frame. Once your files have been successfully uploaded, select **Save and Deploy** and continue to your newly deployed project.
 
 #### Create a new deployment
 
-After you have your project created, select **Create a new deployment** to begin a new version of your site. Next, choose whether your new deployment will be made to your production or preview environment. If choosing preview, you can create a new deployment branch or enter an existing one. 
+After you have your project created, select **Create a new deployment** to begin a new version of your site. Next, choose whether your new deployment will be made to your production or preview environment. If choosing preview, you can create a new deployment branch or enter an existing one.
 
 ## Troubleshoot
 
 ### Limits
 
-{{<table-wrap>}}
-
 | Upload method | File limit   | File size |
 | ------------- | ------------ | --------- |
 | Wrangler      | 20,000 files | 25 MiB    |
 | Drag and drop | 1,000 files  | 25 MiB    |
-
-{{</table-wrap>}}
 
 If using the drag and drop method, a red warning symbol will appear next to an asset if too large and thus unsuccessfully uploaded. In this case, you may choose to delete that asset but you cannot replace it. In order to do so, you must reupload the entire project.
 

--- a/content/web3/reference/gateway-status.md
+++ b/content/web3/reference/gateway-status.md
@@ -8,13 +8,9 @@ weight: 2
 
 Once you [create a gateway](/web3/how-to/manage-gateways/#create-a-gateway), it can have one of several statuses.
 
-{{<table-wrap>}}
-
 | Status | Definition |
 | --- | --- |
 | **Active** | The DNS records for your gateway have been created and are functioning correctly. |
 | **Pending** | Your Web3 gateway is in the process of becoming **Active**. |
 | **Deleting** | Your Web3 gateway is being deleted. |
 | **Error** | The DNS records for your gateway are misconfigured or do not exist. To fix, try [refreshing the gateway](/web3/how-to/manage-gateways/#refresh-a-gateway).|
-
-{{</table-wrap>}}

--- a/content/workers-ai/platform/pricing.md
+++ b/content/workers-ai/platform/pricing.md
@@ -20,14 +20,11 @@ To use more than 10,000 Neurons per day for non-beta models, you need to sign up
 
 You can monitor your Neuron usage in the [Cloudflare Workers AI dashboard](https://dash.cloudflare.com/?to=/:account/ai/workers-ai). To estimate Neurons and costs, use the [pricing calculator](https://ai.cloudflare.com/#pricing-calculator).
 
-{{<table-wrap>}}
-
 |              | Free <br> allocation | Overage<br>pricing            |
 | ------------ | -------------------- | ----------------------------- |
 | Workers Free | 10,000 Neurons per day  | N/A - Upgrade to Workers Paid |
 | Workers Paid | 10,000 Neurons per day  | $0.011 / 1,000 Neurons           |
 
-{{</table-wrap>}}
 All limits reset daily at 00:00 UTC. If you exceed any one of the above limits, further operations will fail with an error.
 
 ## What are Neurons?
@@ -57,62 +54,51 @@ Cloudflare will continue to add Neuron calculations for the other models in the 
 
 ## Pricing comparison
 
-Cloudflare uses Neurons to measure and bill for inference on Workers AI. This may differ from the input-based pricing you might see from other providers. We’ve prepared the below tables to help you understand and evaluate the estimated cost of Neurons and usage on Workers AI compared with the inputs used for the models available in our catalog. 
+Cloudflare uses Neurons to measure and bill for inference on Workers AI. This may differ from the input-based pricing you might see from other providers. We’ve prepared the below tables to help you understand and evaluate the estimated cost of Neurons and usage on Workers AI compared with the inputs used for the models available in our catalog.
 
 **Please note that the below is provided for informational purposes only.** All conversions are based on Cloudflare’s public fees as of March 1, 2024, and do not include taxes and any other fees.
 
 ### Automatic Speech Recognition
 
-{{<table-wrap>}}
 | Model | Price per <br> minute of audio |
 | ------- | ------------------------- |
-| whisper | $0.0022 |
-{{</table-wrap>}}
+| `whisper` | $0.0022 |
 
 ### Image Classification
 
-{{<table-wrap>}}
 | Model | Price per image |
 | --------- | --------------- |
-| Resnet-50 | $0.0000025 |
-{{</table-wrap>}}
+| `Resnet-50` | $0.0000025 |
 
 ### Text Classification
 
-{{<table-wrap>}}
 | Model | Price per 1M <br> input tokens |
 | --------------------- | ------------------------- |
-| distilbert-sst-2-int8 | $0.33 |
-{{</table-wrap>}}
+| `distilbert-sst-2-int8` | $0.33 |
 
 ### Text Embeddings
 
-{{<table-wrap>}}
 | Model | Price per 1M <br> input tokens |
 | ----------------- | ------------------------- |
-| bge-small-en-v1.5 | $0.003 |
-| bge-base-en-v1.5 | $0.014 |
-| bge-large-en-v1.5 | $0.022 |
-{{</table-wrap>}}
+| `bge-small-en-v1.5` | $0.003 |
+| `bge-base-en-v1.5` | $0.014 |
+| `bge-large-en-v1.5` | $0.022 |
 
 ### Text Generation
+
 On April 2, 2024, we updated pricing for our `mistral-7b-instruct` models to be 17x cheaper and `llama-2-7b-chat-int8` to be 7x cheaper. The pricing table below reflects the new pricing, but you can take a look at the [archived pricing](/workers-ai/platform/pricing/#archived-pricing) to see how pricing has changed.
 
-{{<table-wrap>}}
 | Model | Price per 1M <br> input tokens | Price per 1M <br> output tokens |
 | -------------------- | ------------------------------ | ------------------------------- |
-| llama-2-7b-chat-fp16 | $0.56 | $6.66 |
-| llama-2-7b-chat-int8 | $0.16 | $0.24 |
-| mistral-7b-instruct | $0.11 | $0.19 |
-{{</table-wrap>}}
+| `llama-2-7b-chat-fp16` | $0.56 | $6.66 |
+| `llama-2-7b-chat-int8` | $0.16 | $0.24 |
+| `mistral-7b-instruct` | $0.11 | $0.19 |
 
 ### Translation
 
-{{<table-wrap>}}
 | Model | Price per 1M <br> input tokens | Price per 1M <br> output tokens |
 | ----------- | ------------------------ | ------------------------- |
-| m2m100-1.2b | $0.13 | $0.70 |
-{{</table-wrap>}}
+| `m2m100-1.2b` | $0.13 | $0.70 |
 
 ## Pricing Example
 
@@ -126,9 +112,8 @@ If a user uses 50k Neurons per day, every day of the month, the Workers AI usage
 As we find optimizations for our inference platform, we pass on these optimizations to our customers. You can refer to the archived pricing below to see how pricing has changed.
 
 Before April 2, 2024:
-{{<table-wrap>}}
+
 | Model | Price per 1M <br> input tokens | Price per 1M <br> output tokens |
 | -------------------- | ------------------------------ | ------------------------------- |
-| llama-2-7b-chat-int8 | $0.28 | $1.72 |
-| mistral-7b-instruct | $0.28 | $3.33 |
-{{</table-wrap>}}
+| `llama-2-7b-chat-int8` | $0.28 | $1.72 |
+| `mistral-7b-instruct` | $0.28 | $3.33 |

--- a/content/workers/_partials/_durable_objects_pricing.md
+++ b/content/workers/_partials/_durable_objects_pricing.md
@@ -7,14 +7,10 @@ _build:
 
 [Durable Objects](/durable-objects/) are only available on the [Workers Paid plan](/workers/platform/pricing/#workers).
 
-{{<table-wrap>}}
-
 |          | Paid plan                                         |
 | -------- | ------------------------------------------------- |
 | Requests               | 1 million, + $0.15/million<br> Includes HTTP requests, RPC sessions<sup>1</sup>, WebSocket messages<sup>2</sup>, and alarm invocations                      |
 | Duration<sup>3</sup>                    | 400,000 GB-s, + $12.50/million GB-s<sup>4,5</sup> |
-
-{{</table-wrap>}}
 
 <sup>1</sup> Each [RPC session](/workers/runtime-apis/rpc/lifecycle/) is billed as one request to your Durable Object. Every [RPC method call](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/#call-rpc-methods) on a [Durable Objects stub](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/#get-a-durable-object-stub) is its own RPC session and therefore a single billed request.
 

--- a/content/workers/_partials/_kv_pricing.md
+++ b/content/workers/_partials/_kv_pricing.md
@@ -7,8 +7,6 @@ _build:
 
 Workers KV is included in both the Free and Paid [Workers plans](/workers/platform/pricing/).
 
-{{<table-wrap>}}
-
 |                 | Free plan<sup>1</sup> | Paid plan                         |
 | --------------- | --------------------- | --------------------------------- |
 | Read requests   | 100,000 / day         | 10 million/month, + $0.50/million |
@@ -16,7 +14,5 @@ Workers KV is included in both the Free and Paid [Workers plans](/workers/platfo
 | Delete requests | 1,000 / day           | 1 million/month, + $5.00/million  |
 | List requests   | 1,000 / day           | 1 million/month, + $5.00/million  |
 | Stored data     | 1 GB                  | 1 GB, + $0.50/ GB-month           |
-
-{{</table-wrap>}}
 
 <sup>1</sup> The Workers Free plan includes limited Workers KV usage. All limits reset daily at 00:00 UTC. If you exceed any one of these limits, further operations of that type will fail with an error.

--- a/content/workers/_partials/_queues_pricing.md
+++ b/content/workers/_partials/_queues_pricing.md
@@ -19,17 +19,15 @@ Cloudflare Queues charges for the total number of operations against each of you
 * Operations are per message, not per batch. A batch of 10 messages (the default batch size), if processed, would incur 10x write, 10x read, and 10x delete operations: one for each message in the batch.
 * There are no data transfer (egress) or throughput (bandwidth) charges.
 
-{{<table-wrap>}}
-
 |                     | Free Tier                    | Paid                       |
 | ------------------- | ---------------------------- | -------------------------- |
 | Standard operations | 1,000,000 operations / month | $0.40 / million operations |
 
-{{</table-wrap>}}
-
 In most cases, it takes 3 operations to deliver a message: 1 write, 1 read, and 1 delete. Therefore, you can use the following formula to estimate your monthly bill:
 
-    ((Number of Messages * 3) - 1,000,000) / 1,000,000  * $0.40
+```txt
+((Number of Messages * 3) - 1,000,000) / 1,000,000  * $0.40
+```
 
 Additionally:
 

--- a/content/workers/_partials/_storage-products-table.md
+++ b/content/workers/_partials/_storage-products-table.md
@@ -5,17 +5,13 @@ _build:
   list: never
 ---
 
-{{<table-wrap>}}
-
 | Use-case                        | Product                              | Ideal for                                                                                                              |
 | ------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
 | Key-value storage               | [Workers KV](/kv/)                   | Configuration data, service routing metadata, personalization (A/B testing)                                            |
 | Object storage                  | [R2](/r2/)                           | User-facing web assets, images, machine learning and training datasets, analytics datasets, log and event data.        |
 | SQL database                    | [D1](/d1/)                           | Relational data, including user profiles, product listings and orders, and/or customer data.                           |
-| Time-series metrics             | [Analytics Engine](/analytics/analytics-engine/) | Write and query high-cardinality time-series data, usage metrics, and service-level telemetry using Workers and/or SQL. |  
+| Time-series metrics             | [Analytics Engine](/analytics/analytics-engine/) | Write and query high-cardinality time-series data, usage metrics, and service-level telemetry using Workers and/or SQL. |
 | Global co-ordination            | [Durable Objects](/durable-objects/) | Building collaborative applications; global co-ordination across clients; strongly consistent, transactional storage.  |
 | Vector search (database)        | [Vectorize](/vectorize/)             | Storing [embeddings](/workers-ai/models/#text-embeddings) from AI models for semantic search and classification tasks. |
 | Task processing & batching      | [Queues](/queues/)                   | Background job processing (emails, notifications, APIs) and log processing/batching.                                   |
 | Connect to an existing database | [Hyperdrive](/hyperdrive/)           | Connecting to an existing database in a cloud or on-prem.                                                              |
-
-{{</table-wrap>}}

--- a/content/workers/_partials/_transactional_storage_api_pricing.md
+++ b/content/workers/_partials/_transactional_storage_api_pricing.md
@@ -5,11 +5,9 @@ _build:
   list: never
 ---
 
-The Durable Objects [Transactional Storage API](/durable-objects/api/transactional-storage-api) is only accessible from within Durable Objects. 
+The Durable Objects [Transactional Storage API](/durable-objects/api/transactional-storage-api) is only accessible from within Durable Objects.
 
 Durable Objects do not have to use the Transactional Storage API, but if your code does call methods on `state.storage`, it will incur the following additional charges:
-
-{{<table-wrap>}}
 
 |                                  | Paid plan                  |
 | -------------------------------- | -------------------------- |
@@ -17,8 +15,6 @@ Durable Objects do not have to use the Transactional Storage API, but if your co
 | Write request units<sup>3</sup>  | 1 million, + $1.00/million |
 | Delete requests<sup>4</sup>      | 1 million, + $1.00/million |
 | Stored data<sup>5</sup>          | 1 GB, + $0.20/ GB-month    |
-
-{{</table-wrap>}}
 
 <sup>1</sup> A request unit is defined as 4 KB of data read or written. A request that writes or reads more than 4 KB will consume multiple units, for example, a 9 KB write will consume 3 write request units.
 

--- a/content/workers/configuration/cron-triggers/index.md
+++ b/content/workers/configuration/cron-triggers/index.md
@@ -64,8 +64,6 @@ To add Cron Triggers in the Cloudflare dashboard:
 
 Cloudflare supports cron expressions with five fields, along with most [Quartz scheduler](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html#introduction)-like cron syntax extensions:
 
-{{<table-wrap>}}
-
 | Field         | Values                                                             | Characters   |
 | ------------- | ------------------------------------------------------------------ | ------------ |
 | Minute        | 0-59                                                               | \* , - /     |
@@ -73,8 +71,6 @@ Cloudflare supports cron expressions with five fields, along with most [Quartz s
 | Days of Month | 1-31                                                               | \* , - / L W |
 | Months        | 1-12, case-insensitive 3-letter abbreviations ("JAN", "aug", etc.) | \* , - /     |
 | Weekdays      | 1-7, case-insensitive 3-letter abbreviations ("MON", "fri", etc.)  | \* , - / L # |
-
-{{</table-wrap>}}
 
 ### Examples
 

--- a/content/workers/configuration/workers-with-page-rules.md
+++ b/content/workers/configuration/workers-with-page-rules.md
@@ -6,7 +6,7 @@ meta:
   description: Review the interaction between various Page Rules and Workers.
 ---
 
-# Page Rules
+{{<heading-pill style="legacy">}}Page Rules{{</heading-pill>}}
 
 Page Rules (legacy) trigger certain actions whenever a request matches one of the URL patterns you define. You can define a page rule to trigger one or more actions whenever a certain URL pattern is matched. Refer to [Page Rules](/rules/page-rules/) to learn more about configuring Page Rules.
 
@@ -70,204 +70,137 @@ A same zone subrequest is a request the Worker makes to an orange-clouded hostna
 
 ### Always Use HTTPS
 
-{{<table-wrap>}}
-
-|     Page Rule    | Source     | Target     | Behavior       |
-| -----------------|------------|------------|----------------|
-| Always Use HTTPS | Client     | Worker     | Rule Respected |
-| Always Use HTTPS | Worker     | Same Zone  | Rule Ignored   |
-| Always Use HTTPS | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Ignored   |
+| Worker     | Other Zone | Rule Ignored   |
 
 {{<heading-pill style="deprecated" heading="h3">}}Auto Minify{{</heading-pill>}}
 
-{{<table-wrap>}}
-
-|     Page Rule    | Source     | Target     | Behavior       |
-| -----------------|------------|------------|----------------|
-| Auto Minify | Client     | Worker     | Rule Ignored   |
-| Auto Minify | Worker     | Same Zone  | Rule Respected |
-| Auto Minify | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Automatic HTTPS Rewrites
 
-{{<table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Automatic HTTPS Rewrites | Client     | Worker     | Rule Ignored   |
-| Automatic HTTPS Rewrites | Worker     | Same Zone  | Rule Respected |
-| Automatic HTTPS Rewrites | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
 
 ### Browser Cache TTL
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Browser Cache TTL        | Client     | Worker     | Rule Ignored   |
-| Browser Cache TTL        | Worker     | Same Zone  | Rule Respected |
-| Browser Cache TTL        | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Browser Integrity Check
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Browser Integrity Check  | Client     | Worker     | Rule Respected |
-| Browser Integrity Check  | Worker     | Same Zone  | Rule Ignored   |
-| Browser Integrity Check  | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Ignored   |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Cache Deception Armor
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Cache Deception Armor    | Client     | Worker     | Rule Respected |
-| Cache Deception Armor    | Worker     | Same Zone  | Rule Respected |
-| Cache Deception Armor    | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Cache Level
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Cache Level              | Client     | Worker     | Rule Respected |
-| Cache Level              | Worker     | Same Zone  | Rule Respected |
-| Cache Level              | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Disable Zaraz
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Disable Zaraz            | Client     | Worker     | Rule Respected |
-| Disable Zaraz            | Worker     | Same Zone  | Rule Respected |
-| Disable Zaraz            | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Edge Cache TTL
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Edge Cache TTL           | Client     | Worker     | Rule Respected |
-| Edge Cache TTL           | Worker     | Same Zone  | Rule Respected |
-| Edge Cache TTL           | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Email Obfuscation
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
+| Source     | Target     | Behavior       |
 | -------------------------|------------|------------|----------------|
-| Email Obfuscation        | Client     | Worker     | Rule Ignored   |
-| Email Obfuscation        | Worker     | Same Zone  | Rule Respected |
-| Email Obfuscation        | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Forwarding URL
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Forwarding URL           | Client     | Worker     | Rule Ignored   |
-| Forwarding URL           | Worker     | Same Zone  | Rule Respected |
-| Forwarding URL           | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### IP Geolocation Header
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| IP Geolocation Header    | Client     | Worker     | Rule Respected |
-| IP Geolocation Header    | Worker     | Same Zone  | Rule Respected |
-| IP Geolocation Header    | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Origin Cache Control
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Origin Cache Control     | Client     | Worker     | Rule Respected |
-| Origin Cache Control     | Worker     | Same Zone  | Rule Respected |
-| Origin Cache Control     | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### Rocket Loader
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Rocket Loader            | Client     | Worker     | Rule Ignored   |
-| Rocket Loader            | Worker     | Same Zone  | Rule Ignored   |
-| Rocket Loader            | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Ignored   |
+| Worker     | Other Zone | Rule Ignored   |
 
 {{<heading-pill style="deprecated" heading="h3">}}Security Level{{</heading-pill>}}
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Security Level           | Client     | Worker     | Rule Respected |
-| Security Level           | Worker     | Same Zone  | Rule Ignored   |
-| Security Level           | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Ignored   |
+| Worker     | Other Zone | Rule Ignored   |
 
 {{<heading-pill style="deprecated" heading="h3">}}Server Side Excludes{{</heading-pill>}}
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| Server Side Excludes     | Client     | Worker     | Rule Ignored   |
-| Server Side Excludes     | Worker     | Same Zone  | Rule Ignored   |
-| Server Side Excludes     | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Ignored   |
+| Worker     | Same Zone  | Rule Ignored   |
+| Worker     | Other Zone | Rule Ignored   |
 
 ### SSL
 
-{{<table-wrap>}}
-
-|     Page Rule            | Source     | Target     | Behavior       |
-| -------------------------|------------|------------|----------------|
-| SSL                      | Client     | Worker     | Rule Respected |
-| SSL                      | Worker     | Same Zone  | Rule Respected |
-| SSL                      | Worker     | Other Zone | Rule Ignored   |
-
-{{</table-wrap>}}
+| Source     | Target     | Behavior       |
+|------------|------------|----------------|
+| Client     | Worker     | Rule Respected |
+| Worker     | Same Zone  | Rule Respected |
+| Worker     | Other Zone | Rule Ignored   |

--- a/content/workers/observability/errors.md
+++ b/content/workers/observability/errors.md
@@ -13,8 +13,6 @@ Review Workers errors and exceptions.
 
 When a Worker running in production has an error that prevents it from returning a response, the client will receive an error page with an error code, defined as follows:
 
-{{<table-wrap>}}
-
 | Error code | Meaning                                                                                                           |
 | ---------- | ----------------------------------------------------------------------------------------------------------------- |
 | `1101`     | Worker threw a JavaScript exception.                                                                              |
@@ -28,8 +26,6 @@ When a Worker running in production has an error that prevents it from returning
 | `1027`     | Worker exceeded free tier [daily request limit](/workers/platform/limits/#daily-request).                         |
 | `1042`     | Worker tried to fetch from another Worker on the same zone, which is [unsupported](/workers/runtime-apis/fetch/). |
 
-{{</table-wrap>}}
-
 Other `11xx` errors generally indicate a problem with the Workers runtime itself. Refer to the [status page](https://www.cloudflarestatus.com) if you are experiencing an error.
 
 ### Loop limit
@@ -37,8 +33,8 @@ Other `11xx` errors generally indicate a problem with the Workers runtime itself
 A Worker cannot call itself or another Worker more than 16 times. In  order to prevent infinite loops between Workers, the [`CF-EW-Via`](/fundamentals/reference/http-request-headers/#cf-ew-via) header's value is an integer that indicates how many invocations are left. Every time a Worker is invoked, the integer will decrement by 1. If the count reaches zero, a [`1019`](#error-pages-generated-by-workers) error is returned.
 
 ## Errors on Worker upload
-These errors occur when a Worker is uploaded or modified. 
-{{<table-wrap>}}
+These errors occur when a Worker is uploaded or modified.
+
 | Error code | Meaning                                                                                                                       |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `10006`     | Could not parse your Worker's code.                                                                                          |
@@ -47,7 +43,7 @@ These errors occur when a Worker is uploaded or modified.
 | `10016`     | Invalid Worker name.                                                                                                         |
 | `10021`     | Validation Error. Refer to [Validation Errors](/workers/observability/errors/#validation-errors-10021) for details. |
 | `10026`     | Could not parse request body.                                                                                                |
-| `10035`     | Multiple attempts to modify a resource at the same time                                                                      |     
+| `10035`     | Multiple attempts to modify a resource at the same time                                                                      |
 | `10037`     | An account has exceeded the number of [Workers allowed](/workers/platform/limits/#number-of-workers).                        |
 | `10026`     | Could not parse request body.                                                                                                |
 | `10052`     | A [binding](/workers/runtime-apis/bindings/) is uploaded without a name.                                                     |
@@ -56,8 +52,6 @@ These errors occur when a Worker is uploaded or modified.
 | `10056`     | [Binding](/workers/runtime-apis/bindings/)  not found.                                                                       |
 | `10068`     | The uploaded Worker has no registered [event handlers](/workers/runtime-apis/handlers/).                                     |
 | `10069`     | The uploaded Worker contains [event handlers](/workers/runtime-apis/handlers/) unsupported by the Workers runtime.           |
-
-{{</table-wrap>}}
 
 ### Validation Errors (10021)
 
@@ -79,15 +73,11 @@ To analyze what is consuming so much CPU time, you should open Chrome DevTools f
 
 Runtime errors will occur within the runtime, do not throw up an error page, and are not visible to the end user. Runtime errors are detected by the user with logs.
 
-{{<table-wrap>}}
-
 | Error message                              | Meaning                                                                                                         |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | `Network connection lost`                  | Connection failure. Catch a `fetch` or binding invocation and retry it.                                         |
 | `Memory limit`</br>`would be exceeded`</br> `before EOF`| Trying to read a stream or buffer that would take you over the [memory limit](/workers/platform/limits/#memory).|
 | `daemonDown`                               | A temporary problem invoking the Worker.                                                                        |
-
-{{</table-wrap>}}
 
 ## Identify errors: Workers Metrics
 

--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -10,8 +10,6 @@ meta:
 
 ## Account plan limits
 
-{{<table-wrap>}}
-
 | Feature                                                                         | Workers Free      | Workers Paid ([Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model),  [Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model)) and [Standard](/workers/platform/pricing/#example-pricing-standard-usage-model)      |
 | ------------------------------------------------------------------------------- | --------- | --------- |
 | [Subrequests](#subrequests)                                                     | 50/request| 50/request ([Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model)),<br> 1000/request ([Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model), [Standard](/workers/platform/pricing/#example-pricing-standard-usage-model))|
@@ -23,7 +21,6 @@ meta:
 | [Number of Workers](#number-of-workers)<sup>1</sup>                                         | 100       | 500       |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account| 5         | 250       |
 
-{{</table-wrap>}}
 <sup>1</sup> If you are running into Workers script limits, your project may be a good fit for [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
 
 {{<render file="_limits_increase.md">}}
@@ -40,16 +37,12 @@ Cloudflare has network-wide limits on the request body size. This limit is tied 
 
 Cloudflare Enterprise customers may contact their account team or [Cloudflare Support](/support/contacting-cloudflare-support/) to have a request body limit beyond 500 MB.
 
-{{<table-wrap>}}
-
 | Cloudflare Plan | Maximum body size  |
 | --------------- | -------------------|
 | Free            | 100 MB             |
 | Pro             | 100 MB             |
 | Business        | 200 MB             |
 | Enterprise      | 500 MB (by default)|
-
-{{</table-wrap>}}
 
 ---
 


### PR DESCRIPTION
Similar vibes as to #15306.

Adding new guidelines in #15300 around tables + table-wrap.

It's not needed for most tables and causes some unexpected issues on mobile. This removes table-wrap from small tables in the `/workers-ai/`, `/workers/`, and `/pages/` spaces. Used mobile preview while doing local dev and didn't see any issues.