### PR TITLE
[Developer Spotlight] Restructure Developer Spotlight pages

### DIFF
--- a/content/developer-spotlight/_index.md
+++ b/content/developer-spotlight/_index.md
@@ -5,59 +5,32 @@ title: Developer Spotlight program
 
 # Developer Spotlight program
 
-If you use Cloudflare's developer products and would like to share your expertise then Cloudflare's Developer Spotlight program is for you. Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
+Find examples of how our community of developers are getting the most out of our products.
 
-The Developer Spotlight program is not currently open for applicants. Check our official Discord channel for future announcements.
+If you are interested in contributing a tutorial to the Developer Spotlight program, please read our [application guide documentation](/developer-spotlight/application-guide/). Applications are not currently open.
 
-## Who can apply?
+## View latest contributions
 
-Anybody who is not currently a Cloudflare employee and regularly uses our Developer platform products can apply.
+{{<related header="Create a sitemap from Sanity CMS with Workers" href="/developer-spotlight/tutorials/create-sitemap-from-sanity-cms/">}}
 
-## Submission process
+By John Siciliano
 
-Those who apply will be asked to provide a title and details for a tutorial they would like to write for the Developer Spotlight program. Selected applicants will be contacted via email and will be asked to write and submit their completed tutorial to [Cloudflare's documentation GitHub](https://github.com/cloudflare/cloudflare-docs).
+{{</related>}}
 
-Once your tutorial has been submitted as a pull request (PR), we will then conduct two reviews: A technical review to check that the tutorial is technically accurate, and a content review to check that the tutorial adheres to our documentation style guide. After your PR has been approved by both reviewers and your submission has been published, you will be awarded 350 account credits to your Cloudflare account, and your name will be added to the header of your tutorial.
+{{<related header="Recommend products on e-commerce sites using Workers AI and Stripe" href="/developer-spotlight/tutorials/creating-a-recommendation-api/">}}
 
-## Submission rules
+By Hidetaka Okamoto
 
-Your tutorial must be:
+{{</related>}}
 
-1. Easy for anyone to follow.
-2. Technically accurate.
-3. Entirely original, written only by you.
-4. Written following Cloudflare's documentation style guide. For more information, please visit our [style guide documentation](/style-guide/) and our [tutorial style guide documentation](/style-guide/documentation-content-strategy/content-types/tutorial/#template)
-5. About using Cloudflare's Developer Platform products.
-6. Complete, not an unfinished draft.
+{{<related header="Custom access control for files in R2 using D1 and Workers" href="/developer-spotlight/tutorials/custom-access-control-for-files/">}}
 
+By Dominik Fuerst
 
-## Account credits
+{{</related>}}
 
-Account credits can be used towards recurring monthly charges for Cloudflare plans or add-on services. Once your submission has been approved and published, we can then add 350 credits to your Cloudflare account. Credits are only valid for three years. Valid payment details must be stored on the recieving account before credits can be added.
+{{<related header="Send form submissions using Astro and Resend" href="/developer-spotlight/tutorials/handle-form-submission-with-astro-resend/">}}
 
----
+By Cody Walsh
 
-## FAQ
-
-### How many tutorial topic ideas can I submit?
-
-You may submit as many tutorial topics ideas as you like in your application.
-
-### When will I be compensated for my tutorial?
-
-We will add the account credits to your Cloudflare account after your tutorial has been approved and published under the Developer Spotlight program.
-
-### If my tutorial is accepted and published on Cloudflare's Developer Spotlight program, can I republish it elsewhere?
-
-We ask that you do not republish any tutorials that have been published under the Cloudflare Developer Spotlight program.
-
-### Will I be credited for my work?
-
-You will be credited as the author of any tutorial you submit that is successfully published through the Cloudflare Developer Spotlight program. We will add your details to your work after it has been approved.
-
-### What happens If my topic of choice gets accepted but the tutorial submission gets rejected?
-
-Our team will do our best to help you edit your tutorial's pull request to be ready for submission, however in the unlikely chance that your tutorial's pull request is rejected you are still free to publish your work elsewhere.
-
-
-
+{{</related>}}

--- a/content/developer-spotlight/application-guide/index.md
+++ b/content/developer-spotlight/application-guide/index.md
@@ -1,0 +1,63 @@
+---
+pcx_content_type: concept
+title: Application guide
+---
+
+# Developer Spotlight application guide
+
+If you use Cloudflare's developer products and would like to share your expertise then Cloudflare's Developer Spotlight program is for you. Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
+
+The Developer Spotlight program is not currently open for applicants. Check our official Discord channel for future announcements.
+
+## Who can apply?
+
+Anybody who is not currently a Cloudflare employee and regularly uses our Developer platform products can apply.
+
+## Submission process
+
+Those who apply will be asked to provide a title and details for a tutorial they would like to write for the Developer Spotlight program. Selected applicants will be contacted via email and will be asked to write and submit their completed tutorial to [Cloudflare's documentation GitHub](https://github.com/cloudflare/cloudflare-docs).
+
+Once your tutorial has been submitted as a pull request (PR), we will then conduct two reviews: A technical review to check that the tutorial is technically accurate, and a content review to check that the tutorial adheres to our documentation style guide. After your PR has been approved by both reviewers and your submission has been published, you will be awarded 350 account credits to your Cloudflare account, and your name will be added to the header of your tutorial.
+
+## Submission rules
+
+Your tutorial must be:
+
+1. Easy for anyone to follow.
+2. Technically accurate.
+3. Entirely original, written only by you.
+4. Written following Cloudflare's documentation style guide. For more information, please visit our [style guide documentation](/style-guide/) and our [tutorial style guide documentation](/style-guide/documentation-content-strategy/content-types/tutorial/#template)
+5. About using Cloudflare's Developer Platform products.
+6. Complete, not an unfinished draft.
+
+
+## Account credits
+
+Account credits can be used towards recurring monthly charges for Cloudflare plans or add-on services. Once your submission has been approved and published, we can then add 350 credits to your Cloudflare account. Credits are only valid for three years. Valid payment details must be stored on the recieving account before credits can be added.
+
+---
+
+## FAQ
+
+### How many tutorial topic ideas can I submit?
+
+You may submit as many tutorial topics ideas as you like in your application.
+
+### When will I be compensated for my tutorial?
+
+We will add the account credits to your Cloudflare account after your tutorial has been approved and published under the Developer Spotlight program.
+
+### If my tutorial is accepted and published on Cloudflare's Developer Spotlight program, can I republish it elsewhere?
+
+We ask that you do not republish any tutorials that have been published under the Cloudflare Developer Spotlight program.
+
+### Will I be credited for my work?
+
+You will be credited as the author of any tutorial you submit that is successfully published through the Cloudflare Developer Spotlight program. We will add your details to your work after it has been approved.
+
+### What happens If my topic of choice gets accepted but the tutorial submission gets rejected?
+
+Our team will do our best to help you edit your tutorial's pull request to be ready for submission, however in the unlikely chance that your tutorial's pull request is rejected you are still free to publish your work elsewhere.
+
+
+


### PR DESCRIPTION
Restructuring the Developer Spotlight pages to seperate out application guidelines from the landing page

![image](https://github.com/cloudflare/cloudflare-docs/assets/125887610/14ae2405-0ed4-4708-81bb-5937ade0ab9e)
