### PR TITLE
[Docs Site] Add noindex to external_link pages, add on-page redirect to intended page

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -136,6 +136,25 @@ if (Astro.props.entry.data.pcx_content_type === "changelog") {
     content: "",
   });
 }
+
+if (Astro.props.entry.data.external_link) {
+  Astro.props.entry.data.head.push({
+    tag: "meta",
+    attrs: {
+      content: "noindex",
+      name: "robots",
+    },
+    content: ""
+  });
+  Astro.props.entry.data.head.push({
+    tag: "meta",
+    attrs: {
+      content: `0; url=${Astro.props.entry.data.external_link}`,
+      "http-equiv": "refresh",
+    },
+    content: ""
+  });
+}
 ---
 
 <script>


### PR DESCRIPTION
### Summary

Adds `<meta name="robots" content="noindex">` & `<meta http-equiv="refresh" content="0;url=<external_link>">` tags to pages with an `external_link` frontmatter.