### PR TITLE
Set proper Ruby version and remove version minimum in favor of latest to prevent build errors.

### DIFF
--- a/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
+++ b/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
@@ -57,7 +57,7 @@ bundle init
 Open the `Gemfile` that was created for you, and add the following line to the bottom of the file:
 
 ```ruby title="Specifying the github-pages version"
-gem "github-pages", "~> 215", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 ```
 
 Your `Gemfile` should resemble the below:
@@ -70,7 +70,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
-gem "github-pages", "~> 215", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 ```
 
 Run `bundle update`, which will install the `github-pages` gem for you, and create a `Gemfile.lock` file with the resolved dependency versions.

--- a/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
+++ b/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
@@ -49,7 +49,7 @@ Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependenc
 
 Specifically, you will need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
 
-As of Thursday Sep 19, 2024 Cloudflare runs Ruby 3.2.2 for the default Jekyll build.  Please make sure your local development environment is compatible.
+[Version 2 of the Pages build environment](/pages/configuration/build-image/#languages-and-runtime) will use Ruby 3.2.2 for the default Jekyll build.  Please make sure your local development environment is compatible.
 
 ```sh title="Set Ruby Version"
 brew install ruby@3.2

--- a/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
+++ b/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
@@ -49,6 +49,13 @@ Your existing Jekyll-based repository must specify a `Gemfile` (Ruby's dependenc
 
 Specifically, you will need to create a `Gemfile` and install the `github-pages` gem, which includes all of the dependencies that the GitHub Pages environment assumes.
 
+As of Thursday Sep 19, 2024 Cloudflare runs Ruby 3.2.2 for the default Jekyll build.  Please make sure your local development environment is compatible.
+
+```sh title="Set Ruby Version"
+brew install ruby@3.2
+export PATH="/usr/local/opt/ruby@3.2/bin:$PATH"
+```
+
 ```sh title="Create a Gemfile"
 cd my-github-pages-repo
 bundle init


### PR DESCRIPTION
### Summary

Adding a command to set a Ruby version that matches Cloudflare's build, and remove the github-pages version minimum in favor of latest to accommodate the vast majority of users.  If you would like to keep the version minimum, it needs to be updated to ~>232 to support Ruby 3.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
