### PR TITLE
Update sql-statements.mdx

### DIFF
--- a/src/content/docs/d1/reference/sql-statements.mdx
+++ b/src/content/docs/d1/reference/sql-statements.mdx
@@ -129,7 +129,7 @@ Allows you to defer the enforcement of [foreign key constraints](/d1/build-with-
 
 This does not disable foreign key enforcement outside of the current transaction: if you have not resolved outstanding foreign key violations at the end of your transaction, it will fail with a `FOREIGN KEY constraint failed` error.
 
-Note that setting `PRAGMA defer_foreign_keys = on` does not prevent `ON DELETE CASCADE` actions from being executed. While foreign key enforcement is deferred, `ON DELETE CASCADE` operations will still be active during a transaction.
+Note that setting `PRAGMA defer_foreign_keys = ON` does not prevent `ON DELETE CASCADE` actions from being executed. While foreign key constraint checks are deferred until the end of a transaction, `ON DELETE CASCADE` operations will remain active, consistent with SQLite's behavior.
 
 To defer foreign key enforcement, set `PRAGMA defer_foreign_keys = on` at the start of your transaction, or ahead of changes that would violate constraints:
 

--- a/src/content/docs/d1/reference/sql-statements.mdx
+++ b/src/content/docs/d1/reference/sql-statements.mdx
@@ -129,6 +129,8 @@ Allows you to defer the enforcement of [foreign key constraints](/d1/build-with-
 
 This does not disable foreign key enforcement outside of the current transaction: if you have not resolved outstanding foreign key violations at the end of your transaction, it will fail with a `FOREIGN KEY constraint failed` error.
 
+Note that setting `PRAGMA defer_foreign_keys = on` does not prevent `ON DELETE CASCADE` actions from being executed. While foreign key enforcement is deferred, `ON DELETE CASCADE` operations will still be active during a transaction.
+
 To defer foreign key enforcement, set `PRAGMA defer_foreign_keys = on` at the start of your transaction, or ahead of changes that would violate constraints:
 
 ```sql


### PR DESCRIPTION
Updated to reflect `ON DELETE CASCADE` behavior when foreign key enforcement is deferred (`PRAGMA defer_foreign_keys = on`).