### PR TITLE
[WAF] Add managed rulesets (post migration)

### DIFF
--- a/src/content/docs/waf/managed-rules/index.mdx
+++ b/src/content/docs/waf/managed-rules/index.mdx
@@ -6,10 +6,9 @@ sidebar:
 head:
   - tag: title
     content: WAF Managed Rules
-
 ---
 
-import { FeatureTable, Render } from "~/components"
+import { FeatureTable, Render, RuleID } from "~/components";
 
 <Render file="waf-managed-rules-intro" product="waf" />
 
@@ -17,11 +16,17 @@ import { FeatureTable, Render } from "~/components"
 
 Cloudflare provides the following managed rulesets in the WAF:
 
+- [**Cloudflare Managed Ruleset**](/waf/managed-rules/reference/cloudflare-managed-ruleset/): Created by the Cloudflare security team, this ruleset provides fast and effective protection for all of your applications. The ruleset is updated frequently to cover new vulnerabilities and reduce false positives.<br/>Ruleset ID: <RuleID id="efb7b8c949ac4650a09736fc376e9aee" />
 
+- [**Cloudflare OWASP Core Ruleset**](/waf/managed-rules/reference/owasp-core-ruleset/): Cloudflare's implementation of the Open Web Application Security Project, or OWASP ModSecurity Core Rule Set. Cloudflare routinely monitors for updates from OWASP based on the latest version available from the official code repository.<br/>Ruleset ID: <RuleID id="4814384a9e5d4991b9815dcfc25d2f1f" />
+
+- [**Cloudflare Exposed Credentials Check**](/waf/managed-rules/reference/exposed-credentials-check/): Deploy an automated credentials check on your end-user authentication endpoints. For any credential pair, the Cloudflare WAF performs a lookup against a public database of stolen credentials.<br/>Ruleset ID: <RuleID id="c2e184081120413c86c3ab7e14069605" />
+
+- **Cloudflare Free Managed Ruleset**: Available on all Cloudflare plans. Designed to provide mitigation against high and wide impacting vulnerabilities. The rules are safe to deploy on most applications. If you deployed the Cloudflare Managed Ruleset for your site, you do not need to deploy this managed ruleset.<br/>Ruleset ID: <RuleID id="77454fe2d30c4220b5701f6fdfb893ba" />
 
 The following managed rulesets run in a response phase:
 
-
+- [**Cloudflare Sensitive Data Detection**](/waf/managed-rules/reference/sensitive-data-detection/): Created by Cloudflare to address common data loss threats. These rules monitor the download of specific sensitive data — for example, financial and personally identifiable information. Available in **Security** > **Sensitive Data**.<br/>Ruleset ID: <RuleID id="e22d83c647c64a3eae91b71b499d988e" />
 
 ## Availability
 
@@ -33,7 +38,7 @@ The managed rulesets you can deploy depend on your Cloudflare plan.
 
 To customize the behavior of managed rulesets, do one of the following:
 
-* [Create exceptions](/waf/managed-rules/waf-exceptions/) to skip the execution of WAF managed rulesets or some of their rules under certain conditions.
-* [Configure overrides](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) to override the default rule action or disable one or more rules of managed rulesets. Overrides can affect an entire managed ruleset, specific tags, or specific rules in the managed ruleset.
+- [Create exceptions](/waf/managed-rules/waf-exceptions/) to skip the execution of WAF managed rulesets or some of their rules under certain conditions.
+- [Configure overrides](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) to override the default rule action or disable one or more rules of managed rulesets. Overrides can affect an entire managed ruleset, specific tags, or specific rules in the managed ruleset.
 
 Exceptions have priority over overrides.


### PR DESCRIPTION
### Summary

Adds back the list of available WAF managed rulesets, lost in the migration.
