### PR TITLE
[Workers] Fix dark mode styling for architecture diagram

### DIFF
--- a/src/components/WorkersArchitectureDiagram.astro
+++ b/src/components/WorkersArchitectureDiagram.astro
@@ -5,6 +5,7 @@
 	width="701px"
 	height="863px"
 	viewBox="-0.5 -0.5 701 863"
+	class="dark:invert"
 	><defs></defs><g
 		><rect
 			x="140"
@@ -1139,11 +1140,3 @@
 			pointer-events="none"></path></g
 	></svg
 >
-
-<!-- TODO: fix dark mode styling -->
-<style>
-	[data-theme="dark"] svg {
-		filter: invert(1);
-		-webkit-filter: invert(1);
-	}
-</style>


### PR DESCRIPTION
### Summary

Closes https://github.com/cloudflare/cloudflare-docs/issues/16159

Re-adds the "invert in dark mode" styling that the previous Hugo site used.

### Screenshots (optional)

Before:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/0bf9bb5b-5575-4b8b-9f7c-821c714d0b58">

After:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/e3f68f7d-eda5-4ffa-b33c-fe74ea829ab1">