### PR TITLE
[DO] Typo fix in storage-api.mdx

### DIFF
--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -231,7 +231,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 :::note[SQLite in Durable Objects Beta]
 
-SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backen](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-create-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
+SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-create-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
 
 :::
 


### PR DESCRIPTION
### Summary

Small typo fix in the new Durable Object Storage API docs.
> ... with SQLite storage backen -> with SQLite storage backen***d***


### Documentation checklist

N/A, typo fix
