### PR TITLE
[SSL] Adding mTLS known limitation: R2 public bucket

### DIFF
--- a/content/cloudflare-one/identity/devices/access-integrations/mutual-tls-authentication.md
+++ b/content/cloudflare-one/identity/devices/access-integrations/mutual-tls-authentication.md
@@ -245,6 +245,7 @@ mTLS does not currently work for:
 
 - HTTP/3 traffic
 - Cloudflare Pages site served on a [custom domain](/pages/configuration/custom-domains/)
+- Cloudflare R2 public bucket served on a [custom domain](/r2/buckets/public-buckets/#connect-a-bucket-to-a-custom-domain)
 
 ## Set up alerts for mutual TLS certificates
 


### PR DESCRIPTION
### Summary

R2 public bucket seems to be a limitation of mTLS.
More detail in PCX ticket: PCX-12412

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
