### PR TITLE
[Turnstile] Remove ref arch in Turnstile

### DIFF
--- a/content/turnstile/demos.md
+++ b/content/turnstile/demos.md
@@ -1,21 +1,13 @@
 ---
 pcx_content_type: navigation
-title: Demos and architectures
+title: Demos
 weight: 6
 ---
 
-# Demo applications and reference architectures
+# Demo applications
 
-Learn how you can use Turnstile within your existing application and architecture.
-
-## Demos
+Learn how you can use Turnstile within your existing application.
 
 Explore the following {{<glossary-tooltip term_id="demo application">}}demo applications{{</glossary-tooltip>}} for Turnstile.
 
 {{<external-resources resource_type="apps" products="Turnstile">}}
-
-## Reference architectures
-
-Explore the following {{<glossary-tooltip term_id="reference architecture">}}reference architectures{{</glossary-tooltip>}} that use Turnstile:
-
-{{<resource-by-selector products="Turnstile" resource_type="reference-architecture,design-guide,reference-architecture-diagram">}}


### PR DESCRIPTION
### Summary

Remove the reference architecture section for Turnstile under demos and architecture per PM request