### PR TITLE
[Rules] Template to redirect from www to root

### DIFF
--- a/src/content/docs/rules/url-forwarding/examples/redirect-www-to-root.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/redirect-www-to-root.mdx
@@ -1,0 +1,40 @@
+---
+pcx_content_type: example
+summary: Create a redirect rule to forward HTTPS requests from the WWW subdomain to the root (also known as the “apex” or “naked” domain).
+products:
+  - Redirect Rules
+title: Redirect from WWW to root
+description: Create a redirect rule to forward HTTPS requests from the WWW subdomain to the root (also known as the “apex” or “naked” domain).
+---
+
+import { Example } from "~/components";
+
+This example creates a redirect rule that forwards HTTPS requests from the `www` subdomain (`www.example.com`) to the root domain (`example.com`), while retaining the original path and query string.
+
+<Example>
+
+**When incoming requests match**
+
+- **Wildcard pattern**
+  - **Request URL**: `https://www.*`
+
+**Then**
+
+- **Target URL**: `https://${1}`
+- **Status code**: _301_
+- **Preserve query string**: Enabled
+
+</Example>
+
+This rule ensures that only HTTPS requests from `www.` subdomains are redirected to the root domain, leaving other requests (such as HTTP or non-www) unchanged.
+
+For example, the redirect rule would perform the following redirects:
+
+| Request URL                                       | Target URL                                         | Status code |
+| ------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `https://www.example.com/products/`               | `https://example.com/products/`                    | `301`       |
+| `https://www.store.example.com/products/`         | `https://store.example.com/products/`              | `301`       |
+| `https://store.example.com/products/`             | (unchanged)                                        | n/a         |
+| `https://www.example.com/admin/?logged_out=true`  | `https://example.com/admin/?logged_out=true`       | `301`       |
+| `http://www.example.com/?all_items=true`          | (unchanged)                                        | n/a         |
+| `http://example.com/admin/`                       | (unchanged)                                        | n/a         |


### PR DESCRIPTION
### Summary

This example creates a redirect rule that forwards HTTPS requests from the `www` subdomain (`www.example.com`) to the root domain (`example.com`), while retaining the original path and query string.