### PR TITLE
R2 docs: fix grammatical error

### DIFF
--- a/content/r2/api/s3/presigned-urls.md
+++ b/content/r2/api/s3/presigned-urls.md
@@ -68,7 +68,7 @@ A valid alternative design to presigned URLs is to use a Worker with a [binding]
 
 {{<Aside type="note" header="Bindings">}}
 
-A binding is a how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to [Environment Variables](/workers/configuration/environment-variables/) for more information.
+A binding is how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to [Environment Variables](/workers/configuration/environment-variables/) for more information.
 
 A binding is defined in the `wrangler.toml` file of your Worker project's directory.
 

--- a/content/r2/api/workers/workers-api-reference.md
+++ b/content/r2/api/workers/workers-api-reference.md
@@ -17,7 +17,7 @@ R2 organizes the data you store, called objects, into containers, called buckets
 
 {{<Aside type="note" header="Bindings">}}
 
-A binding is a how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to [Environment Variables](/workers/configuration/environment-variables/) for more information.
+A binding is how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to [Environment Variables](/workers/configuration/environment-variables/) for more information.
 
 A binding is defined in the `wrangler.toml` file of your Worker project's directory.
 

--- a/content/r2/api/workers/workers-api-usage.md
+++ b/content/r2/api/workers/workers-api-usage.md
@@ -40,7 +40,7 @@ You will need to bind your bucket to a Worker.
 
 {{<Aside type="note" header="Bindings">}}
 
-A binding is a how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to the [Environment Variables](/workers/configuration/environment-variables/) documentation for more information.
+A binding is how your Worker interacts with external resources such as [KV Namespaces](/kv/reference/kv-namespaces/), [Durable Objects](/durable-objects/), or [R2 Buckets](/r2/buckets/). A binding is a runtime variable that the Workers runtime provides to your code. You can declare a variable name in your `wrangler.toml` file that will be bound to these resources at runtime, and interact with them through this variable. Every binding's variable name and behavior is determined by you when deploying the Worker. Refer to the [Environment Variables](/workers/configuration/environment-variables/) documentation for more information.
 
 A binding is defined in the `wrangler.toml` file of your Worker project's directory.
 

--- a/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
+++ b/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
@@ -77,7 +77,7 @@ $ npx wrangler r2 object put <PATH> -f <FILE_NAME>
 
 ## 3. Bind your bucket to the Worker
 
-A binding is a how your Worker interacts with external resources such as the R2 bucket.
+A binding is how your Worker interacts with external resources such as the R2 bucket.
 
 To bind the R2 bucket to your Worker, add the following to your `wrangler.toml` file. Update the binding property to a valid JavaScript variable identifier. Replace `<YOUR_BUCKET_NAME>` with the name of the bucket you created in [step 2](#2-upload-a-fine-tune-document-to-r2):
 


### PR DESCRIPTION
### Summary

Minor changes. "is a how" didn't quite sound right, so changed it to "is how"

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.