### PR TITLE
[DO] Clarify script_name in durable_objects.bindings

### DIFF
--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -183,7 +183,7 @@ Refer to [Access a Durable Object from a Worker](/durable-objects/best-practices
 
 ## 5. Configure Durable Object bindings
 
-[Bindings](/workers/runtime-apis/bindings/) allow your Workers to interact with resources on the Cloudflare developer platform. The Durable Object bindings in your Worker project's `wrangler.toml` will include a binding name (for this guide, use `MY_DURABLE_OBJECT`) and the class name (`MyDurableObject`).
+[Bindings](/workers/runtime-apis/bindings/) allow your Workers to interact with resources on the Cloudflare developer platform. The Durable Object bindings in your Worker project's `wrangler.toml` will include a binding name (for this guide, use `MY_DURABLE_OBJECT`) and the class name (`MyDurableObject`). Refer to [Wrangler Configuration](/workers/wrangler/configuration/#durable-objects) for more details.
 
 ```toml
 [[durable_objects.bindings]]
@@ -202,7 +202,8 @@ The `[[durable_objects.bindings]]` section contains the following fields:
 
 - `name` - Required. The binding name to use within your Worker.
 - `class_name` - Required. The class name you wish to bind to.
-- `script_name` - Optional. Defaults to the current [environment's](/durable-objects/reference/environments/) Worker code.
+- `script_name` - Optional. The name of the Worker if the Durable Object is external to this Worker.
+- `environment` - Optional. The environment of the `script_name` to bind to.
 
 ## 6. Configure Durable Object classes with migrations
 


### PR DESCRIPTION
### Summary

1. Consistent wording in the DO Get Started page to clarify the `script_name` field of `durable_objects.bindings`.
2. Link to wrangler.toml docs for more details.

**Context:** I got a bit stuck configuring a DO to call it from another worker. Specifically, the mention of "environments" in the DO [Get Started](https://developers.cloudflare.com/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) threw me off.  Fortunately I was able to get help in [Discord](https://discord.com/channels/595317990191398933/773219443911819284/1285621724666138655). I think this small change will help new users.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.