### PR TITLE
Minimize HTML changes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -204,4 +204,13 @@ export default defineConfig({
 			},
 		}),
 	],
+	vite: {
+		build: {
+			rollupOptions: {
+				output: {
+					entryFileNames: "_astro/[name].js",
+				},
+			},
+		},
+	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "cloudflare-docs-starlight",
-	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -21,7 +20,7 @@
 				"@types/node": "^20.16.1",
 				"algoliasearch": "^4.24.0",
 				"astro": "^4.15.7",
-				"astro-breadcrumbs": "^2.3.1",
+				"astro-breadcrumbs": "^3.1.0",
 				"astro-icon": "^1.1.1",
 				"astro-live-code": "^0.0.3",
 				"date-fns": "^3.6.0",
@@ -208,9 +207,9 @@
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.4.1.tgz",
-			"integrity": "sha512-IffPD+CETiR8YJMVC1lcjnhETLpJ2L0ORZCbbRvwo/S11D1j/keR7AqKVMn4TseRJCfjmBFOcFrC+m4sXjyQWA==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.5.2.tgz",
+			"integrity": "sha512-LFkAilO+t06/SsFLTzdyh4FD8FGldCXD6Hf3O1ygcrOrxSNQvowy/Dtmqi68MbGP5/MKj24fFmFWhUGhSPh4wA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -242,17 +241,17 @@
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.4.1.tgz",
-			"integrity": "sha512-nCgWY2p0tZgBqJKmA5E6B3VW+7uqxi1Orf88zNWOihJBRFeOV932pzG4vGrX9l0+p0o/vJabYxuomO35rEt5dw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.5.2.tgz",
+			"integrity": "sha512-fJH+U6LzzI/LnGkD/Uy8VA8MbmF8ERRG5bXYiIsrcMC/QGyOW5G5y3XNhZlxUhqesrO7w+oTE7ZQ0YMXtW/5/Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.4.1",
-				"@algolia/requester-browser-xhr": "5.4.1",
-				"@algolia/requester-fetch": "5.4.1",
-				"@algolia/requester-node-http": "5.4.1"
+				"@algolia/client-common": "5.5.2",
+				"@algolia/requester-browser-xhr": "5.5.2",
+				"@algolia/requester-fetch": "5.5.2",
+				"@algolia/requester-node-http": "5.5.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -346,14 +345,14 @@
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.4.1.tgz",
-			"integrity": "sha512-J6+YfU+maR0nIbsYRHoq0UpneilX97hrZzPuuvSoBojQmPo8PeCXKGeT/F0D8uFI6G4CMTKEPGmQYrC9IpCbcQ==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.5.2.tgz",
+			"integrity": "sha512-fCsJL+97TswpDO5gu8CKf68ZS5yBSksaK8bszeU7BrjSYgu2vL/eFxpN4wxIBGIbDVJtcriWI0aTkT2ovrn/iQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.4.1"
+				"@algolia/client-common": "5.5.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -367,28 +366,28 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.4.1.tgz",
-			"integrity": "sha512-AO/C1pqqpIS8p2IsfM5x92S+UBKkcIen5dHfMEh1rnV0ArWDreeqrtxMD2A+6AjQVwYeZNy56w7o7PVIm6mc8g==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.5.2.tgz",
+			"integrity": "sha512-zKawgSZR7toQEERwP4wazvQ6eR7I8KE4nidQzdWL4/8sxxhwiNvn8x9FjCePDnzzHmeiQy9NnUlw4rmT8R0nYg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.4.1"
+				"@algolia/client-common": "5.5.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.4.1.tgz",
-			"integrity": "sha512-2Y3vffc91egwFxz0SjXFEH4q8nvlNJHcz+0//NaWItRU68AvD+3aI/j66STPjkLQOC0Ku6ckA9ChhbOVfrv+Uw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.5.2.tgz",
+			"integrity": "sha512-rBVG8rgzUws2CB972RSgtn3/gRArvp5VDbnTODANj2V17qV/gm/CmV2Ax0IWpgWDh1xWxpEs8s5l4oc0m8QN9A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.4.1"
+				"@algolia/client-common": "5.5.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -1246,9 +1245,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-shared": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.5.0.tgz",
-			"integrity": "sha512-qLJzGKwl2SiaaieoCFdj2q85hthPgmF5KjRaZzsPdMKtP+PQnzSWfARsd5mZh71ut5/0grYkUCYWedFe4bY++g==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.5.3.tgz",
+			"integrity": "sha512-Yk5Im7zsyKbzd7qi+DrL7ZJR9+bdZwq9BqZWS4muDIWA8MCUeSLsUC+C9u+jdwfPSi5It2AcQG4f0iwZr6jkkQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -1956,9 +1955,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
-			"version": "2.1.32",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.32.tgz",
-			"integrity": "sha512-LeifFZPPKu28O3AEDpYJNdEbvS4/ojAPyIW+pF/vUpJTYnbTiXUHkCh0bwgFRzKvdpb8H4Fbfd/742++MF4fPQ==",
+			"version": "2.1.33",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
+			"integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2692,9 +2691,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz",
-			"integrity": "sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.0.tgz",
+			"integrity": "sha512-/IZQvg6ZR0tAkEi4tdXOraQoWeJy9gbQ/cx4I7k9dJaCk9qrXEcdouxRVz5kZXt5C2bQ9pILoAA+KB4C/d3pfw==",
 			"cpu": [
 				"arm"
 			],
@@ -2706,9 +2705,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz",
-			"integrity": "sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.0.tgz",
+			"integrity": "sha512-ETHi4bxrYnvOtXeM7d4V4kZWixib2jddFacJjsOjwbgYSRsyXYtZHC4ht134OsslPIcnkqT+TKV4eU8rNBKyyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2720,9 +2719,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz",
-			"integrity": "sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.0.tgz",
+			"integrity": "sha512-ZWgARzhSKE+gVUX7QWaECoRQsPwaD8ZR0Oxb3aUpzdErTvlEadfQpORPXkKSdKbFci9v8MJfkTtoEHnnW9Ulng==",
 			"cpu": [
 				"arm64"
 			],
@@ -2734,9 +2733,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz",
-			"integrity": "sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.0.tgz",
+			"integrity": "sha512-h0ZAtOfHyio8Az6cwIGS+nHUfRMWBDO5jXB8PQCARVF6Na/G6XS2SFxDl8Oem+S5ZsHQgtsI7RT4JQnI1qrlaw==",
 			"cpu": [
 				"x64"
 			],
@@ -2748,9 +2747,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz",
-			"integrity": "sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.0.tgz",
+			"integrity": "sha512-9pxQJSPwFsVi0ttOmqLY4JJ9pg9t1gKhK0JDbV1yUEETSx55fdyCjt39eBQ54OQCzAF0nVGO6LfEH1KnCPvelA==",
 			"cpu": [
 				"arm"
 			],
@@ -2762,9 +2761,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz",
-			"integrity": "sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.0.tgz",
+			"integrity": "sha512-YJ5Ku5BmNJZb58A4qSEo3JlIG4d3G2lWyBi13ABlXzO41SsdnUKi3HQHe83VpwBVG4jHFTW65jOQb8qyoR+qzg==",
 			"cpu": [
 				"arm"
 			],
@@ -2776,9 +2775,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz",
-			"integrity": "sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.0.tgz",
+			"integrity": "sha512-U4G4u7f+QCqHlVg1Nlx+qapZy+QoG+NV6ux+upo/T7arNGwKvKP2kmGM4W5QTbdewWFgudQxi3kDNST9GT1/mg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2790,9 +2789,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz",
-			"integrity": "sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.0.tgz",
+			"integrity": "sha512-aQpNlKmx3amwkA3a5J6nlXSahE1ijl0L9KuIjVOUhfOh7uw2S4piR3mtpxpRtbnK809SBtyPsM9q15CPTsY7HQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2804,9 +2803,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz",
-			"integrity": "sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.0.tgz",
+			"integrity": "sha512-9fx6Zj/7vve/Fp4iexUFRKb5+RjLCff6YTRQl4CoDhdMfDoobWmhAxQWV3NfShMzQk1Q/iCnageFyGfqnsmeqQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2818,9 +2817,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz",
-			"integrity": "sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.0.tgz",
+			"integrity": "sha512-VWQiCcN7zBgZYLjndIEh5tamtnKg5TGxyZPWcN9zBtXBwfcGSZ5cHSdQZfQH/GB4uRxk0D3VYbOEe/chJhPGLQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2832,9 +2831,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz",
-			"integrity": "sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.0.tgz",
+			"integrity": "sha512-EHmPnPWvyYqncObwqrosb/CpH3GOjE76vWVs0g4hWsDRUVhg61hBmlVg5TPXqF+g+PvIbqkC7i3h8wbn4Gp2Fg==",
 			"cpu": [
 				"s390x"
 			],
@@ -2846,9 +2845,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz",
-			"integrity": "sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.0.tgz",
+			"integrity": "sha512-tsSWy3YQzmpjDKnQ1Vcpy3p9Z+kMFbSIesCdMNgLizDWFhrLZIoN21JSq01g+MZMDFF+Y1+4zxgrlqPjid5ohg==",
 			"cpu": [
 				"x64"
 			],
@@ -2860,9 +2859,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz",
-			"integrity": "sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.0.tgz",
+			"integrity": "sha512-anr1Y11uPOQrpuU8XOikY5lH4Qu94oS6j0xrulHk3NkLDq19MlX8Ng/pVipjxBJ9a2l3+F39REZYyWQFkZ4/fw==",
 			"cpu": [
 				"x64"
 			],
@@ -2874,9 +2873,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz",
-			"integrity": "sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.0.tgz",
+			"integrity": "sha512-7LB+Bh+Ut7cfmO0m244/asvtIGQr5pG5Rvjz/l1Rnz1kDzM02pSX9jPaS0p+90H5I1x4d1FkCew+B7MOnoatNw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2888,9 +2887,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz",
-			"integrity": "sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.0.tgz",
+			"integrity": "sha512-+3qZ4rer7t/QsC5JwMpcvCVPRcJt1cJrYS/TMJZzXIJbxWFQEVhrIc26IhB+5Z9fT9umfVc+Es2mOZgl+7jdJQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -2902,9 +2901,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz",
-			"integrity": "sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.0.tgz",
+			"integrity": "sha512-YdicNOSJONVx/vuPkgPTyRoAPx3GbknBZRCOUkK84FJ/YTfs/F0vl/YsMscrB6Y177d+yDRcj+JWMPMCgshwrA==",
 			"cpu": [
 				"x64"
 			],
@@ -2916,46 +2915,47 @@
 			]
 		},
 		"node_modules/@shikijs/core": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.17.6.tgz",
