### PR TITLE
[Docs Site] Fix wrong CSS selector

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -5,7 +5,7 @@ select {
 	border-width: 2px;
 }
 
-input:read-only {
+input[readonly] {
 	background-color: var(--sl-color-backdrop-overlay);
 	cursor: not-allowed;
 }


### PR DESCRIPTION
### Summary

By default, checkboxes are readonly. This causes the `input:read-only` CSS selector to be applied. 

Changing the selector to `input[readonly]` will only apply to inputs with the readonly attribute, not checkboxes and radio buttons.

![sc](https://github.com/user-attachments/assets/2cfd3a67-f813-4908-9221-7892631938e4)



