### PR TITLE
[KV] Update KV specific wrangler docs to match global wrangl…

### DIFF
--- a/content/kv/reference/kv-commands.md
+++ b/content/kv/reference/kv-commands.md
@@ -11,54 +11,14 @@ The `wrangler kv ...` commands allow you to manage your Workers KV resources in 
 {{<Aside type="warning">}}
 Since version 3.60.0, Wrangler KV commands support the `kv ...` syntax. If you are using versions of Wrangler below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [`kv:...` syntax deprecation](#kv-syntax-deprecation) section.
 
-To update your Wrangler installation, follow the [Wrangler Install and Update guide](/workers/wrangler/install-and-update/). 
+To update your Wrangler installation, follow the [Wrangler Install and Update guide](/workers/wrangler/install-and-update/).
 {{</Aside>}}
 
 ## `kv namespace`
 
 Manage KV namespaces.
 
-### create
-
-Creates a new KV namespace.
-
-```sh
-$ wrangler kv namespace create <NAMESPACE> [OPTIONS]
-```
-
-{{<definitions>}}
-
-- `NAMESPACE` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-  - The name of the new namespace.
-- `--env` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Perform on a specific environment.
-- `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Interact with a preview namespace (the `preview_id` value).
-
-{{</definitions>}}
-
-#### `create` command to create a KV namespace called `MY_KV`
-
-```sh
-$ wrangler kv namespace create "MY_KV"
-🌀 Creating namespace with title "worker-MY_KV"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-kv_namespaces = [
-  { binding = "MY_KV", id = "e29b263ab50e42ce9b637fa8370175e8" }
-]
-```
-#### `create` command to create a preview KV namespace called `MY_KV`
-
-```sh
-$ wrangler kv namespace create "MY_KV" --preview
-🌀 Creating namespace with title "my-site-MY_KV_preview"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-kv_namespaces = [
-  { binding = "MY_KV", preview_id = "15137f8edf6c09742227e99b08aaf273" }
-]
-```
+{{<render file="/wrangler-commands/kv/_create.md" productFolder="workers">}}
 
 ### list
 
@@ -469,26 +429,26 @@ Success!
 
 # Deprecations
 
-Below are deprecations to Wrangler commands for Workers KV. 
+Below are deprecations to Wrangler commands for Workers KV.
 
 ## `kv:...` syntax deprecation
 
-Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. 
+Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax.
 
-The `kv:...` syntax is deprecated in versions 3.60.0 and beyond and will be removed in a future major version. 
+The `kv:...` syntax is deprecated in versions 3.60.0 and beyond and will be removed in a future major version.
 
 For example, commands using the `kv ...` syntax look as such:
 
 ```sh
 $ wrangler kv namespace list
-$ wrangler kv key get <KEY> 
-$ wrangler kv bulk put <FILENAME> 
+$ wrangler kv key get <KEY>
+$ wrangler kv bulk put <FILENAME>
 ```
 
 The same commands using the `kv:...` syntax look as such:
 
 ```sh
 $ wrangler kv:namespace list
-$ wrangler kv:key get <KEY> 
-$ wrangler kv:bulk put <FILENAME> 
+$ wrangler kv:key get <KEY>
+$ wrangler kv:bulk put <FILENAME>
 ```

--- a/content/kv/reference/kv-commands.md
+++ b/content/kv/reference/kv-commands.md
@@ -138,7 +138,7 @@ Manage key-value pairs within a KV namespace.
 Writes a single key-value pair to a particular KV namespace.
 
 ```sh
-$ wrangler kv key put <KEY> [VALUE] [OPTIONS]
+$ wrangler kv key put <KEY> {<VALUE>|--path=<PATH>} {--binding=<BINDING>|--namespace-id=<NAMESPACE_ID>} [OPTIONS]
 ```
 
 {{<Aside type="warning">}}
@@ -169,6 +169,10 @@ Exactly one of `VALUE` or `--path` is required.
   - The timestamp, in UNIX seconds, indicating when the key-value pair should expire.
 - `--metadata` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Any (escaped) JSON serialized arbitrary object to a maximum of 1024 bytes.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 
@@ -225,6 +229,12 @@ Exactly one of `--binding` or `--namespace-id` is required.
   - Perform on a specific environment.
 - `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Interact with a preview namespace instead of production.
+- `--text` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Decode the returned value as a UTF-8 string.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 
@@ -259,6 +269,10 @@ Exactly one of `--binding` or `--namespace-id` is required.
   - Interact with a preview namespace instead of production.
 - `--prefix` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Only list keys that begin with the given prefix.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 
@@ -302,6 +316,10 @@ Exactly one of `--binding` or `--namespace-id` is required.
   - Perform on a specific environment.
 - `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Interact with a preview namespace instead of production.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 
@@ -341,6 +359,10 @@ Exactly one of `--binding` or `--namespace-id` is required.
   - Perform on a specific environment.
 - `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Interact with a preview namespace instead of production.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 
@@ -423,6 +445,10 @@ Exactly one of `--binding` or `--namespace-id` is required.
   - Perform on a specific environment.
 - `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Interact with a preview namespace instead of production.
+- `--local` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with locally persisted data.
+- `--persist-to` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Specify directory for locally persisted data.
 
 {{</definitions>}}
 

--- a/content/workers/_partials/wrangler-commands/kv/_create.md
+++ b/content/workers/_partials/wrangler-commands/kv/_create.md
@@ -1,0 +1,51 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+---
+
+### `create`
+
+Create a new namespace.
+
+```sh
+$ npx wrangler kv namespace create <NAMESPACE> [OPTIONS]
+```
+
+{{<definitions>}}
+
+- `NAMESPACE` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
+  - The name of the new namespace.
+- `--env` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Perform on a specific environment.
+- `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+  - Interact with a preview namespace (the `preview_id` value).
+
+{{</definitions>}}
+
+#### Example
+
+The following is an example of using the `create` command to create a KV namespace called `MY_KV`.
+
+```sh
+$ npx wrangler kv namespace create "MY_KV"
+🌀 Creating namespace with title "worker-MY_KV"
+✨ Success!
+Add the following to your configuration file in your kv_namespaces array:
+kv_namespaces = [
+  { binding = "MY_KV", id = "e29b263ab50e42ce9b637fa8370175e8" }
+]
+```
+
+The following is an example of using the `create` command to create a preview KV namespace called `MY_KV`.
+
+```sh
+$ npx wrangler kv namespace create "MY_KV" --preview
+🌀 Creating namespace with title "my-site-MY_KV_preview"
+✨ Success!
+Add the following to your configuration file in your kv_namespaces array:
+kv_namespaces = [
+  { binding = "MY_KV", preview_id = "15137f8edf6c09742227e99b08aaf273" }
+]
+```

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -942,58 +942,13 @@ wrangler delete [<SCRIPT>] [OPTIONS]
 
 ## `kv namespace`
 
-Manage Workers KV namespaces.
-
-{{<Aside type="note">}}
-The `kv ...` commands allow you to manage your Workers KV resources in the Cloudflare network. Learn more about using Workers KV with Wrangler in the [Workers KV guide](/kv/get-started/).
-{{</Aside>}}
+Manage Workers [KV namespaces](/kv/).
 
 {{<Aside type="warning">}}
 Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/reference/kv-commands/) for KV page.
 {{</Aside>}}
 
