### PR TITLE
[Chore] More metadata and audit tutorial types

### DIFF
--- a/content/ai-gateway/tutorials/deploy-aig-worker.md
+++ b/content/ai-gateway/tutorials/deploy-aig-worker.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 tags: [AI]
 title: Deploy a Worker that connects to OpenAI via AI Gateway
 products: [Workers]
+languages: [JavaScript]
 ---
 
 # Deploy a Worker that connects to OpenAI via AI Gateway

--- a/content/analytics/graphql-api/tutorials/end-customer-analytics/index.md
+++ b/content/analytics/graphql-api/tutorials/end-customer-analytics/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying HTTP events by hostname with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
+++ b/content/analytics/graphql-api/tutorials/export-graphql-to-csv/index.md
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: tutorial
 title: Export GraphQL data to CSV
+languages: [Python]
 ---
 
 # Export GraphQL data to CSV

--- a/content/analytics/graphql-api/tutorials/querying-access-login-events/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-access-login-events/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Access login events with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-firewall-events/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Firewall Events with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-magic-firewall-ids-samples/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-firewall-ids-samples/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Magic Firewall Intrusion Detection System (IDS) samples with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-firewall-samples/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Magic Firewall Samples with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-bandwidth-analytics/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Magic Transit and Magic WAN tunnel bandwidth analytics with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-magic-transit-tunnel-healthcheck-results/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Querying Magic Transit and Magic WAN tunnel health check results with GraphQL
 ---
 

--- a/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
+++ b/content/analytics/graphql-api/tutorials/querying-workers-metrics/index.md
@@ -1,6 +1,7 @@
 ---
 title: Querying Workers Metrics with GraphQL
-pcx_content_type: tutorial
+pcx_content_type: example
+products: [Workers]
 ---
 
 # Querying Workers Metrics with GraphQL

--- a/content/analytics/graphql-api/tutorials/use-graphql-create-widgets/index.md
+++ b/content/analytics/graphql-api/tutorials/use-graphql-create-widgets/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: example
 title: Use GraphQL to create widgets
 weight: 46
 ---

--- a/content/browser-rendering/get-started/browser-rendering-with-DO.md
+++ b/content/browser-rendering/get-started/browser-rendering-with-DO.md
@@ -2,7 +2,7 @@
 pcx_content_type: tutorial
 title: Deploy a Browser Rendering Worker with Durable Objects
 weight: 2
-products: [Durable Objects, R2]
+products: [Workers, Durable Objects, R2]
 difficulty: Beginner
 content_type: 📝 Tutorial
 updated: 2023-09-28

--- a/content/browser-rendering/get-started/browser-rendering-with-DO.md
+++ b/content/browser-rendering/get-started/browser-rendering-with-DO.md
@@ -6,6 +6,7 @@ products: [Workers, Durable Objects, R2]
 difficulty: Beginner
 content_type: 📝 Tutorial
 updated: 2023-09-28
+languages: [JavaScript]
 ---
 
 # Deploy a Browser Rendering Worker with Durable Objects

--- a/content/cloudflare-one/tutorials/access-workers.md
+++ b/content/cloudflare-one/tutorials/access-workers.md
@@ -6,6 +6,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Create custom headers for Cloudflare Access-protected origins with Workers
 products: [Workers, Access]
+languages: [JavaScript]
 ---
 
 # Create custom headers for Cloudflare Access-protected origins with Workers

--- a/content/cloudflare-one/tutorials/access-workers.md
+++ b/content/cloudflare-one/tutorials/access-workers.md
@@ -2,11 +2,15 @@
 updated: 2023-11-27
 category: 🔐 Access
 difficulty: Intermediate
+content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Create custom headers for Cloudflare Access-protected origins with Workers
+products: [Workers, Access]
 ---
 
 # Create custom headers for Cloudflare Access-protected origins with Workers
+
+{{<tutorial-date-info>}}
 
 This tutorial covers how to use a [Cloudflare Worker](/workers/) to add custom HTTP headers to traffic, and how to send those custom headers to your origin services protected by [Cloudflare Access](/cloudflare-one/policies/access/).
 
@@ -46,7 +50,7 @@ Some applications and networking implementations require specific custom headers
 
    return await fetch(requestWithID);
    }
-   
+
    ```
 
 6. Select **Save and deploy**.
@@ -68,11 +72,11 @@ The Worker will now insert a custom header into requests that match the defined 
    header: Example custom header
    highlight:4-5
    ---
-   "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7", 
-       "Accept-Encoding": "gzip", 
-       "Accept-Language": "en-US,en;q=0.9", 
-       "Cf-Access-Authenticated-User-Email": "user@example.com", 
-       "Company-User-Id": "user@example.com", 
+   "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+       "Accept-Encoding": "gzip",
+       "Accept-Language": "en-US,en;q=0.9",
+       "Cf-Access-Authenticated-User-Email": "user@example.com",
+       "Company-User-Id": "user@example.com",
        "Connection": "keep-alive"
    ```
 

--- a/content/cloudflare-one/tutorials/fastapi.md
+++ b/content/cloudflare-one/tutorials/fastapi.md
@@ -3,6 +3,7 @@ updated: 2023-06-09
 category: 🔐 Access
 pcx_content_type: tutorial
 title: Validate the Access token with FastAPI
+languages: [Python]
 ---
 
 # Validate the Access token with FastAPI

