### PR TITLE
[Gateway] Remove ChatGPT hosts

### DIFF
--- a/content/cloudflare-one/_partials/gateway/policies/_isolate-chatgpt.md
+++ b/content/cloudflare-one/_partials/gateway/policies/_isolate-chatgpt.md
@@ -5,9 +5,8 @@ _build:
   list: never
 ---
 
-| Selector    | Operator | Value                                                                | Logic | Action  |
-| ----------- | -------- | -------------------------------------------------------------------- | ----- | ------- |
-| Application | in       | `ChatGPT`                                                            | Or    | Isolate |
-| Host        | in       | `chat.openai.com`, `auth0.openai.com`, `openai.com`, `cdn.auth0.com` |       |         |
+| Selector    | Operator | Value     | Action  |
+| ----------- | -------- | --------- | ------- |
+| Application | in       | `ChatGPT` | Isolate |
 
 In **Configure policy settings**, you can customize restrictions for ChatGPT. For example, to prevent your users from inputting sensitive information, you can select **Disable copy / paste** and **Disable file uploads**.

--- a/content/cloudflare-one/_partials/gateway/policies/_isolate-chatgpt.md
+++ b/content/cloudflare-one/_partials/gateway/policies/_isolate-chatgpt.md
@@ -7,6 +7,6 @@ _build:
 
 | Selector    | Operator | Value     | Action  |
 | ----------- | -------- | --------- | ------- |
-| Application | in       | `ChatGPT` | Isolate |
+| Application | in       | _ChatGPT_ | Isolate |
 
 In **Configure policy settings**, you can customize restrictions for ChatGPT. For example, to prevent your users from inputting sensitive information, you can select **Disable copy / paste** and **Disable file uploads**.


### PR DESCRIPTION
Intel added the missing OpenAI hostnames to the _ChatGPT_ Application selector, so creating an OR statement with those hostnames is no longer necessary.

PCX-9350