### PR TITLE
[KV] Move shell comment to own line

### DIFF
--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -177,7 +177,8 @@ npx wrangler kv key put --namespace-id=xxxxxxxxxxxxxxxx "<KEY>" "<VALUE>" --loca
 To access the value using Wrangler, run the `wrangler kv key get` subcommand in your terminal, and input your key value:
 
 ```sh
-npx wrangler kv key get <KEY> [OPTIONS] # Replace [OPTIONS] with --binding or --namespace-id
+# Replace [OPTIONS] with --binding or --namespace-id
+npx wrangler kv key get <KEY> [OPTIONS]
 ```
 
 A KV namespace can be specified in two ways:


### PR DESCRIPTION
### Summary

Moves comment to a new line which won't be copied by Expressive Code.