### PR TITLE
Hyperdrive example and tutorial for pgEdge

### DIFF
--- a/content/hyperdrive/_partials/_npx-wrangler-hyperdrive.md
+++ b/content/hyperdrive/_partials/_npx-wrangler-hyperdrive.md
@@ -1,0 +1,22 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+Move to a terminal window, and use the following command to [create a Hyperdrive](/hyperdrive/get-started/):
+
+```sh
+$ npx wrangler hyperdrive create pgedge --connection-string="<PGEDGE_CONNECTION_STRING>"
+```
+
+When the command completes, it will return information about the Hyperdrive, including the Hyperdrive UUID. Copy the ID, and update the `wrangler.toml` file to include the following information:
+
+```toml
+node_compat = true # required for the postgres connection
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "hyperdrive_uuid"
+```

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -1,0 +1,138 @@
+---
+type: example
+summary: Connect Hyperdrive to a pgEdge Postgres database.
+pcx_content_type: configuration
+title: Connect to pgEdge Cloud
+weight: 4
+layout: example
+---
+
+pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres. The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database.
+
+## Prerequisites
+
+Before starting, install the following software on the system you'll use to create the CloudFlare connection:
+
+* [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+* [npx](https://www.npmjs.com/package/npx)
+
+
+## 1. Create a Cloudflare Worker
+
+Use `npx` to run the Cloudflare Wrangler CLI, and log in to your Cloudflare account:
+
+`npx wrangler login`
+
+Move to your project directory, and create a worker project:
+
+`npx wrangler init pgedge-worker`
+
+Follow the on-screen prompts, selecting the `Hello World` worker (with Typescript enabled). When prompted `Do you want to deploy your application`, answer `Yes`. When you're finished responding to prompts, the CLI will deploy the Worker and display a Worker URL similar to:
+
+`https://pgedge-worker.your-name-423.workers.dev`
+
+Use the following command to install the Cloudflare Wrangler CLI:
+
+`npm install wrangler --save-dev`
+
+
+## 2. Create a pgEdge Database
+
+Visit the [pgEdge website](https://www.pgedge.com/get-started/cloud) to sign up for a pgEdge Developer Edition account. After signing up, connect to the pgEdge Cloud console, and [deploy a 3-node cluster](https://docs.pgedge.com/cloud/cluster/create_cluster). When the deployment completes, use the [PSQL connection string](https://docs.pgedge.com/cloud/connecting/psql) displayed in the `Get Started` pane to connect to the Postgres server.
+
+After connecting, use the following statements to generate a table and records:
+
+`CREATE TABLE products(id varchar, name varchar, primary key(id));`
+
+```sql
+INSERT INTO products (id, name) VALUES
+('1', 'Whisper Quiet Vacuum'),
+('2', 'Everlast Lightbulbs'),
+('3', 'Magic Sponge Erasers'),
+('4', 'EcoFresh Laundry Detergent'),
+('5', 'Sunrise Alarm Clock'),
+('6', 'Infinity Batteries'),
+('7', 'Gleam Window Cleaner'),
+('8', 'IronGlide Steam Iron'),
+('9', 'Breeze Air Purifier'),
+('10', 'QuickFix Super Glue');
+```
+
+Return to the pgEdge console and select the `Start Replication` button to [start replication](https://docs.pgedge.com/cloud/database/manage_db#the-start-replication-pane) across your cluster. 
+
+Navigate to the `Connect to your database` panel, and copy the connection string for the `app` user that is displayed on the [`Nearest node` tab](https://docs.pgedge.com/cloud/database/manage_db#connect-to-your-database). 
+
+
+## 3. Create a Hyperdrive
+
+Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
+
+`npx wrangler hyperdrive create pgedge --connection-string="pgedge_connection_string"`
+
+When the command completes, it will return information about the Hyperdrive, including the Hyperdrive UUID. Copy the ID, and update the `wrangler.toml` file to include the following information:
+
+```sql
+node_compat = true # required for the postgres connection
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "hyperdrive_uuid"
+```
+
+## 4. Update the Cloudflare worker to Query pgEdge
+
+Open the `src/index.ts` file, and update the code to include the following:
+
+```js
+import { Client } from 'pg';
+
+export interface Env {
+    HYPERDRIVE: Hyperdrive;
+}
+
+export default {
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+   	 const client = new Client(env.HYPERDRIVE.connectionString);
+   	 try {
+   		 await client.connect();
+   		 const result = await client.query('SELECT * FROM products');
+   		 ctx.waitUntil(client.end());
+   		 const items = result.rows.map((row: any) => {
+   			 return { id: row.id, name: row.name };
+   		 });
+   		 return new Response(JSON.stringify({ items }), {
+   			 headers: { 'Content-Type': 'application/json' },
+   		 });
+   	 } catch (e) {
+   		 console.log(e);
+   		 return Response.json({ error: JSON.stringify(e) }, { status: 500 });
+   	 }
+    },
+};
+```
+
+After updating the file, use the following command to deploy the updates:
+
+`npx wrangler deploy`
+
+After completing these steps, you can use the Cloudflare worker to query your Postgres database, provisioned and managed by pgEdge Cloud. 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -12,34 +12,18 @@ The following example shows you how to connect Hyperdrive to a [pgEdge](https://
 
 
 
-## 2. Create a pgEdge Database
+## 1. Allow Hyperdrive access
 
-Visit the [pgEdge website](https://www.pgedge.com/get-started/cloud) to sign up for a pgEdge Developer Edition account. After signing up, connect to the pgEdge Cloud console, and [deploy a 3-node cluster](https://docs.pgedge.com/cloud/cluster/create_cluster). When the deployment completes, use the [PSQL connection string](https://docs.pgedge.com/cloud/connecting/psql) displayed in the `Get Started` pane to connect to the Postgres server.
+You can connect Hyperdrive to any existing pgEdge database by configuring your Hyperdrive connection with the database connection string.
 
-After connecting, use the following statements to generate a table and records:
+### pgEdge Dashboard
 
-`CREATE TABLE products(id varchar, name varchar, primary key(id));`
+1. Go to the [**pgEdge dashboard**](https://app.pgedge.com/databases) and select the database you wish to connect to.
+2. In the **Connect to your database** section, copy the connection string for the `app` user that is displayed on the [`Nearest node` tab](https://docs.pgedge.com/cloud/database/manage_db#connect-to-your-database). 
 
-```sql
-INSERT INTO products (id, name) VALUES
-('1', 'Whisper Quiet Vacuum'),
-('2', 'Everlast Lightbulbs'),
-('3', 'Magic Sponge Erasers'),
-('4', 'EcoFresh Laundry Detergent'),
-('5', 'Sunrise Alarm Clock'),
-('6', 'Infinity Batteries'),
-('7', 'Gleam Window Cleaner'),
-('8', 'IronGlide Steam Iron'),
-('9', 'Breeze Air Purifier'),
-('10', 'QuickFix Super Glue');
-```
+With the connection string, you can now create a Hyperdrive database configuration.
 
-Return to the pgEdge console and select the `Start Replication` button to [start replication](https://docs.pgedge.com/cloud/database/manage_db#the-start-replication-pane) across your cluster. 
-
-Navigate to the `Connect to your database` panel, and copy the connection string for the `app` user that is displayed on the [`Nearest node` tab](https://docs.pgedge.com/cloud/database/manage_db#connect-to-your-database). 
-
-
-## 3. Create a Hyperdrive
+## 2. Create a database configuration
 
 Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
 

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -1,16 +1,14 @@
 ---
 type: example
 summary: Connect Hyperdrive to a pgEdge Postgres database.
-pcx_content_type: configuration
+pcx_content_type: example
 title: Connect to pgEdge Cloud
 weight: 4
-layout: example
 ---
 
-The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres.
+# Connect to pgEdge Cloud
 
-
-
+This example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of secure, fully-managed, and fully-distributed Postgres.
 
 ## 1. Allow Hyperdrive access
 
@@ -25,25 +23,13 @@ With the connection string, you can now create a Hyperdrive database configurati
 
 ## 2. Create a database configuration
 
-Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
+{{<render file="_npx-wrangler-hyperdrive.md">}}
 
-`npx wrangler hyperdrive create pgedge --connection-string="pgedge_connection_string"`
-
-When the command completes, it will return information about the Hyperdrive, including the Hyperdrive UUID. Copy the ID, and update the `wrangler.toml` file to include the following information:
-
-```sql
-node_compat = true # required for the postgres connection
-
-[[hyperdrive]]
-binding = "HYPERDRIVE"
-id = "hyperdrive_uuid"
-```
-
-## 4. Update the Cloudflare worker to Query pgEdge
+## 3. Update the Cloudflare Worker to query pgEdge
 
 Open the `src/index.ts` file, and update the code to include the following:
 
-```js
+```ts
 import { Client } from 'pg';
 
 export interface Env {
@@ -55,10 +41,10 @@ export default {
    	 const client = new Client(env.HYPERDRIVE.connectionString);
    	 try {
    		 await client.connect();
-   		 const result = await client.query('SELECT * FROM products');
+   		 const result = await client.query('SELECT * FROM spock.node');
    		 ctx.waitUntil(client.end());
    		 const items = result.rows.map((row: any) => {
-   			 return { id: row.id, name: row.name };
+   			 return { id: row.node_id, name: row.node_name };
    		 });
    		 return new Response(JSON.stringify({ items }), {
    			 headers: { 'Content-Type': 'application/json' },
@@ -73,26 +59,8 @@ export default {
 
 After updating the file, use the following command to deploy the updates:
 
-`npx wrangler deploy`
+```sh
+$ npx wrangler deploy
+```
 
-After completing these steps, you can use the Cloudflare worker to query your Postgres database, provisioned and managed by pgEdge Cloud. 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+After completing these steps, you can use the Cloudflare Worker to query your Postgres database, provisioned and managed by pgEdge Cloud. 

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -7,7 +7,7 @@ weight: 4
 layout: example
 ---
 
-pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres. The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database.
+The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres.
 
 ## Prerequisites
 

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -10,23 +10,6 @@ layout: example
 The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres.
 
 
-## 1. Create a Cloudflare Worker
-
-Use `npx` to run the Cloudflare Wrangler CLI, and log in to your Cloudflare account:
-
-`npx wrangler login`
-
-Move to your project directory, and create a worker project:
-
-`npx wrangler init pgedge-worker`
-
-Follow the on-screen prompts, selecting the `Hello World` worker (with Typescript enabled). When prompted `Do you want to deploy your application`, answer `Yes`. When you're finished responding to prompts, the CLI will deploy the Worker and display a Worker URL similar to:
-
-`https://pgedge-worker.your-name-423.workers.dev`
-
-Use the following command to install the Cloudflare Wrangler CLI:
-
-`npm install wrangler --save-dev`
 
 
 ## 2. Create a pgEdge Database

--- a/content/hyperdrive/examples/pgedge.md
+++ b/content/hyperdrive/examples/pgedge.md
@@ -9,13 +9,6 @@ layout: example
 
 The following example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres.
 
-## Prerequisites
-
-Before starting, install the following software on the system you'll use to create the CloudFlare connection:
-
-* [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-* [npx](https://www.npmjs.com/package/npx)
-
 
 ## 1. Create a Cloudflare Worker
 

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -95,7 +95,7 @@ binding = "HYPERDRIVE"
 id = "hyperdrive_uuid"
 ```
 
-## 4. Update the Cloudflare Worker to Query pgEdge
+## 4. Update the Cloudflare Worker to query pgEdge
 
 Open the `src/index.ts` file, and update the Worker code to include the following code that:
 

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -11,7 +11,9 @@ pcx_content_type: tutorial
 
 ## Overview
 
-In this tutorial, we'll walk you through how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-master replication cluster optimized with Hyperdrive. pgEdge Cloud distributes your data to the network edge; when optimized with Hyperdrive, data delivery speeds jump dramatically.
+In this tutorial, you will learn how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-master replication cluster.
+
+You will create a Worker function that connects to your database using [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) to proxy your database connection and maintain a connection pool to prevent us having to make a new database connection on every request. 
 
 You will learn how to:
 
@@ -21,24 +23,22 @@ You will learn how to:
 - Query your pgEdge Postgres database with a Cloudflare Worker.
 - Test your configuration optimizations.
 
-## Prerequisites
+## Before you start
 
-Before starting, install the following software:
-
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-- [npx](https://www.npmjs.com/package/npx)
+All of the tutorials assume you have already completed the [Get started guide](/workers/get-started/guide/), which gets you set up with a Cloudflare Workers account, [C3](https://github.com/cloudflare/workers-sdk/tree/main/packages/create-cloudflare), and [Wrangler](/workers/wrangler/install-and-update/).
 
 ## 1. Create a Cloudflare Worker
 
-You can use a free Cloudflare account or Cloudflare Workers account to access Hyperdrive. Use `npx` to run the Cloudflare Wrangler CLI, and log in to your Cloudflare account:
+Run the following command to create a Worker project from the command line:
 
-`npx wrangler login`
+```sh
+---
+header: Create a project
+---
+$ npm create cloudflare@latest
+```
 
-Then, use the following command to create a Cloudflare Worker project:
-
-`npx wrangler init pgedge-worker`
-
-Follow the on-screen prompts, specifying the following answers:
+For setup, select the following options:
 
 - `Where do you want to create your application?`: Enter: `pgedge`
 - `What type of application do you want to create?`: Select ``Hello World Worker`.
@@ -92,7 +92,7 @@ node_compat = true # required for the postgres connection
 
 [[hyperdrive]]
 binding = "HYPERDRIVE"
-id = "hyperdrive_uuid"
+id = "<HYPERDRIVE_CONFIG_ID>"
 ```
 
 ## 4. Update the Cloudflare Worker to query pgEdge
@@ -143,7 +143,9 @@ When the command completes, the result set includes a URL. Navigate to the URL w
 
 ## 5. Compare System Latency
 
-We tested system latency by using Terraform and a simple `Go` program that issues multiple HTTPS requests to our Cloudflare Worker and recorded the average request latencies. Some of the environments evaluated combine regional TCP connection pooling (via Hyperdrive) with the latency-based DNS routing you get with a pgEdge database. _Latency by Location (in ms)_ improved dramatically when using Hyperdrive and pgEdge nearest node queries:
+We can test the system latency by using Terraform and a simple `Go` program that issues multiple HTTPS requests to our Cloudflare Worker and recorded the average request latencies. A sample open-source project has been created to share scripts and Terraform code to configure this and can be accessed on [GitHub](https://github.com/pgEdge/cloudflare-pgedge-latency-tests).
+
+Some of the environments evaluated combine regional TCP connection pooling (via Hyperdrive) with the latency-based DNS routing you get with a pgEdge database. _Latency by Location (in ms)_ improved dramatically when using Hyperdrive and pgEdge nearest node queries:
 
 | Hyperdrive | pgEdge PostgreSQL   | Los Angeles | Salt Lake City | Dallas | Montreal | London |
 | ---------- | ------------------- | ----------- | -------------- | ------ | -------- | ------ |

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -13,7 +13,7 @@ pcx_content_type: tutorial
 
 In this tutorial, we'll walk you through how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-master replication cluster optimized with Hyperdrive. pgEdge Cloud distributes your data to the network edge; when optimized with Hyperdrive, data delivery speeds jump dramatically.
 
-In this tutorial we demonstrate how to:
+You will learn how to:
 
 - Deploy a Cloudflare Worker with the Cloudflare Wrangler CLI.
 - Create and connect to a pgEdge distributed Postgres cluster.

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -83,9 +83,9 @@ Navigate to the `Connect to your database` pane, and copy the connection string 
 
 Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
 
-`npx wrangler hyperdrive create pgedge --connection-string="pgedge_connection_string"`
+`npx wrangler hyperdrive create pgedge --connection-string="<PGEDGE_CONNECTION_STRING>"`
 
-When the command completes, it will return information about the Hyperdrive, including the Hyperdrive UUID. Copy the ID, and update the `wrangler.toml` file to include the following information:
+When the command completes, it will return information about the Hyperdrive, including the Hyperdrive configuration ID. Copy the ID, and update the `wrangler.toml` file to include the following information:
 
 ```sql
 node_compat = true # required for the postgres connection

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -1,0 +1,163 @@
+---
+pcx_content_type: tutorial
+title: Query a pgEdge Distributed PostgreSQL Cluster from Cloudflare Workers
+updated: 2024-05-07
+difficulty: Beginner
+content_type: 📝 Tutorial
+pcx_content_type: tutorial
+---
+
+# Query a pgEdge Distributed PostgreSQL Cluster from Cloudflare Workers
+
+## Overview
+
+In this tutorial, we'll walk you through how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-master replication cluster optimized with Hyperdrive. pgEdge Cloud distributes your data to the network edge; when optimized with Hyperdrive, data delivery speeds jump dramatically.
+
+In this tutorial we demonstrate how to:
+
+- Deploy a Cloudflare Worker with the Cloudflare Wrangler CLI.
+- Create and connect to a pgEdge distributed Postgres cluster.
+- Use Cloudflare Wrangler to create a [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) connection to your pgEdge Postgres database.
+- Query your pgEdge Postgres database with a Cloudflare Worker.
+- Test your configuration optimizations.
+
+## Prerequisites
+
+Before starting, install the following software:
+
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [npx](https://www.npmjs.com/package/npx)
+
+## 1. Create a Cloudflare Worker
+
+You can use a free Cloudflare account or Cloudflare Workers account to access Hyperdrive. Use `npx` to run the Cloudflare Wrangler CLI, and log in to your Cloudflare account:
+
+`npx wrangler login`
+
+Then, use the following command to create a Cloudflare Worker project:
+
+`npx wrangler init pgedge-worker`
+
+Follow the on-screen prompts, specifying the following answers:
+
+- `Where do you want to create your application?`: Enter: `pgedge`
+- `What type of application do you want to create?`: Select ``Hello World Worker`.
+- `Do you want to use TypeScript?`: Select `Yes`.
+- `Do you want to deploy your application?`: Select `Yes`.
+
+When you're finished responding to prompts, the CLI will deploy the Worker and display a Worker URL similar to:
+
+`https://pgedge-worker.your-name-423.workers.dev`
+
+Then, navigate into the `pgedge` directory, and install the Cloudflare Wrangler CLI in your project:
+
+`cd pgedge`
+`npm install wrangler --save-dev`
+
+## 2. Create a pgEdge Cluster
+
+Visit the pgEdge website to sign up for a free pgEdge Designer Edition Cloud account. After signing up, connect to the pgEdge Cloud console, and deploy a 3-node cluster. When the deployment completes, copy the PSQL connection string displayed in the `Get Started` pane to a terminal window, and connect to the Postgres server hosted in pgEdge Cloud.
+
+After connecting, use the following statements to create a table and populate the table with records:
+
+```sql
+CREATE TABLE products(id varchar, name varchar, primary key(id));
+INSERT INTO products (id, name) VALUES
+('1', 'Whisper Quiet Vacuum'),
+('2', 'Everlast Lightbulbs'),
+('3', 'Magic Sponge Erasers'),
+('4', 'EcoFresh Laundry Detergent'),
+('5', 'Sunrise Alarm Clock'),
+('6', 'Infinity Batteries'),
+('7', 'Gleam Window Cleaner'),
+('8', 'IronGlide Steam Iron'),
+('9', 'Breeze Air Purifier'),
+('10', 'QuickFix Super Glue');
+```
+
+When you return to the pgEdge console, the `products` table will be listed in the `Start Replication` pane. Select the `Start Replication` button to start replication across the nodes in your cluster.
+
+Navigate to the `Connect to your database` pane, and copy the connection string for the `app` user that is displayed on the `Nearest node` tab. You will need to provide this connection string in the command that creates a Hyperdrive.
+
+## 3. Create a Hyperdrive
+
+Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
+
+`npx wrangler hyperdrive create pgedge --connection-string="pgedge_connection_string"`
+
+When the command completes, it will return information about the Hyperdrive, including the Hyperdrive UUID. Copy the ID, and update the `wrangler.toml` file to include the following information:
+
+```sql
+node_compat = true # required for the postgres connection
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "hyperdrive_uuid"
+```
+
+## 4. Update the Cloudflare Worker to Query pgEdge
+
+Open the `src/index.ts` file, and update the Worker code to include the following code that:
+
+- Uses Hyperdrive to create a connection with the pgEdge Postgres database.
+- Queries the `products` table (created in step 2).
+- Returns the result set in a JSON string.
+
+```js
+import { Client } from "pg";
+
+export interface Env {
+  HYPERDRIVE: Hyperdrive;
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
+    const client = new Client(env.HYPERDRIVE.connectionString);
+    try {
+      await client.connect();
+      const result = await client.query("SELECT * FROM products");
+      ctx.waitUntil(client.end());
+      const items = result.rows.map((row: any) => {
+        return { id: row.id, name: row.name };
+      });
+      return new Response(JSON.stringify({ items }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch (e) {
+      console.log(e);
+      return Response.json({ error: JSON.stringify(e) }, { status: 500 });
+    }
+  },
+};
+```
+
+After updating the file, use the following command to deploy your Cloudflare Worker:
+
+`npx wrangler deploy`
+
+When the command completes, the result set includes a URL. Navigate to the URL with your browser or curl to review information about the `products` table.
+
+## 5. Compare System Latency
+
+We tested system latency by using Terraform and a simple `Go` program that issues multiple HTTPS requests to our Cloudflare Worker and recorded the average request latencies. Some of the environments evaluated combine regional TCP connection pooling (via Hyperdrive) with the latency-based DNS routing you get with a pgEdge database. _Latency by Location (in ms)_ improved dramatically when using Hyperdrive and pgEdge nearest node queries:
+
+| Hyperdrive | pgEdge PostgreSQL   | Los Angeles | Salt Lake City | Dallas | Montreal | London |
+| ---------- | ------------------- | ----------- | -------------- | ------ | -------- | ------ |
+| `off`      | pgEdge us-east node | 530         | 549            | 331    | 248      | 604    |
+| `off`      | pgEdge nearest node | 366         | 388            | 333    | 247      | 210    |
+| `on`       | pgEdge us-east node | 88          | 103            | 122    | 71       | 139    |
+| `on`       | pgEdge nearest node | 71          | 79             | 103    | 71       | 72     |
+
+The fastest configuration - Hyperdrive with pgEdge's _nearest node_ - improved request latencies for end-users dramatically. Some users (for example, the user in London) experienced latencies that were cut in half (139 ms to 72 ms) when using pgEdge's nearest-node capability.
+
+When used in conjunction with pgEdge Postgres Cloud, Hyperdrive provides a big win.
+
+## Related Resources
+
+- You can download the pgEdge testing scripts, Terraform code, and test setup from [GitHub](https://github.com/pgEdge/cloudflare-pgedge-latency-tests).
+
+- You can learn more about pgEdge PostgreSQL Cloud by reviewing the [documentation](https://docs.pgedge.com/cloud).

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: tutorial
 title: Query a pgEdge Distributed PostgreSQL Cluster from Cloudflare Workers
-updated: 2024-05-07
+updated: 2024-06-27
 difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -11,7 +11,7 @@ pcx_content_type: tutorial
 
 ## Overview
 
-In this tutorial, you will learn how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-master replication cluster.
+In this tutorial, you will learn how to use a Cloudflare Worker to consume data from a pgEdge Cloud Postgres database in a three-node distributed multi-active replication cluster.
 
 You will create a Worker function that connects to your database using [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) to proxy your database connection and maintain a connection pool to prevent us having to make a new database connection on every request. 
 
@@ -19,7 +19,7 @@ You will learn how to:
 
 - Deploy a Cloudflare Worker with the Cloudflare Wrangler CLI.
 - Create and connect to a pgEdge distributed Postgres cluster.
-- Use Cloudflare Wrangler to create a [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) connection to your pgEdge Postgres database.
+- Use Cloudflare Wrangler to create a [Hyperdrive](/hyperdrive/) connection to your pgEdge Postgres database.
 - Query your pgEdge Postgres database with a Cloudflare Worker.
 - Test your configuration optimizations.
 
@@ -51,8 +51,10 @@ When you're finished responding to prompts, the CLI will deploy the Worker and d
 
 Then, navigate into the `pgedge` directory, and install the Cloudflare Wrangler CLI in your project:
 
-`cd pgedge`
-`npm install wrangler --save-dev`
+```sh
+$ cd pgedge
+$ npm install wrangler --save-dev
+```
 
 ## 2. Create a pgEdge Cluster
 
@@ -81,19 +83,7 @@ Navigate to the `Connect to your database` pane, and copy the connection string 
 
 ## 3. Create a Hyperdrive
 
-Move to a terminal window, and use the following command to [create a Hyperdrive](https://developers.cloudflare.com/hyperdrive/get-started/):
-
-`npx wrangler hyperdrive create pgedge --connection-string="<PGEDGE_CONNECTION_STRING>"`
-
-When the command completes, it will return information about the Hyperdrive, including the Hyperdrive configuration ID. Copy the ID, and update the `wrangler.toml` file to include the following information:
-
-```sql
-node_compat = true # required for the postgres connection
-
-[[hyperdrive]]
-binding = "HYPERDRIVE"
-id = "<HYPERDRIVE_CONFIG_ID>"
-```
+{{<render file="_npx-wrangler-hyperdrive.md">}}
 
 ## 4. Update the Cloudflare Worker to query pgEdge
 
@@ -103,7 +93,7 @@ Open the `src/index.ts` file, and update the Worker code to include the followin
 - Queries the `products` table (created in step 2).
 - Returns the result set in a JSON string.
 
-```js
+```ts
 import { Client } from "pg";
 
 export interface Env {
@@ -137,7 +127,9 @@ export default {
 
 After updating the file, use the following command to deploy your Cloudflare Worker:
 
-`npx wrangler deploy`
+```sh
+$ npx wrangler deploy
+```
 
 When the command completes, the result set includes a URL. Navigate to the URL with your browser or curl to review information about the `products` table.
 

--- a/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
+++ b/content/hyperdrive/tutorials/multi-region-postgres-with-pgedge/index.md
@@ -58,7 +58,13 @@ $ npm install wrangler --save-dev
 
 ## 2. Create a pgEdge Cluster
 
-Visit the pgEdge website to sign up for a free pgEdge Designer Edition Cloud account. After signing up, connect to the pgEdge Cloud console, and deploy a 3-node cluster. When the deployment completes, copy the PSQL connection string displayed in the `Get Started` pane to a terminal window, and connect to the Postgres server hosted in pgEdge Cloud.
+Visit the pgEdge website to sign up for a free pgEdge Designer Edition Cloud account. After signing up, connect to the pgEdge Cloud console, and deploy a 3-node cluster. When the deployment completes, copy the PSQL connection string displayed in the `Get Started` pane, and connect to the Postgres server hosted in pgEdge Cloud. You can connect using the `psql` command-line tool or a GUI tool like pgAdmin.
+
+The PSQL command will look similar to the following:
+
+```sh
+$ PGSSLMODE=require PGPASSWORD=randompassword psql -U app -h random-name.a1.pgedge.io -d defaultdb
+```
 
 After connecting, use the following statements to create a table and populate the table with records:
 


### PR DESCRIPTION
Adds an examples and tutorials page describing how to use Cloudflare Hyperdrive with [pgEdge Cloud](https://www.pgedge.com/).

As discussed with @elithrar in email. Thanks and let us know if any changes are required! 

cc @susan-pgedge

![Screenshot 2024-06-27 at 4 19 02 PM](https://github.com/cloudflare/cloudflare-docs/assets/1389638/4c9da3d2-786d-40eb-815e-a42f34692453)
