### PR TITLE
Disable default spelling

### DIFF
--- a/.github/styles/config/vocabularies/cloudflare/accept.txt
+++ b/.github/styles/config/vocabularies/cloudflare/accept.txt
@@ -1,5 +1,4 @@
 Wrangler
-wrangler
 Cloudflare
 cloudflared
 Internet

--- a/.hyperlint/style_guide_test.md
+++ b/.hyperlint/style_guide_test.md
@@ -7,3 +7,7 @@ Test out Javascript.
 Bad link at [this page](/test/).
 
 Build a better internet.
+
+Hyperdrive is a cool product.
+
+Tell me about namespaces.

--- a/.vale.ini
+++ b/.vale.ini
@@ -14,6 +14,8 @@ TokenIgnores = (<\/?[A-Z].+>), (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\
 
 [*.md]
 BasedOnStyles = Vale, cloudflare
+Vale.Spelling = NO
 
 [*.yaml]
 BasedOnStyles = Vale, cloudflare
+Vale.Spelling = NO


### PR DESCRIPTION
### Summary

Removes the default vale checks to make sure that we don't overlint for common Cloudflare phrases and/or other company names.