### PR TITLE
[Docs Site] Use dashboard deep-links from product in footer

### DIFF
--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -18,7 +18,7 @@ if (currentSection) {
   const product = await getEntry("products", currentSection);
 
   if (product) {
-    if (product.data.resources.dashboard_link) {
+    if (product.data.resources?.dashboard_link) {
       links["Cloudflare Dashboard"] = product.data.resources.dashboard_link;
     }
   }

--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -2,14 +2,27 @@
 import type { Props } from "@astrojs/starlight/props";
 import Default from "@astrojs/starlight/components/Footer.astro";
 import OneTrust from "../OneTrust.astro";
+import { getEntry } from "astro:content";
 
-const links = Object.entries({
+let links = {
   "Cloudflare Dashboard": "https://dash.cloudflare.com",
   Discord: "https://discord.cloudflare.com",
   Community: "https://community.cloudflare.com",
   "Learning Center": "https://www.cloudflare.com/learning/",
   "Support Portal": "/support/contacting-cloudflare-support/",
-});
+};
+
+const currentSection = Astro.params.slug?.split("/")[0];
+
+if (currentSection) {
+  const product = await getEntry("products", currentSection);
+
+  if (product) {
+    if (product.data.resources.dashboard_link) {
+      links["Cloudflare Dashboard"] = product.data.resources.dashboard_link;
+    }
+  }
+}
 
 const homepageLinks = Object.entries({
   "Stay in touch": [
@@ -109,7 +122,7 @@ if (import.meta.env.CF_PAGES_BRANCH === "production" || import.meta.env.GITHUB_R
     <>
       <Default {...Astro.props} />
       <div class="items-center flex flex-wrap">
-        {links.map(([text, href]) => (
+        {Object.entries(links).map(([text, href]) => (
           <a
             href={href}
             class="mx-2 my-2 text-xs text-black dark:text-white decoration-accent-600 dark:decoration-accent-200"


### PR DESCRIPTION
### Summary

Uses product-specific dashboard link if available.

### Screenshots (optional)

<img width="553" alt="image" src="https://github.com/user-attachments/assets/1417a54e-7566-4616-8b51-c14873396852">