### PR TITLE
[Images] Linked to correct partial

### DIFF
--- a/src/content/docs/images/transform-images/transform-via-url.mdx
+++ b/src/content/docs/images/transform-images/transform-via-url.mdx
@@ -101,7 +101,7 @@ You must specify at least one option. Options are comma-separated (spaces are no
 
 ### `onerror`
 
-<Render file="metadata" />
+<Render file="onerror" />
 
 ### `quality`
 

--- a/src/content/docs/images/transform-images/transform-via-workers.mdx
+++ b/src/content/docs/images/transform-images/transform-via-workers.mdx
@@ -88,7 +88,7 @@ The `fetch()` function accepts parameters in the second argument inside the `{cf
 
 ### `onerror`
 
-<Render file="metadata" />
+<Render file="onerror" />
 
 ### `quality`
 


### PR DESCRIPTION
Accidentally linked to metadata partial in the onerror section. This PR corrects that.