### PR TITLE
Update linux curl command with proper flags

### DIFF
--- a/content/logs/logpull/enabling-log-retention/index.md
+++ b/content/logs/logpull/enabling-log-retention/index.md
@@ -26,7 +26,7 @@ To make a `POST` call, you must have zone-scoped `edit` permissions, such as Sup
 ### Check whether log retention is turned on:
 
 ```sh
-$ curl -s -H "X-Auth-Email: <EMAIL>" -H "X-Auth-Key: <API_KEY>" GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" | jq .
+$ curl -s -H "X-Auth-Email: <EMAIL>" -H "X-Auth-Key: <API_KEY>" -X GET "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" | jq .
 ```
 
 #### Response:
@@ -47,7 +47,7 @@ $ curl -s -H "X-Auth-Email: <EMAIL>" -H "X-Auth-Key: <API_KEY>" GET "https://api
 On Linux or macOS:
 
 ```bash
-curl -s -H "X-Auth-Email: <EMAIL>" -H "X-Auth-Key: <API_KEY>" POST "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" -d'{"flag":true}' | jq .
+curl -s -H "X-Auth-Email: <EMAIL>" -H "X-Auth-Key: <API_KEY>" -X POST "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/logs/control/retention/flag" -d'{"flag":true}' | jq .
 ```
 
 On Windows in Command Prompt:


### PR DESCRIPTION
In curl, just having `POST` or `GET` without the `-X` flag (or `--request`) has no meaning, and in fact, returns errors:

Running these curl commands with the `--verbose` flag, we see:

```
* Could not resolve host: POST
* Could not resolve host: GET
```

Why do these commands work? Because curl sees the `GET`/`POST` as another host, and issues the first request to one of those, then the Cloudflare API in the second request.

These flags aren't required at all, since curl knows that when you send a payload (using the `-d` flag), you most likely want a `POST` request. Without a payload, it will, by default, send a `GET` request.

In my changes, I opted to simply correct the flags, as the API is supposed to respond differently to those methods, so there is instructional value.

Note: I don't use cURL on Windows, and haven't tested there, so did not change those.