### PR TITLE
Updated event notifications limitations with jursdictional restrictions

### DIFF
--- a/content/r2/buckets/event-notifications.md
+++ b/content/r2/buckets/event-notifications.md
@@ -5,7 +5,7 @@ pcx_content_type: how-to
 
 # Event notifications
 
-Event notifications send messages to your [queue](/queues/) when data in your R2 bucket changes. You can consume these messages with a [consumer Worker](/queues/reference/how-queues-works/#create-a-consumer-worker) or [pull over HTTP](/queues/configuration/pull-consumers/) from outside of Cloudflare Workers. 
+Event notifications send messages to your [queue](/queues/) when data in your R2 bucket changes. You can consume these messages with a [consumer Worker](/queues/reference/how-queues-works/#create-a-consumer-worker) or [pull over HTTP](/queues/configuration/pull-consumers/) from outside of Cloudflare Workers.
 
 
 {{<Aside type="note" header="Open Beta">}}
@@ -248,3 +248,4 @@ During the beta, event notifications has the following limitations:
 - For a given bucket, only one event notification rule can be created per queue.
 - Each bucket can have up to 5 event notification rules.
 - Deletes that occur as a result of object lifecycle policies will not trigger an event notification.
+- Event notifications are not available for buckets with [jursdictional restrictions](/r2/reference/data-location/#jurisdictional-restrictions).

--- a/content/r2/reference/data-location.md
+++ b/content/r2/reference/data-location.md
@@ -91,7 +91,7 @@ bindings = [
 ]
 ```
 
-For more information on getting started, refer to [Use R2 from Workers](/r2/api/workers/workers-api-usage/). 
+For more information on getting started, refer to [Use R2 from Workers](/r2/api/workers/workers-api-usage/).
 
 ### Using jurisdictions with the S3 API
 
@@ -140,6 +140,7 @@ Cloudflare Enterprise customers may contact their account team or [Cloudflare Su
 During the beta, the following services will not interact with R2 resources with assigned jurisdictions:
 * [Super Slurper](/r2/data-migration/)
 * [Logpush](/logs/get-started/enable-destinations/r2/)
+* [Event Notifications](/r2/buckets/event-notifications/)
 
 ### Additional considerations
 


### PR DESCRIPTION
### Summary

Added documentation about R2 event notifications not being available on buckets with jurisdictional restrictions. 
