### PR TITLE
d1: changelog & docs for run() type

### DIFF
--- a/content/d1/build-with-d1/d1-client-api.md
+++ b/content/d1/build-with-d1/d1-client-api.md
@@ -199,13 +199,12 @@ When using TypeScript, you can pass a [type parameter](/d1/build-with-d1/d1-clie
 
 ### await stmt.run()
 
-Runs the query (or queries) and returns results. Returns all rows as an array of objects, with each result row represented as an object on the `results` property of the `D1Result` type.
+Runs the query (or queries) and returns results. Returns all rows as an array of objects, with each result row represented as an object on the `results` property of the `D1Result` type. For write operations like UPDATE, DELETE or INSERT, `results` will be empty.
 
 Run is functionally equivalent to `stmt.all()` and can be treated as an alias.
 
 ```js
-const stmt = await db.prepare('INSERT INTO users (name, age) VALUES (?1, ?2)')
-                    .bind( "John", 42 )
+const stmt = await db.prepare('SELECT name, age FROM users LIMIT 3')
 const { results } = await stmt.run();
 console.log(results);
 /*

--- a/content/d1/build-with-d1/d1-client-api.md
+++ b/content/d1/build-with-d1/d1-client-api.md
@@ -139,6 +139,8 @@ console.log(results);
 */
 ```
 
+When using TypeScript, you can pass a [type parameter](/d1/build-with-d1/d1-client-api/#typescript-support) to `all()` to return a typed result object.
+
 ### await stmt.raw()
 
 Returns results as an array of arrays, with each row represented by an array. The return type is an array of arrays, and does not include query metadata.
@@ -168,6 +170,8 @@ console.log(columns);
 */
 ```
 
+When using TypeScript, you can pass a [type parameter](/d1/build-with-d1/d1-client-api/#typescript-support) to `raw()` to return a typed result array.
+
 ### await stmt.first([column])
 
 Returns the first row of the results. This does not return metadata like the other methods. Instead, it returns the object directly.
@@ -187,31 +191,42 @@ const values = await stmt.first();
 console.log(values); // { total: 50 }
 ```
 
-If the query returns no rows, then `first()` will return `null`.
-
-If the query returns rows, but `column` does not exist, then `first()` will throw the `D1_ERROR` exception.
+If the query returns no rows, then `first()` will return `null`. If the query returns rows, but `column` does not exist, then `first()` will throw the `D1_ERROR` exception. 
 
 `stmt.first()` does not alter the SQL query. To improve performance, consider appending `LIMIT 1` to your statement.
 
+When using TypeScript, you can pass a [type parameter](/d1/build-with-d1/d1-client-api/#typescript-support) to `first()` to return a typed result object.
+
 ### await stmt.run()
 
-Runs the query (or queries), but returns no results. Instead, `run()` returns the metrics only. Useful for write operations like UPDATE, DELETE or INSERT.
+Runs the query (or queries) and returns results. Returns all rows as an array of objects, with each result row represented as an object on the `results` property of the `D1Result` type.
+
+Run is functionally equivalent to `stmt.all()` and can be treated as an alias.
 
 ```js
-const info = await db.prepare('INSERT INTO users (name, age) VALUES (?1, ?2)')
+const stmt = await db.prepare('INSERT INTO users (name, age) VALUES (?1, ?2)')
                     .bind( "John", 42 )
-                    .run()
-
-console.log(info);
+const { results } = await stmt.run();
+console.log(results);
 /*
-{
-  success: true
-  meta: {
-    duration: 62,
-  }
-}
+[
+  {
+     name: "John",
+     age: 42,
+  },
+   {
+     name: "Anthony",
+     age: 37,
+  },
+    {
+     name: "Dave",
+     age: 29,
+  },
+ ]
 */
 ```
+
+When using TypeScript, you can pass a [type parameter](/d1/build-with-d1/d1-client-api/#typescript-support) to `run()` to return a typed result object.
 
 ### await db.dump()
 

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -8,7 +8,7 @@ entries:
   - publish_date: "2024-07-26"
     title: Fixed bug in TypeScript typings for run() API
     description: |-
-      The `run()` method as part of the [D1 Client API](/d1/build-with-d1/d1-client-api/) had an incorrect (outdated) type definition, which has now been addressed as of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types) version `4.xxxxxxx`.
+      The `run()` method as part of the [D1 Client API](/d1/build-with-d1/d1-client-api/) had an incorrect (outdated) type definition, which has now been addressed as of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types) version `4.20240725.0`.
 
       The correct type definition is `stmt.run<T>(): D1Result`, as `run()` returns the result rows of the query. The previously _incorrect_ type definition was `stmt.run(): D1Response`, which only returns query metadata and no results.
 

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,6 +5,13 @@ productLink: "/d1/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2024-07-26"
+    title: Fixed bug in TypeScript typings for run() API
+    description: |-
+      The `run()` method as part of the [D1 Client API](/d1/build-with-d1/d1-client-api/) had an incorrect (outdated) type definition, which has now been addressed as of [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types) version `4.xxxxxxx`.
+
+      The correct type definition is `stmt.run<T>(): D1Result`, as `run()` returns the result rows of the query. The previously _incorrect_ type definition was `stmt.run(): D1Response`, which only returns query metadata and no results.
+
   - publish_date: "2024-06-17"
     title: HTTP API now returns a HTTP 429 error for overloaded D1 databases
     description: |-


### PR DESCRIPTION
Relates to https://github.com/cloudflare/workerd/pull/2422 

- [x] `workers-types` released with new version
- [x] Changelog updated with version
- [x] Docs updated to fix `run()` type definition
- [x] Docs updated to improve mention of TS type parameters