### PR TITLE
Fix link in Radar glossary

### DIFF
--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -164,7 +164,7 @@ On Cloudflare Radar’s [Security & Attacks page](https://radar.cloudflare.com/s
 * **Later (after multiple data packets)**: Connection resets within the first 10 packets from the client, but after the server has received multiple data packets.
 * **None**: All other connections.
 
-Learn more about the TCP resets and timeouts dataset in our [blog post](https://blog.cloudflare.com/tcp-resets-timeouts].
+Learn more about the TCP resets and timeouts dataset in our [blog post](https://blog.cloudflare.com/tcp-resets-timeouts).
 
 ## Threat Categories
 


### PR DESCRIPTION
### Summary

Fix link to TCP resets and timeouts blog post.
