### PR TITLE
[Workers] Fix note block on Workers Rust landing page

### DIFF
--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -56,10 +56,10 @@ After you have created your first Worker, run the [`wrangler dev`](/workers/wran
 $ npx wrangler dev
 ```
 
-If you have not used Wrangler before, it will try to open your web browser to login with your Cloudflare account. :::note
+If you have not used Wrangler before, it will try to open your web browser to login with your Cloudflare account.
 
-
-If you have issues with this step or you do not have access to a browser interface, refer to the [`wrangler login`](/workers/wrangler/commands/#login) documentation for more information. 
+:::note
+If you have issues with this step or you do not have access to a browser interface, refer to the [`wrangler login`](/workers/wrangler/commands/#login) documentation for more information.
 :::
 
 Go to [http://localhost:8787](http://localhost:8787) to review your Worker running. Any changes you make to your code will trigger a rebuild, and reloading the page will show you the up-to-date output of your Worker.
@@ -83,7 +83,7 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
 There is some counterintuitive behavior going on here:
 
 1. `workers-rs` provides an `event` macro which expects a handler function signature identical to those seen in JavaScript Workers.
-2. `async` is not generally supported by Wasm, but you are able to use `async` in a `workers-rs` project (refer to [`async`](/workers/languages/rust/#async-wasm-bindgen-futures)). 
+2. `async` is not generally supported by Wasm, but you are able to use `async` in a `workers-rs` project (refer to [`async`](/workers/languages/rust/#async-wasm-bindgen-futures)).
    :::
 
 ### Related runtime APIs


### PR DESCRIPTION
### Summary

Fixes a broken note block on https://developers.cloudflare.com/workers/languages/rust/

### Screenshots (optional)

Before:
![image](https://github.com/user-attachments/assets/7e871591-5745-465a-91c4-8d12fd578d6a)

After:
![image](https://github.com/user-attachments/assets/d1789232-4a96-452a-9ee2-80da1f2e32c1)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.