### PR TITLE
Fix Prisma migrate file format

### DIFF
--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -166,7 +166,7 @@ model User {
 Now, run the following command in your terminal to generate the SQL statement that creates a `User` table equivalent to the `User` model above:
 
 ```sh
-npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prisma --script > migrations/0001_create_user_table.sql
+npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prisma --script --output migrations/0001_create_user_table.sql
 ```
 
 This stores a SQL statement to create a new `User` table in your migration file from before, here is what it looks like:


### PR DESCRIPTION
### Summary

When using PowerShell on Windows, the command in the docs to generate a migration file produces a file in UTF-16 format which wrangler is unable to migrate properly.
Updating the command to use the output flag instead produces a file in UTF-8 which runs fine with the migrate command

Solution found in: https://github.com/prisma/prisma/issues/23702
Prisma release with the fix: https://github.com/prisma/prisma/releases/tag/5.12.1

### Screenshots (optional)

![Error produced when file is in UTF-16](https://github.com/user-attachments/assets/e049ddaa-f36b-4f51-9ba9-1f15b8eb78ed)
Error produced when file is in UTF-16