### PR TITLE
Update troubleshooting-cloudflare-5xx-errors.md

### DIFF
--- a/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
+++ b/content/support/Troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.md
@@ -210,6 +210,7 @@ Error 522 occurs when Cloudflare times out contacting the origin web server. Two
 -   [Keepalives](http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html) are disabled at the origin web server.
 -   The origin IP address in your Cloudflare **DNS** app does not match the IP address currently provisioned to your origin web server by your hosting provider.
 -   Packets were dropped at your origin web server.
+-   If port 80 is blocked on your server, certain browsers that attempt http connections first will receive and display the CloudFlare 522 error page instead of automatically retrying with https.
 
 If you are using [Cloudflare Pages](/pages/), verify that you have a custom domain set up and that your CNAME record is pointed to your [custom Pages domain](/pages/configuration/custom-domains/#add-a-custom-domain).
 


### PR DESCRIPTION
Spent the last day trying to debug a case where blocking http traffic causes some browsers (eg Safari on iOS) to display CloudFlare's 522 page instead of retrying on https.  I'm mentioning it here in case it happens to other people.

### Summary

Added one line to the 522 section.

### Screenshots (optional)

n/a

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

