### PR TITLE
Alarms API: Milliseconds and seconds mixed up

### DIFF
--- a/content/durable-objects/examples/alarms-api.md
+++ b/content/durable-objects/examples/alarms-api.md
@@ -22,7 +22,7 @@ export default {
   },
 };
 
-const SECONDS = 1000;
+const SECONDS = 10;
 
 // Durable Object
 export class Batcher {
@@ -42,7 +42,7 @@ export class Batcher {
     // Any further POSTs in the next 10 seconds will be part of this batch.
     let currentAlarm = await this.storage.getAlarm();
     if (currentAlarm == null) {
-      this.storage.setAlarm(Date.now() + 10 * SECONDS);
+      this.storage.setAlarm(Date.now() + (1000 * SECONDS));
     }
 
     // Add the request to the batch.


### PR DESCRIPTION
### Summary

Seconds and milliseconds were mixed up in the docs. 
Date.now() returns a timestamp with millisecond precision, so to add 10 seconds you have to add 1000 * 10. 

Also added brackets for better readability. 

### Screenshots (optional)

not applicable. 
### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.