### PR TITLE
[R2] Remove beta warning from R2 jurisdictions section

### DIFF
--- a/content/r2/reference/data-location.md
+++ b/content/r2/reference/data-location.md
@@ -62,12 +62,6 @@ Location Hints are only honored the first time a bucket with a given name is cre
 
 ## Jurisdictional Restrictions
 
-{{<Aside type="note">}}
-
-This feature is currently in beta. If you have feedback, reach out to us on the [Cloudflare Developer Discord](https://discord.cloudflare.com) in the #r2-storage channel or open a thread on the [Community Forum](https://community.cloudflare.com/c/developers/storage/81).
-
-{{</Aside>}}
-
 Jurisdictional Restrictions guarantee objects in a bucket are stored within a specific jurisdiction.
 
 Use Jurisdictional Restrictions when you need to ensure data is stored and processed within a jurisdiction to meet data residency requirements, including local regulations such as the [GDPR](https://gdpr-info.eu/) or [FedRAMP](https://blog.cloudflare.com/cloudflare-achieves-fedramp-authorization/).


### PR DESCRIPTION
### Summary

R2 jurisdictions are no longer a beta feature

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
