### PR TITLE
[Wrangler] add missing --persist-to for pages dev in wrangler commands.md

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1918,6 +1918,8 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
   - Path to a custom certificate.
 - `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Specify directory to use for local persistence, defaults to `.wrangler/state`.
+- `--log-level` {{<type>}}"debug"|"info"|"log"|"warn"|"error"|"none"{{</type>}} {{<prop-meta>}}(default: log){{</prop-meta>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify logging level.
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1918,6 +1918,8 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
   - Path to a custom certificate key.
 - `--https-cert-path` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Path to a custom certificate.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory to use for local persistence (for use in combination with `--local`).
 
 {{</definitions>}}
 

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -1890,8 +1890,6 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
 
 - `DIRECTORY` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - The directory of static assets to serve.
-- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: true){{</prop-meta>}}
-  - Run on your local machine.
 - `--ip` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - IP address to listen on, defaults to `localhost`.
 - `--port` {{<type>}}number{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: 8788){{</prop-meta>}}
@@ -1919,7 +1917,7 @@ wrangler pages dev [<DIRECTORY>] [OPTIONS]
 - `--https-cert-path` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Path to a custom certificate.
 - `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Specify directory to use for local persistence (for use in combination with `--local`).
+  - Specify directory to use for local persistence, defaults to `.wrangler/state`.
 
 {{</definitions>}}
 


### PR DESCRIPTION
### Summary

The `--persist-to` argument works with `wrangler pages dev` but is not listed in the wangler commands documentation.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.