### PR TITLE
[Docs Site] Shrink font size of h4 & h5

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -133,6 +133,7 @@ export default defineConfig({
 			},
 			sidebar: await autogenSections(),
 			customCss: [
+				"./src/headings.css",
 				"./src/input.css",
 				"./src/kbd.css",
 				"./src/littlefoot.css",

--- a/src/headings.css
+++ b/src/headings.css
@@ -1,0 +1,4 @@
+:root {
+    --sl-text-h4: var(--sl-text-base);
+    --sl-text-h5: var(--sl-text-base);
+}


### PR DESCRIPTION
### Summary

Makes `h4` and `h5` font sizes smaller.

### Screenshots (optional)

Before:
<img width="746" alt="image" src="https://github.com/user-attachments/assets/e8aaa244-7346-45d8-914f-43234aba3a33">

After:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/441ca2d9-cb68-4c37-92cd-86dc9abc1f96">
