### PR TITLE
Clarified queues batch limits

### DIFF
--- a/src/content/docs/queues/configuration/batching-retries.mdx
+++ b/src/content/docs/queues/configuration/batching-retries.mdx
@@ -43,7 +43,7 @@ The following batch-level settings can be configured to adjust how Queues delive
 | Setting                                   | Default     | Minimum   | Maximum      |
 | ----------------------------------------- | ----------- | --------- | ------------ |
 | Maximum Batch Size `max_batch_size`       | 10 messages | 1 message | 100 messages |
-| Maximum Batch Timeout `max_batch_timeout` | 5 seconds   | 0 seconds | 30 seconds   |
+| Maximum Batch Timeout `max_batch_timeout` | 5 seconds   | 0 seconds | 60 seconds   |
 
 </table-wrap>
 

--- a/src/content/docs/queues/platform/limits.mdx
+++ b/src/content/docs/queues/platform/limits.mdx
@@ -25,7 +25,7 @@ Many of these limits will increase during Queues' public beta period. [Follow ou
 | Message retries                               | 100                                                           |
 | Maximum consumer batch size                   | 100 messages <sup>beta</sup>                                  |
 | Maximum messages per `sendBatch` call         | 100 (or 256KB in total)                                       |
-| Batch wait time                               | 60 seconds                                                    |
+| Maximum batch wait time                       | 60 seconds                                                    |
 | Per-queue message throughput <sup>2</sup>     | 400 messages per second <sup>3</sup>                          |
 | Message retention period <sup>4</sup>         | 4 days (96 hours)                                             |
 | Per-queue backlog size <sup>5</sup>           | 25GB                                                          |


### PR DESCRIPTION
### Summary
Clarifies that max batch timeout is 60s
