### PR TITLE
docs: Migrate Preact docs from `wmr` to `create-preact`

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
@@ -9,7 +9,7 @@ import { Render } from "~/components"
 [Preact](https://preactjs.com) is a popular, open-source framework for building modern web applications. Preact can also be used as a lightweight alternative to React because the two share the same API and component model.
 
 In this guide, you will create a new Preact application and deploy it using Cloudflare Pages.
-You will use [`create-preact`](https://github.com/preactjs/create-preact), a lightweight project scaffolding tool to set up a new Preact app in seconds.
+You will use [`create-preact`](https://github.com/preactjs/create-preact), a lightweight project scaffolding tool, to set up a new Preact app in seconds.
 
 ## Setting up a new project
 

--- a/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
@@ -9,16 +9,24 @@ import { Render } from "~/components"
 [Preact](https://preactjs.com) is a popular, open-source framework for building modern web applications. Preact can also be used as a lightweight alternative to React because the two share the same API and component model.
 
 In this guide, you will create a new Preact application and deploy it using Cloudflare Pages.
-You will use [`wmr`](https://github.com/preactjs/wmr), an all-in-one development tool built by the Preact team, to quickly generate an optimized web application.
+You will use [`create-preact`](https://github.com/preactjs/create-preact), a lightweight project scaffolding tool to set up a new Preact app in seconds.
 
 ## Setting up a new project
 
 Create a new project by running the [`npm init`](https://docs.npmjs.com/cli/v6/commands/npm-init) command in your terminal, giving it a title:
 
 ```sh
-$ npm init wmr your-project-name
+$ npm init preact
 $ cd your-project-name
 ```
+
+:::note
+
+
+**Note:** During initialization, you will notice a "Prerender app (SSG)?" option presented. With this, `create-preact` will scaffold your app to produce static HTML pages - along with their assets - for production builds, which is perfect for Pages. 
+
+
+:::
 
 <Render file="tutorials-before-you-start" />
 
@@ -50,14 +58,6 @@ Optionally, you can customize the **Project name** field. It defaults to the Git
 After completing configuration, select **Save and Deploy**.
 
 You will see your first deploy pipeline in progress. Pages installs all dependencies and builds the project as specified.
-
-:::note
-
-
-**Note:** You will notice that within the `package.json` file, the `"build"` script uses the `--prerender` flag. With this, `wmr` produces static HTML pages – along with their assets – which is perfect for Pages.
-
-
-:::
 
 After you have deployed your site, you will receive a unique subdomain for your project on `*.pages.dev`.
 


### PR DESCRIPTION
### Summary

[`wmr` is unfortunately no longer maintained](https://github.com/preactjs/wmr?tab=readme-ov-file#wmr). It was largely extracted into Vite and it's what we (the Preact team) recommend using in its place, [via `create-preact`](https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app).

Prerendering is still functionality that's available to users, but requires a bit more work to setup than just a flag, so I moved the note on prerendering up a bit as it's an option users can enable when initializing a project. If that's what a user wants, easier to have us set it up for them than reading [the docs](https://github.com/preactjs/preset-vite?tab=readme-ov-file#prerendering-configuration) to figure out which bits they need.

### Screenshots (optional)

N/A

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
