### PR TITLE
[Tail Workers] Update Pricing Documentation to reference billing on CPU Time

### DIFF
--- a/content/workers/observability/logging/tail-workers.md
+++ b/content/workers/observability/logging/tail-workers.md
@@ -9,7 +9,7 @@ meta:
 
 A Tail Worker receives information about the execution of other Workers (known as producer Workers), such as HTTP statuses, data passed to `console.log()` or uncaught exceptions. Tail Workers can process logs for alerts, debugging, or analytics.
 
-Tail Workers are available to all customers on the Workers Paid and Enterprise tiers. They are priced the same as [Workers](/workers/platform/pricing/#workers).
+Tail Workers are available to all customers on the Workers Paid and Enterprise tiers. Tail Workers are billed by [CPU time](/workers/platform/pricing/#workers), not by the number of requests. 
 
 ![Tail Worker diagram](/images/workers/platform/tail-workers.png)
 


### PR DESCRIPTION

### Summary

Tail Workers are only billed on CPU time, not number of requests. 

### Screenshots 

![Screenshot 2024-07-22 at 10 57 53 AM](https://github.com/user-attachments/assets/39b278be-4255-4429-bbce-aaba7f5445ff)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.