### PR TITLE
[Workers] Fix unexpectedly over-extended `Notes` section

### DIFF
--- a/src/content/docs/workers/configuration/secrets.mdx
+++ b/src/content/docs/workers/configuration/secrets.mdx
@@ -33,7 +33,7 @@ If using [gradual deployments](/workers/configuration/versions-and-deployments/g
 
 :::note
 Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
-::
+:::
 
 ```sh
 npx wrangler versions secret put <KEY>


### PR DESCRIPTION
### Summary

Currently under the [Secrets Docs Page](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers), `Wrangler versions before 3.73.0 require you to specify a --x-versions flag. ::` seems to be incorrectly formatted so that it misses a `:` to be interpreted as the end of the callout block (Notes). This PR fixes that issue so it renders properly and avoids containing everything below into a callout block.

### Screenshots (optional)

> Omitted, should be pretty straightforward.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
