### PR TITLE
[Rules] Rename dynamic redirects to single redirects

### DIFF
--- a/src/content/docs/rules/page-rules/reference/recommended-rules.mdx
+++ b/src/content/docs/rules/page-rules/reference/recommended-rules.mdx
@@ -24,7 +24,7 @@ Keep in mind that not all rules will be right for everyone, but these are some o
 
 :::note
 
-Consider using [Dynamic Redirects](/rules/url-forwarding/single-redirects/) or [Bulk Redirects](/rules/url-forwarding/bulk-redirects/) to forward or redirect traffic to a different URL due to ease of use, maintenance, and cost. You should only use Page Rules when Dynamic or Bulk Redirects do not meet your use case. 
+Consider using [Single Redirects](/rules/url-forwarding/single-redirects/) or [Bulk Redirects](/rules/url-forwarding/bulk-redirects/) to forward or redirect traffic to a different URL due to ease of use, maintenance, and cost. You should only use Page Rules when Dynamic or Bulk Redirects do not meet your use case. 
 :::
 
 Two common examples for using forwarding URLs are:

--- a/src/content/docs/rules/reference/page-rules-migration/index.mdx
+++ b/src/content/docs/rules/reference/page-rules-migration/index.mdx
@@ -89,7 +89,7 @@ The following table summarizes how different Page Rules settings will be migrate
 
 | Page Rules setting          | New implementation uses...           | Migration/Replacement instructions                                          |
 | --------------------------- | ------------------------------------ | --------------------------------------------------------------------------- |