--- a/content/cloudflare-one/tutorials/s3-buckets.md
+++ b/content/cloudflare-one/tutorials/s3-buckets.md
@@ -4,6 +4,7 @@ category: 🔐 Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Protect access to Amazon S3 buckets with Cloudflare Zero Trust
+tags: [S3]
 ---
 
 # Protect access to Amazon S3 buckets with Cloudflare Zero Trust
@@ -16,7 +17,7 @@ This tutorial demonstrates how to secure access to Amazon S3 buckets with Cloudf
 flowchart TB
     cf1[/Agentless and WARP </br>Zero Trust users/]--Access policy-->cf2{{Cloudflare}}
     cf2--Cloudflare Tunnel-->vpc1
-    
+
     subgraph VPC
     vpc1[EC2 VM]-->vpc2[VPC endpoint]
     end
@@ -129,7 +130,7 @@ flowchart TB
     cf1[/WARP users/]--Egress policy-->cf2{{Cloudflare}}
     cf2--Egress with dedicated IP-->i1[Internet]
     i1-->s3_1
-    
+
     subgraph S3 Service
     s3_1([S3 bucket])
     end

--- a/content/d1/tutorials/build-a-comments-api/index.md
+++ b/content/d1/tutorials/build-a-comments-api/index.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Build a Comments API
 products: [Workers]
 tags: [Hono]
+languages: [JavaScript, SQL]
 ---
 
 # Build a Comments API
