### PR TITLE
Simplify Workers for platforms callout in limits docs

### DIFF
--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -23,7 +23,7 @@ import { Render } from "~/components"
 | [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500                                                                                                                                                                                                                                                                |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250                                                                                                                                                                                                                                                                |
 
-<sup>1</sup> If you are running into Workers script limits, your project may be a good fit for [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
+<sup>1</sup> If you are running into limits, your project may be a good fit for [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
 
 <Render file="limits_increase" />
 


### PR DESCRIPTION
"Workers", not "Scripts"