### PR TITLE
[Network] Adds info about cacheable traffic being buffered not streamed

### DIFF
--- a/src/content/docs/network/response-buffering.mdx
+++ b/src/content/docs/network/response-buffering.mdx
@@ -14,7 +14,7 @@ If your domain sends many small packets, it may be faster to buffer the file and
 
 ## How it works
 
-By default, Cloudflare **streams** data. This means that each packet is sent as it becomes available. Streaming can improve the delivery of large files. If the responses are cached there will still be some buffering.
+By default, Cloudflare **streams** traffic data, meaning that each packet is sent as it becomes available. This can improve the delivery of large files. However, this streaming behavior only applies to dynamic traffic; cacheable traffic is buffered and this behavior cannot be changed.
 
 If your domain sends many small packets, however, it might be faster to **buffer** the file. This approach waits to send the full file until all packets are ready, preventing a client browser from having to re-assemble packets.
 


### PR DESCRIPTION
### Summary

Clarify that cacheable traffic is buffered not streamed. Closes PCX-13398
### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

