### PR TITLE
[Images] Added missing param info & fixed accidental info swap

### DIFF
--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -3,49 +3,84 @@
 ---
 import { Tabs, TabItem } from "~/components"
 
-:::note[Note]
-At the moment, this setting only works directly with [image transformations](/images/transform-images/).
-:::
+Affects interpretation of `width` and `height`. All resizing modes preserve aspect ratio. Used as a string in Workers integration. Available modes are:
 
-The `auto` option will serve the WebP or AVIF format to browsers that support it. If this option is not specified, a standard format like JPEG or PNG will be used. Cloudflare will default to JPEG when possible due to the large size of PNG files.
-
-Workers integration supports:
-
-* `avif`: Generate images in AVIF format if possible (with WebP as a fallback).
-* `webp`: Generate images in Google WebP format. Set the quality to `100` to get the WebP lossless format.
-* `jpeg`: Generate images in interlaced progressive JPEG format, in which data is compressed in multiple passes of progressively higher detail.
-* `baseline-jpeg`: Generate images in baseline sequential JPEG format. It should be used in cases when target devices don't support progressive JPEG or other modern file formats.
-* `json`: Instead of generating an image, outputs information about the image in JSON format. The JSON object will contain data such as image size (before and after resizing), source image's MIME type, and file size.
+- `scale down`\
+  Similar to `contain`, but the image is never enlarged. If the image is larger than given `width` or `height`, it will be resized. Otherwise its original size will be kept. Example:
 
 <Tabs>
   <TabItem label="URL format">
     ```js 
-    format=auto
+    fit=scale-down
     ```
   </TabItem>
-  <TabItem label="URL format alias">
+  <TabItem label="Workers">
   ```js 
-  f=auto
-  ```
-  </TabItem>
-    <TabItem label="Workers">
-  ```js 
-  cf: {image: {format: "avif"}}
+  cf: {image: {fit: "scale-down"}}
   ```
   </TabItem>
 </Tabs>
 
-For the `format:auto` option to work with a custom Worker, you need to parse the `Accept` header. Refer to [this example Worker](/images/transform-images/transform-via-workers/#an-example-worker) for a complete overview of how to set up an image transformation Worker.
+- `contain`\
+  Image will be resized (shrunk or enlarged) to be as large as possible within the given `width` or `height` while preserving the aspect ratio. If you only provide a single dimension (for example, only `width`), the image will be shrunk or enlarged to exactly match that dimension.
 
-```js title="Custom Worker for Image Resizing with format:auto"
-const accept = request.headers.get("accept");
-let image = {};
+<Tabs>
+  <TabItem label="URL format">
+    ```js 
+    fit=contain
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+  ```js 
+  cf: {image: {fit: "contain"}}
+  ```
+  </TabItem>
+</Tabs>
 
-if (/image\/avif/.test(accept)) {
-    image.format = "avif";
-} else if (/image\/webp/.test(accept)) {
-    image.format = "webp";
-}
+- `cover`\
+  Resizes (shrinks or enlarges) to fill the entire area of `width` and `height`. If the image has an aspect ratio different from the ratio of `width` and `height`, it will be cropped to fit.
 
-return fetch(url, {cf:{image}});
-```
+<Tabs>
+  <TabItem label="URL format">
+    ```js 
+    fit=cover
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+  ```js 
+  cf: {image: {fit: "cover"}}
+  ```
+  </TabItem>
+</Tabs>
+
+- `crop`\
+  Image will be shrunk and cropped to fit within the area specified by `width` and `height`. The image will not be enlarged. For images smaller than the given dimensions, it is the same as `scale-down`. For images larger than the given dimensions, it is the same as `cover`. See also [`trim`](#trim)
+
+<Tabs>
+  <TabItem label="URL format">
+    ```js 
+    fit=crop
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+  ```js 
+  cf: {image: {fit: "crop"}}
+  ```
+  </TabItem>
+</Tabs>
+
+- `pad`\
+  Resizes to the maximum size that fits within the given `width` and `height`, and then fills the remaining area with a `background` color (white by default). This mode is not recommended, since you can achieve the same effect more efficiently with the `contain` mode and the CSS `object-fit: contain` property.
+
+<Tabs>
+  <TabItem label="URL format">
+    ```js 
+    fit=pad
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+  ```js 
+  cf: {image: {fit: "pad"}}
+  ```
+  </TabItem>
+</Tabs>

--- a/src/content/partials/images/format.mdx
+++ b/src/content/partials/images/format.mdx
@@ -3,20 +3,49 @@
 ---
 import { Tabs, TabItem } from "~/components"
 
-Affects interpretation of `width` and `height`. All resizing modes preserve aspect ratio. Used as a string in Workers integration. Available modes are:
+:::note[Note]
+At the moment, this setting only works directly with [image transformations](/images/transform-images/).
+:::
 
-- `scale down`\
-  Similar to `contain`, but the image is never enlarged. If the image is larger than given `width` or `height`, it will be resized. Otherwise its original size will be kept. Example:
+The `auto` option will serve the WebP or AVIF format to browsers that support it. If this option is not specified, a standard format like JPEG or PNG will be used. Cloudflare will default to JPEG when possible due to the large size of PNG files.
+
+Workers integration supports:
+
+* `avif`: Generate images in AVIF format if possible (with WebP as a fallback).
+* `webp`: Generate images in Google WebP format. Set the quality to `100` to get the WebP lossless format.
+* `jpeg`: Generate images in interlaced progressive JPEG format, in which data is compressed in multiple passes of progressively higher detail.
+* `baseline-jpeg`: Generate images in baseline sequential JPEG format. It should be used in cases when target devices don't support progressive JPEG or other modern file formats.
+* `json`: Instead of generating an image, outputs information about the image in JSON format. The JSON object will contain data such as image size (before and after resizing), source image's MIME type, and file size.
 
 <Tabs>
   <TabItem label="URL format">
     ```js 
-    fit=scale-down
+    format=auto
     ```
   </TabItem>
-  <TabItem label="Workers">
+  <TabItem label="URL format alias">
   ```js 
-  cf: {image: {fit: "scale-down"}}
+  f=auto
+  ```
+  </TabItem>
+    <TabItem label="Workers">
+  ```js 
+  cf: {image: {format: "avif"}}
   ```
   </TabItem>
 </Tabs>
+
+For the `format:auto` option to work with a custom Worker, you need to parse the `Accept` header. Refer to [this example Worker](/images/transform-images/transform-via-workers/#an-example-worker) for a complete overview of how to set up an image transformation Worker.
+
+```js title="Custom Worker for Image Resizing with format:auto"
+const accept = request.headers.get("accept");
+let image = {};
+
+if (/image\/avif/.test(accept)) {
+    image.format = "avif";
+} else if (/image\/webp/.test(accept)) {
+    image.format = "webp";
+}
+
+return fetch(url, {cf:{image}});
+```


### PR DESCRIPTION
Accidentally swapped the `fit` and `format` parameters and left out details for fit. Corrected both to close https://github.com/cloudflare/cloudflare-docs/issues/16277.