### PR TITLE
[DNS] Add instructions for DNSSEC with outgoing zone transfers

### DIFF
--- a/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/dnssec-for-primary.md
+++ b/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/dnssec-for-primary.md
@@ -3,12 +3,14 @@ pcx_content_type: tutorial
 title: DNSSEC
 weight: 3
 meta:
-   title: Set up multi-signer DNSSEC to use with Cloudflare as Primary
+   title: Set up multi-signer DNSSEC with outgoing zone transfers
 ---
 
 # Set up DNSSEC with Cloudflare as Primary
 
-With [outgoing zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-primary/), you can keep Cloudflare as your primary DNS provider and use one or more secondary providers for increased availability and fault tolerance.
+With [outgoing zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-primary/), you keep Cloudflare as your primary DNS provider and use one or more secondary providers for increased availability and fault tolerance.
+
+If you want to use DNSSEC with outgoing zone transfers, you should configure [multi-signer DNSSEC](/dns/dnssec/multi-signer-dnssec/). After setting up [Cloudflare as primary](/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup/), follow the steps below to enable DNSSEC.
 
 ## Before you begin
 
@@ -77,4 +79,4 @@ $ dig <ZONE_NAME> dnskey @<CLOUDFLARE_NAMESERVER> +noall +answer | grep 256
 
 4. Add DS records to your registrar, one for each provider. You can see your Cloudflare DS record on the [dashboard](https://dash.cloudflare.com/?to=/:account/:zone/dns) by going to **DNS** > **Settings** > **DS Record**.
 
-5. Update the nameserver settings at your registrar to include the nameservers of all providers you will be using for your multi-signer DNSSEC setup.
+The nameserver settings at your registrar should include the nameservers of all providers you will be using for your multi-signer DNSSEC setup.

--- a/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/dnssec-for-primary.md
+++ b/content/dns/zone-setups/zone-transfers/cloudflare-as-primary/dnssec-for-primary.md
@@ -1,0 +1,80 @@
+---
+pcx_content_type: tutorial
+title: DNSSEC
+weight: 3
+meta:
+   title: Set up multi-signer DNSSEC to use with Cloudflare as Primary
+---
+
+# Set up DNSSEC with Cloudflare as Primary
+
+With [outgoing zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-primary/), you can keep Cloudflare as your primary DNS provider and use one or more secondary providers for increased availability and fault tolerance.
+
+## Before you begin
+
+Note that:
+
+- This process requires that your other DNS provider(s) also support multi-signer DNSSEC.
+- Although you can complete a few steps via the dashboard, currently the whole process can only be completed using the API.
+- Enabling **DNSSEC** and **Multi-signer DNSSEC** in [**DNS** > **Settings**](https://dash.cloudflare.com/?to=/:account/:zone/dns/settings) only replaces the first step below. You still have to follow the rest of this tutorial to complete the setup.
+
+## Steps
+
+1. Use the [Edit DNSSEC Status endpoint](/api/operations/dnssec-edit-dnssec-status) to enable DNSSEC and activate multi-signer DNSSEC for your zone. This is done by setting `status` to `active` and `dnssec_multi_signer` to `true`, as in the following example.
+
+```bash
+curl --request PATCH \
+'https://api.cloudflare.com/client/v4/zones/{zone_id}/dnssec' \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "status": "active",
+  "dnssec_multi_signer": true
+}'
+```
+
+2. Add the ZSK(s) of your external provider(s) to Cloudflare by creating a DNSKEY record on your zone.
+
+```bash
+curl 'https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records' \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "type": "DNSKEY",
+  "name": "<ZONE_NAME>",
+  "data": {
+    "flags": 256,
+    "protocol": 3,
+    "algorithm": 13,
+    "public_key": "<PUBLIC_KEY>"
+  },
+  "ttl": 3600
+}'
+```
+
+3. Once the DNSKEY record is transferred out from Cloudflare to your secondary provider, get Cloudflare's ZSK and manually add it to the DNSKEY record.
+
+    Currently, the ZSK is not automatically transferred out. You can use either the API or a query from one of the assigned Cloudflare nameservers to obtain it.
+
+{{<example>}}
+
+API example:
+
+```bash
+curl 'https://api.cloudflare.com/client/v4/zones/{zone_id}/dnssec/zsk' \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>"
+```
+
+Command line query example:
+
+```sh
+$ dig <ZONE_NAME> dnskey @<CLOUDFLARE_NAMESERVER> +noall +answer | grep 256
+```
+{{</example>}}
+
+4. Add DS records to your registrar, one for each provider. You can see your Cloudflare DS record on the [dashboard](https://dash.cloudflare.com/?to=/:account/:zone/dns) by going to **DNS** > **Settings** > **DS Record**.
+
+5. Update the nameserver settings at your registrar to include the nameservers of all providers you will be using for your multi-signer DNSSEC setup.


### PR DESCRIPTION
### Summary

Adds specific instructions for setting up multi-signer DNSSEC when Cloudflare is transferring records out as Primary. PCX-11428

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

