### PR TITLE
Update KDE Plasma instructions for Plasma 6.x System Settings

### DIFF
--- a/content/1.1.1.1/setup/linux.md
+++ b/content/1.1.1.1/setup/linux.md
@@ -64,7 +64,7 @@ DNS=1.1.1.1
 
 ### KDE Plasma
 
-1. Go to **System Settings** > **Connections**.
+1. Go to **System Settings** > **Wi-Fi & Internet** > **Wi-Fi & Networking**. (or **Connections**, if on Plasma 5)
 2. Select the connection you want to configure - like your current connected network.
 3. On the **IPv4** tab, select the **Method** drop-down menu > _Automatic (Only addresses)_.
 4. Select the text box next to **DNS servers**.


### PR DESCRIPTION

### Summary

Plasma 6 has reworked a majority of system settings, most of these are minor changes. "Connections" is now "Wi-Fi & Networking" under "Wi-Fi & Internet".

Retained Plasma 5 System Setting menu in bracket due to SteamOS3 (on Steam Deck), Kubuntu 24.04 and OpenSUSE Leap 15.6 still using Plasma 5.27.

### Screenshots (optional)
On Plasma 6
![image](https://github.com/user-attachments/assets/97784d31-ba9b-4dbd-b600-83e4fde66758)
On Plasma 5.27
![image](https://github.com/user-attachments/assets/3934a497-2770-4822-bf27-58236a058b59)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to. 

