### PR TITLE
[WAF, other] Remove line breaks after Render

### DIFF
--- a/src/content/docs/rules/index.mdx
+++ b/src/content/docs/rules/index.mdx
@@ -6,85 +6,125 @@ sidebar:
 head:
   - tag: title
     content: Cloudflare Rules
-
 ---
 
-import { CardGrid, Feature, LinkTitleCard, Plan, RelatedProduct, Render } from "~/components"
+import {
+	CardGrid,
+	Feature,
+	LinkTitleCard,
+	Plan,
+	RelatedProduct,
+	Render,
+} from "~/components";
 
 <Plan type="all" />
 
-<Render file="rules-definition" /> <br/>
+<Render file="rules-definition" />
 
 Rules features require that you [proxy the DNS records](/dns/manage-dns-records/reference/proxied-dns-records/) of your domain (or subdomain) through Cloudflare.
 
-***
+---
 
 ## Features
 
 <Feature header="Transform Rules" href="/rules/transform/">
-Adjust the URI path, query string, and HTTP headers of requests and responses on the Cloudflare global network. 
+	Adjust the URI path, query string, and HTTP headers of requests and responses
+	on the Cloudflare global network.
 </Feature>
 
-<Feature header="URL normalization" href="/rules/normalization/" cta="Configure URL normalization">
-Modify the URLs of incoming requests so that they conform to a consistent formatting standard. 
+<Feature
+	header="URL normalization"
+	href="/rules/normalization/"
+	cta="Configure URL normalization"
+>
+	Modify the URLs of incoming requests so that they conform to a consistent
+	formatting standard.
 </Feature>
 
 <Feature header="Redirects" href="/rules/url-forwarding/">
-Redirect visitors from a source URL to a target URL with a specific HTTP status code. Use Single Redirects or Bulk Redirects depending on your use case. 
+	Redirect visitors from a source URL to a target URL with a specific HTTP
+	status code. Use Single Redirects or Bulk Redirects depending on your use
+	case.
 </Feature>
 
 <Feature header="Origin Rules" href="/rules/origin-rules/">
-Customize where the incoming traffic will go and with which parameters. Override request properties such as `Host` header, destination hostname, and destination port. 
+	Customize where the incoming traffic will go and with which parameters.
+	Override request properties such as `Host` header, destination hostname, and
+	destination port.
 </Feature>
 
 <Feature header="Configuration Rules" href="/rules/configuration-rules/">
-Customize Cloudflare configuration settings for matching incoming requests. 
+	Customize Cloudflare configuration settings for matching incoming requests.
 </Feature>
 
 <Feature header="Compression Rules" href="/rules/compression-rules/">
-Customize the compression applied to responses from Cloudflare's global network to your website visitors, based on the file extension and content type. 
+	Customize the compression applied to responses from Cloudflare's global
+	network to your website visitors, based on the file extension and content
+	type.
 </Feature>
 
 <Feature header="Snippets" href="/rules/snippets/">
-Customize the behavior of your website or application using short pieces of JavaScript code. 
+	Customize the behavior of your website or application using short pieces of
+	JavaScript code.
 </Feature>
 
-<Feature header="Custom error responses" href="/rules/custom-error-responses/" cta="Configure custom error responses">
-Define custom responses for errors returned by an origin server or by a Cloudflare product, including Workers. 
+<Feature
+	header="Custom error responses"
+	href="/rules/custom-error-responses/"
+	cta="Configure custom error responses"
+>
+	Define custom responses for errors returned by an origin server or by a
+	Cloudflare product, including Workers.
 </Feature>
 
 <Feature header="Page Rules" href="/rules/page-rules/" cta="Use Page Rules">
-Trigger certain actions when a request matches a URL pattern. 
+	Trigger certain actions when a request matches a URL pattern.
 </Feature>
 
-***
+---
 
 ## Related products
 
 <RelatedProduct header="Custom rules" href="/waf/custom-rules/" product="waf">
-Control incoming traffic by filtering requests to a zone. You can block or challenge incoming requests according to rules you define. 
+	Control incoming traffic by filtering requests to a zone. You can block or
+	challenge incoming requests according to rules you define.
 </RelatedProduct>
 
-<RelatedProduct header="Rate limiting rules" href="/waf/rate-limiting-rules/" product="waf">
-Define rate limits for requests matching an expression, and the action to perform when those rate limits are reached. 
+<RelatedProduct
+	header="Rate limiting rules"
+	href="/waf/rate-limiting-rules/"
+	product="waf"
+>
+	Define rate limits for requests matching an expression, and the action to
+	perform when those rate limits are reached.
 </RelatedProduct>
 
-<RelatedProduct header="Cache rules" href="/cache/how-to/cache-rules/" product="cache">
-Customize the cache properties of your HTTP requests. 
+<RelatedProduct
+	header="Cache rules"
+	href="/cache/how-to/cache-rules/"
+	product="cache"
+>
+	Customize the cache properties of your HTTP requests.
 </RelatedProduct>
 
 <RelatedProduct header="Workers" href="/workers/" product="workers">
-Cloudflare Workers provides a serverless execution environment that allows you to create new applications or augment existing ones without configuring or maintaining infrastructure. 
+	Cloudflare Workers provides a serverless execution environment that allows you
+	to create new applications or augment existing ones without configuring or
+	maintaining infrastructure.
 </RelatedProduct>
 
-***
+---
 
 ## More resources
 
 <CardGrid>
 
-<LinkTitleCard title="Plans" href="https://www.cloudflare.com/plans/#overview" icon="document">
-Compare available Cloudflare plans
+<LinkTitleCard
+	title="Plans"
+	href="https://www.cloudflare.com/plans/#overview"
+	icon="document"
+>
+	Compare available Cloudflare plans
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/rules/transform/request-header-modification/index.mdx
+++ b/src/content/docs/rules/transform/request-header-modification/index.mdx
@@ -6,10 +6,9 @@ sidebar:
 head:
   - tag: title
     content: HTTP request header modification rules
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Use HTTP request header modification rules to manipulate the headers of HTTP requests sent to your origin server.
 
@@ -31,36 +30,42 @@ linkStyle 0,2,3 stroke-width: 1px
 linkStyle 1 stroke-width: 3px
 ```
 
-<br/>
+<br />
 
 To modify HTTP headers in the **response** sent to website visitors, refer to [HTTP response header modification rules](/rules/transform/response-header-modification/).
 
 Through HTTP request header modification rules you can:
 
-* Set the value of an HTTP request header to a literal string value, overwriting its previous value or adding a new header to the request.
-* Set the value of an HTTP request header according to an expression, overwriting its previous value or adding a new header to the request.
-* Remove an HTTP header from the request.
+- Set the value of an HTTP request header to a literal string value, overwriting its previous value or adding a new header to the request.
+- Set the value of an HTTP request header according to an expression, overwriting its previous value or adding a new header to the request.
+- Remove an HTTP header from the request.
 
 You can create an HTTP request header modification rule [in the dashboard](/rules/transform/request-header-modification/create-dashboard/) or [via API](/rules/transform/request-header-modification/create-api/).
 
-<Render file="snippets-alternative" params={{ one: "request header modifications" }} /><br />
+<Render
+	file="snippets-alternative"
+	params={{ one: "request header modifications" }}
+/>
 
 ## Important remarks
 
-* You cannot modify or remove HTTP request headers whose name starts with `x-cf-` or `cf-` except for the `cf-connecting-ip` HTTP request header, which you can remove.
+- You cannot modify or remove HTTP request headers whose name starts with `x-cf-` or `cf-` except for the `cf-connecting-ip` HTTP request header, which you can remove.
 
-* Due to protocol compliance reasons, modifying or removing request headers with [forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) (such as `Accept-Encoding`) is generally not allowed in request header modification rules.
+- Due to protocol compliance reasons, modifying or removing request headers with [forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) (such as `Accept-Encoding`) is generally not allowed in request header modification rules.
 
-* You cannot modify the value of any header commonly used to identify the website visitor's IP address, such as `x-forwarded-for`, `true-client-ip`, or `x-real-ip`. Additionally, you cannot remove the `x-forwarded-for` header.
+- You cannot modify the value of any header commonly used to identify the website visitor's IP address, such as `x-forwarded-for`, `true-client-ip`, or `x-real-ip`. Additionally, you cannot remove the `x-forwarded-for` header.
 
-* You cannot set or modify the value of `cookie` HTTP request headers, but you can remove these headers. Configuring a rule that removes the `cookie` HTTP request header will remove all `cookie` headers in matching requests.
+- You cannot set or modify the value of `cookie` HTTP request headers, but you can remove these headers. Configuring a rule that removes the `cookie` HTTP request header will remove all `cookie` headers in matching requests.
 
-* If you modify the value of an existing HTTP request header using an expression that evaluates to an empty string (`""`) or an undefined value, the HTTP request header is **removed**.
+- If you modify the value of an existing HTTP request header using an expression that evaluates to an empty string (`""`) or an undefined value, the HTTP request header is **removed**.
 
-* The HTTP request header removal operation will remove all request headers with the provided name.
+- The HTTP request header removal operation will remove all request headers with the provided name.
 
-* Currently, there is a limited number of HTTP request headers that you cannot modify. Cloudflare may remove restrictions for some of these HTTP request headers when presented with valid use cases. [Create a post in the community](https://community.cloudflare.com) for consideration.
+- Currently, there is a limited number of HTTP request headers that you cannot modify. Cloudflare may remove restrictions for some of these HTTP request headers when presented with valid use cases. [Create a post in the community](https://community.cloudflare.com) for consideration.
 
-* To use [claims inside a JSON Web Token (JWT)](/api-shield/security/jwt-validation/transform-rules/), you must first set up a token validation configuration in API Shield.
+- To use [claims inside a JSON Web Token (JWT)](/api-shield/security/jwt-validation/transform-rules/), you must first set up a token validation configuration in API Shield.
 
-<Render file="troubleshoot-rules-with-trace" params={{ one: "HTTP request header modification rules" }} />
+<Render
+	file="troubleshoot-rules-with-trace"
+	params={{ one: "HTTP request header modification rules" }}
+/>

--- a/src/content/docs/rules/url-forwarding/bulk-redirects/index.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/index.mdx
@@ -6,21 +6,23 @@ sidebar:
 head:
   - tag: title
     content: Bulk Redirects
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Bulk Redirects allow you to define a large number of URL redirects at the account level. These redirects navigate the user from a source URL to a target URL using a given HTTP status code. URL redirection is also known as URL forwarding.
 
 Unlike dynamic URL redirects created in [Single Redirects](/rules/url-forwarding/single-redirects/), Bulk Redirects are essentially static — they do not support string replacement operations or regular expressions. However, you can configure URL redirect parameters that affect their URL matching behavior and their runtime behavior.
 
-<Render file="snippets-alternative" params={{ one: "and customized redirect logic" }} /><br />
+<Render
+	file="snippets-alternative"
+	params={{ one: "and customized redirect logic" }}
+/>
 
-***
+---
 
 ## Related resources
 
-* [Availability](/rules/url-forwarding/#availability): Information on the Bulk Redirects quotas and features per Cloudflare plan.
-* [Execution order](/rules/url-forwarding/#execution-order): Execution order of the different Rules products.
-* [Trace a request](/fundamentals/basic-tasks/trace-request/): Use Cloudflare Trace to determine if a bulk redirect rule is triggering for a specific URL.
+- [Availability](/rules/url-forwarding/#availability): Information on the Bulk Redirects quotas and features per Cloudflare plan.
+- [Execution order](/rules/url-forwarding/#execution-order): Execution order of the different Rules products.
+- [Trace a request](/fundamentals/basic-tasks/trace-request/): Use Cloudflare Trace to determine if a bulk redirect rule is triggering for a specific URL.

--- a/src/content/docs/rules/url-forwarding/single-redirects/index.mdx
+++ b/src/content/docs/rules/url-forwarding/single-redirects/index.mdx
@@ -6,19 +6,21 @@ sidebar:
 head:
   - tag: title
     content: Single Redirects
-
 ---
 
-import { GlossaryTooltip, Render } from "~/components"
+import { GlossaryTooltip, Render } from "~/components";
 
 Single Redirects allow you to create static or dynamic URL <GlossaryTooltip term="redirect">redirects</GlossaryTooltip>. A simple interface with [wildcard support](/ruleset-engine/rules-language/operators/#wildcard-matching) makes it easy to define source and target URL patterns without needing complex functions or regular expressions, efficiently handling thousands of URLs with a single rule. Dynamic URL redirects also support advanced features such as string replacement operations and [regular expressions](/ruleset-engine/rules-language/values/#string-values-and-regular-expressions) (depending on your Cloudflare plan).
 
-<Render file="snippets-alternative" params={{ one: "and customized redirect logic" }} /><br />
+<Render
+	file="snippets-alternative"
+	params={{ one: "and customized redirect logic" }}
+/>
 
-***
+---
 
 ## Related resources
 
-* [Availability](/rules/url-forwarding/#availability): Information on the Single Redirects quotas and features per Cloudflare plan.
-* [Execution order](/rules/url-forwarding/#execution-order): Execution order of the different Rules products.
-* [Trace a request](/fundamentals/basic-tasks/trace-request/): Use Cloudflare Trace to determine if a redirect rule is triggering for a specific URL.
+- [Availability](/rules/url-forwarding/#availability): Information on the Single Redirects quotas and features per Cloudflare plan.
+- [Execution order](/rules/url-forwarding/#execution-order): Execution order of the different Rules products.
+- [Trace a request](/fundamentals/basic-tasks/trace-request/): Use Cloudflare Trace to determine if a redirect rule is triggering for a specific URL.

--- a/src/content/docs/ruleset-engine/rules-language/expressions/index.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/expressions/index.mdx
@@ -6,10 +6,9 @@ sidebar:
 head:
   - tag: title
     content: Rule expressions
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 The Rules language supports two kinds of expressions: simple and compound.
 
@@ -29,11 +28,11 @@ Simple expressions have the following syntax:
 
 Where:
 
-* [Fields](/ruleset-engine/rules-language/fields/) specify properties associated with an HTTP request.
+- [Fields](/ruleset-engine/rules-language/fields/) specify properties associated with an HTTP request.
 
-* [Comparison operators](/ruleset-engine/rules-language/operators/#comparison-operators) define how values must relate to actual request data for an expression to return `true`.
+- [Comparison operators](/ruleset-engine/rules-language/operators/#comparison-operators) define how values must relate to actual request data for an expression to return `true`.
 
-* [Values](/ruleset-engine/rules-language/values/) represent the data associated with fields. When evaluating a rule, Cloudflare compares these values with the actual data obtained from the request.
+- [Values](/ruleset-engine/rules-language/values/) represent the data associated with fields. When evaluating a rule, Cloudflare compares these values with the actual data obtained from the request.
 
 ## Compound expressions
 
@@ -55,7 +54,7 @@ Compound expressions allow you to generate sophisticated, highly targeted rules.
 
 ## Maximum rule expression length
 
-<Render file="max-expression-length" /> <br/>
+<Render file="max-expression-length" />
 
 This limit applies whether you use the visual [Expression Builder](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-builder) to define your expression, or write the expression manually in the [Expression Editor](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-editor).
 
@@ -63,6 +62,6 @@ This limit applies whether you use the visual [Expression Builder](/ruleset-engi
 
 You can also use the following Rules language features in your expressions:
 
-* [Grouping symbols](/ruleset-engine/rules-language/operators/#grouping-symbols) allow you to explicitly group expressions that should be evaluated together.
+- [Grouping symbols](/ruleset-engine/rules-language/operators/#grouping-symbols) allow you to explicitly group expressions that should be evaluated together.
 
-* [Functions](/ruleset-engine/rules-language/functions/) allow you to manipulate and validate values in expressions.
+- [Functions](/ruleset-engine/rules-language/functions/) allow you to manipulate and validate values in expressions.

--- a/src/content/docs/waf/index.mdx
+++ b/src/content/docs/waf/index.mdx
@@ -26,7 +26,7 @@ Get automatic protection from vulnerabilities and the flexibility to create cust
 
 <Plan type="all" />
 
-<Render file="waf-intro" /> <br />
+<Render file="waf-intro" />
 
 Learn how to [get started](/waf/get-started/).
 


### PR DESCRIPTION
### Summary

We no longer need to explicitly add line breaks (`<br/>`) after the `Render` component.
In docs-in-dash and especially when above the fold, removing these breaks helps save some vertical space.

Updating a few tiles in this PR.