@@ -20,7 +21,7 @@ Use [C3](https://developers.cloudflare.com/learning-paths/workers/get-started/c3
 
 {{<render file="_c3-run-command-with-directory.md" productFolder="workers" withParameters="d1-example">}}
 
-{{<render file="_c3-post-run-steps.md" productFolder="workers" withParameters="Hello World example;;Hello World Worker;;JavsScript">}}
+{{<render file="_c3-post-run-steps.md" productFolder="workers" withParameters="Hello World example;;Hello World Worker;;JavaScript">}}
 
 To start developing your Worker, `cd` into your new project directory:
 

--- a/content/d1/tutorials/build-a-staff-directory-app/index.md
+++ b/content/d1/tutorials/build-a-staff-directory-app/index.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Build a Staff Directory Application
 products: [Pages]
 tags: [Hono]
+languages: [TypeScript, SQL]
 ---
 
 # Build a Staff Directory with D1, Cloudflare Pages and HonoX

--- a/content/d1/tutorials/d1-and-prisma-orm/index.md
+++ b/content/d1/tutorials/d1-and-prisma-orm/index.md
@@ -5,6 +5,7 @@ content_type: Tutorial
 pcx_content_type: tutorial
 title: Query D1 using Prisma ORM
 products: [Workers]
+languages: [TypeScript, SQL]
 ---
 
 # Query D1 using Prisma ORM

--- a/content/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.md
+++ b/content/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.md
@@ -5,6 +5,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 title: Create a sitemap from Sanity CMS with Workers
 products: [Workers]
+tags: [CMS]
 spotlight:
   author: John Siciliano
   author_bio_link: https://www.linkedin.com/in/johnsicili/

--- a/content/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.md
+++ b/content/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.md
@@ -6,6 +6,7 @@ content_type: 📝 Tutorial
 title: Create a sitemap from Sanity CMS with Workers
 products: [Workers]
 tags: [CMS]
+languages: [JavaScript, TypeScript]
 spotlight:
   author: John Siciliano
   author_bio_link: https://www.linkedin.com/in/johnsicili/

--- a/content/developer-spotlight/tutorials/creating-a-recommendation-api.md
+++ b/content/developer-spotlight/tutorials/creating-a-recommendation-api.md
@@ -10,7 +10,7 @@ spotlight:
   author: Hidetaka Okamoto
   author_bio_link: https://www.linkedin.com/in/hideokamoto/
   author_bio_source: LinkedIn
-tags: [AI, Hono]
+tags: [AI, Hono, Stripe]
 ---
 
 # Recommend products on e-commerce sites using Workers AI and Stripe

--- a/content/developer-spotlight/tutorials/creating-a-recommendation-api.md
+++ b/content/developer-spotlight/tutorials/creating-a-recommendation-api.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Recommend products on e-commerce sites using Workers AI and Stripe
 weight: 2
 products: [Workers, Vectorize, Workers AI]
+languages: [TypeScript]
 spotlight:
   author: Hidetaka Okamoto
   author_bio_link: https://www.linkedin.com/in/hideokamoto/

--- a/content/developer-spotlight/tutorials/custom-access-control-for-files.md
+++ b/content/developer-spotlight/tutorials/custom-access-control-for-files.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Custom access control for files in R2 using D1 and Workers
 products: [R2, D1, Workers]
+languages: [TypeScript, SQL]
 spotlight:
   author: Dominik Fuerst
   author_bio_link: https://github.com/justDMNK

--- a/content/developer-spotlight/tutorials/custom-access-control-for-files.md
+++ b/content/developer-spotlight/tutorials/custom-access-control-for-files.md
@@ -17,17 +17,14 @@ spotlight:
 
 {{<spotlight-author>}}
 
-This tutorial gives you an overview on how to create a TypeScript-based Cloudflare Worker which allows you to control file access based on a simple username and password authentication. To achieve this, we will use a D1 database for user management and an R2 bucket for file storage.
+This tutorial gives you an overview on how to create a TypeScript-based Cloudflare Worker which allows you to control file access based on a simple username and password authentication. To achieve this, we will use a [D1 database](/d1/) for user management and an [R2 bucket](/r2/) for file storage.
 
 The following sections will guide you through the process of creating a Worker using the Cloudflare CLI, creating and setting up a D1 database and R2 bucket, and then implementing the functionality to securely upload and fetch files from the created R2 bucket.
 
 
 ## Prerequisites
 
-Before you can start with this tutorial, you will need to have the following prerequisites:
-- A Cloudflare account
-- [`npm`](https://docs.npmjs.com/getting-started)
-- [`Node.js`](https://nodejs.org/en/) with version `16.17.0` or later
+{{<render file="_prereqs.md" productFolder="workers">}}
 
 
 ## 1. Create a new Worker application

--- a/content/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.md
+++ b/content/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.md
@@ -5,7 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Send form submissions using Astro and Resend
 products: [Workers]
-tags: [Forms]
+tags: [Forms, Resend, Astro]
 spotlight:
   author: Cody Walsh
   author_bio_link: https://www.linkedin.com/in/cody-walsh-616a979/

--- a/content/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.md
+++ b/content/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Send form submissions using Astro and Resend
 products: [Workers]
 tags: [Forms, Resend, Astro]
+languages: [TypeScript]
 spotlight:
   author: Cody Walsh
   author_bio_link: https://www.linkedin.com/in/cody-walsh-616a979/

--- a/content/fundamentals/concepts/cloudflare-ip-addresses.md
+++ b/content/fundamentals/concepts/cloudflare-ip-addresses.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: how-to
 title: Cloudflare IP addresses
 weight: 4
 ---

--- a/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
+++ b/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Create a serverless, globally distributed time-series API with Timescale
 products: [Workers]
 tags: [PostgreSQL]
+languages: [TypeScript, SQL]
 ---
 
 # Create a serverless, globally distributed time-series API with Timescale

--- a/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
+++ b/content/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed time-series API with Timescale
 products: [Workers]
+tags: [PostgreSQL]
 ---
 
 # Create a serverless, globally distributed time-series API with Timescale

--- a/content/logs/tutorials/parsing-json-log-data.md
+++ b/content/logs/tutorials/parsing-json-log-data.md
@@ -8,7 +8,7 @@ weight: 86
 
 After downloading your Cloudflare Logs data, you can use different tools to parse and analyze your logs.
 
-One of thoes tools used to parse your JSON log data is _jq_. To get started with _jq_, visit the [_jq_ official site](https://jqlang.github.io/jq/).
+One of those tools used to parse your JSON log data is _jq_. To get started with _jq_, visit the [_jq_ official site](https://jqlang.github.io/jq/).
 
 {{<Aside type="note" header="Note">}}
 

--- a/content/logs/tutorials/parsing-json-log-data.md
+++ b/content/logs/tutorials/parsing-json-log-data.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: how-to
 title: Parse Cloudflare Logs JSON data
 weight: 86
 ---
@@ -8,7 +8,7 @@ weight: 86
 
 After downloading your Cloudflare Logs data, you can use different tools to parse and analyze your logs.
 
-In this tutorial, you will learn how to parse your JSON log data using _jq_. To get started with _jq_, visit the [_jq_ official site](https://jqlang.github.io/jq/).
+One of thoes tools used to parse your JSON log data is _jq_. To get started with _jq_, visit the [_jq_ official site](https://jqlang.github.io/jq/).
 
 {{<Aside type="note" header="Note">}}
 

--- a/content/magic-firewall/tutorials/graphql-analytics.md
+++ b/content/magic-firewall/tutorials/graphql-analytics.md
@@ -4,6 +4,7 @@ pcx_content_type: tutorial
 weight: 1
 meta:
   title: GraphQL Analytics
+languages: [GraphQL]
 ---
 
 # GraphQL Analytics

--- a/content/magic-network-monitoring/tutorials/graphql-analytics.md
+++ b/content/magic-network-monitoring/tutorials/graphql-analytics.md
@@ -5,6 +5,7 @@ weight: 1
 meta:
   title: GraphQL Analytics
 updated: 2023-01-04
+languages: [GraphQL]
 ---
 
 # GraphQL Analytics

--- a/content/pages/how-to/deploy-a-wordpress-site.md
+++ b/content/pages/how-to/deploy-a-wordpress-site.md
@@ -4,6 +4,7 @@ difficulty: Intermediate
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Deploy a static WordPress site
+tags: [WordPress]
 ---
 
 # Deploy a static WordPress site

--- a/content/pages/migrations/migrating-from-firebase.md
+++ b/content/pages/migrations/migrating-from-firebase.md
@@ -3,6 +3,7 @@ updated: 2020-09-28
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Migrating from Firebase
+tags: [Firebase]
 ---
 
 # Migrating from Firebase

--- a/content/pages/migrations/migrating-from-netlify/index.md
+++ b/content/pages/migrations/migrating-from-netlify/index.md
@@ -3,6 +3,7 @@ updated: 2022-07-26
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Migrating from Netlify to Pages
+languages: [JavaScript]
 ---
 
 # Migrating from Netlify to Pages

--- a/content/pages/migrations/migrating-jekyll-from-github-pages.md
+++ b/content/pages/migrations/migrating-jekyll-from-github-pages.md
@@ -4,6 +4,7 @@ difficulty: Beginner
 pcx_content_type: tutorial
 title: Migrating a Jekyll-based site from GitHub Pages
 tags: [Jekyll]
+languages: [Ruby]
 ---
 
 # Migrating a Jekyll-based site from GitHub Pages

--- a/content/pages/migrations/migrating-jekyll-from-github-pages.md
+++ b/content/pages/migrations/migrating-jekyll-from-github-pages.md
@@ -3,6 +3,7 @@ updated: 2021-07-27
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Migrating a Jekyll-based site from GitHub Pages
+tags: [Jekyll]
 ---
 
 # Migrating a Jekyll-based site from GitHub Pages

--- a/content/pages/tutorials/add-a-react-form-with-formspree/index.md
+++ b/content/pages/tutorials/add-a-react-form-with-formspree/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Add a React form with Formspree
 tags: [Forms]
+languages: [JavaScript]
 ---
 
 # Add a React form with Formspree

--- a/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
+++ b/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
@@ -4,6 +4,7 @@ pcx_content_type: tutorial
 content_type: 📝 Tutorial
 difficulty: Intermediate
 title: Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages
+tags: [Nuxt.js]
 ---
 
 # Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages

--- a/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
+++ b/content/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.md
@@ -4,7 +4,8 @@ pcx_content_type: tutorial
 content_type: 📝 Tutorial
 difficulty: Intermediate
 title: Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages
-tags: [Nuxt.js]
+tags: [Nuxt.js, Vue]
+languages: [JavaScript]
 ---
 
 # Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages

--- a/content/pages/tutorials/build-an-api-with-pages-functions/index.md
+++ b/content/pages/tutorials/build-an-api-with-pages-functions/index.md
@@ -4,6 +4,7 @@ pcx_content_type: tutorial
 content_type: 📝 Tutorial
 difficulty: Intermediate
 title: Build an API for your front end using Pages Functions
+languages: [JavaScript]
 ---
 
 # Build an API for your front end using Pages Functions

--- a/content/pages/tutorials/forms/index.md
+++ b/content/pages/tutorials/forms/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Create a HTML form
 tags: [Forms]
+languages: [JavaScript]
 ---
 
 # Create a HTML form

--- a/content/pages/tutorials/localize-a-website/index.md
+++ b/content/pages/tutorials/localize-a-website/index.md
@@ -4,6 +4,7 @@ difficulty: Intermediate
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Localize a website with HTMLRewriter
+languages: [JavaScript]
 tags:
   - HTMLRewriter
 ---

--- a/content/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.md
+++ b/content/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.md
@@ -6,6 +6,7 @@ pcx_content_type: tutorial
 title: Use R2 As static asset storage for your Pages app
 products: [R2]
 tags: [Hono]
+languages: [JavaScript]
 ---
 
 # Use R2 as static asset storage for your Pages app

--- a/content/pub-sub/_index.md
+++ b/content/pub-sub/_index.md
@@ -4,7 +4,7 @@ pcx_content_type: overview
 weight: 0
 ---
 
-# Cloudflare Pub/Sub
+{{<heading-pill style="beta">}}Cloudflare Pub/Sub{{</heading-pill>}}
 
 {{<Aside>}}
 
@@ -22,7 +22,7 @@ Pub/Sub:
 - Is global. Cloudflare's Pub/Sub infrastructure runs in [hundreds of cities worldwide](https://www.cloudflare.com/network/). Every edge location is part of one, globally distributed Pub/Sub system.
 - Is secure by default. Clients must authenticate and connect over TLS, and clients are issued credentials that are scoped to a specific broker.
 - Allows you to create multiple brokers to isolate clients or use cases, for example, staging vs. production or customers A vs. B vs. C — as needed. Each broker is addressable by a unique DNS hostname.
-- Integrates with Cloudflare Workers to enable programmable messaging capabilities: parse, filter, aggregate, and re-publish MQTT messages directly from your serverless code. 
+- Integrates with Cloudflare Workers to enable programmable messaging capabilities: parse, filter, aggregate, and re-publish MQTT messages directly from your serverless code.
 - Supports MQTT v5.0, the most recent version of the MQTT specification, and one of the most ubiquitous messaging protocols in use today.
 
 If you are new to the MQTT protocol, visit the [How Pub/Sub works](/pub-sub/learning/how-pubsub-works/) to better understand how MQTT differs from other messaging protocols.

--- a/content/pub-sub/learning/integrate-workers.md
+++ b/content/pub-sub/learning/integrate-workers.md
@@ -6,7 +6,7 @@ weight: 2
 
 # Integrate with Workers
 
-Once of the most powerful features of Pub/Sub is the ability to connect [Cloudflare Workers](/workers) — powerful serverless functions that run on the edge — and filter, aggregate and mutate every message published to that broker. Workers can also mirror those messages to other sources, including writing to [Cloudflare R2 storage](/r2/), external databases, or other cloud services beyond Cloudflare, making it easy to persist or analyze incoming message payloads and data at scale.
+Once of the most powerful features of Pub/Sub is the ability to connect [Cloudflare Workers](/workers/) — powerful serverless functions that run on the edge — and filter, aggregate and mutate every message published to that broker. Workers can also mirror those messages to other sources, including writing to [Cloudflare R2 storage](/r2/), external databases, or other cloud services beyond Cloudflare, making it easy to persist or analyze incoming message payloads and data at scale.
 
 There are three ways to integrate a Worker with Pub/Sub:
 
@@ -221,6 +221,7 @@ You should receive a success response that resembles the example below, with the
   "endpoint": "mqtts://example-broker.namespace.cloudflarepubsub.com:8883",
   "on_publish": {
     "url": "https://your-worker.your-account.workers.dev"
+  }
 }
 ```
 

--- a/content/pulumi/tutorial/add-site.md
+++ b/content/pulumi/tutorial/add-site.md
@@ -1,5 +1,5 @@
 ---
-title: 1 –  Add a site
+title: Add a site
 pcx_content_type: tutorial
 weight: 1
 meta:
@@ -8,9 +8,12 @@ languages:
   - JavaScript
   - TypeScript
   - Python
+updated: 2024-08-02
 ---
 
 # Add site to Cloudflare
+
+{{<tutorial-date-info>}}
 
 In this tutorial, you will go through step-by-step instructions to bring an existing site to Cloudflare using Pulumi Infrastructure as Code (IaC) so that you can become familiar with the resource management lifecycle. In particular, you will create a Zone and a DNS record to resolve your newly added site. This tutorial adopts the IaC principle to complete the steps listed in the [Add site tutorial](/fundamentals/setup/manage-domains/add-site/).
 

--- a/content/pulumi/tutorial/hello-world.md
+++ b/content/pulumi/tutorial/hello-world.md
@@ -8,6 +8,7 @@ products: [Workers]
 updated: 2024-01-08
 content_type: 📝 Tutorial
 difficulty: Beginner
+languages: [TypeScript]
 ---
 
 # Deploy a Hello World app using Cloudflare Workers and Pulumi

--- a/content/pulumi/tutorial/hello-world.md
+++ b/content/pulumi/tutorial/hello-world.md
@@ -1,12 +1,18 @@
 ---
-title: 2 –  Deploy a Hello World app
+title: Deploy a Hello World app with Pulumi
 pcx_content_type: tutorial
 weight: 2
 meta:
   title:  Deploy a Hello World app
+products: [Workers]
+updated: 2024-01-08
+content_type: 📝 Tutorial
+difficulty: Beginner
 ---
 
 # Deploy a Hello World app using Cloudflare Workers and Pulumi
+
+{{<tutorial-date-info>}}
 
 In this tutorial, you will go through step-by-step instructions to deploy a Hello World web application using Cloudflare Workers and Pulumi Infrastructure as Code (IaC) so that you can become familiar with the resource management lifecycle. In particular, you will create a Worker, a Route, and a DNS Record to access the application before cleaning up all the resources.
 
@@ -27,7 +33,7 @@ Ensure you have:
 * A Cloudflare account and API Token with permission to edit the resources in this tutorial. If you need to, sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) before continuing.
 * A Pulumi Cloud account. You can sign up for an [always-free, individual tier](https://app.pulumi.com/signup).
 * [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and the [Pulumi CLI](/pulumi/installing/) installed on your machine.
-* A Cloudflare Zone. Complete the [Add a Site tutorial](/pulumi/tutorial/add-site/) to create one. 
+* A Cloudflare Zone. Complete the [Add a Site tutorial](/pulumi/tutorial/add-site/) to create one.
 
 {{</tutorial-prereqs>}}
 
@@ -36,7 +42,7 @@ Ensure you have:
 You can find the complete solution of this tutorial under [this Pulumi repo and branch](https://github.com/pulumi/tutorials/tree/cloudflare-typescript-hello-world-end). To deploy the final version, run the following:
 
 ```sh
-$ mkdir serverless-cloudflare && cd serverless-cloudflare 
+$ mkdir serverless-cloudflare && cd serverless-cloudflare
 $ pulumi new https://github.com/pulumi/tutorials/tree/cloudflare-typescript-hello-world-end
 $ npm install
 $ pulumi up --yes

--- a/content/queues/tutorials/web-crawler-with-browser-rendering/index.md
+++ b/content/queues/tutorials/web-crawler-with-browser-rendering/index.md
@@ -9,6 +9,7 @@ weight: 1002
 meta:
   title: Cloudflare Queues - Queues & Browser Rendering
 products: [Workers, Browser Rendering, KV]
+languages: [TypeScript]
 ---
 
 # Build a web crawler with Queues and Browser Rendering

--- a/content/queues/tutorials/web-crawler-with-browser-rendering/index.md
+++ b/content/queues/tutorials/web-crawler-with-browser-rendering/index.md
@@ -8,7 +8,7 @@ pcx_content_type: tutorial
 weight: 1002
 meta:
   title: Cloudflare Queues - Queues & Browser Rendering
-products: [Browser Rendering, KV]
+products: [Workers, Browser Rendering, KV]
 ---
 
 # Build a web crawler with Queues and Browser Rendering

--- a/content/r2/examples/upload-logs-event-notifications.md
+++ b/content/r2/examples/upload-logs-event-notifications.md
@@ -39,7 +39,7 @@ $ npx wrangler r2 bucket create example-log-sink-bucket
 
 {{<Aside type="note">}}
 
-You will need a [Workers Paid plan](/workers/platform/pricing/) to create and use Queues and Cloudflare Workers to consume event notifications.
+You will need a [Workers Paid plan](/workers/platform/pricing/) to create and use [Queues](/queues/) and Cloudflare Workers to consume event notifications.
 
 {{</Aside>}}
 

--- a/content/r2/examples/upload-logs-event-notifications.md
+++ b/content/r2/examples/upload-logs-event-notifications.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 products: [Queues, Workers]
 difficulty: Beginner
 updated: 2024-04-02
+languages: [TypeScript]
 ---
 
 # Log and store upload events in R2 with event notifications

--- a/content/randomness-beacon/operator-guide/index.md
+++ b/content/randomness-beacon/operator-guide/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: navigation
 title: Operator Guide
 weight: 5
 ---

--- a/content/randomness-beacon/user-guide/index.md
+++ b/content/randomness-beacon/user-guide/index.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: navigation
 title: User Guide
 weight: 4
 ---

--- a/content/registrar/get-started/enable-dnssec.md
+++ b/content/registrar/get-started/enable-dnssec.md
@@ -1,6 +1,6 @@
 ---
 title: Enable DNSSEC
-pcx_content_type: tutorial
+pcx_content_type: how-to
 meta:
   title: Domain Name System Security Extensions (DNSSEC)
 ---

--- a/content/time-services/roughtime/recipes.md
+++ b/content/time-services/roughtime/recipes.md
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: how-to
 title: Use Roughtime
 weight: 3
 ---
@@ -36,7 +36,7 @@ formatted as a JSON object. For example:
 ```
 
 It includes each server's _root public key_. When the server starts, it
-generates an _online_ public/secret key pair. The root secret key is used to create a _delegation_ for the online public key and the online secret key is used to sign the response. 
+generates an _online_ public/secret key pair. The root secret key is used to create a _delegation_ for the online public key and the online secret key is used to sign the response.
 
 The delegation serves the same function as a traditional [X.509 certificate](https://en.wikipedia.org/wiki/X.509) on the web. The client first uses the root public key to verify the delegation, then uses the online public key to verify the response.
 
@@ -47,7 +47,7 @@ server (currently only [Ed25519](https://en.wikipedia.org/wiki/EdDSA) is support
 
 ## TLS
 
-A good starting example would be to sync a TLS client or server using a single Roughtime server. That would involve computing the time difference between our clock and the Roughtime sever's. 
+A good starting example would be to sync a TLS client or server using a single Roughtime server. That would involve computing the time difference between our clock and the Roughtime sever's.
 
 The first step is to load the configuration file (be sure to
 import `github.com/cloudflare/roughtime`):
@@ -93,7 +93,7 @@ For a full working example, check out our
 
 ## Desktop alerts
 
-A more general way to use Roughtime is to create desktop alerts that warn you when your clock is skewed. 
+A more general way to use Roughtime is to create desktop alerts that warn you when your clock is skewed.
 
 On Ubuntu GNU/Linux, you can do something like this:
 

--- a/content/turnstile/tutorials/login-pages.md
+++ b/content/turnstile/tutorials/login-pages.md
@@ -5,6 +5,8 @@ weight: 2
 updated: 2024-07-09
 difficulty: Beginner
 content_type: 📝 Tutorial
+languages: [JavaScript]
+tags: [Node.js]
 ---
 
 # Protect your login page using Turnstile

--- a/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
+++ b/content/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.md
@@ -7,6 +7,7 @@ title: Build a Retrieval Augmented Generation (RAG) AI
 weight: 2
 products: [Workers, Vectorize]
 tags: [AI, Hono]
+languages: [JavaScript]
 ---
 
 # Build a Retrieval Augmented Generation (RAG) AI

--- a/content/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.md
+++ b/content/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.md
@@ -7,8 +7,8 @@ title: Explore Code Generation Using DeepSeek Coder Models
 meta:
   description: Explore how you can use AI models to generate code and work more efficiently.
 weight: 4
-tags:
-  - AI
+tags: [AI]
+languages: [Python]
 ---
 
 # Explore Code Generation Using DeepSeek Coder Models

--- a/content/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.md
+++ b/content/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.md
@@ -6,8 +6,8 @@ pcx_content_type: tutorial
 title: Explore Workers AI Models Using a Jupyter Notebook
 meta:
   description: This notebook explores the Workers AI REST API using Python and the requests library.
-tags:
-  - AI
+tags: [AI]
+languages: [Python]
 ---
 
 # Explore Workers AI Models Using a Jupyter Notebook

--- a/content/workers-ai/tutorials/fine-tune-models-with-autotrain.md
+++ b/content/workers-ai/tutorials/fine-tune-models-with-autotrain.md
@@ -4,8 +4,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Fine Tune Models With AutoTrain from HuggingFace
-tags:
-  - AI
+tags: [AI]
 ---
 
 # Fine Tune Models With AutoTrain from HuggingFace

--- a/content/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.md
+++ b/content/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.md
@@ -7,8 +7,8 @@ title: Choose the Right Text Generation Model
 meta:
   description: There's a wide range of text generation models available through Workers AI. In an effort to aid you in your journey of finding the right model, this notebook will help you get to know your options in a speed dating type of scenario.
 weight: 1
-tags:
-  - AI
+tags: [AI]
+languages: [Python]
 ---
 
 # Choose the Right Text Generation Model

--- a/content/workers/tutorials/build-a-jamstack-app/index.md
+++ b/content/workers/tutorials/build-a-jamstack-app/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Build a todo list Jamstack application
 products: [KV]
+languages: [JavaScript]
 ---
 
 # Build a todo list Jamstack application

--- a/content/workers/tutorials/build-a-qr-code-generator/index.md
+++ b/content/workers/tutorials/build-a-qr-code-generator/index.md
@@ -4,6 +4,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Build a QR code generator
+languages: [JavaScript]
 ---
 
 # Build a QR code generator

--- a/content/workers/tutorials/build-a-slackbot/index.md
+++ b/content/workers/tutorials/build-a-slackbot/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Build a Slackbot
 tags: [Hono]
+languages: [TypeScript]
 ---
 
 # Build a Slackbot

--- a/content/workers/tutorials/connect-to-turso-using-workers/index.md
+++ b/content/workers/tutorials/connect-to-turso-using-workers/index.md
@@ -4,6 +4,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Connect to and query your Turso database using Workers
+languages: [TypeScript, SQL]
 ---
 
 # Connect to and query your Turso database using Workers

--- a/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
+++ b/content/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.md
@@ -7,6 +7,7 @@ updated: 2024-06-07
 weight: 1
 products: [R2]
 tags: [AI, Hono]
+languages: [TypeScript]
 ---
 
 # Create a fine-tuned OpenAI model with R2

--- a/content/workers/tutorials/deploy-a-realtime-chat-app/index.md
+++ b/content/workers/tutorials/deploy-a-realtime-chat-app/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Deploy a real-time chat application
 products: [Durable Objects]
+languages: [JavaScript]
 ---
 
 # Deploy a real-time chat application

--- a/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
+++ b/content/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Generate YouTube thumbnails with Workers and Cloudflare Image Resizing
 products: [Images]
+languages: [JavaScript, Rust]
 ---
 
 # Generate YouTube thumbnails with Workers and Cloudflare Image Resizing

--- a/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
+++ b/content/workers/tutorials/github-sms-notifications-using-twilio/index.md
@@ -4,6 +4,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: GitHub SMS notifications using Twilio
+languages: [JavaScript]
 ---
 
 # GitHub SMS notifications using Twilio

--- a/content/workers/tutorials/handle-form-submissions-with-airtable/index.md
+++ b/content/workers/tutorials/handle-form-submissions-with-airtable/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Handle form submissions with Airtable
 tags: [Forms]
+languages: [JavaScript]
 ---
 
 # Handle form submissions with Airtable

--- a/content/workers/tutorials/openai-function-calls-workers/index.md
+++ b/content/workers/tutorials/openai-function-calls-workers/index.md
@@ -4,8 +4,8 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: OpenAI GPT function calling with JavaScript and Cloudflare Workers
-tags:
-  - AI
+languages: [JavaScript]
+tags: [AI]
 ---
 
 # Use OpenAI GPT function calling with JavaScript and Cloudflare Workers

--- a/content/workers/tutorials/postgres/index.md
+++ b/content/workers/tutorials/postgres/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Connect to a PostgreSQL database with Cloudflare Workers
 tags: [PostgreSQL]
+languages: [TypeScript, SQL]
 ---
 
 # Connect to a PostgreSQL database with Cloudflare Workers

--- a/content/workers/tutorials/postgres/index.md
+++ b/content/workers/tutorials/postgres/index.md
@@ -4,6 +4,7 @@ difficulty: Intermediate
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Connect to a PostgreSQL database with Cloudflare Workers
+tags: [PostgreSQL]
 ---
 
 # Connect to a PostgreSQL database with Cloudflare Workers

--- a/content/workers/tutorials/send-emails-with-postmark/index.md
+++ b/content/workers/tutorials/send-emails-with-postmark/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Send Emails With Postmark
 tags: [Email]
+languages: [JavaScript]
 ---
 
 # Send Emails With Postmark
@@ -43,7 +44,7 @@ $ npm create cloudflare@latest email-with-postmark -- --type=hello-world --ts=fa
 
 This creates a simple hello-world Worker having the following content:
 
-```jsx
+```js
 ---
 filename: src/index.js
 ---

--- a/content/workers/tutorials/send-emails-with-resend/index.md
+++ b/content/workers/tutorials/send-emails-with-resend/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Send Emails With Resend
 tags: [Email, Resend]
+languages: [JavaScript]
 ---
 
 # Send Emails With Resend
@@ -43,7 +44,7 @@ $ npm create cloudflare@latest email-with-resend -- --type=hello-world --ts=fals
 
 This creates a simple hello-world Worker having the following content:
 
-```jsx
+```js
 ---
 filename: src/index.js
 ---

--- a/content/workers/tutorials/send-emails-with-resend/index.md
+++ b/content/workers/tutorials/send-emails-with-resend/index.md
@@ -4,7 +4,7 @@ difficulty: Beginner
 content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Send Emails With Resend
-tags: [Email]
+tags: [Email, Resend]
 ---
 
 # Send Emails With Resend

--- a/content/workers/tutorials/store-data-with-fauna/index.md
+++ b/content/workers/tutorials/store-data-with-fauna/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed REST API with Fauna
 tags: [Hono]
+languages: [TypeScript]
 ---
 
 # Create a serverless, globally distributed REST API with Fauna

--- a/content/workers/tutorials/upload-assets-with-r2/index.md
+++ b/content/workers/tutorials/upload-assets-with-r2/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Securely access and upload assets with Cloudflare R2
 products: [R2]
+languages: [TypeScript]
 ---
 
 # Securely access and upload assets with Cloudflare R2

--- a/content/workers/tutorials/workers-kv-from-rust/index.md
+++ b/content/workers/tutorials/workers-kv-from-rust/index.md
@@ -5,6 +5,7 @@ content_type: 📝 Tutorial
 pcx_content_type: tutorial
 title: Use Workers KV directly from Rust
 products: [KV]
+languages: [Rust]
 ---
 
 # Use Workers KV directly from Rust

--- a/data/external-resources/apps.yml
+++ b/data/external-resources/apps.yml
@@ -268,3 +268,12 @@ entries:
   languages: [JavaScript]
   cloudflare: true
   updated: 2022-08-01
+- link: https://github.com/lauragift21/staff-directory
+  name: Staff Directory demo
+  description: Built using the powerful combination of HonoX for backend logic, Cloudflare Pages for fast and secure hosting, and Cloudflare D1 for seamless database management.
+  tags: [Hono]
+  products: [Pages, D1]
+  languages: [TypeScript]
+  author: gift
+  cloudflare: true
+  updated: 2024-03-18

--- a/data/external-resources/apps.yml
+++ b/data/external-resources/apps.yml
@@ -168,7 +168,7 @@ entries:
   description: This is a demo of the Northwind dataset, running on Cloudflare Workers, and D1 - Cloudflare's SQL database, running on SQLite.
   tags: [Tailwind, React, Remix]
   products: [Workers, D1]
-  languages: [TypeScript]
+  languages: [TypeScript, SQL]
   cloudflare: true
   updated: 2023-07-12
 - link: https://github.com/cloudflare/workers-chat-demo

--- a/data/external-resources/videos.yml
+++ b/data/external-resources/videos.yml
@@ -3,6 +3,7 @@ entries:
   title: Tool Calling Also Known as Function Calling on Cloudflare Workers AI
   description: Tool calling, also known as function calling, is a powerful concept that lets you build Large Language Model based applications that can perform actions and retrieve external information from defined tools.
   tags: [AI]
+  languages: [TypeScript]
   products: [Workers AI]
   cloudflare: true
   stream_id: 603e94c9803b4779dd612493c0dd7125
@@ -16,6 +17,7 @@ entries:
   description: We are building a URL Shortener, shrty.dev, on Cloudflare. The apps uses Workers KV and Workers Analytics engine. Craig decided to build with Workers AI runWithTools to provide a chat interface for admins.
   tags: [Workers Analytics Engine, AI]
   products: [Workers AI, KV]
+  languages: [TypeScript]
   cloudflare: true
   author: craig
   updated: 2024-07-01
@@ -26,6 +28,7 @@ entries:
   title: Build Rust Powered Apps
   description: In this video, we will show you how to build a global database using workers-rs to keep track of every country and city you’ve visited.
   tags: []
+  languages: [Rust]
   products: [Workers, KV]
   cloudflare: true
   author: confidence
@@ -37,6 +40,7 @@ entries:
   title: API Roll (Father's Day)
   description: This walks through how to use Workers AI with Hono and Zod to create a streaming pun generating API.
   tags: [AI, Hono]
+  languages: [TypeScript]
   products: [Workers AI]
   cloudflare: true
   author: craig
@@ -48,6 +52,7 @@ entries:
   title: AI can see clearly now - Build Vision Apps on Cloudflare Workers AI
   description: The LlaVa model is hosted on Cloudflare Workers AI. Which means you are an API call away from brand new powerful vision use cases in all of your applications.
   tags: [AI]
+  languages: [TypeScript]
   products: [Workers AI]
   cloudflare: true
   author: craig
@@ -59,6 +64,7 @@ entries:
   title: Stateful Apps with Cloudflare Workers
   description: Learn how to access external APIs, cache and retrieve data using Workers KV, and create SQL-driven applications with Cloudflare D1.
   tags: []
+  languages: [TypeScript, SQL]
   products: [Workers, KV, D1]
   cloudflare: true
   author: kristian
@@ -70,6 +76,7 @@ entries:
   title: Workers AI - Getting Started - Vanilla Chat App
   description: Get started building AI apps on Cloudflare using Pages and the GitHub starter template for a Vanilla JavaScript Chat App.
   tags: [AI]
+  languages: [TypeScript]
   products: [Workers AI]
   cloudflare: true
   author: craig
@@ -82,6 +89,7 @@ entries:
   description: Learn how to build your first Cloudflare Workers application and deploy it to Cloudflare's global network.
   tags: []
   products: [Workers]
+  languages: [TypeScript]
   cloudflare: true
   author: kristian
   updated: 2024-03-12
@@ -93,6 +101,7 @@ entries:
   description: Is that person you are about to swipe right on, actually real? Are they AI Generated?
   tags: [AI]
   products: [Workers AI]
+  languages: [Python]
   cloudflare: true
   author: craig
   updated: 2024-03-08
@@ -115,6 +124,7 @@ entries:
   description: In this workshop, Kristian Freeman, Cloudflare Developer Advocate, shows how to optimize your existing AI applications with Cloudflare AI Gateway, and how to finetune OpenAI models using R2.
   tags: [AI]
   products: [Workers, R2, AI Gateway]
+  languages: [JavaScript]
   cloudflare: true
   author: kristian
   updated: 2023-12-14
@@ -125,6 +135,7 @@ entries:
   title: How to use Cloudflare AI models and inference in Python with Jupyter Notebooks
   description: Cloudflare Workers AI provides a ton of AI models and inference capabilities. In this video, we will explore how to make use of Cloudflare’s AI model catalog using a Python Jupyter Notebook.
   tags: [AI]
+  languages: [Python]
   products: [Workers, AI Gateway]
   cloudflare: true
   author: craig


### PR DESCRIPTION
### Summary

- Adding some more metadata to different tutorials in the DevPlat space
- In other places, updating the content type value for things that aren't really `tutorials`.
- Added a new demo app mentioned in one of the D1 tutorials.
- Updated the titles for the `Pulumi` tutorials so the one associated with Workers will now appear in the `/workers/tutorials/` page and have an accessible title in that context 
- Adds a `languages` array to the metadata (that we already have for a lot of our Examples and Apps) to be used in a future PR for filtering and surfacing.