### PR TITLE
New limits and documentation refresh for Snippets

### DIFF
--- a/content/rules/snippets/_index.md
+++ b/content/rules/snippets/_index.md
@@ -8,9 +8,9 @@ meta:
 
 {{<heading-pill style="alpha">}} Cloudflare Snippets {{</heading-pill>}}
 
-Cloudflare Snippets (alpha) provide a powerful and flexible way to customize the behavior of your website or application using short pieces of JavaScript code. With Snippets, you can modify HTTP response headers, implement {{<glossary-tooltip term_id="JSON web token (JWT)" prepend="JSON web token (JWT) is ">}}JWT{{</glossary-tooltip>}} validation, perform complex {{<glossary-tooltip term_id="redirect">}}redirects{{</glossary-tooltip>}}, and much more.
+Cloudflare Snippets (alpha) provide a powerful and flexible way to customize the behavior of your website or application using short pieces of JavaScript code. With Snippets, you can modify HTTP response headers, implement {{<glossary-tooltip term_id="JSON web token (JWT)" prepend="JSON web token (JWT) is ">}}JWT{{</glossary-tooltip>}} validation, perform complex {{<glossary-tooltip term_id="redirect">}}redirects,{{</glossary-tooltip>}} and much more.
 
-For code samples addressing common use cases, please refer to the [Examples](examples/) section.
+For code samples addressing common use cases, please refer to the [Examples](/rules/snippets/examples/) section.
 
 ## Snippets elements
 

--- a/content/rules/snippets/_index.md
+++ b/content/rules/snippets/_index.md
@@ -8,42 +8,26 @@ meta:
 
 {{<heading-pill style="alpha">}} Cloudflare Snippets {{</heading-pill>}}
 
-Cloudflare Snippets (alpha) provide a flexible way to customize the behavior of your website or application using short pieces of JavaScript code. Use snippets to customize HTTP response headers, implement {{<glossary-tooltip term_id="JSON web token (JWT)" prepend="JSON web token (JWT) is ">}}JWT{{</glossary-tooltip>}} validation, define complex {{<glossary-tooltip term_id="redirect">}}redirect{{</glossary-tooltip>}} functionality, and more.
+Cloudflare Snippets (alpha) provide a powerful and flexible way to customize the behavior of your website or application using short pieces of JavaScript code. With Snippets, you can modify HTTP response headers, implement {{<glossary-tooltip term_id="JSON web token (JWT)" prepend="JSON web token (JWT) is ">}}JWT{{</glossary-tooltip>}} validation, perform complex {{<glossary-tooltip term_id="redirect">}}redirects{{</glossary-tooltip>}}, and much more.
 
-Refer to [Examples](/rules/snippets/examples/) for code samples addressing common use cases.
+For code samples addressing common use cases, please refer to the [Examples](examples/) section.
 
-## Snippet elements
+## Snippets elements
 
-To create and deploy a snippet you must define the following elements:
+To create and deploy a Snippet, you need to define the following elements:
 
-* **Snippet**: Contains a name and the JavaScript code that will be executed as part of the request handling process.
-* **Snippet rule**: Contains a [filter expression](/ruleset-engine/rules-language/expressions/) that will define for which requests the snippet will run.
+* **Snippet**: JavaScript code to be executed during the request-handling process.
+* **Snippet rule**: A [filter expression](/ruleset-engine/rules-language/expressions/) that determines which requests the Snippet will be applied to. Each Snippet can only be associated with one Snippet Rule.
 
