### PR TITLE
[SSL] Fix dupe beta badge in sidebar

### DIFF
--- a/src/content/docs/ssl/edge-certificates/geokey-manager/setup.mdx
+++ b/src/content/docs/ssl/edge-certificates/geokey-manager/setup.mdx
@@ -3,8 +3,6 @@ pcx_content_type: how-to
 title: Setup
 sidebar:
   order: 1
-  badge:
-    text: Beta
 head:
   - tag: title
     content: Setup - Geo Key Manager
@@ -12,7 +10,9 @@ description: Learn how to set up Geo Key Manager and choose the geographical
   boundaries of where your private encryption keys are stored.
 ---
 
-import { Render, TabItem, Tabs } from "~/components";
+import { Render, TabItem, Tabs, InlineBadge } from "~/components";
+
+## Geo Key Manager v2 <InlineBadge preset="beta" />
 
 :::note
 


### PR DESCRIPTION
### Summary

Badge should have been present on an accidentally removed `Geo Key Manager v2` header, as [per the old site](https://silverlock-fix-images-pricin.cloudflare-docs-7ou.pages.dev/ssl/edge-certificates/geokey-manager/setup/).