### PR TITLE
thomasgauvin: add static assets example to kv

### DIFF
--- a/src/content/docs/kv/examples/index.mdx
+++ b/src/content/docs/kv/examples/index.mdx
@@ -1,0 +1,15 @@
+---
+type: overview
+hideChildren: false
+pcx_content_type: navigation
+title: Examples
+sidebar:
+  order: 4
+
+---
+
+import { GlossaryTooltip, ListExamples } from "~/components"
+
+Explore the following <GlossaryTooltip term="code example">examples</GlossaryTooltip> for KV.
+
+<ListExamples directory="kv/examples/" />

--- a/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
+++ b/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
@@ -1,11 +1,15 @@
 ---
-updated: 2024-08-21
-difficulty: Intermediate
-content_type: 📝 Tutorial
-pcx_content_type: tutorial
+type: example
+summary: Store and retrieve static assets with Workers KV
+tags:
+  - KV
+pcx_content_type: configuration
 title: Store and retrieve static assets with Workers KV
-products: [Workers]
+sidebar:
+  order: 4
+description: Example of how to use Workers KV to store static assets
 ---
+
 
 import { Render, PackageManagers } from "~/components";
 

--- a/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
+++ b/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
@@ -13,12 +13,10 @@ description: Example of how to use Workers KV to store static assets
 
 import { Render, PackageManagers } from "~/components";
 
-This tutorial will teach you how to store and retrieve static assets using KV, and use them to generate your Workers response.
-
 By storing static assets in Workers KV, you can retrieve these assets globally with low-latency and high throughput. You can then serve these assets directly, or use them to dynamically generate responses. This can be useful when serving files and images, or when generating dynamic HTML responses from static assets such as translations.
 
 :::note[Note]
-This tutorial demonstrates how to access data and assets from KV and use them to generate static and dynamic responses. If you want to serve static assets of a frontend web application, consider using [Cloudflare Pages](/pages/) which provides a purpose-built experience for web applications with built-in environments, CI/CD, Pages Functions for dynamic responses, and more.
+This example demonstrates how to access data and assets from KV and use them to generate static and dynamic responses. If you want to serve static assets of a frontend web application, consider using [Cloudflare Pages](/pages/) which provides a purpose-built experience for web applications with built-in environments, CI/CD, Pages Functions for dynamic responses, and more.
 :::
 
 <Render file="tutorials-before-you-start" product="workers" />
@@ -30,7 +28,7 @@ To get started, create a Worker application using the [`create-cloudflare` CLI](
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest"
-	args={"tutorial-kv-assets"}
+	args={"example-kv-assets"}
 />
 
 <Render
@@ -46,7 +44,7 @@ To get started, create a Worker application using the [`create-cloudflare` CLI](
 Then, move into your newly created application
 
 ```sh
-cd tutorial-kv-assets
+cd example-kv-assets
 ```
 
 We'll also install the dependencies we will need for this project.
@@ -58,7 +56,7 @@ npm install --save-dev @types/accept-language-parser
 
 ## 2. Create a new KV namespace
 
-Next, we will create a KV store. This can be done through the Cloudflare dashboard or the Wrangler CLI. For this tutorial, we will use the Wrangler CLI.
+Next, we will create a KV store. This can be done through the Cloudflare dashboard or the Wrangler CLI. For this example, we will use the Wrangler CLI.
 
 To create a KV store via Wrangler:
 
@@ -75,7 +73,7 @@ To create a KV store via Wrangler:
    ```
 
    ```sh {6} output
-   🌀 Creating namespace with title "tutorial-kv-assets-assets"
+   🌀 Creating namespace with title "example-kv-assets-assets"
    ✨ Success!
    Add the following to your configuration file in your kv_namespaces array:
    [[kv_namespaces]]
@@ -108,7 +106,7 @@ To create a KV store via Wrangler:
    ```
 
    ```sh {6} output
-   🌀 Creating namespace with title "tutorial-kv-assets-assets_preview"
+   🌀 Creating namespace with title "example-kv-assets-assets_preview"
    ✨ Success!
    Add the following to your configuration file in your kv_namespaces array:
    [[kv_namespaces]]
@@ -380,7 +378,7 @@ Run `wrangler deploy` to deploy your Workers project to Cloudflare with the bind
 npx wrangler deploy
 ```
 
-Wrangler will automatically set your KV binding to use the production KV namespace set in our `wrangler.toml` file with the KV namespace id. Throughout this tutorial, we uploaded our assets to both the preview and the production KV namespaces.
+Wrangler will automatically set your KV binding to use the production KV namespace set in our `wrangler.toml` file with the KV namespace id. Throughout this example, we uploaded our assets to both the preview and the production KV namespaces.
 
 We can now verify that our project is properly working by accessing our Workers default hostname and accessing `<WORKER-SUBDOMAIN>.<DEFAULT-ACCOUNT-HOSTNAME>.dev/index.html` or `<WORKER-SUBDOMAIN>.<DEFAULT-ACCOUNT-HOSTNAME>.dev/hello-world` to see our deployed Worker in action, generating responses from the values in our KV store.
 


### PR DESCRIPTION
This needs to land in it's own Examples section, separate from tutorial external links and resources that are not KV specific and more involved.