### PR TITLE
Add `wrangler.toml` files to DO examples

### DIFF
--- a/src/content/docs/durable-objects/examples/alarms-api.mdx
+++ b/src/content/docs/durable-objects/examples/alarms-api.mdx
@@ -69,3 +69,17 @@ export class Batcher {
 ```
 
 The `alarm()` handler will be called once every 10 seconds. If an unexpected error terminates the Durable Object, the `alarm()` handler will be re-instantiated on another machine. Following a short delay, the `alarm()` handler will run from the beginning on the other machine.
+
+Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+
+```toml
+name = "durable-object-alarm"
+
+[[durable_objects.bindings]]
+name = "BATCHER"
+class_name = "Batcher"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["Batcher"]
+```

--- a/src/content/docs/durable-objects/examples/alarms-api.mdx
+++ b/src/content/docs/durable-objects/examples/alarms-api.mdx
@@ -72,7 +72,7 @@ The `alarm()` handler will be called once every 10 seconds. If an unexpected err
 
 Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
-```toml
+```toml title="wrangler.toml"
 name = "durable-object-alarm"
 
 [[durable_objects.bindings]]

--- a/src/content/docs/durable-objects/examples/build-a-counter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-counter.mdx
@@ -172,7 +172,7 @@ export class Counter extends DurableObject {
 
 Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
-```toml
+```toml title="wrangler.toml"
 name = "my-counter"
 
 [[durable_objects.bindings]]

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -68,7 +68,7 @@ New Location: ${request.cf.city}`);
 
 Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
-```toml
+```toml title="wrangler.toml"
 name = "durable-object-in-memory-state"
 
 [[durable_objects.bindings]]

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -65,3 +65,17 @@ New Location: ${request.cf.city}`);
   }
 }
 ```
+
+Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+
+```toml
+name = "durable-object-in-memory-state"
+
+[[durable_objects.bindings]]
+name = "LOCATION"
+class_name = "Location"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["Location"]
+```

--- a/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
@@ -179,7 +179,7 @@ export class WebSocketHibernationServer extends DurableObject {
 
 Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
-```toml
+```toml title="wrangler.toml"
 name = "websocket-hibernation-server"
 
 [[durable_objects.bindings]]

--- a/src/content/docs/durable-objects/examples/websocket-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-server.mdx
@@ -189,7 +189,7 @@ export class WebSocketServer extends DurableObject {
 
 Finally, configure your `wrangler.toml` file to include a Durable Object [binding](/durable-objects/get-started/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
-```toml
+```toml title="wrangler.toml"
 name = "websocket-server"
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
### Summary

Adding wrangler.toml content to the Durable Object examples.

### Screenshots (optional)


### Documentation checklist