-			"integrity": "sha512-9ztslig6/YmCg/XwESAXbKjAjOhaq6HVced9NY6qcbDz1X5g/S90Wco2vMjBNX/6V71ASkzri76JewSGPa7kiQ==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.17.7.tgz",
+			"integrity": "sha512-ZnIDxFu/yvje3Q8owSHaEHd+bu/jdWhHAaJ17ggjXofHx5rc4bhpCSW+OjC6smUBi5s5dd023jWtZ1gzMu/yrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-javascript": "1.17.6",
-				"@shikijs/engine-oniguruma": "1.17.6",
-				"@shikijs/types": "1.17.6",
+				"@shikijs/engine-javascript": "1.17.7",
+				"@shikijs/engine-oniguruma": "1.17.7",
+				"@shikijs/types": "1.17.7",
 				"@shikijs/vscode-textmate": "^9.2.2",
 				"@types/hast": "^3.0.4",
 				"hast-util-to-html": "^9.0.2"
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.17.6.tgz",
-			"integrity": "sha512-5EEZj8tVcierNxm4V0UMS2PVoflb0UJPalWWV8l9rRg+oOfnr5VivqBJbkyq5grltVPvByIXvVbY8GSM/356jQ==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.17.7.tgz",
+			"integrity": "sha512-wwSf7lKPsm+hiYQdX+1WfOXujtnUG6fnN4rCmExxa4vo+OTmvZ9B1eKauilvol/LHUPrQgW12G3gzem7pY5ckw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "1.17.6",
+				"@shikijs/types": "1.17.7",
+				"@shikijs/vscode-textmate": "^9.2.2",
 				"oniguruma-to-js": "0.4.3"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.17.6.tgz",
