### PR TITLE
Add Tail Workers to bindings section

### DIFF
--- a/content/workers/runtime-apis/bindings/tail-worker.md
+++ b/content/workers/runtime-apis/bindings/tail-worker.md
@@ -1,0 +1,12 @@
+---
+pcx_content_type: navigation
+title: Tail Workers
+
+external_link: /workers/observability/logging/tail-workers/
+_build:
+  publishResources: false
+  render: never
+
+meta:
+  description: Receive and transform logs, exceptions, and other metadata. Then forward them to observability tools for alerting, debugging, and analytics purposes.
+---


### PR DESCRIPTION
Tail Workers should be shown on the list of bindings:

https://developers.cloudflare.com/workers/runtime-apis/bindings/