### PR TITLE
[Browser Rendering] add available on paid plan only warning

### DIFF
--- a/content/browser-rendering/_index.md
+++ b/content/browser-rendering/_index.md
@@ -13,7 +13,7 @@ meta:
 Browser automation for [Cloudflare Workers](/workers/).
 {{</description>}}
 
-{{<plan type="workers_all">}}
+{{<plan type="workers-paid">}}
 
 The Workers Browser Rendering API allows developers to programmatically control and interact with a headless browser instance and create automation flows for their applications and products. Once you configure the service, Workers Browser Rendering gives you access to a WebSocket endpoint that speaks the [DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/). DevTools is what allows Cloudflare to instrument a Chromium instance running in the Cloudflare global network.
 


### PR DESCRIPTION
### Summary

Add warning about browser rendering being only available on the workers paid plan

### Screenshots (optional)
<img width="858" alt="Screenshot 2024-08-07 at 11 52 01" src="https://github.com/user-attachments/assets/a390fe6e-1c8f-413c-818e-c8d83d1fc17a">



### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
