### PR TITLE
Add detail about Splunk HTTP Collector webhooks

### DIFF
--- a/src/content/docs/notifications/get-started/configure-webhooks.mdx
+++ b/src/content/docs/notifications/get-started/configure-webhooks.mdx
@@ -115,6 +115,7 @@ For [Splunk](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTP
    1. We only support three Splunk endpoints: services/collector, services/collector/raw, and services/collector/event.
    2. If SSL is enabled on the token, the port must be 443. If SSL is not enabled on the token, the port must be 8088.
    3. SSL must be enabled on the server.
+   4. "Enable indexer acknowledgement" must be disabled on the Splunk HTTP Event Collector.
 
 ### Feishu
 

--- a/src/content/docs/notifications/get-started/configure-webhooks.mdx
+++ b/src/content/docs/notifications/get-started/configure-webhooks.mdx
@@ -115,7 +115,7 @@ For [Splunk](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTP
    1. We only support three Splunk endpoints: services/collector, services/collector/raw, and services/collector/event.
    2. If SSL is enabled on the token, the port must be 443. If SSL is not enabled on the token, the port must be 8088.
    3. SSL must be enabled on the server.
-   4. "Enable indexer acknowledgement" must be disabled on the Splunk HTTP Event Collector.
+   4. **Enable indexer acknowledgement** must be disabled on the Splunk HTTP Event Collector.
 
 ### Feishu
 


### PR DESCRIPTION
### Summary

Clarify that "Enable indexer acknowledgement" must be disabled when configuring Splunk HTTP Collector webhooks.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
