### PR TITLE
hyperdrive: clarify client vs pooled limits

### DIFF
--- a/content/hyperdrive/platform/limits.md
+++ b/content/hyperdrive/platform/limits.md
@@ -18,7 +18,7 @@ The following limits apply to Hyperdrive configuration, connections, and queries
 | Maximum username length                        | 63 characters (bytes) <sup>1</sup>                                                   |
 | Maximum database name length                   | 63 characters (bytes) <sup>1</sup>                                                   |
 | Maximum origin database connections per region | 10-20                                                                                |
-| Maximum potential origin database connections           | 10 \* number of regions serving traffic (approx. ~80 - 100 connections) <sup>3</sup> |
+| Maximum potential origin database connections           | 10 \* number of regions serving traffic (approx. ~80 - 100 connections) <sup>2</sup> |
 
 {{<Aside type="note">}}
 

--- a/content/hyperdrive/platform/limits.md
+++ b/content/hyperdrive/platform/limits.md
@@ -15,16 +15,22 @@ The following limits apply to Hyperdrive configuration, connections, and queries
 | Idle connection timeout                        | 10 minutes                                                                           |
 | Maximum cached query response size             | 50 MB                                                                                |
 | Maximum query (statement) duration             | 60 seconds                                                                           |
-| Maximum username length                        | 63 characters (bytes) <sup>2</sup>                                                   |
-| Maximum database name length                   | 63 characters (bytes) <sup>2</sup>                                                   |
+| Maximum username length                        | 63 characters (bytes) <sup>1</sup>                                                   |
+| Maximum database name length                   | 63 characters (bytes) <sup>1</sup>                                                   |
 | Maximum origin database connections per region | 10-20                                                                                |
-| Maximum potential origin connections           | 10 \* number of regions serving traffic (approx. ~80 - 100 connections) <sup>3</sup> |
+| Maximum potential origin database connections           | 10 \* number of regions serving traffic (approx. ~80 - 100 connections) <sup>3</sup> |
 
-<sup>1</sup> Enterprise customers can request an increase. Submit a [Limit Increase Request Form](https://docs.google.com/forms/d/e/1FAIpQLSd_fwAVOboH9SlutMonzbhCxuuuOmiU1L_I5O2CFbXf_XXMRg/viewform) and we will contact you with the next steps.
+{{<Aside type="note">}}
 
-<sup>2</sup> This is a limit enforced by PostgreSQL. Some database providers may enforce smaller limits.
+Hyperdrive does not have a hard limit on the number of concurrent _client_ connections made from your Workers.
 
-<sup>3</sup> Hyperdrive maintains semi-regional connection pools to balance between latency, reliability and overall load on your origin database.
+As many hosted databases have limits on the number of unique connections they can manage, Hyperdrive attempts to keep number of concurrent pooled connections to your origin database lower.
+
+{{</Aside>}}
+
+<sup>1</sup> This is a limit enforced by PostgreSQL. Some database providers may enforce smaller limits.
+
+<sup>2</sup> Hyperdrive maintains semi-regional connection pools to balance between latency, reliability and overall load on your origin database.
 
 {{<Aside type="note">}}
 


### PR DESCRIPTION
Clarify client conns vs pooled conns. Clean up footnotes.