### PR TITLE
Update _universal-ssl-enable-full.md

### DIFF
--- a/content/ssl/_partials/_universal-ssl-enable-full.md
+++ b/content/ssl/_partials/_universal-ssl-enable-full.md
@@ -5,7 +5,7 @@ _build:
   list: never
 ---
 
-For domains on a [full setup](/dns/zone-setups/full-setup/)[^1], your domain should **automatically** receive its Universal SSL certificate within **15 minutes to 24 hours** of domain activation[^2]. 
+For domains on a [full setup](/dns/zone-setups/full-setup/)[^1], your domain should **automatically** receive its Universal SSL certificate within **15 minutes to 24 hours** of domain activation[^2]. The Universal SSL certificate will be provisioned whether your records are DNS-Only or with proxy mode on.
 
 This certificate will cover your zone apex (`example.com`) and all first-level subdomains (`subdomain.example.com`), as long as your domain or subdomains have [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/) within Cloudflare DNS.
 

--- a/content/ssl/_partials/_universal-ssl-enable-full.md
+++ b/content/ssl/_partials/_universal-ssl-enable-full.md
@@ -5,9 +5,9 @@ _build:
   list: never
 ---
 
-For domains on a [full setup](/dns/zone-setups/full-setup/)[^1], your domain should **automatically** receive its Universal SSL certificate within **15 minutes to 24 hours** of domain activation[^2]. The Universal SSL certificate will be provisioned whether your records are DNS-Only or with proxy mode on.
+For domains on a [full setup](/dns/zone-setups/full-setup/)[^1], your domain should **automatically** receive its Universal SSL certificate within **15 minutes to 24 hours** of domain activation[^2].
 
-This certificate will cover your zone apex (`example.com`) and all first-level subdomains (`subdomain.example.com`), as long as your domain or subdomains have [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/) within Cloudflare DNS.
+This certificate will cover your zone apex (`example.com`) and all first-level subdomains (`subdomain.example.com`), and is provisioned even if your records are DNS only. However, the certificate will only be presented if your domain or subdomains are [proxied](/dns/manage-dns-records/reference/proxied-dns-records/).
 
 [^1]: The most common Cloudflare setup that involves changing your authoritative nameservers.
 [^2]: Provisioning time depends on certain security checks and other requirements mandated by Certificate Authorities (CA).


### PR DESCRIPTION
I have come across some tickets where customer are confused as to why they are receiving USSL for full zones when their records are DNS-only. 

Small change to let them know that is expected behavior.