### PR TITLE
Use a real dark for the dark accent

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,6 @@
 import starlightPlugin from "@astrojs/starlight-tailwind";
 
-const accent = { 200: "#F6821F", 600: "#F6821F", 900: "#F0F0F0" };
+const accent = { 200: "#230C00", 600: "#F6821F", 900: "#F0F0F0" };
 const gray = {
 	100: "#f6f6f6",
 	200: "#eeeeee",


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Right now, the sidebar has really low contrast compared to either the reference implementation or the old sidebar. This is because the "dark" color is actually white. This sets the dark color to a real dark color. (It was derived from Material algorithms at high contrast levels.)

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

Before:
![image](https://github.com/user-attachments/assets/ec1a7001-245d-477f-af79-8f4e8fae3570)
After:
![image](https://github.com/user-attachments/assets/551a0ac6-1db8-442b-b17b-df709ec21c0c)
(That was a concept image and wasn't actually tested, I'll update this if it gets tested)

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
