### PR TITLE
[Docs Site] Fix styling of OneTrust cookie button

### DIFF
--- a/src/components/OneTrust.astro
+++ b/src/components/OneTrust.astro
@@ -34,8 +34,23 @@
     <a
         role="button"
         id="ot-sdk-btn"
-        class="ot-sdk-show-settings !text-accent-600 !border-accent-600 hover:!bg-gray-800"
+        class="ot-sdk-show-settings"
         >Cookie Settings</a
     >
     <!-- OneTrust Cookies Settings button end -->
 </span>
+
+<style>
+    #ot-sdk-btn.ot-sdk-show-settings {
+        border: none !important;
+        color: inherit !important;
+        font-size: inherit !important;
+        line-height: inherit !important;
+        padding: inherit !important;
+        font-family: var(--sl-font-family) !important;
+    }
+
+    #ot-sdk-btn.ot-sdk-show-settings:hover {
+        background-color: inherit !important;
+    }
+</style>

--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -100,7 +100,8 @@ if (import.meta.env.CF_PAGES_BRANCH === "production" || import.meta.env.GITHUB_R
               </a>
             </li>
           ))}
-          {isProduction && <OneTrust />}
+            {isProduction && <OneTrust />}
+          </li>
         </ul>
       </div>
     </>
@@ -111,12 +112,16 @@ if (import.meta.env.CF_PAGES_BRANCH === "production" || import.meta.env.GITHUB_R
         {links.map(([text, href]) => (
           <a
             href={href}
-            class="mx-2 my-2 text-black dark:text-white decoration-accent-200"
+            class="mx-2 my-2 text-xs text-black dark:text-white decoration-accent-200"
           >
             <span>{text}</span>
           </a>
         ))}
-        {isProduction && <OneTrust />}
+        {isProduction && 
+          <div class="mx-2 my-2 text-xs text-black dark:text-white underline decoration-accent-200">
+            <OneTrust />
+          </div>
+        }
       </div>
     </>
   )


### PR DESCRIPTION
### Summary

Makes the cookie consent button styling in-line with the rest of the footer links.

### Screenshots (optional)

Before:
<img width="671" alt="image" src="https://github.com/user-attachments/assets/b3cc57ed-2d8a-4bb6-9b01-b364a52528c5">
<img width="679" alt="image" src="https://github.com/user-attachments/assets/80083529-d8cd-4f72-a571-89815c6329d4">

After:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/70f280c3-690e-4dfc-b2f8-22ba00e5450d">
<img width="695" alt="image" src="https://github.com/user-attachments/assets/c2819ad7-d21f-4d0e-9727-789d7e0102a2">
