### PR TITLE
docs: set `init` command as deprecated

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -13,7 +13,7 @@ import { TabItem, Tabs } from "~/components"
 Wrangler offers a number of commands to manage your Cloudflare Workers.
 
 * [`docs`](#docs) - Open this page in your default browser.
-* [`init`](#init) - Create a new project from a variety of web frameworks and templates. _**DEPRECATED**_
+* [`init`](#init) - Create a new project from a variety of web frameworks and templates. (Deprecated — use `npm create cloudflare@latest` instead)
 * [`generate`](#generate) - Create a Wrangler project using an existing [Workers template](https://github.com/cloudflare/worker-template).
 * [`d1`](#d1) - Interact with D1.
 * [`vectorize`](#vectorize) - Interact with Vectorize indexes.

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -13,7 +13,7 @@ import { TabItem, Tabs } from "~/components"
 Wrangler offers a number of commands to manage your Cloudflare Workers.
 
 * [`docs`](#docs) - Open this page in your default browser.
-* [`init`](#init) - Create a new project from a variety of web frameworks and templates.
+* [`init`](#init) - Create a new project from a variety of web frameworks and templates. _**DEPRECATED**_
 * [`generate`](#generate) - Create a Wrangler project using an existing [Workers template](https://github.com/cloudflare/worker-template).
 * [`d1`](#d1) - Interact with D1.
 * [`vectorize`](#vectorize) - Interact with Vectorize indexes.


### PR DESCRIPTION
### Summary

According to the CLI application, the init command is deprecated. I added this change to the document.

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/4a3f2cb0-de8d-4768-b110-ee9e72443f29)

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
