### PR TITLE
[Various] Added more demo repos and new pages / sections as necessary

### DIFF
--- a/content/calls/demos.md
+++ b/content/calls/demos.md
@@ -1,0 +1,15 @@
+---
+pcx_content_type: navigation
+title: Demos
+weight: 10
+---
+
+# Demos applications
+
+Learn how you can use Calls within your existing architecture.
+
+## Demos
+
+Explore the following {{<glossary-tooltip term_id="demo application">}}demo applications{{</glossary-tooltip>}} for Calls.
+
+{{<external-resources resource_type="apps" products="Calls">}}

--- a/content/cloudflare-for-platforms/workers-for-platforms/demos.md
+++ b/content/cloudflare-for-platforms/workers-for-platforms/demos.md
@@ -1,0 +1,15 @@
+---
+pcx_content_type: navigation
+title: Demos
+weight: 8
+---
+
+# Demos applications
+
+Learn how you can use Workers for Platforms within your existing architecture.
+
+## Demos
+
+Explore the following {{<glossary-tooltip term_id="demo application">}}demo applications{{</glossary-tooltip>}} for Workers for Platforms.
+
+{{<external-resources resource_type="apps" products="Workers for Platforms">}}

--- a/content/email-routing/email-workers/demos.md
+++ b/content/email-routing/email-workers/demos.md
@@ -1,0 +1,15 @@
+---
+pcx_content_type: navigation
+title: Demos
+weight: 6
+---
+
+# Demos applications
+
+Learn how you can use Email Workers within your existing architecture.
+
+## Demos
+
+Explore the following {{<glossary-tooltip term_id="demo application">}}demo applications{{</glossary-tooltip>}} for Email Workers.
+
+{{<external-resources resource_type="apps" products="Email Workers">}}

--- a/content/images/demos.md
+++ b/content/images/demos.md
@@ -1,12 +1,18 @@
 ---
 pcx_content_type: navigation
-title: Architectures
+title: Demos and architectures
 weight: 6
 ---
 
-# Reference Architectures
+# Demos applications and reference architectures
 
 Learn how you can use Images within your existing architecture.
+
+## Demos
+
+Explore the following {{<glossary-tooltip term_id="demo application">}}demo applications{{</glossary-tooltip>}} for Images.
+
+{{<external-resources resource_type="apps" products="Images">}}
 
 ## Reference architectures
 

--- a/data/external-resources/apps.yml
+++ b/data/external-resources/apps.yml
@@ -228,6 +228,30 @@ entries:
   languages: [TypeScript]
   cloudflare: true
   updated: 2024-07-05
+- link: https://github.com/cloudflare/calls-examples/tree/main/whip-whep-server
+  name: WHIP-WHEP Server
+  description: WHIP and WHEP server implemented on top of Calls API.
+  tags: []
+  products: [Calls]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2022-06-12
+- link: https://github.com/cloudflare/calls-examples/tree/main/echo
+  name: Calls Echo Demo
+  description: Demonstrates a local stream alongside a remote echo stream.
+  tags: []
+  products: [Calls]
+  languages: [JavaScript]
+  cloudflare: true
+  updated: 2025-05-10
+- link: https://github.com/cloudflare/calls-examples/tree/main/echo-datachannels
+  name: Calls DataChannel Test
+  description: This example establishes two datachannels, one publishes data and the other one subscribes, the test measures how fast a message travels to and from the server.
+  tags: []
+  products: [Calls]
+  languages: [JavaScript]
+  cloudflare: true
+  updated: 2022-06-04
 - link: https://github.com/cloudflare/wildebeest
   name: Wildebeest
   description: Wildebeest is an ActivityPub and Mastodon-compatible server whose goal is to allow anyone to operate their Fediverse server and identity on their domain without needing to keep infrastructure, with minimal setup and maintenance, and running in minutes.

--- a/data/external-resources/apps.yml
+++ b/data/external-resources/apps.yml
@@ -168,7 +168,7 @@ entries:
   description: This is a demo of the Northwind dataset, running on Cloudflare Workers, and D1 - Cloudflare's SQL database, running on SQLite.
   tags: [Tailwind, React, Remix]
   products: [Workers, D1]
-  languages: [Typescript]
+  languages: [TypeScript]
   cloudflare: true
   updated: 2023-07-12
 - link: https://github.com/cloudflare/workers-chat-demo
@@ -196,3 +196,51 @@ entries:
   author: harshil
   cloudflare: true
   updated: 2024-07-29
+- link: https://github.com/cloudflare/workers-for-platforms-example
+  name: Workers for Platforms Example Project
+  description: Explore how you could manage thousands of Workers with a single Cloudflare Workers account.
+  tags: [Hono]
+  products: [D1, Workers, Workers for Platforms]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2024-04-03
+- link: https://github.com/cloudflare/dmarc-email-worker
+  name: DMARC Email Worker
+  description: A Cloudflare worker script to process incoming DMARC reports, store them, and produce analytics.
+  tags: []
+  products: [R2, Workers, Email Workers]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2023-03-17
+- link: https://github.com/cloudflare/pages-fns-with-wasm-demo
+  name: Pages Functions with WebAssembly
+  description: This is a demo application that exemplifies the use of Wasm module imports inside Pages Functions code.
+  tags: []
+  products: [Pages]
+  languages: [Rust]
+  cloudflare: true
+  updated: 2023-03-22
+- link: https://github.com/cloudflare/orange
+  name: Orange Meets
+  description: Orange Meets is a demo WebRTC application built using Cloudflare Calls.
+  tags: []
+  products: [Calls]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2024-07-05
+- link: https://github.com/cloudflare/wildebeest
+  name: Wildebeest
+  description: Wildebeest is an ActivityPub and Mastodon-compatible server whose goal is to allow anyone to operate their Fediverse server and identity on their domain without needing to keep infrastructure, with minimal setup and maintenance, and running in minutes.
+  tags: []
+  products: [Workers, Pages, Durable Objects, Queues, D1, Access, Images]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2023-07-31
+- link: https://github.com/cloudflare/workers-access-external-auth-example
+  name: Access External Auth Rule Example Worker
+  description: This is a worker that allows you to quickly setup an external evalutation rule in Cloudflare Access.
+  tags: []
+  products: [Workers, Access]
+  languages: [JavaScript]
+  cloudflare: true
+  updated: 2022-08-01


### PR DESCRIPTION
### Summary

Follows the pattern introduced by #15911, #15580, and #15809 to add in other repos that I found within the Cloudflare space that seemed to be relatively new or timeless + added new pages as appropriate (Calls / W4P / Email Workers).

### Screenshots

[Calls](https://more-github-repos.cloudflare-docs-7ou.pages.dev/calls/demos/)
![image](https://github.com/user-attachments/assets/0d489c08-7c1e-4c05-aa2b-0743be018402)

[WFP](https://more-github-repos.cloudflare-docs-7ou.pages.dev/cloudflare-for-platforms/workers-for-platforms/demos/)
![Screenshot 2024-08-01 at 10 55 34 AM](https://github.com/user-attachments/assets/33aad704-0384-4cce-a29f-11908053945c)

[Email Workers](https://more-github-repos.cloudflare-docs-7ou.pages.dev/email-routing/email-workers/demos/)
![image](https://github.com/user-attachments/assets/e21f3b08-2ff8-4203-8f28-997b2c0d7368)
