### PR TITLE
[Docs Site] Never consider sidebar.label for group labels

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -74,7 +74,7 @@ async function handleGroup(group: Group): Promise<SidebarEntry> {
 
 	const frontmatter = indexPage.data;
 
-	group.label = frontmatter.sidebar.group?.label ?? frontmatter.sidebar.label ?? frontmatter.title;
+	group.label = frontmatter.sidebar.group?.label ?? frontmatter.title;
 	group.order = frontmatter.sidebar.order ?? Number.MAX_VALUE;
 
 	if (frontmatter.hideChildren) {


### PR DESCRIPTION
### Summary

Never consider `sidebar.label`, only `sidebar.group.label` and `title`, for group labels - per https://developers.cloudflare.com/style-guide/frontmatter/sidebar/