### PR TITLE
[MWAN] Corrected link in overview

### DIFF
--- a/src/content/docs/magic-wan/index.mdx
+++ b/src/content/docs/magic-wan/index.mdx
@@ -35,7 +35,7 @@ Learn how to [get started](/magic-wan/get-started/).
 Use Magic WAN Connector to automatically connect, steer, and shape any IP traffic.
 </Feature>
 
-<Feature header="Connect with third-party device" href="/magic-wan/configuration/manually/" cta="Use a third-party device">
+<Feature header="Connect with third-party device" href="/magic-wan/configuration/manually/third-party/alibaba-cloud/" cta="Use a third-party device">
 Magic WAN is compatible with a host of third-party devices. If you do not have Magic WAN Connector, start here to learn how to set up Magic WAN manually.
 </Feature>
 


### PR DESCRIPTION
### Summary

Corrects link in overview that goes to a hidden and empty overview page for 3rd party integrations
