### PR TITLE
Remove backticks from .dev.vars in filename

### DIFF
--- a/content/pages/functions/bindings.md
+++ b/content/pages/functions/bindings.md
@@ -691,7 +691,7 @@ When developing locally, add secrets by creating a `.dev.vars` file in the root 
 
 ```
 ---
-filename:  .dev.vars
+filename: .dev.vars
 ---
 SECRET_NAME=<SECRET_VALUE>
 ```

--- a/content/pages/functions/bindings.md
+++ b/content/pages/functions/bindings.md
@@ -691,7 +691,7 @@ When developing locally, add secrets by creating a `.dev.vars` file in the root 
 
 ```
 ---
-filename:  `.dev.vars`
+filename:  .dev.vars
 ---
 SECRET_NAME=<SECRET_VALUE>
 ```


### PR DESCRIPTION
Remove extra backticks from the filename