### PR TITLE
Fix command output formatting

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-connector.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-connector.mdx
@@ -158,8 +158,9 @@ In this example, we will create a WARP Connector for subnet `10.0.0.0/24` and in
 
     ```sh
     warp-cli status
+    ```
 
-    	```sh output
+    ```sh output
     Status update: Connected
     Success
     ```


### PR DESCRIPTION
### Summary

The command-and-output block for `warp-cli status` command wasn't rendered properly because of a formatting issue.

### Screenshots (optional)

This is how it previously [looked](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/private-net/warp-connector/):
![Screenshot 2024-09-05 at 8 06 09 PM](https://github.com/user-attachments/assets/d7a0fe1c-b27a-4b7a-b296-433736fa6c7c)

It's changed to:
![Screenshot 2024-09-05 at 8 06 21 PM](https://github.com/user-attachments/assets/a91700a3-55ce-4e38-a3f1-257003c37ca1)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
