### PR TITLE
[Chore] Add redirect for sitemap + customize behavior

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { h } from 'hastscript';
 import { readdir } from "fs/promises";
 import icon from "astro-icon";
+import sitemap from '@astrojs/sitemap';
 
 async function autogenSections() {
 	const sections = (
@@ -136,5 +137,13 @@ export default defineConfig({
 		}),
 		liveCode({ layout: "~/components/live-code/Layout.astro" }),
 		icon(),
+    sitemap({
+      serialize(item) {
+        item.changefreq = 'daily';
+        item.lastmod = new Date();
+        item.priority = 0.9;
+        return item;
+      },
+    }),
 	],
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -139,9 +139,7 @@ export default defineConfig({
 		icon(),
     sitemap({
       serialize(item) {
-        item.changefreq = 'daily';
         item.lastmod = new Date();
-        item.priority = 0.9;
         return item;
       },
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astro-community/astro-embed-youtube": "^0.5.2",
         "@astrojs/check": "^0.9.2",
         "@astrojs/rss": "^4.0.7",
+        "@astrojs/sitemap": "^3.1.6",
         "@astrojs/starlight": "^0.25.5",
         "@astrojs/starlight-docsearch": "^0.1.1",
         "@astrojs/starlight-tailwind": "^2.0.3",
@@ -594,6 +595,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.1.6.tgz",
       "integrity": "sha512-1Qp2NvAzVImqA6y+LubKi1DVhve/hXXgFvB0szxiipzh7BvtuKe4oJJ9dXSqaubaTkt4nMa6dv6RCCAYeB6xaQ==",
+      "license": "MIT",
       "dependencies": {
         "sitemap": "^7.1.2",
         "stream-replace-string": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astro-community/astro-embed-youtube": "^0.5.2",
     "@astrojs/check": "^0.9.2",
     "@astrojs/rss": "^4.0.7",
+    "@astrojs/sitemap": "^3.1.6",
     "@astrojs/starlight": "^0.25.5",
     "@astrojs/starlight-docsearch": "^0.1.1",
     "@astrojs/starlight-tailwind": "^2.0.3",

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,7 +3,7 @@
 /zero-trust/ /products/?product-group=Cloudflare+One 301
 /dashboarding-landing/ / 301
 /tutorials/ /search/?content_type%5B0%5D=Tutorial 301
-/sitemap.xml /sitemap-0.xml
+/sitemap.xml /sitemap-index.xml
 
 # 1dot1_redirect
 /1.1.1.1/1.1.1.1-for-families/ /1.1.1.1/setup/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,6 +3,7 @@
 /zero-trust/ /products/?product-group=Cloudflare+One 301
 /dashboarding-landing/ / 301
 /tutorials/ /search/?content_type%5B0%5D=Tutorial 301
+/sitemap.xml /sitemap-0.xml
 
 # 1dot1_redirect
 /1.1.1.1/1.1.1.1-for-families/ /1.1.1.1/setup/ 301


### PR DESCRIPTION
### Summary

Starlight makes the -- to me at least -- somewhat odd decision to host our sitemap at `/sitemap-index.xml`, which then has all our entries at `/sitemap-0.xml`.

Adding a redirect + some config logic around adding `lastMod` to entries within the sitemap.

Tried following the customization instructions at https://docs.astro.build/en/guides/integrations-guide/sitemap/#_top.