### PR TITLE
add missing backtick on section `Transitive loading of @types/node overrides @cloudflare/workers-types `

### DIFF
--- a/content/workers/languages/typescript/_index.md
+++ b/content/workers/languages/typescript/_index.md
@@ -12,7 +12,7 @@ TypeScript is a first-class language on Cloudflare Workers. Cloudflare publishes
 
 ### Known issues
 
-#### Transitive loading of `@types/node` overrides `@cloudflare/workers-types
+#### Transitive loading of `@types/node` overrides `@cloudflare/workers-types`
 
 You project's dependencies may load the `@types/node` package on their own. As of `@types/node@20.8.4` that package now overrides `Request`, `Response` and `fetch` types (possibly others) specified by `@cloudflare/workers-types` causing type errors.
 


### PR DESCRIPTION
## Why

Because it is malformed on the website.

![Screenshot-2024-06-30 at 15 14 11@2x](https://github.com/cloudflare/cloudflare-docs/assets/23056537/dd5022a7-465c-464f-894f-34214f849fb0)

