### PR TITLE
[DO] Indicating non-development for WebGPU API

### DIFF
--- a/src/content/docs/durable-objects/api/webgpu.mdx
+++ b/src/content/docs/durable-objects/api/webgpu.mdx
@@ -6,14 +6,15 @@ sidebar:
 
 ---
 
-The [WebGPU API](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API), allows you to use the GPU directly from JavaScript.
+:::caution
 
-The WebGPU API is only accessible from within [Durable Objects](/durable-objects/). The WebGPU API cannot be used from within Workers.
+The WebGPU API is only available in local development. You cannot deploy Durable Objects to Cloudflare that rely on the WebGPU API. See [Workers AI](workers-ai/index) for information on running machine learning models on the GPUs in Cloudflare's global network.
 
-:::note
-
-The WebGPU API is currently only available in local development. You cannot yet deploy Durable Objects to Cloudflare that rely on the WebGPU API. 
 :::
+
+The [WebGPU API](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API) allows you to use the GPU directly from JavaScript.
+
+The WebGPU API is only accessible from within [Durable Objects](/durable-objects/). You cannot use the WebGPU API from within Workers.
 
 To use the WebGPU API in local development, enable the `experimental` and `webgpu` [compatibility flags](/workers/configuration/compatibility-dates/#compatibility-flags) in the [`wrangler.toml` configuration file](/workers/wrangler/configuration/) of your Durable Object.
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

- Removing references to words that imply we'll work on WebGPU in future, such as "yet" and "currently".
- Redirecting users to Workers-AI for GPU-related projects.
- Repurposing the "note" component into a "caution" component.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

![Pasted Graphic](https://github.com/user-attachments/assets/05db5266-8281-487d-8e50-032e9a9349f0)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
