### PR TITLE
[Dev Spotlight] Add notes to highlight the Developer Spotlight program

### DIFF
--- a/content/developer-spotlight/_index.md
+++ b/content/developer-spotlight/_index.md
@@ -9,7 +9,7 @@ Find examples of how our community of developers are getting the most out of our
 
 While applications are not currently open, you can register your interest to get updates on the program via email by filling out the [Developer Spotlight program interest form](https://docs.google.com/forms/d/e/1FAIpQLSd7CESg7obtOh7CPVEbBeJ2_DtwWeAwb6aazNpukjbka_zYUw/viewform?usp=sf_link).
 
-If you are interested in contributing a tutorial to the Developer Spotlight program or would like to learn more, please read our [application guide](/developer-spotlight/application-guide/). 
+If you would like to learn more about the Developer Spotlight program, please read our [application guide](/developer-spotlight/application-guide/). 
 
 ## View latest contributions
 

--- a/content/developer-spotlight/_index.md
+++ b/content/developer-spotlight/_index.md
@@ -7,7 +7,9 @@ title: Developer Spotlight program
 
 Find examples of how our community of developers are getting the most out of our products.
 
-If you are interested in contributing a tutorial to the Developer Spotlight program, please read our [application guide documentation](/developer-spotlight/application-guide/). Applications are not currently open.
+While applications are not currently open, you can register your interest to get updates on the program via email by filling out the [Developer Spotlight interest form](https://docs.google.com/forms/d/e/1FAIpQLSd7CESg7obtOh7CPVEbBeJ2_DtwWeAwb6aazNpukjbka_zYUw/viewform?usp=sf_link).
+
+If you are interested in contributing a tutorial to the Developer Spotlight program or would like to learn more, please read our [application guide documentation](/developer-spotlight/application-guide/). 
 
 ## View latest contributions
 

--- a/content/developer-spotlight/_index.md
+++ b/content/developer-spotlight/_index.md
@@ -7,9 +7,9 @@ title: Developer Spotlight program
 
 Find examples of how our community of developers are getting the most out of our products.
 
-While applications are not currently open, you can register your interest to get updates on the program via email by filling out the [Developer Spotlight interest form](https://docs.google.com/forms/d/e/1FAIpQLSd7CESg7obtOh7CPVEbBeJ2_DtwWeAwb6aazNpukjbka_zYUw/viewform?usp=sf_link).
+While applications are not currently open, you can register your interest to get updates on the program via email by filling out the [Developer Spotlight program interest form](https://docs.google.com/forms/d/e/1FAIpQLSd7CESg7obtOh7CPVEbBeJ2_DtwWeAwb6aazNpukjbka_zYUw/viewform?usp=sf_link).
 
-If you are interested in contributing a tutorial to the Developer Spotlight program or would like to learn more, please read our [application guide documentation](/developer-spotlight/application-guide/). 
+If you are interested in contributing a tutorial to the Developer Spotlight program or would like to learn more, please read our [application guide](/developer-spotlight/application-guide/). 
 
 ## View latest contributions
 

--- a/content/workers-ai/tutorials/_index.md
+++ b/content/workers-ai/tutorials/_index.md
@@ -5,6 +5,7 @@ weight: 5
 layout: wide
 hideChildren: true
 ---
+{{<Aside type="note">}}[Explore our community-written tutorials contributed through the Developer Spotlight program.](/developer-spotlight/#developer-spotlight-program){{</Aside>}}
 
 # Tutorials
 

--- a/content/workers-ai/tutorials/_index.md
+++ b/content/workers-ai/tutorials/_index.md
@@ -6,7 +6,6 @@ layout: wide
 hideChildren: true
 ---
 {{<Aside type="note">}}[Explore our community-written tutorials contributed through the Developer Spotlight program.](/developer-spotlight/#developer-spotlight-program){{</Aside>}}
-
 # Tutorials
 
 Explore the following tutorials for Workers AI.

--- a/content/workers/examples/_index.md
+++ b/content/workers/examples/_index.md
@@ -6,7 +6,7 @@ title: Examples
 weight: 3
 layout: wide
 ---
-
+{{<Aside type="note">}}[Explore our community-written tutorials contributed through the Developer Spotlight program.](/developer-spotlight/#developer-spotlight-program){{</Aside>}}
 # Examples
 
 {{<list-examples filters="languages,tags,preview">}}

--- a/content/workers/tutorials/_index.md
+++ b/content/workers/tutorials/_index.md
@@ -6,7 +6,7 @@ title: Tutorials
 weight: 4
 layout: wide
 ---
-
+{{<Aside type="note">}}[Explore our community-written tutorials contributed through the Developer Spotlight program.](/developer-spotlight/#developer-spotlight-program){{</Aside>}}
 # Tutorials
 
 {{<tutorial-listing>}}


### PR DESCRIPTION
### Summary

Adding aside notes to workers/tutorials, workers/examples and workers-ai/tutorials to highlight the recent Dev Spotlight program submissions.

Also updating the Dev Spotlight description to include the following survey link for people to register their interest in the program
https://docs.google.com/forms/d/e/1FAIpQLSd7CESg7obtOh7CPVEbBeJ2_DtwWeAwb6aazNpukjbka_zYUw/viewform?usp=sf_link
