### PR TITLE
fix(turnstile): remove wrong onload behaviour from docs

### DIFF
--- a/src/content/docs/turnstile/get-started/client-side-rendering.mdx
+++ b/src/content/docs/turnstile/get-started/client-side-rendering.mdx
@@ -82,12 +82,6 @@ To:
 https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit
 ```
 
-Or:
-
-```txt
-https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback
-```
-
 When using `render=explicit`, HTML elements with the `cf-turnstile` class will not show a challenge. The `turnstile.render` function must be invoked using the following steps. To combine both options, pass a query string of `?render=explicit&onload=onloadTurnstileCallback`:
 
 `https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadTurnstileCallback`


### PR DESCRIPTION
### Summary

This statement was clearly wrong, as this isn't the case. If the customers want to use the explicit rendering they should specify it alongside the callback.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
