### PR TITLE
[Docs Site] Make URLs absolute in RSS feeds

### DIFF
--- a/src/pages/[...changelog].xml.ts
+++ b/src/pages/[...changelog].xml.ts
@@ -1,7 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection, getEntry } from "astro:content";
 import type { APIRoute } from 'astro';
-import { marked } from 'marked';
+import { marked, type Token } from 'marked';
 import { getWranglerChangelog } from '~/util/changelogs';
 import { slug } from "github-slugger"
 
@@ -23,6 +23,16 @@ export async function getStaticPaths() {
 }
 
 export const GET: APIRoute = async (context) => {
+    function walkTokens(token: Token) {
+        if (token.type === 'image' || token.type === 'link') {
+            if (token.href.startsWith("/")) {
+                token.href = context.site + token.href.slice(1);
+            }
+        }
+    }
+
+    marked.use({ walkTokens });
+
     const entry = context.props.entry;
 
     if (!entry.data.changelog_file_name && !entry.data.changelog_product_area_name) {

--- a/src/pages/changelog/index/index.xml.ts
+++ b/src/pages/changelog/index/index.xml.ts
@@ -6,6 +6,16 @@ import { getWranglerChangelog } from '~/util/changelogs';
 import { slug } from "github-slugger"
 
 export const GET: APIRoute = async (context) => {
+    function walkTokens(token: Token) {
+        if (token.type === 'image' || token.type === 'link') {
+            if (token.href.startsWith("/")) {
+                token.href = context.site + token.href.slice(1);
+            }
+        }
+    }
+
+    marked.use({ walkTokens });
+
     const changelogs = await getCollection("changelogs")
 
     changelogs.push(await getWranglerChangelog());


### PR DESCRIPTION
### Summary

Make URLs absolute in RSS feeds

Before:
```xml
<description><ul> <li>Workers now support the <a href="/workers/configuration/compatibility-dates/#allow-specifying-a-custom-port-when-making-a-subrequest-with-the-fetch-api"><code>allow_custom_ports</code> compatibility flag</a> which enables using the <code>fetch()</code> calls to custom ports.</li> </ul> </description>
```

After:

```xml
<description><ul> <li>Workers now support the <a href="https://developers.cloudflare.com/workers/configuration/compatibility-dates/#allow-specifying-a-custom-port-when-making-a-subrequest-with-the-fetch-api"><code>allow_custom_ports</code> compatibility flag</a> which enables using the <code>fetch()</code> calls to custom ports.</li> </ul> </description>
```