### PR TITLE
[Docs Site] Don't run publish-preview workflow on forks

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,6 +1,6 @@
 on:
-  pull_request:
-    branches:
+  push:
+    branches-ignore:
       - production
 
 concurrency:


### PR DESCRIPTION
### Summary

Don't run publish-preview workflow on forks