### PR TITLE
[Docs Site] Fix wrong CSS selector

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -5,7 +5,7 @@ select {
 	border-width: 2px;
 }
 
-input:read-only {
+input[readonly] {
 	background-color: var(--sl-color-backdrop-overlay);
 	cursor: not-allowed;
 }


### PR DESCRIPTION
### Summary

Supersedes https://github.com/cloudflare/cloudflare-docs/pull/16121/ due to a CI issue. The checkbox was functional, but the not-allowed cursor was appearing.

### Screenshots (optional)

Before:
![image](https://github.com/user-attachments/assets/062f64eb-4dd4-42fa-98c2-b9c62d662e9c)

After:
<img width="133" alt="image" src="https://github.com/user-attachments/assets/13e54a96-f022-4927-977c-cbd429f8512e">
