### PR TITLE
[Docs Site] Add output code blocks

### DIFF
--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -106,6 +106,16 @@ function outputCodeblocks() {
 						border-top-width: 0 !important;
 						background: var(--sl-color-gray-6) !important;
 					}
+
+					.code-output > pre > code {
+						user-select: none;
+						transition: opacity 0.5s ease;
+					}
+
+					.code-output > pre > code:hover {
+						cursor: default;
+						opacity: 0.5;
+					}
 				`);
 			},
 		},

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -82,8 +82,38 @@ function workersPlaygroundButton() {
 	});
 }
 
+function outputCodeblocks() {
+	return definePlugin({
+		name: "Adds the '.code-output' class if 'output' is passed on the opening codefence.",
+		hooks: {
+			preprocessMetadata: async (context) => {
+				if (!context.codeBlock.meta.includes("output")) return;
+				context.codeBlock.props.frame = "none";
+			},
+			postprocessRenderedBlock: async (context) => {
+				if (!context.codeBlock.meta.includes("output")) return;
+				context.renderData.blockAst.properties.className.push("code-output");
+				context.addStyles(`
+					div.expressive-code:has(figure.code-output) {
+						margin-top: 0 !important;
+					}
+
+					.code-output .copy {
+						display: none !important;
+					}
+
+					.code-output > pre {
+						border-top-width: 0 !important;
+						background: var(--sl-color-gray-6) !important;
+					}
+				`);
+			},
+		},
+	});
+}
+
 export default {
-	plugins: [workersPlaygroundButton()],
+	plugins: [workersPlaygroundButton(), outputCodeblocks()],
 	themes: [darkTheme, lightTheme],
 	styleOverrides: {
 		textMarkers: {

--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -53,11 +53,15 @@ index_name = "tutorial-index"
 
 ````mdx
 ```sh
-echo "foo"
+npx wrangler vectorize create tutorial-index --dimensions=3 --metric=cosine
 ```
 
 ```sh output
-foo
+✅ Successfully created index 'tutorial-index'
+
+[[vectorize]]
+binding = "VECTORIZE_INDEX" # available in your Worker on env.VECTORIZE_INDEX
+index_name = "tutorial-index"
 ```
 ````
 

--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -35,6 +35,32 @@ function demo() {
 ```
 ````
 
+## Output
+
+If you would like to include the output of your code block, create a second code block below and add the `output` property to the opening code fence.
+
+```sh
+npx wrangler vectorize create tutorial-index --dimensions=3 --metric=cosine
+```
+
+```sh output
+✅ Successfully created index 'tutorial-index'
+
+[[vectorize]]
+binding = "VECTORIZE_INDEX" # available in your Worker on env.VECTORIZE_INDEX
+index_name = "tutorial-index"
+```
+
+````mdx
+```sh
+echo "foo"
+```
+
+```sh output
+foo
+```
+````
+
 ## Playground
 
 If you add the `playground` option to the opening code fence for a Worker example, it will


### PR DESCRIPTION
### Summary

Adds "output" code blocks that have no frame or top margin, are unselectable and fade on hover.

### Screenshots (optional)

<img width="739" alt="image" src="https://github.com/user-attachments/assets/090b9f29-e3b6-4d58-9928-01e357befad2">