### PR TITLE
cache_eligibility_api_update.mdx

### DIFF
--- a/src/content/docs/cache/how-to/cache-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/settings.mdx
@@ -251,13 +251,13 @@ Cloudflare will still enforce the plan-based [cacheable file limits](/cache/conc
 
 API configuration object name: `"cache_reserve"`.
 
-API property name for enabling Cache Reserve: `"enabled"` (boolean).
+API property name for enabling Cache Reserve: `"eligible"` (boolean).
 
 ```json title="API configuration example"
 "action_parameters": {
   "cache": true
   "cache_reserve": {
-    "enabled": true,
+    "eligible": true,
     "minimum_file_size": 100000
   }
 }


### PR DESCRIPTION
As per https://developers.cloudflare.com/api/operations/updateZoneRulesetRule, the parameter name changed from "enabled" to "eligible" as the documentation was not updated.

I have tested and confirmed this due to a case opened by Canva as they were using the old name "enabled" and they could not use the endpoint.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
