### PR TITLE
[Docs Site] Add area support to ProductChangelog, add ToCs

### DIFF
--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -29,12 +29,21 @@ const name = page.data.changelog_product_area_name ?? page.data.changelog_file_n
 let changelogs;
 
 if (page.data.changelog_product_area_name) {
-	({ changelogs } = await getChangelogs((entry) => { return entry.data.productArea === name}));
+	const opts = {
+		filter: (entry) => { return entry.data.productArea === name}
+	};
+	({ changelogs } = await getChangelogs(opts));
 } else {
 	if (name === "wrangler") {
-		changelogs = await getWranglerChangelog();
+		const opts = {
+			wranglerOnly: true
+		};
+		({ changelogs } = await getChangelogs(opts));
 	} else {
-		({ changelogs } = await getChangelogs((entry) => { return entry.id === name}));
+		const opts = {
+			filter: (entry) => { return entry.id === name }
+		};
+		({ changelogs } = await getChangelogs(opts));
 	}
 }
 
@@ -43,8 +52,6 @@ if (!changelogs) {
 		`[ProductChangelog] Failed to find changelog called ${name}.`,
 	);
 }
-
-console.log(changelogs)
 ---
 
 {

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -1,9 +1,8 @@
 ---
-import { getEntry } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 import { marked } from "marked";
-import { getWranglerChangelog } from "~/util/changelogs";
-import { slug } from "github-slugger";
-import { AnchorHeading, Details } from "~/components";
+import { getChangelogs, getWranglerChangelog } from "~/util/changelogs";
+import { AnchorHeading } from "~/components";
 
 const page = await getEntry("docs", Astro.params.slug!);
 
@@ -13,45 +12,52 @@ if (!page) {
 	);
 }
 
