### PR TITLE
[pages] Add undocumented `pages dev` flags

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1882,6 +1882,10 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
   - Runtime compatibility date to apply.
 - `--show-interactive-dev-session` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: true if the terminal supports interactivity){{</prop-meta>}}
   - Show the interactive dev session.
+- `--https-key-path` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Path to a custom certificate key.
+- `--https-cert-path` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Path to a custom certificate.
 
 {{</definitions>}}
 


### PR DESCRIPTION
This commit adds two undocumented `pages dev` flags: `--https-key-path` and `--https-cert-path` (related to https://github.com/cloudflare/workers-sdk/issues/1994)