### PR TITLE
[R2-2462] update r2 storage classes doc to callout waterfall transition between storage classes

### DIFF
--- a/src/content/docs/r2/buckets/storage-classes.mdx
+++ b/src/content/docs/r2/buckets/storage-classes.mdx
@@ -115,4 +115,12 @@ To learn more about how to specify the storage class for new objects, refer to t
 
 ### Use object lifecycle rules to transition objects to Infrequent Access storage
 
+:::note
+
+
+Once an object is stored in Infrequent Access, it cannot be transitioned to Standard Access using lifecycle policies.
+
+
+:::
+
 To learn more about how to transition objects from Standard storage to Infrequent Access storage, refer to [Object lifecycles](/r2/buckets/object-lifecycles/).


### PR DESCRIPTION
### Summary

We are updating the R2 Storage Classes page to clarify to customers that objects in Infrequent Storage cannot be transitioned to Standard Storage via object lifecycle policies.

### Screenshots (optional)

<img width="746" alt="Screenshot 2024-09-12 at 9 34 25 PM" src="https://github.com/user-attachments/assets/7cdfbc96-26fb-4c74-8c51-315fdbd2ecc8">
<img width="746" alt="Screenshot 2024-09-12 at 9 34 25 PM" src="https://github.com/user-attachments/assets/7cdfbc96-26fb-4c74-8c51-315fdbd2ecc8">

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
