### PR TITLE
[Pages] Fix pages hono examples

### DIFF
--- a/.github/styles/config/vocabularies/cloudflare/accept.txt
+++ b/.github/styles/config/vocabularies/cloudflare/accept.txt
@@ -5,3 +5,4 @@ cloudflared
 Internet
 JavaScript
 TypeScript
+Hono

--- a/src/components/ExternalResources.astro
+++ b/src/components/ExternalResources.astro
@@ -1,6 +1,6 @@
 ---
 import { getEntry } from "astro:content";
-import { getCollection, z } from "astro:content";
+import { z } from "astro:content";
 
 type Props = z.infer<typeof props>;
 
@@ -25,12 +25,13 @@ const filtered = resources.data.entries.filter((entry) => {
 	);
 });
 
-filtered.sort((a, b) => b.updated - a.updated);
+filtered.sort((a, b) => Number(b.updated) - Number(a.updated));
 ---
 
 <ul>
 	{
 		filtered.map((entry) => {
+			// @ts-expect-error TODO: fix resource types
 			const title = entry.name ?? entry.title;
 			return (
 				<li>

--- a/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
@@ -139,12 +139,16 @@ Every time you commit new code to your Hono site, Cloudflare Pages will automati
 
 ### Tutorials
 
-For more tutorials involving Hono, refer to the following resources:
+For more tutorials involving Hono and Cloudflare Pages, refer to the following resources:
 
-<ResourcesBySelector tags={["Hono"]} types={["tutorial"]} />
+<ResourcesBySelector
+	tags={["Hono"]}
+	types={["tutorial"]}
+	products={["Pages"]}
+/>
 
 ### Demo apps
 
-For demo applications using Hono, refer to the following resources:
+For demo applications using Hono and Cloudflare Pages, refer to the following resources:
 
-<ExternalResources tags={["Hono"]} type="apps" />
+<ExternalResources tags={["Hono"]} type="apps" products={["Pages"]} />


### PR DESCRIPTION
### Summary

Fixes #16445. This now only lists things that have been explicitly tagged as Pages, rather than _all_ Hono things, which includes Workers. It also includes some minor TS fixes for the `ExternalResources` component.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
