### PR TITLE
[Docs Site] Hide "view more terms" when rows do not exceed initial visible amount

### DIFF
--- a/src/components/Glossary.astro
+++ b/src/components/Glossary.astro
@@ -34,9 +34,12 @@ const INITIAL_VISIBLE_ROWS = 20;
 		}
 	</tbody>
 </table>
-<LinkButton id="glossary-button" href="" class="justify-center">
-	View more terms
-</LinkButton>
+
+{ terms.length > INITIAL_VISIBLE_ROWS && 
+	<LinkButton id="glossary-button" href="" class="justify-center">
+		View more terms
+	</LinkButton>
+}
 
 <script>
 	// function filterRows(search: string) {


### PR DESCRIPTION
### Summary

Only render the `LinkButton` when `terms.length` is more than `INITIAL_VISIBLE_ROWS `.

### Screenshots (optional)

Before:
<img width="759" alt="image" src="https://github.com/user-attachments/assets/03242bbb-4306-402e-8d15-7741d90c3ecb">

After:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/7550e4cc-9145-44c0-9c99-9dc398dbc0e1">
