### PR TITLE
add node:url to built-in node.js runtime apis

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/url.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/url.mdx
@@ -1,0 +1,41 @@
+---
+pcx_content_type: configuration
+title: url
+
+---
+
+import { Render } from "~/components"
+
+<Render file="nodejs-compat-howto" />
+
+## domainToASCII
+
+Returns the Punycode ASCII serialization of the domain. If domain is an invalid domain, the empty string is returned.
+
+```js
+import { domainToASCII } from 'node:url';
+
+console.log(domainToASCII('español.com'));
+// Prints xn--espaol-zwa.com
+console.log(domainToASCII('中文.com'));
+// Prints xn--fiq228c.com
+console.log(domainToASCII('xn--iñvalid.com'));
+// Prints an empty string
+```
+
+## domainToUnicode
+
+Returns the Unicode serialization of the domain. If domain is an invalid domain, the empty string is returned.
+
+It performs the inverse operation to `domainToASCII()`.
+
+```js
+import { domainToUnicode } from 'node:url';
+
+console.log(domainToUnicode('xn--espaol-zwa.com'));
+// Prints español.com
+console.log(domainToUnicode('xn--fiq228c.com'));
+// Prints 中文.com
+console.log(domainToUnicode('xn--iñvalid.com'));
+// Prints an empty string
+```


### PR DESCRIPTION
Adds the URL module which is missing from the nodejs compat documentation.