### PR TITLE
Update wrangler D1 docs to be consistent with CLI

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -293,7 +293,7 @@ You must provide either `--command` or `--file` for this command to run successf
 * `--command` string optional
   * The SQL query you wish to execute.
 * `--file` string optional
-  * Path to the SQL file you wish to execute.
+  * A .sql file to ingest.
 * `-y, --yes` boolean optional
   * Answer `yes` to any prompts.
 * `--local` boolean(default: true) optional


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Updating wrangler d1 docs to be consistent - the current description of the `--file` flag is misrepresented.  The CLI mentions that this switch is used for files to be **ingested** which may cause confusion as to expected behaviour.

```
npx wrangler@latest d1 execute --help
Need to install the following packages:
wrangler@3.71.0
Ok to proceed? (y) y
wrangler d1 execute <database>

Execute a command or SQL file

POSITIONALS
  database  The name or binding of the DB  [string] [required]

GLOBAL FLAGS
  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
  -c, --config                    Path to .toml configuration file  [string]
  -e, --env                       Environment to use for operations and .env files  [string]
  -h, --help                      Show help  [boolean]
  -v, --version                   Show version number  [boolean]

OPTIONS
  -y, --yes         Answer "yes" to any prompts  [boolean]
      --local       Execute commands/files against a local DB for use with wrangler dev  [boolean]
      --remote      Execute commands/files against a remote DB for use with wrangler dev  [boolean]
      --file        A .sql file to ingest  [string]
      --command     A single SQL statement to execute  [string]
      --persist-to  Specify directory to use for local persistence (for --local)  [string]
      --json        Return output as clean JSON  [boolean] [default: false]
      --preview     Execute commands/files against a preview D1 DB  [boolean] [default: false]
```

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
