### PR TITLE
[Workers] Add await writer.close(), otherwise it takes 4m30s to get the response from TCP sockets API

### DIFF
--- a/content/workers/runtime-apis/tcp-sockets.md
+++ b/content/workers/runtime-apis/tcp-sockets.md
@@ -36,6 +36,7 @@ export default {
       const encoder = new TextEncoder();
       const encoded = encoder.encode(url.pathname + "\r\n");
       await writer.write(encoded);
+      await writer.close();
 
       return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
     } catch (error) {


### PR DESCRIPTION
### Summary

Add await writer.close(), otherwise it takes 4m30s to get the response from TCP sockets

```
% date && curl https://abc.xyz.workers.dev && date
Fri Jul 26 14:33:23 JST 2024
...
Fri Jul 26 14:37:53 JST 2024
```