### PR TITLE
Fix OpenAPI specification typo

### DIFF
--- a/content/workers-ai/function-calling/embedded/examples/openapi.md
+++ b/content/workers-ai/function-calling/embedded/examples/openapi.md
@@ -8,7 +8,7 @@ tags: [AI]
 
 # Example using tools based on OpenAPI Spec
 
-Oftentimes APIs are defined and documented via [OpenAPI sepc](https://swagger.io/specification/). The Cloudflare `ai-utils` package's `createToolsFromOpenAPISpec` function creates tools from the OpenAPI spec, which the LLM can then leverage to fullfil the prompt.
+Oftentimes APIs are defined and documented via [OpenAPI specification](https://swagger.io/specification/). The Cloudflare `ai-utils` package's `createToolsFromOpenAPISpec` function creates tools from the OpenAPI spec, which the LLM can then leverage to fullfil the prompt.
 
 In this example the LLM will describe the a Github user, based Github's API and its OpenAPI spec.
 


### PR DESCRIPTION
### Summary

Written `sepc` instead of `spec`. Replaced with `specification`, as that's the wording used on `swagger.io`i.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
