### PR TITLE
[Workers] Add await writer.close() to get promise

### DIFF
--- a/src/content/docs/workers/runtime-apis/tcp-sockets.mdx
+++ b/src/content/docs/workers/runtime-apis/tcp-sockets.mdx
@@ -36,6 +36,7 @@ export default {
       const encoder = new TextEncoder();
       const encoded = encoder.encode(url.pathname + "\r\n");
       await writer.write(encoded);
+      await writer.close();
 
       return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
     } catch (error) {
@@ -151,6 +152,7 @@ export default {
       const encoder = new TextEncoder();
       const encoded = encoder.encode("GET / HTTP/1.0\r\n\r\n");
       await writer.write(encoded);
+      await writer.close();
 
       return new Response(socket.readable, { headers: { "Content-Type": "text/plain" } });
     } catch (error) {


### PR DESCRIPTION
PCX-12482

### Summary

Add await writer.close() to get promise, otherwise it takes 4m30s to get the response from TCP sockets

```
% date && curl https://abc.xyz.workers.dev && date
Fri Jul 26 14:33:23 JST 2024
...
Fri Jul 26 14:37:53 JST 2024
```

https://github.com/cloudflare/cloudflare-docs/pull/15817