### PR TITLE
[Docs Site] Manually render ImageZoom component

### DIFF
--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -1,6 +1,8 @@
 ---
 import type { Props } from "@astrojs/starlight/props";
 import '@astrojs/starlight/style/markdown.css';
+// @ts-expect-error no types available
+import ImageZoom from "starlight-image-zoom/components/ImageZoom.astro";
 /*
     MIT License
 
@@ -36,6 +38,7 @@ const { tableOfContents } = Astro.props.entry.data;
 		</style>
 }
 
+<ImageZoom />
 <div class="sl-markdown-content">
     <slot />
 </div>


### PR DESCRIPTION
### Summary

Adds back the ImageZoom component since we have our own `MarkdownContent` override for anchor links in headings.

This doesn't suppress the warning, this is tracked upstream: https://github.com/HiDeoo/starlight-image-zoom/issues/18