### PR TITLE
Fix documented duration limit for bulk compute types

### DIFF
--- a/content/workers/platform/limits.md
+++ b/content/workers/platform/limits.md
@@ -61,7 +61,7 @@ Cloudflare does not enforce response limits, but cache limits for [Cloudflare's 
 | [Request](#request)         | 100,000 requests/day<br/>1000 requests/min | none                                        | none                                        |
 | [Worker memory](#memory)    | 128 MB                                     | 128 MB                                      | 128 MB                                      |
 | [CPU time](#cpu-time) | 10 ms                                      | 50 ms HTTP request <br/> 50 ms [Cron Trigger](/workers/configuration/cron-triggers/) | 30 s HTTP request <br/> 15 min [Cron Trigger](/workers/configuration/cron-triggers/) <br/> 15 min [Queue Consumer](/queues/configuration/javascript-apis/#consumer) |     |
-| [Duration](#duration)       |   None                                         |  none                                           | none                                  |
+| [Duration](#duration)       |   None                                         |  none                                           | 15 min [Cron Trigger](/workers/configuration/cron-triggers/) <br/> 15 min [Durable Object Alarm](/durable-objects/api/alarms/) <br/> 15 min [Queue Consumer](/queues/configuration/javascript-apis/#consumer)                                  |
 
 {{</table-wrap>}}
 


### PR DESCRIPTION
Cron triggers, DO alarms, and Queue consumers all have a 15 minute duration limit that wasn't documented here.

I didn't add DO alarms to the "CPU time" column because it looks like alarms aren't actually given any more CPU time than normal DO invocations, the only thing that makes them unique is having the duration limit applied.

This section now renders as:

<img width="821" alt="Screenshot 2024-07-26 at 1 25 55 PM" src="https://github.com/user-attachments/assets/a8d34e01-0214-4d99-9c5d-e6ac70f9bbd7">

@maheshwarip @vy-ton @irvinebroque 