### PR TITLE
Add Troubleshooting section to assets docs

### DIFF
--- a/src/content/docs/workers/static-assets/index.mdx
+++ b/src/content/docs/workers/static-assets/index.mdx
@@ -65,6 +65,10 @@ Requests to a project with static assets can either return static assets or invo
 
 **Requests to static assets are free and unlimited**. Requests to the Worker script (e.g. in the case of SSR content) are billed according to Workers pricing. Refer to [pricing](/workers/platform/pricing/#example-2) for an example.
 
+### Troubleshooting
+
+- `assets.bucket is a required field` — if you see this error, you need to update Wrangler to at least `3.78.10` or later. `bucket` is not a required field.
+
 ### Limitations
 
 The following limitations apply for Workers with static assets:


### PR DESCRIPTION
explain `assets.bucket is a required field` error
