### PR TITLE
Document `wrangler.json` as an alternative to `wrangler.toml`

### DIFF
--- a/content/d1/build-with-d1/local-development.md
+++ b/content/d1/build-with-d1/local-development.md
@@ -49,7 +49,7 @@ In this example, the Worker has access to local-only D1 database. The correspond
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[d1_databases]]
 binding = "DB"

--- a/content/hyperdrive/get-started.md
+++ b/content/hyperdrive/get-started.md
@@ -83,7 +83,7 @@ To enable Node.js compatibility, add the `nodejs_compat` compatibility flag in y
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_compat" ]
 ```

--- a/content/kv/reference/kv-namespaces.md
+++ b/content/kv/reference/kv-namespaces.md
@@ -40,7 +40,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 kv_namespaces = [
   { binding = "<TEST_NAMESPACE>", id = "<TEST_ID>" }

--- a/content/queues/configuration/batching-retries.md
+++ b/content/queues/configuration/batching-retries.md
@@ -209,7 +209,7 @@ Delays can also be configured in [`wrangler.toml`](/workers/wrangler/configurati
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[queues.producers]]
   binding = "<BINDING_NAME>"

--- a/content/workers/configuration/compatibility-dates.md
+++ b/content/workers/configuration/compatibility-dates.md
@@ -89,7 +89,7 @@ A [growing subset](/workers/runtime-apis/nodejs/) of Node.js APIs are available 
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_compat" ]
 ```
@@ -100,7 +100,7 @@ The Node.js `AsyncLocalStorage` API is a particularly useful feature for Workers
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_als" ]
 ```

--- a/content/workers/runtime-apis/bindings/mTLS.md
+++ b/content/workers/runtime-apis/bindings/mTLS.md
@@ -35,7 +35,7 @@ Then, update your Worker project's `wrangler.toml` file to create an mTLS certif
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 mtls_certificates = [
   { binding = "MY_CERT", certificate_id = "<CERTIFICATE_ID>" }

--- a/content/workers/runtime-apis/bindings/version-metadata.md
+++ b/content/workers/runtime-apis/bindings/version-metadata.md
@@ -15,7 +15,7 @@ To use the version metadata binding, update your Worker's `wrangler.toml` file:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [version_metadata]
 binding = "CF_VERSION_METADATA"

--- a/content/workers/runtime-apis/nodejs/_index.md
+++ b/content/workers/runtime-apis/nodejs/_index.md
@@ -30,7 +30,7 @@ Add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-com
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_compat" ]
 ```
@@ -62,7 +62,7 @@ To enable the Node.js `AsyncLocalStorage` API only, use the `nodejs_als` compati
 
 ```toml
 ---
-header:wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_als" ]
 ```

