### PR TITLE
Revert "hyperdrive: revert nodejs_compat_v2 for node-postgres"

### DIFF
--- a/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
@@ -48,7 +48,7 @@ Hyperdrive uses Workers [TCP socket support](/workers/runtime-apis/tcp-sockets/#
 | Driver                        | Documentation                                                                | Minimum Version Required | Notes                                                                                                                                                                                                        |
 | ----------------------------- | ---------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Postgres.js (**recommended**) | [https://github.com/porsager/postgres](https://github.com/porsager/postgres) | `postgres@3.4.4`         | Supported in both Workers & Pages.                                                                                                                                                                           |
-| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [`node_compat`](/workers/wrangler/configuration/#add-polyfills-using-wrangler) compatibility flag to be set. |
+| node-postgres - `pg`          | [https://node-postgres.com/](https://node-postgres.com/)                     | `pg@8.11.0`              | `8.11.4` introduced a bug with URL parsing and will not work. `8.11.5` fixes this. Requires the [`nodejs_compat_v2`](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) compatibility flag to be set. |
 | Drizzle                       | [https://orm.drizzle.team/](https://orm.drizzle.team/)                       | `0.26.2`^                |                                                                                                                                                                                                              |
 | Kysely                        | [https://kysely.dev/](https://kysely.dev/)                                   | `0.26.3`^                |                                                                                                                                                                                                              |
 
@@ -139,12 +139,12 @@ Install the `node-postgres` driver:
 npm install pg
 ```
 
-Ensure you have `node_compat = true` set in your `wrangler.toml` configuration file:
+Ensure you have "nodejs_compat_v2" in compatibility flags in your `wrangler.toml` configuration file:
 
 ```toml
 # other fields elided
-# required for node-postgres to work
-node_compat = true
+# require for node-postgres to work
+compatibility_flags = [ "nodejs_compat_v2"]
 ```
 
 Create a new `Client` instance and pass the Hyperdrive parameters:


### PR DESCRIPTION
Reverts cloudflare/cloudflare-docs#16830

Since this revert, `pg` and `wrangler` have both had released which now make it work with `nodejs_compat_v2`. So we should revert the revert!

Screenshot of a worker logging a `pg` query as proof 16091

![Screenshot 2024-09-20 at 9 54 18 AM](https://github.com/user-attachments/assets/6a0bcb03-0f9b-458b-9887-ee6b41d0b200)
