### PR TITLE
[Workers] Indication of where node_compat is supported

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1084,6 +1084,8 @@ It is not possible to polyfill all Node APIs or behaviors, but it is possible to
 
 This is currently powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 
+The `node_compat` option only works for Workers, not Pages. As such, the above option to use runtime APIs directly with `compatibility_flags = [ "nodejs_compat" ]` should be used when possible. 
+
 ## Source maps
 
 [Source maps](/workers/observability/source-maps/) translate compiled and minified code back to the original code that you wrote. Source maps are combined with the stack trace returned by the JavaScript runtime to present you with a stack trace.


### PR DESCRIPTION
I need a way to help customers understand the limitations of node-postgres (requires legacy node_compat) and why we recommend Postgres.js (uses modern nodejs_compat) instead. This way, there is a reference in our docs I can point to as the authoritative source on the impact of choosing between node_compat and nodejs_compat. Folks should not have to run into this issue and have to ping our Discord or community forum to understand why things aren't working https://community.cloudflare.com/t/cloudflare-pages-not-compatible-with-node-modules/566178