### PR TITLE
[Durable Objects] Specifying Workers for Platforms do not have a DO namespace limit.

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/limits.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/limits.mdx
@@ -16,6 +16,10 @@ Cloudflare provides an unlimited number of scripts for Workers for Platforms cus
 
 The [`cf` object](/workers/runtime-apis/request/#the-cf-property-requestinitcfproperties) contains Cloudflare-specific properties of a request. This field is not accessible in [user Workers](/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works/#user-workers) because some fields in this object are sensitive and can be used to manipulate Cloudflare features (eg.`cacheKey`, `resolveOverride`, `scrapeShield`.)
 
+## Durable Object namespace limits
+
+Workers for Platforms do not have a limit for the number of Durable Object namespaces.
+
 ## Cache API
 
 For isolation, `caches.default()` is disabled for namespaced scripts. To learn more about the cache, refer to [How the cache Works](/workers/reference/how-the-cache-works/).

--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -6,25 +6,27 @@ sidebar:
 
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Durable Objects are only available on the [Workers Paid plan](/workers/platform/pricing/#workers). Durable Objects limits are the same as [Workers Limits](/workers/platform/limits/), as well as the following limits that are specific to Durable Objects:
 
-| Feature                           | Limit                                                            |
-| --------------------------------- | ---------------------------------------------------------------- |
-| Number of Objects                 | Unlimited (within an account or of a given class)                |
-| Maximum Durable Object namespaces | 500 (identical to the [script limit](/workers/platform/limits/)) |
-| Storage per account               | 50 GB (can be raised by contacting Cloudflare) <sup>1</sup>      |
-| Storage per class                 | Unlimited                                                        |
-| Storage per Object                | Unlimited                                                        |
-| Key size                          | 2 KiB(2048 bytes)                                                |
-| Value size                        | 128 KiB (131072 bytes)                                           |
-| WebSocket message size            | 1 MiB (only for received messages)                               |
-| CPU per request                   | 30s (including WebSocket messages) <sup>2</sup>                  |
+| Feature                           | Limit                                                                |
+| --------------------------------- | -------------------------------------------------------------------- |
+| Number of Objects                 | Unlimited (within an account or of a given class)                    |
+| Maximum Durable Object namespaces | 500 (identical to the [script limit](/workers/platform/limits/)) [^1]|
+| Storage per account               | 50 GB (can be raised by contacting Cloudflare) [^2]                  |
+| Storage per class                 | Unlimited                                                            |
+| Storage per Object                | Unlimited                                                            |
+| Key size                          | 2 KiB(2048 bytes)                                                    |
+| Value size                        | 128 KiB (131072 bytes)                                               |
+| WebSocket message size            | 1 MiB (only for received messages)                                   |
+| CPU per request                   | 30s (including WebSocket messages) [^3]                              |
 
-<sup>1</sup> Durable Objects both bills and measures storage based on a gigabyte <br/> (1 GB = 1,000,000,000 bytes) and not a gibibyte (GiB). <br/>
+[^1]: Workers for Platforms do not have a Durable Object namespace limit. Refer to [Workers for Platforms limits](/cloudflare-for-platforms/workers-for-platforms/platform/limits/#durable-object-namespace-limits).
 
-<sup>2</sup> Each incoming HTTP request or WebSocket *message* resets the remaining available CPU time to 30 seconds. This allows the Durable Object to consume up to 30 seconds of compute after each incoming network request, with each new network request resetting the timer. If you consume more than 30 seconds of compute between incoming network requests, there is a heightened chance that the individual Durable Object is evicted and reset.
+[^2]: Durable Objects both bills and measures storage based on a gigabyte <br/> (1 GB = 1,000,000,000 bytes) and not a gibibyte (GiB). <br/>
+
+[^3]: Each incoming HTTP request or WebSocket *message* resets the remaining available CPU time to 30 seconds. This allows the Durable Object to consume up to 30 seconds of compute after each incoming network request, with each new network request resetting the timer. If you consume more than 30 seconds of compute between incoming network requests, there is a heightened chance that the individual Durable Object is evicted and reset.
 
 <Render file="limits_increase" product="workers" />
 
@@ -32,9 +34,9 @@ Durable Objects are only available on the [Workers Paid plan](/workers/platform/
 
 Durable Objects can scale horizontally across many Durable Objects. Each individual Object is inherently single-threaded.
 
-* An individual Object has a soft limit of 1,000 requests per second. You can have an unlimited number of individual objects per namespace.
-* A simple [storage](/durable-objects/api/transactional-storage-api/) `get()` on a small value that directly returns the response may realize a higher request throughput compared to a Durable Object that (for example) serializes and/or deserializes large JSON values.
-* Similarly, a Durable Object that performs multiple `list()` operations may be more limited in terms of request throughput.
+- An individual Object has a soft limit of 1,000 requests per second. You can have an unlimited number of individual objects per namespace.
+- A simple [storage](/durable-objects/api/transactional-storage-api/) `get()` on a small value that directly returns the response may realize a higher request throughput compared to a Durable Object that (for example) serializes and/or deserializes large JSON values.
+- Similarly, a Durable Object that performs multiple `list()` operations may be more limited in terms of request throughput.
 
 A Durable Object that receives too many requests will, after attempting to queue them, return an [overloaded](/durable-objects/observability/troubleshooting/#durable-object-is-overloaded) error to the caller.
 
@@ -42,6 +44,6 @@ A Durable Object that receives too many requests will, after attempting to queue
 
 Durable Objects are designed such that the number of individual objects in the system do not need to be limited, and can scale horizontally.
 
-* You can create and run as many separate Durable Objects as you want within a given Durable Object namespace.
-* The main limit to your usage of Durable Objects is the total storage limit per account.
-* If you need more storage, contact your account team or complete the [Limit Increase Request Form](https://forms.gle/ukpeZVLWLnKeixDu7) and we will contact you with next steps.
+- You can create and run as many separate Durable Objects as you want within a given Durable Object namespace.
+- The main limit to your usage of Durable Objects is the total storage limit per account.
+- If you need more storage, contact your account team or complete the [Limit Increase Request Form](https://forms.gle/ukpeZVLWLnKeixDu7) and we will contact you with next steps.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Turning `<sup>` syntax into proper footnotes in DO/Limits page.
2. Including a footnote to state that Workers for Platforms do not have a DO namespace limit, with a link.
3. Adding a new header in CF for Platforms/Workers for Platforms/Platform/Limits to state that there is no DO namespace limit.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
