### PR TITLE
Fix code sample in write-key-value-pairs.mdx

### DIFF
--- a/src/content/docs/kv/api/write-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/write-key-value-pairs.mdx
@@ -116,11 +116,11 @@ To create expiring keys, set `expiration` in the `put()` options to a number rep
 
 ```js
 await env.NAMESPACE.put(key, value, {
-  metadata: {expiration: secondsSinceEpoch},
+  expiration: secondsSinceEpoch,
 });
 
 await env.NAMESPACE.put(key, value, {
-  metadata: {expirationTtl: secondsFromNow},
+  expirationTtl: secondsFromNow,
 });
 ```
 


### PR DESCRIPTION
### Summary

I believe that the code sample on this page incorrectly placed the `expiration` and `expirationTtl` keys inside a `metadata` object. According to [these docs](https://developers.cloudflare.com/kv/api/write-key-value-pairs/#parameters), those two keys are top-level when passed as the third argument of the `put()` method. 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.