### PR TITLE
[Hyperdrive] Add pgEdge cloud example

### DIFF
--- a/src/content/docs/hyperdrive/examples/pgedge.mdx
+++ b/src/content/docs/hyperdrive/examples/pgedge.mdx
@@ -1,0 +1,28 @@
+---
+type: example
+summary: Connect Hyperdrive to a pgEdge Postgres database.
+pcx_content_type: example
+title: Connect to pgEdge Cloud
+sidebar:
+  order: 9
+description: Connect Hyperdrive to a Neon Postgres database.
+
+---
+
+import { Render } from "~/components"
+
+This example shows you how to connect Hyperdrive to a [pgEdge](https://pgedge.com/) Postgres database. pgEdge Cloud provides easy deployment of fully-managed, fully-distributed, and secure Postgres. 
+
+## 1. Allow Hyperdrive access
+
+You can connect Hyperdrive to any existing pgEdge database with the default user and password 
+provided by pgEdge.
+
+### pgEdge dashboard
+
+1. Go to the [**pgEdge dashboard**](https://app.pgedge.com) and select the database you wish to connect to.
+2. From the **Connect to your database** section, note down the connection string (starting with `postgres://app@...`) from the **Connection String** text box.
+
+## 2. Create a database configuration
+
+<Render file="create-hyperdrive-config" />

--- a/src/content/docs/hyperdrive/examples/pgedge.mdx
+++ b/src/content/docs/hyperdrive/examples/pgedge.mdx
@@ -5,7 +5,7 @@ pcx_content_type: example
 title: Connect to pgEdge Cloud
 sidebar:
   order: 9
-description: Connect Hyperdrive to a Neon Postgres database.
+description: Connect Hyperdrive to a pgEdge Postgres database.
 
 ---
 


### PR DESCRIPTION
Completes https://github.com/cloudflare/cloudflare-docs/pull/15377

Adding the pgEdge provider as per the standardized way to add a Hyperdrive example which reuses content across examples.

Omits the tutorial due to significant overlap and minimal additional content. The docs is not the appropriate place for us to have vendor-specific benchmarks. 