### PR TITLE
[Docs site] use space indenting for yaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false
 
-[*.yml]
+[*.{yml,yaml}]
 indent_style = space


### PR DESCRIPTION
### Summary

I forgot there were both `yaml` and `yml` files in https://github.com/cloudflare/cloudflare-docs/pull/16107

Should prevent tabs landing like at https://github.com/cloudflare/cloudflare-docs/pull/16290 in future, sorry @kodster28 