### PR TITLE
Clarify queues pricing

### DIFF
--- a/content/workers/_partials/_queues_pricing.md
+++ b/content/workers/_partials/_queues_pricing.md
@@ -19,9 +19,9 @@ Cloudflare Queues charges for the total number of operations against each of you
 * Operations are per message, not per batch. A batch of 10 messages (the default batch size), if processed, would incur 10x write, 10x read, and 10x delete operations: one for each message in the batch.
 * There are no data transfer (egress) or throughput (bandwidth) charges.
 
-|                     | Free Tier                    | Paid                       |
-| ------------------- | ---------------------------- | -------------------------- |
-| Standard operations | 1,000,000 operations / month | $0.40 / million operations |
+|                     | Workers Paid                                                   |
+| ------------------- | -------------------------------------------------------------- |
+| Standard operations | 1,000,000 operations/month included + $0.40/million operations |
 
 In most cases, it takes 3 operations to deliver a message: 1 write, 1 read, and 1 delete. Therefore, you can use the following formula to estimate your monthly bill:
 


### PR DESCRIPTION
Queues are only offered on the Workers Paid plan. The first 1M operations are included.

Current:
<img width="542" alt="Screenshot 2024-06-27 at 2 02 51 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/13840886/dfa30a7a-5174-44e5-b61a-a1967eb84caf">

New:

<img width="702" alt="Screenshot 2024-06-27 at 2 13 40 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/13840886/11088845-63f7-4232-8d23-5f9bd6ca3767">

