### PR TITLE
Update aside styling and remove titles from workers-ai asides

### DIFF
--- a/src/asides.css
+++ b/src/asides.css
@@ -1,6 +1,6 @@
 .starlight-aside {
 	border: unset;
-	border-radius: 4px;
+	border-radius: 0.25rem;
 
 	&.starlight-aside--note {
 		background-color: rgb(236, 244, 255);
@@ -8,20 +8,23 @@
 
 	&.starlight-aside--caution {
 		background-color: rgb(255, 248, 228);
-
 	}
 
 	.starlight-aside__title {
-		margin-left: 30px;
+		margin-left: 2rem;
+		margin-bottom: 0.25rem;
+		gap: 0.75rem;
+		font-size: 0.875rem;
 
 		svg {
-			margin-left: -30px;
+			margin-left: -2rem;
 		}
 	}
 
 	.starlight-aside__content {
 		margin-top: unset;
-		margin-left: 30px;
+		margin-left: 2rem;
+		font-size: 0.875rem;
 	}
 }
 

--- a/src/content/partials/workers-ai/custom_requirements.mdx
+++ b/src/content/partials/workers-ai/custom_requirements.mdx
@@ -3,10 +3,8 @@
 
 ---
 
-:::note[Custom requirements]
-
+:::note
 
 If you have custom requirements like private custom models or higher limits, complete the [Custom Requirements Form](https://forms.gle/axnnpGDb6xrmR31T6). Cloudflare will contact you with next steps.
-
 
 :::

--- a/src/content/partials/workers-ai/file_issues.mdx
+++ b/src/content/partials/workers-ai/file_issues.mdx
@@ -3,10 +3,9 @@
 
 ---
 
-:::caution[Workers AI is now Generally Available]
+:::caution
 
-
-To report bugs or give feedback, go to the [#workers-ai Discord channel](https://discord.cloudflare.com). If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+Workers AI is now Generally Available. To report bugs or give feedback, go to the [#workers-ai Discord channel](https://discord.cloudflare.com). If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 
 
 :::

--- a/src/content/partials/workers-ai/file_issues.mdx
+++ b/src/content/partials/workers-ai/file_issues.mdx
@@ -5,7 +5,7 @@
 
 :::caution
 
-Workers AI is now Generally Available. To report bugs or give feedback, go to the [#workers-ai Discord channel](https://discord.cloudflare.com). If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+Workers AI is now Generally Available. To report bugs or give feedback, go to the [#Workers-ai Discord channel](https://discord.cloudflare.com). If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 
 
 :::

--- a/src/content/partials/workers-ai/file_issues.mdx
+++ b/src/content/partials/workers-ai/file_issues.mdx
@@ -3,7 +3,7 @@
 
 ---
 
-:::caution
+:::note
 
 Workers AI is now Generally Available. To report bugs or give feedback, go to the [#Workers-ai Discord channel](https://discord.cloudflare.com). If you are having issues with Wrangler, report issues in the [Wrangler GitHub repository](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 

--- a/src/content/partials/workers-ai/openai-compatibility.mdx
+++ b/src/content/partials/workers-ai/openai-compatibility.mdx
@@ -1,6 +1,5 @@
 ---
 {}
-
 ---
 
 Workers AI supports OpenAI compatible endpoints for [text generation](/workers-ai/models/#text-generation) (`/v1/chat/completions`) and [text embedding models](/workers-ai/models/#text-embeddings) (`/v1/embeddings`). This allows you to use the same code as you would for your OpenAI commands, but swap in Workers AI easily.


### PR DESCRIPTION
### Summary

• Update the styling of the asides to make them smaller
• Start the process of removing titles from asides (starting with /workers-aI)

### Screenshots (optional)

<img width="765" alt="image" src="https://github.com/user-attachments/assets/a3308e3a-4c00-4480-9265-d2c8e09ce229">


### Documentation checklist


