### PR TITLE
[WAF] fix IPv6 range sizes in custom-lists.mdx

### DIFF
--- a/src/content/docs/waf/tools/lists/custom-lists.mdx
+++ b/src/content/docs/waf/tools/lists/custom-lists.mdx
@@ -56,7 +56,7 @@ List items in custom lists with IP addresses must be in one of the following for
 
 - Individual IPv4 addresses
 - IPv4 CIDR ranges with a prefix from `/8` to `/32`
-- IPv6 CIDR ranges with a prefix from `/4` to `/64`
+- IPv6 CIDR ranges with a prefix from `/12` to `/64`
 
 You can combine individual addresses and CIDR ranges in the same list.
 


### PR DESCRIPTION
### Summary

The documentation does not match the actual API behavior. Attempting to add an IPv6 CIDR range as large as `/4` (as documented) will get the error 10035: `invalid value for ip at position 0: filters.api.IPv6 CIDRs should have a prefix length from /12 to /64 inclusive`.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.