### PR TITLE
[WAF] Link to get started from overview page

### DIFF
--- a/content/waf/_index.md
+++ b/content/waf/_index.md
@@ -17,6 +17,9 @@ Get automatic protection from vulnerabilities and the flexibility to create cust
 {{<plan type="all">}}
 
 {{<render file="_waf-intro.md">}}
+<br />
+
+Learn how to [get started](/waf/get-started/).
 
 ---
 


### PR DESCRIPTION
### Summary

Add link to Get started in the Overview page of the WAF.
Based on internal discussions.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
