### PR TITLE
Fix variable name in email error handling

### DIFF
--- a/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
@@ -159,11 +159,11 @@ export const POST: APIRoute = async ({ request }) => {
 	} else {
 		return new Response(
 			JSON.stringify({
-				message: `Message failed to send: ${sendCustom.error}`,
+				message: `Message failed to send: ${sendResend.error}`,
 			}),
 			{
 				status: 500,
-				statusText: `Internal Server Error: ${sendCustom.error}`,
+				statusText: `Internal Server Error: ${sendResend.error}`,
 			},
 		);
 	}


### PR DESCRIPTION
This PR fixes the variable name in the email error handling code by replacing `sendCustom` with `sendResend`. This change resolves a runtime error caused by referencing an undefined variable, ensuring correct error reporting for failed email sends.

### Summary

This update corrects a variable name in the error handling section of the email sending tutorial within the Cloudflare documentation, specifically under the Developer Spotlight tutorials for [handling form submissions with Astro and Resend](https://developers.cloudflare.com/developer-spotlight/tutorials/handle-form-submission-with-astro-resend/).

### Screenshots (optional)

![Screenshot 2024-09-04 at 9 10 21 PM](https://github.com/user-attachments/assets/78df090a-4a00-4a88-bfad-6f7f6a74f6bc)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
