### PR TITLE
[Docs] Fix href to Tail Workers in two places

### DIFF
--- a/src/content/docs/workers/observability/logging/real-time-logs.mdx
+++ b/src/content/docs/workers/observability/logging/real-time-logs.mdx
@@ -145,7 +145,7 @@ Logs can be persisted in two ways:
 
 Refer to the [Workers Logpush documentation](/workers/observability/logging/logpush/) to learn how to create and configure Logpush jobs.
 
-[Tail Workers](/workers/observability/logging/logpush/) allow you to automatically invoke Tail Workers after the invocation of a producer Worker (the Worker the Tail Worker will track) that contains the application logic. It captures events after the producer has finished executing. You can filter, change the format of the data and send events to any HTTP endpoint.
+[Tail Workers](/workers/observability/logging/tail-workers/) allow you to automatically invoke Tail Workers after the invocation of a producer Worker (the Worker the Tail Worker will track) that contains the application logic. It captures events after the producer has finished executing. You can filter, change the format of the data and send events to any HTTP endpoint.
 
 Refer to the [Tail Workers documentation](/workers/observability/logging/tail-workers/) to learn how to create and configure Tail Workers.
 
@@ -154,5 +154,5 @@ Refer to the [Tail Workers documentation](/workers/observability/logging/tail-wo
 - [Errors and exceptions](/workers/observability/errors/) - Review common Workers errors.
 - [Local development and testing](/workers/testing/local-development/) - Develop and test you Workers locally.
 - [Logpush](/workers/observability/logging/logpush/) - Learn how to push Workers Trace Event Logs to supported destinations.
-- [Tail Workers](/workers/observability/logging/logpush/) - Learn how to attach Tail Workers to transform your logs and send them to HTTP endpoints.
+- [Tail Workers](/workers/observability/logging/tail-workers/) - Learn how to attach Tail Workers to transform your logs and send them to HTTP endpoints.
 - [Source maps and stack traces](/workers/observability/source-maps) - Learn how to enable source maps and generate stack traces for Workers.


### PR DESCRIPTION
### Summary

Two links on the [Real-time Logs](https://developers.cloudflare.com/workers/observability/logging/real-time-logs/) page incorrectly linked to Logpush when they should have linked to Tail Workers. This PR fixes those links

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
