### PR TITLE
[wrangler] Fix options list in "wrangler versions secret bulk"

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1878,7 +1878,8 @@ wrangler versions secret bulk <FILENAME> [OPTIONS]
 
 - `FILENAME` string optional
   - The JSON file containing key-value pairs to upload as secrets, in the form `{"SECRET_NAME": "secret value", ...}`.
-  - If omitted, Wrangler expects to receive input from `stdin` rather than a file.- `--name` string optional
+  - If omitted, Wrangler expects to receive input from `stdin` rather than a file.
+- `--name` string optional
   - Perform on a specific Worker rather than inheriting from `wrangler.toml`.
 - `--env` string optional
   - Perform on a specific environment.


### PR DESCRIPTION
### Summary

A typo in the docs causes a list item to be embedded into the previous one.

Fix: Add an appropriate linebreak.

### Screenshots (optional)

| Before | After
| - | -
| ![Before](https://github.com/user-attachments/assets/95a76052-ca84-4704-8943-df1c612bb95a) | ![After](https://github.com/user-attachments/assets/35b001cc-b414-40b0-bf01-87c25508a583)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
