### PR TITLE
[Chore] Restore copy code button tracking

### DIFF
--- a/assets/events.ts
+++ b/assets/events.ts
@@ -15,7 +15,7 @@ export function $focus(elem: HTMLElement, bool: boolean) {
   if (SEARCH_ID && SEARCH_ID.test(elem.id)) {
     SEARCH_INPUT = elem;
 
-    if(!elem.parentElement || !elem.parentElement.parentElement) return;
+    if (!elem.parentElement || !elem.parentElement.parentElement) return;
     elem.parentElement.parentElement.toggleAttribute("is-focused", bool);
     elem.setAttribute("aria-expanded", "" + bool);
 
@@ -46,7 +46,7 @@ export function load() {
     item &&
     setInterval(() => {
       if (document.readyState !== "complete") return;
-      if(timer){
+      if (timer) {
         clearInterval(timer);
       }
       setTimeout(() => {
@@ -59,7 +59,7 @@ export function load() {
 export function mobile() {
   let root = document.documentElement;
   let btn = document.querySelector(
-    ".DocsMobileTitleHeader--sidebar-toggle-button"
+    ".DocsMobileTitleHeader--sidebar-toggle-button",
   );
   if (btn)
     btn.addEventListener("click", () => {
@@ -103,7 +103,7 @@ function $tab(ev: MouseEvent) {
     ?.getAttribute("data-id");
 
   let tabs = document.querySelectorAll<HTMLElement>(
-    `div[tab-wrapper-id="${tabBlockId}"] > .tab`
+    `div[tab-wrapper-id="${tabBlockId}"] > .tab`,
   );
 
   for (let i = 0; i < tabs.length; i++) {
@@ -117,10 +117,12 @@ function $tab(ev: MouseEvent) {
   // escape ID for use in querySelector
   const tabID = CSS.escape(`${link}-${tabBlockId}`);
   const linkElement = document.querySelector<HTMLElement>(`#${tabID}`);
-  if(linkElement){
+  if (linkElement) {
     linkElement.style.display = "block";
   }
-  zaraz.track("tab click", {selected_option: (ev.target as HTMLElement).innerText})
+  zaraz.track("tab click", {
+    selected_option: (ev.target as HTMLElement).innerText,
+  });
 }
 
 export function tabs() {
@@ -131,7 +133,8 @@ export function tabs() {
     for (let i = 0; i < wrappers.length; i++) {
       const labels = wrappers[i].querySelectorAll<HTMLElement>(".tab-label");
       const tabs = wrappers[i].querySelectorAll<HTMLElement>(".tab");
-      const defaultTab = wrappers[i].querySelector<HTMLElement>(".tab.tab-default");
+      const defaultTab =
+        wrappers[i].querySelector<HTMLElement>(".tab.tab-default");
 
       if (tabs.length > 0) {
         // if a tab has been specified as default, set that
@@ -143,11 +146,11 @@ export function tabs() {
           const tabId = parts.slice(0, parts.length - 1).join("-");
 
           const defaultTabLabel = wrappers[i].querySelector(
-            `a[data-link="${tabId}"]`
+            `a[data-link="${tabId}"]`,
           );
 
           defaultTab.style.display = "block";
-          if(defaultTabLabel){
+          if (defaultTabLabel) {
             defaultTabLabel.classList.add("active");
           }
         } else {
@@ -172,7 +175,7 @@ export function activeTab() {
       for (var i = 0; i < tabs.length; i++) {
         tabs[i].addEventListener("click", function name() {
           let current = block.querySelector(`.active`);
-          if(current){
+          if (current) {
             current.classList.remove("active");
           }
           this.classList.add("active");
@@ -186,7 +189,6 @@ export function dropdowns() {
   let attr = "data-expanded";
 
   document.querySelectorAll(".Dropdown").forEach((div) => {
-
     let btn = div.querySelector("button");
     let links = div.querySelectorAll<HTMLAnchorElement>("li>a");
     let focused = 0; // index
@@ -254,28 +256,34 @@ export function dropdowns() {
 }
 
 export function zarazTrackDocEvents() {
-  const links = document.querySelectorAll<HTMLAnchorElement>(".DocsMarkdown--link");
-  const dropdowns = document.querySelectorAll("details")
-  const glossaryTooltips = document.querySelectorAll(".glossary-tooltip")
-  const playgroundLinks = document.querySelectorAll<HTMLAnchorElement>(".playground-link")
-  const copyCodeBlockButtons = document.querySelectorAll(".copyCode-button")
+  const links = document.querySelectorAll<HTMLAnchorElement>(
+    ".DocsMarkdown--link",
+  );
+  const dropdowns = document.querySelectorAll("details");
+  const glossaryTooltips = document.querySelectorAll(".glossary-tooltip");
+  const playgroundLinks =
+    document.querySelectorAll<HTMLAnchorElement>(".playground-link");
+
   addEventListener("DOMContentLoaded", () => {
     if (links.length > 0) {
       for (const link of links) {
-        const linkURL = new URL(link.href)
-        const cfSubdomainRegex = new RegExp(`^[^.]+?\.cloudflare\.com`)
+        const linkURL = new URL(link.href);
+        const cfSubdomainRegex = new RegExp(`^[^.]+?\.cloudflare\.com`);
         if (linkURL.hostname !== "developers.cloudflare.com") {
-          if (linkURL.hostname === "workers.cloudflare.com" && linkURL.pathname.startsWith("/playground#")) {
+          if (
+            linkURL.hostname === "workers.cloudflare.com" &&
+            linkURL.pathname.startsWith("/playground#")
+          ) {
             link.addEventListener("click", () => {
-              $zarazLinkEvent('playground link click', link);
+              $zarazLinkEvent("playground link click", link);
             });
           } else if (cfSubdomainRegex.test(linkURL.hostname)) {
             link.addEventListener("click", () => {
-              $zarazLinkEvent('Cross Domain Click', link);
+              $zarazLinkEvent("Cross Domain Click", link);
             });
           } else {
             link.addEventListener("click", () => {
-              $zarazLinkEvent('external link click', link);
+              $zarazLinkEvent("external link click", link);
             });
           }
         }
@@ -286,76 +294,73 @@ export function zarazTrackDocEvents() {
         dropdown.addEventListener("click", () => {
           $zarazDropdownEvent(dropdown.querySelectorAll("summary")[0]);
         });
+      }
     }
-  }
-  if (glossaryTooltips.length > 0) {
-    for (const tooltip of glossaryTooltips) {
-      tooltip.addEventListener("pointerleave", () => {
-        $zarazGlossaryTooltipEvent(tooltip.getAttribute('aria-label'))
-      });
-      tooltip.addEventListener("blur", () => {
-        $zarazGlossaryTooltipEvent(tooltip.getAttribute('aria-label'))
-      });
-  }
-}
-  if (playgroundLinks.length > 0) {
-    for (const playgroundLink of playgroundLinks) {
-      playgroundLink.addEventListener("click", () => {
-        $zarazLinkEvent('playground link click', playgroundLink);
-      });
-  }
-  }
-  if (copyCodeBlockButtons.length > 0) {
-    for (const copyButton of copyCodeBlockButtons) {
-      copyButton.addEventListener("click", () => {
-        const codeBlockElement = copyButton?.parentElement?.parentElement?.firstElementChild;
-        zaraz.track('copy button link click', {
-          title: codeBlockElement?.getAttribute('title') ?? 'title not set',
-          language: codeBlockElement?.getAttribute('language') ?? 'language not set',});
-      });
-    }
-  }
-  });
-}
-
-function $zarazLinkEvent(type: string, link: HTMLAnchorElement) {
-  zaraz.track(type, {href: link.href, hostname: link.hostname})
-}
-
-function $zarazDropdownEvent(summary: HTMLElement) {
-  zaraz.track('dropdown click', {text: summary.innerText})
-}
-
-function $zarazGlossaryTooltipEvent(term: string | null) {
-  zaraz.track('glossary tooltip view', {term: term})
-}
-
-export function zarazTrackHomepageLinks() {
-  const links = document.querySelectorAll<HTMLAnchorElement>(".DocsMarkdown--link");
-  const playgroundLinks = document.querySelectorAll<HTMLAnchorElement>(".playground-link")
-  const copyCodeBlockButtons = document.querySelectorAll<HTMLButtonElement>(".copyCode-button")
-  addEventListener("DOMContentLoaded", () => {
-    if (links.length > 0) {
-      for (const link of links) {
-        link.addEventListener("click", () => {
-          zaraz.track('homepage link click', {href: link.href})
+    if (glossaryTooltips.length > 0) {
+      for (const tooltip of glossaryTooltips) {
+        tooltip.addEventListener("pointerleave", () => {
+          $zarazGlossaryTooltipEvent(tooltip.getAttribute("aria-label"));
+        });
+        tooltip.addEventListener("blur", () => {
+          $zarazGlossaryTooltipEvent(tooltip.getAttribute("aria-label"));
         });
       }
     }
     if (playgroundLinks.length > 0) {
       for (const playgroundLink of playgroundLinks) {
         playgroundLink.addEventListener("click", () => {
-          $zarazLinkEvent('playground link click', playgroundLink);
+          $zarazLinkEvent("playground link click", playgroundLink);
         });
+      }
     }
+  });
+}
+
+function $zarazLinkEvent(type: string, link: HTMLAnchorElement) {
+  zaraz.track(type, { href: link.href, hostname: link.hostname });
+}
+
+function $zarazDropdownEvent(summary: HTMLElement) {
+  zaraz.track("dropdown click", { text: summary.innerText });
+}
+
+function $zarazGlossaryTooltipEvent(term: string | null) {
+  zaraz.track("glossary tooltip view", { term: term });
+}
+
+export function zarazTrackHomepageLinks() {
+  const links = document.querySelectorAll<HTMLAnchorElement>(
+    ".DocsMarkdown--link",
+  );
+  const playgroundLinks =
+    document.querySelectorAll<HTMLAnchorElement>(".playground-link");
+  const copyCodeBlockButtons =
+    document.querySelectorAll<HTMLButtonElement>(".copyCode-button");
+  addEventListener("DOMContentLoaded", () => {
+    if (links.length > 0) {
+      for (const link of links) {
+        link.addEventListener("click", () => {
+          zaraz.track("homepage link click", { href: link.href });
+        });
+      }
+    }
+    if (playgroundLinks.length > 0) {
+      for (const playgroundLink of playgroundLinks) {
+        playgroundLink.addEventListener("click", () => {
+          $zarazLinkEvent("playground link click", playgroundLink);
+        });
+      }
     }
     if (copyCodeBlockButtons.length > 0) {
       for (const copyButton of copyCodeBlockButtons) {
         copyButton.addEventListener("click", () => {
-          const codeBlockElement = copyButton?.parentElement?.parentElement?.firstElementChild;
-          zaraz.track('copy button link click', {
-            title: codeBlockElement?.getAttribute('title') ?? 'title not set',
-            language: codeBlockElement?.getAttribute('language') ?? 'language not set',});
+          const codeBlockElement =
+            copyButton?.parentElement?.parentElement?.firstElementChild;
+          zaraz.track("copy button link click", {
+            title: codeBlockElement?.getAttribute("title") ?? "title not set",
+            language:
+              codeBlockElement?.getAttribute("language") ?? "language not set",
+          });
         });
       }
     }

--- a/components/CodeCopy.vue
+++ b/components/CodeCopy.vue
@@ -45,6 +45,12 @@ function copyCode(e: MouseEvent) {
       }
     }
   }
+  // Fire zaraz event
+  const codeBlockElement = e.target.parentElement?.parentElement?.firstElementChild;
+  zaraz.track('copy button link click', {
+    title: codeBlockElement?.getAttribute('title') ?? 'title not set',
+    language: codeBlockElement?.getAttribute('language') ?? 'language not set',});
+
 }
 </script>
 

--- a/content/workers-ai/get-started/workers-wrangler.md
+++ b/content/workers-ai/get-started/workers-wrangler.md
@@ -50,7 +50,7 @@ To bind Workers AI to your Worker, add the following to the end of your `wrangle
 
 ```toml
 ---
-filename: wrangler.toml
+header: wrangler.toml
 ---
 
 [ai]
@@ -70,7 +70,7 @@ Update the `index.ts` file in your `hello-ai` application directory with the fol
 
 ```typescript
 ---
-filename: "src/index.ts"
+header: src/index.ts
 ---
 export interface Env {
   // If you set another name in wrangler.toml as the value for 'binding',

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,9 +29,9 @@
     {{- block "scripts" . -}}{{- end -}}
 
     <!-- <script>var $$r=document.documentElement;$$r.className='';!function(){var a=localStorage.getItem("dark");(a=a&&+a)||a||window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches,$$r.classList.toggle("dark",a=!!a),localStorage.setItem("dark",+a+"")}()</script> -->
-    {{- if eq (os.Getenv "CF_PAGES_BRANCH") "production" -}}
-    <script src="/cdn-cgi/zaraz/i.js" referrerpolicy="origin" async></script>
-    {{- end -}}
+
+    <script src="https://developers.cloudflare.com/cdn-cgi/zaraz/i.js" referrerpolicy="origin" async></script>
+
   </head>
   <body>
     {{- block "main" . -}}{{- end -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
 
     <!-- <script>var $$r=document.documentElement;$$r.className='';!function(){var a=localStorage.getItem("dark");(a=a&&+a)||a||window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches,$$r.classList.toggle("dark",a=!!a),localStorage.setItem("dark",+a+"")}()</script> -->
     {{- if eq (os.Getenv "CF_PAGES_BRANCH") "production" -}}
-    <script src="https://developers.cloudflare.com/cdn-cgi/zaraz/i.js" referrerpolicy="origin" async></script>
+    <script src="/cdn-cgi/zaraz/i.js" referrerpolicy="origin" async></script>
     {{- end -}}
   </head>
   <body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,9 +29,9 @@
     {{- block "scripts" . -}}{{- end -}}
 
     <!-- <script>var $$r=document.documentElement;$$r.className='';!function(){var a=localStorage.getItem("dark");(a=a&&+a)||a||window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches,$$r.classList.toggle("dark",a=!!a),localStorage.setItem("dark",+a+"")}()</script> -->
-
+    {{- if eq (os.Getenv "CF_PAGES_BRANCH") "production" -}}
     <script src="https://developers.cloudflare.com/cdn-cgi/zaraz/i.js" referrerpolicy="origin" async></script>
-
+    {{- end -}}
   </head>
   <body>
     {{- block "main" . -}}{{- end -}}


### PR DESCRIPTION
### Summary

As part of #15267, we updated how query selectors grab certain values.

This inadvertently broke our tracking for copying code blocks (I think b/c the Vue renders them shortly after the page is loaded formally or they exist differently on the page?).

This PR moves the logic into the Vue component itself.

### Screenshots (optional)

<img width="627" alt="Screenshot 2024-07-25 at 12 08 58 PM" src="https://github.com/user-attachments/assets/8bd1dd15-47b0-402a-8637-a1921b954696">

