### PR TITLE
Specified maximum delay in queues documentation

### DIFF
--- a/content/queues/configuration/batching-retries.md
+++ b/content/queues/configuration/batching-retries.md
@@ -125,6 +125,8 @@ When publishing messages to a queue, or when [marking a message or batch for ret
 
 Delaying messages allows you to defer tasks until later, and/or respond to backpressure when consuming from a queue. For example, if an upstream API you are calling to returns a `HTTP 429: Too Many Requests`, you can delay messages to slow down how quickly you are consuming them before they are re-processed.
 
+Messages can be delayed by upto 12 hours.
+
 {{<Aside type="note">}}
 
 Configuring delivery and retry delays via the `wrangler` CLI or when [developing locally](/queues/configuration/local-development/) requires `wrangler` version `3.38.0` or greater. Use `npx wrangler@latest` to always use the latest version of `wrangler`.


### PR DESCRIPTION
### Summary
Added 1 line explaining the maximum permitted delay while sending, or retrying, messages.