### PR TITLE
[Docs Site] Trim GlossaryTooltip definition to first line

### DIFF
--- a/src/components/GlossaryTooltip.astro
+++ b/src/components/GlossaryTooltip.astro
@@ -21,6 +21,8 @@ let definition = prepend
 	: tooltip.general_definition;
 
 definition = definition.charAt(0).toUpperCase() + definition.slice(1);
+
+definition = definition.split(/\r?\n/)[0];
 ---
 
 <span


### PR DESCRIPTION
### Summary

With Hugo we used to only show the first line of a tooltip, as per this guidance: https://developers.cloudflare.com/style-guide/documentation-content-strategy/component-attributes/glossary-entry/#glossary-entry:~:text=Because%20of%20space%20limitations%2C%20the%20tooltip%20will%20always%20default%20to%20the%20short%20definition%20of%20a%20term%2C%20meaning%20the%20definition%20text%20before%20the%20first%20line%20break.

### Screenshots (optional)

Before:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/bc010bf3-141b-4a77-941a-55c34ab20303">

After:
<img width="366" alt="image" src="https://github.com/user-attachments/assets/b2e7df51-e9aa-4292-a15b-c69032bfaf39">
