### PR TITLE
Update managed-networks.md

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -16,7 +16,7 @@ A TLS endpoint is a host on your network that serves a TLS certificate. The TLS 
 The WARP client will automatically exclude the managed network endpoint from all device profiles.  
 {{</Aside>}}
 
-The TLS certificate can be hosted by any device on your network. However, the endpoint must be inaccessible to users outside of the network location. Therefore, do not choose a [private network IP](/cloudflare-one/connections/connect-networks/private-net/cloudflared/) that is exposed to users over Cloudflare Tunnel. One option is to choose a host that is physically in the office which remote users do not need to access, such as a printer.
+The TLS certificate can be hosted by any device on your network. However, the endpoint must be inaccessible to users outside of the network location. WARP will automatically exclude the managed network endpoint from all device profiles to ensure that users cannot connect to this endpoint over Cloudflare Tunnel. We recommend choosing a host that is physically in the office which remote users do not need to access, such as a printer.
 
 ### Create a new TLS endpoint
 

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -12,9 +12,6 @@ Cloudflare WARP allows you to selectively apply WARP client settings if the devi
 
 A TLS endpoint is a host on your network that serves a TLS certificate. The TLS endpoint acts like a network location beacon — when a device connects to a network, WARP detects the TLS endpoint and validates its certificate against an uploaded SHA-256 fingerprint.
 
-{{<Aside type="note">}}
-{{</Aside>}}
-
 The TLS certificate can be hosted by any device on your network. However, the endpoint must be inaccessible to users outside of the network location. WARP will automatically exclude the managed network endpoint from all device profiles to ensure that users cannot connect to this endpoint over Cloudflare Tunnel. We recommend choosing a host that is physically in the office which remote users do not need to access, such as a printer.
 
 ### Create a new TLS endpoint

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -12,6 +12,10 @@ Cloudflare WARP allows you to selectively apply WARP client settings if the devi
 
 A TLS endpoint is a host on your network that serves a TLS certificate. The TLS endpoint acts like a network location beacon — when a device connects to a network, WARP detects the TLS endpoint and validates its certificate against an uploaded SHA-256 fingerprint.
 
+{{<Aside type="note">}}
+The WARP client will automatically exclude the managed network endpoint from all device profiles.  
+{{</Aside>}}
+
 The TLS certificate can be hosted by any device on your network. However, the endpoint must be inaccessible to users outside of the network location. Therefore, do not choose a [private network IP](/cloudflare-one/connections/connect-networks/private-net/cloudflared/) that is exposed to users over Cloudflare Tunnel. One option is to choose a host that is physically in the office which remote users do not need to access, such as a printer.
 
 ### Create a new TLS endpoint

--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks.md
@@ -13,7 +13,6 @@ Cloudflare WARP allows you to selectively apply WARP client settings if the devi
 A TLS endpoint is a host on your network that serves a TLS certificate. The TLS endpoint acts like a network location beacon — when a device connects to a network, WARP detects the TLS endpoint and validates its certificate against an uploaded SHA-256 fingerprint.
 
 {{<Aside type="note">}}
-The WARP client will automatically exclude the managed network endpoint from all device profiles.  
 {{</Aside>}}
 
 The TLS certificate can be hosted by any device on your network. However, the endpoint must be inaccessible to users outside of the network location. WARP will automatically exclude the managed network endpoint from all device profiles to ensure that users cannot connect to this endpoint over Cloudflare Tunnel. We recommend choosing a host that is physically in the office which remote users do not need to access, such as a printer.


### PR DESCRIPTION
When you create a Managed Network Endpoint it is expected to be auto-excluded from all tunnels.  Meaning that if you attempt to otherwise access that particular endpoint over WARP -> Tunnel, it will not work. 

If the endpoint is shared or otherwise needs to be accessible over WARP -> Tunnel, a different endpoint should be chosen.