### PR TITLE
Fix typo in vector tutorial

### DIFF
--- a/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -332,7 +332,7 @@ app.delete("/notes/:id", async (c) => {
 	const { id } = c.req.param();
 
 	const query = `DELETE FROM notes WHERE id = ?`;
-	await c.env.DATABASE.prepare(query).bind(id).run();
+	await c.env.DB.prepare(query).bind(id).run();
 
 	await c.env.VECTOR_INDEX.deleteByIds([id]);
 


### PR DESCRIPTION
### Summary

Vector documentation tutorial was using `DATABASE` in the delete method instead of `DB` like elsewhere.
