### PR TITLE
Remove outdated warning

### DIFF
--- a/content/warp-client/warp-modes.md
+++ b/content/warp-client/warp-modes.md
@@ -20,12 +20,6 @@ The WARP application uses [BoringTun](https://blog.cloudflare.com/boringtun-user
 
 Read more about WARP in our blog post [Introducing WARP: Fixing Mobile Internet Performance and Security](https://blog.cloudflare.com/1111-warp-better-vpn/).
 
-{{<Aside type="warning" header="Warning">}}
-
-WARP does not provide anonymity and is not designed to prevent servers you communicate with from identifying you. WARP also does not allow you to pretend to be accessing the Internet from a different country than the one you are currently in.
-
-{{</Aside>}}
-
 ## WARP via Local Proxy
 
 Currently, this mode is available on desktop clients only. When WARP is configured as a local proxy, only the applications that you configure to use the proxy (HTTPS or SOCKS5) will have their traffic sent through WARP. This allows you to pick and choose which traffic is encrypted — for example, your web browser or a specific application. Everything else will not be encrypted and will be sent over a regular Internet connection.


### PR DESCRIPTION
This warning seems to be, at least partially, outdated.

### IP address isn't revealed.

Previously, WARP revealed the IP address in `X-Forwarded-For` and `CF-Connecting-IP` HTTP headers to Cloudflare sites[^1]. This seems to not be the case anymore.

The blog post announcing the geo-exit rollout[^2] explicitly advertises "privacy benefits of obscuring your location" and "without revealing your IP address". With #5907, the FAQ entry[^3] was also changed to "No.".

It's unclear why WARP would provide less anonymity than any other VPN. If the warning is about logging, this should be made explicit.

### IP address is approximate location.

This is specified in other parts of the documentation, like in the FAQ entry[^3] "1.1.1.1 + WARP replaces your original IP address with a Cloudflare IP that consistently and accurately represents your approximate location". It's unclear why this should be a warning.

Also, if the closest egress IP location happens to be in a nearby country, contrary to the current wording, you would "pretend to be accessing the Internet from a different country than the one you are currently in". Not sure where that could happen, but nowhere on Earth seems to be a highly unlikely claim.

[^1]: [Does WARP hide IP Address?](https://www.reddit.com/r/CloudFlare/comments/d8tu4c/comment/f2utn26/)
[^2]: [1.1.1.1 + WARP: More features, still private](https://blog.cloudflare.com/geoexit-improving-warp-user-experience-larger-network/)
[^3]: [Does WARP reveal my IP address to websites I visit?](https://developers.cloudflare.com/warp-client/known-issues-and-faq/#does-warp-reveal-my-ip-address-to-websites-i-visit)