### PR TITLE
Clarifies that Python packages cannot run in prod

### DIFF
--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -20,7 +20,7 @@ Cloudflare Workers provides first-class support for Python, including support fo
 * A robust [foreign function interface (FFI)](/workers/languages/python/ffi) that lets you use JavaScript objects and functions directly from Python — including all [Runtime APIs](/workers/runtime-apis/)
 * [Built-in packages](/workers/languages/python/packages), including [FastAPI](https://fastapi.tiangolo.com/), [Langchain](https://pypi.org/project/langchain/), [httpx](https://www.python-httpx.org/) and more.
 
-:::note[Python Workers are in beta. Packages do not run in production.]
+:::caution[Python Workers are in beta. Packages do not run in production.]
 
 Currently, you can only deploy Python Workers that use the standard library. [Packages](/workers/languages/python/packages/#supported-packages) **cannot be deployed** and will only work in local development for the time being.
 

--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -20,9 +20,9 @@ Cloudflare Workers provides first-class support for Python, including support fo
 * A robust [foreign function interface (FFI)](/workers/languages/python/ffi) that lets you use JavaScript objects and functions directly from Python — including all [Runtime APIs](/workers/runtime-apis/)
 * [Built-in packages](/workers/languages/python/packages), including [FastAPI](https://fastapi.tiangolo.com/), [Langchain](https://pypi.org/project/langchain/), [httpx](https://www.python-httpx.org/) and more.
 
-:::note[Python Workers are in open beta.]
+:::note[Python Workers are in beta. Packages do not run in production.]
 
-You can currently only use the [built-in packages](/workers/languages/python/packages) in local development. Support for deploying packages with a `requirements.txt` file is coming soon.
+Currently, you can only deploy Python Workers that use the standard library. [Packages](/workers/languages/python/packages/#supported-packages) **cannot be deployed** and will only work in local development for the time being.
 
 You must add the `python_workers` compatibility flag to your Worker, while Python Workers are in open beta.
 

--- a/src/content/partials/workers/python-workers-beta-packages.mdx
+++ b/src/content/partials/workers/python-workers-beta-packages.mdx
@@ -3,7 +3,7 @@
 
 ---
 
-:::note[Python Workers are in open beta.]
+:::note[Python Workers are in beta. Packages do not run in production.]
 
-You can currently only use [built-in packages](/workers/languages/python/packages/#supported-packages) in local development. Support for deploying packages with a `requirements.txt` file is coming soon. 
+Currently, you can only deploy Python Workers that use the standard library. [Packages](/workers/languages/python/packages/#supported-packages) **cannot be deployed** and will only work in local development for the time being.
 :::

--- a/src/content/partials/workers/python-workers-beta-packages.mdx
+++ b/src/content/partials/workers/python-workers-beta-packages.mdx
@@ -3,7 +3,7 @@
 
 ---
 
-:::note[Python Workers are in beta. Packages do not run in production.]
+:::caution[Python Workers are in beta. Packages do not run in production.]
 
 Currently, you can only deploy Python Workers that use the standard library. [Packages](/workers/languages/python/packages/#supported-packages) **cannot be deployed** and will only work in local development for the time being.
 :::


### PR DESCRIPTION
### Summary

Rewords python package message for clarity.

A user mentioned that the status of packages was unclear (https://github.com/cloudflare/python-workers-examples/issues/11) - this should make it more clear.

<img width="1438" alt="Screenshot 2024-08-16 at 2 54 14 PM" src="https://github.com/user-attachments/assets/b5623302-2a50-4929-bc68-9798e3b9bfcb">
<img width="1418" alt="Screenshot 2024-08-16 at 2 54 34 PM" src="https://github.com/user-attachments/assets/9f61661e-1c9e-40d3-a970-583b372ad6cb">