-			"integrity": "sha512-NLfWDMXFYe0nDHFbEoyZdz89aIIey3bTfF3zLYSUNTXks5s4uinZVmuPOFf1HfTeGqIn8uErJSBc3VnpJO7Alw==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.17.7.tgz",
+			"integrity": "sha512-pvSYGnVeEIconU28NEzBXqSQC/GILbuNbAHwMoSfdTBrobKAsV1vq2K4cAgiaW1TJceLV9QMGGh18hi7cCzbVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "1.17.6",
+				"@shikijs/types": "1.17.7",
 				"@shikijs/vscode-textmate": "^9.2.2"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.17.6.tgz",
-			"integrity": "sha512-ndTFa2TJi2w51ddKQDn3Jy8f6K4E5Q2x3dA3Hmsd3+YmxDQ10UWHjcw7VbVbKzv3VcUvYPLy+z9neqytSzUMUg==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.17.7.tgz",
+			"integrity": "sha512-+qA4UyhWLH2q4EFd+0z4K7GpERDU+c+CN2XYD3sC+zjvAr5iuwD1nToXZMt1YODshjkEGEDV86G7j66bKjqDdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3084,9 +3084,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3179,9 +3179,9 @@
 			}
 		},
 		"node_modules/@types/qs": {
-			"version": "6.9.15",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-			"integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+			"version": "6.9.16",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+			"integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3232,14 +3232,14 @@
 			"license": "ISC"
 		},
 		"node_modules/@volar/kit": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.4.tgz",
