### PR TITLE
Inform client-filtering doesn't apply to test-command

### DIFF
--- a/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
+++ b/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
@@ -19,7 +19,7 @@ Client IP address restrictions control which IP addresses can make API requests 
 
 > [!NOTE]  
 > The client IP address filtering does not apply for the test command   
-> I.e. this can be done from ANY client 
+> That is, this action can be performed from any client.
 > ```
 > curl -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
 >      -H "Authorization: Bearer <your-token>" \

--- a/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
+++ b/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
@@ -17,14 +17,11 @@ Client IP address restrictions control which IP addresses can make API requests 
 
 ![IP Address filtering options](~/assets/images/fundamentals/api/ip-filter.png)
 
-> [!NOTE]  
-> The client IP address filtering does not apply for the test command   
-> That is, this action can be performed from any client.
-> ```
-> curl -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
->      -H "Authorization: Bearer <your-token>" \
->      -H "Content-Type:application/json"
-> ```
+:::note
+
+Client IP address range filtering is not applied to the [Verify Token](https://developers.cloudflare.com/api/operations/user-api-tokens-verify-token) endpoint.
+
+:::
 
 
 ## Time to live (TTL) constraints

--- a/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
+++ b/src/content/docs/fundamentals/api/how-to/restrict-tokens.mdx
@@ -17,6 +17,16 @@ Client IP address restrictions control which IP addresses can make API requests 
 
 ![IP Address filtering options](~/assets/images/fundamentals/api/ip-filter.png)
 
+> [!NOTE]  
+> The client IP address filtering does not apply for the test command   
+> I.e. this can be done from ANY client 
+> ```
+> curl -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
+>      -H "Authorization: Bearer <your-token>" \
+>      -H "Content-Type:application/json"
+> ```
+
+
 ## Time to live (TTL) constraints
 
 By default, tokens do not expire and are long lived. Defining a TTL sets when a token starts being valid and when a token is no longer valid. This is often referred to as `notBefore` and `notAfter`. Setting these timestamps limits the lifetime of the token to the defined period. Not setting the start date or `notBefore` means the token is active as soon as it is created. Not setting the end date or `notAfter` means the token does not expire.


### PR DESCRIPTION
### Summary

Client filtering doesn't apply to the test command. This is either a bug or it should be mentioned in the docs

### Screenshots (optional)

\-

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
