### PR TITLE
EW-8589: Add documentation for allow_custom_ports workers compatibility flag

### DIFF
--- a/src/content/changelogs/workers.yaml
+++ b/src/content/changelogs/workers.yaml
@@ -5,6 +5,9 @@ productLink: "/workers/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+- publish_date: '2024-08-19'
+  description: |-
+    -  Workers now support the [`allow_custom_ports` compatibility flag](/workers/configuration/compatibility-dates/#allow-specifying-a-custom-port-when-making-a-subrequest-with-the-fetch-api) which enables using the `fetch()` calls to custom ports.
 - publish_date: '2024-07-19'
   description: |-
     -  Workers with the [mTLS](/workers/runtime-apis/bindings/mtls/) binding now support [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/).

--- a/src/content/compatibility-dates/allow-custom-ports.md
+++ b/src/content/compatibility-dates/allow-custom-ports.md
@@ -1,0 +1,27 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Allow specifying a custom port when making a subrequest with the fetch() API"
+sort_date: "2024-09-02"
+enable_date: "2024-09-02"
+enable_flag: "allow_custom_ports"
+disable_flag: "ignore_custom_ports"
+---
+
+When this flag is enabled, and you specify a port when making a subrequest with the [`fetch()` API](/workers/runtime-apis/fetch/), the port number you specify will be used.
+
+When you make a subrequest to a website that uses Cloudflare ("Orange Clouded") — only [ports supported by Cloudflare's reverse proxy](/fundamentals/reference/network-ports/#network-ports-compatible-with-cloudflares-proxy) can be specified. If you attempt to specify an unsupported port, it will be ignored.
+
+When you make a subrequest to a website that doesn't use Cloudflare ("Grey Clouded") - any port can be specified.
+
+For example:
+
+```js
+const response = await fetch("https://example.com:8000");
+```
+With allow_custom_ports the above example would fetch `https://example.com:8000` rather than
+`https://example.com:443`.
+


### PR DESCRIPTION
### Summary

Add documentation for allow_custom_ports workers compatibility flag
<img width="767" alt="image" src="https://github.com/user-attachments/assets/558b4c6a-9125-48a6-b48b-3d46e85098f9">

