### PR TITLE
Update _view-audit-log.md

### DIFF
--- a/content/fundamentals/_partials/_view-audit-log.md
+++ b/content/fundamentals/_partials/_view-audit-log.md
@@ -11,3 +11,9 @@ To access audit logs in the Cloudflare dashboard:
 2. Go to **Manage Account** > **Audit Log**.
 
 You can search these audit logs by user email or domain and filter by date range. To download audit logs, click **Download CSV**.
+
+{{<Aside type="note">}}
+
+Depending on the volume of data, the export of large amounts of events from Audit Logs might fail with errors. We always recommend using Cloudflare [Log Push](/logs/about/) to make sure Audit Logs are always available and stored externally.
+
+{{</Aside>}}


### PR DESCRIPTION
Explain that the download of audit logs can throw some server errors if the amount of data that is being exported is to large. We also recommend storing the logs externally with logpush as an alternative.

This was discovered in this CUSTESC-41665