### PR TITLE
[rules-language] Adds backslash to escape the dot in regex in operators.md

### DIFF
--- a/content/ruleset-engine/rules-language/operators.md
+++ b/content/ruleset-engine/rules-language/operators.md
@@ -311,7 +311,7 @@ You can nest expressions grouped by parentheses inside other groups to create ve
 ```sql
 (
  (http.host eq "api.example.com" and http.request.uri.path eq "/api/v2/auth") or
- (http.host matches "^(www|store|blog)\.example.com" and http.request.uri.path contains "wp-login.php") or
+ (http.host matches "^(www|store|blog)\.example\.com" and http.request.uri.path contains "wp-login.php") or
  ip.geoip.country in {"CN" "TH" "US" "ID" "KR" "MY" "IT" "SG" "GB"} or ip.geoip.asnum in {12345 54321 11111}
 ) and not ip.src in {11.22.33.0/24}
 ```


### PR DESCRIPTION
### Summary

Periods should be escaped in regex. The dot before .com in example.com should also be escaped in the example rule provided in https://developers.cloudflare.com/ruleset-engine/rules-language/operators/#nest-expressions. This PR just adds a backslash to escape the dot.


