### PR TITLE
[Rules] Example: Change URI Path and Host Header + Cloud Connector changelog

### DIFF
--- a/src/content/changelogs/rules.yaml
+++ b/src/content/changelogs/rules.yaml
@@ -6,6 +6,11 @@ productArea: Application performance
 productAreaLink: /fundamentals/reference/changelog/performance/
 entries:
 
+- publish_date: '2024-08-20'
+  title: Cloud Connector now available to all customers
+  description:  |-
+    Cloud Connector (beta) is now available to all customers. For setup details, refer to the [documentation](/rules/cloud-connector/), explore [examples](/rules/cloud-connector/examples/), and check out the [blog post](https://blog.cloudflare.com/cloud-connector).
+
 - publish_date: '2024-08-16'
   title: Cloud Connector now available to all free customers
   description:  |-

--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -12,7 +12,7 @@ import { FeatureTable } from "~/components"
 Cloud Connector allows you to route matching incoming traffic from your website to a public cloud provider that you define such as AWS, Google Cloud, and Azure. With Cloud Connector you can make Cloudflare the control center for your web traffic, including traffic served from public cloud providers, without having to configure additional rules.
 
 :::note
-We are gradually rolling out access to Cloud Connector throughout 2024. Refer to [Availability](#availability) for details. Support for Cloudflare R2 will be added soon.
+Support for Cloudflare R2 will be added soon.
 :::
 
 ## How it works
@@ -33,6 +33,6 @@ Cloud Connector will perform the following configurations automatically, dependi
 
 ## Availability
 
-Cloud Connector is being rolled out gradually throughout 2024 to all customers. Once you have access, the Cloudflare dashboard will show a new **Cloud Connector** tab under **Rules** at the zone level. The maximum number of rules depends on your Cloudflare plan:
+Cloud Connector is available in beta to all customers. The maximum number of rules depends on your Cloudflare plan:
 
 <FeatureTable id="rules.cloud_connector" />

--- a/src/content/docs/rules/origin-rules/examples/change-uri-path-and-host-header.mdx
+++ b/src/content/docs/rules/origin-rules/examples/change-uri-path-and-host-header.mdx
@@ -1,0 +1,77 @@
+---
+title: Change URI Path and Host Header
+pcx_content_type: example
+summary: Modify both the URI path and `Host` header of incoming requests using Transform Rules and Origin Rules.
+description: Learn how to adjust the URI path and `Host` header for incoming requests. This example demonstrates using both Transform Rules and Origin Rules to achieve simultaneous modifications.
+product:
+  - Transform Rules
+  - Origin Rules
+  
+---
+
+import { Example } from "~/components"
+
+To change URI Path and Host Header on incoming requests simultaneously:
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account and domain.
+2. Create a **Transform Rule**:
+    - Navigate to **Rules > Transform Rules**.
+    - Click on the **Rewrite URL** tab and select **Create rule**.
+    - Configure the rule to modify the path. For instance, to remove `/uploads` from the path:
+
+<Example>
+
+Text in **Expression Editor**:
+
+```txt
+raw.http.request.uri.path matches "^/uploads/.*"
+```
+
+Text after **Path** > **Rewrite to...** > *Dynamic*:
+
+```txt
+regex_replace(raw.http.request.uri.path, "^/uploads/", "/")
+```
+
+</Example>
+
+The `regex_replace()` [function](/ruleset-engine/rules-language/functions/#regex_replace) replaces the `/uploads/` part of the path with `/`, changing `/uploads/example.jpg` to `/example.jpg`.
+
+3. Create an **Origin Rule**:
+    - If routing traffic to an object storage bucket, use [Cloud Connector](/rules/cloud-connector). Otherwise, navigate to **Rules > Origin Rules**.
+    - Click **Create rule** and select **Host Header > Rewrite to...**
+    - Configure the rule to modify the Host header to desired hostname:
+
+<Example>
+
+Text in **Expression Editor**:
+
+```txt
+raw.http.request.uri.path matches "^/uploads/.*"
+```
+
+Text after **Host Header** > **Rewrite to...**:
+
+```txt
+example.com
+```
+
+This will set [the Host header](/rules/origin-rules/features/#host-header) to `example.com` for matching requests.
+
+**Optional:**
+To route requests to a different origin (DNS target), use [DNS override](/rules/origin-rules/features/#dns-record):
+
+Text after **DNS Record** > **Override to...**:
+
+```txt
+example.com
+```
+
+This will route requests to the DNS target of `example.com` instead of your default [DNS record](/dns/manage-dns-records/how-to/create-dns-records/).
+</Example>
+
+This setup routes traffic from `https://<YOUR_SOURCE_HOSTNAME>/uploads/*` to `https://<YOUR_TARGET_HOSTNAME>/*`. Ensure the filters for [Transform Rules](/rules/transform/) and [Origin Rules](/rules/origin-rules/) (or [Cloud Connector](/rules/cloud-connector/)) are precise to avoid unintended rule executions.
+
+Remember that rules are evaluated [in sequence](/ruleset-engine/reference/phases-list/), so Transform Rules run before Origin Rules or Cloud Connector.
+
+Make sure to replace `example.com` with your actual hostname and adjust the example paths according to your setup. By following these steps, you can effectively manage both URI paths and Host headers to route traffic appropriately and optimize request handling.


### PR DESCRIPTION
### Summary

Adding an example on how to leverage URL Rewrites and Origin Rules together to change URI Path and Host Header simultaneously.