### PR TITLE
[Workers/Snippets] Remove non-applicable warnings

### DIFF
--- a/content/rules/snippets/examples/auth-with-headers.md
+++ b/content/rules/snippets/examples/auth-with-headers.md
@@ -13,11 +13,7 @@ layout: example
 ---
 
 {{<Aside type="warning" header="Caution when using in production">}}
-
-- This code is provided as a sample, and is not suitable for production without protecting against timing attacks. Refer to the [Workers' `timingSafeEqual` example](/workers/examples/protect-against-timing-attacks/) for more information on how to mitigate timing attacks. Alternatively, consider [signing requests with HMAC](/rules/snippets/examples/signing-requests/).
-
-- The example code contains a generic header key and value of `X-Custom-PSK` and `mypresharedkey`. To best protect your resources, change the header key and value in the Snippets editor before saving your code.
-
+The example code contains a generic header key and value of `X-Custom-PSK` and `mypresharedkey`. To best protect your resources, change the header key and value in the Snippets editor before saving your code.
 {{</Aside>}}
 
 ```js

--- a/content/workers/examples/auth-with-headers.md
+++ b/content/workers/examples/auth-with-headers.md
@@ -16,11 +16,7 @@ layout: example
 ---
 
 {{<Aside type="warning" header="Caution when using in production">}}
-
-- This code is provided as a sample, and is not suitable for production code without protecting against timing attacks. To learn how to implement production-safe code, refer to the [`timingSafeEqual` example](/workers/examples/protect-against-timing-attacks/) for more information on how to mitigate against timing attacks in your Workers code.
-
-- The example code contains a generic header key and value of `X-Custom-PSK` and `mypresharedkey`. To best protect your resources, change the header key and value in the Workers editor before saving your code.
-
+The example code contains a generic header key and value of `X-Custom-PSK` and `mypresharedkey`. To best protect your resources, change the header key and value in the Workers editor before saving your code.
 {{</Aside>}}
 
 {{<tabs labels="js | ts | py">}}


### PR DESCRIPTION
There is no timing-attack angle in this PSK auth example. Change also reviewed by @nouvellonsteph.