### PR TITLE
[Magic, CNI] Hide overview pages 

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -699,7 +699,8 @@
 /magic-firewall/how-to/collect-pcaps/ /magic-firewall/packet-captures/collect-pcaps/ 301
 
 # magic-network-monitoring
-/magic-network-monitoring/routers/ /magic-network-monitoring/routers/supported-routers/
+/magic-network-monitoring/routers/ /magic-network-monitoring/routers/supported-routers/ 301
+/magic-network-monitoring/tutorials/ /magic-network-monitoring/tutorials/graphql-analytics/ 301
 
 # magic-transit
 /magic-transit/magic-firewall/ /magic-firewall/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -698,6 +698,9 @@
 /magic-firewall/how-to/pcaps-bucket-setup/ /magic-firewall/packet-captures/pcaps-bucket-setup/ 301
 /magic-firewall/how-to/collect-pcaps/ /magic-firewall/packet-captures/collect-pcaps/ 301
 
+# magic-network-monitoring
+/magic-network-monitoring/routers/ /magic-network-monitoring/routers/supported-routers/
+
 # magic-transit
 /magic-transit/magic-firewall/ /magic-firewall/ 301
 /magic-transit/set-up/onboarding/ /magic-transit/get-started/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -719,6 +719,7 @@
 /magic-transit/how-to/auto-advertise-prefixes/ /magic-network-monitoring/rules/ 301
 /magic-transit/prerequisites/ /magic-transit/get-started/ 301
 /magic-transit/how-to/ /magic-transit/how-to/configure-tunnels/ 301
+/magic-transit/reference/ /magic-transit/reference/anti-replay-protection/ 301
 
 # magic-wan
 /magic-wan/tutorials/ipsec/ /magic-wan/reference/tunnels/#ipsec-tunnels 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -718,6 +718,7 @@
 /magic-transit/flow-based-monitoring/ /magic-transit/magic-network-monitoring/ 301
 /magic-transit/how-to/auto-advertise-prefixes/ /magic-network-monitoring/rules/ 301
 /magic-transit/prerequisites/ /magic-transit/get-started/ 301
+/magic-transit/how-to/ /magic-transit/how-to/configure-tunnels/ 301
 
 # magic-wan
 /magic-wan/tutorials/ipsec/ /magic-wan/reference/tunnels/#ipsec-tunnels 301

--- a/src/content/docs/magic-cloud-networking/index.mdx
+++ b/src/content/docs/magic-cloud-networking/index.mdx
@@ -27,7 +27,7 @@ Magic Cloud Networking is in a closed beta. If you are interested in trying out 
 
 Learn how to [get started](/magic-cloud-networking/get-started/).
 
-***
+---
 
 ## Features
 
@@ -39,7 +39,7 @@ Discover your cloud resources like virtual private clouds (VPCs), subnets, virtu
 Automatically build VPN tunnels between cloud networks and Magic WAN.
 </Feature>
 
-***
+---
 
 ## Related products
 

--- a/src/content/docs/magic-network-monitoring/index.mdx
+++ b/src/content/docs/magic-network-monitoring/index.mdx
@@ -27,7 +27,7 @@ Magic Network Monitoring is automatically enabled for all Magic Transit and Magi
 
 Learn how to [get started](/magic-network-monitoring/get-started/).
 
-***
+---
 
 ## Features
 
@@ -49,7 +49,7 @@ Set up notifications to learn about an attack.
 
 </Feature>
 
-***
+---
 
 ## Related products
 

--- a/src/content/docs/magic-network-monitoring/routers/index.mdx
+++ b/src/content/docs/magic-network-monitoring/routers/index.mdx
@@ -3,11 +3,8 @@ title: Routers
 pcx_content_type: navigation
 sidebar:
   order: 3
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing, GlossaryTooltip } from "~/components"
-
-This section covers everything you need to send your router’s <GlossaryTooltip term="NetFlow">NetFlow</GlossaryTooltip> or <GlossaryTooltip term="sFlow">sFlow</GlossaryTooltip> data to Cloudflare’s network.
-
-<DirectoryListing />

--- a/src/content/docs/magic-network-monitoring/tutorials/index.mdx
+++ b/src/content/docs/magic-network-monitoring/tutorials/index.mdx
@@ -3,9 +3,7 @@ title: Tutorials
 pcx_content_type: navigation
 sidebar:
   order: 5
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-<DirectoryListing />

