### PR TITLE
[Docs] Remove extra spaces in glossary tooltips

### DIFF
--- a/src/components/GlossaryTooltip.astro
+++ b/src/components/GlossaryTooltip.astro
@@ -25,6 +25,7 @@ definition = definition.charAt(0).toUpperCase() + definition.slice(1);
 definition = definition.split(/\r?\n/)[0];
 ---
 
+<!-- prettier-ignore -->
 <span
 	id={tooltip.term}
 	data-tooltip
@@ -32,14 +33,11 @@ definition = definition.split(/\r?\n/)[0];
 	class="border-b-2 border-dashed border-accent-600"
 	>{
 		link ? (
-			<a href={link}>
-				<slot />
-			</a>
+			<a href={link}><slot /></a>
 		) : (
 			<slot />
 		)
-	}</span
-><script>
+	}</span><script>
 	import tippy from "tippy.js";
 
 	const tooltips = document.querySelectorAll<HTMLSpanElement>("[data-tooltip]");
@@ -50,7 +48,7 @@ definition = definition.split(/\r?\n/)[0];
 			allowHTML: true,
 			interactive: true,
 			placement: "auto",
-			arrow: false
+			arrow: false,
 		});
 	}
 </script><style is:global>


### PR DESCRIPTION
### Summary

Removes extra spaces around glossary tooltips with links.
Had to turn off `prettier` (via HTML comment) to avoid getting the newlines back.

Before:
![image](https://github.com/user-attachments/assets/9b8304df-1af7-4fb0-a582-9baf8e17fa18)

After:
![image](https://github.com/user-attachments/assets/17d78e3a-813b-425e-8806-21eb0a03d6a7)
