### PR TITLE
[D1] Removing redundant Overview tabs from the sidebar.

### DIFF
--- a/src/content/docs/d1/build-with-d1/index.mdx
+++ b/src/content/docs/d1/build-with-d1/index.mdx
@@ -3,9 +3,10 @@ title: Build with D1
 pcx_content_type: navigation
 sidebar:
   order: 3
-
+  group:
+    hideIndex: true
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 <DirectoryListing />

--- a/src/content/docs/d1/configuration/index.mdx
+++ b/src/content/docs/d1/configuration/index.mdx
@@ -3,9 +3,10 @@ title: Configuration
 pcx_content_type: navigation
 sidebar:
   order: 4
-
+  group:
+    hideIndex: true
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 <DirectoryListing />

--- a/src/content/docs/d1/examples/index.mdx
+++ b/src/content/docs/d1/examples/index.mdx
@@ -5,6 +5,8 @@ pcx_content_type: navigation
 title: Examples
 sidebar:
   order: 6
+  group:
+    hideIndex: true
 ---
 
 import { GlossaryTooltip, ListExamples } from "~/components";

--- a/src/content/docs/d1/observability/index.mdx
+++ b/src/content/docs/d1/observability/index.mdx
@@ -3,9 +3,10 @@ title: Observability
 pcx_content_type: navigation
 sidebar:
   order: 5
-
+  group:
+    hideIndex: true
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 <DirectoryListing />

--- a/src/content/docs/d1/platform/index.mdx
+++ b/src/content/docs/d1/platform/index.mdx
@@ -3,9 +3,10 @@ pcx_content_type: navigation
 title: Platform
 sidebar:
   order: 8
-
+  group:
+    hideIndex: true
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 <DirectoryListing />

--- a/src/content/docs/d1/reference/index.mdx
+++ b/src/content/docs/d1/reference/index.mdx
@@ -3,9 +3,10 @@ pcx_content_type: navigation
 title: Reference
 sidebar:
   order: 9
-
+  group:
+    hideIndex: true
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 <DirectoryListing />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

- Using `hideIndex: true` to remove redundant "Overview" tabs in the sidebar.
- Ensured no links were broken by searching the directory in `cloudflare-docs`. (Though static redirects might still point to these hidden index.mdx pages).

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
