### PR TITLE
add node:zlib to nodejs compat modules list

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/zlib.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/zlib.mdx
@@ -1,0 +1,18 @@
+---
+pcx_content_type: configuration
+title: zlib
+
+---
+
+import { Render } from "~/components"
+
+<Render file="nodejs-compat-howto" />
+
+The node:zlib module provides compression functionality implemented using Gzip, Deflate/Inflate, and Brotli.
+To access it:
+
+```js
+import zlib from 'node:zlib';
+```
+
+The full `node:zlib` API is documented in the [Node.js documentation for `node:zlib`](https://nodejs.org/api/zlib.html).


### PR DESCRIPTION
Adds `node:zlib` to node.js built-in modules list.