-			"integrity": "sha512-6WusqQ4YhtIYbqY3nlLnkSbfBRSakx5HcTKdF+WjGKBj5D74ux9nsLq3uAqQlbpKgVkkt425KEDymQTb4C36Kg==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.5.tgz",
+			"integrity": "sha512-ZzyErW5UiDfiIuJ/lpqc2Kx5PHDGDZ/bPlPJYpRcxlrn8Z8aDhRlsLHkNKcNiH65TmNahk2kbLaiejiqu6BD3A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-service": "2.4.4",
-				"@volar/typescript": "2.4.4",
+				"@volar/language-service": "2.4.5",
+				"@volar/typescript": "2.4.5",
 				"typesafe-path": "^0.2.2",
 				"vscode-languageserver-textdocument": "^1.0.11",
 				"vscode-uri": "^3.0.8"
@@ -3249,25 +3249,25 @@
 			}
 		},
 		"node_modules/@volar/language-core": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.4.tgz",
-			"integrity": "sha512-kO9k4kTLfxpg+6lq7/KAIv3m2d62IHuCL6GbVgYZTpfKvIGoAIlDxK7pFcB/eczN2+ydg/vnyaeZ6SGyZrJw2w==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.5.tgz",
+			"integrity": "sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/source-map": "2.4.4"
+				"@volar/source-map": "2.4.5"
 			}
 		},
 		"node_modules/@volar/language-server": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.4.tgz",
-			"integrity": "sha512-rBzTgRw4/msZSFRSJURFU53qcDfBNm40NtYoMwOyaZuPcLzdgDAZ3hzVE80Rj0pk82LQJ0AfH13Y+EYFvUWkfQ==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.5.tgz",
+			"integrity": "sha512-l5PswE0JzCtstTlwBUpikeSa3lNUBJhTuWtj9KclZTGi2Uex4RcqGOhTiDsUUtvdv/hEuYCxGq1EdJJPlQsD/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.4",
-				"@volar/language-service": "2.4.4",
-				"@volar/typescript": "2.4.4",
+				"@volar/language-core": "2.4.5",
+				"@volar/language-service": "2.4.5",
+				"@volar/typescript": "2.4.5",
 				"path-browserify": "^1.0.1",
 				"request-light": "^0.7.0",
 				"vscode-languageserver": "^9.0.1",
@@ -3277,33 +3277,33 @@
 			}
 		},
 		"node_modules/@volar/language-service": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.4.tgz",
-			"integrity": "sha512-QXfZV3IpJdcNQcdWFEG+iXOIb3NiC6/cNIQeH2QAOMx2vpkshuMcWD7AzrhVavobircOXJNiGmRGwqf2okYE3A==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.5.tgz",
+			"integrity": "sha512-xiFlL0aViGg6JhwAXyohPrdlID13uom8WQg6DWYaV8ob8RRy+zoLlBUI8SpQctwlWEO9poyrYK01revijAwkcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.4",
+				"@volar/language-core": "2.4.5",
 				"vscode-languageserver-protocol": "^3.17.5",
 				"vscode-languageserver-textdocument": "^1.0.11",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/@volar/source-map": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.4.tgz",
-			"integrity": "sha512-xG3PZqOP2haG8XG4Pg3PD1UGDAdqZg24Ru8c/qYjYAnmcj6GBR64mstx+bZux5QOyRaJK+/lNM/RnpvBD3489g==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.5.tgz",
+			"integrity": "sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@volar/typescript": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.4.tgz",
-			"integrity": "sha512-QQMQRVj0fVHJ3XdRKiS1LclhG0VBXdFYlyuHRQF/xLk2PuJuHNWP26MDZNvEVCvnyUQuUQhIAfylwY5TGPgc6w==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.5.tgz",
+			"integrity": "sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.4",
+				"@volar/language-core": "2.4.5",
 				"path-browserify": "^1.0.1",
 				"vscode-uri": "^3.0.8"
 			}
