### PR TITLE
[ZT] Remove redundant beta

### DIFF
--- a/src/content/docs/cloudflare-one/insights/dex/notifications.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/notifications.mdx
@@ -3,9 +3,6 @@ pcx_content_type: reference
 title: Notifications
 sidebar:
   order: 3
-  badge:
-    variant: caution
-    text: Beta
 head:
   - tag: title
     content: DEX notifications


### PR DESCRIPTION
DEX section already has a beta tag on the Overview page. This PR removes the beta tag from a child page.