### PR TITLE
[Network Analytics] Update main-dashboard.md to add filter limitation

### DIFF
--- a/content/analytics/network-analytics/understand/main-dashboard.md
+++ b/content/analytics/network-analytics/understand/main-dashboard.md
@@ -85,6 +85,8 @@ You can filter by the following parameters:
 * TCP flag
 * TTL
 
+Note that the IP Range filter currently has a limitation that only supports filtering /24 IPv4 Ranges and /64 IPv6 Ranges.
+
 {{<render file="_network-analytics-tabs-other-parameters.md" withParameters="filter parameters">}}
 
 ### Traffic direction


### PR DESCRIPTION
Added the following limitation under filters on https://developers.cloudflare.com/analytics/network-analytics/understand/main-dashboard/

"Note that the IP Range filter currently has a limitation that only supports filtering /24 IPv4 Ranges and /64 IPv6 Ranges."

SPM-1675