### PR TITLE
[Docs Site] Add sticky headers to global changelog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@astrojs/starlight-docsearch": "^0.1.1",
         "@astrojs/starlight-tailwind": "^2.0.3",
         "@astrojs/tailwind": "^5.1.0",
+        "@codingheads/sticky-header": "^1.0.2",
         "algoliasearch": "^4.24.0",
         "astro": "^4.14.2",
         "astro-breadcrumbs": "^2.3.1",
@@ -1107,6 +1108,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.1.0.tgz",
       "integrity": "sha512-SyD4iw6jM4anZaG+ujgVETV4fulF2KHBOW31eavbVN7TNpk2l4aJgwY1YSPK00IKSWsoQuH2TigR446KuT5lqQ=="
+    },
+    "node_modules/@codingheads/sticky-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@codingheads/sticky-header/-/sticky-header-1.0.2.tgz",
+      "integrity": "sha512-pNaKWoDBN2393L++sRLfctsXpG6nDuy9+eq+NVv/Vf+z/23MUPqF4JpFHzZ9W0sQmFb3KGtwcclgDyUwt1klww==",
+      "license": "GPL-3"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@astrojs/starlight-docsearch": "^0.1.1",
     "@astrojs/starlight-tailwind": "^2.0.3",
     "@astrojs/tailwind": "^5.1.0",
+    "@codingheads/sticky-header": "^1.0.2",
     "algoliasearch": "^4.24.0",
     "astro": "^4.14.2",
     "astro-breadcrumbs": "^2.3.1",

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -27,7 +27,7 @@ const { products, productAreas, changelogs } = await getChangelogs();
 	</select>
 	{
 		changelogs.map(([date, entries]) => (
-			<div data-date={date}>
+			<div style="overflow-anchor: none;" data-date={date}>
 				<h2>{date}</h2>
 				{entries?.map((entry) => (
 					<div data-product={entry.product.toLowerCase()} data-productArea={entry.productAreaName.toLowerCase()}>
@@ -50,6 +50,16 @@ const { products, productAreas, changelogs } = await getChangelogs();
 </StarlightPage>
 
 <script>
+	import StickyHeader from '@codingheads/sticky-header';
+
+	document.addEventListener("DOMContentLoaded", () => {
+		const navHeightRem = getComputedStyle(document.body).getPropertyValue('--sl-nav-height');
+		const navHeightPx = Number(navHeightRem.split("rem")[0]) * 16 + 16;
+
+		const headers = document.querySelectorAll<HTMLElement>("[data-date] > h2");
+		headers.forEach((header) => new StickyHeader(header, { offset: 0 - navHeightPx }));
+	});
+
 	const productFilter = document.querySelector<HTMLSelectElement>("#products");
 	productFilter?.addEventListener("change", filterEntries);
 
@@ -94,3 +104,10 @@ const { products, productAreas, changelogs } = await getChangelogs();
 		}
 	}
 </script>
+
+<style>
+	h2.sticky-pinned {
+		top: var(--sl-nav-height);
+		background-color: var(--sl-color-bg);
+	}
+</style>


### PR DESCRIPTION
### Summary

Adds sticky headers to the global changelog.

### Screenshots (optional)

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/a8bd62cd-f649-4aff-9d4c-5a5fc24a0c95">
