### PR TITLE
[Docs Site] Increase content width when ToC is hidden

### DIFF
--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -24,7 +24,17 @@ import '@astrojs/starlight/style/markdown.css';
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 */
+const { tableOfContents } = Astro.props.entry.data;
 ---
+
+{
+	tableOfContents === false &&
+		<style>
+			:root {
+				--sl-content-width: 60rem;
+			}
+		</style>
+}
 
 <div class="sl-markdown-content">
     <slot />


### PR DESCRIPTION
### Summary

Expands the content width when `tableOfContents` is set to `false` in the frontmatter.

### Screenshots (optional)

Before:
![image](https://github.com/user-attachments/assets/f4d44cc4-a10d-47ae-8cf9-a1be9668db8a)

After:
![image](https://github.com/user-attachments/assets/d6029599-bb12-4eaa-87fd-aef8522f605a)
