### PR TITLE
[Docs Site] Render individual_page entries in RSS feeds

### DIFF
--- a/src/pages/[...changelog].xml.ts
+++ b/src/pages/[...changelog].xml.ts
@@ -4,6 +4,7 @@ import type { APIRoute } from 'astro';
 import { marked, type Token } from 'marked';
 import { getWranglerChangelog } from '~/util/changelogs';
 import { slug } from "github-slugger"
+import { entryToString } from '~/util/container';
 
 export async function getStaticPaths() {
     const changelogs = await getCollection("docs", (entry) => {
@@ -57,7 +58,7 @@ export const GET: APIRoute = async (context) => {
 
                 if (!page) throw new Error(`Changelog entry points to ${link.slice(1, -1)} but unable to find entry with that slug`)
 
-                description = page.body;
+                description = await entryToString(page) ?? page.body;
             } else {
                 description = entry.description;
             }

--- a/src/pages/changelog/index/index.xml.ts
+++ b/src/pages/changelog/index/index.xml.ts
@@ -4,6 +4,7 @@ import type { APIRoute } from 'astro';
 import { marked } from 'marked';
 import { getWranglerChangelog } from '~/util/changelogs';
 import { slug } from "github-slugger"
+import { entryToString } from '~/util/container';
 
 export const GET: APIRoute = async (context) => {
     function walkTokens(token: Token) {
@@ -30,7 +31,7 @@ export const GET: APIRoute = async (context) => {
 
                 if (!page) throw new Error(`Changelog entry points to ${link.slice(1, -1)} but unable to find entry with that slug`)
 
-                description = page.body;
+                description = await entryToString(page) ?? page.body;
             } else {
                 description = entry.description;
             }

--- a/src/util/container.ts
+++ b/src/util/container.ts
@@ -1,0 +1,23 @@
+import { experimental_AstroContainer } from "astro/container";
+import { getContainerRenderer } from "@astrojs/mdx";
+import { loadRenderers } from "astro:container";
+import type { CollectionEntry } from "astro:content";
+
+export async function entryToString(entry: CollectionEntry<"docs">) {
+	if (!entry.render) {
+		return undefined;
+	}
+
+	const renderers = await loadRenderers([getContainerRenderer()]);
+	const container = await experimental_AstroContainer.create({
+		renderers,
+	});
+
+	const { Content } = await entry.render();
+
+	const html = await container.renderToString(Content, {
+		params: { slug: entry.slug },
+	});
+
+    return html;
+}

--- a/src/util/description.ts
+++ b/src/util/description.ts
@@ -1,9 +1,6 @@
-import { experimental_AstroContainer } from "astro/container";
-import { getContainerRenderer } from "@astrojs/mdx";
-import { loadRenderers } from "astro:container";
 import type { CollectionEntry } from "astro:content";
 import { parse } from "node-html-parser";
-
+import { entryToString } from "./container"
 /*
     1. If there is a `description` property in the frontmatter, return that.
     2. If there is a `<p>...</p>` element in the HTML, return that.
@@ -12,20 +9,9 @@ import { parse } from "node-html-parser";
 export async function getPageDescription(entry: CollectionEntry<"docs">) {
 	if (entry.data.description) return entry.data.description;
 
-	if (!entry.render) {
-		return undefined;
-	}
+	const html = await entryToString(entry);
 
-	const renderers = await loadRenderers([getContainerRenderer()]);
-	const container = await experimental_AstroContainer.create({
-		renderers,
-	});
-
-	const { Content } = await entry.render();
-
-	const html = await container.renderToString(Content, {
-		params: { slug: entry.slug },
-	});
+	if (!html) return undefined;
 
 	const dom = parse(html);
 	const description = dom.querySelector(":root > p");


### PR DESCRIPTION
### Summary

Fixes MDX rendering for `individual_page` entries in RSS feeds.

### Test plan

Test the preview URL with some RSS readers.

### Screenshots (optional)

Before:

```xml
<description><p>import { RuleID } from &quot;~/components&quot;</p> <table style="width: 100%"> <thead> <tr> <th>Announcement Date</th> <th>Release Date</th> <th>Release Behavior</th> <th>Legacy Rule ID</th> <th>Rule ID</th> <th>Description</th> <th>Comments</th> </tr> </thead> <tbody> <tr> <td>2024-08-19</td> <td>2024-08-26</td> <td>Log</td> <td>100526_BETA</td> <td><RuleID id="53ed4a0e545b46efadcec7ceb0f0367b" /></td> <td>VMware vCenter - CVE:CVE-2022-22954, CVE:CVE-2022-22948</td> <td>This will replace 100526 in old WAF and <RuleID id="bbf685d70ddc467e8efb0ed0a24f08b7"/> in new WAF</td> </tr> </tbody> </table></description>
```

After:

```xml
<description><!DOCTYPE html><table style="width: 100%"><thead><tr><th>Announcement Date</th><th>Release Date</th><th>Release Behavior</th><th>Legacy Rule ID</th><th>Rule ID</th><th>Description</th><th>Comments</th></tr></thead><tbody><tr><td>2024-08-12</td><td>2024-08-19</td><td>Log</td><td>100666</td><td><code title="Click to copy the full ID" onclick="navigator.clipboard.writeText(&#34;7ff77f19b2ec4f1dab9f031ef3f42616&#34;)" class="flex w-fit hover:bg-accent-600/50 hover:cursor-pointer active:bg-accent-600" data-astro-source-file="/Users/kian/cf-repos/GitHub/cloudflare-docs/src/components/RuleID.astro" data-astro-source-loc="20:2"> ...f3f42616 <svg aria-hidden="true" class="!inline justify-center astro-c6vsoqas" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;" data-astro-source-file="/Users/kian/cf-repos/GitHub/cloudflare-docs/node_modules/@astrojs/starlight/user-components/Icon.astro" data-astro-source-loc="16:2"><path d="M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3.06a1.3 1.3 0 0 0-.06-.27v-.09c-.05-.1-.11-.2-.19-.28l-6-6a1.07 1.07 0 0 0-.28-.19h-.09a.88.88 0 0 0-.33-.11H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8.94Zm-6-3.53L16.59 8H15a1 1 0 0 1-1-1V5.41ZM18 19a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z"/></svg> </code></td><td>Apache OFBiz - Remote Code Execution - CVE:CVE-2024-32113 </td><td>New Detection</td></tr><tr><td>2024-08-12</td><td>2024-08-19</td><td>Log</td><td>100665</td><td><code title="Click to copy the full ID" onclick="navigator.clipboard.writeText(&#34;e960ac54d6e841cebcfe89d571eefd6f&#34;)" class="flex w-fit hover:bg-accent-600/50 hover:cursor-pointer active:bg-accent-600" data-astro-source-file="/Users/kian/cf-repos/GitHub/cloudflare-docs/src/components/RuleID.astro" data-astro-source-loc="20:2"> ...71eefd6f <svg aria-hidden="true" class="!inline justify-center astro-c6vsoqas" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;" data-astro-source-file="/Users/kian/cf-repos/GitHub/cloudflare-docs/node_modules/@astrojs/starlight/user-components/Icon.astro" data-astro-source-loc="16:2"><path d="M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3.06a1.3 1.3 0 0 0-.06-.27v-.09c-.05-.1-.11-.2-.19-.28l-6-6a1.07 1.07 0 0 0-.28-.19h-.09a.88.88 0 0 0-.33-.11H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8.94Zm-6-3.53L16.59 8H15a1 1 0 0 1-1-1V5.41ZM18 19a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z"/></svg> </code></td><td>Zoho ManageEngine - Remote Code Execution - CVE:CVE-2023-29084 </td><td>New Detection</td></tr></tbody></table></description>
```