### PR TITLE
Update Sippy docs for GA

### DIFF
--- a/src/content/docs/r2/data-migration/sippy.mdx
+++ b/src/content/docs/r2/data-migration/sippy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sippy (beta)
+title: Sippy
 pcx_content_type: how-to
 learning_center:
   title: What is data migration?
@@ -11,14 +11,6 @@ sidebar:
 import { Render } from "~/components";
 
 Sippy is a data migration service that allows you to copy data from other cloud providers to R2 as the data is requested, without paying unnecessary cloud egress fees typically associated with moving large amounts of data.
-
-:::note[Open Beta]
-
-This feature is currently in beta. We do not recommend using Sippy for production traffic while in beta.
-
-To report bugs or request features, reach out to us on the [Cloudflare Developer Discord](https://discord.cloudflare.com) in the #r2-storage channel or fill out our [feedback form](https://forms.gle/7WuCsbu5LmWkQVu76).
-
-:::
 
 Migration-specific egress fees are reduced by leveraging requests within the flow of your application where you would already be paying egress fees to simultaneously copy objects to R2.
 
@@ -81,6 +73,48 @@ For information on required parameters and examples of how to enable Sippy, refe
 If your bucket is setup with [jurisdictional restrictions](/r2/reference/data-location/#jurisdictional-restrictions), you will need to pass a `cf-r2-jurisdiction` request header with that jurisdiction. For example, `cf-r2-jurisdiction: eu`.
 
 :::
+
+### View migration metrics
+
+When enabled, Sippy exposes metrics that help you understand the progress of your ongoing migrations.
+
+<table>
+	<tbody>
+		<th colspan="5" rowspan="1" style="width:220px">
+			Metric
+		</th>
+		<th colspan="5" rowspan="1">
+			Description
+		</th>
+		<tr>
+			<td colspan="5" rowspan="1">
+				Requests served by Sippy
+			</td>
+			<td colspan="5" rowspan="1">
+				The percentage of overall requests served by R2 over a period of time.{" "}
+				<br />A higher percentage indicates that fewer requests need to be made
+				to the source bucket.
+			</td>
+		</tr>
+		<tr>
+			<td colspan="5" rowspan="1">
+				Data migrated by Sippy
+			</td>
+			<td colspan="5" rowspan="1">
+				The amount of data that has been copied from the source bucket to R2
+				over a period of time. Reported in bytes.
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+To view current and historical metrics:
+
+2. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
+3. Go to the [R2 tab](https://dash.cloudflare.com/?to=/:account/r2) and select your bucket.
+4. Select the **Metrics** tab.
+
+You can optionally select a time window to query. This defaults to the last 24 hours.
 
 ## Disable Sippy on your R2 bucket
 

--- a/src/content/docs/r2/platform/metrics-analytics.mdx
+++ b/src/content/docs/r2/platform/metrics-analytics.mdx
@@ -43,17 +43,17 @@ Metrics can be queried (and are retained) for the past 31 days. These datasets r
 
 ## View via the dashboard
 
-Per-database analytics for R2 are available in the Cloudflare dashboard. To view current and historical metrics for a database:
+Per-bucket analytics for R2 are available in the Cloudflare dashboard. To view current and historical metrics for a bucket:
 
 2. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
-3. Go to the [R2 tab](https://dash.cloudflare.com/?to=/:account/workers/r2) and select your bucket.
+3. Go to the [R2 tab](https://dash.cloudflare.com/?to=/:account/r2) and select your bucket.
 4. Select the **Metrics** tab.
 
 You can optionally select a time window to query. This defaults to the last 24 hours.
 
 ## Query via the GraphQL API
 
-You can programmatically query analytics for your R2 databases via the [GraphQL Analytics API](/analytics/graphql-api/). This API queries the same dataset as the Cloudflare dashboard, and supports GraphQL [introspection](/analytics/graphql-api/features/discovery/introspection/).
+You can programmatically query analytics for your R2 buckets via the [GraphQL Analytics API](/analytics/graphql-api/). This API queries the same dataset as the Cloudflare dashboard, and supports GraphQL [introspection](/analytics/graphql-api/features/discovery/introspection/).
 
 ## Examples
 
@@ -70,7 +70,7 @@ query {
 				filter: {
 					datetime_geq: $startDate
 					datetime_leq: $endDate
-					bucketName: $bucketName 
+					bucketName: $bucketName
 				}
 			) {
 				sum {
@@ -78,7 +78,7 @@ query {
 				}
 				dimensions {
 					actionType
-				} 
+				}
 			}
 		}
 	}
@@ -100,7 +100,7 @@ query {
 				filter: {
 					datetime_geq: $startDate
 					datetime_leq: $endDate
-					bucketName: $bucketName 
+					bucketName: $bucketName
 				}
 				orderBy: [datetime_DESC]
 			) {
@@ -112,7 +112,7 @@ query {
 				}
 				dimensions {
 					datetime
-				} 
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Removed the beta label for Sippy as it's now GA. 
Fixed typos on R2 metrics and analytics page.
