### PR TITLE
[Docs Site] Fix Markdown in FeatureTable titles, relax table wrapping behaviour

### DIFF
--- a/src/components/FeatureTable.astro
+++ b/src/components/FeatureTable.astro
@@ -30,11 +30,15 @@ const markdown = (content: any) => {
 <table>
 	<thead>
 		<tr>
-			<td></td>
-			<td>Free</td>
-			<td>Pro</td>
-			<td>Business</td>
-			<td>Enterprise</td>
+			<th></th>
+			<th>Free</th>
+			<th>Pro</th>
+			<th>Business</th>
+			<th>Enterprise</th>
+			{
+				plan.ent_plus &&
+				<th>{plan.ent_plus}</th>
+			}
 		</tr>
 	</thead>
 	<tbody>
@@ -61,11 +65,15 @@ const markdown = (content: any) => {
 
 				return (
 					<tr>
-						<td set:html={renderTitle(v.title)} />
+						<th set:html={renderTitle(v.title)} />
 						<td set:html={markdown(v.free)} />
 						<td set:html={markdown(v.pro)} />
 						<td set:html={markdown(v.biz)} />
 						<td set:html={markdown(v.ent)} />
+						{
+							plan.ent_plus &&
+							<td set:html={markdown(v.ent_plus)} />
+						}
 					</tr>
 				);
 			})

--- a/src/components/FeatureTable.astro
+++ b/src/components/FeatureTable.astro
@@ -19,6 +19,12 @@ const plan = await indexPlans(id);
 
 // @ts-ignore types not implemented for plans JSON
 const properties = plan.properties;
+
+const markdown = (content: any) => {
+	if (typeof content !== "string") return content;
+
+	return marked.parse(content);
+};
 ---
 
 <table>
@@ -50,17 +56,12 @@ const properties = plan.properties;
           );
         }
 
-        return title;
-      };
-
-	  const markdown = (content) => {
-        if (typeof content !== "string") return content;
-        return marked.parse(content);
+        return markdown(title);
       };
 
 				return (
 					<tr>
-						<td>{renderTitle(v.title)}</td>
+						<td set:html={renderTitle(v.title)} />
 						<td set:html={markdown(v.free)} />
 						<td set:html={markdown(v.pro)} />
 						<td set:html={markdown(v.biz)} />

--- a/src/table.css
+++ b/src/table.css
@@ -1,3 +1,6 @@
+/*
+	Override the default `overflow-wrap: anywhere` when inside a table.
+*/
 table * {
-	text-wrap: nowrap;
+	overflow-wrap: normal;
 }


### PR DESCRIPTION
### Summary

Fixes Markdown in titles (i.e links and line breaks), relaxes wrapping behaviour (allow wrapping but only at natural breaks like spaces).