### PR TITLE
[Turnstile] Flexible height fix

### DIFF
--- a/src/content/docs/turnstile/get-started/client-side-rendering.mdx
+++ b/src/content/docs/turnstile/get-started/client-side-rendering.mdx
@@ -217,7 +217,7 @@ The Turnstile widget can have two different fixed sizes or a flexible width size
 | Size    | Width | Height |
 | ------- | ----- | ------ |
 | Normal  | 300px | 65px   |
-| Flexible | 100% (min: 300px) | 120px |
+| Flexible | 100% (min: 300px) | 65px |
 | Compact | 150px | 140px  |
 
 ## Configurations


### PR DESCRIPTION
### Summary

Fixing the height for flexible Turnstile widget. 120px -> 65px
Closes #16170

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.