### PR TITLE
[DNS Firewall] Update FAQ with current behavior for SERVFAIL caching

### DIFF
--- a/src/content/docs/dns/dns-firewall/faq.mdx
+++ b/src/content/docs/dns/dns-firewall/faq.mdx
@@ -6,19 +6,15 @@ sidebar:
 head:
   - tag: title
     content: FAQs — DNS Firewall
-
 ---
 
-
-import { Details, GlossaryTooltip } from "~/components"
+import { Details, GlossaryTooltip } from "~/components";
 
 <Details header="How does DNS Firewall choose a backend nameserver to query upstream?">
 
 DNS Firewall alternates between a customer's nameservers, using an algorithm is more likely to send queries to the faster upstream nameservers than slower nameservers.
 
-
 </Details>
-
 
 <Details header="How long does DNS Firewall cache a stale object?">
 
@@ -26,17 +22,13 @@ DNS Firewall sets cache longevity according to allocated memory.
 
 As long as there is enough allocated memory, Cloudflare does not clear items from the cache forcefully, even when the TTL expires. This feature allows Cloudflare to serve stale objects from cache if your nameservers are offline.
 
-
 </Details>
-
 
 <Details header="Does the DNS Firewall cache SERVFAIL?">
 
-No. If the customer's nameservers respond with a SERVFAIL, the DNS Firewall will try again on the next request.
-
+Yes. `SERVFAIL` is treated like any other negative answer for caching purposes. The default TTL is 30 seconds. You can use the [API](/api/operations/dns-firewall-update-dns-firewall-cluster) to set a different `negative_cache_ttl`.
 
 </Details>
-
 
 <Details header="Does DNS Firewall support EDNS Client Subnet (ECS)?">
 
@@ -51,29 +43,22 @@ When EDNS is enabled, the DNS Firewall gives out the geographically correct answ
 
 :::note
 
-
 EDNS limits the effectiveness of the DNS cache.
-
 
 :::
 
 Some resolvers might not be sending any EDNS data. When you set the `ecs_fallback` parameter to `true` via the [API](/api/operations/dns-firewall-update-dns-firewall-cluster), DNS Firewall will forward the IP subnet of the resolver instead only if there is no EDNS data present in incoming the DNS query.
 
-
 </Details>
-
 
 <Details header="Does DNS Firewall cache negative answers?">
 
-Not by default, but you can set `negative_cache_ttl` via the [API](/api/operations/dns-firewall-update-dns-firewall-cluster). This will affect the TTL of responses with status `REFUSED` or `NXDOMAIN`.
-
+Yes. The default TTL is 30 seconds. You can set `negative_cache_ttl` via the [API](/api/operations/dns-firewall-update-dns-firewall-cluster). This will affect the TTL of responses with status `REFUSED`, `NXDOMAIN`, or `SERVFAIL`.
 
 </Details>
-
 
 <Details header="How can I set PTR records for nameserver hostnames?">
 
 If you want PTR records on the assigned DNS Firewall cluster IPs that point to your nameserver hostnames, please reach out to your Cloudflare account team.
-
 
 </Details>


### PR DESCRIPTION
### Summary

SERVFAILs are also cached for the configured "negative cache TTL" just like other negative answers, such as NXDOMAINs.

PCX-12941

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
