### PR TITLE
[Docs Site] Support group badges with new frontmatter property

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -86,6 +86,7 @@ async function handleGroup(group: Group): Promise<SidebarEntry> {
 
 	group.label = frontmatter.sidebar.group?.label ?? frontmatter.title;
 	group.order = frontmatter.sidebar.order ?? Number.MAX_VALUE;
+	group.badge = frontmatter.sidebar.group?.badge;
 
 	if (frontmatter.hideChildren) {
 		return {

--- a/src/content/docs/style-guide/frontmatter/index.mdx
+++ b/src/content/docs/style-guide/frontmatter/index.mdx
@@ -4,9 +4,10 @@ description: |
     You can customize individual Markdown and MDX pages in Starlight by setting values in their frontmatter.
     For example, a regular page might set title and description fields.
 sidebar:
-    badge:
-        variant: tip
-        text: New!
+    group:
+        badge:
+            variant: tip
+            text: Badges!
     order: 3
 banner:
     content: |
@@ -25,10 +26,11 @@ description: |
     You can customize individual Markdown and MDX pages in Starlight by setting values in their frontmatter.
     For example, a regular page might set title and description fields.
 sidebar:
-    label: Overview
-    badge:
-        variant: tip
-        text: New!
+    group:
+        badge:
+            variant: tip
+            text: Badges!
+    order: 3
 banner:
     content: |
         <h2>Hello, world!</h2>

--- a/src/content/docs/style-guide/frontmatter/index.mdx
+++ b/src/content/docs/style-guide/frontmatter/index.mdx
@@ -4,10 +4,6 @@ description: |
     You can customize individual Markdown and MDX pages in Starlight by setting values in their frontmatter.
     For example, a regular page might set title and description fields.
 sidebar:
-    group:
-        badge:
-            variant: tip
-            text: Badges!
     order: 3
 banner:
     content: |
@@ -26,10 +22,6 @@ description: |
     You can customize individual Markdown and MDX pages in Starlight by setting values in their frontmatter.
     For example, a regular page might set title and description fields.
 sidebar:
-    group:
-        badge:
-            variant: tip
-            text: Badges!
     order: 3
 banner:
     content: |

--- a/src/content/docs/style-guide/frontmatter/sidebar.mdx
+++ b/src/content/docs/style-guide/frontmatter/sidebar.mdx
@@ -157,3 +157,40 @@ Since these pages are still accessible via other links and directly navigating t
 ### Hiding child pages of a group
 
 To make a group render as if it was a single page, which links to the index page, use the top-level `hideChildren` property.
+
+## Badges
+
+### Links
+
+To specify a badge next to the link, use the `sidebar.badge` property.
+
+```mdx title="/src/content/docs/examples/example.mdx"
+---
+title: Example
+sidebar:
+  badge: New!
+---
+```
+
+<FileTree>
+- Examples
+  - Example [New!]
+</FileTree>
+
+### Groups
+
+To specify a badge next to the group label, use the `sidebar.group.badge` inside the group's `index.mdx` frontmatter.
+
+```mdx title="/src/content/docs/examples/index.mdx"
+---
+title: Examples
+sidebar:
+  group:
+    badge: New!
+---
+```
+
+<FileTree>
+- Examples [New!]
+  - Example
+</FileTree>

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -1,4 +1,5 @@
 import { z } from "astro:schema";
+import { BadgeConfigSchema } from "./types/badge";
 
 const spotlightAuthorDetails = z
 	.object({
@@ -89,6 +90,7 @@ export const baseSchema = z.object({
 						.describe(
 							"Hides the index page from the sidebar. Refer to https://developers.cloudflare.com/style-guide/frontmatter/sidebar/.",
 						),
+					badge: BadgeConfigSchema(),
 				})
 				.optional(),
 		})

--- a/src/schemas/types/badge.ts
+++ b/src/schemas/types/badge.ts
@@ -1,0 +1,40 @@
+// Vendored from https://github.com/withastro/starlight/blob/a171a996b842f1fdb37a0bdbb2c9d86e1073e1a4/packages/starlight/schemas/badge.ts#
+import { z } from 'astro:schema';
+
+const badgeBaseSchema = z.object({
+	variant: z.enum(['note', 'danger', 'success', 'caution', 'tip', 'default']).default('default'),
+	class: z.string().optional(),
+});
+
+const badgeSchema = badgeBaseSchema.extend({
+	text: z.string(),
+});
+
+const i18nBadgeSchema = badgeBaseSchema.extend({
+	text: z.union([z.string(), z.record(z.string())]),
+});
+
+export const BadgeComponentSchema = badgeSchema
+	.extend({
+		size: z.enum(['small', 'medium', 'large']).default('small'),
+	})
+	.passthrough();
+
+export type BadgeComponentProps = z.input<typeof BadgeComponentSchema>;
+
+export const BadgeConfigSchema = () =>
+	z
+		.union([z.string(), badgeSchema])
+		.transform((badge) => {
+			if (typeof badge === 'string') {
+				return { variant: 'default' as const, text: badge };
+			}
+			return badge;
+		})
+		.optional();
+
+export const I18nBadgeConfigSchema = () => z.union([z.string(), i18nBadgeSchema]).optional();
+
+export type Badge = z.output<typeof badgeSchema>;
+export type I18nBadge = z.output<typeof i18nBadgeSchema>;
+export type I18nBadgeConfig = z.output<ReturnType<typeof I18nBadgeConfigSchema>>;


### PR DESCRIPTION
### Summary

Support group badges with new frontmatter property

### Screenshots (optional)

(these changes are opt-in, by moving `sidebar.badge` to `sidebar.group.badge`)

Before:
![image](https://github.com/user-attachments/assets/d3c8a160-f74f-4570-a0e9-b6f917187ae9)

After:
![image](https://github.com/user-attachments/assets/aa8bcad8-9084-4805-8633-26a3bb8d9bfe)
