### PR TITLE
r2: correct wording for audit logs

### DIFF
--- a/content/r2/platform/audit-logs.md
+++ b/content/r2/platform/audit-logs.md
@@ -5,7 +5,7 @@ title: Audit Logs
 
 # Audit Logs
 
-[Audit logs](/fundamentals/setup/account/account-security/review-audit-logs/) provide a comprehensive summary of changes made within your Cloudflare account, including those made to R2 buckets. This functionality is available on all plan types, free of charge, and is enabled by default.
+[Audit logs](/fundamentals/setup/account/account-security/review-audit-logs/) provide a comprehensive summary of changes made within your Cloudflare account, including those made to R2 buckets. This functionality is available on all plan types, free of charge, and is always enabled.
 
 ## Viewing audit logs
 


### PR DESCRIPTION
### Summary

R2 config audit logs are always enabled and cannot be toggled, previous wording implied otherwise

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist
