### PR TITLE
Fix wording in documentation of Durable Object blockConcurrencyWhile

### DIFF
--- a/src/content/docs/durable-objects/reference/in-memory-state.mdx
+++ b/src/content/docs/durable-objects/reference/in-memory-state.mdx
@@ -62,6 +62,6 @@ If the callback throws an exception, the object will be terminated and reset. Th
 
 `state.blockConcurrencyWhile()` takes effect right away, pausing everything else, other than the currently executing event and any I/O started from within the `state.blockConcurrencyWhile()` callback. The value returned by the callback becomes the value returned by `state.blockConcurrencyWhile()` itself.
 
-To simulate eviction, use `state.blockConcurrencyWhile()`. Inside the callback, throw an exception. Throwing an exception causes the system to recreate the in-memory object, without affecting the durable storage. Uncaught exceptions inside the `state.blockConcurrencyWhile()` will break the actor.
+To simulate eviction, use `state.blockConcurrencyWhile()`. Inside the callback, throw an exception. Throwing an exception causes the system to recreate the in-memory object, without affecting the durable storage. Uncaught exceptions inside the `state.blockConcurrencyWhile()` will break the object.
 
 To help prevent deadlocks in your critical section, there is a 30s timeout on the callback passed into `state.blockConcurrencyWhile`. When this timeout is exceeded, your Durable Object will be reset. It is generally good practice to have your critical section in `blockConcurrencyWhile()` be as brief as possible.


### PR DESCRIPTION
@vy-ton @Frederik-Baetens 