### PR TITLE
[Speed] Update Auto Minify banner

### DIFF
--- a/content/speed/_partials/_auto-minify-deprecation-warning.md
+++ b/content/speed/_partials/_auto-minify-deprecation-warning.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+{{<Aside type="warning" header="Deprecation notice">}}
+Auto Minify is deprecated and will be removed on 2024-08-05. After this date, Auto Minify will no longer be available via the Cloudflare dashboard, API, or Terraform.
+
+Once the feature is removed, Cloudflare will no longer minify content. We recommend that you minify at the origin during the build phase. Minification is included in most modern web development frameworks.
+{{</Aside>}}

--- a/content/speed/optimization/content/auto-minify.md
+++ b/content/speed/optimization/content/auto-minify.md
@@ -12,11 +12,7 @@ learning_center:
 
 Cloudflare Auto Minify improves website performance by dynamically removing all unnecessary characters from HTML, CSS and JavaScript files.
 
-{{<Aside type="warning" header="Deprecation notice">}}
-Auto Minify is deprecated and will be removed on 2024-08-05. After this date, Auto Minify will no longer be available via the Cloudflare dashboard, API, or Terraform.
-
-We recommend that you minify at the origin during the build phase. Minification is included in most modern web development frameworks.
-{{</Aside>}}
+{{<render file="_auto-minify-deprecation-warning.md">}}
 
 HTML files are minified dynamically by removing comments and unnecessary empty lines only. It does not require files to be cached. CSS and JS minification operates on cached CSS and JS files only. Once Cloudflare returns a cache `HIT` for the file it will be returned to browsers in minified form. This allows us to deliver a more complete minification result. If you need to enable or disable minification for CSS and JS files, you need to [purge your Cloudflare cache](/cache/how-to/purge-cache/).
 

--- a/content/speed/optimization/content/troubleshooting/auto-minify-not-working.md
+++ b/content/speed/optimization/content/troubleshooting/auto-minify-not-working.md
@@ -6,11 +6,7 @@ title: Auto Minify is not working
 
 # Auto Minify is not working
 
-{{<Aside type="warning" header="Deprecation notice">}}
-Auto Minify is deprecated and will be removed on 2024-08-05. After this date, Auto Minify will no longer be available via the Cloudflare dashboard, API, or Terraform.
-
-We recommend that you minify at the origin during the build phase. Minification is included in most modern web development frameworks.
-{{</Aside>}}
+{{<render file="_auto-minify-deprecation-warning.md">}}
 
 Once enabled, Cloudflare's Auto Minify will minify your HTML and your cached CSS and JS files. If you view the source of your files in your web browser or via a command line tool (such as cURL) and you do not see the code being minified, here are some things you should check:
 


### PR DESCRIPTION
Adds the following sentence to the second paragraph:

> Once the feature is removed, Cloudflare will no longer minify content.

Moves the banner to a partial to have the content single-sourced.