-| Always Use HTTPS            | Redirect Rules (dynamic redirects)   | [Migrate Always Use HTTPS](#migrate-always-use-https)                       |
+| Always Use HTTPS            | Redirect Rules (Single Redirects)    | [Migrate Always Use HTTPS](#migrate-always-use-https)                       |
 | Browser Cache TTL           | Cache Rules                          | [Migrate Browser Cache TTL](#migrate-browser-cache-ttl)                     |
 | Browser Integrity Check     | Configuration Rules                  | [Migrate Browser Integrity Check](#migrate-browser-integrity-check)         |
 | Bypass Cache on Cookie      | Cache Rules                          | [Migrate Bypass Cache on Cookie](#migrate-bypass-cache-on-cookie)           |
@@ -106,7 +106,7 @@ The following table summarizes how different Page Rules settings will be migrate
 | Disable Zaraz               | Configuration Rules                  | [Migrate Disable Zaraz](#migrate-disable-zaraz)                             |
 | Edge Cache TTL              | Cache Rules                          | [Migrate Edge Cache TTL](#migrate-edge-cache-ttl)                           |
 | Email Obfuscation           | Configuration Rules                  | [Migrate Email Obfuscation](#migrate-email-obfuscation)                     |
-| Forwarding URL              | Redirect Rules (dynamic redirects)   | [Migrate Forwarding URL](#migrate-forwarding-url)                           |
+| Forwarding URL              | Redirect Rules (Single Redirects)    | [Migrate Forwarding URL](#migrate-forwarding-url)                           |
 | Host Header Override        | Origin Rules                         | [Migrate Host Header Override](#migrate-host-header-override)               |
 | IP Geolocation Header       | Transform Rules (Managed Transforms) | [Migrate IP Geolocation Header](#migrate-ip-geolocation-header)             |
 | Mirage                      | Configuration Rules                  | [Migrate Mirage](#migrate-mirage)                                           |
@@ -137,7 +137,7 @@ You configured a Page Rule to perform an automatic redirect from HTTP to HTTPS f
 
 **How to migrate**:
 
-1. [Create a dynamic redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to always redirect HTTP requests to HTTPS for any hostname that contains `example.com`:
+1. [Create a single redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to always redirect HTTP requests to HTTPS for any hostname that contains `example.com`:
 
     <div class="DocsMarkdown--example">
 
@@ -161,9 +161,9 @@ You configured a Page Rule to perform an automatic redirect from HTTP to HTTPS f
 
 </TabItem> <TabItem label="visual guide">
 
-| Page Rules configuration                                                                                                           | Migrate to a dynamic redirect                                                                                                                                          |
+| Page Rules configuration                                                                                                           | Migrate to a single redirect                                                                                                                                          |
 | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Example Page Rule with 'Always Use HTTPS' setting](~/assets/images/rules/reference/page-rules-migration/pr-always-use-https.png) | ![Dynamic redirect matching the 'Always Use HTTPS' setting of the example Page Rule](~/assets/images/rules/reference/page-rules-migration/pr-always-use-https-new.png) |
+| ![Example Page Rule with 'Always Use HTTPS' setting](~/assets/images/rules/reference/page-rules-migration/pr-always-use-https.png) | ![Single redirect matching the 'Always Use HTTPS' setting of the example Page Rule](~/assets/images/rules/reference/page-rules-migration/pr-always-use-https-new.png) |
 
 </TabItem> </Tabs>
 
@@ -899,7 +899,7 @@ You configured a Page Rule permanently redirecting `www.example.com` to `example
 
 **How to migrate**:
 
-1. [Create a dynamic redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to permanently redirect requests from `www.example.com` to `example.com`:
+1. [Create a single redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to permanently redirect requests from `www.example.com` to `example.com`:
 
     <div class="DocsMarkdown--example">
 
@@ -923,9 +923,9 @@ You configured a Page Rule permanently redirecting `www.example.com` to `example
 
 </TabItem> <TabItem label="visual guide">
 
-| Page Rules configuration                                                                                                          | Migrate to a dynamic redirect                                                                                                                                         |
+| Page Rules configuration                                                                                                          | Migrate to a single redirect                                                                                                                                         |
 | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Example Page Rule #1 with 'Forwarding URL' setting](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url.png) | ![Dynamic redirect matching the 'Forwarding URL' setting of the example Page Rule #1](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-new.png) |
+| ![Example Page Rule #1 with 'Forwarding URL' setting](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url.png) | ![Single redirect matching the 'Forwarding URL' setting of the example Page Rule #1](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-new.png) |
 
 </TabItem> </Tabs>
 
@@ -944,7 +944,7 @@ You configured a Page Rule permanently redirecting `example.com/old-path` to `ex
 
 **How to migrate**:
 
-1. [Create a dynamic redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to permanently redirect requests for `example.com/old-path` to `example.com/new-path`:
+1. [Create a single redirect](/rules/url-forwarding/single-redirects/create-dashboard/) to permanently redirect requests for `example.com/old-path` to `example.com/new-path`:
 
     <div class="DocsMarkdown--example">
 
@@ -969,9 +969,9 @@ You configured a Page Rule permanently redirecting `example.com/old-path` to `ex
 
 </TabItem> <TabItem label="visual guide">
 
-| Page Rules configuration                                                                                                            | Migrate to a dynamic redirect                                                                                                                                           |
+| Page Rules configuration                                                                                                            | Migrate to a single redirect                                                                                                                                           |
 | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Example Page Rule #2 with 'Forwarding URL' setting](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-2.png) | ![Dynamic redirect matching the 'Forwarding URL' setting of the example Page Rule #2](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-2-new.png) |
+| ![Example Page Rule #2 with 'Forwarding URL' setting](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-2.png) | ![Single redirect matching the 'Forwarding URL' setting of the example Page Rule #2](~/assets/images/rules/reference/page-rules-migration/pr-forwarding-url-2-new.png) |
 
 </TabItem> </Tabs>
 

--- a/src/content/docs/rules/url-forwarding/examples/perform-mobile-redirects.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/perform-mobile-redirects.mdx
@@ -41,7 +41,7 @@ Notes about this example:
 
 ## Redirect mobile users keeping the original path
 
-This example dynamic redirect will redirect requests for the current zone (`example.com`) from mobile users to `m.example.com`, keeping the URI path of the original HTTP request.
+This example single redirect will redirect requests for the current zone (`example.com`) from mobile users to `m.example.com`, keeping the URI path of the original HTTP request.
 
 <Example>
 

--- a/src/content/docs/rules/url-forwarding/examples/redirect-admin-https.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/redirect-admin-https.mdx
@@ -12,7 +12,7 @@ description: Create a redirect rule to redirect requests for the administration
 
 import { Example } from "~/components";
 
-This example dynamic redirect for zone `example.com` will redirect requests for the administration area of a specific subdomain (`store.example.com`) to HTTPS, keeping the original path and query string.
+This example single redirect for zone `example.com` will redirect requests for the administration area of a specific subdomain (`store.example.com`) to HTTPS, keeping the original path and query string.
 
 <Example>
 

--- a/src/content/docs/rules/url-forwarding/examples/redirect-all-different-hostname.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/redirect-all-different-hostname.mdx
@@ -13,7 +13,7 @@ description: Create a redirect rule to redirect all requests for
 
 import { Example } from "~/components";
 
-This example dynamic redirect will redirect all requests for `smallshop.example.com` to a different hostname `globalstore.example.net` using HTTPS, keeping the original path and query string.
+This example single redirect will redirect all requests for `smallshop.example.com` to a different hostname `globalstore.example.net` using HTTPS, keeping the original path and query string.
 
 <Example>
 

--- a/src/content/docs/rules/url-forwarding/examples/redirect-country-subdomains.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/redirect-country-subdomains.mdx
@@ -15,7 +15,7 @@ description: Create a redirect rule to redirect United Kingdom and France
 
 import { Example } from "~/components";
 
-This example dynamic redirect for zone `example.com` will redirect United Kingdom and France visitors requesting the website's root path (`/`) to their localized subdomains `https://gb.example.com` and `https://fr.example.com`, respectively.
+This example single redirect for zone `example.com` will redirect United Kingdom and France visitors requesting the website's root path (`/`) to their localized subdomains `https://gb.example.com` and `https://fr.example.com`, respectively.
 
 <Example>
 

--- a/src/content/docs/rules/url-forwarding/examples/remove-locale-url.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/remove-locale-url.mdx
@@ -11,7 +11,7 @@ description: Create a redirect rule to redirect visitors from an old URL format
 
 import { Example } from "~/components";
 
-This example dynamic redirect for zone `example.com` will redirect visitors from an old URL format that included the locale (for example, `/en-us/<page_name>`) to the new format `/<page_name>`.
+This example single redirect for zone `example.com` will redirect visitors from an old URL format that included the locale (for example, `/en-us/<page_name>`) to the new format `/<page_name>`.
 
 <Example>
 

--- a/src/content/docs/rules/url-forwarding/single-redirects/create-api.mdx
+++ b/src/content/docs/rules/url-forwarding/single-redirects/create-api.mdx
@@ -207,4 +207,4 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
 
 The API token used in API requests to manage redirect rules must have at least the following permission:
 
-* *Zone* > *Dynamic Redirect* > *Edit*
+* *Zone* > *Single Redirect* > *Edit*

--- a/src/content/docs/ssl/edge-certificates/additional-options/always-use-https.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/always-use-https.mdx
@@ -29,7 +29,7 @@ To redirect traffic for all subdomains and hosts in your application, you can en
 
 :::note
 
-If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use a [dynamic redirect](/rules/url-forwarding/single-redirects/) to selectively perform the redirect to HTTPS. Refer to [Redirect admin area requests to HTTPS](/rules/url-forwarding/examples/redirect-admin-https/) for an example.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use a [single redirect](/rules/url-forwarding/single-redirects/) to selectively perform the redirect to HTTPS. Refer to [Redirect admin area requests to HTTPS](/rules/url-forwarding/examples/redirect-admin-https/) for an example.
 :::
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">

--- a/src/content/docs/ssl/edge-certificates/encrypt-visitor-traffic.mdx
+++ b/src/content/docs/ssl/edge-certificates/encrypt-visitor-traffic.mdx
@@ -34,4 +34,4 @@ To avoid these issues, enable [Automatic HTTPS Rewrites](/ssl/edge-certificates/
 
 If your entire application can support HTTPS traffic, enable [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/#encrypt-all-visitor-traffic).
 
-If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use a [dynamic redirect](/rules/url-forwarding/single-redirects/) to selectively perform the redirect to HTTPS. Refer to [Redirect admin area requests to HTTPS](/rules/url-forwarding/examples/redirect-admin-https/) for an example.
+If only some parts of your application can support HTTPS traffic, do not enable **Always Use HTTPS** and use a [single redirect](/rules/url-forwarding/single-redirects/) to selectively perform the redirect to HTTPS. Refer to [Redirect admin area requests to HTTPS](/rules/url-forwarding/examples/redirect-admin-https/) for an example.

--- a/src/content/partials/rules/url-forwarding/different-hostname-example.mdx
+++ b/src/content/partials/rules/url-forwarding/different-hostname-example.mdx
@@ -5,7 +5,7 @@
 
 import { Example } from "~/components"
 
-This example dynamic redirect will redirect all requests for `smallshop.example.com` to a different hostname using HTTPS, keeping the original path and query string.
+This example single redirect will redirect all requests for `smallshop.example.com` to a different hostname using HTTPS, keeping the original path and query string.
 
 <Example>
 


### PR DESCRIPTION
### Summary

Dynamic redirects were renamed to Single redirects a while ago. This update cleans up the documentation as things are named differently in the dashboard now.