### PR TITLE
Update minimum-tls.mdx

### DIFF
--- a/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
@@ -54,7 +54,7 @@ In the following example, the minimum TLS version for the zone will be set to `1
 
 ```bash
 curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/min_tls_version \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/min_tls_version" \
 --header "Authorization: Bearer <API_TOKEN>" \
 --header "Content-Type: application/json" \
 --data '{
@@ -80,7 +80,7 @@ In the following example, the minimum TLS version for a specific hostname will b
 
 ```bash
 curl --request PUT \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/hostnames/settings/min_tls_version/{hostname} \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/hostnames/settings/min_tls_version/{hostname}" \
 --header "Authorization: Bearer <API_TOKEN>" \
 --header "Content-Type: application/json" \
 --data '{

--- a/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
@@ -50,6 +50,17 @@ To manage the TLS version applied to your whole zone when proxied through Cloudf
 
 Use the [Edit zone setting](/api/operations/zone-settings-edit-single-setting) endpoint with `min_tls_version` as the setting name in the URI path, and specify your preferred minimum version in the `value` parameter.
 
+```bash
+curl --request PATCH \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/min_tls_version" \
+--header 'Authorization: Bearer <API_TOKEN>' \
+--header "Content-Type: application/json" \
+--data '{
+    "id": "min_tls_version",
+    "value": "1.2"
+  }'
+```
+
 </TabItem> </Tabs>
 
 ### Per-hostname
@@ -62,6 +73,16 @@ This is currently only available via the API:
 - Use the [Delete TLS setting for hostname](/api/operations/per-hostname-tls-settings-delete) endpoint to clear previously defined `min_tls_version` setting.
 
 Cloudflare uses the [hostname priority logic](/ssl/reference/certificate-and-hostname-priority/) to determine which setting to apply.
+
+```bash
+curl --request PUT \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/hostnames/settings/min_tls_version/{hostname}" \
+--header 'Authorization: Bearer <API_TOKEN>' \
+--header "Content-Type: application/json" \
+--data '{
+    "value": "1.2"
+  }'
+```
 
 ## Test supported TLS versions
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
@@ -52,8 +52,8 @@ Use the [Edit zone setting](/api/operations/zone-settings-edit-single-setting) e
 
 ```bash
 curl --request PATCH \
-"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/min_tls_version" \
---header 'Authorization: Bearer <API_TOKEN>' \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/min_tls_version \
+--header "Authorization: Bearer <API_TOKEN>" \
 --header "Content-Type: application/json" \
 --data '{
     "id": "min_tls_version",
@@ -76,8 +76,8 @@ Cloudflare uses the [hostname priority logic](/ssl/reference/certificate-and-hos
 
 ```bash
 curl --request PUT \
-"https://api.cloudflare.com/client/v4/zones/{zone_id}/hostnames/settings/min_tls_version/{hostname}" \
---header 'Authorization: Bearer <API_TOKEN>' \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/hostnames/settings/min_tls_version/{hostname} \
+--header "Authorization: Bearer <API_TOKEN>" \
 --header "Content-Type: application/json" \
 --data '{
     "value": "1.2"

--- a/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/minimum-tls.mdx
@@ -48,7 +48,9 @@ To manage the TLS version applied to your whole zone when proxied through Cloudf
 
 </TabItem> <TabItem label="API">
 
-Use the [Edit zone setting](/api/operations/zone-settings-edit-single-setting) endpoint with `min_tls_version` as the setting name in the URI path, and specify your preferred minimum version in the `value` parameter.
+Use the [Edit zone setting](/api/operations/zone-settings-edit-single-setting) endpoint with `min_tls_version` as the setting name in the URI path, and specify your preferred minimum version in the `value` field.
+
+In the following example, the minimum TLS version for the zone will be set to `1.2`. Replace the zone ID and API token placeholders with your information, and adjust the `value` field with your chosen TLS version.
 
 ```bash
 curl --request PATCH \
@@ -73,6 +75,8 @@ This is currently only available via the API:
 - Use the [Delete TLS setting for hostname](/api/operations/per-hostname-tls-settings-delete) endpoint to clear previously defined `min_tls_version` setting.
 
 Cloudflare uses the [hostname priority logic](/ssl/reference/certificate-and-hostname-priority/) to determine which setting to apply.
+
+In the following example, the minimum TLS version for a specific hostname will be set to `1.2`. Replace the zone ID, hostname, and API token placeholders with your information, and adjust the `value` field with your chosen TLS version.
 
 ```bash
 curl --request PUT \


### PR DESCRIPTION
Adding examples to the minimum TLS for zone and hostname API endpoint calls.

We still see a lot of customers having trouble with the API syntax to set the minimum TLS version. The idea is to add a clear example to try to reduce the number of requests we get.

This way, we can simply point the customers to this document and they can copy and past the syntax on their end.