--- a/src/content/docs/magic-transit/analytics/index.mdx
+++ b/src/content/docs/magic-transit/analytics/index.mdx
@@ -3,7 +3,6 @@ title: Analytics
 pcx_content_type: how-to
 sidebar:
   order: 7
-  label: Types of analytics
 head: []
 description: Use Magic Transit's different analytic options for an overview of
   the performance of your sites, or to troubleshoot potential issues.

--- a/src/content/docs/magic-transit/analytics/index.mdx
+++ b/src/content/docs/magic-transit/analytics/index.mdx
@@ -3,6 +3,7 @@ title: Analytics
 pcx_content_type: how-to
 sidebar:
   order: 7
+  label: Types of analytics
 head: []
 description: Use Magic Transit's different analytic options for an overview of
   the performance of your sites, or to troubleshoot potential issues.

--- a/src/content/docs/magic-transit/ddos.mdx
+++ b/src/content/docs/magic-transit/ddos.mdx
@@ -16,7 +16,7 @@ Cloudflare DDoS protection automatically detects and mitigates Distributed Denia
 
 Refer to [Cloudflare DDoS documentation](/ddos-protection/) for more information.
 
-***
+---
 
 ## Execution order
 

--- a/src/content/docs/magic-transit/how-to/index.mdx
+++ b/src/content/docs/magic-transit/how-to/index.mdx
@@ -3,11 +3,7 @@ pcx_content_type: navigation
 title: How to
 sidebar:
   order: 5
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-Review the tasks below for more information on setting up or modifying your Magic Transit configuration.
-
-<DirectoryListing />

--- a/src/content/docs/magic-transit/index.mdx
+++ b/src/content/docs/magic-transit/index.mdx
@@ -21,39 +21,39 @@ Magic Transit is a network security and performance solution that offers DDoS pr
 
 Learn how to [get started](/magic-transit/get-started/).
 
-***
+---
 
 ## Features
 
 <Feature header="Tunnel health checks" href="/magic-transit/reference/tunnel-health-checks/" cta="Learn about health checks">
-Magic Transit sends health check probes to monitor network status and the health of specific network components. 
+Magic Transit sends health check probes to monitor network status and the health of specific network components.
 </Feature>
 
 <Feature header="Traffic steering" href="/magic-transit/reference/traffic-steering/" cta="Learn about traffic steering">
-Magic Transit steers traffic along tunnel routes based on priorities you define during the onboarding process. 
+Magic Transit steers traffic along tunnel routes based on priorities you define during the onboarding process.
 </Feature>
 
 <Feature header="Cloudflare IPs" href="/magic-transit/cloudflare-ips/">
-Use Cloudflare-owned IP addresses if you want to protect a smaller network and do not meet Magic Transit's `/24` prefix length requirements. 
+Use Cloudflare-owned IP addresses if you want to protect a smaller network and do not meet Magic Transit's `/24` prefix length requirements.
 </Feature>
 
-***
+---
 
 ## Related products
 
 <RelatedProduct header="Magic Firewall" href="/magic-firewall/" product="magic-firewall">
-Magic Firewall is a firewall-as-a-service (FWaaS) delivered from the Cloudflare global network to protect office networks and cloud infrastructure with advanced, scalable protection. 
+Magic Firewall is a firewall-as-a-service (FWaaS) delivered from the Cloudflare global network to protect office networks and cloud infrastructure with advanced, scalable protection.
 </RelatedProduct>
 
 <RelatedProduct header="Cloudflare Network Interconnect" href="/network-interconnect/" product="network-interconnect">
-Cloudflare Network Interconnect (CNI) allows you to connect your network infrastructure directly with Cloudflare – rather than using the public Internet – for a more reliable and secure experience. 
+Cloudflare Network Interconnect (CNI) allows you to connect your network infrastructure directly with Cloudflare – rather than using the public Internet – for a more reliable and secure experience.
 </RelatedProduct>
 
 <RelatedProduct header="DDoS Protection" href="/ddos-protection/" product="ddos-protection">
-Cloudflare DDoS protection secures websites, applications, and entire networks while ensuring the performance of legitimate traffic is not compromised. 
+Cloudflare DDoS protection secures websites, applications, and entire networks while ensuring the performance of legitimate traffic is not compromised.
 </RelatedProduct>
 
-***
+---
 
 ## More resources
 
@@ -61,7 +61,7 @@ Cloudflare DDoS protection secures websites, applications, and entire networks w
 
 <LinkTitleCard title="Reference Architecture" href="/reference-architecture/architectures/magic-transit/" icon="pen">
 
