### PR TITLE
[docs site] minor TS / formatting improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,11 +3,11 @@ root = true
 
 [*]
 indent_size = 2
-indent_style = space
+indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false
 
-[Makefile]
-indent_style = tab
+[*.yml]
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 *.js text eol=lf
 *.json text eol=lf
 *.md text eol=lf
-*.md text eol=lf
+*.mdx text eol=lf
 *.mjs text eol=lf
 *.svg text eol=lf
 *.toml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
+*.astro text eol=lf
 *.go text eol=lf
 *.html text eol=lf
+*.ini text eol=lf
 *.js text eol=lf
 *.json text eol=lf
 *.md text eol=lf
+*.mjs text eol=lf
 *.toml text eol=lf
 *.ts text eol=lf
 *.txt text eol=lf
@@ -11,3 +14,4 @@
 *.yaml text eol=lf
 *.yml text eol=lf
 .gitattributes text eol=lf
+.editorconfig text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,9 @@
 *.js text eol=lf
 *.json text eol=lf
 *.md text eol=lf
+*.md text eol=lf
 *.mjs text eol=lf
+*.svg text eol=lf
 *.toml text eol=lf
 *.ts text eol=lf
 *.txt text eol=lf
@@ -13,5 +15,7 @@
 *.xml text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
-.gitattributes text eol=lf
+_redirects text eol=lf
 .editorconfig text eol=lf
+.gitattributes text eol=lf
+.prettierignore text eol=lf

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+# generated actions JS
+.github/**/*/index.js

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,13 @@
+/** @type {import("prettier").Config} */
+export default {
+	plugins: ["prettier-plugin-astro"],
+	useTabs: true,
+	overrides: [
+		{
+			files: "*.astro",
+			options: {
+				parser: "astro",
+			},
+		},
+	],
+};

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "astro-build.astro-vscode",
         "unifiedjs.vscode-mdx",
         "bradlc.vscode-tailwindcss",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,11 @@
 {
-    "recommendations": [
-        "mhutchie.git-graph",
-        "EditorConfig.EditorConfig",
-        "astro-build.astro-vscode",
-        "unifiedjs.vscode-mdx",
-        "bradlc.vscode-tailwindcss",
-        "redhat.vscode-yaml",
-        "esbenp.prettier-vscode"
-    ]
+	"recommendations":[
+		"mhutchie.git-graph",
+		"EditorConfig.EditorConfig",
+		"astro-build.astro-vscode",
+		"unifiedjs.vscode-mdx",
+		"bradlc.vscode-tailwindcss",
+		"redhat.vscode-yaml",
+		"esbenp.prettier-vscode"
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "astro.content-intellisense": true
+	"astro.content-intellisense": true,
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "format": "prettier \"**/*.{js,jsx,ts,tsx,mjs,astro,css,json,yaml,yml}\" --write ."
   },
   "dependencies": {
     "@astro-community/astro-embed-youtube": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "postinstall": "patch-package",
-    "format": "prettier \"**/*.{js,jsx,ts,tsx,mjs,astro,css,json,yaml,yml}\" --write ."
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,mjs,astro,css,json,yaml,yml}\""
   },
   "dependencies": {
     "@astro-community/astro-embed-youtube": "^0.5.2",

--- a/src/components/Plan.astro
+++ b/src/components/Plan.astro
@@ -1,6 +1,7 @@
 ---
 import { z } from "astro:content";
 import { indexPlans } from "~/util/plans";
+import { zodEnumFromObjKeys } from "~/util/helpers";
 
 const mappings = {
 	all: "Available on all plans",
@@ -14,14 +15,11 @@ const mappings = {
 	"workers-paid": "Available on Workers Paid plan",
 } as const satisfies Record<string, string>;
 
-const keys = Object.keys(mappings);
-
 type Props = z.infer<typeof props>;
 
 const props = z
 	.object({
-		// @ts-ignore this is functional but TS is upset
-		type: z.enum(keys),
+		type: zodEnumFromObjKeys(mappings),
 	})
 	.or(
 		z.object({

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -34,22 +34,22 @@ import "instantsearch.css/themes/satellite.css";
 
 	// Functions needed for dropdowns, pulled from https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/facet-dropdown/js/
 
-	function hasClassName(elem, className) {
+	function hasClassName(elem: HTMLElement, className: string) {
 		return elem.className.split(" ").indexOf(className) >= 0;
 	}
 
-	function addClassName(elem, className) {
+	function addClassName(elem: HTMLElement, className: string) {
 		elem.className = [...elem.className.split(" "), className].join(" ");
 	}
 
-	function removeClassName(elem, className) {
+	function removeClassName(elem: HTMLElement, className: string) {
 		elem.className = elem.className
 			.split(" ")
 			.filter((name) => name !== className)
 			.join(" ");
 	}
 
-	function capitalize(str) {
+	function capitalize(str: string) {
 		if (typeof str !== "string") return "";
 		return str.charAt(0).toUpperCase() + str.slice(1);
 	}
@@ -58,7 +58,7 @@ import "instantsearch.css/themes/satellite.css";
 	const CLASS_BUTTON = "ais-Dropdown-button";
 	const CLASS_CLOSE_BUTTON = "ais-Dropdown-close";
 
-	const cx = (...args) => args.filter(Boolean).join(" ");
+	const cx = (...args: string[]) => args.filter(Boolean).join(" ");
 
 	export function createDropdown(
 		baseWidget,

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,0 +1,8 @@
+import { z, type ZodEnum } from "astro/zod";
+
+export function zodEnumFromObjKeys<K extends string>(
+	obj: Record<K, any>,
+): ZodEnum<[K, ...K[]]> {
+	const [firstKey, ...otherKeys] = Object.keys(obj) as K[];
+	return z.enum([firstKey, ...otherKeys]);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "astro/tsconfigs/strict",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "~/*": ["src/*"]
-    }
-  },
-  "exclude": [
-    "dist"
-  ]
+	"extends": "astro/tsconfigs/strict",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"~/*": ["src/*"]
+		}
+	},
+	"exclude": ["dist"]
 }


### PR DESCRIPTION
### Summary

No functional changes, just a few TS cleanups, updated editorconfig to better match repo now, and added formatting scripts.

`astro check` currently reports:

```
Result (145 files):
- 232 errors
- 0 warnings
- 28 hints
```
Most of these likely wouldn't take very long to resolve.

And at some point it would be good if someone ran `npm run format` and committed that back to the repo.