### PR TITLE
[Key transparency auditor] Bump minimal Rust version

### DIFF
--- a/src/content/docs/key-transparency/monitor-the-auditor/index.mdx
+++ b/src/content/docs/key-transparency/monitor-the-auditor/index.mdx
@@ -19,7 +19,7 @@ In order to verify our work, you can use [Plexi](https://github.com/cloudflare/p
 
 | Environment                                                   | CLI Command           |
 | :------------------------------------------------------------ | :-------------------- |
-| [Cargo](https://www.rust-lang.org/tools/install) (Rust 1.76+) | `cargo install plexi` |
+| [Cargo](https://www.rust-lang.org/tools/install) (Rust 1.81+) | `cargo install plexi` |
 
 ## Usage
 


### PR DESCRIPTION
### Summary
The product requires Rust 1.81+ to be installed. This commit updates the version accordingly.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
