### PR TITLE
[APO] Update caching-static-html-with-wordpresswoocommerce.mdx

### DIFF
--- a/src/content/docs/support/third-party-software/content-management-system-cms/caching-static-html-with-wordpresswoocommerce.mdx
+++ b/src/content/docs/support/third-party-software/content-management-system-cms/caching-static-html-with-wordpresswoocommerce.mdx
@@ -20,7 +20,7 @@ Enterprise Cloudflare customers can use *Custom Cache Keys* to take their perf
 
 ## Prerequisites
 
-Before starting - be sure that Cloudflare is set to respect *Cache-Control* headers from your origin web server; otherwise, you may find *Cache-Control* headers are overridden by Cloudflare with the value set in the **Browser Cache TTL** option. To set the *Respect Existing Headers* option,
+Before starting - be sure that Cloudflare is set to respect `Cache-Control` headers from your origin web server; otherwise, you may find `Cache-Control` headers are overridden by Cloudflare with the value set in the **Browser Cache TTL** option. To set the **Respect Existing Headers** option:
 
 1. Log into your Cloudflare account.
 2. Click the **Caching** app.

--- a/src/content/docs/support/third-party-software/content-management-system-cms/caching-static-html-with-wordpresswoocommerce.mdx
+++ b/src/content/docs/support/third-party-software/content-management-system-cms/caching-static-html-with-wordpresswoocommerce.mdx
@@ -24,7 +24,7 @@ Before starting - be sure that Cloudflare is set to respect `Cache-Control` he
 
 1. Log into your Cloudflare account.
 2. Click the **Caching** app.
-3. Scroll down to **Browser Cache TTL**, and select the *Respect Existing Headers* value.
+3. Scroll down to **Browser Cache TTL**, and select the **Respect Existing Headers** value.
 
 ***
 


### PR DESCRIPTION
Hello team, 

### Summary

These changes are based upon the writing pattern we see on CF docs in general.

Examples:
 
https://developers.cloudflare.com/support/third-party-software/e-commerce/caching-static-html-with-magento-business-and-enterprise-only/

<img width="737" alt="Screenshot 2024-08-19 at 14 46 23" src="https://github.com/user-attachments/assets/693970d8-cbdd-44b2-9856-af61ac715e98">

https://developers.cloudflare.com/images/polish/cf-polished-statuses/

<img width="282" alt="Screenshot 2024-08-19 at 14 48 15" src="https://github.com/user-attachments/assets/80b51dde-4e0a-4fac-b1be-cdc874881740">

Thanks!
