### PR TITLE
[Rules] Add Cloud Connector example using Terraform

### DIFF
--- a/src/content/docs/rules/cloud-connector/examples/route-images-to-aws-s3-using-terraform.mdx
+++ b/src/content/docs/rules/cloud-connector/examples/route-images-to-aws-s3-using-terraform.mdx
@@ -1,0 +1,29 @@
+---
+pcx_content_type: example
+summary: Route requests with a URI path starting with `/images` to a specific AWS S3 bucket with Cloud Connector using Terraform.
+products:
+  - Cloud Connector
+title: Route /images to an S3 Bucket using Terraform
+description: Route requests with a URI path starting with `/images` to a specific AWS S3 bucket with Cloud Connector using Terraform.
+---
+
+import { Render } from "~/components";
+
+The following example defines a single Cloud Connector rule for a zone using Terraform. The rule routes requests to `/images` on your domain to an AWS S3 bucket.
+
+```tf
+resource "cloudflare_cloud_connector_rules" "serve_images_in_aws" {
+  zone_id = "<ZONE_ID>"
+  rules {
+    description = "Route images to AWS S3 bucket"
+    enabled     = true
+    expression  = "http.request.full_uri wildcard \"https://<YOUR_HOSTNAME>/images/*\""
+    provider    = "aws_s3"
+    parameters {
+      host = "<BUCKET_NAME>.s3.amazonaws.com"
+    }
+  }
+}
+```
+
+<Render file="terraform-additional-resources" />


### PR DESCRIPTION
### Summary

Adds Terraform example for routing requests via Cloud Connector to an AWS S3 bucket.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
