### PR TITLE
ai: link to AI Gateway in sidebar

### DIFF
--- a/content/workers-ai/ai-gateway.md
+++ b/content/workers-ai/ai-gateway.md
@@ -1,0 +1,9 @@
+---
+pcx_content_type: navigation
+title: AI Gateway
+weight: 6
+external_link: https://developers.cloudflare.com/ai-gateway/
+_build:
+  publishResources: false
+  render: never
+---

--- a/content/workers-ai/platform/ai-gateway.md
+++ b/content/workers-ai/platform/ai-gateway.md
@@ -1,8 +1,8 @@
 ---
 pcx_content_type: navigation
 title: AI Gateway
-weight: 6
-external_link: https://developers.cloudflare.com/ai-gateway/
+weight: 5
+external_link: /ai-gateway/
 _build:
   publishResources: false
   render: never


### PR DESCRIPTION
Could also alternatively be under Platform? The cross-link is important for discovery!