### PR TITLE
[Docs Site] Escape selector in events.ts#load

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -36,7 +36,12 @@ export function $tabbable(links: NodeListOf<Element>, bool: boolean) {
 // but only on load if `#hash` in URL
 export function load() {
   let hash = location.hash.substring(1);
-  let item = hash && document.querySelector(`#${hash.toLowerCase()}`);
+
+  if (!hash) return;
+
+  const headerID = CSS.escape(hash.toLowerCase());
+  let item = document.querySelector(`#${headerID}`);
+
   let timer =
     item &&
     setInterval(() => {


### PR DESCRIPTION
Fixes a bug with IDs that need escaping (`3-create-a-lan`).