@@ -3727,9 +3727,9 @@
 			}
 		},
 		"node_modules/astro-breadcrumbs": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/astro-breadcrumbs/-/astro-breadcrumbs-2.3.1.tgz",
-			"integrity": "sha512-9SUAGZiUP9iCnYOdtngZpHk1Fyge78T3tR7QR1mdx5qjOv1jIGXxtqCdxL84rMJsxgGg+NEI72rb1lK7AeCb+w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/astro-breadcrumbs/-/astro-breadcrumbs-3.1.0.tgz",
+			"integrity": "sha512-1A5g0PHoF3M+9Kb1zm+M4xS7fISdLUnt+7wxTwj3f99HUt2iDSC8iFSW0lf14KbWHD5qXmdvzaDoCBKYZDMgew==",
 			"dev": true,
 			"funding": [
 				{
@@ -3794,13 +3794,6 @@
 				"magic-string": "^0.30.5",
 				"unist-util-visit-parents": "^6.0.1"
 			}
-		},
-		"node_modules/astro/node_modules/path-to-regexp": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -4130,9 +4123,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001660",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-			"integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+			"version": "1.0.30001662",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
+			"integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5669,9 +5662,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.22",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.22.tgz",
-			"integrity": "sha512-tKYm5YHPU1djz0O+CGJ+oJIvimtsCcwR2Z9w7Skh08lUdyzXY5djods3q+z2JkWdb7tCcmM//eVavSRAiaPRNg==",
+			"version": "1.5.25",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz",
+			"integrity": "sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5683,9 +5676,9 @@
 			"license": "EPL-2.0"
 		},
 		"node_modules/emmet": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.7.tgz",
-			"integrity": "sha512-O5O5QNqtdlnQM2bmKHtJgyChcrFMgQuulI+WdiOw2NArzprUqqxUW6bgYtKvzKgrsYpuLWalOkdhNP+1jluhCA==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.8.tgz",
+			"integrity": "sha512-wFe/dxsx7oi/M2UJ/3yBu4Fm24Irho6lqut4C1YFaZebCvCCMygoDGC7W6I+8+K8PAjfa/Ojn52UHi8WCdDiRA==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -6596,6 +6589,26 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hast-util-format": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+			"integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-embedded": "^3.0.0",
+				"hast-util-minify-whitespace": "^1.0.0",
+				"hast-util-phrasing": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-whitespace-sensitive-tag-names": "^3.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-from-dom": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.0.tgz",
@@ -6631,9 +6644,9 @@
 			}
 		},
 		"node_modules/hast-util-from-html": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.2.tgz",
-			"integrity": "sha512-HwOHwxdt2zC5KQ/CNoybBntRook2zJvfZE/u5/Ap7aLPe22bDqen7KwGkOqOyzL5zIqKwiYX/OTtE0FWgr6XXA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6761,6 +6774,24 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hast-util-minify-whitespace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.0.tgz",
+			"integrity": "sha512-gD1m4YJSIk62ij32TlhFNqsC3dOQvpA4QAhyZOZFAT4u8LfEfB6N+F0V9oXQGBWXoqrs0h9wQRKa8RCeo8j61g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-embedded": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-parse-selector": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -6878,9 +6909,9 @@
 			}
 		},
 		"node_modules/hast-util-to-html": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.2.tgz",
-			"integrity": "sha512-RP5wNpj5nm1Z8cloDv4Sl4RS8jH5HYa0v93YB6Wb4poEzgMo/dAAL0KcT4974dCjcNG5pkLqTImeFHHCwwfY3g==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
+			"integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8393,9 +8424,9 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.2.0.tgz",
-			"integrity": "sha512-ZinOa063lk81lujX8vkINNqmFaNMk1A95Z4kCL7fE6QLAi01CxeiUJVw+tpXU+lAM73utO39G+2PLjxS2GYS/w==",
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.2.1.tgz",
+			"integrity": "sha512-F8TEaLVVyxTUmvKswVFyOkjPrlJA5h5vNR1f7ZnSWSpqxgEZG1hggtn/QCa7znC28bhlcrNh10qYaIiill7q4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9089,9 +9120,9 @@
 			}
 		},
 		"node_modules/micromark-extension-directive": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.1.tgz",
