### PR TITLE
Delete link to deprecated template file

### DIFF
--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/index.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/index.mdx
@@ -10,8 +10,6 @@ import { Description } from "~/components"
 
 All new [developers.cloudflare.com](https://developers.cloudflare.com/) products should include the required content sections that are listed in the following table. The other sections are available depending on what information users need to successfully use the product.
 
-Templates for each content type are also available in our [Cloudflare-docs GitHub repository](https://github.com/cloudflare/cloudflare-docs/tree/production/static/_templates).
-
 <table>
     <tr>
         <th style="width:25%">Content section</th>


### PR DESCRIPTION
### Summary

Removed a link to a folder that no longer exists. 