### PR TITLE
[Docs Site] Let HomepageHero infer image size

### DIFF
--- a/src/components/HomepageHero.astro
+++ b/src/components/HomepageHero.astro
@@ -8,8 +8,6 @@ const { title = data.title, tagline, image } = data.hero || {};
 const imageAttrs = {
 	loading: "eager" as const,
 	decoding: "async" as const,
-	width: 400,
-	height: 400,
 	alt: image?.alt || "",
 };
 


### PR DESCRIPTION
### Summary

Removes hardcoded width/height values to let `<Image>` infer the right size.

### Screenshots (optional)

Before:
<img width="423" alt="image" src="https://github.com/user-attachments/assets/b2bd1efb-57e3-4833-b991-650b4448d1aa">

After:
<img width="399" alt="image" src="https://github.com/user-attachments/assets/034e542e-1b7a-49d5-b23e-3dd2bd966eba">