-			"integrity": "sha512-VGV2uxUzhEZmaP7NSFo2vtq7M2nUD+WfmYQD+d8i/1nHbzE+rMy9uzTvUybBbNiVbrhOZibg3gbyoARGqgDWyg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+			"integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9865,9 +9896,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20240909.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240909.0.tgz",
-			"integrity": "sha512-20eJCCToBvxohLW0vWZHPRL6JPbqJQ4nkCK6MelgTRkw4CLd7MUYbY70M8olJjTuBDK/84/1CkNC4Q/OrbHIDA==",
+			"version": "3.20240909.3",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240909.3.tgz",
+			"integrity": "sha512-HsWMexA4m0Ti8wTjqRdg50otufgoQ/I/rL3AHxf3dI/TN8zJC/5aMApqspW6I88Lzm24C+SRKnW0nm465PStIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10215,9 +10246,9 @@
 			}
 		},
 		"node_modules/ohash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
-			"integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+			"integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10765,9 +10796,9 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10863,9 +10894,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
-			"integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+			"version": "1.47.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.1.tgz",
+			"integrity": "sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -10894,9 +10925,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.45",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-			"integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+			"version": "8.4.47",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+			"integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -10915,8 +10946,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.1",
-				"source-map-js": "^1.2.0"
+				"picocolors": "^1.1.0",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -11044,9 +11075,9 @@
 			"license": "MIT"
 		},
 		"node_modules/preact": {
-			"version": "10.23.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
-			"integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
+			"version": "10.24.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.24.0.tgz",
+			"integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -11314,20 +11345,14 @@
 			}
 		},
 		"node_modules/rehype-format": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.0.tgz",
-			"integrity": "sha512-kM4II8krCHmUhxrlvzFSptvaWh280Fr7UGNJU5DCMuvmAwGCNmGfi9CvFAQK6JDjsNoRMWQStglK3zKJH685Wg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+			"integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
-				"hast-util-embedded": "^3.0.0",
-				"hast-util-is-element": "^3.0.0",
-				"hast-util-phrasing": "^3.0.0",
-				"hast-util-whitespace": "^3.0.0",
-				"html-whitespace-sensitive-tag-names": "^3.0.0",
-				"rehype-minify-whitespace": "^6.0.0",
-				"unist-util-visit-parents": "^6.0.0"
+				"hast-util-format": "^1.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11353,24 +11378,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/remcohaszing"
-			}
-		},
-		"node_modules/rehype-minify-whitespace": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.0.tgz",
-			"integrity": "sha512-i9It4YHR0Sf3GsnlR5jFUKXRr9oayvEk9GKQUkwZv6hs70OH9q3OCZrq9PpLvIGKt3W+JxBOxCidNVpH/6rWdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"hast-util-embedded": "^3.0.0",
-				"hast-util-is-element": "^3.0.0",
-				"hast-util-whitespace": "^3.0.0",
-				"unist-util-is": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/rehype-parse": {
@@ -11643,9 +11650,9 @@
 			}
 		},
 		"node_modules/remark-rehype": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.0.tgz",
-			"integrity": "sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
+			"integrity": "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11862,9 +11869,9 @@
 			"license": "Unlicense"
 		},
 		"node_modules/rollup": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
-			"integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.0.tgz",
+			"integrity": "sha512-W21MUIFPZ4+O2Je/EU+GP3iz7PH4pVPUXSbEZdatQnxo29+3rsUjgrJmzuAZU24z7yRAnFN6ukxeAhZh/c7hzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11878,22 +11885,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.21.3",
-				"@rollup/rollup-android-arm64": "4.21.3",
-				"@rollup/rollup-darwin-arm64": "4.21.3",
-				"@rollup/rollup-darwin-x64": "4.21.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.21.3",
-				"@rollup/rollup-linux-arm-musleabihf": "4.21.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.21.3",
-				"@rollup/rollup-linux-arm64-musl": "4.21.3",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.21.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.21.3",
-				"@rollup/rollup-linux-s390x-gnu": "4.21.3",
-				"@rollup/rollup-linux-x64-gnu": "4.21.3",
-				"@rollup/rollup-linux-x64-musl": "4.21.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.21.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.21.3",
-				"@rollup/rollup-win32-x64-msvc": "4.21.3",
+				"@rollup/rollup-android-arm-eabi": "4.22.0",
+				"@rollup/rollup-android-arm64": "4.22.0",
+				"@rollup/rollup-darwin-arm64": "4.22.0",
+				"@rollup/rollup-darwin-x64": "4.22.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.0",
+				"@rollup/rollup-linux-arm64-musl": "4.22.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.0",
+				"@rollup/rollup-linux-x64-gnu": "4.22.0",
+				"@rollup/rollup-linux-x64-musl": "4.22.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.0",
+				"@rollup/rollup-win32-x64-msvc": "4.22.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -11951,6 +11958,13 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
 			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rollup/node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12179,16 +12193,16 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.17.6.tgz",
