### PR TITLE
[Support] Adding note and link to Cloud Connect on S3 config guide

### DIFF
--- a/src/content/docs/support/third-party-software/others/configuring-an-amazon-web-services-static-site-to-use-cloudflare.mdx
+++ b/src/content/docs/support/third-party-software/others/configuring-an-amazon-web-services-static-site-to-use-cloudflare.mdx
@@ -98,6 +98,12 @@ your content displays.
 
 ## Set up your site on Cloudflare
 
+:::note
+
+Consider creating a [Cloud Connector](https://developers.cloudflare.com/rules/cloud-connector/) rule for this step to automatically set all the Cloudflare settings required to route traffic to your bucket.
+
+:::
+
 Before setting up your site on Cloudflare, ensure you have the URLs or endpoints for both your subdomain and root buckets. For each bucket, you can find the URL in the AWS S3 console under **Properties** > **Static website hosting** > **Endpoint**.
 
 To get started:

--- a/src/content/docs/support/third-party-software/others/configuring-an-amazon-web-services-static-site-to-use-cloudflare.mdx
+++ b/src/content/docs/support/third-party-software/others/configuring-an-amazon-web-services-static-site-to-use-cloudflare.mdx
@@ -100,7 +100,7 @@ your content displays.
 
 :::note
 
-Consider creating a [Cloud Connector](https://developers.cloudflare.com/rules/cloud-connector/) rule for this step to automatically set all the Cloudflare settings required to route traffic to your bucket.
+Consider creating a [Cloud Connector](/rules/cloud-connector/) rule for this step to automatically set all the Cloudflare settings required to route traffic to your bucket.
 
 :::
 


### PR DESCRIPTION
### Summary

Adding note to existing S3 config guide to reference Cloud Connector as a way to set up the required Cloudflare settings.

### Screenshots (optional)

<img width="986" alt="Screenshot 2024-08-16 at 16 20 16" src="https://github.com/user-attachments/assets/d39a3b78-8fb9-49c4-80d7-3897eb3d7528">

