### PR TITLE
Remove some alpha/beta info from D1 wrangler command docs

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -179,11 +179,6 @@ wrangler generate [<NAME>] [TEMPLATE]
 
 Interact with Cloudflare's D1 service.
 
-:::note
-
-Report D1 bugs in [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
-:::
-
 ### `create`
 
 Creates a new D1 database, and provides the binding and UUID that you will put in your `wrangler.toml` file.
@@ -271,13 +266,6 @@ You must provide either `--command` or `--file` for this command to run successf
   - Number of queries to send in a single batch.
 
 ### `export`
-
-:::caution
-
-This command does not work with databases created during D1's alpha period. You can check which version your database uses with `wrangler d1 info <DATABASE_NAME>`.
-
-Refer to the [Backups (Legacy)](/d1/reference/backups/) in the D1 documentation for more information on D1's backup approach during the alpha period. Also, please check the [Alpha version migration guide](/d1/platform/alpha-migration/) for more information on migrating your database to the current version.
-:::
 
 Export a D1 database or table's schema and/or content to a `.sql` file.
 


### PR DESCRIPTION
The "Report bugs" notes are generally only used for beta products, but D1 has been GA since the spring, so I don't think it's really needed anymore (unless you'd want to make the claim that all products should have a note like that).

And the Export command doesn't really need a caution about alpha DBs, given that alpha DBs are fully deprecated at this point (https://developers.cloudflare.com/d1/platform/alpha-migration/)

@vy-ton 