### PR TITLE
[WAF, Rules, other] Fix links to specific fields

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -693,7 +693,7 @@
 /logs/reference/logpush-api-configuration/examples/example-logpush-curl/ /logs/tutorials/examples/example-logpush-curl/ 301
 
 # magic-firewall
-/magic-firewall/reference/magic-firewall-fields/ /ruleset-engine/rules-language/fields/#magic-firewall-fields 301
+/magic-firewall/reference/magic-firewall-fields/ /ruleset-engine/rules-language/fields/magic-firewall/ 301
 /magic-firewall/reference/examples/ /magic-firewall/how-to/add-rules/ 301
 /magic-firewall/how-to/pcaps-bucket-setup/ /magic-firewall/packet-captures/pcaps-bucket-setup/ 301
 /magic-firewall/how-to/collect-pcaps/ /magic-firewall/packet-captures/collect-pcaps/ 301

--- a/src/content/docs/rules/custom-error-responses/create-api.mdx
+++ b/src/content/docs/rules/custom-error-responses/create-api.mdx
@@ -6,7 +6,6 @@ sidebar:
 head:
   - tag: title
     content: Create a custom error response via API
-
 ---
 
 Configure custom error responses as [rules](/ruleset-engine/about/rules/) belonging to the `http_custom_errors` phase. Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create custom error responses via API.
@@ -15,9 +14,9 @@ Configure custom error responses as [rules](/ruleset-engine/about/rules/) belong
 
 When creating a custom error response via API, make sure you:
 
-* Set the rule action to `serve_error`.
-* Define the [parameters](/rules/custom-error-responses/parameters/) in the `action_parameters` field according to response type.
-* Deploy the custom error response rule to the `http_custom_errors` phase at the zone level.
+- Set the rule action to `serve_error`.
+- Define the [parameters](/rules/custom-error-responses/parameters/) in the `action_parameters` field according to response type.
+- Deploy the custom error response rule to the `http_custom_errors` phase at the zone level.
 
 The first rule in the `http_custom_errors` phase ruleset that matches will be applied. No other rules in the ruleset will be matched or applied.
 
@@ -34,9 +33,9 @@ Follow this workflow to create a custom error response rule for a given zone via
 
 The examples in this section use the following fields in their rule expressions:
 
