### PR TITLE
Update custom-fields.mdx to inform that Range header is not supported

### DIFF
--- a/src/content/docs/logs/reference/custom-fields.mdx
+++ b/src/content/docs/logs/reference/custom-fields.mdx
@@ -214,4 +214,4 @@ If you are a Cloudflare Access user, as of March 2022 you have to manually add t
 * The maximum length of custom field data for HTTP request headers, Cookies, and HTTP response headers combined is 8 KB. Any data over this limit will be truncated.
 * For headers which may be included multiple times (for example, the `set-cookie` response header), a custom field will only log the first instance of the header. Subsequent headers of the same type will be ignored.
 * Currently, Cloudflare only logs original request/response headers. Headers that were modified earlier in the request lifecycle with [Transform Rules](/rules/transform/) will not be logged.
-* The request header `Range` is not supported by Custom Fields at the moment.
+* The request header `Range` is currently not supported by Custom Fields.

--- a/src/content/docs/logs/reference/custom-fields.mdx
+++ b/src/content/docs/logs/reference/custom-fields.mdx
@@ -214,3 +214,4 @@ If you are a Cloudflare Access user, as of March 2022 you have to manually add t
 * The maximum length of custom field data for HTTP request headers, Cookies, and HTTP response headers combined is 8 KB. Any data over this limit will be truncated.
 * For headers which may be included multiple times (for example, the `set-cookie` response header), a custom field will only log the first instance of the header. Subsequent headers of the same type will be ignored.
 * Currently, Cloudflare only logs original request/response headers. Headers that were modified earlier in the request lifecycle with [Transform Rules](/rules/transform/) will not be logged.
+* The request header `Range` is not supported by Custom Fields at the moment.


### PR DESCRIPTION
### Summary

The Range header is currently not supported by Custom Fields. Suggesting the update of the documentation page to include this information.


### Documentation checklist

- [ x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
