### PR TITLE
[Ruleset Engine] Fix two broken links

### DIFF
--- a/src/content/docs/ruleset-engine/rules-language/fields/http-request-header.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/fields/http-request-header.mdx
@@ -124,7 +124,7 @@ When `true`, `http.request.headers`, `http.request.headers.names`, and `http.req
 
 Represents the list of language tags provided in the [`Accept-Language`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) HTTP request header, sorted by weight (`;q=<weight>`, with a default weight of `1`) in descending order.
 
-If the HTTP header is not present in the request or is empty, `http.request.accepted_languages[0]` will return a "[missing value](https://example.com/ruleset-engine/rules-language/values/#array-notes)", which the `concat()` function will handle as an empty string.
+If the HTTP header is not present in the request or is empty, `http.request.accepted_languages[0]` will return a "[missing value](/ruleset-engine/rules-language/values/#array-notes)", which the `concat()` function will handle as an empty string.
 
 If the HTTP header includes the language tag `*` it will not be stored in the array.
 
@@ -140,5 +140,5 @@ Request without an `Accept-Language` HTTP header and a URI of `https://www.examp
 `concat("/", http.request.accepted_languages[0], http.request.uri.path) == "//my-path"`.
 
 :::note
-This field is only available in [Transform Rules](https://example.com/rules/transform/).
+This field is only available in [Transform Rules](/rules/transform/).
 :::


### PR DESCRIPTION
### Summary

A couple of links still had `https://example.com` inadvertently (migration glitch?).
