### PR TITLE
[Docs Site] Add figcaption from img title attribute

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,7 @@ import { h } from "hastscript";
 import { readdir } from "fs/promises";
 import icon from "astro-icon";
 import sitemap from "@astrojs/sitemap";
+import rehypeTitleFigure from "rehype-title-figure";
 
 const runLinkCheck = process.env.RUN_LINK_CHECK || false;
 
@@ -83,6 +84,7 @@ export default defineConfig({
 			],
 			rehypeSlug,
 			[rehypeAutolinkHeadings, autolinkConfig],
+			rehypeTitleFigure,
 		],
 	},
 	experimental: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"rehype-external-links": "^3.0.0",
 				"rehype-mermaid": "^2.1.0",
 				"rehype-slug": "^6.0.0",
+				"rehype-title-figure": "^0.1.2",
 				"sharp": "^0.33.5",
 				"solarflare-theme": "^0.0.2",
 				"starlight-image-zoom": "^0.8.0",
@@ -11398,6 +11399,141 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/rehype-title-figure": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rehype-title-figure/-/rehype-title-figure-0.1.2.tgz",
+			"integrity": "sha512-CHMIb46yg5/ocVYtLUlvxYSRLCLidijOkSBXRCebTWD6qOuJ3eo/J4gG4zri1Xo4fNH0C8KrA/J4aNdhikzYdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hastscript": "6.0.0",
+				"unist-util-visit": "2.0.3"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/@types/hast": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+			"integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rehype-title-figure/node_modules/comma-separated-tokens": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/hast-util-parse-selector": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+			"integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/hastscript": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+			"integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^2.0.0",
+				"comma-separated-tokens": "^1.0.0",
+				"hast-util-parse-selector": "^2.0.0",
+				"property-information": "^5.0.0",
+				"space-separated-tokens": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/property-information": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+			"integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xtend": "^4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/space-separated-tokens": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/unist-util-is": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+			"integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/unist-util-visit": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+			"integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^4.0.0",
+				"unist-util-visit-parents": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-title-figure/node_modules/unist-util-visit-parents": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+			"integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-directive": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.0.tgz",
@@ -14352,6 +14488,16 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
 			}
 		},
 		"node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"rehype-external-links": "^3.0.0",
 		"rehype-mermaid": "^2.1.0",
 		"rehype-slug": "^6.0.0",
+		"rehype-title-figure": "^0.1.2",
 		"sharp": "^0.33.5",
 		"solarflare-theme": "^0.0.2",
 		"starlight-image-zoom": "^0.8.0",


### PR DESCRIPTION
### Summary

Adds `figcaption` elements below an `img` using the `title` attribute which is the string after the path: `![foo](/url "title")`

Before:
<img width="479" alt="image" src="https://github.com/user-attachments/assets/f29e695c-f871-45fe-b9c1-785a0a36b4b5">

After:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/9bfbdd84-c628-4123-a712-60ca5bad0e41">
