### PR TITLE
[Docs Site] Support variables within codeblocks in partials

### DIFF
--- a/layouts/shortcodes/render.html
+++ b/layouts/shortcodes/render.html
@@ -34,7 +34,11 @@
 {{- range $elem_index, $elem_val := $parameterValues -}}
 {{ $elem_val := ((default "" $elem_val) | markdownify) }}
 {{ $elem_index := add $elem_index 1 | string}}
-{{ $regexPlaceholder = print "\\$" $elem_index }}
+<!--
+  We URL encode the contents of code-blocks into a data-code attribute
+  (which happens before `render` gets the page) so we have to look for '%24' as well.
+-->
+{{ $regexPlaceholder = print `(%24|\$)` $elem_index }}
 {{- $replaceArray = $replaceArray | append (dict "elem_value" $elem_val "index" $elem_index "placeholder" $regexPlaceholder) -}}
 {{- end -}}
 


### PR DESCRIPTION
When using `$1` in a partial, within a codeblock, the `render` shortcode receives something like this:

```html
data-code="%241"
```

This is because it is URL encoded by the [render-codeblock.html](https://github.com/cloudflare/cloudflare-docs/blob/a8c009efb1fa0e760b5d3620302af5885b97cf9b/layouts/_default/_markup/render-codeblock.html#L2) hook.

This change means users can use `$1, $n...` inside of codeblocks.