### PR TITLE
Remove hyperdrive beta label

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -528,10 +528,6 @@ wrangler d1 migrations apply <DATABASE_NAME> [OPTIONS]
 
 ## `hyperdrive`
 
-{{<Aside type="note">}}
-Report Hyperdrive bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
-{{</Aside>}}
-
 Manage [Hyperdrive](/hyperdrive/) database configurations.
 
 ### `create`

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -529,7 +529,7 @@ wrangler d1 migrations apply <DATABASE_NAME> [OPTIONS]
 ## `hyperdrive`
 
 {{<Aside type="note">}}
-Hyperdrive is currently in open beta. Report Hyperdrive bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+Report Hyperdrive bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 {{</Aside>}}
 
 Manage [Hyperdrive](/hyperdrive/) database configurations.


### PR DESCRIPTION
Found one more — Hyperdrive is GA now! 🎉