-			"integrity": "sha512-RejGugKpDM75vh6YtF9R771acxHRDikC/01kxsUGW+Pnaz3pTY+c8aZB5CnD7p0vuFPs1HaoAIU/4E+NCfS+mQ==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.17.7.tgz",
+			"integrity": "sha512-Zf6hNtWhFyF4XP5OOsXkBTEx9JFPiN0TQx4wSe+Vqeuczewgk2vT4IZhF4gka55uelm052BD5BaHavNqUNZd+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "1.17.6",
-				"@shikijs/engine-javascript": "1.17.6",
-				"@shikijs/engine-oniguruma": "1.17.6",
-				"@shikijs/types": "1.17.6",
+				"@shikijs/core": "1.17.7",
+				"@shikijs/engine-javascript": "1.17.7",
+				"@shikijs/engine-oniguruma": "1.17.7",
+				"@shikijs/types": "1.17.7",
 				"@shikijs/vscode-textmate": "^9.2.2",
 				"@types/hast": "^3.0.4"
 			}
@@ -12350,6 +12364,7 @@
 			"resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.12.0.tgz",
 			"integrity": "sha512-R4EfOyyeTHLPZX2QJmkk1s2cln9ejN+BJIucRhlavqd1R/hM05CMtP5Tpfb7WTzrTHGlqFlQlL0gbRAhc2+mQA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"github-slugger": "2.0.0",
 				"hast-util-from-html": "2.0.1",
@@ -12392,6 +12407,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -12760,9 +12776,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.11",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.11.tgz",
-			"integrity": "sha512-qhEuBcLemjSJk5ajccN9xJFtM/h0AVCPaA6C92jNP+M2J8kX+eMJHI7R2HFKUvvAsMpcfLILMCFYSeDwpMmlUg==",
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.12.tgz",
+			"integrity": "sha512-Htf/gHj2+soPb9UayUNci/Ja3d8pTmu9ONTfh4QY8r3MATTZOzmv6UYWF7ZwikEIC8okpfqmGqrmDehua8mF8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13098,9 +13114,9 @@
 		},
 		"node_modules/unenv": {
 			"name": "unenv-nightly",
-			"version": "2.0.0-1724863496.70db6f1",
-			"resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-1724863496.70db6f1.tgz",
-			"integrity": "sha512-r+VIl1gnsI4WQxluruSQhy8alpAf1AsLRLm4sEKp3otCyTIVD6I6wHEYzeQnwsyWgaD4+3BD4A/eqrgOpdTzhw==",
+			"version": "2.0.0-1726478054.1e87097",
+			"resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-1726478054.1e87097.tgz",
+			"integrity": "sha512-uZso8dCkGlJzWQqkyjOA5L4aUqNJl9E9oKRm03V/d+URrg6rFMJwBonlX9AAq538NxwJpPnCX0gAz0IfTxsbFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13403,9 +13419,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.5.tgz",
-			"integrity": "sha512-pXqR0qtb2bTwLkev4SE3r4abCNioP3GkjvIDLlzziPpXtHgiJIjuKl+1GN6ESOT3wMjG3JTeARopj2SwYaHTOA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
+			"integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13879,28 +13895,28 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.77.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.77.0.tgz",
-			"integrity": "sha512-XdzStAdB6c87cc9CJRinMzAAFqqSZ19pQ+m6Gzx5fHeWXSclrOFsfD2iSmil8C3/LsrtwoIXghibK98FN0HhhQ==",
+			"version": "3.78.5",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.78.5.tgz",
+			"integrity": "sha512-EqCQOuuxHCBHLSjWw7kWT/1PDSw38XUhSxPC3VnDcL7F6TukVBfHHyLFO4NYGTDDoH+G8KVK1bL1q8LXY2Rcbg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.3.4",
-				"@cloudflare/workers-shared": "0.5.0",
+				"@cloudflare/workers-shared": "0.5.3",
 				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
 				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"date-fns": "^3.6.0",
 				"esbuild": "0.17.19",
-				"miniflare": "3.20240909.0",
+				"miniflare": "3.20240909.3",
 				"nanoid": "^3.3.3",
-				"path-to-regexp": "^6.2.0",
+				"path-to-regexp": "^6.3.0",
 				"resolve": "^1.22.8",
 				"resolve.exports": "^2.0.2",
 				"selfsigned": "^2.0.1",
 				"source-map": "^0.6.1",
-				"unenv": "npm:unenv-nightly@2.0.0-1724863496.70db6f1",
+				"unenv": "npm:unenv-nightly@2.0.0-1726478054.1e87097",
 				"workerd": "1.20240909.0",
 				"xxhash-wasm": "^1.0.1"
 			},
