### PR TITLE
d1: 32 -> 127 args per func limit

### DIFF
--- a/content/d1/platform/limits.md
+++ b/content/d1/platform/limits.md
@@ -19,7 +19,7 @@ weight: 2
 | Maximum string, `BLOB` or table row size           | 1,000,000 bytes (1 MB)                        |
 | Maximum SQL statement length                       | 100,000 bytes (100 KB)                        |
 | Maximum bound parameters per query                 | 100                                          |
-| Maximum arguments per SQL function                 | 32                                           |
+| Maximum arguments per SQL function                 | 127                                          |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern | 50 bytes                               |
 | Maximum bindings per Workers script                 | Approximately 5,000 <sup>2</sup>     |
 | Maximum SQL query duration                    | 30 seconds                        |

--- a/data/changelogs/d1.yaml
+++ b/data/changelogs/d1.yaml
@@ -5,6 +5,13 @@ productLink: "/d1/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2024-08-30"
+    title: Increased SQL function argument limit
+    description: |-
+      D1 now allows up to 127 arguments (parameters) to be passed to SQL functions, up from the previous limit of 32. This enables more complex queries, including those that [operate over JSON data](/d1/build-with-d1/query-json/), to run against D1 databases.
+
+      Visit the [limits documentation](/d1/platform/limits/) to review D1's limits.
+
   - publish_date: "2024-07-26"
     title: Fixed bug in TypeScript typings for run() API
     description: |-


### PR DESCRIPTION
Requires https://github.com/cloudflare/workerd/pull/2493/files to be merged and released into EW first.