### PR TITLE
change incorrect `connStr` to correct `DB_URL` env var

### DIFF
--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -185,7 +185,7 @@ import postgres from 'postgres'
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const sql = postgres(connStr)
+		const sql = postgres(env.DB_URL)
 
 		// Query the products table
 		const result = await sql`SELECT * FROM products;`


### PR DESCRIPTION
I'm pretty sure the `connStr` used in the code snippet is wrong and that it should be `env.DB_URL` instead

It was changed to `connStr` in https://github.com/cloudflare/cloudflare-docs/pull/16438 so maybe can @thomasgauvin can let me know if this was a mistake or intentional 🙂 