### PR TITLE
[Docs Site] Move GlossaryTooltip CSS from inline to global

### DIFF
--- a/src/components/GlossaryTooltip.astro
+++ b/src/components/GlossaryTooltip.astro
@@ -47,7 +47,7 @@ const definition = prepend
 			interactive: true,
 		});
 	}
-</script><style is:inline>
+</script><style is:global>
 	.tippy-box {
 		background-color: var(--sl-color-bg);
 		color: var(--sl-color-white);


### PR DESCRIPTION
### Summary

Fixes the inline CSS appearing in the `description` meta, shown in embeds.

### Screenshots (optional)

Before:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/31b3482d-ecce-4499-998a-6dba0575a06b">
After:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/be50994d-4565-44c9-98cb-b4dbc8ffd4b1">

