### PR TITLE
[Pages] Correct header syntax typo in early-hints.md

### DIFF
--- a/content/pages/configuration/early-hints.md
+++ b/content/pages/configuration/early-hints.md
@@ -25,7 +25,7 @@ filename: _headers
   Link: </styles.css>; rel=preload; as=style
 ```
 
-Pages will attach this `Link: </styles.css>; rel=preload; as=stylesheet` header. Early Hints will then emit this header as an Early Hint once cached.
+Pages will attach this `Link: </styles.css>; rel=preload; as=style` header. Early Hints will then emit this header as an Early Hint once cached.
 
 ### 2. Automatic `Link` header generation
 


### PR DESCRIPTION
This fixes a typo in early-hints.md where the incorrect attribute `as=stylesheet` is used instead of the correct `as=style` used elsewhere in the document.