--- a/content/workers/tutorials/postgres/index.md
+++ b/content/workers/tutorials/postgres/index.md
@@ -59,7 +59,7 @@ If you choose to deploy, you will be asked to authenticate (if not logged in alr
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 node_compat = true
 ```

--- a/content/workers/tutorials/store-data-with-fauna/index.md
+++ b/content/workers/tutorials/store-data-with-fauna/index.md
@@ -138,7 +138,7 @@ Next, go to your Worker project directory and update the `wrangler.toml` file to
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 name = "fauna-workers"
 ```

--- a/content/workers/wrangler/configuration.md
+++ b/content/workers/wrangler/configuration.md
@@ -231,7 +231,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 route = { pattern = "example.com", custom_domain = true }
 
@@ -264,7 +264,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 routes = [
 	{ pattern = "subdomain.example.com/*", zone_id = "<YOUR_ZONE_ID>" }
@@ -289,7 +289,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 routes = [
 	{ pattern = "subdomain.example.com/*", zone_name = "example.com" }
@@ -304,7 +304,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 route = "example.com/*"
 ```
@@ -323,7 +323,7 @@ Cloudflare Workers accounts come with a `workers.dev` subdomain that is configur
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 workers_dev = false
 ```
@@ -346,7 +346,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [triggers]
 crons = ["* * * * *"]
@@ -376,7 +376,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [build]
 command = "npm run build"
@@ -404,7 +404,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [limits]
 cpu_ms = 100
@@ -430,7 +430,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 browser = { binding = "<BINDING_NAME>" }
 
@@ -478,7 +478,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 d1_databases = [
   { binding = "<BINDING_NAME>", database_name = "<DATABASE_NAME>", database_id = "<DATABASE_ID>" }
@@ -516,7 +516,7 @@ Dispatch namespace bindings allow for communication between a [dynamic dispatch 
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[dispatch_namespaces]]
 binding = "<BINDING_NAME>"
@@ -555,7 +555,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 durable_objects.bindings = [
   { name = "<BINDING_NAME>", class_name = "<CLASS_NAME>" }
@@ -597,7 +597,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[migrations]]
 tag = "v1" # Should be unique for each entry
@@ -660,7 +660,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 
 node_compat = true # required for database drivers to function
@@ -703,7 +703,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 kv_namespaces = [
   { binding = "<BINDING_NAME1>", id = "<NAMESPACE_ID1>" },
@@ -747,7 +747,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[queues.producers]]
   binding = "<BINDING_NAME>"
@@ -796,7 +796,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [[queues.consumers]]
   queue = "my-queue"
@@ -844,7 +844,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 r2_buckets  = [
   { binding = "<BINDING_NAME1>", bucket_name = "<BUCKET_NAME1>"},
@@ -884,7 +884,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 vectorize  = [
   { binding = "<BINDING_NAME>", index_name = "<INDEX_NAME>"}
@@ -922,7 +922,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 services = [
   { binding = "<BINDING_NAME>", service = "<WORKER_NAME>", entrypoint = "<ENTRYPOINT_NAME>" }
@@ -991,7 +991,7 @@ Example of a `wrangler.toml` configuration that includes an mTLS certificate bin
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 mtls_certificates = [
     { binding = "<BINDING_NAME1>", certificate_id = "<CERTIFICATE_ID1>" },
@@ -1066,7 +1066,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 rules = [
   { type = "Text", globs = ["**/*.md"], fallthrough = true }
@@ -1123,7 +1123,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [dev]
 ip = "192.168.1.1"
@@ -1147,7 +1147,7 @@ A [growing subset of Node.js APIs](/workers/runtime-apis/nodejs/) are available 
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 compatibility_flags = [ "nodejs_compat" ]
 ```
@@ -1158,7 +1158,7 @@ Add polyfills for a subset of Node.js APIs to your Worker by adding the `node_co
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 node_compat = true
 ```
@@ -1184,7 +1184,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 upload_source_maps = true
 
@@ -1218,7 +1218,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [site]
 bucket = "./public"

--- a/content/workers/wrangler/custom-builds.md
+++ b/content/workers/wrangler/custom-builds.md
@@ -37,7 +37,7 @@ Example:
 
 ```toml
 ---
-header: wrangler.toml
+filename: wrangler.toml
 ---
 [build]
 command = "npm run build"

--- a/content/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.md
+++ b/content/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.md
@@ -79,7 +79,7 @@ kv_namespaces = [
 name = "your-worker-helloworld"
 account_id = "your-other-account-id"
 
-[vars]
+[env.helloworld.vars]
 FOO = "env-helloworld FOO value"
 BAR = "env-helloworld BAR value"
 
@@ -573,59 +573,59 @@ type = "CommonJS"
 globs = ["**/*.js", "**/*.cjs"]
 ```
 
-  - `type` {{<prop-meta>}}required{{</prop-meta>}}
+- `type` {{<prop-meta>}}required{{</prop-meta>}}
 
-    - The module type, see the table below for acceptable options:
-      <div class="DocsMarkdown--table-wrap">
-        <div class="DocsMarkdown--table-wrap-inner">
-          <table>
-            <thead>
-              <tr>
-                <th>
-                  <code>type</code>
-                </th>
-                <th>JavaScript type</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>ESModule</td>
-                <td>-</td>
-              </tr>
-              <tr>
-                <td>CommonJS</td>
-                <td>-</td>
-              </tr>
-              <tr>
-                <td>Text</td>
-                <td>
-                  <code>String</code>
-                </td>
-              </tr>
-              <tr>
-                <td>Data</td>
-                <td>
-                  <code>ArrayBuffer</code>
-                </td>
-              </tr>
-              <tr>
-                <td>CompiledWasm</td>
-                <td>
-                  <code>WebAssembly.Module</code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+  - The module type, see the table below for acceptable options:
+    <div class="DocsMarkdown--table-wrap">
+      <div class="DocsMarkdown--table-wrap-inner">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                <code>type</code>
+              </th>
+              <th>JavaScript type</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>ESModule</td>
+              <td>-</td>
+            </tr>
+            <tr>
+              <td>CommonJS</td>
+              <td>-</td>
+            </tr>
+            <tr>
+              <td>Text</td>
+              <td>
+                <code>String</code>
+              </td>
+            </tr>
+            <tr>
+              <td>Data</td>
+              <td>
+                <code>ArrayBuffer</code>
+              </td>
+            </tr>
+            <tr>
+              <td>CompiledWasm</td>
+              <td>
+                <code>WebAssembly.Module</code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+    </div>
 
-  - `globs` {{<prop-meta>}}required{{</prop-meta>}}
+- `globs` {{<prop-meta>}}required{{</prop-meta>}}
 
-    - UNIX-style [glob rules](https://docs.rs/globset/0.4.6/globset/#syntax) that are used to determine the module type to use for a given file in `dir`. Globs are matched against the module's relative path from `build.upload.dir` without the `./` prefix. Rules are evaluated in order, starting at the top.
+  - UNIX-style [glob rules](https://docs.rs/globset/0.4.6/globset/#syntax) that are used to determine the module type to use for a given file in `dir`. Globs are matched against the module's relative path from `build.upload.dir` without the `./` prefix. Rules are evaluated in order, starting at the top.
 
-  - `fallthrough` {{<prop-meta>}}optional{{</prop-meta>}}
+- `fallthrough` {{<prop-meta>}}optional{{</prop-meta>}}
 
-    - This option allows further rules for this module type to be considered if set to true. If not specified or set to false, further rules for this module type will be ignored.
+  - This option allows further rules for this module type to be considered if set to true. If not specified or set to false, further rules for this module type will be ignored.
 
 {{</definitions>}}
 

--- a/layouts/_default/_markup/render-codeblock-toml.html
+++ b/layouts/_default/_markup/render-codeblock-toml.html
@@ -1,0 +1,41 @@
+{{ if (strings.Contains .Inner "filename: wrangler.toml") }}
+{{- $text := "wrangler.toml | wrangler.json" -}}
+{{- $labels := split $text " | " -}}
+{{- $unique_id := lower (substr (md5 .Inner) 0 16) -}}
+
+<div class="tabs-wrapper" tab-wrapper-id="{{$unique_id}}">
+    <nav role="navigation" class="tabs">
+        <ul class="tab-active" block-id="{{$unique_id}}">
+            {{ range $idx, $txt := $labels }}
+            {{- $link := replace $txt "/" "-" -}}
+            {{- $dataLink := printf "tab-%s" (lower $link) }}
+            <li class="tab-label-wrapper">
+                <a class="tab-label noCodeLabel" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+                    {{$link}}
+                </a>
+            </li>
+            {{ end }}
+        </ul>
+    </nav>
+
+    <div class="tab tab-default" id="tab-wrangler.toml-{{ $unique_id }}">
+        <div class="code-container">
+            <unparsed-codeblock data-language="{{ .Type }}" data-code="{{ urlquery (strings.Replace .Inner "filename: wrangler.toml" "") }}"></unparsed-codeblock>
+            <vue-component name="CodeCopy"></vue-component>
+        </div>
+    </div>
+
+    <div class="tab" id="tab-wrangler.json-{{ $unique_id }}">
+        <div class="code-container">
+            <toml-to-json data-toml="{{ urlquery .Inner }}"/></toml-to-json>
+            <vue-component name="CodeCopy"></vue-component>
+        </div>
+    </div>
+
+</div>
+{{ else }}
+<div class="code-container">
+    <unparsed-codeblock data-language="{{ .Type }}" data-code="{{ urlquery .Inner }}"></unparsed-codeblock>
+    <vue-component name="CodeCopy"></vue-component>
+</div>
+{{ end }}

--- a/layouts/_default/_markup/render-codeblock-toml.html
+++ b/layouts/_default/_markup/render-codeblock-toml.html
@@ -1,37 +1,31 @@
 {{ if (strings.Contains .Inner "filename: wrangler.toml") }}
-{{- $text := "wrangler.toml | wrangler.json" -}}
-{{- $labels := split $text " | " -}}
-{{- $unique_id := lower (substr (md5 .Inner) 0 16) -}}
-
-<div class="tabs-wrapper" tab-wrapper-id="{{$unique_id}}">
+<div class="tabs-wrapper">
     <nav role="navigation" class="tabs">
-        <ul class="tab-active" block-id="{{$unique_id}}">
-            {{ range $idx, $txt := $labels }}
-            {{- $link := replace $txt "/" "-" -}}
-            {{- $dataLink := printf "tab-%s" (lower $link) }}
+        <ul class="tab-active">
             <li class="tab-label-wrapper">
-                <a class="tab-label noCodeLabel" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
-                    {{$link}}
+                <a class="tab-label noCodeLabel" href="#">
+                    wrangler.toml
                 </a>
             </li>
-            {{ end }}
+            <li class="tab-label-wrapper">
+                <a class="tab-label noCodeLabel" href="#">
+                    wrangler.json
+                </a>
+            </li>
         </ul>
     </nav>
-
-    <div class="tab tab-default" id="tab-wrangler.toml-{{ $unique_id }}">
+    <div class="tab tab-default">
         <div class="code-container">
             <unparsed-codeblock data-language="{{ .Type }}" data-code="{{ urlquery (strings.Replace .Inner "filename: wrangler.toml" "") }}"></unparsed-codeblock>
             <vue-component name="CodeCopy"></vue-component>
         </div>
     </div>
-
-    <div class="tab" id="tab-wrangler.json-{{ $unique_id }}">
+    <div class="tab">
         <div class="code-container">
             <toml-to-json data-toml="{{ urlquery .Inner }}"/></toml-to-json>
             <vue-component name="CodeCopy"></vue-component>
         </div>
     </div>
-
 </div>
 {{ else }}
 <div class="code-container">

--- a/layouts/shortcodes/build-environment.html
+++ b/layouts/shortcodes/build-environment.html
@@ -18,7 +18,7 @@
 
 <div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
   <nav role="navigation" class="tabs">
-    <ul class="tab-active" block-id="{{ $unique_id }}">
+    <ul class="tab-active">
       {{ range $idx, $file := $files }}
       <li class="tab-label-wrapper">
         <a class="tab-label noCodeLabel" href="#" data-link="tab-{{ $file.name }}"

--- a/layouts/shortcodes/languages.html
+++ b/layouts/shortcodes/languages.html
@@ -18,7 +18,7 @@
 
 <div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
   <nav role="navigation" class="tabs">
-    <ul class="tab-active" block-id="{{ $unique_id }}">
+    <ul class="tab-active">
       {{ range $idx, $file := $files }}
       <li class="tab-label-wrapper">
         <a class="tab-label noCodeLabel" href="#" data-link="tab-{{ $file.name }}"

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -2,4 +2,4 @@
 {{- $default := .Get "default" -}}
 {{- $noCode := .Get "no-code" -}}
 
-<div class="tab {{ if eq $default "true" }}tab-default{{ end }} {{ if eq $noCode "true" }}noCodeTab{{ end }}" id="tab-{{ (lower $label) }}-UNIQUE_ID">{{ $.Inner | $.Page.RenderString }}</div>
+<div class="tab {{ if eq $default "true" }}tab-default{{ end }} {{ if eq $noCode "true" }}noCodeTab{{ end }}">{{ $.Inner | $.Page.RenderString }}</div>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,16 +1,14 @@
 {{- $text := .Get "labels" -}}
 {{- $labels := split $text " | " -}}
-{{- $unique_id := lower (substr (md5 .Inner) 0 16) -}}
 
-<div class="tabs-wrapper" tab-wrapper-id="{{$unique_id}}">
+<div class="tabs-wrapper">
 <nav role="navigation" class="tabs">
-<ul class="tab-active" block-id="{{$unique_id}}">
+<ul class="tab-active">
 {{ range $idx, $txt := $labels }}
 {{- $link := replace $txt "/" "-" -}}
-{{- $dataLink := printf "tab-%s" (lower $link) }}
 <li class="tab-label-wrapper">
 {{ if (eq $link "js") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
     xmlns="http://www.w3.org/2000/svg">
 <path
@@ -22,7 +20,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "js-sw") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
         xmlns="http://www.w3.org/2000/svg">
     <title>JavaScript</title>
@@ -35,7 +33,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +46,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts-sw") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -62,7 +60,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "py") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
     <path d="M253.806,1.783c-20.678,0.098-40.426,1.859-57.803,4.935c-51.187,9.044-60.48,27.97-60.48,62.877v46.103
           h120.963v15.366H135.522H90.126c-35.155,0-65.937,21.13-75.563,61.325c-11.107,46.075-11.603,74.83,0,122.939
@@ -82,7 +80,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "js-esm") }}
-<a class="tab-label " href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label " href="#">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em"
         xmlns="http://www.w3.org/2000/svg">
     <title>JavaScript</title>
@@ -95,7 +93,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "rs") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" height="1em" width="1em" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
     <path d="M15 3.77a.951.951 0 1 1 1.902 0 .951.951 0 0 1-1.902 0m-11.346 8.61a.951.951 0 1 1 1.902 0 .951.951 0 0 1-1.902 0m22.692.044a.951.951 0 0 1 1.902 0 .951.951 0 0 1-1.902 0M6.406 13.73a.87.87 0 0 0 .441-1.146l-.422-.954h1.66v7.48H4.736a11.71 11.71 0 0 1-.379-4.47zm6.942.184v-2.205H17.3c.204 0 1.44.236 1.44 1.16 0 .768-.95 1.044-1.73 1.044zM7.952 25.785a.951.951 0 1 1 1.902 0 .951.951 0 0 1-1.902 0m14.093.044a.951.951 0 0 1 1.902 0 .951.951 0 0 1-1.902 0m.294-2.157c-.47-.1-.93.198-1.03.667l-.477 2.228a11.71 11.71 0 0 1-9.765-.047l-.477-2.228c-.1-.47-.56-.768-1.03-.667l-1.967.422a11.71 11.71 0 0 1-1.017-1.199h9.57c.108 0 .18-.02.18-.118v-3.385c0-.1-.072-.118-.18-.118h-2.8v-2.146h3.027c.276 0 1.477.08 1.862 1.614l.565 2.5c.18.55.913 1.653 1.693 1.653h4.94a11.71 11.71 0 0 1-1.085 1.255zm5.314-8.938a11.71 11.71 0 0 1 .025 2.033h-1.2c-.12 0-.17.08-.17.197v.552c0 1.3-.732 1.58-1.374 1.653-.61.07-1.29-.256-1.372-.63-.36-2.028-.96-2.46-1.9-3.21 1.177-.748 2.402-1.85 2.402-3.327 0-1.594-1.093-2.598-1.838-3.09-1.045-.69-2.202-.827-2.514-.827H7.277a11.71 11.71 0 0 1 6.551-3.697l1.465 1.537c.33.347.88.36 1.226.028l1.64-1.567a11.71 11.71 0 0 1 8.017 5.709l-1.122 2.534a.87.87 0 0 0 .441 1.146zm2.798.04l-.038-.392 1.156-1.078c.235-.22.147-.66-.153-.772l-1.477-.552-.116-.38.92-1.28c.188-.26.015-.675-.3-.727l-1.558-.253-.187-.35.655-1.437c.134-.293-.115-.667-.437-.655l-1.58.055-.25-.303.363-1.54c.073-.313-.244-.63-.557-.557l-1.54.363-.304-.25.055-1.58c.012-.32-.362-.57-.654-.437l-1.436.655-.35-.188-.254-1.558c-.05-.316-.467-.488-.727-.3l-1.28.92-.38-.115-.552-1.477c-.112-.3-.553-.388-.772-.154l-1.078 1.156-.392-.038-.832-1.345c-.168-.272-.62-.272-.787 0l-.832 1.345-.392.038L13.305.43c-.22-.234-.66-.147-.772.154l-.552 1.477-.38.115-1.28-.92c-.26-.188-.676-.015-.727.3l-.254 1.558-.35.188-1.436-.655c-.292-.133-.667.117-.654.437l.055 1.58-.304.25-1.54-.363c-.313-.073-.63.244-.557.557l.363 1.54-.25.303-1.58-.055c-.32-.01-.57.362-.437.655l.655 1.437-.188.35-1.558.253c-.316.05-.488.467-.3.727l.92 1.28-.116.38-1.477.552c-.3.112-.388.553-.153.772l1.156 1.078-.038.392-1.345.832c-.272.168-.272.62 0 .787l1.345.832.038.392L.43 18.697c-.234.22-.147.66.153.772l1.477.552.116.38-.92 1.28c-.187.26-.015.676.3.727l1.557.253.188.35-.655 1.436c-.133.292.118.667.437.655l1.58-.055.25.304-.363 1.54c-.073.312.244.63.557.556l1.54-.363.304.25-.055 1.58c-.012.32.362.57.654.437l1.436-.655.35.188.254 1.557c.05.317.467.488.727.302l1.28-.922.38.116.552 1.477c.112.3.553.388.772.153l1.078-1.156.392.04.832 1.345c.168.27.618.272.787 0l.832-1.345.392-.04 1.078 1.156c.22.235.66.147.772-.153l.552-1.477.38-.116 1.28.922c.26.187.676.015.727-.302l.254-1.557.35-.188 1.436.655c.292.133.666-.116.654-.437l-.055-1.58.303-.25 1.54.363c.313.073.63-.244.557-.556l-.363-1.54.25-.304 1.58.055c.32.013.57-.363.437-.655l-.655-1.436.187-.35 1.558-.253c.317-.05.49-.466.3-.727l-.92-1.28.116-.38 1.477-.552c.3-.113.388-.553.153-.772l-1.156-1.078.038-.392 1.345-.832c.272-.168.273-.618 0-.787z" />
   </svg>
@@ -103,7 +101,7 @@ JavaScript
 </a>
 
 {{ else if (eq $link "ts-esm") }}
-<a class="tab-label" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label" href="#">
   <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em"
         width="1em"
         xmlns="http://www.w3.org/2000/svg">
@@ -117,7 +115,7 @@ JavaScript
 </a>
 
 {{ else }}
-<a class="tab-label noCodeLabel" href="#" data-link="{{$dataLink}}" data-id="{{$unique_id}}">
+<a class="tab-label noCodeLabel" href="#">
 {{$link}}
 </a>
 {{ end }}
@@ -126,5 +124,5 @@ JavaScript
 </ul>
 </nav>
 
-{{ replace .Inner "UNIQUE_ID" $unique_id | .Page.RenderString  }}
+{{ .Inner | .Page.RenderString  }}
 </div>

--- a/layouts/shortcodes/tools.html
+++ b/layouts/shortcodes/tools.html
@@ -18,7 +18,7 @@
 
 <div class="tabs-wrapper" tab-wrapper-id="{{ $unique_id }}">
   <nav role="navigation" class="tabs">
-    <ul class="tab-active" block-id="{{ $unique_id }}">
+    <ul class="tab-active">
       {{ range $idx, $file := $files }}
       <li class="tab-label-wrapper">
         <a class="tab-label noCodeLabel" href="#" data-link="tab-{{ lower $file.name }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "4.20240620.0",
+        "@iarna/toml": "^2.2.5",
         "@tsconfig/node20": "^20.1.4",
         "@types/glob": "^8.1.0",
         "@types/node": "^20.14.10",
@@ -764,6 +765,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20240620.0",
+    "@iarna/toml": "^2.2.5",
     "@tsconfig/node20": "^20.1.4",
     "@types/glob": "^8.1.0",
     "@types/node": "^20.14.10",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -139,19 +139,34 @@ const renderCodeBlock = (): PluginOption => {
                 decoded = decoded.split("---")[2]
               }
 
-              const [tomlSnippet] = decoded.split("# or\n"); // Some TOML snippets showcase multiple TOML syntaxes. Only take the first
-              const json = JSON.stringify(TOML.parse(tomlSnippet), null, 2)
-              const code = `// For Wrangler to read a JSON configuration file, you must add the \`-j\` flag\n// e.g. \`wrangler -j dev\`\n` + json + "\n";
-              element.replace(
-                await highlight(
-                  code,
-                  "json",
-                  ""
-                ),
-                {
-                  html: true,
-                }
-              );
+              try {
+                const [tomlSnippet] = decoded.split("# or\n"); // Some TOML snippets showcase multiple TOML syntaxes. Only take the first
+                const json = JSON.stringify(TOML.parse(tomlSnippet), null, 2)
+                const code = `// For Wrangler to read a JSON configuration file, you must add the \`-j\` flag\n// e.g. \`wrangler -j dev\`\n` + json + "\n";
+                element.replace(
+                  await highlight(
+                    code,
+                    "json",
+                    ""
+                  ),
+                  {
+                    html: true,
+                  }
+                );
+              } catch(e) {
+                console.error(e)
+                element.replace(
+                  await highlight(
+                    "Invalid TOML",
+                    "json",
+                    ""
+                  ),
+                  {
+                    html: true,
+                  }
+                );
+              }
+              
             },
           },
         ],


### PR DESCRIPTION
### Summary

This ensures that all `wrangler.toml` snippets in the docs have a corresponding `wrangler.json` tab, showing the equivalent config in JSON format (supported by Wrangler with the `-j` flag). The JSON config has a comment explaining how to make Wrangler recognise the format.

No additional work is required to add these tabs—they're generated automatically for every `toml` snippet that references `filename: wrangler.toml` (to ensure we don't accidentally break e.g. `cargo.toml` files).

Some other things have also been changed/improved:
- The tab system has been reworked to no longer require IDs, instead relying on child indexes in the DOM. These IDs were based on the hash of tab contents, which caused unexpected behaviour with multiple tabs on the same page with the same contents (as this change introduced in a few places)

### Screenshots (optional)

![Screenshot 2024-07-24 at 21 22 07](https://github.com/user-attachments/assets/6883fa28-2329-4322-8511-542f13b528da)