### PR TITLE
Fix broken cURL command

### DIFF
--- a/src/content/docs/images/get-started.mdx
+++ b/src/content/docs/images/get-started.mdx
@@ -19,7 +19,7 @@ Refer to [Find zone and account IDs](/fundamentals/setup/find-account-and-zone-i
 ```bash
 curl --request POST \
   --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/images/v1 \
-  --header 'Authorization: <API_TOKEN> \
+  --header 'Authorization: Bearer <API_TOKEN>' \
   --header 'Content-Type: multipart/form-data' \
   --form file=@./<YOUR_IMAGE.IMG>
 ```


### PR DESCRIPTION
### Summary

cURL command was incorrectly specified in the getting started page for images (missing `Bearer` and missing end quote)

### Screenshots (optional)

NA

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
