### PR TITLE
chore: add 3 Nuxt full-stack examples

### DIFF
--- a/src/content/apps/index.yaml
+++ b/src/content/apps/index.yaml
@@ -291,7 +291,7 @@ entries:
   tags: [Nuxt]
   products: [Pages, R2, Workers AI]
   languages: [TypeScript]
-  cloudflare: true
+  cloudflare: false
   updated: 2024-08-12
 - link: https://github.com/atinux/atidone
   name: Atidone
@@ -299,13 +299,13 @@ entries:
   tags: [Nuxt]
   products: [Pages, D1]
   languages: [TypeScript]
-  cloudflare: true
+  cloudflare: false
   updated: 2024-08-12
 - link: https://github.com/atinux/atinotes
   name: Atinotes
-  description: Store Markdown notes in Cloudflare KV with this full-stack application made with Nuxt & deployed on Cloudflare pages.
+  description: Store Markdown notes in Cloudflare KV with this full-stack application made with Nuxt & deployed on Cloudflare Pages.
   tags: [Nuxt]
   products: [Pages, KV]
   languages: [TypeScript]
-  cloudflare: true
+  cloudflare: false
   updated: 2024-08-12

--- a/src/content/apps/index.yaml
+++ b/src/content/apps/index.yaml
@@ -285,3 +285,27 @@ entries:
   author: gift
   cloudflare: true
   updated: 2024-03-18
+- link: https://github.com/atinux/atidraw
+  name: Atidraw
+  description: A web application made with Nuxt that lets you to create, enhance, and share your drawings with the world. Harnessing the power of Cloudflare R2 and Cloudflare AI to store and enhance your drawings.
+  tags: [Nuxt]
+  products: [Pages, R2, Workers AI]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2024-08-12
+- link: https://github.com/atinux/atidone
+  name: Atidone
+  description: A full-stack application made with Nuxt, Cloudflare D1 and Authentication to store your todos on the web.
+  tags: [Nuxt]
+  products: [Pages, D1]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2024-08-12
+- link: https://github.com/atinux/atinotes
+  name: Atinotes
+  description: Store Markdown notes in Cloudflare KV with this full-stack application made with Nuxt & deployed on Cloudflare pages.
+  tags: [Nuxt]
+  products: [Pages, KV]
+  languages: [TypeScript]
+  cloudflare: true
+  updated: 2024-08-12


### PR DESCRIPTION
### Summary

Added 3 popular open source examples I built with Nuxt & Cloudflare resources.

- https://github.com/atinux/atidone (Pages + D1): 600+ stars
- https://github.com/atinux/atidraw (Pages + R2 + AI): 100+ stars (AI will [soon be released](https://github.com/atinux/atidraw/pull/6))
- https://github.com/atinux/atinotes (Pages + KV): 100+ stars

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
