### PR TITLE
[Logs] Removes Splunk for Magic Transit tutorial

### DIFF
--- a/src/content/docs/logs/get-started/enable-destinations/splunk.mdx
+++ b/src/content/docs/logs/get-started/enable-destinations/splunk.mdx
@@ -214,9 +214,3 @@ The WAF should now ignore requests made to Splunk HEC by Cloudflare.
 
 To analyze and visualize Cloudflare Logs using the Cloudflare App for Splunk, follow the steps in the [Splunk Analytics integration page](/analytics/analytics-integrations/splunk/). 
 :::
-
-***
-
-## More resources
-
-<Render file="video-send-network-analytics-logs-to-splunk" />


### PR DESCRIPTION
### Summary

Removes Splunk for Magic Transit tutorial. Closes PCX-13183.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
(https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
