### PR TITLE
fix: incorrect version for wrangler types --x-include-runtime inclusion

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2604,7 +2604,7 @@ After running the command, you must add the path of the generated runtime types 
 
 You may use the shorthand `--x-include-runtime` flag in place of `--experimental-include-runtime` anywhere it is mentioned.
 
-The minimum required Wrangler version to use this command is 3.66.1.
+The minimum required Wrangler version to use this command is 3.66.0.
 
 :::
 


### PR DESCRIPTION
### Summary

It was pointed out that we had the incorrect version for the inclusion of `wrangler types --experimental-include-runtime` ([see here for correct release](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%403.66.0)). This PR is the fix.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
