### PR TITLE
Redirect /workers/ai to /workers-ai

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1434,6 +1434,7 @@
 /workers/tutorials/create-sitemap-from-sanity-cms/ /developer-spotlight/tutorials/create-sitemap-from-sanity-cms/ 301
 /workers/tutorials/custom-access-control-for-files-in-r2-using-d1-and-workers/ /developer-spotlight/tutorials/custom-access-control-for-files/ 301
 /workers/tutorials/handle-form-submission-with-astro-resend/ /developer-spotlight/tutorials/handle-form-submission-with-astro-resend/ 301
+/workers/ai/ /workers-ai/ 301
 
 # workers ai
 /workers-ai/models/llm/ /workers-ai/models/#text-generation 301


### PR DESCRIPTION
Was a 404 from https://blog.cloudflare.com/introducing-cursor-the-ai-assistant-for-docs to /workers/ai