### PR TITLE
add hyperdrive bindings to the `getPlatformProxy` supported bindings list

### DIFF
--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -376,6 +376,16 @@ The bindings supported by `getPlatformProxy` are:
 
 * [D1 database bindings](/d1/build-with-d1/d1-client-api/)
 
+* [Hyperdrive bindings](/hyperdrive)
+
+  :::note[Hyperdrive values are simple passthrough ones]
+
+  Values provided by hyperdrive bindings such as `connectionString` and `host` don't have a valid meaning outside of a workerd process,
+  so hyperdrive proxies, instead of returning such values which would be unusable from within node.js, return value correspondent to the
+  database connection provided by the user (making hyperdrive proxied values simple passthrough).
+
+  :::
+
 * [Workers AI bindings](/workers-ai/get-started/workers-wrangler/#2-connect-your-worker-to-workers-ai)
 
   <Render file="ai-local-usage-charges" product="workers" />

--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -381,8 +381,7 @@ The bindings supported by `getPlatformProxy` are:
   :::note[Hyperdrive values are simple passthrough ones]
 
   Values provided by hyperdrive bindings such as `connectionString` and `host` do not have a valid meaning outside of a `workerd` process.
-  so hyperdrive proxies, instead of returning such values which would be unusable from within node.js, return value correspondent to the
-  database connection provided by the user (making hyperdrive proxied values simple passthrough).
+  This means that Hyperdrive proxies return passthrough values, which are values corresponding to the database connection provided by the user.  Otherwise, it would return values which would be unusable from within node.js.
 
   :::
 

--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -380,7 +380,7 @@ The bindings supported by `getPlatformProxy` are:
 
   :::note[Hyperdrive values are simple passthrough ones]
 
-  Values provided by hyperdrive bindings such as `connectionString` and `host` don't have a valid meaning outside of a workerd process,
+  Values provided by hyperdrive bindings such as `connectionString` and `host` do not have a valid meaning outside of a `workerd` process.
   so hyperdrive proxies, instead of returning such values which would be unusable from within node.js, return value correspondent to the
   database connection provided by the user (making hyperdrive proxied values simple passthrough).
 


### PR DESCRIPTION
### Summary

Add hyperdrive bindings to the `getPlatformProxy` list as I've introduced support for in https://github.com/cloudflare/workers-sdk/pull/6612

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
