### PR TITLE
[Workers] Update wrangler global flags

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -53,7 +53,7 @@ The following global flags work on every command, with some exceptions for `page
 - `--config` {{<type>}}string{{</type>}} {{<prop-meta>}}(not supported by Pages){{</prop-meta>}}
   - Path to `.toml` configuration file.
 - `--experimental-json-config` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(not supported by Pages){{</prop-meta>}}
-  - ⚠️ This is an experimental command. Read configuration from a `wrangler.json` file, instead of `wrangler.toml`. `wrangler.json` is a [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) file.
+  - ⚠️ This is an experimental command. Read configuration from a `wrangler.json` or `wrangler.jsonc` file, instead of `wrangler.toml`. `wrangler.json` is a [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) file.
 
 {{</definitions>}}
 
@@ -1683,7 +1683,7 @@ wrangler r2 object delete <OBJECT_PATH> [OPTIONS]
 
 ## `secret`
 
-Manage the secret variables for a Worker. 
+Manage the secret variables for a Worker.
 
 This action creates a new [version](/workers/configuration/versions-and-deployments/#versions) of the Worker and [deploys](/workers/configuration/versions-and-deployments/#deployments) it immediately. To only create a new version of the Worker, use the [`wrangler versions secret`](/workers/wrangler/commands/#secret-put) commands.
 


### PR DESCRIPTION
### Summary

This commit updates the global falgs section of wrangler commands, by specifying that `--experimental-json-config` now supports `wrangler.jsonc` files as well.

See https://github.com/cloudflare/workers-sdk/issues/5437 and https://github.com/cloudflare/workers-sdk/pull/6276

### Screenshots (optional)

<img width="812" alt="Screenshot 2024-07-24 at 12 53 38" src="https://github.com/user-attachments/assets/0bb97ff8-af8b-49ff-9c86-658dfe46b456">


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