-{{<Aside type="note">}}
-Currently, each snippet can only be associated with one snippet rule.
-{{</Aside>}}
-
-## How it works
-
-For each incoming request, Cloudflare evaluates the expression of each snippet rule defined in the zone checking for a match based on the request properties. Snippets are defined for each zone.
-
-A snippet can run on every request or only on certain requests, based on various criteria such as bot score, country of origin, or a cookie.
-
-Multiple snippets may run on the same request if their rule expressions match. This means that you could have a snippet adding an HTTP header and another snippet rewriting the URL, and they would both run if their corresponding expression matches the incoming request. Each snippet receives the modified request from the previous snippet and applies new modifications to it.
-
-For each snippet rule whose expression matches the incoming request, the corresponding snippet code will be scheduled for execution. Cloudflare will apply the following logic for each snippet rule:
-
-```txt
-If <rule_expression> evaluates to true, then schedule <snippet_code> for execution
-```
-
-After evaluating all snippet rules, Cloudflare will execute the code of all scheduled snippets, in the same order their rules matched.
-
-For more information, refer to our [blog post](https://blog.cloudflare.com/cloudflare-snippets-alpha).
+For more information, refer to the [How it works](how-it-works/) and [Create in the dashboard](create-dashboard/) sections.
 
 ## Availability
 
 {{<feature-table id="rules.snippets">}}
+
+{{<Aside type="warning" header="Redirects will count as subrequests">}}
+Each {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequest{{</glossary-tooltip>}} in a redirect chain counts against the subrequest limit. This means that if a subrequest was redirected it would count as two subrequests. To avoid issues, ensure that you make a subrequest to the end location of the redirect chain.
+{{</Aside>}}
 
 ## Limits
 
@@ -54,11 +38,6 @@ Description                                | All plans
 Maximum execution time                     | 5 ms
 Maximum memory                             | 2 MB
 Maximum total package size                 | 32 KB
-Subrequests<br>_(refer to the note below)_ | 1
-
-{{<Aside type="warning" header="Redirects will count as subrequests">}}
-Each subrequest in a redirect chain counts against the subrequest limit. This means that if a subrequest was redirected it would count as two subrequests. To avoid issues, ensure that you make a subrequest to the end location of the redirect chain.
-{{</Aside>}}
 
 ## Execution order
 

--- a/content/rules/snippets/errors.md
+++ b/content/rules/snippets/errors.md
@@ -7,18 +7,21 @@ meta:
 ---
 
 # Common errors
+
 Cloudflare Snippets may encounter specific errors during execution. Here are the common errors:
 
 ## Error 1201: Snippet tried to continue to origin multiple times
 
-This error occurs when a Snippet attempts to call ```fetch(request)``` more than once.
+This error occurs when a Snippet attempts to call `fetch(request)` more than once.
 
 ### Resolution
-Ensure that your Snippet code only calls ```fetch(request)``` once. This method is used to send the modified request to the origin server, and it should be called only once per Snippet to avoid conflicts.
+
+Ensure that your Snippet code only calls `fetch(request)` once. This method is used to send the modified request to the origin server, and it should be called only once per Snippet to avoid conflicts.
 
 ## Error 1202: Snippets exceeded subrequests limit:
 
-This error occurs when the number of {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequests{{</glossary-tooltip>}} exceeds [the limit](../#availability) for your Cloudflare plan.
+This error occurs when the number of {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequests{{</glossary-tooltip>}} exceeds [the limit](/rules/snippets/#availability) for your Cloudflare plan.
 
 ### Resolution
-Review your Snippet to ensure your code is within the {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequest{{</glossary-tooltip>}} [limits](../#availability) for your plan. Each subrequest counts against your limit, including any redirects within a subrequest chain.
+
+Review your Snippet to ensure your code is within the {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequest{{</glossary-tooltip>}} [limits](/rules/snippets/#availability) for your plan. Each subrequest counts against your limit, including any redirects within a subrequest chain.

--- a/content/rules/snippets/errors.md
+++ b/content/rules/snippets/errors.md
@@ -1,0 +1,24 @@
+---
+title: Common errors
+pcx_content_type: troubleshooting
+weight: 4
+meta:
+  title: Common errors
+---
+
+# Common errors
+Cloudflare Snippets may encounter specific errors during execution. Here are the common errors:
+
+## Error 1201: Snippet tried to continue to origin multiple times
+
+This error occurs when a Snippet attempts to call ```fetch(request)``` more than once.
+
+### Resolution
+Ensure that your Snippet code only calls ```fetch(request)``` once. This method is used to send the modified request to the origin server, and it should be called only once per Snippet to avoid conflicts.
+
+## Error 1202: Snippets exceeded subrequests limit:
+
+This error occurs when the number of {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequests{{</glossary-tooltip>}} exceeds [the limit](../#availability) for your Cloudflare plan.
+
+### Resolution
+Review your Snippet to ensure your code is within the {{<glossary-tooltip term_id="Snippets subrequest" prepend="A subrequest is ">}}subrequest{{</glossary-tooltip>}} [limits](../#availability) for your plan. Each subrequest counts against your limit, including any redirects within a subrequest chain.

--- a/content/rules/snippets/how-it-works.md
+++ b/content/rules/snippets/how-it-works.md
@@ -8,16 +8,19 @@ meta:
 
 # How it works
 
-Cloudflare Snippets are executed based on rules defined within your zone. Here's how the process works:
+Cloudflare Snippets are executed based on rules defined within your zone. Here is how the process works:
 
 ## Request evaluation
+
 For each incoming request, Cloudflare evaluates the expression of every Snippet Rule defined in the zone. The evaluation checks for a match based on various request properties (such as bot score, country of origin, cookies).
 
 ## Snippet execution
+
 If a Snippet Rule's expression evaluates to true, the corresponding Snippet's code is scheduled for execution.
 Multiple Snippets may run on the same request if their respective expressions match. In such cases, each Snippet receives the modified request from the previous Snippet and applies further modifications.
 
 ## Execution order
+
 After evaluating all Snippet Rules, Cloudflare executes the code of all scheduled Snippets in the order their rules matched.
 
 For more information, refer to our [blog post](https://blog.cloudflare.com/cloudflare-snippets-alpha).

--- a/content/rules/snippets/how-it-works.md
+++ b/content/rules/snippets/how-it-works.md
@@ -1,0 +1,23 @@
+---
+title: How it works
+pcx_content_type: concept
+weight: 1
+meta:
+  title: How it works
+---
+
+# How it works
+
+Cloudflare Snippets are executed based on rules defined within your zone. Here's how the process works:
+
+## Request evaluation
+For each incoming request, Cloudflare evaluates the expression of every Snippet Rule defined in the zone. The evaluation checks for a match based on various request properties (such as bot score, country of origin, cookies).
+
+## Snippet execution
+If a Snippet Rule's expression evaluates to true, the corresponding Snippet's code is scheduled for execution.
+Multiple Snippets may run on the same request if their respective expressions match. In such cases, each Snippet receives the modified request from the previous Snippet and applies further modifications.
+
+## Execution order
+After evaluating all Snippet Rules, Cloudflare executes the code of all scheduled Snippets in the order their rules matched.
+
+For more information, refer to our [blog post](https://blog.cloudflare.com/cloudflare-snippets-alpha).

--- a/data/changelogs/rules.yaml
+++ b/data/changelogs/rules.yaml
@@ -6,6 +6,11 @@ productArea: Application performance
 productAreaLink: /fundamentals/reference/changelog/performance/
 entries:
 
+- publish_date: '2024-08-12'
+  title: Cloudflare Snippets limits have been upgraded
+  description: |-
+    Cloudflare Snippets (alpha) now allow multiple subrequests depending on your plan. For more information, refer to the [Availability](/rules/snippets/#availability).
+
 - publish_date: '2024-07-31'
   title: Wildcard support added to Ruleset Engine products
   description: |-

--- a/data/glossary/rules.yaml
+++ b/data/glossary/rules.yaml
@@ -14,3 +14,7 @@ entries:
 - term: URL rewrite
   general_definition: |-
     an operation performed by a server that converts a source URL into a target URL.
+
+- term: Snippets subrequest
+  general_definition: |-
+    any request that a Snippet makes to either Internet resources using the Fetch API or requests to other Cloudflare services.

--- a/data/plans.json
+++ b/data/plans.json
@@ -1170,6 +1170,13 @@
           "pro": 10,
           "biz": 25,
           "ent": 50
+        },
+        "subrequests": {
+          "title": "Number of {{<glossary-tooltip term_id=\"Snippets subrequest\" prepend=\"A subrequest is \">}}subrequests{{</glossary-tooltip>}}",
+          "free": 0,
+          "pro": 2,
+          "biz": 3,
+          "ent": 5
         }
       }
     },


### PR DESCRIPTION
### Summary

Upgraded subrequest limits per plan. Split "How it works" into a separate page, added "Common errors" section.