@@ -14334,6 +14350,13 @@
 				"@esbuild/win32-ia32": "0.17.19",
 				"@esbuild/win32-x64": "0.17.19"
 			}
+		},
+		"node_modules/wrangler/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/wrangler/node_modules/source-map": {
 			"version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@types/node": "^20.16.1",
 		"algoliasearch": "^4.24.0",
 		"astro": "^4.15.7",
-		"astro-breadcrumbs": "^2.3.1",
+		"astro-breadcrumbs": "^3.1.0",
 		"astro-icon": "^1.1.1",
 		"astro-live-code": "^0.0.3",
 		"date-fns": "^3.6.0",

--- a/patches/astro-breadcrumbs+3.1.0.patch
+++ b/patches/astro-breadcrumbs+3.1.0.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/astro-breadcrumbs/src/Breadcrumbs.astro b/node_modules/astro-breadcrumbs/src/Breadcrumbs.astro
+index b4a60ee..25fc657 100644
+--- a/node_modules/astro-breadcrumbs/src/Breadcrumbs.astro
++++ b/node_modules/astro-breadcrumbs/src/Breadcrumbs.astro
+@@ -28,12 +28,12 @@ const {
+   excludeCurrentPage = false,
+   debug = false,
+   separatorAriaHidden = true,
++	id = crypto.randomUUID(),
+ } = Astro.props as BreadcrumbsProps;
+ 
+ const paths = Astro.url.pathname.split("/").filter((crumb: any) => crumb);
+ const hasTrailingSlash = Astro.url.pathname.endsWith("/");
+ const pathLength = paths?.length;
+-const UUID = crypto.randomUUID();
+ const listCssClasses = [
+   `${mainBemClass}__crumbs`,
+   Astro.slots.has("separator") ? " has-separators" : " has-no-separators",
+@@ -63,11 +63,11 @@ debugInformation(debug, parts, customizedParts);
+ 
+ <astro-breadcrumbs
+   data-main-bem-class={mainBemClass}
+-  data-id={UUID}
++  data-id={id}
+   data-path-length={pathLength}
+   data-truncated={truncated}
+ >
+-  <nav aria-label={ariaLabel} class={mainBemClass} id={UUID} {...customizeNav}>
++  <nav aria-label={ariaLabel} class={mainBemClass} id={id} {...customizeNav}>
+     <ol class:list={listCssClasses} {...customizeList}>
+       {
+         processedParts.map(
+diff --git a/node_modules/astro-breadcrumbs/src/breadcrumbs.types.ts b/node_modules/astro-breadcrumbs/src/breadcrumbs.types.ts
+index 019011e..5459a37 100644
+--- a/node_modules/astro-breadcrumbs/src/breadcrumbs.types.ts
++++ b/node_modules/astro-breadcrumbs/src/breadcrumbs.types.ts
+@@ -15,6 +15,7 @@ export interface BreadcrumbsProps {
+   excludeCurrentPage?: boolean;
+   debug?: boolean;
+   separatorAriaHidden?: boolean;
++	id?: string;
+ }
+ 
+ export interface CustomizeElement extends AddAttributes {

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -27,6 +27,7 @@ const breadcrumbProps: Record<string, any> = {
 		},
 	],
 	truncated: true,
+	id: "breadcrumbs",
 };
 
 const slug = Astro.props.entry.slug;


### PR DESCRIPTION
This _should_ mean that HTML files don't change when you make an unrelated change to a different page's content. This will quite significantly speed up deployments.

Still needs a fair bit of testing. And also has the disadvantage of meaning that we can't aggressively cache client-side since you lose the JS asset hash fingerprinting. We currently aren't sending any Cache-Control headers to take advantage of that, so nothing lost, but it does mean we close the door to that optimization in the future.

now
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/72589aee-81da-4b48-a211-e8c7d5301e4f">

vs.

previous
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/8b7075d0-02a6-450f-baf6-f0df54401344">
