### PR TITLE
Clarify getting started with C3 docs

### DIFF
--- a/content/pages/get-started/c3.md
+++ b/content/pages/get-started/c3.md
@@ -1,65 +1,62 @@
 ---
-title: C3
+title: CLI
 pcx_content_type: get-started
 meta:
   title: Create projects with C3 CLI
   description: Use C3 (`create-cloudflare` CLI) to set up and deploy new applications using framework-specific setup guides to ensure each new application follows Cloudflare and any third-party best practices for deployment.
 ---
 
-# C3 (`create-cloudflare` CLI)
+# CLI (`npm create cloudflare`)
 
-[C3 (create-cloudflare-cli)](https://github.com/cloudflare/workers-sdk/tree/main/packages/create-cloudflare) is a command-line tool designed to help you set up and deploy new applications to Cloudflare. In addition to speed, it leverages officially developed templates for Workers and framework-specific setup guides to ensure each new application that you set up follows Cloudflare and any third-party best practices for deployment on the Cloudflare network.
+Cloudflare provides a CLI command for creating new Workers and Pages projects — `npm create cloudflare`, powered by the [`create-cloudflare` package](https://www.npmjs.com/package/create-cloudflare).
 
 ## Create a new application
 
-To get started, open a terminal window and run:
+Open a terminal window and run:
 
 {{<render file="/_c3-run-command-no-directory.md" productFolder="/workers/" >}}
 
-Running `create cloudflare@latest` will prompt you to install the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) package, and lead you through a setup wizard. After you have entered the setup wizard, you will be asked which type of application you would like to create.
-
-The list of applications includes a variety of Workers templates as well as an option to select a web framework to create a website or web application.
+Running this command will prompt you to install the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) package, and then ask you questions about the type of application you wish to create.
 
 ## Web frameworks
 
-If you choose to create a new website or application using a web framework, C3 will prompt you to choose one of the following supported frameworks:
+If you choose the "Framework Starter" option, you will be prompted to choose a framework to use. The following frameworks are currently supported:
 
-- Analog
-- Angular
-- Astro
-- Docusaurus
-- Gatsby
-- Hono
-- Next
-- Nuxt
-- Qwik
-- React
-- Remix
-- Solid
-- Svelte
-- Vue
+- [Analog](/pages/framework-guides/deploy-an-analog-site/)
+- [Angular](/pages/framework-guides/deploy-an-angular-site/)
+- [Astro](/pages/framework-guides/deploy-an-astro-site/)
+- [Docusaurus](/pages/framework-guides/deploy-a-docusaurus-site/)
+- [Gatsby](/pages/framework-guides/deploy-a-gatsby-site/)
+- [Hono](/pages/framework-guides/deploy-a-hono-site/)
+- [Next.js](/pages/framework-guides/nextjs/)
+- [Nuxt](/pages/framework-guides/deploy-a-nuxt-site/)
+- [Qwik](/pages/framework-guides/deploy-a-qwik-site/)
+- [React](/pages/framework-guides/deploy-a-react-site/)
+- [Remix](/pages/framework-guides/deploy-a-remix-site/)
+- [Solid](/pages/framework-guides/deploy-a-solid-site/)
+- [Svelte](/pages/framework-guides/deploy-a-svelte-site/)
+- [Vue](/pages/framework-guides/deploy-a-vue-site/)
 
-Select a framework and you will be prompted to install its create package which will lead you through the framework's own setup wizard.
+When you use a framework, `npm create cloudflare` directly uses the framework's own command for generating a new projects, which may prompt additional questions. This ensures that the project you create is up-to-date with the latest version of the framework, and you have all the same options when creating you project via `npm create cloudflare` that you would if you created your project using the framework's tooling directly.
 
 ## Deploy
 
 Once your project has been configured, you will be asked if you would like to deploy the project to Cloudflare. This is optional.
 
-If you choose _not_ to deploy, the project will be created for you locally, and C3 will display some helpful links for further development. Go to the newly created project folder to begin development.
+If you choose to deploy, you will be asked to sign into your Cloudflare account (if you aren't already), and your project will be deployed.
 
-If you choose to deploy, you will be asked to authenticate (if not logged in already), and your project will be deployed immediately. C3 will display your project's URL and some helpful links.
+## Creating a new Pages project that is connected to a git repository
 
-{{<Aside type="warning" header="Git integration">}}
+To create a new project using `npm create cloudflare`, and then connect it to a Git repository on your Github or Gitlab account, take the following steps:
 
-The initial deployment created via C3 is referred to as a [Direct Upload](/pages/get-started/direct-upload/). To set up a deployment via Git integration, choose `No` to deploy with C3 and refer to the [Git integration guide](/pages/get-started/git-integration/) to complete setup.
-
-Currently, you cannot add Git integration to existing Pages applications. If you have already deployed your application (using C3 for example), you need to create a new Pages application in order to add Git integration to it.
-
-{{</Aside>}}
+1. Run `npm create cloudflare@latest`, and choose your desired options
+2. Select `no` to the prompt, "Do you want to deploy your application?". This is important — if you select `yes` and deploy your application from your terminal ([Direct Upload](/pages/get-started/direct-upload/)), then it will not be possible to connect this Pages project to a git repository later on. You will have to create a new Cloudflare Pages project.
+3. Create a new git repository, using the application that `npm create cloudflare@latest` just created for you.
+4. Follow the steps outlined in the [Git integration guide](/pages/get-started/git-integration/)
 
 ## CLI Arguments
 
-C3 collects any required input through a series of interactive prompts. You may also specify your choices via command line arguments, which will skip these prompts. To use C3 in a non-interactive context such as CI, specify all required arguments via the command line.
+C3 collects any required input through a series of interactive prompts. You may also specify your choices via command line arguments, which will skip these prompts. To use C3 in a non-interactive context such as CI, you must specify all required arguments via the command line.
 
 This is the full format of a C3 invocation alongside the possible CLI arguments:
 


### PR DESCRIPTION
- Simplify language
- Add links to framework guides
- Add more explicit section on how to start with `npm create cloudflare`, and then use the git integration
- Change the headings and title to be clearer — call it by the command we tell you to run (`npm create cloudflare`) rather than referring to things everywhere as ("C3")