### PR TITLE
[Rules] Move beta badges to section name

### DIFF
--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -3,13 +3,17 @@ title: Cloud Connector
 pcx_content_type: concept
 sidebar:
   order: 8
-  badge:
-    text: Beta
+  group:
+    badge:
+      text: Beta
+head:
+  - tag: title
+    content: Cloud Connector (beta)
 ---
 
-import { FeatureTable } from "~/components"
+import { FeatureTable } from "~/components";
 
-Cloud Connector allows you to route matching incoming traffic from your website to a public cloud provider that you define such as AWS, Google Cloud, and Azure. With Cloud Connector you can make Cloudflare the control center for your web traffic, including traffic served from public cloud providers, without having to configure additional rules.
+Cloud Connector (beta) allows you to route matching incoming traffic from your website to a public cloud provider that you define such as AWS, Google Cloud, and Azure. With Cloud Connector you can make Cloudflare the control center for your web traffic, including traffic served from public cloud providers, without having to configure additional rules.
 
 :::note
 Support for Cloudflare R2 will be added soon.
@@ -18,6 +22,7 @@ Support for Cloudflare R2 will be added soon.
 ## How it works
 
 First, you configure a Cloud Connector rule that specifies:
+
 - The cloud provider and a supported cloud service that will accept traffic.
 - The traffic that will be routed to that cloud service.
 
@@ -28,8 +33,9 @@ Cloud Connector rules are evaluated last in the request evaluation workflow. Whe
 ## Applied configurations
 
 Cloud Connector will perform the following configurations automatically, depending on the cloud provider:
-* Modify the `Host` header.
-* Adjust SSL/TLS for bucket-related traffic (AWS S3 only).
+
+- Modify the `Host` header.
+- Adjust SSL/TLS for bucket-related traffic (AWS S3 only).
 
 ## Availability
 

--- a/src/content/docs/rules/custom-error-responses/index.mdx
+++ b/src/content/docs/rules/custom-error-responses/index.mdx
@@ -3,25 +3,23 @@ pcx_content_type: concept
 title: Custom Error Responses
 sidebar:
   order: 12
-  badge:
-    text: Beta
+  group:
+    badge:
+      text: Beta
 head:
   - tag: title
-    content: Custom Error Responses
-
+    content: Custom Error Responses (beta)
 ---
 
-Custom Error Responses, powered by the [Ruleset Engine](/ruleset-engine/), allow you to define custom responses for errors returned by an origin server or by a Cloudflare product (including Workers). Custom Error Responses will apply to responses whose HTTP status code is greater than or equal to 400 that match the expression of the custom error response rule.
+Custom Error Responses (beta), powered by the [Ruleset Engine](/ruleset-engine/), allow you to define custom responses for errors returned by an origin server or by a Cloudflare product (including Workers). Custom Error Responses will apply to responses whose HTTP status code is greater than or equal to 400 that match the expression of the custom error response rule.
 
 To configure a custom error response, create a custom error response rule at the zone level. Custom error response rules will override [Custom Pages](/support/more-dashboard-apps/cloudflare-custom-pages/configuring-custom-pages-error-and-challenge/) at the zone or account level.
 
 :::note[Notes about the beta]
 
-
 During the beta, you can define Custom Error Responses using inline templates and specify the response's content type and HTTP status code.
 
 Additionally, at this stage you can only create custom error response rules [using the API](/rules/custom-error-responses/create-api/).
-
 
 :::
 
@@ -35,10 +33,7 @@ Additionally, you can configure [HTTP response header modification rules](/rules
 
 Custom Error Responses are available in beta to all paid plans. The exact features depend on your Cloudflare plan:
 
-
-
 |                                       | Free | Pro | Business | Enterprise |
 | ------------------------------------- | :--: | :-: | :------: | :--------: |
-| Custom Error Responses                |  No  | Yes |    Yes   |     Yes    |
-| Number of custom error response rules |   —  |  5  |    20    |     50     |
-|                                       |      |     |          |            |
+| Custom Error Responses                |  No  | Yes |   Yes    |    Yes     |
+| Number of custom error response rules |  —   |  5  |    20    |     50     |

--- a/src/content/docs/rules/snippets/index.mdx
+++ b/src/content/docs/rules/snippets/index.mdx
@@ -3,8 +3,9 @@ pcx_content_type: concept
 title: Snippets
 sidebar:
   order: 3
-  badge:
-    text: Beta
+  group:
+    badge:
+      text: Beta
 head:
   - tag: title
     content: Cloudflare Snippets (beta)


### PR DESCRIPTION
### Summary

Move "Beta" badges from "Overview" child pages to the corresponding section name.

After:
![image](https://github.com/user-attachments/assets/2bb69fd8-9bdb-4ec1-8ba8-ccb626962b97)

