### PR TITLE
[Docs Site] Don't take titles from comments in codeblocks

### DIFF
--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -153,4 +153,7 @@ export default {
 			defaultLuminance: ["32%", "88%"],
 		},
 	},
+	frames: {
+		extractFileNameFromCode: false,
+	},
 };


### PR DESCRIPTION
### Summary

Don't take titles from comments in codeblocks

### Screenshots (optional)

Before:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/4a514ef0-16be-448c-b580-8bb2cbde0b0f">

After:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/fa8c98ba-bab8-4fcd-be18-07693e43eb0e">
