### PR TITLE
update workers analytics engine one-liner

### DIFF
--- a/content/analytics/_index.md
+++ b/content/analytics/_index.md
@@ -16,7 +16,7 @@ Cloudflare visualizes the metadata collected by our products in the Cloudflare d
 ## Features
 
 {{<feature header="Workers Analytics Engine" href="/analytics/analytics-engine/">}}
-Provides analytics about anything using Cloudflare Workers.
+Send unlimited-cardinality data from your Worker to a time-series database. Query it with SQL.
 {{</feature>}}
 
 {{<feature header="Cloudflare Web Analytics" href="/analytics/web-analytics/">}}
@@ -32,7 +32,7 @@ Provides near real-time visibility into network and transport-layer traffic patt
 {{</feature>}}
 
 {{<feature header="GraphQL Analytics API" href="/analytics/graphql-api/">}}
-Provides all of your performance, security, and reliability data from one endpoint. And you can select exactly what you need, from one metric for a domain to multiple metrics aggregated for your account.
+Provides all of your performance, security, and reliability data from one endpoint. Select exactly what you need, from one metric for a domain to multiple metrics aggregated for your account.
 {{</feature>}}
 
 ---


### PR DESCRIPTION
### Summary

Updating the Workers Analytics Engine tagline to better reflect how Workers Analytics Engine operates. It now references how events can be published, where they are published, and how they can be read.

Also includes a small update to the language for GraphQL Analytics API to match sentence structure.

<img width="671" alt="Screenshot 2024-07-08 at 2 14 26 PM" src="https://github.com/cloudflare/cloudflare-docs/assets/13840886/a6c50f7e-74ce-4114-84d9-a808f4a38e64">


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
