### PR TITLE
Remove reference to templates

### DIFF
--- a/src/content/docs/workers/get-started/quickstarts.mdx
+++ b/src/content/docs/workers/get-started/quickstarts.mdx
@@ -24,12 +24,6 @@ npm create cloudflare@latest <NEW_PROJECT_NAME> -- --template <GITHUB_REPO_URL>
 - `template`
   - This is the URL of the GitHub repo starter, as below. Refer to the [create-cloudflare documentation](/pages/get-started/c3/) for a full list of possible values.
 
-:::note[Cloudflare templates repository]
-
-To access a full list of available Cloudflare templates, refer to the [Cloudflare templates repository](https://github.com/cloudflare/workers-sdk/tree/main/templates).
-
-:::
-
 ## Example Projects
 
 <WorkerStarter


### PR DESCRIPTION
### Summary

We've recently removed the templates folder from workers-sdk, and so should no longer link to it from the docs
