### PR TITLE
docs: add documentation for the --experimental-include-runtime flag (draft)

### DIFF
--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -13,6 +13,36 @@ head:
 
 TypeScript is a first-class language on Cloudflare Workers. Cloudflare publishes type definitions to [GitHub](https://github.com/cloudflare/workers-types) and [npm](https://www.npmjs.com/package/@cloudflare/workers-types) (`npm install -D @cloudflare/workers-types`). All APIs provided in Workers are fully typed, and type definitions are generated directly from [workerd](https://github.com/cloudflare/workerd), the open-source Workers runtime.
 
+### Generate types that match your Worker's configuration (experimental)
+
+Cloudflare continuously improves [workerd](https://github.com/cloudflare/workerd), the open-source Workers runtime.
+Some updates change the TypeScript types that APIs return. For example, the [`urlsearchparams_delete_has_value_arg`](/workers/configuration/compatibility-dates/#urlsearchparams-delete-and-has-value-argument) compatibility flag adds optional arguments to some methods, in order to support new additions to the WHATWG URL standard API.
+
+This means the correct TypeScript types for your Worker depend on:
+
+1. Your Worker's [Compatibility Date](/workers/configuration/compatibility-dates/).
+2. Your Worker's [Compatibility Flags](/workers/configuration/compatibility-dates/#compatibility-flags).
+
+For example, if you have `compatibility_flags = ["nodejs_als"]` in your `wrangler.toml`, then the runtime will allow you to use the [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) class in your worker code, but you will not see this reflected in the type definitions in `@cloudflare/workers-types`.
+
+In order to solve this issue, and to ensure that your type definitions are always up-to-date with your compatibility settings, you can dynamically generate the runtime types (as of `wrangler 3.66.0`):
+
+```bash
+wrangler types --experimental-include-runtime
+```
+
+This will generate a `d.ts` file and (by default) save it to `.wrangler/types/runtime.d.ts`. You will be prompted in the command's output to add that file to your `tsconfig.json`'s `compilerOptions.types` array.
+
+If you would like to commit the file to git, you can provide a custom path. Here, for instance, the `runtime.d.ts` file will be saved to the root of your project:
+
+```bash
+wrangler types --experimental-include-runtime="./runtime.d.ts"
+```
+
+Note that the `--experimental-include-runtime` command replaces the need for the `@cloudflare/workers-types` package, so if you do have that package installed, you should remove it to avoid any potential for conflict.
+
+See [the full list of available flags](/workers/wrangler/commands/#types) for more details.
+
 ### Known issues
 
 #### Transitive loading of `@types/node` overrides `@cloudflare/workers-types`

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -41,7 +41,7 @@ wrangler types --experimental-include-runtime="./runtime.d.ts"
 
 {{<Aside type="warning">}}
 
-To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your `wrangler.toml` file.
+To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your config file.
 
 {{</Aside>}}
 
@@ -49,17 +49,39 @@ See [the full list of available flags](/workers/wrangler/commands/#types) for mo
 
 #### Migrating from `@cloudflare/workers-types` to `wrangler types --experimental-include-runtime`
 
-The `@cloudflare/workers-types` package provides runtime types according to your compatibility date, and therefore it is superceeded by the `wrangler types --experimental-include-runtime` command.
+The `@cloudflare/workers-types` package provides runtime types according to your compatibility date, but is superceeded by the `wrangler types --experimental-include-runtime` command.
 
-Here are the steps to switch from `@cloudflare/workers-types` to using wrangler types with the experimental runtime inclusion:
+Here are the steps to switch from `@cloudflare/workers-types` to using `wrangler types` with the experimental runtime inclusion:
 
-##### 1. Uninstall `@cloudflare/workers-types`
+##### Uninstall `@cloudflare/workers-types`
 
-```bash
+<Tabs> <TabItem label="npm">
+
+```sh
 npm uninstall @cloudflare/workers-types
 ```
 
-##### 2. Generate runtime types using wrangler
+</TabItem> <TabItem label="yarn">
+
+```sh
+yarn remove @cloudflare/workers-types
+```
+
+</TabItem> <TabItem label="pnpm">
+
+```sh
+pnpm uninstall @cloudflare/workers-types
+```
+
+</TabItem> <TabItem label="bun">
+
+```sh
+bun remove @cloudflare/workers-types
+```
+
+</TabItem> </Tabs>
+
+##### Generate runtime types using wrangler
 
 ```bash
 wrangler types --experimental-include-runtime
@@ -67,7 +89,7 @@ wrangler types --experimental-include-runtime
 
 This will generate a `.d.ts` file, saved to `.wrangler/types/runtime.d.ts` by default.
 
-##### 3. Update your `tsconfig.json` to include the generated types
+##### Update your `tsconfig.json` to include the generated types
 
 ```json
 {
@@ -79,7 +101,7 @@ This will generate a `.d.ts` file, saved to `.wrangler/types/runtime.d.ts` by de
 
 Note that if you have specified a custom path for the runtime types file, you should use that in your `compilerOptions.types` array instead of the default path.
 
-##### 4. Update your scripts and CI pipelines
+##### Update your scripts and CI pipelines
 
 When switching to `wrangler types --experimental-include-runtime`, you'll want to ensure that your development process always uses the most up-to-date types. The main thing to remember here is that - regardless of your specific framework or build tools - you should run the `wrangler types --experimental-include-runtime` command before any development tasks that rely on TypeScript. This ensures your editor and build tools always have access to the latest types.
 
@@ -88,8 +110,8 @@ Most projects will have existing build and development scripts scripts, as well 
 ```json
 {
   "scripts": {
-    "dev": "your-existing-dev-command",
-    "build": "your-existing-build-command",
+    "dev": "existing-dev-command",
+    "build": "-existing-build-command",
     "type-check": "wrangler types --experimental-include-runtime && tsc"
   }
 }
@@ -97,7 +119,7 @@ Most projects will have existing build and development scripts scripts, as well 
 
 In CI, you may have a separate build and test commands. It is best practice to run `wrangler types --experimental-include-runtime` before other CI commands. For example:
 
-```text
+```yaml
 - run: npm run generate-types
 - run: npm run build
 - run: npm test

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -39,9 +39,71 @@ If you would like to commit the file to git, you can provide a custom path. Here
 wrangler types --experimental-include-runtime="./runtime.d.ts"
 ```
 
-Note that the `--experimental-include-runtime` command replaces the need for the `@cloudflare/workers-types` package, so if you do have that package installed, you should remove it to avoid any potential for conflict.
+{{<Aside type="warning">}}
+
+To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your `wrangler.toml` file.
+
+{{</Aside>}}
 
 See [the full list of available flags](/workers/wrangler/commands/#types) for more details.
+
+#### Migrating from `@cloudflare/workers-types` to `wrangler types --experimental-include-runtime`
+
+The `@cloudflare/workers-types` package provides runtime types according to your compatibility date, and therefore it is superceeded by the `wrangler types --experimental-include-runtime` command.
+
+Here are the steps to switch from `@cloudflare/workers-types` to using wrangler types with the experimental runtime inclusion:
+
+##### 1. Uninstall `@cloudflare/workers-types`
+
+```bash
+npm uninstall @cloudflare/workers-types
+```
+
+##### 2. Generate runtime types using wrangler
+
+```bash
+wrangler types --experimental-include-runtime
+```
+
+This will generate a `.d.ts` file, saved to `.wrangler/types/runtime.d.ts` by default.
+
+##### 3. Update your `tsconfig.json` to include the generated types
+
+```json
+{
+  "compilerOptions": {
+    "types": ["./.wrangler/types/runtime"]
+  }
+}
+```
+
+Note that if you have specified a custom path for the runtime types file, you should use that in your `compilerOptions.types` array instead of the default path.
+
+##### 4. Update your scripts and CI pipelines
+
+When switching to `wrangler types --experimental-include-runtime`, you'll want to ensure that your development process always uses the most up-to-date types. The main thing to remember here is that - regardless of your specific framework or build tools - you should run the `wrangler types --experimental-include-runtime` command before any development tasks that rely on TypeScript. This ensures your editor and build tools always have access to the latest types.
+
+Most projects will have existing build and development scripts scripts, as well as some type-checking. In the example below, we're adding the `wrangler types --experimental-include-runtime` before the type-checking script in the project:
+
+```json
+{
+  "scripts": {
+    "dev": "your-existing-dev-command",
+    "build": "your-existing-build-command",
+    "type-check": "wrangler types --experimental-include-runtime && tsc"
+  }
+}
+```
+
+In CI, you may have a separate build and test commands. It is best practice to run `wrangler types --experimental-include-runtime` before other CI commands. For example:
+
+```text
+- run: npm run generate-types
+- run: npm run build
+- run: npm test
+```
+
+By integrating the `wrangler types --experimental-include-runtime` command into your workflow this way, you ensure that your development environment, builds, and CI processes always use the most accurate and up-to-date types for your Cloudflare Worker, regardless of your specific framework or tooling choices.
 
 ### Known issues
 

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -6,7 +6,6 @@ sidebar:
 head:
   - tag: title
     content: Write Cloudflare Workers in TypeScript
-
 ---
 
 import { TabItem, Tabs } from "~/components";
@@ -41,11 +40,7 @@ If you would like to commit the file to git, you can provide a custom path. Here
 wrangler types --experimental-include-runtime="./runtime.d.ts"
 ```
 
-{{<Aside type="warning">}}
-
-To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your config file.
-
-{{</Aside>}}
+**Note: To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your config file.**
 
 See [the full list of available flags](/workers/wrangler/commands/#types) for more details.
 
@@ -95,9 +90,9 @@ This will generate a `.d.ts` file, saved to `.wrangler/types/runtime.d.ts` by de
 
 ```json
 {
-  "compilerOptions": {
-    "types": ["./.wrangler/types/runtime"]
-  }
+	"compilerOptions": {
+		"types": ["./.wrangler/types/runtime"]
+	}
 }
 ```
 
@@ -111,11 +106,11 @@ Most projects will have existing build and development scripts scripts, as well 
 
 ```json
 {
-  "scripts": {
-    "dev": "existing-dev-command",
-    "build": "-existing-build-command",
-    "type-check": "wrangler types --experimental-include-runtime && tsc"
-  }
+	"scripts": {
+		"dev": "existing-dev-command",
+		"build": "-existing-build-command",
+		"type-check": "wrangler types --experimental-include-runtime && tsc"
+	}
 }
 ```
 
@@ -177,7 +172,7 @@ For more information, refer to [this GitHub issue](https://github.com/cloudflare
 
 ### Resources
 
-* [TypeScript template](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript)
-* [@cloudflare/workers-types](https://github.com/cloudflare/workers-types)
-* [Runtime APIs](/workers/runtime-apis/)
-* [TypeScript Examples](/workers/examples/?languages=TypeScript)
+- [TypeScript template](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript)
+- [@cloudflare/workers-types](https://github.com/cloudflare/workers-types)
+- [Runtime APIs](/workers/runtime-apis/)
+- [TypeScript Examples](/workers/examples/?languages=TypeScript)

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -119,11 +119,39 @@ Most projects will have existing build and development scripts scripts, as well 
 
 In CI, you may have a separate build and test commands. It is best practice to run `wrangler types --experimental-include-runtime` before other CI commands. For example:
 
+<Tabs> <TabItem label="npm">
+
 ```yaml
 - run: npm run generate-types
 - run: npm run build
 - run: npm test
 ```
+
+</TabItem> <TabItem label="yarn">
+
+```yaml
+- run: yarn generate-types
+- run: yarn build
+- run: yarn test
+```
+
+</TabItem> <TabItem label="pnpm">
+
+```yaml
+- run: pnpm run generate-types
+- run: pnpm run build
+- run: pnpm test
+```
+
+</TabItem> <TabItem label="bun">
+
+```yaml
+- run: bun run generate-types
+- run: bun run build
+- run: bun test
+```
+
+</TabItem> </Tabs>
 
 By integrating the `wrangler types --experimental-include-runtime` command into your workflow this way, you ensure that your development environment, builds, and CI processes always use the most accurate and up-to-date types for your Cloudflare Worker, regardless of your specific framework or tooling choices.
 

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -9,6 +9,8 @@ head:
 
 ---
 
+import { TabItem, Tabs } from "~/components";
+
 ## TypeScript
 
 TypeScript is a first-class language on Cloudflare Workers. Cloudflare publishes type definitions to [GitHub](https://github.com/cloudflare/workers-types) and [npm](https://www.npmjs.com/package/@cloudflare/workers-types) (`npm install -D @cloudflare/workers-types`). All APIs provided in Workers are fully typed, and type definitions are generated directly from [workerd](https://github.com/cloudflare/workerd), the open-source Workers runtime.

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -17,19 +17,19 @@ TypeScript is a first-class language on Cloudflare Workers. Cloudflare publishes
 ### Generate types that match your Worker's configuration (experimental)
 
 Cloudflare continuously improves [workerd](https://github.com/cloudflare/workerd), the open-source Workers runtime.
-Some updates change the TypeScript types that APIs return. For example, the [`urlsearchparams_delete_has_value_arg`](/workers/configuration/compatibility-dates/#urlsearchparams-delete-and-has-value-argument) compatibility flag adds optional arguments to some methods, in order to support new additions to the WHATWG URL standard API.
+Changes in workerd can introduce JavaScript API changes, thus changing the respective TypeScript types. For example, the [`urlsearchparams_delete_has_value_arg`](/workers/configuration/compatibility-dates/#urlsearchparams-delete-and-has-value-argument) compatibility flag adds optional arguments to some methods, in order to support new additions to the WHATWG URL standard API.
 
 This means the correct TypeScript types for your Worker depend on:
 
 1. Your Worker's [Compatibility Date](/workers/configuration/compatibility-dates/).
 2. Your Worker's [Compatibility Flags](/workers/configuration/compatibility-dates/#compatibility-flags).
 
-For example, if you have `compatibility_flags = ["nodejs_als"]` in your `wrangler.toml`, then the runtime will allow you to use the [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) class in your worker code, but you will not see this reflected in the type definitions in `@cloudflare/workers-types`.
+For example, if you have `compatibility_flags = ["nodejs_als"]` in your `wrangler.toml`, then the runtime will allow you to use the [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) class in your worker code, but you will not see this reflected in the type definitions in `@cloudflare/workers-types`.
 
 In order to solve this issue, and to ensure that your type definitions are always up-to-date with your compatibility settings, you can dynamically generate the runtime types (as of `wrangler 3.66.0`):
 
 ```bash
-wrangler types --experimental-include-runtime
+npx wrangler types --experimental-include-runtime
 ```
 
 This will generate a `d.ts` file and (by default) save it to `.wrangler/types/runtime.d.ts`. You will be prompted in the command's output to add that file to your `tsconfig.json`'s `compilerOptions.types` array.
@@ -37,7 +37,7 @@ This will generate a `d.ts` file and (by default) save it to `.wrangler/types/ru
 If you would like to commit the file to git, you can provide a custom path. Here, for instance, the `runtime.d.ts` file will be saved to the root of your project:
 
 ```bash
-wrangler types --experimental-include-runtime="./runtime.d.ts"
+npx wrangler types --experimental-include-runtime="./runtime.d.ts"
 ```
 
 **Note: To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your config file.**
@@ -46,7 +46,7 @@ See [the full list of available flags](/workers/wrangler/commands/#types) for mo
 
 #### Migrating from `@cloudflare/workers-types` to `wrangler types --experimental-include-runtime`
 
-The `@cloudflare/workers-types` package provides runtime types according to your compatibility date, but is superceeded by the `wrangler types --experimental-include-runtime` command.
+The `@cloudflare/workers-types` package provides runtime types for each distinct [compatibility date](https://github.com/cloudflare/workerd/tree/main/npm/workers-types#compatibility-dates), which is specified by the user in their `tsconfig.json`. But this package is superseded by the `wrangler types --experimental-include-runtime` command.
 
 Here are the steps to switch from `@cloudflare/workers-types` to using `wrangler types` with the experimental runtime inclusion:
 
@@ -81,7 +81,7 @@ bun remove @cloudflare/workers-types
 ##### Generate runtime types using wrangler
 
 ```bash
-wrangler types --experimental-include-runtime
+npx wrangler types --experimental-include-runtime
 ```
 
 This will generate a `.d.ts` file, saved to `.wrangler/types/runtime.d.ts` by default.

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -298,6 +298,7 @@ wrangler d1 export <DATABASE_NAME> [OPTIONS]
 - `--no-schema` boolean (default: false) optional
   - Controls whether export SQL file contains database schema. Note that `--no-schema=true` is not recommended due to a known wrangler limitation that intreprets the value as false.
 
+
 ### `time-travel restore`
 
 Restore a database to a specific point-in-time using [Time Travel](/d1/reference/time-travel/).
@@ -2155,7 +2156,7 @@ wrangler whoami
 
 The `--experimental-versions` flag is required to use the `wrangler versions` commands. You may use the shorthand `--x-versions` flag in place of `--experimental-versions` anywhere it is mentioned. For consistency in Wrangler's output, it is recommended that you use the `--experimental-versions` flag for all commands where it is an option.
 
-The minimum required wrangler version to use these commands is 3.40.0.
+The minimum required Wrangler version to use these commands is 3.40.0.
 
 :::
 
@@ -2272,7 +2273,7 @@ This command is currently in closed beta. Report bugs in [GitHub](https://github
 
 The `--experimental-versions` flag is required to use the `wrangler triggers` commands. You may use the shorthand `--x-versions` flag in place of `--experimental-versions` anywhere it is mentioned. For consistency in Wrangler's output, it is recommended that you use the `--experimental-versions` flag for all commands where it is an option.
 
-The minimum required wrangler version to use these commands is 3.40.0.
+The minimum required Wrangler version to use these commands is 3.40.0.
 
 :::
 
@@ -2592,13 +2593,36 @@ Generate types from bindings and module rules in configuration.
 wrangler types [<PATH>] [OPTIONS]
 ```
 
-- `PATH` string (default: `worker-configuration.d.ts`)
+{{<Aside type="warning">}}
 
-  - The path to where the declaration file for your Worker will be written.
-  - The path to the declaration file must have a `d.ts` extension.
+The `--experimental-include-runtime` flag dynamically generates runtime types according to the `compatibility_date` and `compatibility_flags` defined in your [config file](/workers/wrangler/configuration/).
+
+It is a replacement for the [`@cloudflare/workers-types` package](https://www.npmjs.com/package/@cloudflare/workers-types), so that package should be uninstalled to avoid any potential conflict.
+
+After running the command, you must add the path of the generated runtime types file to the [`compilerOptions.types` field](https://www.typescriptlang.org/tsconfig/#types) in your project's [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) file.
+
+You may use the shorthand `--x-include-runtime` flag in place of `--experimental-include-runtime` anywhere it is mentioned.
+
+The minimum required Wrangler version to use this command is 3.66.1.
+
+{{</Aside>}}
+
+{{<definitions>}}
+
+- `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `./worker-configuration.d.ts`){{</prop-meta>}}
+  - The path to where **the `Env` types** for your Worker will be written.
+  - The path must have a `d.ts` extension.
 
 - `--env-interface` string (default: `Env`)
   - The name of the interface to generate for the environment object.
   - Not valid if the Worker uses the Service Worker syntax.
 
-{/* <!--TODO Add examples of DTS generated output --> */}
+- `--experimental-include-runtime` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: `./.wrangler/types/runtime.d.ts`){{</prop-meta>}}
+  - The path to where the  **runtime types** file will be written.
+  - Leave the path blank to use the default option, e.g. `npx wrangler types --x-include-runtime`
+  - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
+  - A custom path must have a `d.ts` extension.
+
+{{</definitions>}}
+
+<!--TODO Add examples of DTS generated output -->

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -298,7 +298,6 @@ wrangler d1 export <DATABASE_NAME> [OPTIONS]
 - `--no-schema` boolean (default: false) optional
   - Controls whether export SQL file contains database schema. Note that `--no-schema=true` is not recommended due to a known wrangler limitation that intreprets the value as false.
 
-
 ### `time-travel restore`
 
 Restore a database to a specific point-in-time using [Time Travel](/d1/reference/time-travel/).
@@ -2597,7 +2596,7 @@ wrangler types [<PATH>] [OPTIONS]
 
 The `--experimental-include-runtime` flag dynamically generates runtime types according to the `compatibility_date` and `compatibility_flags` defined in your [config file](/workers/wrangler/configuration/).
 
-It is a replacement for the [`@cloudflare/workers-types` package](https://www.npmjs.com/package/@cloudflare/workers-types), so that package should be uninstalled to avoid any potential conflict.
+It is a replacement for the [`@cloudflare/workers-types` package](https://www.npmjs.com/package/@cloudflare/workers-types), so that package, if installed, should be uninstalled to avoid any potential conflict.
 
 After running the command, you must add the path of the generated runtime types file to the [`compilerOptions.types` field](https://www.typescriptlang.org/tsconfig/#types) in your project's [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) file.
 
@@ -2610,15 +2609,17 @@ The minimum required Wrangler version to use this command is 3.66.1.
 {{<definitions>}}
 
 - `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `./worker-configuration.d.ts`){{</prop-meta>}}
+
   - The path to where **the `Env` types** for your Worker will be written.
   - The path must have a `d.ts` extension.
 
 - `--env-interface` string (default: `Env`)
+
   - The name of the interface to generate for the environment object.
   - Not valid if the Worker uses the Service Worker syntax.
 
 - `--experimental-include-runtime` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: `./.wrangler/types/runtime.d.ts`){{</prop-meta>}}
-  - The path to where the  **runtime types** file will be written.
+  - The path to where the **runtime types** file will be written.
   - Leave the path blank to use the default option, e.g. `npx wrangler types --x-include-runtime`
   - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
   - A custom path must have a `d.ts` extension.

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2592,7 +2592,7 @@ Generate types from bindings and module rules in configuration.
 wrangler types [<PATH>] [OPTIONS]
 ```
 
-{{<Aside type="warning">}}
+:::note
 
 The `--experimental-include-runtime` flag dynamically generates runtime types according to the `compatibility_date` and `compatibility_flags` defined in your [config file](/workers/wrangler/configuration/).
 
@@ -2604,11 +2604,9 @@ You may use the shorthand `--x-include-runtime` flag in place of `--experimental
 
 The minimum required Wrangler version to use this command is 3.66.1.
 
-{{</Aside>}}
+:::
 
-{{<definitions>}}
-
-- `PATH` {{<type>}}string{{</type>}} {{<prop-meta>}}(default: `./worker-configuration.d.ts`){{</prop-meta>}}
+- `PATH` string (default: `./worker-configuration.d.ts`)
 
   - The path to where **the `Env` types** for your Worker will be written.
   - The path must have a `d.ts` extension.
@@ -2618,12 +2616,8 @@ The minimum required Wrangler version to use this command is 3.66.1.
   - The name of the interface to generate for the environment object.
   - Not valid if the Worker uses the Service Worker syntax.
 
-- `--experimental-include-runtime` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}(default: `./.wrangler/types/runtime.d.ts`){{</prop-meta>}}
+- `--experimental-include-runtime` string optional (default: `./.wrangler/types/runtime.d.ts`)
   - The path to where the **runtime types** file will be written.
   - Leave the path blank to use the default option, e.g. `npx wrangler types --x-include-runtime`
   - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
   - A custom path must have a `d.ts` extension.
-
-{{</definitions>}}
-
-<!--TODO Add examples of DTS generated output -->


### PR DESCRIPTION
### Summary

This adds documentation for the `wrangler types --experimental-include-runtime` flag that dynamically generates runtime types for any combination of `compatibility_date` and `compatibility_flags`.

The PR that introduces the feature: https://github.com/cloudflare/workers-sdk/pull/6295

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
