### PR TITLE
Adding steps to allow Warp connector to work as a private net offramp

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-connector.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-connector.mdx
@@ -265,9 +265,19 @@ If you are setting up WARP Connector on a [virtual private cloud (VPC)](https://
           "-A FORWARD -o CloudflareWARP -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
         )
 
+        NAT=(
+          "-A POSTROUTING -o ens18 -j MASQUERADE"
+        )
+
+
         # Apply the rules
         for rule in "${RULES[@]}"; do
           iptables -t mangle $rule
+        done
+
+        # Apply the rules
+        for rule in "${NAT[@]}"; do
+          iptables -t nat $NAT
         done
 
         # Save the rules


### PR DESCRIPTION
Found during testing the current steps work for S2S connectivity, but if you try to access the private net behind the warp connector from a remote device connected to Warp, it fails due to traffic making it to the private net resources with a source IP in the 100.92.0.0/12 subnet, leading to the return route not being valid since the local subnet isn't aware of how to route to this  100.92.0.0/12 subnet. Adding the command "sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE" resolves this by changing the source IP of warp client traffic to the LAN IP of the warp connector, which private resources are able to locate.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