-if (!page.data.changelog_file_name) {
+if (!page.data.changelog_file_name && !page.data.changelog_product_area_name) {
 	throw new Error(
-		`[ProductChangelog] ${Astro.params.slug} does not have a 'changelog_file_name' frontmatter property.`,
+		`[ProductChangelog] ${Astro.params.slug} does not have a 'changelog_file_name' or 'changaelog_product_area_name' frontmatter property.`,
 	);
 }
 
-if (page.data.changelog_file_name.length > 1) {
+if (page.data.changelog_file_name && page.data.changelog_file_name.length > 1) {
 	throw new Error(
 		`[ProductChangelog] This component cannot be used on files that have more than 1 entry in their 'changelog_file_name' frontmatter property.`,
 	);
 }
 
-const name = page.data.changelog_file_name[0];
+const name = page.data.changelog_product_area_name ?? page.data.changelog_file_name[0];
 
-let changelog;
+let changelogs;
 
-if (name === "wrangler") {
-	changelog = await getWranglerChangelog();
+if (page.data.changelog_product_area_name) {
+	({ changelogs } = await getChangelogs((entry) => { return entry.data.productArea === name}));
 } else {
-	changelog = await getEntry("changelogs", name);
+	if (name === "wrangler") {
+		changelogs = await getWranglerChangelog();
+	} else {
+		({ changelogs } = await getChangelogs((entry) => { return entry.id === name}));
+	}
 }
 
-if (!changelog) {
+if (!changelogs) {
 	throw new Error(
 		`[ProductChangelog] Failed to find changelog called ${name}.`,
 	);
 }
 
-const entries = changelog.data.entries.sort(
-	(a, b) => new Date(b.publish_date) - new Date(a.publish_date),
-);
+console.log(changelogs)
 ---
 
 {
-	entries.map((entry) => (
+	changelogs.map(([date, entries]) => (
 		<>
-      <AnchorHeading depth={2} title={entry.publish_date} />
-			{entry.title && <AnchorHeading depth={3} title={entry.title} />}
-			<Fragment set:html={marked.parse(entry.description)} />
+      		<AnchorHeading depth={2} title={date} />
+			{ entries.map((entry) => (
+				<>
+				{ page.data.changelog_product_area_name && <h3 class="!mt-4"><a href={entry.productLink}>{entry.product}</a></h3>}
+				{entry.title && <strong>{entry.title}</strong>}
+				<Fragment set:html={marked.parse(entry.description)} />
+				</>
+			))}
 		</>
 	))
 }

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -27,12 +27,13 @@ if (page.data.changelog_file_name && page.data.changelog_file_name.length > 1) {
 const name = page.data.changelog_product_area_name ?? page.data.changelog_file_name[0];
 
 let changelogs;
+let products;
 
 if (page.data.changelog_product_area_name) {
 	const opts = {
 		filter: (entry) => { return entry.data.productArea === name}
 	};
-	({ changelogs } = await getChangelogs(opts));
+	({ changelogs, products } = await getChangelogs(opts));
 } else {
 	if (name === "wrangler") {
 		const opts = {
@@ -55,16 +56,68 @@ if (!changelogs) {
 ---
 
 {
+	products &&
+	<>
+		<label for="products">Product: </label>
+		<select name="products" id="products">
+			<option value="all">Select...</option>
+			{products.map((product) => <option value={product.toLowerCase()}>{product}</option>)}
+		</select>
+	</>
+}
+{
 	changelogs.map(([date, entries]) => (
-		<>
+		<div data-date={date}>
       		<AnchorHeading depth={2} title={date} />
 			{ entries.map((entry) => (
-				<>
+				<div data-product={entry.product.toLowerCase()}>
 				{ page.data.changelog_product_area_name && <h3 class="!mt-4"><a href={entry.productLink}>{entry.product}</a></h3>}
 				{entry.title && <strong>{entry.title}</strong>}
 				<Fragment set:html={marked.parse(entry.description)} />
-				</>
+				</div>
 			))}
-		</>
+		</div>
 	))
 }
+
+<script>
+	const productFilter = document.querySelector<HTMLSelectElement>("#products");
+	productFilter?.addEventListener("change", filterEntries);
+
+	function filterEntries() {
+		const dates = document.querySelectorAll<HTMLElement>("[data-date]");
+
+		for (const date of dates) {
+			const entries = date.querySelectorAll<HTMLElement>("[data-product]");
+
+			if (productFilter?.value === "all") {
+				dates.forEach((x) => {
+					x.style.display = "";
+				});
+				entries.forEach((x) => {
+					x.style.display = "";
+				});
+				continue;
+			}
+
+			let entriesHidden = 0;
+
+			for (const entry of entries) {
+				const product = entry.dataset.product;
+
+				if (productFilter?.value === product) {
+					entry.style.display = "";
+					date.style.display = "";
+				} else {
+					entry.style.display = "none";
+					entriesHidden++;
+					
+				}
+			}
+
+			if (entriesHidden >= entries.length) {
+				date.style.display = "none";
+			}
+		}
+	}
+</script>

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -1,7 +1,7 @@
 ---
-import { getCollection, getEntry } from "astro:content";
+import { getEntry } from "astro:content";
 import { marked } from "marked";
-import { getChangelogs, getWranglerChangelog } from "~/util/changelogs";
+import { getChangelogs } from "~/util/changelogs";
 import { AnchorHeading } from "~/components";
 
 const page = await getEntry("docs", Astro.params.slug!);
@@ -27,13 +27,12 @@ if (page.data.changelog_file_name && page.data.changelog_file_name.length > 1) {
 const name = page.data.changelog_product_area_name ?? page.data.changelog_file_name[0];
 
 let changelogs;
-let products;
 
 if (page.data.changelog_product_area_name) {
 	const opts = {
 		filter: (entry) => { return entry.data.productArea === name}
 	};
-	({ changelogs, products } = await getChangelogs(opts));
+	({ changelogs } = await getChangelogs(opts));
 } else {
 	if (name === "wrangler") {
 		const opts = {
@@ -56,16 +55,6 @@ if (!changelogs) {
 ---
 
 {
-	products &&
-	<>
-		<label for="products">Product: </label>
-		<select name="products" id="products">
-			<option value="all">Select...</option>
-			{products.map((product) => <option value={product.toLowerCase()}>{product}</option>)}
-		</select>
-	</>
-}
-{
 	changelogs.map(([date, entries]) => (
 		<div data-date={date}>
       		<AnchorHeading depth={2} title={date} />
@@ -79,45 +68,3 @@ if (!changelogs) {
 		</div>
 	))
 }
-
-<script>
-	const productFilter = document.querySelector<HTMLSelectElement>("#products");
-	productFilter?.addEventListener("change", filterEntries);
-
-	function filterEntries() {
-		const dates = document.querySelectorAll<HTMLElement>("[data-date]");
-
-		for (const date of dates) {
-			const entries = date.querySelectorAll<HTMLElement>("[data-product]");
-
-			if (productFilter?.value === "all") {
-				dates.forEach((x) => {
-					x.style.display = "";
-				});
-				entries.forEach((x) => {
-					x.style.display = "";
-				});
-				continue;
-			}
-
-			let entriesHidden = 0;
-
-			for (const entry of entries) {
-				const product = entry.dataset.product;
-
-				if (productFilter?.value === product) {
-					entry.style.display = "";
-					date.style.display = "";
-				} else {
-					entry.style.display = "none";
-					entriesHidden++;
-					
-				}
-			}
-
-			if (entriesHidden >= entries.length) {
-				date.style.display = "none";
-			}
-		}
-	}
-</script>

--- a/src/components/overrides/PageSidebar.astro
+++ b/src/components/overrides/PageSidebar.astro
@@ -2,6 +2,8 @@
 import type { Props } from "@astrojs/starlight/props";
 import Default from "@astrojs/starlight/components/PageSidebar.astro";
 import { slug } from "github-slugger"
+import { getChangelogs } from "~/util/changelogs";
+
 if (Astro.props.slug === "workers-ai/models") {
     const headings = [
         "Automatic Speech Recognition",
@@ -23,6 +25,38 @@ if (Astro.props.slug === "workers-ai/models") {
             depth: 2,
             children: []
         })
+    }
+}
+
+if (Astro.props.entry.data.changelog_file_name || Astro.props.entry.data.changelog_product_area_name) {
+    if (Astro.props.entry.data.changelog_product_area_name) {
+        const name = Astro.props.entry.data.changelog_product_area_name;
+        const { changelogs } = await getChangelogs((entry) => { return entry.data.productArea === name});
+
+        const headings = Object.keys(Object.fromEntries(changelogs));
+
+        for (const heading of headings) {
+            Astro.props.toc?.items.push({
+                text: heading,
+                slug: slug(heading),
+                depth: 2,
+                children: []
+            })
+        }
+    } else if (Astro.props.entry.data.changelog_file_name.length === 1) {
+        const name = Astro.props.entry.data.changelog_file_name[0];
+        const { changelogs } = await getChangelogs((entry) => { return entry.id === name});
+
+        const headings = Object.keys(Object.fromEntries(changelogs));
+
+        for (const heading of headings) {
+            Astro.props.toc?.items.push({
+                text: heading,
+                slug: slug(heading),
+                depth: 2,
+                children: []
+            })
+        }
     }
 }
 

--- a/src/content/docs/cloudflare-one/changelog/index.mdx
+++ b/src/content/docs/cloudflare-one/changelog/index.mdx
@@ -10,4 +10,8 @@ description: Review recent changes to Cloudflare One.
 
 ---
 
+import { ProductChangelog } from "~/components"
+
 {/* <!-- All changelog entries live in associated src/content/changelogs/{productName}.yaml. For more details, refer to https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/#yaml-file --> */}
+
+<ProductChangelog />

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -63,10 +63,10 @@ const { products, productAreas, changelogs } = await getChangelogs();
 			const entries = date.querySelectorAll<HTMLElement>("[data-product]");
 
 			if (productAreaFilter.value === "all" && productFilter.value === "all") {
-				dates.forEach((x) => () => {
+				dates.forEach((x) => {
 					x.style.display = "";
 				});
-				entries.forEach((x) => () => {
+				entries.forEach((x) => {
 					x.style.display = "";
 				});
 				continue;

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -1,8 +1,8 @@
 import { getCollection, z } from "astro:content";
 import { type CollectionEntry } from "astro:content";
 
-export async function getChangelogs() {
-	const changelogs = await getCollection("changelogs");
+export async function getChangelogs(filter?: Function) {
+	const changelogs = await getCollection("changelogs", filter);
 
 	const products = [...new Set(changelogs.flatMap((x) => x.data.productName))];
 	const productAreas = [...new Set(changelogs.flatMap((x) => x.data.productArea))];
@@ -16,6 +16,7 @@ export async function getChangelogs() {
 				description: entry.description,
 				title: entry.title,
 				scheduled: entry.scheduled,
+				productLink: product.data.productLink,
 				productAreaName: product.data.productArea,
 				productAreaLink: product.data.productAreaLink,
 			};

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -1,8 +1,18 @@
 import { getCollection, z } from "astro:content";
 import { type CollectionEntry } from "astro:content";
 
-export async function getChangelogs(filter?: Function) {
-	const changelogs = await getCollection("changelogs", filter);
+export async function getChangelogs(opts?: { filter?: Function, wranglerOnly?: boolean }) {
+	let changelogs;
+
+	if (opts?.wranglerOnly) {
+		changelogs = [await getWranglerChangelog()];
+	} else {
+		changelogs = await getCollection("changelogs", opts?.filter);
+	}
+
+	if (!changelogs) {
+		throw new Error(`[getChangelogs] Unable to find any changelogs with ${JSON.stringify(opts)}`);
+	}
 
 	const products = [...new Set(changelogs.flatMap((x) => x.data.productName))];
 	const productAreas = [...new Set(changelogs.flatMap((x) => x.data.productArea))];


### PR DESCRIPTION
### Summary

Adds support for product areas (i.e the generic Cloudflare One changelog) in the `ProductChangelog` component and adds right sidebar ToC entries for changelog date headings.

### Screenshots (optional)

Before:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/63c47d12-23a8-4b7c-b095-42785b749ecf">

After:
<img width="913" alt="image" src="https://github.com/user-attachments/assets/9bff8f84-ec22-4532-af2f-50152b3d4dfa">
