### PR TITLE
[pages] Add undocumented pages dev flags

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1862,6 +1862,8 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
   - The directory of static assets to serve.
 - `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: true){{</prop-meta>}}
   - Run on your local machine.
+- `--ip` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - IP address to listen on, defaults to `localhost`.
 - `--port` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: 8788){{</prop-meta>}}
   - The port to listen on (serve from).
 - `--binding` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}


### PR DESCRIPTION
This commit adds the following undocumented `pages dev` flag: `--ip`

Raised in https://github.com/cloudflare/workers-sdk/issues/1994