### PR TITLE
Add AVIF to supported image formats for Cloudflare Images

### DIFF
--- a/src/content/docs/images/upload-images/index.mdx
+++ b/src/content/docs/images/upload-images/index.mdx
@@ -17,6 +17,7 @@ You can upload the following image formats to Cloudflare Images:
 * JPEG
 * WebP (Cloudflare Images also supports uploading animated WebP files)
 * SVG
+* AVIF
 
 :::note
 


### PR DESCRIPTION
### Summary

According to [this blog post](https://blog.cloudflare.com/images-avif-blur-bundle/) it looks like AVIF is supported by Cloudflare Images? If that's not the case I think a note (like the one for HEIC) would be useful.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
