### PR TITLE
Callout @opennextjs/cloudflare from Next.js Pages SSR docs

### DIFF
--- a/src/content/docs/pages/framework-guides/nextjs/ssr/index.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/index.mdx
@@ -10,4 +10,10 @@ import { DirectoryListing } from "~/components"
 
 [Next.js](https://nextjs.org) is an open-source React.js framework for building full-stack applications. This section helps you deploy a full-stack Next.js project to Cloudflare Pages using [`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages/tree/main/packages/next-on-pages/docs).
 
+:::note
+You may want to consider using [`@opennextjs/cloudflare`](https://opennext.js.org/cloudflare), which allows you to build and deploy Next.js apps to [Cloudflare Workers](/workers/static-assets/), use [Node.js APIs](/workers/runtime-apis/nodejs/) that Cloudflare Workers supports, and supports additional Next.js features.
+
+Refer to the [OpenNext docs](https://opennext.js.org/cloudflare) and the [Workers vs. Pages compatibility matrix](/workers/static-assets/compatibility-matrix/) for more information to help you decide whether Workers or Pages currently fits best for your Next.js app.
+:::
+
 <DirectoryListing />


### PR DESCRIPTION
When you land on this page:

<img width="1135" alt="Screenshot 2024-09-29 at 12 22 57 PM" src="https://github.com/user-attachments/assets/009a80c2-0ca8-47e1-b37a-6c0ae6fcae64">

We should let you know that `@opennextjs/cloudflare` exists, and give you links and context that lets you choose what is right for your use case.