### PR TITLE
[Docs Site] PCX-12912 Dont render filters on small viewports

### DIFF
--- a/src/pages/products.astro
+++ b/src/pages/products.astro
@@ -34,7 +34,7 @@ const groups = productGroups(products);
 		{frontmatter.description}
 	</span>
 	<div class="flex">
-		<div class="w-1/4 pr-4">
+		<div class="w-1/4 pr-4 hidden md:block">
 			<div class="border-b-2 border-orange-400">
 				<h2>Filters</h2>
 			</div>


### PR DESCRIPTION
### Summary

Hides filter bar on /products/ on small devices as a hotfix until we re-add mobile-specific filters.

### Screenshots (optional)

Before:

<img width="315" alt="image" src="https://github.com/user-attachments/assets/29c41c0c-b338-412c-a15a-1f96357fd54e">

After:

<img width="318" alt="image" src="https://github.com/user-attachments/assets/64bbbd7b-6ffa-4e8e-a1ba-81a57253880b">