### PR TITLE
cdnjs should always be lowercase

### DIFF
--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -11,7 +11,7 @@ level: warning
 ignorecase: false
 swap:
   (?<!https?:\/\/[^\s]*)(?<!create-)(?!Cloudflare)(?:[cC]loud[fF]lare)): Cloudflare
-  (?<!https?:\/\/[^\s]*)(?<!create-)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
-  (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
-  (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitLab)(?:[gG]it\s?[lL]ab): GitLab
-  (?<!https?:\/\/[^\s]*)(?<!create-)(?!Next\.js)(?:[nN][eE][xX][tT][\s\.]?[jJ[sS]): Next.js
+  (?<!https?:\/\/[^\s]*)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
+  (?<!https?:\/\/[^\s]*)(?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
+  (?<!https?:\/\/[^\s]*)(?!GitLab)(?:[gG]it\s?[lL]ab): GitLab
+  (?<!https?:\/\/[^\s]*)(?!Next\.js)(?:[nN][eE][xX][tT][\s\.]?[jJ[sS]): Next.js

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -10,7 +10,7 @@ message: "**Warning**: Use correct brand name: '%s' instead of '%s'."
 level: warning
 ignorecase: false
 swap:
-  (?<=^|\s)(?!Cloudflare)(?:[cC]loud[fF]lare)(?='s|\s|$): Cloudflare
-  (?<=^|\s)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS])(?='s|\s|$): cdnjs
-  (?<=^|\s)(?!GitHub)(?:[gG]it\s?[hH]ub)(?='s|\s|$): GitHub
-  (?<=^|\s)(?!GitLab)(?:[gG]it\s?[lL]ab)(?='s|\s|$): GitLab
+  (?<!https?:\/\/[^\s]*)(?<!create-)(?!Cloudflare)(?:[cC]loud[fF]lare)): Cloudflare
+  (?<!https?:\/\/[^\s]*)(?<!create-)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
+  (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
+  (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitLab)(?:[gG]it\s?[lL]ab): GitLab

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -10,5 +10,5 @@ message: "**Warning**: Use correct brand name: '%s' instead of '%s'."
 level: warning
 ignorecase: false
 swap:
-  CloudFlare: Cloudflare
+  (?!Cloudflare)([cC]loud[fF]lare): Cloudflare
   (?!cdnjs)([cC][dD][nN]\.?[jJ][sS]): cdnjs

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -10,7 +10,7 @@ message: "**Warning**: Use correct brand name: '%s' instead of '%s'."
 level: warning
 ignorecase: false
 swap:
-  (?!Cloudflare)(?:[cC]loud[fF]lare): Cloudflare
-  (?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
-  (?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
-  (?!GitLab)(?:[gG]it\s?[lL]ab): GitLab
+  (?<=^|\s)(?!Cloudflare)(?:[cC]loud[fF]lare)(?='s|\s|$): Cloudflare
+  (?<=^|\s)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS])(?='s|\s|$): cdnjs
+  (?<=^|\s)(?!GitHub)(?:[gG]it\s?[hH]ub)(?='s|\s|$): GitHub
+  (?<=^|\s)(?!GitLab)(?:[gG]it\s?[lL]ab)(?='s|\s|$): GitLab

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -12,3 +12,5 @@ ignorecase: false
 swap:
   (?!Cloudflare)([cC]loud[fF]lare): Cloudflare
   (?!cdnjs)([cC][dD][nN]\.?[jJ][sS]): cdnjs
+  (?!GitHub)([gG]it\s?[hH]ub): GitHub
+  (?!GitLab)([gG]it\s?[lL]ab): GitLab

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -1,0 +1,14 @@
+---
+# Warning: cloudflare.BrandNames
+#
+# Suggests correct spelling and capitalization for brand names.
+#
+# For a list of all options, see https://vale.sh/docs/topics/styles/
+
+extends: substitution
+message: "**Warning**: Use correct brand name: '%s' instead of '%s'."
+level: warning
+ignorecase: false
+swap:
+  CloudFlare: Cloudflare
+  (?!cdnjs)([cC][dD][nN]\.?[jJ][sS]): cdnjs

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -10,7 +10,7 @@ message: "**Warning**: Use correct brand name: '%s' instead of '%s'."
 level: warning
 ignorecase: false
 swap:
-  (?!Cloudflare)([cC]loud[fF]lare): Cloudflare
-  (?!cdnjs)([cC][dD][nN]\.?[jJ][sS]): cdnjs
-  (?!GitHub)([gG]it\s?[hH]ub): GitHub
-  (?!GitLab)([gG]it\s?[lL]ab): GitLab
+  (?!Cloudflare)(?:[cC]loud[fF]lare): Cloudflare
+  (?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
+  (?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
+  (?!GitLab)(?:[gG]it\s?[lL]ab): GitLab

--- a/.github/styles/cloudflare/BrandNames.yml
+++ b/.github/styles/cloudflare/BrandNames.yml
@@ -14,3 +14,4 @@ swap:
   (?<!https?:\/\/[^\s]*)(?<!create-)(?!cdnjs)(?:[cC][dD][nN]\.?[jJ][sS]): cdnjs
   (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitHub)(?:[gG]it\s?[hH]ub): GitHub
   (?<!https?:\/\/[^\s]*)(?<!create-)(?!GitLab)(?:[gG]it\s?[lL]ab): GitLab
+  (?<!https?:\/\/[^\s]*)(?<!create-)(?!Next\.js)(?:[nN][eE][xX][tT][\s\.]?[jJ[sS]): Next.js

--- a/src/content/docs/logs/reference/pathing-status.mdx
+++ b/src/content/docs/logs/reference/pathing-status.mdx
@@ -25,7 +25,7 @@ Cloudflare issues the following **Edge Pathing Statuses**:
 * `bic` (browser integrity check)
 * `hot` (hotlink protection)
 * `macro` (the reputation list)
-* `skip` (Always Online or CDNJS resources)
+* `skip` (Always Online or cdnjs resources)
 * `user` (user firewall rule)
 
 For example:
@@ -254,4 +254,3 @@ The macro stage is comprised of many different paths. They are categorized by th
 | `ao_crawl`        | AO (Always Online) crawler request.                       | `wl`          | `skip`         |
 | `cdnjs`           | Request to a cdnjs resource.                              | `wl`          | `skip`         |
 |                   | Certain challenge forced by Cloudflare's special headers. |               | `forced`       |
-

--- a/src/content/docs/waf/tools/replace-insecure-js-libraries.mdx
+++ b/src/content/docs/waf/tools/replace-insecure-js-libraries.mdx
@@ -22,7 +22,7 @@ Additionally, if you are defining a CSP via HTML `meta` tag, you must either tur
 
 ## How it works
 
-When turned on, Cloudflare will check HTTP(S) proxied traffic for `script` tags with an `src` attribute pointing to a potentially insecure service and replace the `src` value with the equivalent link hosted under [CDNJS](https://cdnjs.cloudflare.com/).
+When turned on, Cloudflare will check HTTP(S) proxied traffic for `script` tags with an `src` attribute pointing to a potentially insecure service and replace the `src` value with the equivalent link hosted under [cdnjs](https://cdnjs.cloudflare.com/).
 
 The rewritten URL will keep the original URL scheme (`http://` or `https://`).
 


### PR DESCRIPTION
Couldn't see any existing rule for enforcing correct capitalization of brand names (was surprised given Cloudflare vs. CloudFlare), so I've added one as part of this. Haven't written a Vale rule before so it could be wrong!