### PR TITLE
Fix string interpolation in code blocks using Starlight's Code component

### DIFF
--- a/src/content/partials/workers/c3-run-command-with-directory.mdx
+++ b/src/content/partials/workers/c3-run-command-with-directory.mdx
@@ -4,19 +4,16 @@ inputParameters: directoryName
 ---
 
 import { Markdown, TabItem, Tabs } from "~/components"
+import { Code } from "@astrojs/starlight/components"
 
 <Tabs> <TabItem label="npm">
 
-```sh
-$ npm create cloudflare@latest {props.one}
-```
+<Code code={`$ npm create cloudflare@latest ${props.one}`} lang="sh" />
 
 </TabItem>
 
 <TabItem label="yarn">
 
-```sh
-$ yarn create cloudflare@latest {props.one}
-```
+<Code code={`$ yarn create cloudflare@latest ${props.one}`} lang="sh" />
 
 </TabItem> </Tabs>


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

I fixed the issue where string interpolation wasn't working inside code blocks in https://developers.cloudflare.com/workers/get-started/guide/ by using Starlight's [Code](https://starlight.astro.build/guides/components/#code) component.

### Screenshots (optional)

| Before | After |
|--------|--------|
| <img width="749" alt="Screenshot 2024-08-15 at 0 25 55" src="https://github.com/user-attachments/assets/a58349f6-f02c-406c-bcdc-8af491d36577"> | <img width="745" alt="Screenshot 2024-08-15 at 0 26 09" src="https://github.com/user-attachments/assets/35b5a834-3224-4c11-a4b4-0ac1a9d331bf"> |

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