-Deep dive into the key architecture, functionalities, and network deployment options of Cloudflare Magic Transit. 
+Deep dive into the key architecture, functionalities, and network deployment options of Cloudflare Magic Transit.
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/magic-transit/partners/index.mdx
+++ b/src/content/docs/magic-transit/partners/index.mdx
@@ -3,9 +3,8 @@ title: Partners
 pcx_content_type: navigation
 sidebar:
   order: 12
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing } from "~/components"
-
-<DirectoryListing />

--- a/src/content/docs/magic-transit/reference/index.mdx
+++ b/src/content/docs/magic-transit/reference/index.mdx
@@ -3,11 +3,8 @@ title: Reference
 pcx_content_type: navigation
 sidebar:
   order: 13
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing } from "~/components"
-
-For more information on concepts related to Magic Transit, review the items below.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
@@ -3,6 +3,7 @@ pcx_content_type: how-to
 title: Configure hardware Connector
 sidebar:
   order: 3
+  label: Configure hardware Connector
 
 ---
 

--- a/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
@@ -16,7 +16,7 @@ You also need to purchase a Magic WAN Connector before you can start configuring
 
 Contact your account representative to learn more about purchasing options for the Magic WAN Connector device.
 
-***
+---
 
 ## High availability configurations
 
@@ -32,7 +32,7 @@ If you do not need a high availability configuration for you premises, proceed t
 You cannot enable high availability for an existing site. To add high availability to an existing site in the Cloudflare dashboard, you need to delete the site and start again. Plan accordingly to create a high availability configuration from the start if needed.
 :::
 
-***
+---
 
 ## Port speeds
 
