### PR TITLE
[Chore] Remove collapse sidebar component

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -253,56 +253,6 @@ export function dropdowns() {
   });
 }
 
-export function toggleSidebar() {
-  const toggleButton = document.querySelectorAll(".toggleSidebar");
-  if (toggleButton.length > 0) {
-    let div = document.querySelector(".DocsSidebar--sections .toggleSidebar");
-    if(!div) return;
-    let btn = div.querySelector("button");
-    if(!btn) return;
-    btn.addEventListener("click", () => {
-      let classToggleList = [
-        ".DocsSidebar",
-        ".DocsToolbar",
-        ".DocsFooter",
-        ".DocsContent",
-        ".DocsMarkdown",
-        ".DocsSidebar--sections .toggleSidebar",
-        ".breadcrumb",
-      ];
-
-      classToggleList.forEach(function (querySelector) {
-        let item = document.querySelector(querySelector);
-        if(!item) return;
-        item.classList.toggle("collapsed");
-      });
-
-      let attr = "is-visually-hidden";
-      let attrToggleList = [
-        ".DocsSidebar--nav-item",
-        ".DocsSidebar--section-more",
-        ".DocsSidebar--docs-title-section a div span span",
-        ".DocsSidebar--header-section a div span",
-      ];
-
-      attrToggleList.forEach(function (querySelector) {
-        let item = document.querySelector(querySelector);
-        if(!item) return;
-        let isHidden = item.hasAttribute(attr);
-        item.toggleAttribute(attr, !isHidden);
-      });
-
-      let moduleCounters = document.querySelectorAll(".moduleCounter")
-      if (moduleCounters) {
-        for (const counter of moduleCounters) {
-          let isHidden2 = counter.hasAttribute(attr);
-          counter.toggleAttribute(attr, !isHidden2)
-        }
-      }
-    });
-  }
-}
-
 export function zarazTrackDocEvents() {
   const links = document.querySelectorAll<HTMLAnchorElement>(".DocsMarkdown--link");
   const dropdowns = document.querySelectorAll("details")

--- a/assets/main.ts
+++ b/assets/main.ts
@@ -19,7 +19,6 @@ declare global {
   events.mobile();
   events.dropdowns();
   contents.toc();
-  events.toggleSidebar();
   events.activeTab();
   events.tabs();
   events.zarazTrackDocEvents();

--- a/layouts/partials/sidebar.nav.html
+++ b/layouts/partials/sidebar.nav.html
@@ -101,11 +101,6 @@
         <div style="position:relative;display:block;width:100%" class="Scrollbars--thumb Scrollbars--thumb-vertical"></div>
       </div>
     </div>
-    <div class="toggleSidebar" >
-    <button id="toggleSidebarButton" style="width: 2em; height: 2em;" title="Select to collapse and expand the sidebar navigation">
-      <svg id="toggleSidebarSVG" aria-hidden="true" class="" height="1" width="1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path id="toggleSidebarSVGPath" d="M15 2a1 1 0 0 0-1 1v10a1 1 0 0 0 2 0V3a1 1 0 0 0-1-1zm-10.407.993l-4.3 4.3a1 1 0 0 0 0 1.414l4.3 4.3a1 1 0 0 0 1.415-1.416L3.417 9H10a1 1 0 1 0 0-2H3.417l2.591-2.591a1 1 0 1 0-1.415-1.416z"></path></svg>
-    </button>
-  </div>
   </div>
   <div class="DocsSidebar--shadow"></div>
 </div>

--- a/static/style.css
+++ b/static/style.css
@@ -1706,73 +1706,6 @@ html[is-docs-page] body {
   top: auto;
 }
 
-.toggleSidebar {
-  width: 2em;
-  height: 2em;
-}
-
-[theme="dark"] .toggleSidebar {
-  filter: invert(100%) sepia(4%) saturate(159%) hue-rotate(297deg)
-    brightness(116%) contrast(100%);
-}
-
-.toggleSidebar button {
-  border: none;
-  background-color: transparent;
-  outline: none;
-  cursor: pointer;
-}
-
-@media (max-width: 769px) {
-  .toggleSidebar {
-    visibility: hidden;
-  }
-}
-
-.toggleSidebar.collapsed button svg {
-  transform: rotate(180deg);
-}
-
-@media (min-width: 769px) {
-  .DocsSidebar.collapsed {
-    width: 4.5em;
-  }
-
-  .DocsToolbar.collapsed {
-    left: 4.5em;
-  }
-
-  .DocsFooter.collapsed {
-    margin-left: 4.5em;
-  }
-
-  .DocsContent.collapsed {
-    padding-left: 0em;
-    padding-right: 0em;
-    margin-left: -10em;
-  }
-
-  .DocsMarkdown.collapsed {
-    padding-right: 0em;
-  }
-
-  .DocsSidebar.collapsed .DocsSidebar--nav-item {
-    position: absolute;
-    height: 1px;
-    width: 1px;
-    padding: 0;
-    border: 0;
-    clip: rect(1px 1px 1px 1px);
-    clip: rect(1px, 1px, 1px, 1px);
-    -webkit-clip-path: inset(0 0 99.9% 99.9%);
-    clip-path: inset(0 0 99.9% 99.9%);
-    overflow: hidden;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-  }
-}
-
 [theme="dark"] .DocsSidebar {
   --sidebar-background-color: var(--gray-0F);
 }
@@ -5125,12 +5058,6 @@ pre {
     margin-left: 0;
     padding: 0.5rem 1rem;
   }
-}
-
-.breadcrumb.collapsed {
-  padding-left: 0em;
-  padding-right: 0em;
-  margin-left: -10em;
 }
 
 .breadcrumb li {


### PR DESCRIPTION
### Summary

We're starting to implement a migration over to Starlight, which has built-in styling for a more trimmed sidebar navigation experience.

Deprecating this workaround helps us streamline the migration process + clean up our CSS more generally.

