### PR TITLE
Fix incorrect DCV delegation example

### DIFF
--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/methods/delegated-dcv.mdx
@@ -64,7 +64,7 @@ _acme-challenge.example.com CNAME example.com.<COPIED_VALIDATION_URL>.
 For example, a certificate covering `example.com`, `*.example.com`, and `sub.example.com` would require the following records.
 
 ```txt
-_acme-challenge.example.com CNAME .example.com.<COPIED_VALIDATION_URL>.
+_acme-challenge.example.com CNAME example.com.<COPIED_VALIDATION_URL>.
 _acme-challenge.sub.example.com CNAME sub.example.com.<COPIED_VALIDATION_URL>.
 ```
 


### PR DESCRIPTION
### Summary
- The example for DCV delegation has an incorrect CNAME record, prefixed with a `.`. This is evident a mistake compared to the secondary DCV record for the `sub.example.com` domain below it.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
