### PR TITLE
Adds information about local dev environment vars

### DIFF
--- a/content/workers/configuration/environment-variables.md
+++ b/content/workers/configuration/environment-variables.md
@@ -71,6 +71,24 @@ SERVICE_X_DATA = { URL = "service-x-api.dev.example", MY_ID = 123 }
 API_HOST = "production.example.com"
 API_ACCOUNT_ID = "production_example_user"
 SERVICE_X_DATA = { URL = "service-x-api.prod.example", MY_ID = 456 }
+
+# used when providing "--env=local" flag to "wrangler dev"
+[env.local.vars]
+API_HOST = "localhost:3000"
+API_ACCOUNT_ID = "local_example_user"
+SERVICE_X_DATA = { URL = "localhost:4000", MY_ID = 789 }
+```
+
+For local development, you can specify an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`. Note that you may want to modify your `package.json` if you include a `dev` script that calls `wrangler dev`.
+
+Alternatively, wrangler automatically uses values defined in a `.dev.vars` file located in the root directory of your worker when you run `wrangler dev`. These values will override any values specified in your `wrangler.toml` file. Nested variables are not supported in `.dev.vars`.
+
+```shell
+---
+filename: .dev.vars
+---
+API_HOST = "localhost:4000"
+API_ACCOUNT_ID = "local_example_user"
 ```
 
 ## Add environment variables via the dashboard

--- a/content/workers/configuration/environment-variables.md
+++ b/content/workers/configuration/environment-variables.md
@@ -83,7 +83,7 @@ API_HOST = "localhost:4000"
 API_ACCOUNT_ID = "local_example_user"
 ```
 
-Alternatively, you can specify local-only values in `wrangler.toml` and provide an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`.
+Alternatively, you can specify per-environment values in `wrangler.toml` and provide an `environment` value via the `env` flag when developing locally like so `wrangler dev --env=local`.
 
 ## Add environment variables via the dashboard
 

--- a/content/workers/configuration/environment-variables.md
+++ b/content/workers/configuration/environment-variables.md
@@ -71,17 +71,9 @@ SERVICE_X_DATA = { URL = "service-x-api.dev.example", MY_ID = 123 }
 API_HOST = "production.example.com"
 API_ACCOUNT_ID = "production_example_user"
 SERVICE_X_DATA = { URL = "service-x-api.prod.example", MY_ID = 456 }
-
-# used when providing "--env=local" flag to "wrangler dev"
-[env.local.vars]
-API_HOST = "localhost:3000"
-API_ACCOUNT_ID = "local_example_user"
-SERVICE_X_DATA = { URL = "localhost:4000", MY_ID = 789 }
 ```
 
-For local development, you can specify an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`. Note that you may want to modify your `package.json` if you include a `dev` script that calls `wrangler dev`.
-
-Alternatively, wrangler automatically uses values defined in a `.dev.vars` file located in the root directory of your worker when you run `wrangler dev`. These values will override any values specified in your `wrangler.toml` file. Nested variables are not supported in `.dev.vars`.
+For local development with `wrangler dev`, variables in `wrangler.toml` are automatically overridden by any values defined in a `.dev.vars` file located in the root directory of your worker. This is useful for providing values you do not want to check in to source control.
 
 ```shell
 ---
@@ -90,6 +82,8 @@ filename: .dev.vars
 API_HOST = "localhost:4000"
 API_ACCOUNT_ID = "local_example_user"
 ```
+
+Alternatively, you can specify local-only values in `wrangler.toml` and provide an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`.
 
 ## Add environment variables via the dashboard
 

--- a/content/workers/testing/local-development.md
+++ b/content/workers/testing/local-development.md
@@ -106,29 +106,12 @@ Any deleted folders will be created automatically the next time you run `wrangle
 
 When developing locally, you may wish to use environment variables or secrets that are different from your production values. This can be achieved in several ways.
 
