### PR TITLE
[R2] Add constraint on list `limit`

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-reference.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-reference.mdx
@@ -352,6 +352,8 @@ Only a single hashing algorithm can be specified at once.
 * <code>limit</code>numberoptional
   * The number of results to return. Defaults to `1000`, with a maximum of `1000`.
 
+  * If `include` is set, you may receive fewer than `limit` results in your response to accommodate metadata.
+
 * <code>prefix</code>stringoptional
   * The prefix to match keys against. Keys will only be returned if they start with given prefix.
 


### PR DESCRIPTION
When listing object, R2 API on workers might not respect the `limit` parameter set by the user, if `include` is set. This is due a limit on the total amount of data that a single `list` operation can return.

### Summary

Make it clear when reading the `limit` documentation for R2 that it can be affected by other options, such as `include`.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
