### PR TITLE
Fix title typo in hyperdrive docs

### DIFF
--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -249,7 +249,7 @@ In the code above, you have:
 2. Initiated a query via `await sql` that outputs all tables (user and system created) in the database (as an example query).
 3. Returned the response as JSON to the client.
 
-## 6. Deploy your database
+## 6. Deploy your Worker
 
 You can now deploy your Worker to make your project accessible on the Internet. To deploy your Worker, run:
 


### PR DESCRIPTION
### Summary

Title incorrectly mentions 'database', which is already deployed. Correct to 'Worker'.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [X] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [X] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
