### PR TITLE
Pin node@22 with Volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "lz-string": "^1.5.0",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1"
+  },
+  "volta": {
+    "node": "22.8.0"
   }
 }


### PR DESCRIPTION
For those that use Volta, this saves them manually specifying the Node.js version when setting up this repo. For those that don't use Volta, this has no impact.