@@ -40,7 +40,7 @@ The hardware version of the Magic WAN connector includes two [SFP+ ports](https:
 
 Refer to [SFP+ port information](/magic-wan/configuration/connector/configure-hardware-connector/sfp-port-information/) for details on this topic.
 
-***
+---
 
 ## Configure Cloudflare dashboard settings
 
@@ -118,7 +118,7 @@ To use your Connector on a network configuration with a static IP:
 3. Adjust your physical connections as required to match the configuration specified in the [site configuration](#1-create-a-site) step (for example, static IP WAN plugged into a physical port with no DHCP connection).
 4. Power cycle the Connector.
 
-***
+---
 
 ## About high availability configurations
 
@@ -159,13 +159,13 @@ To set up a high availability configuration:
 13. From the **High availability probing link** drop-down menu, select the port that should be used to monitor the node’s health. Cloudflare recommends you choose a reliable interface as the HA probing link. The primary and secondary node’s probing link should be connected over a switch, and cannot be a direct connection.
 14. Follow the instructions in [Set up your Magic WAN Connector](#set-up-your-magic-wan-connector) and [Activate connector](#activate-connector) to finish setting up your Connectors.
 
-***
+---
 
 ## IP sec tunnels and static routes
 
 <Render file="connector/ipsec-static-tunnels" />
 
-***
+---
 
 ## Next steps
 

--- a/src/content/docs/magic-wan/configuration/connector/configure-virtual-connector.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-virtual-connector.mdx
@@ -111,13 +111,13 @@ You cannot use the same license key twice, or reuse a key once the virtual machi
 4. If successful, the [tunnel health checks](/magic-wan/configuration/common-settings/check-tunnel-health-dashboard/) will show as healthy.
 5. If you do not see a [healthy heartbeat](/magic-wan/configuration/connector/maintenance/heartbeat/) the Cloudflare dashboard, reboot the Virtual Connector's VM in VMware.
 
-***
+---
 
 ## IP sec tunnels and static routes
 
 <Render file="connector/ipsec-static-tunnels" />
 
-***
+---
 
 ## Next steps
 

--- a/src/content/docs/magic-wan/configuration/connector/maintenance/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/maintenance/index.mdx
@@ -3,11 +3,7 @@ pcx_content_type: navigation
 title: Maintenance
 sidebar:
   order: 7
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-Refer to the pages below to learn more about these topics.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/connector/network-options/dhcp/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/network-options/dhcp/index.mdx
@@ -1,11 +1,9 @@
 ---
 pcx_content_type: navigation
 title: DHCP options
+sidebar:
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing } from "~/components"
-
-Depending on how you want to configure your Connector, you have different Dynamic Host Configuration Protocol (DHCP) options. Refer to the pages below to learn more about these topics.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/connector/network-options/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/network-options/index.mdx
@@ -3,11 +3,7 @@ pcx_content_type: navigation
 title: Network options
 sidebar:
   order: 6
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-Refer to the pages below to learn more about these topics.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/connector/reference.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/reference.mdx
@@ -17,13 +17,13 @@ Magic WAN Connector software is certified for use on the [Dell Networking Virtua
 - The Magic WAN Connector does not support fail open.
 - Customers have the ability to layer on additional security features/policies that are enforced at the Cloudflare network.
 
-***
+---
 
 ## ICMP traffic
 
 <GlossaryTooltip term="ICMP">ICMP traffic</GlossaryTooltip> is routed through the Internet and bypasses [Cloudflare Gateway](/cloudflare-one/policies/gateway/). This enables you to ping resources on the Internet from the Magic WAN connector directly, which can be useful for debugging.
 
-***
+---
 
 ## VLAN ID
 

--- a/src/content/docs/magic-wan/configuration/index.mdx
+++ b/src/content/docs/magic-wan/configuration/index.mdx
@@ -3,9 +3,8 @@ title: Configuration
 pcx_content_type: navigation
 sidebar:
   order: 5
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing } from "~/components"
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/manually/how-to/index.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/how-to/index.mdx
@@ -3,11 +3,7 @@ title: How to
 pcx_content_type: navigation
 sidebar:
   order: 1
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-To configure Magic WAN manually, start by setting up your tunnel endpoints, static routes and health alerts.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/manually/index.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/index.mdx
@@ -3,11 +3,8 @@ title: Manual configuration
 pcx_content_type: navigation
 sidebar:
   order: 1
+  group:
+    hideIndex: true
 
 ---
 
-import { DirectoryListing } from "~/components"
-
-Review this section to learn how to configure Magic WAN manually, as well as tutorials for setting up devices compatible with GRE and IPSec.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/manually/third-party/fitelnet.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/fitelnet.mdx
@@ -204,7 +204,7 @@ Use the CLI to configure these settings:
 ip route 192.168.1.0 255.255.255.0 tunnel 2
 ```
 
-***
+---
 
 ## Connection test
 

--- a/src/content/docs/magic-wan/configuration/manually/third-party/index.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/index.mdx
@@ -3,15 +3,11 @@ title: Third-party integration
 pcx_content_type: navigation
 sidebar:
   order: 2
+  group:
+    hideIndex: true
 head:
   - tag: title
     content: Third-party integration tutorials
 description: Learn how to integrate Cloudflare Magic WAN with third-party products.
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-Review the tutorials to learn more about how you can use Magic WAN with the following third-party products.
-
-<DirectoryListing />

--- a/src/content/docs/magic-wan/configuration/manually/third-party/palo-alto.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/palo-alto.mdx
@@ -43,7 +43,7 @@ The following IP addresses are used throughout this tutorial. Any legally routab
 | VLAN0010 - remote Magic WAN site  | `10.1.10.0/24`                     |                              |
 | VLAN0020 - remote Magic WAN site  | `10.1.20.0/24`                     |                              |
 
-***
+---
 
 ## Cloudflare Magic WAN
 

--- a/src/content/docs/magic-wan/index.mdx
+++ b/src/content/docs/magic-wan/index.mdx
@@ -27,55 +27,55 @@ Refer to [On-ramps](/magic-wan/on-ramps/) for a full list of supported on-ramps.
 
 Learn how to [get started](/magic-wan/get-started/).
 
-***
+---
 
 ## Features
 
 <Feature header="Magic WAN Connector" href="/magic-wan/configuration/connector/" cta="Use Magic WAN Connector">
-Use Magic WAN Connector to automatically connect, steer, and shape any IP traffic. 
+Use Magic WAN Connector to automatically connect, steer, and shape any IP traffic.
 </Feature>
 
 <Feature header="Connect with third-party device" href="/magic-wan/configuration/manually/" cta="Use a third-party device">
-Magic WAN is compatible with a host of third-party devices. If you do not have Magic WAN Connector, start here to learn how to set up Magic WAN manually. 
+Magic WAN is compatible with a host of third-party devices. If you do not have Magic WAN Connector, start here to learn how to set up Magic WAN manually.
 </Feature>
 
 <Feature header="Tunnel health checks" href="/magic-wan/reference/tunnel-health-checks/" cta="Learn about health checks">
-Magic WAN sends health check probes to monitor network status and the health of specific network components. 
+Magic WAN sends health check probes to monitor network status and the health of specific network components.
 </Feature>
 
 <Feature header="Automatic cloud on-ramps" href="/magic-wan/configuration/magic-cloud-networking/" cta="Automate your cloud on-ramps">
-Automate resource discovery, and reduce management burden when connecting to your public cloud. 
+Automate resource discovery, and reduce management burden when connecting to your public cloud.
 </Feature>
 
 <Feature header="Network analytics" href="/magic-wan/analytics/">
-Network analytics allows you to check traffic patterns and DDoS attacks in near real-time, to troubleshoot IP traffic issues. 
+Network analytics allows you to check traffic patterns and DDoS attacks in near real-time, to troubleshoot IP traffic issues.
 </Feature>
 
-***
+---
 
 ## Related products
 
 <RelatedProduct header="Cloudflare Zero Trust" href="/cloudflare-one/" product="cloudflare-one">
-Cloudflare Zero Trust replaces legacy security perimeters with our global edge, making the Internet faster and safer for teams around the world. 
+Cloudflare Zero Trust replaces legacy security perimeters with our global edge, making the Internet faster and safer for teams around the world.
 </RelatedProduct>
 
 <RelatedProduct header="Magic Firewall" href="/magic-firewall/" product="magic-firewall">
-Magic Firewall is a firewall-as-a-service (FWaaS) delivered from the Cloudflare global network to protect office networks and cloud infrastructure with advanced, and scalable protection. 
+Magic Firewall is a firewall-as-a-service (FWaaS) delivered from the Cloudflare global network to protect office networks and cloud infrastructure with advanced, and scalable protection.
 </RelatedProduct>
 
 <RelatedProduct header="Magic Cloud Networking" href="/magic-cloud-networking/" product="magic-cloud-networking">
-Simplify and automate cloud resource discovery, and reduce your management burden when connecting to your public cloud. 
+Simplify and automate cloud resource discovery, and reduce your management burden when connecting to your public cloud.
 </RelatedProduct>
 
 <RelatedProduct header="Cloudflare Network Interconnect" href="/network-interconnect/" product="network-interconnect">
-Cloudflare Network Interconnect (CNI) allows you to connect your network infrastructure directly with Cloudflare – rather than using the public Internet – for a more reliable and secure experience. 
+Cloudflare Network Interconnect (CNI) allows you to connect your network infrastructure directly with Cloudflare – rather than using the public Internet – for a more reliable and secure experience.
 </RelatedProduct>
 
 <RelatedProduct header="Load Balancing" href="/load-balancing/" product="load-balancing">
-Cloudflare Load Balancing distributes traffic across your endpoints, which reduces endpoint strain and latency and improves the experience for end users. 
+Cloudflare Load Balancing distributes traffic across your endpoints, which reduces endpoint strain and latency and improves the experience for end users.
 </RelatedProduct>
 
-***
+---
 
 ## More resources
 
@@ -83,7 +83,7 @@ Cloudflare Load Balancing distributes traffic across your endpoints, which reduc
 
 <LinkTitleCard title="Reference Architecture" href="/reference-architecture/architectures/sase/" icon="pen">
 
-Deep dive into key architecture and functionalities aspects of Cloudflare One, and learn more about Magic WAN and its structure. 
+Deep dive into key architecture and functionalities aspects of Cloudflare One, and learn more about Magic WAN and its structure.
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/magic-wan/legal/index.mdx
+++ b/src/content/docs/magic-wan/legal/index.mdx
@@ -3,7 +3,8 @@ pcx_content_type: navigation
 title: Legal
 sidebar:
   order: 12
+  group:
+    hideIndex: true
 
 ---
 
-- [Third party licenses](/magic-wan/legal/3rdparty/)

--- a/src/content/docs/magic-wan/reference/index.mdx
+++ b/src/content/docs/magic-wan/reference/index.mdx
@@ -3,11 +3,7 @@ pcx_content_type: navigation
 title: Reference
 sidebar:
   order: 11
+  group:
+    hideIndex: true
 
 ---
-
-import { DirectoryListing } from "~/components"
-
-For more information on concepts related to Magic WAN, review the items below.
-
-<DirectoryListing />


### PR DESCRIPTION
### Summary

- Closes PCX-13036
- Hides extra overview pages
- Sets some redirects in places where it's clear where the redirect should point to, but in most cases (specially with MWAN) no redirect was set
### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
