### PR TITLE
[Docs Site] Fix breadcrumbs path logic

### DIFF
--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -62,7 +62,7 @@ for (let i = 0; i < segments.length; i++) {
 
   breadcrumbProps.crumbs.push({
     text: title,
-    href: `/${segments.join("/")}/`,
+    href: `/${path}/`,
   });
 }
 ---


### PR DESCRIPTION
### Summary

Was accidentally joining all segments rather than the current slice.