### PR TITLE
[do not merge] Style Guide Setup

### DIFF
--- a/.hyperlint/style_guide_test.md
+++ b/.hyperlint/style_guide_test.md
@@ -1,0 +1,3 @@
+# This is a test
+
+clouDflare is spellt wrong

--- a/.vale.ini
+++ b/.vale.ini
@@ -12,7 +12,7 @@ mdx = md
 TokenIgnores = (<\/?[A-Z].+>), (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+)
 
 [*.md]
-BasedOnStyles = cloudflare
+BasedOnStyles = Vale, cloudflare
 
 [*.yaml]
-BasedOnStyles = cloudflare
+BasedOnStyles = Vale, cloudflare


### PR DESCRIPTION
@kodster28 , you'll see the change necessary here. You have to add "vale" as a style so that it uses the vocabulary. It's a Vale default style to be able to do it.


When using a `style_guide_test.md` file. It will flag all issues **but will not do suggestions**. Those only come up on 'real' PRs. This allows you to iterate on the style guide very easily (and quickly) and see the results / see test cases and share them with others.