### PR TITLE
Update deploy-a-vitepress-site.mdx

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
@@ -83,8 +83,8 @@ Finally create a `.gitignore` file with the following content:
 
 ```
 node_modules
-cache
-dist 
+.vitepress/cache
+.vitepress/dist
 ```
 
 This step makes sure that unnecessary files are not going to be included in the project's git repository (which we will set up next).

--- a/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
@@ -83,7 +83,8 @@ Finally create a `.gitignore` file with the following content:
 
 ```
 node_modules
-.vitepress
+cache
+dist 
 ```
 
 This step makes sure that unnecessary files are not going to be included in the project's git repository (which we will set up next).


### PR DESCRIPTION
In the original document, it is mentioned that `.vitepress` is added to the `.gitignore` file, which makes the entire `.vitepress` directory ignored and not uploaded to `github`.

However, the configuration file of `vitepress` is in this directory. Without the configuration file, the website built by `Cloudflare Pages` will not be able to correctly identify the route, and accessing the deployed website will only display a 404 page.

To ensure that the configuration file of `vitepress` is uploaded to `github` and other directories generated by local builds are ignored, just delete `.vitepress` from the `.gitignore` file and add `dist` and `cache`.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
