### PR TITLE
Improve wording in Magic WAN connector's static WAN config

### DIFF
--- a/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
@@ -110,7 +110,7 @@ If there is a firewall deployed upstream of the Magic WAN Connector, configure t
 
 ### WAN with a static IP address
 
-After activating your Connector, you can use it in a network configuration with the WAN interface set to a static IP address — that is, an Internet configuration that isn't automatically set by DHCP.
+After activating your Connector, you can use it in a network configuration with the WAN interface set to a static IP address — that is, an Internet configuration that is not automatically set by DHCP.
 
 To use your Connector on a network configuration with a static IP:
 

--- a/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
@@ -110,7 +110,7 @@ If there is a firewall deployed upstream of the Magic WAN Connector, configure t
 
 ### WAN with a static IP address
 
-After activating your Connector, you can use it in a network configuration with the WAN interface set to a static IP address — that is, an internet configuration that isn't automatically set by DHCP.
+After activating your Connector, you can use it in a network configuration with the WAN interface set to a static IP address — that is, an Internet configuration that isn't automatically set by DHCP.
 
 To use your Connector on a network configuration with a static IP:
 

--- a/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/configure-hardware-connector/index.mdx
@@ -110,7 +110,7 @@ If there is a firewall deployed upstream of the Magic WAN Connector, configure t
 
 ### WAN with a static IP address
 
-After activating your Connector, you can use it in a network configuration based on a static IP address — that is, a network configuration without a route to the Internet that has DHCP enabled.
+After activating your Connector, you can use it in a network configuration with the WAN interface set to a static IP address — that is, an internet configuration that isn't automatically set by DHCP.
 
 To use your Connector on a network configuration with a static IP:
 


### PR DESCRIPTION
Leading with "without a route to the internet... that has DHCP enabled" is a weird way to phrase this - why lead with something that suggests the Connector can run without a route to internet and then clarifies that it is actually related to DHCP?

I proposed a clearer way to express this.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

(others did not apply)