### PR TITLE
Pm patch queues gs

### DIFF
--- a/content/queues/configuration/batching-retries.md
+++ b/content/queues/configuration/batching-retries.md
@@ -45,7 +45,7 @@ The following batch-level settings can be configured to adjust how Queues delive
 | ----------------------------------------- | ------------- | ------------ | ------------- |
 | Maximum Batch Size `max_batch_size`       | 10 messages   | 1 message    | 100 messages  |
 | Maximum Batch Timeout `max_batch_timeout` | 5 seconds     | 0 seconds    | 30 seconds    |
-  
+
 {{</table-wrap>}}
 
 ## Explicit acknowledgement and retries
@@ -55,11 +55,11 @@ You can acknowledge individual messages within a batch by explicitly acknowledgi
 * Each message can be acknowledged as you process it within a batch, and avoids the entire batch from being re-delivered if your consumer throws an error during batch processing.
 * Acknowledging individual messages is useful when you are calling external APIs, writing messages to a database, or otherwise performing non-idempotent (state changing) actions on individual messages.
 
-To explicitly acknowledge a message as delivered, call the `ack()` method on the message. 
+To explicitly acknowledge a message as delivered, call the `ack()` method on the message.
 
 ```ts
 ---
-header: index.js 
+header: index.js
 ---
 export default {
   async queue(batch: MessageBatch, env: Env, ctx: ExecutionContext) {
@@ -115,7 +115,7 @@ When a single message within a batch fails to be delivered, the entire batch is 
 
 {{<Aside type="warning" header="Retried messages and consumer concurrency">}}
 
-Retrying messages with `retry()` or calling `retryAll()` on a batch will **not** cause the consumer to autoscale down if consumer concurrency is enabled. Refer to [Consumer concurrency](/queues/configuration/consumer-concurrency/) to learn more. 
+Retrying messages with `retry()` or calling `retryAll()` on a batch will **not** cause the consumer to autoscale down if consumer concurrency is enabled. Refer to [Consumer concurrency](/queues/configuration/consumer-concurrency/) to learn more.
 
 {{</Aside>}}
 
@@ -151,7 +151,7 @@ You can also configure a default, global delay on a per-queue basis by passing `
 
 ```sh
 # Delay all messages by 5 minutes as a default
-$ npx wrangler queues create $QUEUE_NAME --delivery-delay-secs=300
+$ npx wrangler queues create $QUEUE-NAME --delivery-delay-secs=300
 ```
 
 ### Delay on retry