-First, wrangler automatically uses values defined in a `.dev.vars` file located in the root directory of your worker when you run `wrangler dev`. These values will override any values specified in your `wrangler.toml` file. This is particularly useful for values you do not with to check into source control.
+Firstly, when running `wrangler dev`, variables in `wrangler.toml` are automatically overridden by values defined in a `.dev.vars` file located in the root directory of your worker. This is useful for providing values you do not want to check in to source control.
 
 ```shell
 ---
 filename: .dev.vars
 ---
-API_HOST = "localhost:4000"
-API_ACCOUNT_ID = "local_example_user"
-```
-
-Alternatively, you can specify local-only values in `wrangler.toml` and provide an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`.
-
-```toml
----
-filename: wrangler.toml
----
-name = "my-worker-dev"
-
-[vars]
-API_HOST = "production-app.example.com"
-API_ACCOUNT_ID = "prod_example_user"
-
-[env.local.vars]
 API_HOST = "localhost:4000"
 API_ACCOUNT_ID = "local_example_user"
 ```

--- a/content/workers/testing/local-development.md
+++ b/content/workers/testing/local-development.md
@@ -55,7 +55,7 @@ With any bindings that are not supported locally, you will need to use the `--re
 
 ## Work with local data
 
-When running `wrangler dev`, resources such as KV, Durable Objects, D1, and R2 will be stored and persisted locally and not affect the production resources. 
+When running `wrangler dev`, resources such as KV, Durable Objects, D1, and R2 will be stored and persisted locally and not affect the production resources.
 
 ### Use bindings in `wrangler.toml`
 
@@ -101,6 +101,37 @@ Running `wrangler kv:key put` will create a new key `test` with a value of `1234
 If you need to clear local storage entirely, delete the `.wrangler/state` folder. You can also be more fine-grained and delete specific resource folders within `.wrangler/state`.
 
 Any deleted folders will be created automatically the next time you run `wrangler dev`.
+
+## Local-only environment variables
+
+When developing locally, you may wish to use environment variables or secrets that are different from your production values. This can be achieved in several ways.
+
+First, wrangler automatically uses values defined in a `.dev.vars` file located in the root directory of your worker when you run `wrangler dev`. These values will override any values specified in your `wrangler.toml` file. This is particularly useful for values you do not with to check into source control.
+
+```shell
+---
+filename: .dev.vars
+---
+API_HOST = "localhost:4000"
+API_ACCOUNT_ID = "local_example_user"
+```
+
+Alternatively, you can specify local-only values in `wrangler.toml` and provide an `environment` value via the `env` flag when running the development command like so `wrangler dev --env=local`.
+
+```toml
+---
+filename: wrangler.toml
+---
+name = "my-worker-dev"
+
+[vars]
+API_HOST = "production-app.example.com"
+API_ACCOUNT_ID = "prod_example_user"
+
+[env.local.vars]
+API_HOST = "localhost:4000"
+API_ACCOUNT_ID = "local_example_user"
+```
 
 ## Develop using remote resources and bindings
 

--- a/content/workers/testing/local-development.md
+++ b/content/workers/testing/local-development.md
@@ -104,9 +104,7 @@ Any deleted folders will be created automatically the next time you run `wrangle
 
 ## Local-only environment variables
 
-When developing locally, you may wish to use environment variables or secrets that are different from your production values. This can be achieved in several ways.
-
-Firstly, when running `wrangler dev`, variables in `wrangler.toml` are automatically overridden by values defined in a `.dev.vars` file located in the root directory of your worker. This is useful for providing values you do not want to check in to source control.
+When running `wrangler dev`, variables in `wrangler.toml` are automatically overridden by values defined in a `.dev.vars` file located in the root directory of your worker. This is useful for providing values you do not want to check in to source control.
 
 ```shell
 ---


### PR DESCRIPTION
### Summary

It took me a while to figure out the best way of doing dev-only environment variables, so I'm adding some additional information to the docs.

I'm not positive that there isn't some automatic "environment" value applied in dev mode. If there is, I should mention this instead of pointing people towards the `--env` flag. Or if we have some preferred/alternative way of doing this, let me know!