### PR TITLE
[D1] Specifying import limit for D1 as 5 GiB

### DIFF
--- a/src/content/docs/d1/build-with-d1/import-export-data.mdx
+++ b/src/content/docs/d1/build-with-d1/import-export-data.mdx
@@ -71,9 +71,10 @@ The `_cf_KV` table is a reserved table used by D1's underlying storage system. I
 
 From here, you can now query our new table from our Worker [using the D1 client API](/d1/build-with-d1/d1-client-api/).
 
-### Known limitations
+:::caution[Known limitations]
 
-- For imports, `wrangler d1 execute --file` is limited to 5GiB files, the same as the [R2 upload limit](/r2/platform/limits/). For imports larger than 5GiB, we recommend splitting the data into multiple files.
+For imports, `wrangler d1 execute --file` is limited to 5GiB files, the same as the [R2 upload limit](/r2/platform/limits/). For imports larger than 5GiB, we recommend splitting the data into multiple files.
+:::
 
 ### Convert SQLite database files
 

--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -12,7 +12,7 @@ import { Render } from "~/components"
 | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | Databases                                                                                                           | 50,000 (Workers Paid) / 10 (Free)                 |
 | Maximum database size                                                                                               | 10 GB (Workers Paid) / 500 MB (Free)              |
-| Maximum storage per account                                                                                         | 250 GB (Workers Paid)<sup>1</sup> / 5 GB (Free)   |
+| Maximum storage per account                                                                                         | 250 GB (Workers Paid)[^1] / 5 GB (Free)           |
 | [Time Travel](/d1/reference/time-travel/) duration (point-in-time recovery)                                         | 30 days (Workers Paid) / 7 days (Free)            |
 | Maximum Time Travel restore operations                                                                              | 10 restores per 10 minute (per database)          |
 | Queries per Worker invocation (read [subrequest limits](/workers/platform/limits/#how-many-subrequests-can-i-make)) | 50 (Bundled) / 1000 (Unbound)                     |
@@ -23,9 +23,9 @@ import { Render } from "~/components"
 | Maximum bound parameters per query                                                                                  | 100                                               |
 | Maximum arguments per SQL function                                                                                  | 32                                                |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern                                                            | 50 bytes                                          |
-| Maximum bindings per Workers script                                                                                 | Approximately 5,000 <sup>2</sup>                  |
+| Maximum bindings per Workers script                                                                                 | Approximately 5,000 [^2]                          |
 | Maximum SQL query duration                                                                                          | 30 seconds                                        |
-| Maximum file import (`d1 execute`) size                                                                             | 5 GiB <sup>3</sup>                                |
+| Maximum file import (`d1 execute`) size                                                                             | 5 GiB [^3]                                        |
 
 :::note
 
@@ -37,10 +37,10 @@ Refer to the [Choose a data or storage product](/workers/platform/storage-option
 
 :::
 
-<sup>1</sup> The maximum storage per account can be increased by request on Workers Paid and Enterprise plans. See the guidance on limit increases on this page to request an increase.
+[^1]: The maximum storage per account can be increased by request on Workers Paid and Enterprise plans. See the guidance on limit increases on this page to request an increase.
 
-<sup>2</sup> A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to \~5,000 D1 databases to a single Worker script.
+[^2]: A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to \~5,000 D1 databases to a single Worker script.
 
-<sup>3</sup> The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
+[^3] The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
 
 <Render file="limits_increase" product="workers" />

--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -25,6 +25,7 @@ import { Render } from "~/components"
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern                                                            | 50 bytes                                          |
 | Maximum bindings per Workers script                                                                                 | Approximately 5,000 <sup>2</sup>                  |
 | Maximum SQL query duration                                                                                          | 30 seconds                                        |
+| Maximum file import (`d1 execute`) size                                                                             | 5 GiB <sup>3</sup>                                |
 
 :::note
 
@@ -39,5 +40,7 @@ Refer to the [Choose a data or storage product](/workers/platform/storage-option
 <sup>1</sup> The maximum storage per account can be increased by request on Workers Paid and Enterprise plans. See the guidance on limit increases on this page to request an increase.
 
 <sup>2</sup> A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to \~5,000 D1 databases to a single Worker script.
+
+<sup>3</sup> The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
 
 <Render file="limits_increase" product="workers" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Specifying the import limit for D1 via the `d1 execute` command.

1. The H3 has been turned into a caution aside component.
![AD_4nXcNXn10yMmA5n7Q5R7f8zBsstDwkdApbZz0tneyYM5H7Xr4rNPHr9fBtJDbQhGDVA3qpt_Gp6hR3Zzc-N41oiIEYGOlKfXR8VrtuXshIDez8eiRST-X9bjW](https://github.com/user-attachments/assets/8f777348-251d-4941-93ab-53cfff5dbc54)

2. The Limits table has been updated to show the import limit for D1.
![AD_4nXfHna4HJj39rigYfT4p-sF-3F0R4OCSRsT1KwUyaM8zhdWDTA85v036og--ateq-Yy4tVqCqN5P5lGHn3dPbOtIaXDPmwgm3sHIjBr_K7cM9Lb1Zxs20U9A](https://github.com/user-attachments/assets/96d185da-955c-4e59-b5ab-ee6a36dd0c4c)
 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
