### PR TITLE
Updates Node.js documentation to account for node_compat_v2

### DIFF
--- a/src/content/docs/browser-rendering/platform/wrangler.mdx
+++ b/src/content/docs/browser-rendering/platform/wrangler.mdx
@@ -29,7 +29,6 @@ If you are using [Puppeteer](/browser-rendering/platform/puppeteer/) in your Wor
 name = "browser-rendering"
 main = "src/index.ts"
 workers_dev = true
-compatibility_date = "2023-09-04"
 compatibility_flags = ["nodejs_compat_v2"]
 
 browser = { binding = "MYBROWSER" }

--- a/src/content/docs/browser-rendering/platform/wrangler.mdx
+++ b/src/content/docs/browser-rendering/platform/wrangler.mdx
@@ -3,7 +3,6 @@ pcx_content_type: configuration
 title: Wrangler
 sidebar:
   order: 20
-
 ---
 
 [Wrangler](/workers/wrangler/) is a command-line tool for building with Cloudflare developer products.
@@ -22,15 +21,16 @@ To deploy a Browser Rendering Worker, you must declare a [browser binding](/work
 
 :::note[Wrangler configuration]
 
-If you are using [Puppeteer](/browser-rendering/platform/puppeteer/) in your Worker code, then you also need to add `node_compat = true` to your Worker's `wrangler.toml` configuration. More information [here](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers), including for [pages functions](/workers/runtime-apis/nodejs/#enable-nodejs-with-pages-functions). 
+If you are using [Puppeteer](/browser-rendering/platform/puppeteer/) in your Worker code, then you also need to add "nodejs_compat_v2" to the compatibility_flags in your Worker's `wrangler.toml` configuration. More information [here](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers), including for [pages functions](/workers/runtime-apis/nodejs/#enable-nodejs-with-pages-functions).
 :::
 
 ```toml
 # Top-level configuration
 name = "browser-rendering"
 main = "src/index.ts"
-node_compat = true
 workers_dev = true
+compatibility_date = "2023-09-04"
+compatibility_flags = ["nodejs_compat_v2"]
 
 browser = { binding = "MYBROWSER" }
 ```

--- a/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
@@ -29,7 +29,8 @@ npx wrangler hyperdrive create my-first-hyperdrive --connection-string="postgres
 The command above will output the ID of your Hyperdrive, which you will need to set in the `wrangler.toml` configuration file for your Workers project:
 
 ```toml
-node_compat = true # required for database drivers to function
+# required for database drivers to function
+compatibility_flags = [ "nodejs_compat_v2" ]
 
 [[hyperdrive]]
 binding = "HYPERDRIVE"
@@ -44,12 +45,12 @@ Refer to the [Examples documentation](/hyperdrive/examples/) for step-by-step gu
 
 Hyperdrive uses Workers [TCP socket support](/workers/runtime-apis/tcp-sockets/#connect) to support TCP connections to databases. The following table lists the supported database drivers and the minimum version that works with Hyperdrive:
 
-| Driver                        | Documentation                                                                | Minimum Version Required | Notes                                                                                                                                                                                                                                    |
-| ----------------------------- | ---------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Postgres.js (**recommended**) | [https://github.com/porsager/postgres](https://github.com/porsager/postgres) | `postgres@3.4.4`         | Supported in both Workers & Pages.                                                                                                                                                                                                       |
-| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [legacy `node_compat = true`](/workers/wrangler/configuration/#add-polyfills-using-wrangler) to be set, which is not supported in Pages. |
-| Drizzle                       | [https://orm.drizzle.team/](https://orm.drizzle.team/)                       | `0.26.2`^                |                                                                                                                                                                                                                                          |
-| Kysely                        | [https://kysely.dev/](https://kysely.dev/)                                   | `0.26.3`^                |                                                                                                                                                                                                                                          |
+| Driver                        | Documentation                                                                | Minimum Version Required | Notes                                                                                                                                                                                                        |
+| ----------------------------- | ---------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Postgres.js (**recommended**) | [https://github.com/porsager/postgres](https://github.com/porsager/postgres) | `postgres@3.4.4`         | Supported in both Workers & Pages.                                                                                                                                                                           |
+| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [`nodejs_compat_v2`](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) compatability flag to be set. |
+| Drizzle                       | [https://orm.drizzle.team/](https://orm.drizzle.team/)                       | `0.26.2`^                |                                                                                                                                                                                                              |
+| Kysely                        | [https://kysely.dev/](https://kysely.dev/)                                   | `0.26.3`^                |                                                                                                                                                                                                              |
 
 ^ _The marked libraries use `node-postgres` as a dependency._
 
@@ -138,11 +139,12 @@ Install the `node-postgres` driver:
 npm install pg
 ```
 
-Ensure you have `node_compat = true` set in your `wrangler.toml` configuration file:
+Ensure you have "nodejs_compat_v2" in compatability flags in your `wrangler.toml` configuration file:
 
 ```toml
 # other fields elided
-node_compat = true # required for node-postgres to work
+# require for node-postgres to work
+compatibility_flags = [ "nodejs_compat_v2"]
 ```
 
 Create a new `Client` instance and pass the Hyperdrive parameters:

--- a/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
@@ -48,7 +48,7 @@ Hyperdrive uses Workers [TCP socket support](/workers/runtime-apis/tcp-sockets/#
 | Driver                        | Documentation                                                                | Minimum Version Required | Notes                                                                                                                                                                                                        |
 | ----------------------------- | ---------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Postgres.js (**recommended**) | [https://github.com/porsager/postgres](https://github.com/porsager/postgres) | `postgres@3.4.4`         | Supported in both Workers & Pages.                                                                                                                                                                           |
-| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [`nodejs_compat_v2`](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) compatability flag to be set. |
+| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [`nodejs_compat_v2`](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) compatibility flag to be set. |
 | Drizzle                       | [https://orm.drizzle.team/](https://orm.drizzle.team/)                       | `0.26.2`^                |                                                                                                                                                                                                              |
 | Kysely                        | [https://kysely.dev/](https://kysely.dev/)                                   | `0.26.3`^                |                                                                                                                                                                                                              |
 
@@ -139,7 +139,7 @@ Install the `node-postgres` driver:
 npm install pg
 ```
 
-Ensure you have "nodejs_compat_v2" in compatability flags in your `wrangler.toml` configuration file:
+Ensure you have "nodejs_compat_v2" in compatibility flags in your `wrangler.toml` configuration file:
 
 ```toml
 # other fields elided

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
@@ -145,7 +145,7 @@ This command outputs your Hyperdrive ID. You can now bind your Hyperdrive config
 ```toml
 name = "timescale-api"
 main = "src/index.ts"
-compatibility_date = "2024-08-28"
+compatibility_date = "2024-08-21"
 compatibility_flags = [ "nodejs_compat_v2"]
 
 [[hyperdrive]]

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
@@ -145,9 +145,8 @@ This command outputs your Hyperdrive ID. You can now bind your Hyperdrive config
 ```toml
 name = "timescale-api"
 main = "src/index.ts"
-compatibility_date = "2023-10-30"
-
-node_compat = true
+compatibility_date = "2024-08-28"
+compatibility_flags = [ "nodejs_compat_v2"]
 
 [[hyperdrive]]
 binding = "HYPERDRIVE"

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -75,6 +75,13 @@ Compatibility flags can be set when uploading a Worker using the [Workers Script
 
 ### Node.js compatibility flag
 
+:::note
+You can opt into improved Node.js compatability by using "nodejs_compat_v2" instead of "nodejs_compat". This provides the functionality of "nodejs_compat", but
+additionally you can import Node.js modules without the "node:" prefix and use polyfilled Node.js modules and globals that are not available with "nodejs_compat".
+
+On September 23, 2024, "nodejs_compat" will use the improved Node.js compatability currently enabled with "nodejs_compat_v2".
+:::
+
 A [growing subset](/workers/runtime-apis/nodejs/) of Node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:
 
 ```toml title="wrangler.toml"

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -76,10 +76,10 @@ Compatibility flags can be set when uploading a Worker using the [Workers Script
 ### Node.js compatibility flag
 
 :::note
-You can opt into improved Node.js compatibility by using "nodejs_compat_v2" instead of "nodejs_compat". This provides the functionality of "nodejs_compat", but
-additionally you can import Node.js modules without the "node:" prefix and use polyfilled Node.js modules and globals that are not available with "nodejs_compat".
+You can opt into improved Node.js compatibility by using `nodejs_compat_v2` instead of `nodejs_compat`. This provides the functionality of `nodejs_compat`, but
+additionally you can import Node.js modules without the `node:` prefix and use polyfilled Node.js modules and globals that are not available with `nodejs_compat`.
 
-On September 23, 2024, "nodejs_compat" will use the improved Node.js compatibility currently enabled with "nodejs_compat_v2". This will require updating your
+On September 23, 2024, `nodejs_compat` will use the improved Node.js compatibility currently enabled with `nodejs_compat_v2`. This will require updating your
 compatability_date to 2024-09-23 or later.
 :::
 

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -6,7 +6,7 @@ head: []
 description: Opt into a specific version of the Workers runtime for your Workers project.
 ---
 
-import { CompatibilityDates } from "~/components"
+import { CompatibilityDates } from "~/components";
 
 Cloudflare regularly updates the Workers runtime. These updates apply to all Workers globally and should never cause a Worker that is already deployed to stop functioning. Sometimes, though, some changes may be backwards-incompatible. In particular, there might be bugs in the runtime API that existing Workers may inadvertently depend upon. Cloudflare implements bug fixes that new Workers can opt into while existing Workers will continue to see the buggy behavior to prevent breaking deployed Workers.
 
@@ -79,7 +79,8 @@ Compatibility flags can be set when uploading a Worker using the [Workers Script
 You can opt into improved Node.js compatibility by using "nodejs_compat_v2" instead of "nodejs_compat". This provides the functionality of "nodejs_compat", but
 additionally you can import Node.js modules without the "node:" prefix and use polyfilled Node.js modules and globals that are not available with "nodejs_compat".
 
-On September 23, 2024, "nodejs_compat" will use the improved Node.js compatibility currently enabled with "nodejs_compat_v2".
+On September 23, 2024, "nodejs_compat" will use the improved Node.js compatibility currently enabled with "nodejs_compat_v2". This will require updating your
+compatability_date to 2024-09-23 or later.
 :::
 
 A [growing subset](/workers/runtime-apis/nodejs/) of Node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -76,10 +76,10 @@ Compatibility flags can be set when uploading a Worker using the [Workers Script
 ### Node.js compatibility flag
 
 :::note
-You can opt into improved Node.js compatability by using "nodejs_compat_v2" instead of "nodejs_compat". This provides the functionality of "nodejs_compat", but
+You can opt into improved Node.js compatibility by using "nodejs_compat_v2" instead of "nodejs_compat". This provides the functionality of "nodejs_compat", but
 additionally you can import Node.js modules without the "node:" prefix and use polyfilled Node.js modules and globals that are not available with "nodejs_compat".
 
-On September 23, 2024, "nodejs_compat" will use the improved Node.js compatability currently enabled with "nodejs_compat_v2".
+On September 23, 2024, "nodejs_compat" will use the improved Node.js compatibility currently enabled with "nodejs_compat_v2".
 :::
 
 A [growing subset](/workers/runtime-apis/nodejs/) of Node.js APIs are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the `nodejs_compat` compatibility flag to your `wrangler.toml`:

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -61,7 +61,7 @@ Unless otherwise specified, implementations of Node.js APIs in Workers are inten
 Add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
 
 ```toml title="wrangler.toml"
-compatibility_flags = [ "nodejs_compat" ]
+compatibility_flags = [ "nodejs_compat_v2" ]
 ```
 
 ## Enable Node.js with Pages Functions
@@ -83,7 +83,7 @@ To enable Node.js for your Pages Function from the Cloudflare dashboard:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Select **Workers & Pages** and in **Overview**, select your Pages project.
 3. Select **Settings** > **Functions** > **Compatibility Flags**.
-4. Add the `nodejs_compat` compatibility flag to your Preview and Production deployments.
+4. Add the `nodejs_compat_v2` compatibility flag to your Preview and Production deployments.
 
 ### Enable only AsyncLocalStorage
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -20,19 +20,13 @@ You can view which APIs are supported using the [Node.js compatability matrix](h
 
 To enable both built-in runtime APIs and polyfills for your Worker, add the [`nodejs_compat_v2`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
 
-```toml
----
-header: wrangler.toml
----
+```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat_v2" ]
 ```
 
 To only enable built-in runtime APIs, add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
 
-```toml
----
-header: wrangler.toml
----
+```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat" ]
 ```
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -2,15 +2,45 @@
 pcx_content_type: concept
 title: Node.js compatibility
 head: []
-description: Implemented Node.js runtime APIs and enablement instructions for
-  your Worker project.
+description: Node.js APIs available in Cloudflare Workers
 ---
 
 import { DirectoryListing } from "~/components";
 
-Most Workers import one or more packages of JavaScript or TypeScript code from [npm](https://www.npmjs.com/) as dependencies in `package.json`. Many of these packages rely on APIs from the [Node.js runtime](https://nodejs.org/en/about), and will not work unless these APIs are present.
+When you write a Worker, you may need to import packages from [npm](https://www.npmjs.com/). Many npm packages rely on APIs from the [Node.js runtime](https://nodejs.org/en/about), and will not work unless these Node.js APIs are available.
 
-To ensure compatibility with a wider set of npm packages, and make it easier for you to run existing applications on Cloudflare Workers, the following APIs from the [Node.js runtime](https://nodejs.org/en/about) are available directly as Workers runtime APIs, with no need to add polyfills to your own code:
+Cloudflare Workers provides a subset of Node.js APIs in two forms:
+
+1. As built-in APIs provided by the Workers Runtime
+2. As polyfills that [Wrangler](/workers/wrangler/) adds to your Worker's code
+
+## Get Started
+
+To enable both built-in runtime APIs and polyfills for your Worker, add the [`nodejs_compat_v2`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
+
+```toml
+---
+header: wrangler.toml
+---
+compatibility_flags = [ "nodejs_compat_v2" ]
+```
+
+To only enable built-in runtime APIs, add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
+
+```toml
+---
+header: wrangler.toml
+---
+compatibility_flags = [ "nodejs_compat" ]
+```
+
+:::note
+Starting on September 23rd, 2024, when your compatibility date is on or after `2024-09-23`, the `nodejs_compat` compatibility flag will enable the exact same behavior as `nodejs_compat_v2`.
+:::
+
+## Built-in Node.js Runtime APIs
+
+The following APIs from Node.js are provided directly by the Workers Runtime:
 
 <DirectoryListing />
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -14,6 +14,8 @@ Cloudflare Workers provides a subset of Node.js APIs in two forms:
 1. As built-in APIs provided by the Workers Runtime
 2. As polyfills that [Wrangler](/workers/wrangler/) adds to your Worker's code
 
+You can view which APIs are supported using the [Node.js compatability matrix](https://workers-nodejs-compat-matrix.pages.dev).
+
 ## Get Started
 
 To enable both built-in runtime APIs and polyfills for your Worker, add the [`nodejs_compat_v2`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
@@ -40,7 +42,7 @@ Starting on September 23rd, 2024, when your compatibility date is on or after `2
 
 ## Built-in Node.js Runtime APIs
 
-The following APIs from Node.js are provided directly by the Workers Runtime:
+The following APIs from Node.js are provided directly by the Workers Runtime. They are available when using `nodejs_compat` or `nodejs_compat_v2`:
 
 <DirectoryListing />
 
@@ -56,6 +58,24 @@ import { Buffer } from "buffer";
 
 Unless otherwise specified, implementations of Node.js APIs in Workers are intended to match the implementation in the [Current release of Node.js](https://github.com/nodejs/release#release-schedule).
 
+## Node.js API Polyfills
+
+When using the `nodejs_compat_v2` compatability flag, in addition to enabling Node.js APIs in the Workers Runtime, [Wrangler](/workers/wrangler/) will use [unenv](https://github.com/unjs/unenv) to automatically detect uses of Node.js APIs, and add polyfills where relevant.
+
+Adding polyfills maximizes compatibility with existing npm packages, while recognizing that not all APIs from Node.js make sense in the context of serverless functions.
+
+Where it is possible to provide a fully functional polyfill of the relevant Node.js API, unenv will do so.
+In cases where this is not possible, such as the [`fs`](https://nodejs.org/api/fs.html), unenv adds a module with mocked methods.
+Calling these mocked methods will either noop or will throw an error with a message like:
+
+```
+[unenv] <method name> is not implemented yet!
+```
+
+This allows you to import packages that use these Node.js modules, even if certain methods are not supported.
+
+For a full list of APIs supported, including information on which are mocked, see the [Node.js compatability matrix](https://workers-nodejs-compat-matrix.pages.dev).
+
 ## Enable Node.js with Workers
 
 Add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) [compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml`:
@@ -64,9 +84,9 @@ Add the [`nodejs_compat`](/workers/configuration/compatibility-dates/#nodejs-com
 compatibility_flags = [ "nodejs_compat_v2" ]
 ```
 
-## Enable Node.js with Pages Functions
+## Enable Node.js in Pages Functions
 
-### Enable Node.js with Wrangler
+### Enable Node.js in Pages with Wrangler
 
 To enable `nodejs_compat` in local development, pass the [`--compatibility-flags`](/workers/wrangler/commands/#dev-1) argument with the `nodejs_compat` flag to `wrangler pages dev`:
 
@@ -76,7 +96,7 @@ npx wrangler pages dev [<DIRECTORY>] --compatibility-flags="nodejs_compat"
 
 For additional options, refer to the list of [Pages-specific CLI commands](/workers/wrangler/commands/#dev-1).
 
-### Enable Node.js from the Cloudflare dashboard
+### Enable Node.js in Pages from the Cloudflare dashboard
 
 To enable Node.js for your Pages Function from the Cloudflare dashboard:
 
@@ -85,7 +105,7 @@ To enable Node.js for your Pages Function from the Cloudflare dashboard:
 3. Select **Settings** > **Functions** > **Compatibility Flags**.
 4. Add the `nodejs_compat_v2` compatibility flag to your Preview and Production deployments.
 
-### Enable only AsyncLocalStorage
+## Enable only AsyncLocalStorage
 
 To enable the Node.js `AsyncLocalStorage` API only, use the `nodejs_als` compatibility flag.
 

--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -150,7 +150,7 @@ async function generateQRCode(request) {
 }
 ```
 
-The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ("nodejs_compat_v2" compatability flag)(/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
+The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ("nodejs_compat_v2" compatibility flag)(/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
 
 ```toml
 compatibility_flags = [ "nodejs_compat_v2"]

--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -153,7 +153,6 @@ async function generateQRCode(request) {
 The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ("nodejs_compat_v2" compatability flag)(/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
 
 ```toml
-compatibility_date = "2024-08-28"
 compatibility_flags = [ "nodejs_compat_v2"]
 ```
 

--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -150,10 +150,11 @@ async function generateQRCode(request) {
 }
 ```
 
-The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the `node_compat` flag in your Wrangler configuration file:
+The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ("nodejs_compat_v2" compatability flag)(/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
 
 ```toml
-node_compat = true
+compatibility_date = "2024-08-28"
+compatibility_flags = [ "nodejs_compat_v2"]
 ```
 
 ## 4. Test in an application UI

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -59,7 +59,7 @@ cd postgres-tutorial
 ### Enable Node.js compatibility
 
 When creating your Worker application, [add polyfills](/workers/wrangler/configuration/#add-polyfills-using-wrangler) for a subset of Node.js APIs by including
-the "nodejs_compat_v2" compatability flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
+the "nodejs_compat_v2" compatibility flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
 
 ```toml title="wrangler.toml"
 compatibility_flags = ["nodejs_compat_v2"]
@@ -107,7 +107,7 @@ npx wrangler secret put DB_URL
 
 Set your `DB_URL` secret locally in a `.dev.vars` file as documented in [Local Development with Secrets](/workers/configuration/secrets/).
 
-```toml 
+```toml
 DB_URL="<ENTER YOUR POSTGRESQL CONNECTION STRING>"
 ```
 
@@ -141,7 +141,7 @@ npx wrangler secret put DB_PASSWORD
 Open your Worker's main file (for example, `worker.ts`) and import the `Client` class from the `pg` library:
 
 ```typescript
-import postgres from 'postgres'
+import postgres from "postgres";
 ```
 
 In the `fetch` event handler, connect to the PostgreSQL database using your chosen method, either the connection string or the explicit parameters.
@@ -149,7 +149,7 @@ In the `fetch` event handler, connect to the PostgreSQL database using your chos
 ### Use a connection string
 
 ```typescript
-const sql = postgres(env.DB_URL)
+const sql = postgres(env.DB_URL);
 ```
 
 ### Set explicit parameters
@@ -186,14 +186,14 @@ CREATE TABLE products (
 Replace the existing code in your `worker.ts` file with the following code:
 
 ```typescript
-import postgres from 'postgres'
+import postgres from "postgres";
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const sql = postgres(env.DB_URL)
+		const sql = postgres(env.DB_URL);
 
 		// Query the products table
-		const result = await sql`SELECT * FROM products;`
+		const result = await sql`SELECT * FROM products;`;
 
 		// Return the result as JSON
 		const resp = new Response(JSON.stringify(result), {
@@ -228,25 +228,25 @@ Assume the `products` table has the following columns: `id`, `name`, `descriptio
 Add the following code snippet inside the `fetch` event handler in your `worker.ts` file, before the existing query code:
 
 ```typescript {9-32}
-import postgres from 'postgres'
+import postgres from "postgres";
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const sql = postgres(env.DB_URL)
+		const sql = postgres(env.DB_URL);
 
-  	const url = new URL(request.url);
+		const url = new URL(request.url);
 		if (request.method === "POST" && url.pathname === "/products") {
 			// Parse the request's JSON payload
 			const productData = await request.json();
 
 			// Insert the new product into the database
 			const values = {
-				name: productData.name, 
-				description: productData.description, 
-				price: productData.price
+				name: productData.name,
+				description: productData.description,
+				price: productData.price,
 			};
 			const insertResult = await sql`
-				INSERT INTO products ${ sql(values) }
+				INSERT INTO products ${sql(values)}
 				RETURNING *
 			`;
 
@@ -260,7 +260,7 @@ export default {
 		}
 
 		// Query the products table
-		const result = await sql`SELECT * FROM products;`
+		const result = await sql`SELECT * FROM products;`;
 
 		// Return the result as JSON
 		const resp = new Response(JSON.stringify(result), {
@@ -338,7 +338,7 @@ export default {
 		const sql = postgres(env.HYPERDRIVE.connectionString)
 
 		const url = new URL(request.url);
-		
+
 		//rest of the routes and database queries
 	},
 } satisfies ExportedHandler<Env>;
@@ -354,7 +354,6 @@ npx wrangler deploy
 ```
 
 Your Worker application is now live and accessible at `<YOUR_WORKER>.<YOUR_SUBDOMAIN>.workers.dev`, using Hyperdrive. Hyperdrive accelerates database queries by pooling your connections and caching your requests across the globe.
-
 
 ## Next steps
 

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -62,7 +62,6 @@ When creating your Worker application, [add polyfills](/workers/wrangler/configu
 the "nodejs_compat_v2" compatability flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
 
 ```toml title="wrangler.toml"
-compatibility_date = "2024-08-28"
 compatibility_flags = ["nodejs_compat_v2"]
 ```
 

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -58,7 +58,13 @@ cd postgres-tutorial
 
 ### Enable Node.js compatibility
 
-When creating your Worker application, the `wrangler.toml` file will have automatically set `compatibility_flags = ["nodejs_compat"]`. This will be needed to use the library to connect to your PostgreSQL database.
+When creating your Worker application, [add polyfills](/workers/wrangler/configuration/#add-polyfills-using-wrangler) for a subset of Node.js APIs by including
+the "nodejs_compat_v2" compatability flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
+
+```toml title="wrangler.toml"
+compatibility_date = "2024-08-28"
+compatibility_flags = ["nodejs_compat_v2"]
+```
 
 ## 2. Add the PostgreSQL connection library
 

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -58,8 +58,8 @@ cd postgres-tutorial
 
 ### Enable Node.js compatibility
 
-When creating your Worker application, [add polyfills](/workers/wrangler/configuration/#add-polyfills-using-wrangler) for a subset of Node.js APIs by including
-the "nodejs_compat_v2" compatibility flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
+When creating your Worker application, [enable Node.js APIs](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) by including the
+"nodejs_compat_v2" compatibility flag to your `wrangler.toml`. This will be needed to use the library to connect to your PostgreSQL database.
 
 ```toml title="wrangler.toml"
 compatibility_flags = ["nodejs_compat_v2"]

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -145,7 +145,7 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
 
 * `node_compat` boolean optional
 
-  * Deprecated — Instead, [enable the `nodejs_compat_v2` compatibility flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
+  * Deprecated — Instead, [enable the `nodejs_compat_v2` compatibility flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers), which enables both built-in Node.js APIs, and adds polyfills as necessary.
 	Setting `node_compat = true` will add polyfills for Node.js built-in modules and globals to your Worker's code, when bundled with Wrangler.
 	This is powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -145,7 +145,7 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
 
 * `node_compat` boolean optional
 
-  * Add polyfills for Node.js built-in modules and globals. Refer to [Node compatibility](#node-compatibility).
+  * Add polyfills for Node.js built-in modules and globals. Refer to [Node compatibility](#node-compatibility). As of 2024-08-28, this has been replaced by the "node_compat_v2" compatibility flag.
 
 * `preserve_file_names` boolean optional
 
@@ -619,7 +619,9 @@ Example:
 Example:
 
 ```toml title="wrangler.toml"
-node_compat = true # required for database drivers to function
+# required for database drivers to function
+compatibility_date = "2024-08-28"
+compatibility_flags = ["nodejs_compat_v2"]
 
 [[hyperdrive]]
 binding = "<BINDING_NAME>"
@@ -1072,11 +1074,16 @@ A [growing subset of Node.js APIs](/workers/runtime-apis/nodejs/) are available 
 compatibility_flags = [ "nodejs_compat" ]
 ```
 
-### Add polyfills using Wrangler
+### Add polyfills using Wrangler (Legacy)
 
 Add polyfills for a subset of Node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
 
+:::note
+The preferred method of adding polyfills is now [setting the "node_compat_v2" compatability flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
+:::
+
 ```toml title="wrangler.toml"
+# sets legacy node compatability
 node_compat = true
 ```
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -145,7 +145,9 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
 
 * `node_compat` boolean optional
 
-  * Add polyfills for Node.js built-in modules and globals. Refer to [Node compatibility](#node-compatibility). As of 2024-08-28, this has been replaced by the "node_compat_v2" compatibility flag.
+  * Deprecated — Instead, [enable the `nodejs_compat_v2` compatibility flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
+	Setting `node_compat = true` will add polyfills for Node.js built-in modules and globals to your Worker's code, when bundled with Wrangler.
+	This is powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 
 * `preserve_file_names` boolean optional
 
@@ -1060,35 +1062,6 @@ local_protocol = "http"
 [Secrets](/workers/configuration/secrets/) are a type of binding that allow you to [attach encrypted text values](/workers/wrangler/commands/#secret) to your Worker.
 
 <Render file="secrets-in-dev" />
-
-## Node compatibility
-
-If you depend on Node.js APIs, either directly in your own code or via a library you depend on, you can either use a subset of Node.js APIs available directly in the Workers runtime, or add polyfills for a subset of Node.js APIs to your own code.
-
-### Use runtime APIs directly
-
-A [growing subset of Node.js APIs](/workers/runtime-apis/nodejs/) are available directly as [Runtime APIs](/workers/runtime-apis/nodejs), with no need to add polyfills to your own code. To enable these APIs in your Worker, add the [`nodejs_compat` ](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) compatibility flag to your `wrangler.toml`:
-
-```toml title="wrangler.toml"
-compatibility_flags = [ "nodejs_compat" ]
-```
-
-### Add polyfills using Wrangler (Legacy)
-
-Add polyfills for a subset of Node.js APIs to your Worker by adding the `node_compat` key to your `wrangler.toml` or by passing the `--node-compat` flag to `wrangler`.
-
-:::note
-The preferred method of adding polyfills is now [setting the "node_compat_v2" compatability flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers).
-:::
-
-```toml title="wrangler.toml"
-# sets legacy node compatability
-node_compat = true
-```
-
-It is not possible to polyfill all Node APIs or behaviors, but it is possible to polyfill some of them.
-
-This is currently powered by `@esbuild-plugins/node-globals-polyfill` which in itself is powered by [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills/).
 
 ## Module Aliasing
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -620,7 +620,6 @@ Example:
 
 ```toml title="wrangler.toml"
 # required for database drivers to function
-compatibility_date = "2024-08-28"
 compatibility_flags = ["nodejs_compat_v2"]
 
 [[hyperdrive]]

--- a/src/content/partials/workers/nodejs-compat-howto.mdx
+++ b/src/content/partials/workers/nodejs-compat-howto.mdx
@@ -6,7 +6,7 @@
 :::caution
 
 
-To use Node.js APIs in your Worker, add the [`nodejs_compat` compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml` file.
+To use Node.js APIs in your Worker, add the [`nodejs_compat_v2` compatibility flag](/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) to your `wrangler.toml` file.
 
 
 :::


### PR DESCRIPTION
### Summary

This updates Node.js workers documentation to account for node_compat_v2.

A fuller PR will come as a follow up that details individual APIs, but this should be enough to merge to unblock an announcement blog post and start pointing new users towards node_compat_v2.

Also, worth noting, after Sept 23, we will be able to remove "_v2" from compatibility_flags and update the compatability_dates. We will update the docs then.
