### PR TITLE
Remove references to Queues and Vectorize still being in beta

### DIFF
--- a/src/content/docs/vectorize/index.mdx
+++ b/src/content/docs/vectorize/index.mdx
@@ -72,7 +72,7 @@ Store large amounts of unstructured data without the costly egress bandwidth fee
 <CardGrid>
 
 <LinkTitleCard title="Limits" href="/vectorize/platform/limits/" icon="document">
-Learn about Vectorize's limits and how to work within them.
+Learn about Vectorize limits and how to work within them.
 </LinkTitleCard>
 
 <LinkTitleCard title="Use cases" href="/use-cases/ai/" icon="document">

--- a/src/content/docs/vectorize/index.mdx
+++ b/src/content/docs/vectorize/index.mdx
@@ -72,7 +72,7 @@ Store large amounts of unstructured data without the costly egress bandwidth fee
 <CardGrid>
 
 <LinkTitleCard title="Limits" href="/vectorize/platform/limits/" icon="document">
-Learn about what limits Vectorize has during the open beta and how to work within them.
+Learn about Vectorize's limits and how to work within them.
 </LinkTitleCard>
 
 <LinkTitleCard title="Use cases" href="/use-cases/ai/" icon="document">
@@ -84,7 +84,7 @@ Learn more about the storage and database options you can build on with Workers.
 </LinkTitleCard>
 
 <LinkTitleCard title="Developer Discord" href="https://discord.cloudflare.com" icon="discord">
-Connect with the Workers community on Discord to ask questions, join the `#vectorize-open-beta` channel to show what you are building, and discuss the platform with other developers.
+Connect with the Workers community on Discord to ask questions, join the `#vectorize` channel to show what you are building, and discuss the platform with other developers.
 </LinkTitleCard>
 
 <LinkTitleCard title="@CloudflareDev" href="https://x.com/cloudflaredev" icon="x.com">

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -485,11 +485,6 @@ Manage [Hyperdrive](/hyperdrive/) database configurations.
 
 ## `vectorize`
 
-:::note
-
-Vectorize is currently in open beta. Report Vectorize bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
-:::
-
 Interact with a [Vectorize](/vectorize/) vector database.
 
 ### `create`
@@ -1520,11 +1515,6 @@ wrangler pages secret bulk [<FILENAME>] [OPTIONS]
 ---
 
 ## `queues`
-
-:::note
-
-Queues is currently in open beta. Report Queues bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
-:::
 
 Manage your Workers [Queues](/queues/) configurations.
 


### PR DESCRIPTION
Since both products are now GA.

@maheshwarip @pdwittig 