### PR TITLE
[pages] Add undocumented `pages secret` commands

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2030,11 +2030,8 @@ This command has been deprecated as of v3 in favor of [`wrangler pages deploy`](
 
 {{</Aside>}}
 
-### `secret`
 
-Generate a secret that can be referenced in a Pages project.
-
-### `put`
+### `secret put`
 
 Create or update a secret for a Pages project.
 
@@ -2054,7 +2051,7 @@ wrangler pages secret put <KEY> [OPTIONS]
 
 {{</definitions>}}
 
-### `delete`
+### `secret delete`
 
 Delete a secret from a Pages project.
 
@@ -2074,7 +2071,7 @@ wrangler pages secret delete <KEY> [OPTIONS]
 
 {{</definitions>}}
 
-### `list`
+### `secret list`
 
 List the names of all the secrets for a Pages project.
 
@@ -2090,7 +2087,7 @@ wrangler pages secret list [OPTIONS]
 
 {{</definitions>}}
 
-### `bulk`
+### `secret bulk`
 
 Upload multiple secrets for a Pages project at once.
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -2030,6 +2030,87 @@ This command has been deprecated as of v3 in favor of [`wrangler pages deploy`](
 
 {{</Aside>}}
 
+### `secret`
+
+Generate a secret that can be referenced in a Pages project.
+
+### `put`
+
+Create or update a secret for a Pages project.
+
+```txt
+wrangler pages secret put <KEY> [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `KEY` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The variable name for this secret to be accessed in the Pages project.
+
+- `--project-name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The name of your Pages project.
+
+{{</definitions>}}
+
+### `delete`
+
+Delete a secret from a Pages project.
+
+```txt
+wrangler pages secret delete <KEY> [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `KEY` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+
+  - The variable name for this secret to be accessed in the Pages project.
+
+- `--project-name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The name of your Pages project.
+
+{{</definitions>}}
+
+### `list`
+
+List the names of all the secrets for a Pages project.
+
+```txt
+wrangler pages secret list [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `--project-name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The name of your Pages project.
+
+{{</definitions>}}
+
+### `bulk`
+
+Upload multiple secrets for a Pages project at once.
+
+```txt
+wrangler pages secret bulk [<FILENAME>] [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `FILENAME` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The JSON file containing key-value pairs to upload as secrets, in the form `{"SECRET_NAME": "secret value", ...}`.
+  - If omitted, Wrangler expects to receive input from `stdin` rather than a file.
+
+- `--project-name` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+
+  - The name of your Pages project.
+
+{{</definitions>}}
+
 ---
 
 ## `queues`


### PR DESCRIPTION
### Summary
This commit adds documentation for the following missing `wrangler pages` commands:
- `wrangler pages secret put`
- `wrangler pages secret delete`
- `wrangler pages secret list`
- `wrangler pages secret bulk`

Fixes https://github.com/cloudflare/workers-sdk/issues/6217

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
<img width="856" alt="Screenshot 2024-07-16 at 21 15 17" src="https://github.com/user-attachments/assets/30fe6216-24e1-4b12-98c7-2b63d560d896">

<img width="836" alt="Screenshot 2024-07-16 at 21 15 12" src="https://github.com/user-attachments/assets/bc69871e-99a2-49b0-80df-f10d7fb571f1">

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
