### PR TITLE
[D1] Clarifying how individual limits apply to batch statements.

### DIFF
--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -35,7 +35,7 @@ Limits for individual queries (listed above) applies to each individual statemen
 
 [^2]: A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to \~5,000 D1 databases to a single Worker script.
 
-[^3]: The duration limit determines the maximum number of queries that can be run in a single batch statement.
+[^3]: Requests to Cloudflare API must resolve in 30 seconds. Therefore, this duration limit also applies to the entire batch call.
 
 [^4]: The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
 

--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 | Feature                                                                                                             | Limit                                             |
 | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
@@ -24,23 +24,23 @@ import { Render } from "~/components"
 | Maximum arguments per SQL function                                                                                  | 32                                                |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern                                                            | 50 bytes                                          |
 | Maximum bindings per Workers script                                                                                 | Approximately 5,000 [^2]                          |
-| Maximum SQL query duration                                                                                          | 30 seconds                                        |
-| Maximum file import (`d1 execute`) size                                                                             | 5 GiB [^3]                                        |
+| Maximum SQL query duration                                                                                          | 30 seconds [^3]                                   |
+| Maximum file import (`d1 execute`) size                                                                             | 5 GiB [^4]                                        |
 
-:::note
-
-
-If you would like to explore other storage solutions for your application, Cloudflare also offers [Workers KV](/kv/api/), [Durable Objects](/durable-objects/), and [R2](/r2/get-started/).
-
-Refer to the [Choose a data or storage product](/workers/platform/storage-options/) to review which storage option is right for your use case.
-
-
+:::note[Batch limits]
+Limits for individual queries (listed above) applies to each individual statement contained within a batch statement. For example, the maximum SQL statement length of 100 KB applies to each statement inside a `db.batch()`.
 :::
 
 [^1]: The maximum storage per account can be increased by request on Workers Paid and Enterprise plans. See the guidance on limit increases on this page to request an increase.
 
 [^2]: A single Worker script can have up to 1 MB of script metadata. A binding is defined as a binding to a resource, such as a D1 database, KV namespace, environmental variable or secret. Each resource binding is approximately 150-bytes, however environmental variables and secrets are controlled by the size of the value you provide. Excluding environmental variables, you can bind up to \~5,000 D1 databases to a single Worker script.
 
-[^3]: The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
+[^3]: The duration limit determines the maximum number of queries that can be run in a single batch statement.
+
+[^4]: The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
+
+If you would like to explore other storage solutions for your application, Cloudflare also offers [Workers KV](/kv/api/), [Durable Objects](/durable-objects/), and [R2](/r2/get-started/).
+
+Refer to the [Choose a data or storage product](/workers/platform/storage-options/) to review which storage option is right for your use case.
 
 <Render file="limits_increase" product="workers" />

--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -28,7 +28,7 @@ import { Render } from "~/components";
 | Maximum file import (`d1 execute`) size                                                                             | 5 GiB [^4]                                        |
 
 :::note[Batch limits]
-Limits for individual queries (listed above) applies to each individual statement contained within a batch statement. For example, the maximum SQL statement length of 100 KB applies to each statement inside a `db.batch()`.
+Limits for individual queries (listed above) apply to each individual statement contained within a batch statement. For example, the maximum SQL statement length of 100 KB applies to each statement inside a `db.batch()`.
 :::
 
 [^1]: The maximum storage per account can be increased by request on Workers Paid and Enterprise plans. See the guidance on limit increases on this page to request an increase.

--- a/src/content/docs/d1/platform/limits.mdx
+++ b/src/content/docs/d1/platform/limits.mdx
@@ -39,8 +39,6 @@ Limits for individual queries (listed above) applies to each individual statemen
 
 [^4]: The imported file is uploaded to R2. See [R2 upload limit](/r2/platform/limits).
 
-If you would like to explore other storage solutions for your application, Cloudflare also offers [Workers KV](/kv/api/), [Durable Objects](/durable-objects/), and [R2](/r2/get-started/).
-
-Refer to the [Choose a data or storage product](/workers/platform/storage-options/) to review which storage option is right for your use case.
+Cloudflare also offers other storage solutions such as [Workers KV](/kv/api/), [Durable Objects](/durable-objects/), and [R2](/r2/get-started/). Each product has different advantages and limits. Refer to [Choose a data or storage product](/workers/platform/storage-options/) to review which storage option is right for your use case.
 
 <Render file="limits_increase" product="workers" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Adding a footnote to indicate that the query duration limit applies to the entire batch call.
2. Adding a note section to indicate that query limits apply to each individual query contained within a `db.batch`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
