### PR TITLE
[Calls] Aligned numbers to example picture

### DIFF
--- a/content/calls/example-architecture.md
+++ b/content/calls/example-architecture.md
@@ -14,7 +14,7 @@ weight: 10
 
 1. Clients connect to the backend service
 2. Backend service manages the relationship between the clients and the tracks they should subscribe to
-3. Backend service contacts the Cloudflare Calls API to pass the SDP from the clients to establish the WebRTC connection and relays back the Calls API SDP reply and renegotiation messages.
-4. Admin manages the rooms and room members.
-5. If desired, functions like "breakout rooms" can be implemented in the backend service without disconnecting the WebRTC connection of the clients.
-6. If desired, headless clients can be used to record the content from other clients or publish content.
+3. Backend service contacts the Cloudflare Calls API to pass the SDP from the clients to establish the WebRTC connection.
+4. Calls API relays back the Calls API SDP reply and renegotiation messages.
+5. If desired, headless clients can be used to record the content from other clients or publish content.
+6. Admin manages the rooms and room members.


### PR DESCRIPTION
### Summary

The numbered items on the Calls example architecture page weren't aligned with the numbers provided in the reference picture. This PR tries to align the text with the picture.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.