### PR TITLE
Allow hidden index external links

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -110,7 +110,9 @@ async function handleGroup(group: Group): Promise<SidebarEntry> {
 	group.entries = group.entries.sort(sortGroup);
 
 	const indexIdx = group.entries.findIndex(
-		(x) => x.type === "link" && x.href === indexLink.href,
+		(x) =>
+			x.type === "link" &&
+			[indexLink.href, frontmatter.external_link].includes(x.href),
 	) as number;
 
 	if (indexPage.data.sidebar.group?.hideIndex) {


### PR DESCRIPTION
### Summary

Super bizarre, I know, but we want to have a hidden index (and just in case someone hits it manually, let's redirect them to a sensible location).

I don't love how we're identifying items to slice here, but didn't want to intrude too much.

Used in #16610.

