### PR TITLE
[Docs Site] fix: escape IDs passing to querySelector for tabs

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -109,7 +109,9 @@ function $tab(ev: MouseEvent) {
     .closest("[data-link]")
     ?.getAttribute("data-link");
 
-  const linkElement = document.querySelector<HTMLElement>(`#${link}-${tabBlockId}`);
+  // escape ID for use in querySelector
+  const tabID = CSS.escape(`${link}-${tabBlockId}`);
+  const linkElement = document.querySelector<HTMLElement>(`#${tabID}`);
   if(linkElement){
     linkElement.style.display = "block";
   }


### PR DESCRIPTION
It turns out tabs can have spaces in them which `querySelector` doesn't like, whoops. Sorry.

Followup from #15267 