### PR TITLE
Update Vectorize's `returnMetadata` param to `boolean`

### DIFF
--- a/src/content/docs/vectorize/best-practices/query-vectors.mdx
+++ b/src/content/docs/vectorize/best-practices/query-vectors.mdx
@@ -47,7 +47,7 @@ let queryVector = [54.8, 5.5, 3.1, ...];
 let matches = await env.YOUR_INDEX.query(queryVector, {
 	topK: 1,
 	returnValues: true,
-	returnMetadata: "all",
+	returnMetadata: true,
 });
 ```
 


### PR DESCRIPTION
### Summary

Got this after providing `returnMetadata: "all"`:

```
 {
    "role": "tool",
    "content": "Error executing tool search-docs: Invalid returnMetadata option. Expected boolean; got: all",
    "name": "search-docs"
  }
```

Replacing to `boolean`

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
