### PR TITLE
add legacy assets flag to wrangler dev/deploy

### DIFF
--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -794,7 +794,7 @@ As of Wrangler v3.2.0, `wrangler dev` is supported by any Linux distributions pr
   - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --legacy-assets dist/ --latest`.
 - `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
   - Root folder of static assets to be served.
-  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead.{{</Aside>}}
+  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead to ensure that you get consistent behavior when this option changes.{{</Aside>}}
 - `--site` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets for Workers Sites.
 - `--site-include` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
@@ -871,7 +871,7 @@ None of the options for this command are required. Also, many can be set in your
   - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --legacy-assets dist/ --latest`.
 - `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
   - Root folder of static assets to be served.
-  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead.{{</Aside>}}
+  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead to ensure that you get consistent behavior when this option changes.{{</Aside>}}
 - `--site` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets for Workers Sites.
 - `--site-include` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}

--- a/content/workers/wrangler/commands.md
+++ b/content/workers/wrangler/commands.md
@@ -789,9 +789,12 @@ As of Wrangler v3.2.0, `wrangler dev` is supported by any Linux distributions pr
   - Path to a custom certificate.
 - `--local-upstream` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Host to act as origin in local mode, defaults to `dev.host` or route.
-- `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+- `--legacy-assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
   - Root folder of static assets to be served.
-  - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --assets dist/ --latest`.
+  - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --legacy-assets dist/ --latest`.
+- `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
+  - Root folder of static assets to be served.
+  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead.{{</Aside>}}
 - `--site` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets for Workers Sites.
 - `--site-include` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
@@ -863,9 +866,12 @@ None of the options for this command are required. Also, many can be set in your
   - Flags to use for compatibility checks.
 - `--latest` {{<type>}}boolean{{</type>}} {{<prop-meta>}}(default: true){{</prop-meta>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Use the latest version of the Workers runtime.
-- `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
+- `--legacy-assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
   - Root folder of static assets to be served.
-  - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `npx wrangler deploy --name personal_blog --assets dist/ --latest`.
+  - Use in combination with `--name` and `--latest` for basic static file hosting. For example: `wrangler dev --name personal_blog --legacy-assets dist/ --latest`.
+- `--assets` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}} {{<prop-meta>}}experimental{{</prop-meta>}}
+  - Root folder of static assets to be served.
+  - {{<Aside type="warning">}}This is an experimental feature and its behavior will be changing soon. Use `--legacy-assets` instead.{{</Aside>}}
 - `--site` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
   - Root folder of static assets for Workers Sites.
 - `--site-include` {{<type>}}string[]{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}


### PR DESCRIPTION
### Summary
Updating docs for wrangler dev/deploy --assets

<img width="766" alt="Screenshot 2024-08-12 at 11 50 47" src="https://github.com/user-attachments/assets/676f189a-07dc-490d-879f-5427cc9d72f1">

See [this PR](https://github.com/cloudflare/workers-sdk/pull/6272) for further details.

