### PR TITLE
[D1] update for d1 alpha query shutdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
 	"astro.content-intellisense": true,
 	"editor.formatOnSave": true,
-	"editor.defaultFormatter": "esbenp.prettier-vscode"
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/content/changelogs/d1.yaml
+++ b/src/content/changelogs/d1.yaml
@@ -5,6 +5,19 @@ productLink: "/d1/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2024-08-23"
+    title: D1 alpha databases have stopped accepting SQL queries
+    description: |-
+      Following the [deprecation warning](/d1/platform/changelog/#2024-04-30) on 2024-04-30, D1 alpha databases have stopped accepting queries.
+
+      Requests to D1 alpha databases now respond with a HTTP 400 error, containing the following text:
+
+      ```txt
+      You can no longer query a D1 alpha database. Please follow https://developers.cloudflare.com/d1/platform/alpha-migration/ to migrate your alpha database and resume querying.
+      ```
+
+      You can upgrade to the new, generally available version of D1 by following the [alpha database migration guide](/d1/platform/alpha-migration/).
+
   - publish_date: "2024-07-26"
     title: Fixed bug in TypeScript typings for run() API
     description: |-

--- a/src/content/changelogs/d1.yaml
+++ b/src/content/changelogs/d1.yaml
@@ -8,7 +8,7 @@ entries:
   - publish_date: "2024-08-23"
     title: D1 alpha databases have stopped accepting SQL queries
     description: |-
-      Following the [deprecation warning](/d1/platform/changelog/#2024-04-30) on 2024-04-30, D1 alpha databases have stopped accepting queries.
+      Following the [deprecation warning](/d1/platform/changelog/#2024-04-30) on 2024-04-30, D1 alpha databases have stopped accepting queries (you are still able to create and retrieve backups).
 
       Requests to D1 alpha databases now respond with a HTTP 400 error, containing the following text:
 

--- a/src/content/docs/d1/platform/alpha-migration.mdx
+++ b/src/content/docs/d1/platform/alpha-migration.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 :::caution
 
-D1 alpha databases will stop accepting live SQL queries on August 15, 2024.
+D1 alpha databases stopped accepting live SQL queries on August 22, 2024.
 
 :::
 


### PR DESCRIPTION
### Summary

This PR adds a changelog entry for today, saying we're no longer accepting queries to D1 alpha DBs, and how to proceed.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
