### PR TITLE
[MWAN] Adding to removed redundant messages

### DIFF
--- a/src/content/partials/magic-transit/tunnels-reference/tunnels-encapsulation-opening.mdx
+++ b/src/content/partials/magic-transit/tunnels-reference/tunnels-encapsulation-opening.mdx
@@ -117,7 +117,7 @@ IKE SA is sometimes referred to as Phase 1 as per IKEv1 language.
 
   Below is a list of all Diffie-Hellman (DH) groups supported by Cloudflare.
 
-  :::caution[Warning]
+  :::caution
   Cloudflare recommends that you use only one DH group when configuring your device, specifically **DH group 14**.
   :::
 
@@ -154,7 +154,7 @@ The Child SA. Sometimes referred to as Phase 2 as per IKEv1 language.
 
   Below is a list of all Diffie-Hellman (DH) groups supported by Cloudflare.
 
-  :::caution[Warning]
+  :::caution
   Cloudflare recommends that you use only one DH group when configuring your device, specifically **DH group 14**.
   :::
 

--- a/src/content/partials/magic-wan/connector/before-you-begin.mdx
+++ b/src/content/partials/magic-wan/connector/before-you-begin.mdx
@@ -20,6 +20,6 @@ You must decide the type of configuration you want for your site from the beginn
 
 </Card>
 
-:::caution[Warning]
+:::caution
 You cannot enable high availability for an existing site. To add high availability to an existing site in the Cloudflare dashboard, you need to delete the site and start again. Plan accordingly to create a high availability configuration from the start if needed.
 :::


### PR DESCRIPTION
### Summary

Adds to PCX-13715 and removes redundant `[Warning]` header in `caution` notes in partials
