### PR TITLE
[Docs Site] Dont wrap text in tables

### DIFF
--- a/src/table.css
+++ b/src/table.css
@@ -1,3 +1,3 @@
-table * code {
-	overflow-wrap: normal;
+table * {
+	text-wrap: nowrap;
 }


### PR DESCRIPTION
### Summary

Stops text from wrapping in tables.

### Screenshots (optional)

Before:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/9dcc3252-d475-48ce-b288-c0a7fa541592">

After:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/442a38e5-b14b-47a9-b777-af4a3b273f56">