-### `create`
-
-Create a new namespace.
-
-```txt
-wrangler kv namespace create <NAMESPACE> [OPTIONS]
-```
-
-{{<definitions>}}
-
-- `NAMESPACE` {{<type>}}string{{</type>}} {{<prop-meta>}}required{{</prop-meta>}}
-  - The name of the new namespace.
-- `--env` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Perform on a specific environment.
-- `--preview` {{<type>}}boolean{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
-  - Interact with a preview namespace (the `preview_id` value).
-
-{{</definitions>}}
-
-The following is an example of using the `create` command to create a KV namespace called `MY_KV`.
-
-```sh
-$ npx wrangler kv namespace create "MY_KV"
-🌀 Creating namespace with title "worker-MY_KV"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-kv_namespaces = [
-  { binding = "MY_KV", id = "e29b263ab50e42ce9b637fa8370175e8" }
-]
-```
-
-The following is an example of using the `create` command to create a preview KV namespace called `MY_KV`.
-
-```sh
-$ npx wrangler kv namespace create "MY_KV" --preview
-🌀 Creating namespace with title "my-site-MY_KV_preview"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-kv_namespaces = [
-  { binding = "MY_KV", preview_id = "15137f8edf6c09742227e99b08aaf273" }
-]
-```
+{{<render file="/wrangler-commands/kv/_create.md" productFolder="workers">}}
 
 ### `list`
 
@@ -1683,7 +1638,7 @@ wrangler r2 object delete <OBJECT_PATH> [OPTIONS]
 
 ## `secret`
 
-Manage the secret variables for a Worker. 
+Manage the secret variables for a Worker.
 
 This action creates a new [version](/workers/configuration/versions-and-deployments/#versions) of the Worker and [deploys](/workers/configuration/versions-and-deployments/#deployments) it immediately. To only create a new version of the Worker, use the [`wrangler versions secret`](/workers/wrangler/commands/#secret-put) commands.
 


### PR DESCRIPTION
https://developers.cloudflare.com/kv/reference/kv-commands/ has gotten out of date from https://developers.cloudflare.com/workers/wrangler/commands/

Mostly around the absence of --local and --persist-to CLI args.