### PR TITLE
Update challenge-passage.md

### DIFF
--- a/content/waf/tools/challenge-passage.md
+++ b/content/waf/tools/challenge-passage.md
@@ -28,4 +28,4 @@ To update the Challenge Passage (and the value of the `cf_clearance` cookie):
 
 ## Limitations
 
-The Challenge Passage does not apply to challenges issued by WAF managed rules. Also, Challenge Passage does not apply to rate limiting rules unless the rate limit is configured to issue a challenge.
+The Challenge Passage does not apply to challenges issued by WAF managed rules. Also, Challenge Passage does not apply to rate limiting rules.


### PR DESCRIPTION
### Summary

Removed the section that mentioned Rate Limiting + challenge action. It seems in contradiction with that section https://developers.cloudflare.com/waf/rate-limiting-rules/parameters/#:~:text=When%20visitors%20pass%20a%20challenge%2C%20their%20corresponding%20request%20counter%20is%20set%20to%20zero.%20When%20visitors%20with%20the%20same%20values%20for%20the%20rule%20characteristics%20make%20enough%20requests%20to%20trigger%20the%20rate%20limiting%20rule%20again%2C%20they%20will%20receive%20a%20new%20challenge.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
