### PR TITLE
[Docs Site] Overhaul sidebar styling

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -207,40 +207,44 @@ const lookupProductTitle = async (slug: string) => {
 	:root {
 		.sidebar-content {
 			--sl-color-hairline-light: #cacaca !important;
+
+			& > * {
+				a {
+					padding: 0.2375em var(--sl-sidebar-item-padding-inline) !important;
+
+					&[aria-current="page"] {
+						background-color: unset !important;
+						border: unset !important;
+						border-color: unset !important;
+						color: var(--sl-color-accent) !important;
+						font-weight: 600 !important;
+					}
+				}
+
+				summary {
+					padding: 0.1375em var(--sl-sidebar-item-padding-inline) !important;
+				}
+
+				.large {
+					color: var(--sl-color-gray-2) !important;
+					font-weight: unset !important;
+					font-size: unset !important;
+
+					@media (min-width: 50rem) {
+						font-size: var(--sl-text-sm) !important;
+					}
+				}
+
+				.caret {
+					font-size: 1rem !important;
+				}
+			}
 		}
 	}
 
 	:root[data-theme="dark"] {
 		.sidebar-content {
 			--sl-color-hairline-light: #444444 !important;
-		}
-	}
-
-	.sidebar-content > * a {
-		padding: 0.2375em var(--sl-sidebar-item-padding-inline) !important;
-	}
-
-	.sidebar-content > * summary {
-		padding: 0.1375em var(--sl-sidebar-item-padding-inline) !important;
-	}
-
-	.sidebar-content > * .large {
-		color: var(--sl-color-gray-2) !important;
-		font-weight: unset !important;
-		font-size: unset !important;
-	}
-
-	.sidebar-content > * a[aria-current="page"] {
-		background-color: unset !important;
-		border: unset !important;
-		border-color: unset !important;
-		color: var(--sl-color-accent) !important;
-		font-weight: 600 !important;
-	}
-
-	@media (min-width: 50rem) {
-		.sidebar-content > * .large {
-			font-size: var(--sl-text-sm) !important;
 		}
 	}
 </style>

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -205,20 +205,42 @@ const lookupProductTitle = async (slug: string) => {
 
 <style is:global>
 	:root {
-		a[aria-current="page"] {
-			background-color: var(--sidebar-blue-accent-600) !important;
-			border: 1px solid !important;
-			border-color: var(--blue-accent-900) !important;
-			color: var(--sidebar-blue-text) !important;
+		.sidebar-content {
+			--sl-color-hairline-light: #cacaca !important;
 		}
 	}
 
 	:root[data-theme="dark"] {
-		a[aria-current="page"] {
-			background-color: var(--sidebar-orange-accent-600) !important;
-			border: 1px solid !important;
-			border-color: var(--orange-accent-200) !important;
-			color: var(--sl-color-white) !important;
+		.sidebar-content {
+			--sl-color-hairline-light: #444444 !important;
+		}
+	}
+
+	.sidebar-content > * a {
+		padding: 0.2375em var(--sl-sidebar-item-padding-inline) !important;
+	}
+
+	.sidebar-content > * summary {
+		padding: 0.1375em var(--sl-sidebar-item-padding-inline) !important;
+	}
+
+	.sidebar-content > * .large {
+		color: var(--sl-color-gray-2) !important;
+		font-weight: unset !important;
+		font-size: unset !important;
+	}
+
+	.sidebar-content > * a[aria-current="page"] {
+		background-color: unset !important;
+		border: unset !important;
+		border-color: unset !important;
+		color: var(--sl-color-accent) !important;
+		font-weight: 600 !important;
+	}
+
+	@media (min-width: 50rem) {
+		.sidebar-content > * .large {
+			font-size: var(--sl-text-sm) !important;
 		}
 	}
 </style>


### PR DESCRIPTION
### Summary

Overhauls the sidebar styling in-line with new designs.

Before:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/5b68a318-f9a1-4b49-a0bd-8edfaf3dd9f8">

After:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/52e0a0be-f025-413f-a8ae-3ca8c9f41e47">

Edit:

Shrinked caret size.

After:
<img width="294" alt="image" src="https://github.com/user-attachments/assets/bf4d1e3d-f845-4826-a424-b99127129120">