@@ -198,11 +198,11 @@ Delays can be configured via the `wrangler` CLI:
 ```sh
 # Push-based consumers
 # Delay any messages that are retried by 60 seconds (1 minute) by default.
-$ npx wrangler@latest queues consumer worker add $QUEUE_NAME $WORKER_SCRIPT_NAME --retry-delay-secs=60
+$ npx wrangler@latest queues consumer worker add $QUEUE-NAME $WORKER_SCRIPT_NAME --retry-delay-secs=60
 
 # Pull-based consumers
 # Delay any messages that are retried by 60 seconds (1 minute) by default.
-$ npx wrangler@latest queues consumer http add $QUEUE_NAME --retry-delay-secs=60
+$ npx wrangler@latest queues consumer http add $QUEUE-NAME --retry-delay-secs=60
 ```
 
 Delays can also be configured in [`wrangler.toml`](/workers/wrangler/configuration/#queues) with the `delivery_delay` setting for producers (when sending) and/or the `retry_delay` (when retrying) per-consumer:
@@ -213,7 +213,7 @@ header: wrangler.toml
 ---
 [[queues.producers]]
   binding = "<BINDING_NAME>"
-  queue = "<QUEUE_NAME>"
+  queue = "<QUEUE-NAME>"
   delivery_delay = 60 # delay every message delivery by 1 minute
 
 [[queues.consumers]]
@@ -239,7 +239,7 @@ You can apply a backoff algorithm to increasingly delay messages based on the cu
 
 Each message delivered to a consumer includes an `attempts` property that tracks the number of delivery attempts made.
 
-For example, to generate an [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) for a message, you can create a helper function that calculates this for you: 
+For example, to generate an [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) for a message, you can create a helper function that calculates this for you:
 
 ```ts
 const calculateExponentialBackoff = (attempts: number, baseDelaySeconds: number) => { return baseDelaySeconds**attempts }

--- a/content/queues/configuration/pull-consumers.md
+++ b/content/queues/configuration/pull-consumers.md
@@ -45,12 +45,12 @@ A HTTP consumer can be configured in `wrangler.toml` by setting `type = "http_pu
 ```toml
 [[queues.consumers]]
 # Required
-queue = "QUEUE_NAME"
+queue = "QUEUE-NAME"
 type = "http_pull"
 # Optional
 visibility_timeout_ms = 5000
 max_retries = 5
-dead_letter_queue = "SOME_OTHER_QUEUE"
+dead_letter_queue = "SOME-OTHER-QUEUE"
 ```
 
 Omitting the `type` property will default the queue to push-based.
@@ -60,13 +60,13 @@ Omitting the `type` property will default the queue to push-based.
 You can enable a pull-based consumer on any existing queue by using the `wrangler queues consumer http` sub-commands and providing a queue name.
 
 ```sh
-$ npx wrangler queues consumer http add $QUEUE_NAME
+$ npx wrangler queues consumer http add $QUEUE-NAME
 ```
 
 If you have an existing push-based consumer, you will need to remove that first. `wrangler` will return an error if you attempt to call `consumer http add` on a queue with an existing consumer configuration:
 
 ```sh
-$ wrangler queues consumer worker remove $QUEUE_NAME $SCRIPT_NAME
+$ wrangler queues consumer worker remove $QUEUE-NAME $SCRIPT_NAME
 ```
 
 {{<Aside type="note">}}

--- a/content/queues/get-started.md
+++ b/content/queues/get-started.md
@@ -77,7 +77,7 @@ To use queues, you need to create at least one queue to publish messages to and 
 To create a queue, run:
 
 ```sh
-$ npx wrangler queues create <MY_FIRST_QUEUE>
+$ npx wrangler queues create <MY-QUEUE-NAME>
 ```
 
 Choose a name that is descriptive and relates to the types of messages you intend to use this queue for. Descriptive queue names look like: `debug-logs`, `user-clickstream-data`, or `password-reset-prod`.
@@ -97,11 +97,11 @@ To create a binding, open your newly generated `wrangler.toml` configuration fil
 filename: wrangler.toml
 ---
 [[queues.producers]]
- queue = "YOUR_QUEUE_NAME"
+ queue = "MY-QUEUE-NAME"
  binding = "MY_QUEUE"
 ```
 
-Replace `YOUR_QUEUE_NAME` with the name of the queue you created in [step 3](/queues/get-started/#3-create-a-queue). Next, replace `MY_QUEUE` with the name you want for your `binding`. The binding must be a valid JavaScript variable name. This is the variable you will use to reference this queue in your Worker.
+Replace `MY-QUEUE-NAME` with the name of the queue you created in [step 3](/queues/get-started/#3-create-a-queue). Next, replace `MY_QUEUE` with the name you want for your `binding`. The binding must be a valid JavaScript variable name. This is the variable you will use to reference this queue in your Worker.
 
 ### Write your producer Worker
 
@@ -226,14 +226,14 @@ To connect your queue to your consumer Worker, open your `wrangler.toml` file an
 filename: wrangler.toml
 ---
 [[queues.consumers]]
- queue = "<YOUR_QUEUE_NAME>"
+ queue = "<MY-QUEUE-NAME>"
  # Required: this should match the name of the queue you created in step 3.
  # If you misspell the name, you will receive an error when attempting to publish your Worker.
  max_batch_size = 10 # optional: defaults to 10
  max_batch_timeout = 5 # optional: defaults to 5 seconds
 ```
 
-Replace `YOUR_QUEUE_NAME` with the queue you created in [step 3](/queues/get-started/#3-create-a-queue).
+Replace `MY-QUEUE-NAME` with the queue you created in [step 3](/queues/get-started/#3-create-a-queue).
 
 In your consumer Worker, you are using queues to auto batch messages using the `max_batch_size` option and the `max_batch_timeout` option. The consumer Worker will receive messages in batches of `10` or every `5` seconds, whichever happens first.
 


### PR DESCRIPTION
### Summary

The Queues docs often include underscores in placeholder queue names, even though underscores aren't allowed in queue names. I replaced the underscores with dashes.

### Screenshots
**Before:**
<img width="876" alt="Screenshot 2024-07-12 at 3 30 20 PM" src="https://github.com/user-attachments/assets/de2fd92b-b999-4b52-861a-be68bbfe6ad5">

**After:**
<img width="577" alt="Screenshot 2024-07-12 at 3 30 42 PM" src="https://github.com/user-attachments/assets/d4d5e696-df54-44b9-88d1-3987a6525580">

