### PR TITLE
[Workers] Fix spelling issues found with codespell

### DIFF
--- a/content/workers-ai/function-calling/embedded/api-reference.md
+++ b/content/workers-ai/function-calling/embedded/api-reference.md
@@ -40,7 +40,7 @@ This method lets you automatically create tool schemas based on OpenAPI specs, s
 {{<definitions>}}
 
 - `spec`{{<type>}}string {{</type>}}
-  - The OpenAPI specifiction in either JSON or YAML format, or a URL to a remote OpenAPI specification.
+  - The OpenAPI specification in either JSON or YAML format, or a URL to a remote OpenAPI specification.
 - `config`{{<type>}}Config {{</type>}}{{<prop-meta>}} optional {{</prop-meta>}} - Configuration options for the createToolsFromOpenAPISpec function
   - `overrides`{{<type>}}ConfigRule[] {{</type>}}{{<prop-meta>}} optional {{</prop-meta>}}
   - `matchPatterns`{{<type>}}RegExp[] {{</type>}}{{<prop-meta>}} optional {{</prop-meta>}}

--- a/content/workers-ai/function-calling/embedded/examples/openapi.md
+++ b/content/workers-ai/function-calling/embedded/examples/openapi.md
@@ -8,7 +8,7 @@ tags: [AI]
 
 # Example using tools based on OpenAPI Spec
 
-Oftentimes APIs are defined and documented via [OpenAPI specification](https://swagger.io/specification/). The Cloudflare `ai-utils` package's `createToolsFromOpenAPISpec` function creates tools from the OpenAPI spec, which the LLM can then leverage to fullfil the prompt.
+Oftentimes APIs are defined and documented via [OpenAPI specification](https://swagger.io/specification/). The Cloudflare `ai-utils` package's `createToolsFromOpenAPISpec` function creates tools from the OpenAPI spec, which the LLM can then leverage to fulfill the prompt.
 
 In this example the LLM will describe the a Github user, based Github's API and its OpenAPI spec.
 

--- a/content/workers/configuration/compatibility-dates.md
+++ b/content/workers/configuration/compatibility-dates.md
@@ -59,7 +59,7 @@ Most developers will not need to use `compatibility_flags`. `compatibility_flags
 
 #### Via Wrangler
 
-Compatability flags can be set in a Worker's [`wrangler.toml`](/workers/wrangler/configuration/) file.
+Compatibility flags can be set in a Worker's [`wrangler.toml`](/workers/wrangler/configuration/) file.
 
 This example enables the specific flag `formdata_parser_supports_files`, which is described [below](/workers/configuration/compatibility-dates/#formdata-parsing-supports-file). As of the specified date, `2021-09-14`, this particular flag was not yet enabled by default, but, by specifying it in `compatibility_flags`, we can enable it anyway. `compatibility_flags` can also be used to disable changes that became the default in the past.
 

--- a/content/workers/configuration/multipart-upload-metadata.md
+++ b/content/workers/configuration/multipart-upload-metadata.md
@@ -40,7 +40,7 @@ At a minimum, the `main_module` key is required to upload a Worker.
 
   - The part name that contains the module entry point of the Worker that will be executed. For example, `main.js`.
 
-- `bindings` {{<type>}}array[objec]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+- `bindings` {{<type>}}array[object]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
   - [Bindings](#bindings) to expose in the Worker.
 

--- a/content/workers/examples/data-loss-prevention.md
+++ b/content/workers/examples/data-loss-prevention.md
@@ -210,7 +210,7 @@ async def on_fetch(request):
         if match:
             # Alert a data breach
             await post_data_breach(request)
-            # Respond with a block if credit card, therwise replace sensitive text with `*`s
+            # Respond with a block if credit card, otherwise replace sensitive text with `*`s
             card_resp = Response.new(kind + " found\nForbidden\n", status=403,statusText="Forbidden")
             sensitive_resp = Response.new(re.sub(regex, "*"*10, text, flags=re.IGNORECASE), response)
             return card_resp if kind == "credit_card" else  sensitive_resp

--- a/content/workers/examples/read-post.md
+++ b/content/workers/examples/read-post.md
@@ -209,7 +209,7 @@ async fn fetch(req: Request, _env: Env, _ctx: Context) -> Result<Response> {
             let req_body = read_request_body(req).await;
             Response::ok(format!("The request body sent in was {}", req_body))
         }
-        _ => Response::ok(format!("The resut was a {:?}", req.method())),
+        _ => Response::ok(format!("The result was a {:?}", req.method())),
     }
 }
 ```

--- a/content/workers/observability/errors.md
+++ b/content/workers/observability/errors.md
@@ -100,7 +100,7 @@ This is typically caused by calling a function that calls `this`, but the value 
 
 For example, given an `obj` object with the `obj.foo()` method which logic relies on `this`, executing the method via `obj.foo();` will make sure that `this` properly references the `obj` object. However, assigning the method to a variable, e.g.`const func = obj.foo;` and calling such variable, e.g. `func();` would result in `this` being `undefined`. This is because `this` is lost when the method is called as a standalone function. This is standard behavior in JavaScript.
 
-In practice, this is often seen when destructuring runtime provided Javscript objects that have functions that rely on the presence of `this`, such as `ctx`.
+In practice, this is often seen when destructuring runtime provided Javascript objects that have functions that rely on the presence of `this`, such as `ctx`.
 
 The following code will error:
 

--- a/data/changelogs/workers-ai.yaml
+++ b/data/changelogs/workers-ai.yaml
@@ -9,7 +9,7 @@ entries:
 - publish_date: '2024-07-23'
   title: Meta Llama 3.1 now available on Workers AI
   description: |-
-    Workers AI now suppoorts [Meta Llama 3.1](/workers-ai/models/llama-3.1-8b-instruct/).
+    Workers AI now supports [Meta Llama 3.1](/workers-ai/models/llama-3.1-8b-instruct/).
 
 - publish_date: '2024-07-11'
   title: New community-contributed tutorial


### PR DESCRIPTION
### Summary

Resolves several spelling issues found with [codespell](https://github.com/codespell-project/codespell).
\- There are more spelling issues in the documentation that can be found this way. Ideally we'd have a tool like this set up on CI to lint the code base automatically, but then again there are inevitably false positives that make this more difficult.

### Documentation checklist

Not applicable here.