-* [`http.response.code`](/ruleset-engine/rules-language/fields/http-request-response/#httpresponsecode): Represents the HTTP status code returned to the client, either set by a Cloudflare product or returned by the origin server. Use this field to customize the error response for error codes returned by the origin server or by a Cloudflare product such as a Worker.
+- [`http.response.code`](/ruleset-engine/rules-language/fields/http-request-response/#httpresponsecode): Represents the HTTP status code returned to the client, either set by a Cloudflare product or returned by the origin server. Use this field to customize the error response for error codes returned by the origin server or by a Cloudflare product such as a Worker.
 
-* [`cf.response.1xxx_code`](/ruleset-engine/rules-language/fields/#cf-response-1xxx_code): Contains the specific error code for Cloudflare-generated errors. This field will only work for Cloudflare-generated errors such as [52x](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/) and [1xxx](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/).
+- [`cf.response.1xxx_code`](/ruleset-engine/rules-language/fields/http-request-response/#cfresponse1xxx_code): Contains the specific error code for Cloudflare-generated errors. This field will only work for Cloudflare-generated errors such as [52x](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/) and [1xxx](/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/).
 
 ### Custom JSON response for all 5xx errors
 
@@ -118,10 +117,10 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_custom
 
 This `PUT` request, corresponding to the [Update a zone entry point ruleset](/api/operations/updateZoneEntrypointRuleset) operation, replaces any existing rules in the `http_custom_errors` phase entry point ruleset.
 
-***
+---
 
 ## ​​Required API token permissions
 
 The API token used in API requests to manage custom error responses must have at least the following permission:
 
-* *Custom Error Rules* > *Edit*
+- _Custom Error Rules_ > _Edit_

--- a/src/content/docs/rules/transform/managed-transforms/reference.mdx
+++ b/src/content/docs/rules/transform/managed-transforms/reference.mdx
@@ -3,18 +3,21 @@ title: Available Managed Transforms
 pcx_content_type: reference
 sidebar:
   order: 2
-
 ---
 
-import { GlossaryTooltip, Render } from "~/components"
+import { GlossaryTooltip, Render } from "~/components";
 
 This page lists the available Managed Transforms. They can modify HTTP request headers or response headers.
 
-<Render file="snippets-alternative" params={{ one: "and customized header modifications" }} /><br />
+<Render
+	file="snippets-alternative"
+	params={{ one: "and customized header modifications" }}
+/>
+<br />
 
 :::caution[Warning]
 
-The names of HTTP headers are case-insensitive. Cloudflare may use a capitalization different from the one presented in this page. Make sure that your origin server can handle HTTP request headers regardless of the exact capitalization of their names. 
+The names of HTTP headers are case-insensitive. Cloudflare may use a capitalization different from the one presented in this page. Make sure that your origin server can handle HTTP request headers regardless of the exact capitalization of their names.
 :::
 
 ## HTTP request headers
@@ -23,64 +26,64 @@ The names of HTTP headers are case-insensitive. Cloudflare may use a capitalizat
 
 :::note
 
-Requires an Enterprise plan with [Bot Management](/bots/plans/bm-subscription/) enabled. 
+Requires an Enterprise plan with [Bot Management](/bots/plans/bm-subscription/) enabled.
 :::
 
 Adds HTTP headers with bot-related values to the request sent to the origin server:
 
-* `cf-bot-score`: Contains the <GlossaryTooltip term="bot score" link="/bots/concepts/bot-score/">bot score</GlossaryTooltip> (for example, `30`).
-* `cf-verified-bot`: Contains `true` if the request comes from a <GlossaryTooltip term="verified bot" link="/bots/concepts/bot/#verified-bots">verified bot</GlossaryTooltip>, or `false` otherwise.
-* `cf-threat-score`: Contains the <GlossaryTooltip term="threat score" link="/waf/tools/security-level/#threat-score">threat score</GlossaryTooltip> (for example, `10`).
-* `cf-ja3-hash`: Contains the <GlossaryTooltip term="JA3 fingerprint" link="/bots/concepts/ja3-ja4-fingerprint/">JA3 fingerprint</GlossaryTooltip>.
-* `cf-ja4`: Contains the <GlossaryTooltip term="JA3 fingerprint" link="/bots/concepts/ja3-ja4-fingerprint/">JA4 fingerprint</GlossaryTooltip>.
+- `cf-bot-score`: Contains the <GlossaryTooltip term="bot score" link="/bots/concepts/bot-score/">bot score</GlossaryTooltip> (for example, `30`).
+- `cf-verified-bot`: Contains `true` if the request comes from a <GlossaryTooltip term="verified bot" link="/bots/concepts/bot/#verified-bots">verified bot</GlossaryTooltip>, or `false` otherwise.
+- `cf-threat-score`: Contains the <GlossaryTooltip term="threat score" link="/waf/tools/security-level/#threat-score">threat score</GlossaryTooltip> (for example, `10`).
+- `cf-ja3-hash`: Contains the <GlossaryTooltip term="JA3 fingerprint" link="/bots/concepts/ja3-ja4-fingerprint/">JA3 fingerprint</GlossaryTooltip>.
+- `cf-ja4`: Contains the <GlossaryTooltip term="JA3 fingerprint" link="/bots/concepts/ja3-ja4-fingerprint/">JA4 fingerprint</GlossaryTooltip>.
 
 ### Add TLS client auth headers
 
 Adds HTTP headers with [Mutual TLS](/api-shield/security/mtls/) (mTLS) client authentication values to the request sent to the origin server:
 
-* `cf-cert-revoked`: Value from the [`cf.tls_client_auth.cert_revoked`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_revoked) field.
-* `cf-cert-verified`: Value from the [`cf.tls_client_auth.cert_verified`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_verified) field.
-* `cf-cert-presented`: Value from the [`cf.tls_client_auth.cert_presented`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_presented) field.
-* `cf-cert-issuer-dn`: Value from the [`cf.tls_client_auth.cert_issuer_dn`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_issuer_dn) field.
-* `cf-cert-subject-dn`: Value from the [`cf.tls_client_auth.cert_subject_dn`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_subject_dn) field.
-* `cf-cert-issuer-dn-rfc2253`: Value from the [`cf.tls_client_auth.cert_issuer_dn_rfc2253`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_issuer_dn_rfc2253) field.
-* `cf-cert-subject-dn-rfc2253`: Value from the [`cf.tls_client_auth.cert_subject_dn_rfc2253`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_subject_dn_rfc2253) field.
-* `cf-cert-issuer-dn-legacy`: Value from the [`cf.tls_client_auth.cert_issuer_dn_legacy`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_issuer_dn_legacy) field.
-* `cf-cert-subject-dn-legacy`: Value from the [`cf.tls_client_auth.cert_subject_dn_legacy`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_subject_dn_legacy) field.
-* `cf-cert-serial`: Value from the [`cf.tls_client_auth.cert_serial`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_serial) field.
-* `cf-cert-issuer-serial`: Value from the [`cf.tls_client_auth.cert_issuer_serial`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_issuer_serial) field.
-* `cf-cert-fingerprint-sha256`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha256`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_fingerprint_sha256) field.
-* `cf-cert-fingerprint-sha1`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha1`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_fingerprint_sha1) field.
-* `cf-cert-not-before`: Value from the [`cf.tls_client_auth.cert_not_before`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_not_before) field.
-* `cf-cert-not-after`: Value from the [`cf.tls_client_auth.cert_not_after`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_not_after) field.
-* `cf-cert-ski`: Value from the [`cf.tls_client_auth.cert_ski`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_ski) field.
-* `cf-cert-issuer-ski`: Value from the [`cf.tls_client_auth.cert_issuer_ski`](/ruleset-engine/rules-language/fields/#cf-tls_client_auth-cert_issuer_ski) field.
+- `cf-cert-revoked`: Value from the [`cf.tls_client_auth.cert_revoked`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_revoked) field.
+- `cf-cert-verified`: Value from the [`cf.tls_client_auth.cert_verified`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_verified) field.
+- `cf-cert-presented`: Value from the [`cf.tls_client_auth.cert_presented`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_presented) field.
+- `cf-cert-issuer-dn`: Value from the [`cf.tls_client_auth.cert_issuer_dn`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_issuer_dn) field.
+- `cf-cert-subject-dn`: Value from the [`cf.tls_client_auth.cert_subject_dn`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_subject_dn) field.
+- `cf-cert-issuer-dn-rfc2253`: Value from the [`cf.tls_client_auth.cert_issuer_dn_rfc2253`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_issuer_dn_rfc2253) field.
+- `cf-cert-subject-dn-rfc2253`: Value from the [`cf.tls_client_auth.cert_subject_dn_rfc2253`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_subject_dn_rfc2253) field.
+- `cf-cert-issuer-dn-legacy`: Value from the [`cf.tls_client_auth.cert_issuer_dn_legacy`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_issuer_dn_legacy) field.
+- `cf-cert-subject-dn-legacy`: Value from the [`cf.tls_client_auth.cert_subject_dn_legacy`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_subject_dn_legacy) field.
+- `cf-cert-serial`: Value from the [`cf.tls_client_auth.cert_serial`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_serial) field.
+- `cf-cert-issuer-serial`: Value from the [`cf.tls_client_auth.cert_issuer_serial`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_issuer_serial) field.
+- `cf-cert-fingerprint-sha256`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha256`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_fingerprint_sha256) field.
+- `cf-cert-fingerprint-sha1`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha1`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_fingerprint_sha1) field.
+- `cf-cert-not-before`: Value from the [`cf.tls_client_auth.cert_not_before`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_not_before) field.
+- `cf-cert-not-after`: Value from the [`cf.tls_client_auth.cert_not_after`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_not_after) field.
+- `cf-cert-ski`: Value from the [`cf.tls_client_auth.cert_ski`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_ski) field.
+- `cf-cert-issuer-ski`: Value from the [`cf.tls_client_auth.cert_issuer_ski`](/ruleset-engine/rules-language/fields/dynamic-fields/#cftls_client_authcert_issuer_ski) field.
 
 ### Add visitor location headers
 
 Adds HTTP headers with location information for the visitor's IP address to the request sent to the origin server:
 
-* `cf-ipcity`: The visitor's city (value from the [`ip.src.city`](/ruleset-engine/rules-language/fields/#ip-src-city) field).
-* `cf-ipcountry`: The visitor's country (value from the [`ip.src.country`](/ruleset-engine/rules-language/fields/#ip-src-country) field).
-* `cf-ipcontinent`: The visitor's continent (value from the [`ip.src.continent`](/ruleset-engine/rules-language/fields/#ip-src-continent) field).
-* `cf-iplongitude`: The visitor's longitude (value from the [`ip.src.lon`](/ruleset-engine/rules-language/fields/#ip-src-lon) field).
-* `cf-iplatitude`: The visitor's latitude (value from the [`ip.src.lat`](/ruleset-engine/rules-language/fields/#ip-src-lat) field).
-* `cf-region`: The visitor's region (value from the [`ip.src.region`](/ruleset-engine/rules-language/fields/#ip-src-region) field).
-* `cf-region-code`: The visitor's region code (value from the [`ip.src.region_code`](/ruleset-engine/rules-language/fields/#ip-src-region_code) field).
-* `cf-metro-code`: The visitor's metro code (value from the [`ip.src.metro_code`](/ruleset-engine/rules-language/fields/#ip-src-metro_code) field).
-* `cf-postal-code`: The visitor's postal code (value from the [`ip.src.postal_code`](/ruleset-engine/rules-language/fields/#ip-src-postal_code) field).
-* `cf-timezone`: The name of the visitor's timezone (value from the [`ip.src.timezone.name`](/ruleset-engine/rules-language/fields/#ip-src-timezone-name) field).
+- `cf-ipcity`: The visitor's city (value from the [`ip.src.city`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrccity) field).
+- `cf-ipcountry`: The visitor's country (value from the [`ip.src.country`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrccountry) field).
+- `cf-ipcontinent`: The visitor's continent (value from the [`ip.src.continent`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrccontinent) field).
+- `cf-iplongitude`: The visitor's longitude (value from the [`ip.src.lon`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrclon) field).
+- `cf-iplatitude`: The visitor's latitude (value from the [`ip.src.lat`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrclat) field).
+- `cf-region`: The visitor's region (value from the [`ip.src.region`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcregion) field).
+- `cf-region-code`: The visitor's region code (value from the [`ip.src.region_code`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcregion_code) field).
+- `cf-metro-code`: The visitor's metro code (value from the [`ip.src.metro_code`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcmetro_code) field).
+- `cf-postal-code`: The visitor's postal code (value from the [`ip.src.postal_code`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcpostal_code) field).
+- `cf-timezone`: The name of the visitor's timezone (value from the [`ip.src.timezone.name`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrctimezonename) field).
 
 :::caution[Warning]
 
-Turning on [IP geolocation](/network/ip-geolocation/) will send a `cf-ipcountry` HTTP header to your origin server even when **Add visitor location headers** is turned off. 
+Turning on [IP geolocation](/network/ip-geolocation/) will send a `cf-ipcountry` HTTP header to your origin server even when **Add visitor location headers** is turned off.
 :::
 
 ### Add "True-Client-IP" header
 
 :::note
 
-Only available on Enterprise plans. 
+Only available on Enterprise plans.
 :::
 
 Adds a `true-client-ip` request header with the visitor's IP address.
@@ -91,9 +94,9 @@ This Managed Transform is unavailable when [**Remove visitor IP headers**](#remo
 
 Removes HTTP headers that may contain the visitor's IP address from the request sent to the origin server. Handles the following HTTP request headers:
 
-* `cf-connecting-ip`
-* `x-forwarded-for` (refer to the [notes](#visitor-ip-address-in-the-x-forwarded-for-http-header) below)
-* `true-client-ip`
+- `cf-connecting-ip`
+- `x-forwarded-for` (refer to the [notes](#visitor-ip-address-in-the-x-forwarded-for-http-header) below)
+- `true-client-ip`
 
 This Managed Transform is unavailable when [**Add "True-Client-IP" header**](#add-true-client-ip-header) is enabled.
 
@@ -117,10 +120,10 @@ Removes the `X-Powered-By` HTTP response header that provides information about 
 
 Adds several security-related HTTP response headers. The added response headers and values are the following:
 
-* `x-content-type-options: nosniff`
-* `x-xss-protection: 1; mode=block`
-* `x-frame-options: SAMEORIGIN`
-* `referrer-policy: same-origin`
-* `expect-ct: max-age=86400, enforce`
+- `x-content-type-options: nosniff`
+- `x-xss-protection: 1; mode=block`
+- `x-frame-options: SAMEORIGIN`
+- `referrer-policy: same-origin`
+- `expect-ct: max-age=86400, enforce`
 
 To increase protection, [enable HTTP Strict Transport Security (HSTS)](/ssl/edge-certificates/additional-options/http-strict-transport-security/) for your website.

--- a/src/content/docs/ruleset-engine/rules-language/fields/dynamic-fields.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/fields/dynamic-fields.mdx
@@ -106,13 +106,13 @@ Returns the string representation of the per-hostname [custom metadata](/cloudfl
 
 `cf.random_seed` `Bytes`
 
-Returns per-request random bytes that you can use in the [`uuidv4()`](https://example.com/ruleset-engine/rules-language/functions/#uuidv4) function.
+Returns per-request random bytes that you can use in the [`uuidv4()`](/ruleset-engine/rules-language/functions/#uuidv4) function.
 
 ## `cf.ray_id`
 
 `cf.ray_id` `String`
 
-The Ray ID of the current request. A [Ray ID](https://example.com/fundamentals/reference/cloudflare-ray-id/) is an identifier given to every request that goes through Cloudflare.
+The Ray ID of the current request. A [Ray ID](/fundamentals/reference/cloudflare-ray-id/) is an identifier given to every request that goes through Cloudflare.
 
 ## `cf.threat_score`
 

--- a/src/content/docs/ruleset-engine/rules-language/functions.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/functions.mdx
@@ -337,7 +337,7 @@ any(url_decode(http.request.body.form.values[*])[*] contains "an xss attack")
 
 `uuidv4(Bytes)` → `String`
 
-Generates a random UUIDv4 (Universally Unique Identifier, version 4) based on the given argument (a source of randomness). To obtain an array of random bytes, use the [`cf.random_seed`](/ruleset-engine/rules-language/fields/#cf-random_seed) field.
+Generates a random UUIDv4 (Universally Unique Identifier, version 4) based on the given argument (a source of randomness). To obtain an array of random bytes, use the [`cf.random_seed`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfrandom_seed) field.
 
 For example, `uuidv4(cf.random_seed)` will return a UUIDv4 similar to `49887398-6bcf-485f-8899-f15dbef4d1d5`.
 

--- a/src/content/docs/waf/about/content-scanning/index.mdx
+++ b/src/content/docs/waf/about/content-scanning/index.mdx
@@ -3,10 +3,9 @@ title: Uploaded content scanning
 pcx_content_type: concept
 sidebar:
   order: 3
-
 ---
 
-import { GlossaryTooltip } from "~/components"
+import { GlossaryTooltip } from "~/components";
 
 WAF content scanning is a WAF [traffic detection](/waf/about/#detection-versus-mitigation) that scans content being uploaded to your application.
 
@@ -14,7 +13,7 @@ When enabled, content scanning attempts to detect content objects, such as uploa
 
 :::note
 
-This feature is available to customers on an Enterprise plan with a paid add-on. 
+This feature is available to customers on an Enterprise plan with a paid add-on.
 :::
 
 ## How it works
@@ -29,18 +28,18 @@ Cloudflare uses the same [anti-virus (AV) scanner used in Cloudflare Zero Trust]
 
 Content scanning will not apply any mitigation actions to requests with content objects considered malicious. It only provides a signal that you can use to define your attack mitigation strategy. You must create rules — [custom rules](/waf/custom-rules/) or [rate limiting rules](/waf/rate-limiting-rules/) — to perform actions based on detected signals.
 
-For more information on detection versus mitigation, refer to [Concepts](/waf/about/#detection-versus-mitigation). 
+For more information on detection versus mitigation, refer to [Concepts](/waf/about/#detection-versus-mitigation).
 :::
 
 ## What is a content object?
 
 A content object is any request payload detected by heuristics that does not match any of the following types: `text/html`, `text/x-shellscript`, `application/json`, `text/csv`, and `text/xml`. All other content types are considered a content object, such as the following:
 
-* Executable files (for example, `.exe`, `.bat`, `.dll`, and `.wasm`)
-* Documents (for example, `.doc`, `.docx`, `.pdf`, `.ppt`, and `.xls`)
-* Compressed files (for example, `.gz`, `.zip`, and `.rar`)
-* Image files (for example, `.jpg`, `.png`, `.gif`, `.webp`, and `.tif`)
-* Video and audio files
+- Executable files (for example, `.exe`, `.bat`, `.dll`, and `.wasm`)
+- Documents (for example, `.doc`, `.docx`, `.pdf`, `.ppt`, and `.xls`)
+- Compressed files (for example, `.gz`, `.zip`, and `.rar`)
+- Image files (for example, `.jpg`, `.png`, `.gif`, `.webp`, and `.tif`)
+- Video and audio files
 
 Content scanning does not take the request's `Content-Type` header into account, since this header can be manipulated. If the system detects a malicious object but cannot determine its exact content type, it reports the malicious content object as having an `application/octet-stream` content type.
 
@@ -48,9 +47,9 @@ Content scanning does not take the request's `Content-Type` header into account,
 
 Content scanning can check the following content objects for malicious content:
 
-* Uploaded files in a request
-* Portions of the request body for multipart requests encoded as `multipart/form-data` or `multipart/mixed`
-* Specific JSON properties in the request body (containing, for example, files encoded in Base64) according to the [custom scan expressions](#custom-scan-expressions) you provide
+- Uploaded files in a request
+- Portions of the request body for multipart requests encoded as `multipart/form-data` or `multipart/mixed`
+- Specific JSON properties in the request body (containing, for example, files encoded in Base64) according to the [custom scan expressions](#custom-scan-expressions) you provide
 
 All content objects in an incoming request will be checked, namely for requests with multiple uploaded files (for example, a submitted HTML form with several file inputs).
 
@@ -58,7 +57,7 @@ The content scanner will fully check content objects with a size up to 15 MB. Fo
 
 :::caution[Warning]
 
-The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations. 
+The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations.
 :::
 
 ## Custom scan expressions
@@ -66,7 +65,7 @@ The AV scanner will not scan some particular types of files, namely encrypted or
 Sometimes, you may wish to specify where to find the content objects, such as when the content is a Base64-encoded string within a JSON payload. For example:
 
 ```json
-{"file": "<BASE64_ENCODED_STRING>"}
+{ "file": "<BASE64_ENCODED_STRING>" }
 ```
 
 In these situations, configure a custom scan expression to tell the content scanner where to find the content objects. For more information, refer to [Configure a custom scan expression](/waf/about/content-scanning/get-started/#4-optional-configure-a-custom-scan-expression).
@@ -75,19 +74,15 @@ In these situations, configure a custom scan expression to tell the content scan
 
 When content scanning is enabled, you can use the following fields in WAF rules:
 
-
-
-| Field name in the dashboard                                                                | Field name in expressions                                                                                                     |
-| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| Has content object                                                                         | [`cf.waf.content_scan.has_obj`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-has_obj)                     |
-| Has malicious content object                                                               | [`cf.waf.content_scan.has_malicious_obj`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-has_malicious_obj) |
-| Number of malicious content objects                                                        | [`cf.waf.content_scan.num_malicious_obj`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-num_malicious_obj) |
-| Content scan has failed                                                                    | [`cf.waf.content_scan.has_failed`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-has_failed)               |
-| Number of content objects                                                                  | [`cf.waf.content_scan.num_obj`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-num_obj)                     |
-| Content object size (in bytes)                                                             | [`cf.waf.content_scan.obj_sizes`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-obj_sizes)                 |
-| Content object type                                                                        | [`cf.waf.content_scan.obj_types`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-obj_types)                 |
-| Content object result<br/>Values: `clean`, `suspicious`,<br/>`infected`, and `not scanned` | [`cf.waf.content_scan.obj_results`](/ruleset-engine/rules-language/fields/#cf-waf-content_scan-obj_results)             |
-
-
+| Field name in the dashboard                                                                | Field name in expressions                                                                                                           |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Has content object                                                                         | [`cf.waf.content_scan.has_obj`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanhas_obj)                     |
+| Has malicious content object                                                               | [`cf.waf.content_scan.has_malicious_obj`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanhas_malicious_obj) |
+| Number of malicious content objects                                                        | [`cf.waf.content_scan.num_malicious_obj`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scannum_malicious_obj) |
+| Content scan has failed                                                                    | [`cf.waf.content_scan.has_failed`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanhas_failed)               |
+| Number of content objects                                                                  | [`cf.waf.content_scan.num_obj`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scannum_obj)                     |
+| Content object size (in bytes)                                                             | [`cf.waf.content_scan.obj_sizes`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanobj_sizes)                 |
+| Content object type                                                                        | [`cf.waf.content_scan.obj_types`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanobj_types)                 |
+| Content object result<br/>Values: `clean`, `suspicious`,<br/>`infected`, and `not scanned` | [`cf.waf.content_scan.obj_results`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafcontent_scanobj_results)             |
 
 For examples of rule expressions using these fields, refer to [Example rules](/waf/about/content-scanning/example-rules/).

--- a/src/content/docs/waf/about/waf-attack-score.mdx
+++ b/src/content/docs/waf/about/waf-attack-score.mdx
@@ -3,10 +3,9 @@ title: WAF attack score
 pcx_content_type: concept
 sidebar:
   order: 2
-
 ---
 
-import { GlossaryTooltip } from "~/components"
+import { GlossaryTooltip } from "~/components";
 
 WAF attack score is a feature that complements [WAF Managed Rules](/waf/managed-rules/).
 
@@ -18,30 +17,26 @@ To maximize protection, Cloudflare recommends that you use both Managed Rules an
 
 :::note
 
-This feature is available to Enterprise customers. Business plans have access to a single field (WAF Attack Score Class). 
+This feature is available to Enterprise customers. Business plans have access to a single field (WAF Attack Score Class).
 :::
 
 ## Available scores
 
 The Cloudflare WAF provides the following attack scores:
 
-
-
-| Score                  | Minimum plan required | Attack vector               | Field                                                                                   |
-| ---------------------- | --------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
-| WAF Attack Score       | Enterprise            | N/A (global score)          | [`cf.waf.score`](/ruleset-engine/rules-language/fields/#cf-waf-score)             |
-| WAF SQLi Attack Score  | Enterprise            | SQL injection (SQLi)        | [`cf.waf.score.sqli`](/ruleset-engine/rules-language/fields/#cf-waf-score-sqli)   |
-| WAF XSS Attack Score   | Enterprise            | Cross-site scripting (XSS)  | [`cf.waf.score.xss`](/ruleset-engine/rules-language/fields/#cf-waf-score-xss)     |
-| WAF RCE Attack Score   | Enterprise            | Remote Code Execution (RCE) | [`cf.waf.score.rce`](/ruleset-engine/rules-language/fields/#cf-waf-score-rce)     |
-| WAF Attack Score Class | Business              | N/A (global classification) | [`cf.waf.score.class`](/ruleset-engine/rules-language/fields/#cf-waf-score-class) |
-
-
+| Score                  | Minimum plan required | Attack vector               | Field                                                                                         |
+| ---------------------- | --------------------- | --------------------------- | --------------------------------------------------------------------------------------------- |
+| WAF Attack Score       | Enterprise            | N/A (global score)          | [`cf.waf.score`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafscore)            |
+| WAF SQLi Attack Score  | Enterprise            | SQL injection (SQLi)        | [`cf.waf.score.sqli`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafscoresqli)   |
+| WAF XSS Attack Score   | Enterprise            | Cross-site scripting (XSS)  | [`cf.waf.score.xss`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafscorexss)     |
+| WAF RCE Attack Score   | Enterprise            | Remote Code Execution (RCE) | [`cf.waf.score.rce`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafscorerce)     |
+| WAF Attack Score Class | Business              | N/A (global classification) | [`cf.waf.score.class`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfwafscoreclass) |
 
 You can use the fields for these scores in expressions of [custom rules](/waf/custom-rules/) and [rate limiting rules](/waf/rate-limiting-rules/) where:
 
-* A score of `1` indicates that the request is almost certainly malicious.
-* A score of `99` indicates that the request is likely clean.
-* A score of `100` indicates that the Cloudflare WAF did not score the request.
+- A score of `1` indicates that the request is almost certainly malicious.
+- A score of `99` indicates that the request is likely clean.
+- A score of `100` indicates that the Cloudflare WAF did not score the request.
 
 The available scores are independent of each other. Namely, the WAF Attack Score is not a sum of the other scores.
 
@@ -49,16 +44,16 @@ The WAF Attack Score Class field can have one of the following values, depending
 
 | Dashboard label | Field value     | Description                         |
 | --------------- | --------------- | ----------------------------------- |
-| *Attack*        | `attack`        | Attack score between `1` and `20`.  |
-| *Likely attack* | `likely_attack` | Attack score between `21` and `50`. |
-| *Likely clean*  | `likely_clean`  | Attack score between `51` and `80`. |
-| *Clean*         | `clean`         | Attack score between `81` and `99`. |
+| _Attack_        | `attack`        | Attack score between `1` and `20`.  |
+| _Likely attack_ | `likely_attack` | Attack score between `21` and `50`. |
+| _Likely clean_  | `likely_clean`  | Attack score between `51` and `80`. |
+| _Clean_         | `clean`         | Attack score between `81` and `99`. |
 
-Requests with an attack score of `100` will have a class of *Unscored* in the Cloudflare dashboard, but you cannot use this class value in rule expressions.
+Requests with an attack score of `100` will have a class of _Unscored_ in the Cloudflare dashboard, but you cannot use this class value in rule expressions.
 
 Attack score automatically detects and decodes Base64, JavaScript (Unicode escape sequences), and URL encoded content anywhere in the request: URL, headers, and body.
 
-***
+---
 
 ## Start using the WAF attack score
 
@@ -66,11 +61,11 @@ Attack score automatically detects and decodes Base64, JavaScript (Unicode escap
 
 If you are an Enterprise customer:
 
-* Create a [WAF custom rule](/waf/custom-rules/create-dashboard/) that logs all requests with a WAF Attack Score below 40 (recommended initial threshold). For example, set the rule expression to `cf.waf.score lt 40` and the rule action to *Log*.
+- Create a [WAF custom rule](/waf/custom-rules/create-dashboard/) that logs all requests with a WAF Attack Score below 40 (recommended initial threshold). For example, set the rule expression to `cf.waf.score lt 40` and the rule action to _Log_.
 
 If you are a Business customer:
 
-* Create a [WAF custom rule](/waf/custom-rules/create-dashboard/) matching requests with a WAF Attack Score Class of *Attack*. For example, set the rule expression to `cf.waf.score.class eq "attack"` and the rule action to a challenge action (such as *Managed Challenge*) or *Block*.
+- Create a [WAF custom rule](/waf/custom-rules/create-dashboard/) matching requests with a WAF Attack Score Class of _Attack_. For example, set the rule expression to `cf.waf.score.class eq "attack"` and the rule action to a challenge action (such as _Managed Challenge_) or _Block_.
 
 ### 2. Monitor domain traffic
 
@@ -78,9 +73,9 @@ Monitor the rule you created, especially in the first few days, to make sure you
 
 ### 3. Update the rule action
 
-If you are an Enterprise customer and you created a rule with *Log* action, change the rule action to a more severe one, like *Managed Challenge* or *Block*.
+If you are an Enterprise customer and you created a rule with _Log_ action, change the rule action to a more severe one, like _Managed Challenge_ or _Block_.
 
-***
+---
 
 ## Additional remarks
 

--- a/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-specific-countries.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-specific-countries.mdx
@@ -1,14 +1,13 @@
 ---
 pcx_content_type: configuration
 title: Allow traffic from specific countries only
-
 ---
 
-This example blocks requests based on country code using the [`ip.geoip.country`](/ruleset-engine/rules-language/fields/#ip-src-country) field, only allowing requests from two countries: United States and Mexico.
+This example blocks requests based on country code using the [`ip.geoip.country`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrccountry) field, only allowing requests from two countries: United States and Mexico.
 
 - **Expression**: `(not ip.geoip.country in {"US" "MX"})`
-- **Action**: *Block*
+- **Action**: _Block_
 
 ## Other resources
 
-* [Use case: Block traffic from specific countries](/waf/custom-rules/use-cases/block-traffic-from-specific-countries/)
+- [Use case: Block traffic from specific countries](/waf/custom-rules/use-cases/block-traffic-from-specific-countries/)

--- a/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-verified-bots.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-verified-bots.mdx
@@ -4,19 +4,18 @@ title: Allow traffic from search engine bots
 head:
   - tag: title
     content: Allow traffic from search engine bots and other verified bots
-
 ---
 
 This example challenges requests from a list of countries, but allows traffic from search engine bots — such as Googlebot and Bingbot — and from other [verified bots](/bots/concepts/bot/#verified-bots).
 
-The rule expression uses the [`cf.client.bot`](/ruleset-engine/rules-language/fields/#cf-client-bot) field to determine if the request originated from a known good bot or crawler.
+The rule expression uses the [`cf.client.bot`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfclientbot) field to determine if the request originated from a known good bot or crawler.
 
 - **Expression**: `(ip.geoip.country in {"US" "MX"} and not cf.client.bot)`
 - **Action**: <em>Managed Challenge</em>
 
 ## Other resources
 
-* [Use case: Challenge bad bots](/waf/custom-rules/use-cases/challenge-bad-bots/)
-* [Cloudflare bot solutions](/bots/)
-* [Troubleshooting: Bing’s Site Scan blocked by a WAF managed rule](/waf/troubleshooting/blocked-bing-site-scans/)
-* [Learning Center: What is a web crawler?](https://www.cloudflare.com/learning/bots/what-is-a-web-crawler/)
+- [Use case: Challenge bad bots](/waf/custom-rules/use-cases/challenge-bad-bots/)
+- [Cloudflare bot solutions](/bots/)
+- [Troubleshooting: Bing’s Site Scan blocked by a WAF managed rule](/waf/troubleshooting/blocked-bing-site-scans/)
+- [Learning Center: What is a web crawler?](https://www.cloudflare.com/learning/bots/what-is-a-web-crawler/)

--- a/src/content/docs/waf/custom-rules/use-cases/block-traffic-from-specific-countries.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/block-traffic-from-specific-countries.mdx
@@ -1,14 +1,13 @@
 ---
 pcx_content_type: configuration
 title: Block traffic from specific countries
-
 ---
 
-This example blocks requests based on country code using the [`ip.geoip.country`](/ruleset-engine/rules-language/fields/#ip-src-country) field.
+This example blocks requests based on country code using the [`ip.geoip.country`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrccountry) field.
 
 - **Expression**: `(ip.geoip.country in {"KN" "SY"})`
-- **Action**: *Block*
+- **Action**: _Block_
 
 ## Other resources
 
-* [Use case: Allow traffic from specific countries only](/waf/custom-rules/use-cases/allow-traffic-from-specific-countries/)
+- [Use case: Allow traffic from specific countries only](/waf/custom-rules/use-cases/allow-traffic-from-specific-countries/)

--- a/src/content/docs/waf/custom-rules/use-cases/challenge-bad-bots.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/challenge-bad-bots.mdx
@@ -1,16 +1,13 @@
 ---
 pcx_content_type: configuration
 title: Challenge bad bots
-
 ---
 
 Cloudflare’s Bot Management feature scores the likelihood that a request originates from a bot.
 
 :::caution
 
-
 Access to [Bot Management](/bots/plans/bm-subscription/) requires a Cloudflare Enterprise plan with Bot Management enabled.
-
 
 :::
 
@@ -18,16 +15,16 @@ Bot score ranges from 1 through 99. A low score indicates the request comes from
 
 These examples use:
 
-* [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/#cf-bot_management-score) to target requests from bots
-* [`cf.bot_management.verified_bot`](/ruleset-engine/rules-language/fields/#cf-bot_management-verified_bot) to identify requests from [known good bots](https://radar.cloudflare.com/verified-bots)
-* [`cf.bot_management.ja3_hash`](/ruleset-engine/rules-language/fields/#cf-bot_management-ja3_hash) to target specific [JA3 Fingerprints](/bots/concepts/ja3-ja4-fingerprint/)
+- [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfbot_managementscore) to target requests from bots
+- [`cf.bot_management.verified_bot`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfbot_managementverified_bot) to identify requests from [known good bots](https://radar.cloudflare.com/verified-bots)
+- [`cf.bot_management.ja3_hash`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfbot_managementja3_hash) to target specific [JA3 Fingerprints](/bots/concepts/ja3-ja4-fingerprint/)
 
 ## Suggested rules
 
 For best results:
 
-* Use [Bot Analytics](/bots/bot-analytics/bm-subscription/) to learn about your traffic before applying rules.
-* Start small and increase your bot threshold over time.
+- Use [Bot Analytics](/bots/bot-analytics/bm-subscription/) to learn about your traffic before applying rules.
+- Start small and increase your bot threshold over time.
 
 Your rules may also vary based on the [nature of your site](/bots/get-started/bm-subscription/) and your tolerance for false positives.
 
@@ -35,26 +32,30 @@ Your rules may also vary based on the [nature of your site](/bots/get-started/bm
 
 The following three rules provide baseline protection against malicious bots:
 
-
 1. Rule 1:
-  - **Expression**: `(cf.bot_management.verified_bot)`
-  - **Action**: *Skip:*
-    - All remaining custom rules
+
+- **Expression**: `(cf.bot_management.verified_bot)`
+- **Action**: _Skip:_
+  - All remaining custom rules
+
 2. Rule 2:
-  - **Expression**: `(cf.bot_management.score eq 1)`
-  - **Action**: *Block*
+
+- **Expression**: `(cf.bot_management.score eq 1)`
+- **Action**: _Block_
+
 3. Rule 3:
-  - **Expression**: `(cf.bot_management.score gt 1 and cf.bot_management.score lt 30)`
-  - **Action**: *Managed Challenge*
+
+- **Expression**: `(cf.bot_management.score gt 1 and cf.bot_management.score lt 30)`
+- **Action**: _Managed Challenge_
 
 ### Specific protection for browser, API, and mobile traffic
 
 #### Protect browser endpoints
 
-When a request is definitely automated (score of 1) or likely automated (scores 2 through 29) and is *not* on the list of known good bots, Cloudflare blocks the request.
+When a request is definitely automated (score of 1) or likely automated (scores 2 through 29) and is _not_ on the list of known good bots, Cloudflare blocks the request.
 
 - **Expression**: `(cf.bot_management.score lt 30 and not cf.bot_management.verified_bot)`
-- **Action**: *Block*
+- **Action**: _Block_
 
 #### Exempt API traffic
 
@@ -63,8 +64,8 @@ Since Bot Management detects automated users, you need to explicitly allow your 
 This example offers the same protection as the browser-only rule, but allows automated traffic to your API.
 
 - **Expression**: `(cf.bot_management.score lt 30 and not cf.bot_management.verified_bot and not
-          starts_with(http.request.uri.path, "/api"))`
-- **Action**: *Block*
+        starts_with(http.request.uri.path, "/api"))`
+- **Action**: _Block_
 
 #### Adjust for mobile traffic
 
@@ -74,24 +75,27 @@ If you are handling requests from your own mobile application, you could potenti
 
 - **Expression**: `(cf.bot_management.ja3_hash eq "df669e7ea913f1ac0c0cce9a201a2ec1")`
 - **Action**: <em>Skip:</em>
-    — <em>All remaining custom rules</em>
+  — <em>All remaining custom rules</em>
 
 Otherwise, you could set lower thresholds for mobile traffic. The following rules would block definitely automated mobile traffic and challenge likely automated traffic.
 
 1. Rule 1:
-  - **Expression**: `(cf.bot_management.score lt 2 and http.user_agent contains "App_Name 2.0")`
-  - **Action**: *Block*
+
+- **Expression**: `(cf.bot_management.score lt 2 and http.user_agent contains "App_Name 2.0")`
+- **Action**: _Block_
+
 2. Rule 2:
-  - **Expression**: `(cf.bot_management.score lt 30 and http.user_agent contains "App_Name 2.0")`
-  - **Action**: *Managed Challenge*
+
+- **Expression**: `(cf.bot_management.score lt 30 and http.user_agent contains "App_Name 2.0")`
+- **Action**: _Managed Challenge_
 
 #### Combine the different rules
 
 If your domain handles mobile, browser, and API traffic, you would want to arrange these example rules in the following order:
 
-* Rule for [API traffic](#exempt-api-traffic)
-* Rule(s) for [mobile traffic](#adjust-for-mobile-traffic)
-* Rule for [browser traffic](#protect-browser-endpoints)
+- Rule for [API traffic](#exempt-api-traffic)
+- Rule(s) for [mobile traffic](#adjust-for-mobile-traffic)
+- Rule for [browser traffic](#protect-browser-endpoints)
 
 ### Static resource protection
 
@@ -105,8 +109,8 @@ From there, you could customize your custom rules based on specific request path
 
 Make sure you review [Bot Analytics](/bots/bot-analytics/bm-subscription/) and [Security Events](/waf/analytics/security-events/) to check if your rules need more tuning.
 
-***
+---
 
 ## Other resources
 
-* [Use case: Allow traffic from verified bots](/waf/custom-rules/use-cases/allow-traffic-from-verified-bots/)
+- [Use case: Allow traffic from verified bots](/waf/custom-rules/use-cases/allow-traffic-from-verified-bots/)

--- a/src/content/docs/waf/custom-rules/use-cases/require-specific-http-ports.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/require-specific-http-ports.mdx
@@ -1,26 +1,23 @@
 ---
 pcx_content_type: configuration
 title: Require specific HTTP ports
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 By default, Cloudflare allows requests on a [number of different HTTP ports](/fundamentals/reference/network-ports/).
 
-You can target requests based on their HTTP port with the [`cf.edge.server_port`](/ruleset-engine/rules-language/fields/#cf-edge-server_port) field. Use the `in` [comparison operator](/ruleset-engine/rules-language/operators/#comparison-operators) to target a set of ports.
+You can target requests based on their HTTP port with the [`cf.edge.server_port`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfedgeserver_port) field. Use the `in` [comparison operator](/ruleset-engine/rules-language/operators/#comparison-operators) to target a set of ports.
 
 This example blocks requests to `www.example.com` that are not on ports `80` or `443`:
 
 - **Expression**: `(http.host eq "www.example.com" and not cf.edge.server_port in {80 443})`
-- **Action**: *Block*
+- **Action**: _Block_
 
 :::note[Open server ports and blocked traffic]
-
 
 <Render file="open-ports-blocked-traffic" />
 
 Custom rules and WAF Managed Rules can block traffic at the application layer (layer 7 in the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/)), preventing HTTP/HTTPS requests over non-standard ports from reaching the origin server.
-
 
 :::

--- a/src/content/docs/waf/custom-rules/use-cases/update-rules-customers-partners.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/update-rules-customers-partners.mdx
@@ -1,19 +1,18 @@
 ---
 pcx_content_type: configuration
 title: Update custom rules for customers or partners
-
 ---
 
 You may want to adjust your custom rules to increase access by customers or partners.
 
 Potential examples include:
 
-* Removing rate limiting for an API
-* Sharing brand assets and marketing materials
+- Removing rate limiting for an API
+- Sharing brand assets and marketing materials
 
 :::caution
 
-The example rules in this page can bypass Cloudflare's security features and are generally not recommended. Use with caution. 
+The example rules in this page can bypass Cloudflare's security features and are generally not recommended. Use with caution.
 :::
 
 ## Use ASN in custom rules
@@ -24,18 +23,16 @@ If a customer or partner is large enough, you could set up a custom rule based o
 
 This example uses:
 
-* The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#ip-src-asnum) field to specify the general region.
-* The [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/#cf-bot_management-score) field to ensure partner traffic does not come from bots.
+- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcasnum) field to specify the general region.
+- The [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfbot_managementscore) field to ensure partner traffic does not come from bots.
 
-- **Expression**: `(ip.geoip.asnum eq 64496 and cf.bot_management.score gt 30)`
-- **Action**: <em>Skip:</em>
+* **Expression**: `(ip.geoip.asnum eq 64496 and cf.bot_management.score gt 30)`
+* **Action**: <em>Skip:</em>
   — <em>All remaining custom rules</em>
 
 :::caution[Important]
 
-
 Access to [Bot Management](/bots/plans/bm-subscription/) requires a Cloudflare Enterprise plan with Bot Management.
-
 
 :::
 
@@ -43,11 +40,10 @@ Access to [Bot Management](/bots/plans/bm-subscription/) requires a Cloudflare E
 
 This example uses:
 
-* The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/#ip-src-asnum) field to specify the general region.
-* The [`cf.threat_score`](/ruleset-engine/rules-language/fields/#cf-threat_score) dynamic field to ensure requests are not high-risk traffic.
+- The [`ip.geoip.asnum`](/ruleset-engine/rules-language/fields/standard-fields/#ipsrcasnum) field to specify the general region.
+- The [`cf.threat_score`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfthreat_score) dynamic field to ensure requests are not high-risk traffic.
 
 If a request meets these criteria, your custom rule skips [User Agent Blocking](/waf/tools/user-agent-blocking/) rules.
-
 
 - **Expression**: `(ip.geoip.asnum eq 64496 and cf.threat_score lt 14)`
 - **Action**: <em>Skip:</em>
@@ -61,11 +57,11 @@ For smaller organizations, you could set up custom rules based on IP addresses.
 
 This example:
 
-* Specifies the source IP address and the host.
-* Uses the [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/#cf-bot_management-score) field to ensure requests are not high-risk traffic.
+- Specifies the source IP address and the host.
+- Uses the [`cf.bot_management.score`](/ruleset-engine/rules-language/fields/dynamic-fields/#cfbot_managementscore) field to ensure requests are not high-risk traffic.
 
-- **Expression**: `(ip.src eq 203.0.113.1 and http.host eq "example.com" and cf.bot_management.score gt 30)`
-- **Action**: <em>Skip:</em>
+* **Expression**: `(ip.src eq 203.0.113.1 and http.host eq "example.com" and cf.bot_management.score gt 30)`
+* **Action**: <em>Skip:</em>
   — <em>All remaining custom rules</em>
 
 ### Adjust rules by IP address

--- a/src/content/partials/bots/firewall-variables.mdx
+++ b/src/content/partials/bots/firewall-variables.mdx
@@ -1,13 +1,12 @@
 ---
 {}
-
 ---
 
-Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields/#dynamic-fields) within the expression builder of Ruleset Engine-based products such as [WAF custom rules](/waf/custom-rules/).
+Bot Management provides access to several [new variables](/ruleset-engine/rules-language/fields/dynamic-fields/) within the expression builder of Ruleset Engine-based products such as [WAF custom rules](/waf/custom-rules/).
 
-* **Bot Score** (`cf.bot_management.score`): An integer between 1-99 that indicates [Cloudflare's level of certainty](/bots/concepts/bot-score/) that a request comes from a bot.
-* **Verified Bot** (`cf.bot_management.verified_bot`): A boolean value that is true if the request comes from a good bot, like Google or Bing. Most customers choose to allow this traffic. For more details, see [Traffic from known bots](/waf/troubleshooting/faq/#how-does-the-waf-handle-traffic-from-known-bots).
-* **Serves Static Resource** (`cf.bot_management.static_resource`): An identifier that matches [file extensions](/bots/reference/static-resources/) for many types of static resources. Use this variable if you send emails that retrieve static images.
-* **ja3Hash** (`cf.bot_management.ja3_hash`) and **ja4** (`cf.bot_management.ja4`): A [**JA3/JA4 fingerprint**](/bots/concepts/ja3-ja4-fingerprint/) helps you profile specific SSL/TLS clients across different destination IPs, Ports, and X509 certificates.
-* **Bot Detection IDs** (`cf.bot_management.detection_ids`): List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
-* **Verified Bot Categories** (`cf.verified_bot_category`): A string that allows you to segment your verified bot traffic by its [type and purpose](/bots/reference/verified-bot-categories/).
+- **Bot Score** (`cf.bot_management.score`): An integer between 1-99 that indicates [Cloudflare's level of certainty](/bots/concepts/bot-score/) that a request comes from a bot.
+- **Verified Bot** (`cf.bot_management.verified_bot`): A boolean value that is true if the request comes from a good bot, like Google or Bing. Most customers choose to allow this traffic. For more details, see [Traffic from known bots](/waf/troubleshooting/faq/#how-does-the-waf-handle-traffic-from-known-bots).
+- **Serves Static Resource** (`cf.bot_management.static_resource`): An identifier that matches [file extensions](/bots/reference/static-resources/) for many types of static resources. Use this variable if you send emails that retrieve static images.
+- **ja3Hash** (`cf.bot_management.ja3_hash`) and **ja4** (`cf.bot_management.ja4`): A [**JA3/JA4 fingerprint**](/bots/concepts/ja3-ja4-fingerprint/) helps you profile specific SSL/TLS clients across different destination IPs, Ports, and X509 certificates.
+- **Bot Detection IDs** (`cf.bot_management.detection_ids`): List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
+- **Verified Bot Categories** (`cf.verified_bot_category`): A string that allows you to segment your verified bot traffic by its [type and purpose](/bots/reference/verified-bot-categories/).

--- a/src/content/partials/rules/transform/header-modification-fields.mdx
+++ b/src/content/partials/rules/transform/header-modification-fields.mdx
@@ -1,49 +1,46 @@
 ---
 {}
-
 ---
 
-* `cf.bot_management.*`
-* `cf.client.bot`
-* `cf.threat_score`
-* `cf.edge.server_ip`
-* `cf.edge.server_port`
-* `cf.edge.client_port`
-* `cf.zone.name`
-* `cf.metal.id`
-* `cf.ray_id`
-* `cf.tls_client_auth.*`
-* `http.cookie`
-* `http.host`
-* `http.referer`
-* `http.request.headers`
-* `http.request.accepted_languages`
-* `http.request.method`
-* `http.request.timestamp.sec`
-* `http.request.timestamp.msec`
-* `http.request.full_uri`
-* `http.request.uri`
-* `http.request.uri.*`
-* `http.request.version`
-* `raw.http.request.full_uri`
-* `raw.http.request.uri`
-* `http.user_agent`
-* `http.x_forwarded_for`
-* `ip.src`
-* `ip.src.lat`
-* `ip.src.lon`
-* `ip.src.city`
-* `ip.geoip.*`
-* `ssl`
+- `cf.bot_management.*`
+- `cf.client.bot`
+- `cf.threat_score`
+- `cf.edge.server_ip`
+- `cf.edge.server_port`
+- `cf.edge.client_port`
+- `cf.zone.name`
+- `cf.metal.id`
+- `cf.ray_id`
+- `cf.tls_client_auth.*`
+- `http.cookie`
+- `http.host`
+- `http.referer`
+- `http.request.headers`
+- `http.request.accepted_languages`
+- `http.request.method`
+- `http.request.timestamp.sec`
+- `http.request.timestamp.msec`
+- `http.request.full_uri`
+- `http.request.uri`
+- `http.request.uri.*`
+- `http.request.version`
+- `raw.http.request.full_uri`
+- `raw.http.request.uri`
+- `http.user_agent`
+- `http.x_forwarded_for`
+- `ip.src`
+- `ip.src.lat`
+- `ip.src.lon`
+- `ip.src.city`
+- `ip.geoip.*`
+- `ssl`
 
 Refer to [Fields](/ruleset-engine/rules-language/fields/) for reference information on these fields.
 
 :::caution[Important]
 
+- To obtain the value of an HTTP request header using the [`http.request.headers`](/ruleset-engine/rules-language/fields/http-request-header/#httprequestheaders) field, specify the header name in **lowercase**. For example, to get the first value of the `Accept-Encoding` request header in an expression, use: `http.request.headers["accept-encoding"][0]`.
 
-* To obtain the value of an HTTP request header using the [`http.request.headers`](/ruleset-engine/rules-language/fields/#http-request-headers) field, specify the header name in **lowercase**. For example, to get the first value of the `Accept-Encoding` request header in an expression, use: `http.request.headers["accept-encoding"][0]`.
-
-* Use the `to_string()` function to get the string representation of a non-string value like an Integer value. For example, `to_string(cf.bot_management.score)`.
-
+- Use the `to_string()` function to get the string representation of a non-string value like an Integer value. For example, `to_string(cf.bot_management.score)`.
 
 :::

--- a/src/content/partials/rules/transform/transform-phase-fields.mdx
+++ b/src/content/partials/rules/transform/transform-phase-fields.mdx
@@ -1,48 +1,45 @@
 ---
 {}
-
 ---
 
-* `cf.edge.server_ip`
-* `cf.edge.server_port`
-* `cf.edge.client_port`
-* `cf.zone.name`
-* `cf.metal.id`
-* `cf.ray_id`
-* `cf.tls_client_auth.*`
-* `http.cookie`
-* `http.host`
-* `http.referer`
-* `http.request.headers`
-* `http.request.headers.*`
-* `http.request.accepted_languages`
-* `http.request.method`
-* `http.request.timestamp.sec`
-* `http.request.timestamp.msec`
-* `http.request.full_uri`
-* `http.request.uri`
-* `http.request.uri.*`
-* `http.request.version`
-* `raw.http.request.full_uri`
-* `raw.http.request.uri`
-* `raw.http.request.uri.*`
-* `http.user_agent`
-* `http.x_forwarded_for`
-* `ip.src`
-* `ip.src.lat`
-* `ip.src.lon`
-* `ip.src.city`
-* `ip.geoip.*`
-* `ssl`
+- `cf.edge.server_ip`
+- `cf.edge.server_port`
+- `cf.edge.client_port`
+- `cf.zone.name`
+- `cf.metal.id`
+- `cf.ray_id`
+- `cf.tls_client_auth.*`
+- `http.cookie`
+- `http.host`
+- `http.referer`
+- `http.request.headers`
+- `http.request.headers.*`
+- `http.request.accepted_languages`
+- `http.request.method`
+- `http.request.timestamp.sec`
+- `http.request.timestamp.msec`
+- `http.request.full_uri`
+- `http.request.uri`
+- `http.request.uri.*`
+- `http.request.version`
+- `raw.http.request.full_uri`
+- `raw.http.request.uri`
+- `raw.http.request.uri.*`
+- `http.user_agent`
+- `http.x_forwarded_for`
+- `ip.src`
+- `ip.src.lat`
+- `ip.src.lon`
+- `ip.src.city`
+- `ip.geoip.*`
+- `ssl`
 
 Refer to [Fields](/ruleset-engine/rules-language/fields/) for reference information on these fields.
 
 :::caution[Important]
 
+- To obtain the value of an HTTP request header using the [`http.request.headers`](/ruleset-engine/rules-language/fields/http-request-header/#httprequestheaders) field, specify the header name in **lowercase**. For example, to get the first value of the `Accept-Encoding` request header in an expression, use: `http.request.headers["accept-encoding"][0]`.
 
-* To obtain the value of an HTTP request header using the [`http.request.headers`](/ruleset-engine/rules-language/fields/#http-request-headers) field, specify the header name in **lowercase**. For example, to get the first value of the `Accept-Encoding` request header in an expression, use: `http.request.headers["accept-encoding"][0]`.
-
-* Use the `to_string()` function to get the string representation of a non-string value like an Integer value.
-
+- Use the `to_string()` function to get the string representation of a non-string value like an Integer value.
 
 :::


### PR DESCRIPTION
### Summary

Fixes links pointing to specific fields (these got broken recently because we split the fields page into several pages).
Also fixed a couple of links pointing to `example.com` (migration glitch?).
