### PR TITLE
[Docs Site] fix analytic tracking errors

### DIFF
--- a/src/scripts/analytics.ts
+++ b/src/scripts/analytics.ts
@@ -4,30 +4,34 @@ function $zarazLinkEvent(type: string, link: HTMLAnchorElement) {
 	// @ts-expect-error TODO: type zaraz
 	zaraz.track(type, { href: link.href, hostname: link.hostname });
 }
-
-addEventListener("DOMContentLoaded", () => {
-	if (links.length > 0) {
-		for (const link of links) {
-			const linkURL = new URL(link.href);
-			const cfSubdomainRegex = new RegExp(`^[^.]+?\\.cloudflare\\.com`);
-			if (linkURL.hostname !== "developers.cloudflare.com") {
-				if (
-					linkURL.hostname === "workers.cloudflare.com" &&
-					linkURL.pathname.startsWith("/playground#")
-				) {
-					link.addEventListener("click", () => {
-						$zarazLinkEvent("playground link click", link);
-					});
-				} else if (cfSubdomainRegex.test(linkURL.hostname)) {
-					link.addEventListener("click", () => {
-						$zarazLinkEvent("Cross Domain Click", link);
-					});
-				} else {
-					link.addEventListener("click", () => {
-						$zarazLinkEvent("external link click", link);
-					});
-				}
+function registerLinkAnalytics() {
+	if (!links || links.length === 0) {
+		return;
+	}
+	for (const link of links) {
+		if (!link.href) {
+			continue;
+		}
+		const linkURL = new URL(link.href);
+		const cfSubdomainRegex = new RegExp(`^[^.]+?\\.cloudflare\\.com`);
+		if (linkURL.hostname !== "developers.cloudflare.com") {
+			if (
+				linkURL.hostname === "workers.cloudflare.com" &&
+				linkURL.pathname.startsWith("/playground#")
+			) {
+				link.addEventListener("click", () => {
+					$zarazLinkEvent("playground link click", link);
+				});
+			} else if (cfSubdomainRegex.test(linkURL.hostname)) {
+				link.addEventListener("click", () => {
+					$zarazLinkEvent("Cross Domain Click", link);
+				});
+			} else {
+				link.addEventListener("click", () => {
+					$zarazLinkEvent("external link click", link);
+				});
 			}
 		}
 	}
-});
+}
+registerLinkAnalytics();


### PR DESCRIPTION
### Summary

Every page on the docs in production is throwing this client side JS error:

```
Uncaught TypeError: Failed to construct 'URL': Invalid URL
    at hoisted.BYWK-PrN.js:2:1136
```

This is due to some `a` elements on the page not always having a `href`, specifically the OneTrust button: https://github.com/cloudflare/cloudflare-docs/blob/8ccb6d75ab90addc4c3a8726492f29b7d88a5485/src/components/OneTrust.astro#L32

This adds a guard to prevent this code from erroring when a `href` isn't set. It also cleans up the code a little bit, as there's no need for a `DOMContentLoaded` listener since this will always execute as a `defer`-ed script, since it's loaded by Astro as `type=module`. 