### PR TITLE
Add 8443 to the list of allowed captive portal ports

### DIFF
--- a/content/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/captive-portals.md
+++ b/content/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/captive-portals.md
@@ -27,7 +27,7 @@ To allow users to connect through a captive portal, administrators can configure
 If WARP cannot establish a connection to Cloudflare, it will:
 1. Temporarily open the [system firewall](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#ip-traffic) so that the device can send traffic outside of the WARP tunnel. The firewall only allows the following traffic:
 
-    - HTTP/HTTPS on TCP ports `80`, `443`, and `8080`
+    - HTTP/HTTPS on TCP ports `80`, `443`, `8080`, and `8443`
     - DNS on UDP port `53`
 
 2. Send a series of requests to the [captive portal test URLs](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#captive-portal). If the HTTPS request is intercepted, WARP assumes the network is behind a captive portal.


### PR DESCRIPTION
The June GA release (2024.6.416.0) of the WARP client now adds port 8443 to the list of allowed captive portal ports. See CLIENT-10004 for reference.