### PR TITLE
Improve wording on robots.txt caching behaviour 

### DIFF
--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -31,7 +31,7 @@ When [Origin Cache Control](/cache/concepts/cache-control/) is enabled on an Ent
 
 ## Default cached file extensions
 
-Cloudflare only caches based on file extension and not by MIME type. The Cloudflare CDN does not cache HTML or JSON by default. Additionally, Cloudflare caches a website’s robots.txt.
+Cloudflare only caches based on file extension and not by MIME type. The Cloudflare CDN does not cache HTML or JSON by default. Additionally, Cloudflare always caches a website’s robots.txt, overriding any `Cache-Control` directives or Cache Rules.
 
 |       |      |      |      |      |       |     |
 | ----- | ---- | ---- | ---- | ---- | ----- | --- |


### PR DESCRIPTION
### Summary
Currently, Cloudflare always caches robots.txt no matter what header or cache rule is set. And the only way to have the file updated is to purge it. This PR improves the existing wording to reflect the behaviour.
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
