### PR TITLE
[Docs] Fix API links

### DIFF
--- a/content/vectorize/best-practices/insert-vectors.md
+++ b/content/vectorize/best-practices/insert-vectors.md
@@ -22,7 +22,7 @@ In most cases, a `number[]` array is the easiest when dealing with other APIs, a
 
 Metadata is an optional set of key-value pairs that can be attached to a vector on insert or upsert, and allows you to embed or co-locate data about the vector itself.
 
-Metadata keys cannot be empty, contain the dot character (.), contain the double-quote character ("), or start with the dollar character ($).
+Metadata keys cannot be empty, contain the dot character (`.`), contain the double-quote character (`"`), or start with the dollar character (`$`).
 
 Metadata can be used to:
 
@@ -42,7 +42,7 @@ Namespaces provide a way to segment the vectors within your index. For example, 
 
 To associate vectors with a namespace, you can optionally provide a `namespace: string` value when performing an insert or upsert operation. When querying, you can pass the namespace to search within as an optional parameter to your query.
 
-A namespace can be up to 63 characters (bytes) in length and you can have up to 1000 namespaces per index. Refer to the [Limits](/vectorize/platform/limits/) documentation for more details.
+A namespace can be up to 63 characters (bytes) in length and you can have up to 1,000 namespaces per index. Refer to the [Limits](/vectorize/platform/limits/) documentation for more details.
 
 When a namespace is provided, only vectors within that namespace are used for the search. Namespace filtering is applied before vector search, not after.
 
@@ -119,7 +119,7 @@ Refer to [Vectorize API](/vectorize/reference/client-api/) for additional exampl
 
 You can bulk upload vector embeddings directly:
 
-- The file must be in newline-delimited JSON (NDJSON format): each complete vector must be newline separated, and not within an array or object. 
+- The file must be in newline-delimited JSON (NDJSON format): each complete vector must be newline separated, and not within an array or object.
 - Vectors must be complete and include a unique string `id` per vector.
 
 An example NDJSON formatted file:
@@ -142,7 +142,7 @@ $ wrangler vectorize insert <your-index-name> --file=embeddings.ndjson
 
 ### HTTP API
 
-Vectorize also supports inserting vectors via the [REST API](https://developers.cloudflare.com/api/operations/vectorize-update-vectorize-index), which allows you to operate on a Vectorize index from existing machine-learning tooling and languages (including Python).
+Vectorize also supports inserting vectors via the [REST API](/api/operations/vectorize-insert-vector), which allows you to operate on a Vectorize index from existing machine-learning tooling and languages (including Python).
 
 For example, to insert embeddings in [NDJSON format](#workers-api) directly from a Python script:
 

--- a/data/changelogs/radar.yaml
+++ b/data/changelogs/radar.yaml
@@ -5,6 +5,13 @@ productLink: "/radar/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+- publish_date: '2024-06-27'
+  title: Change TCP connection tampering API endpoints to TCP Resets Timeouts
+  description: |-
+    * Changed the connection tampering summary and timeseries API endpoints to
+    TCP resets timeouts [summary](/api/operations/radar-get-tcp-resets-timeouts-summary)
+    and [timeseries](/api/operations/radar-get-tcp-resets-timeouts-timeseries-group),
+    respectively.
 - publish_date: '2023-11-27'
   title: Add more meta information's
   description: |-
@@ -13,84 +20,83 @@ entries:
 - publish_date: '2023-11-16'
   title: Add new Layer 3 endpoints and Layer 7 dimensions
   description: |-
-    * Added Layer 3 [top origin locations](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-top-origin-locations)
-      and [top target location](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-top-target-locations).
+    * Added Layer 3 [top origin locations](/api/operations/radar-get-attacks-layer3-top-origin-locations)
+      and [top target location](/api/operations/radar-get-attacks-layer3-top-target-locations).
     * Added Layer 7 Summaries by `http_method`, `http_version`, `ip_version`, `managed_rules`, `mitigation_product`.
     * Added Layer 7 Timeseries Groups by `http_method`, `http_version`, `ip_version`, `managed_rules`, `mitigation_product`, `industry`, `vertical`.
     * Added Layer 7 Top by `industry`, `vertical`.
-    * Deprecated Layer 7 [timeseries groups without dimension](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer7-timeseries-group).
+    * Deprecated Layer 7 [timeseries groups without dimension](/api/operations/radar-get-attacks-layer7-timeseries-group).
       * To continue getting this data, switch to the new
-        [timeseries group by mitigation_product](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer7-timeseries-group-by-mitigation-product)
+        [timeseries group by mitigation_product](/api/operations/radar-get-attacks-layer7-timeseries-group-by-mitigation-product)
         endpoint.
-    * Deprecated Layer 7 [summary without dimension)](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer7-summary).
+    * Deprecated Layer 7 [summary without dimension)](/api/operations/radar-get-attacks-layer7-summary).
       * To continue getting this data, switch to the new
-        [summary by mitigation_product](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer7-summary-by-mitigation-product)
+        [summary by mitigation_product](/api/operations/radar-get-attacks-layer7-summary-by-mitigation-product)
         endpoint.
-    * Added new [Error codes](https://developers.cloudflare.com/radar/get-started/error-codes/).
+    * Added new [Error codes](/radar/get-started/error-codes/).
 - publish_date: '2023-10-31'
   title: Add new Layer 3 direction parameter
   description: |-
     * Added a `direction` parameter to all Layer 3 endpoints. Use together with `location` parameter to filter by origin or
-      target location [timeseries groups](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-group-by-vector).
+      target location [timeseries groups](/api/operations/radar-get-attacks-layer3-timeseries-group-by-vector).
 - publish_date: '2023-09-08'
   title: Add Connection Tampering endpoints
   description: |-
-    * Added Connection Tampering [summary](https://developers.cloudflare.com/api/operations/radar-get-connection-tampering-summary)
-      and [timeseries](https://developers.cloudflare.com/api/operations/radar-get-connection-tampering-timeseries-group) endpoints.
+    * Added Connection Tampering [summary](/api/operations/radar-get-tcp-resets-timeouts-summary)
+      and [timeseries](/api/operations/radar-get-tcp-resets-timeouts-timeseries-group) endpoints.
 - publish_date: '2023-08-14'
   title: Deprecate old layer 3 dataset
   description: |-
     * Added Regional Internet Registry (see field `source` in response)
-      to [get asn by id](https://developers.cloudflare.com/api/operations/radar-get-entities-asn-by-id)
-      and [get asn by ip](https://developers.cloudflare.com/api/operations/radar-get-entities-asn-by-ip) endpoints.
+      to [get asn by id](/api/operations/radar-get-entities-asn-by-id)
+      and [get asn by ip](/api/operations/radar-get-entities-asn-by-ip) endpoints.
     * Stopped collecting data in the old Layer 3 data source.
     * Updated Layer 3
-      [timeseries](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-by-bytes) endpoint
+      [timeseries](/api/operations/radar-get-attacks-layer3-timeseries-by-bytes) endpoint
       to start using the new Layer 3 data source by default, fetching the old data source now requires sending the parameter
       `metric=bytes_old`.
     * Deprecated Layer 3
-      [summary](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-summary) endpoint, this will stop
+      [summary](/api/operations/radar-get-attacks-layer3-summary) endpoint, this will stop
       receiving data after 2023-08-14.
       * To continue getting this data, switch to the
-        new [timeseries group protocol](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-summary-by-protocol)
+        new [timeseries group protocol](/api/operations/radar-get-attacks-layer3-summary-by-protocol)
         endpoint.
     * Deprecated Layer 3
-      [timeseries groups](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-groups)
+      [timeseries groups](/api/operations/radar-get-attacks-layer3-timeseries-groups)
       endpoint, this will stop receiving data after 2023-08-14.
       * To continue getting this data, switch to the
-        new [timeseries group protocol](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-group-by-protocol)
+        new [timeseries group protocol](/api/operations/radar-get-attacks-layer3-timeseries-group-by-protocol)
         endpoint.
 - publish_date: '2023-07-31'
   title: Fix HTTP timeseries endpoint urls
   description: |-
     * Updated HTTP `timeseries` endpoints urls
-      to `timeseries_groups` ([example](https://developers.cloudflare.com/api/operations/radar-get-http-timeseries-group-by-browser-families))
+      to `timeseries_groups` ([example](/api/operations/radar-get-http-timeseries-group-by-browser-families))
       due to consistency. Old timeseries endpoints are still available, but will soon be removed.
 - publish_date: '2023-07-20'
   title: Add URL Scanner endpoints
   description: |-
-    * Added [urlscanner endpoints](https://developers.cloudflare.com/api/operations/urlscanner-search-scans), read
-      more [here](https://developers.cloudflare.com/radar/investigate/url-scanner/).
+    * Added [urlscanner endpoints](/api/operations/urlscanner-search-scans). For more information, refer to [URL Scanner](/radar/investigate/url-scanner/).
 - publish_date: '2023-06-20'
   title: Add Quality endpoints
   description: |-
-    * Added [quality endpoints](https://developers.cloudflare.com/api/operations/radar-get-quality-index-summary).
+    * Added [quality endpoints](/api/operations/radar-get-quality-index-summary).
 - publish_date: '2023-06-07'
   title: Add BGP stats, pfx2as and moas endpoint
   description: |-
-    * Added BGP [stats](https://developers.cloudflare.com/api/operations/radar-get-bgp-routes-stats),
-      [pfx2as](https://developers.cloudflare.com/api/operations/radar-get-bgp-pfx2as)
-      and [moas](https://developers.cloudflare.com/api/operations/radar-get-bgp-pfx2as-moas) endpoints.
+    * Added BGP [stats](/api/operations/radar-get-bgp-routes-stats),
+      [pfx2as](/api/operations/radar-get-bgp-pfx2as)
+      and [moas](/api/operations/radar-get-bgp-pfx2as-moas) endpoints.
 - publish_date: '2023-05-10'
   title: Added `IOS` as an option for the OS parameter in all HTTP
   description: |-
     * Added `IOS` as an option for the OS parameter in all HTTP
-      endpoints ([example](https://developers.cloudflare.com/api/operations/radar-get-http-summary-by-bot-class)).
+      endpoints ([example](/api/operations/radar-get-http-summary-by-bot-class)).
 - publish_date: '2023-03-20'
   title: Add AS112 and email endpoints
   description: |-
-    * Added [AS112 endpoints](https://developers.cloudflare.com/api/operations/radar-get-dns-as112-timeseries-by-dnssec).
-    * Added [email endpoints](https://developers.cloudflare.com/api/operations/radar-get-email-security-summary-by-arc).
+    * Added [AS112 endpoints](/api/operations/radar-get-dns-as112-timeseries-by-dnssec).
+    * Added [email endpoints](/api/operations/radar-get-email-security-summary-by-arc).
 - publish_date: '2023-01-23'
   title: Updated IPv6 calculation method
   description: |-
@@ -101,11 +107,11 @@ entries:
   description: |-
     * Added new Layer 3 data source and related endpoints.
     * Updated Layer 3
-      [timeseries](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-by-bytes) endpoint
+      [timeseries](/api/operations/radar-get-attacks-layer3-timeseries-by-bytes) endpoint
       to support fetching both current and new data sources. For retro-compatibility
       reasons, fetching the new data source requires sending the parameter `metric=bytes` else the current data
       source will be returned.
     * Deprecated old Layer 3 endpoints
-      [TimeseriesGroups](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-timeseries-groups) and
-      [Summary](https://developers.cloudflare.com/api/operations/radar-get-attacks-layer3-summary).
+      [TimeseriesGroups](/api/operations/radar-get-attacks-layer3-timeseries-groups) and
+      [Summary](/api/operations/radar-get-attacks-layer3-summary).
       Users should upgrade to newer endpoints.


### PR DESCRIPTION
### Summary

Fixes API links in Dev Docs.
Also adds Radar changelog about endpoint changes.
Closes #15967.

### Notes

API reference links don't need to include the hostname (in fact, you'll get a Vale warning if you do), **unless** the YAML file is being directly used elsewhere outside Dev Docs.
Links in changelog RSS feeds (namely in [Radar's feed](https://developers.cloudflare.com/radar/changelog/index.xml)) will always include the hostname, so that they don't get broken outside the Dev Docs context.

Changelog preview:
https://pedro-issue15967-docs-fix-ap.cloudflare-docs-7ou.pages.dev/radar/changelog/
