### PR TITLE
Add an explanation of how Pages determines whether the user's build command has failed

### DIFF
--- a/src/content/docs/pages/configuration/build-configuration.mdx
+++ b/src/content/docs/pages/configuration/build-configuration.mdx
@@ -18,7 +18,7 @@ Build directories indicates where your project's build command outputs the built
 
 <Details header="Understanding your build configuration">
 
-The build command is provided by your framework. For example, the Gatsby framework uses `gatsby build` as its build command. When you are working without a framework, leave the **Build command** field blank.
+The build command is provided by your framework. For example, the Gatsby framework uses `gatsby build` as its build command. When you are working without a framework, leave the **Build command** field blank. Pages determines whether a build has suceeded or failed by reading the exit code returned from the user supplied build command. Any non-zero return code will cause a build to be marked as failed. An exit code of 0 will cause the Pages build to be marked as successful and assets will be uploaded regardless of if error logs are written to standard error. 
 
 The build directory is generated from the build command. Each framework has its own naming convention, for example, the build output directory is named `/public` for many frameworks.
 

--- a/src/content/docs/pages/configuration/build-configuration.mdx
+++ b/src/content/docs/pages/configuration/build-configuration.mdx
@@ -18,7 +18,7 @@ Build directories indicates where your project's build command outputs the built
 
 <Details header="Understanding your build configuration">
 
-The build command is provided by your framework. For example, the Gatsby framework uses `gatsby build` as its build command. When you are working without a framework, leave the **Build command** field blank. Pages determines whether a build has suceeded or failed by reading the exit code returned from the user supplied build command. Any non-zero return code will cause a build to be marked as failed. An exit code of 0 will cause the Pages build to be marked as successful and assets will be uploaded regardless of if error logs are written to standard error. 
+The build command is provided by your framework. For example, the Gatsby framework uses `gatsby build` as its build command. When you are working without a framework, leave the **Build command** field blank. Pages determines whether a build has succeeded or failed by reading the exit code returned from the user supplied build command. Any non-zero return code will cause a build to be marked as failed. An exit code of 0 will cause the Pages build to be marked as successful and assets will be uploaded regardless of if error logs are written to standard error. 
 
 The build directory is generated from the build command. Each framework has its own naming convention, for example, the build output directory is named `/public` for many frameworks.
 


### PR DESCRIPTION
### Summary

We don't clarify how Pages determines if a user's build command failed. This PR clarifies by adding some information on how Pages uses the build command exit code.

### Screenshots (optional)

<img width="810" alt="Screenshot 2024-08-29 at 1 01 37 PM" src="https://github.com/user-attachments/assets/c0550390-5a61-4651-9963-65833b6a561e">

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
