### PR TITLE
[Pages] Use build image v2 tab as first tab

### DIFF
--- a/src/components/PagesBuildEnvironment.astro
+++ b/src/components/PagesBuildEnvironment.astro
@@ -8,7 +8,7 @@ const versions = await getCollection("pages-build-environment");
 
 <Tabs>
 	{
-		versions.map((version) => (
+		versions.reverse().map((version) => (
 			<TabItem label={version.id}>
 				<table>
 					<tbody>

--- a/src/components/PagesBuildEnvironmentLanguages.astro
+++ b/src/components/PagesBuildEnvironmentLanguages.astro
@@ -7,7 +7,7 @@ const versions = await getCollection("pages-build-environment");
 
 <Tabs>
 	{
-		versions.map((version) => (
+		versions.reverse().map((version) => (
 			<TabItem label={version.id}>
 				<table>
 					<thead>

--- a/src/components/PagesBuildEnvironmentTools.astro
+++ b/src/components/PagesBuildEnvironmentTools.astro
@@ -7,7 +7,7 @@ const versions = await getCollection("pages-build-environment");
 
 <Tabs>
 	{
-		versions.map((version) => (
+		versions.reverse().map((version) => (
 			<TabItem label={version.id}>
 				<table>
 					<thead>


### PR DESCRIPTION
### Summary

Makes the `v2` tabs the first tab.

### Screenshots (optional)

Before:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/aa03772a-e052-429a-9465-1b17df42593b">

After:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/f5a489bc-3fe3-4aa4-b291-c29f3da2687f">
