### PR TITLE
Add "Replace insecure JS library" to brotli-compression-warning.mdx

### DIFF
--- a/src/content/partials/speed/brotli-compression-warning.mdx
+++ b/src/content/partials/speed/brotli-compression-warning.mdx
@@ -1,24 +1,20 @@
 ---
 {}
-
 ---
 
 ## Notes about end-to-end compression
 
-Even when using the same compression algorithm end to end (between your origin server and Cloudflare, and between the Cloudflare global network and your website visitor), Cloudflare will need to decompress the response and compress it again if you enable any of the following options for the request:
+Even when using the same compression algorithm end to end (between your origin server and Cloudflare, and between the Cloudflare global network and your website visitor), Cloudflare will need to decompress the response and compress it again if you enable any of the following settings for the request:
 
-* [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/)
-* [Rocket Loader](/speed/optimization/content/rocket-loader/)
-* [Mirage](/speed/optimization/images/mirage/)
-* [Automatic HTTPS Rewrites](/ssl/edge-certificates/additional-options/automatic-https-rewrites/)
-* [Polish](/images/polish/)
-* [Replace Insecure JS Libraries](/waf/tools/replace-insecure-js-libraries/)
+- [Automatic HTTPS Rewrites](/ssl/edge-certificates/additional-options/automatic-https-rewrites/)
+- [Cloudflare Fonts](/speed/optimization/content/fonts/)
+- [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/)
+- [Mirage](/speed/optimization/images/mirage/)
+- [Polish](/images/polish/)
+- [Rocket Loader](/speed/optimization/content/rocket-loader/)
 
-To disable these features for specific URI paths, create a [Configuration Rule](/rules/configuration-rules/).
-
-Additionally, [Cloudflare Fonts](/speed/optimization/content/fonts/) also requires Cloudflare to decompress the response and compress it again, and cannot be disabled through Rules at this time.
+To disable these settings for specific URI paths, create a [configuration rule](/rules/configuration-rules/).
 
 :::note
-
-If you want to use [Cloudflare Web Analytics](/web-analytics/), we recommend that you use the [manual mode setup](/web-analytics/get-started/#sites-not-proxied-through-cloudflare) (adding a JavaScript snippet to your HTML pages) to avoid decompression. 
+Additionally, the [Replace insecure JS libraries](/waf/tools/replace-insecure-js-libraries/) setting also requires Cloudflare to decompress the response and compress it again. At this time, you cannot turn it off using Configuration Rules.
 :::

--- a/src/content/partials/speed/brotli-compression-warning.mdx
+++ b/src/content/partials/speed/brotli-compression-warning.mdx
@@ -12,6 +12,7 @@ Even when using the same compression algorithm end to end (between your origin s
 * [Mirage](/speed/optimization/images/mirage/)
 * [Automatic HTTPS Rewrites](/ssl/edge-certificates/additional-options/automatic-https-rewrites/)
 * [Polish](/images/polish/)
+* [Replace Insecure JS Libraries](/waf/tools/replace-insecure-js-libraries/)
 
 To disable these features for specific URI paths, create a [Configuration Rule](/rules/configuration-rules/).
 


### PR DESCRIPTION
Based on discussion at https://community.cloudflare.com/t/cloudflare-not-serving-pre-compressed-brotli-from-the-origin/701864/3, looks like "Replace Inssecure JS Library" also must be disabled for end-to-end compression to work.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
