### PR TITLE
[Docs Site] Add <Markdown> component

### DIFF
--- a/src/components/Markdown.astro
+++ b/src/components/Markdown.astro
@@ -1,7 +1,14 @@
 ---
+import { z } from "astro:content";
 import { marked } from "marked";
 
-const content = await Astro.slots.render("default");
+type Props = z.infer<typeof props>;
+
+const props = z.object({
+  text: z.string(),
+});
+
+const { text } = props.parse(Astro.props);
 ---
 
-<Fragment set:html={marked.parseInline(content)} />
+<Fragment set:html={marked.parseInline(text)} />

--- a/src/content/docs/style-guide/components/markdown.mdx
+++ b/src/content/docs/style-guide/components/markdown.mdx
@@ -1,0 +1,11 @@
+---
+title: Markdown
+---
+
+This component uses `marked` to turn the `text` prop into HTML.
+
+```mdx live
+import { Markdown } from "~/components";
+
+<Markdown text="**foo** <br/> [bar](/style-guide/components/markdown/)" />
+```


### PR DESCRIPTION
### Summary

Adds a `<Markdown>` component to be used in flexible partials.
