### PR TITLE
Use early return, set satisfies for exported handler

### DIFF
--- a/content/browser-rendering/get-started/screenshots.md
+++ b/content/browser-rendering/get-started/screenshots.md
@@ -97,7 +97,7 @@ export default {
 
 		return new Response(img, { headers: { "content-type": "image/jpeg" } });
 	},
-} satisfies ExportedHandler<Env>;
+};
 ```
 {{</tab>}}
 {{<tab label="ts">}}
@@ -115,30 +115,22 @@ export default {
 	async fetch(request, env): Promise<Response> {
 		const { searchParams } = new URL(request.url);
 		let url = searchParams.get("url");
-		let img: Buffer;
-		if (url) {
-			url = new URL(url).toString(); // normalize
-			img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
-			if (img === null) {
-				const browser = await puppeteer.launch(env.MYBROWSER);
-				const page = await browser.newPage();
-				await page.goto(url);
-				img = (await page.screenshot()) as Buffer;
-				await env.BROWSER_KV_DEMO.put(url, img, {
-					expirationTtl: 60 * 60 * 24,
-				});
-				await browser.close();
-			}
-			return new Response(img, {
-				headers: {
-					"content-type": "image/jpeg",
-				},
-			});
-		} else {
-			return new Response(
-				"Please add an ?url=https://example.com/ parameter"
-			);
+		if (!url) {
+			return new Response("Please add an ?url=https://example.com/ parameter");
 		}
+
+		url = new URL(url).toString(); // normalize
+		let img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
+		if (img === null) {
+			const browser = await puppeteer.launch(env.MYBROWSER);
+			const page = await browser.newPage();
+			await page.goto(url);
+			img = (await page.screenshot()) as Buffer;
+			await env.BROWSER_KV_DEMO.put(url, img, { expirationTtl: 60 * 60 * 24 });
+			await browser.close();
+		}
+
+		return new Response(img, { headers: { "content-type": "image/jpeg" } });
 	},
 } satisfies ExportedHandler<Env>;
 ```

--- a/content/browser-rendering/get-started/screenshots.md
+++ b/content/browser-rendering/get-started/screenshots.md
@@ -89,9 +89,7 @@ export default {
 			const page = await browser.newPage();
 			await page.goto(url);
 			img = await page.screenshot();
-			await env.BROWSER_KV_DEMO.put(url, img, {
-				expirationTtl: 60 * 60 * 24,
-			});
+			await env.BROWSER_KV_DEMO.put(url, img, { expirationTtl: 60 * 60 * 24 });
 			await browser.close();
 		}
 

--- a/content/browser-rendering/get-started/screenshots.md
+++ b/content/browser-rendering/get-started/screenshots.md
@@ -77,32 +77,27 @@ export default {
 	async fetch(request, env) {
 		const { searchParams } = new URL(request.url);
 		let url = searchParams.get("url");
-		let img;
-		if (url) {
-			url = new URL(url).toString(); // normalize
-			img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
-			if (img === null) {
-				const browser = await puppeteer.launch(env.MYBROWSER);
-				const page = await browser.newPage();
-				await page.goto(url);
-				img = await page.screenshot();
-				await env.BROWSER_KV_DEMO.put(url, img, {
-					expirationTtl: 60 * 60 * 24,
-				});
-				await browser.close();
-			}
-			return new Response(img, {
-				headers: {
-					"content-type": "image/jpeg",
-				},
-			});
-		} else {
-			return new Response(
-				"Please add an ?url=https://example.com/ parameter"
-			);
+		if (!url) {
+			return new Response("Please add an ?url=https://example.com/ parameter");
 		}
+
+		url = new URL(url).toString(); // normalize
+		let img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
+
+		if (img === null) {
+			const browser = await puppeteer.launch(env.MYBROWSER);
+			const page = await browser.newPage();
+			await page.goto(url);
+			img = await page.screenshot();
+			await env.BROWSER_KV_DEMO.put(url, img, {
+				expirationTtl: 60 * 60 * 24,
+			});
+			await browser.close();
+		}
+
+		return new Response(img, { headers: { "content-type": "image/jpeg" } });
 	},
-};
+} satisfies ExportedHandler<Env>;
 ```
 {{</tab>}}
 {{<tab label="ts">}}


### PR DESCRIPTION
### Summary

A few "cleanup" items for the typescript example here that (I believe) make the code a bit simpler and idiomatic, specifically using an "early return" rather than an if/else and separating logical blocks with newlines.

This change also means you don't have to pre-define `img` and give it the type `Buffer` which was wrong (should be `ArrayBuffer | null`)

Formatted with Prettier default formatting (which I believe is the convention)

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
