### PR TITLE
Add documentation and release note for worker version overrides.

### DIFF
--- a/content/workers/configuration/versions-and-deployments/gradual-deployments.md
+++ b/content/workers/configuration/versions-and-deployments/gradual-deployments.md
@@ -188,7 +188,7 @@ In this example, your deployment is initially configured to route all traffic to
 | :------------------------------------: | :--------: |
 | db7cd8d3-4425-4fe7-8c81-01bf963b6067   | 100%       |
 
-Create a new deployment using [`wrangler versions deploy --experimental-versions`](https://developers.cloudflare.com/workers/wrangler/commands/#deploy-2) and specify 0% for the new version whilst keeping the previous version at 100%.
+Create a new deployment using [`wrangler versions deploy --experimental-versions`](/workers/wrangler/commands/#deploy-2) and specify 0% for the new version whilst keeping the previous version at 100%.
 
 | Version ID                             | Percentage |
 | :------------------------------------: | :--------: |

--- a/content/workers/configuration/versions-and-deployments/gradual-deployments.md
+++ b/content/workers/configuration/versions-and-deployments/gradual-deployments.md
@@ -164,7 +164,7 @@ $ curl -s https://$SCRIPT_NAME.$SUBDOMAIN.workers.dev -H 'Cloudflare-Workers-Ver
 
 The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
 
-A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list --experimental-versions`](https://developers.cloudflare.com/workers/wrangler/commands/#list---experimental-versions) command or on the [Workers Dashboard](https://dash.cloudflare.com/?to=/:account/workers) under Worker > Deployments > Active Deployment. 
+A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list --experimental-versions`](/workers/wrangler/commands/#list---experimental-versions) command or on the [Workers Dashboard](https://dash.cloudflare.com/?to=/:account/workers) under Worker > Deployments > Active Deployment. 
 
 {{<Aside type="note" header="Verifying that the version override was applied">}}
 

--- a/data/changelogs/workers.yaml
+++ b/data/changelogs/workers.yaml
@@ -5,6 +5,9 @@ productLink: "/workers/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+- publish_date: '2024-07-01'
+  description: |-
+    - When using [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/), you can now use [version overrides](/workers/configuration/versions-and-deployments/gradual-deployments/#version-overrides) to send a request to a specific version of your Worker.
 - publish_date: '2024-06-19'
   description: |-
     - When using [`nodejs_compat` compatibility flag](/workers/runtime-apis/nodejs/), the `buffer` module now has an implementation of `isAscii()` and `isUtf8()` methods.


### PR DESCRIPTION
Note that the documentation for both version keys/affinity and version overrides are effectively "how to" guides. We may want to consider adding reference-style documentation for these headers.

Since there was no pre-existing header-based API, there is not an existing/obvious location in the docs to add this. We mention "Cloudflare headers" (i.e. headers which are set by Cloudflare) [here](https://developers.cloudflare.com/workers/runtime-apis/headers/) which is the most appropriate place I can find. Interested to hear what others think is the best way to approach this.