### PR TITLE
bugfix documentation (incorrect cmd script)

### DIFF
--- a/content/workers/languages/python/packages/fastapi.md
+++ b/content/workers/languages/python/packages/fastapi.md
@@ -21,7 +21,7 @@ Clone the `cloudflare/python-workers-examples` repository and run the FastAPI ex
 
 ```bash
 git clone https://github.com/cloudflare/python-workers-examples
-cd 03-fastapi
+cd python-workers-examples/03-fastapi
 npx wrangler@latest dev
 ```
 


### PR DESCRIPTION
### Summary

On [the tutorial of using FastAPI with Workers](https://developers.cloudflare.com/workers/languages/python/packages/fastapi), the command for installing the demo appears to have a small oversight. 

The current command is as follows:
![image](https://github.com/user-attachments/assets/c4a0cb70-e697-49af-8d21-c7bb241b1827)

However, this fails to work since after git cloning the file, the cmd remains in the parent folder. To resolve this, I suggest a slight modification to the second line of the command. This change will ensure that the command correctly navigates to the intended directory after cloning the repository. The revised command should read:

```bash
cd python-workers-examples/03-fastapi 
``` 


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
