### PR TITLE
[Docs Site] Move package.json scripts to use npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,18 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"astro": "astro",
-		"build": "astro build",
+		"astro": "npx astro",
+		"build": "npx astro build",
 		"build:worker": "npx wrangler types -c wrangler-workers.toml --experimental-include-runtime && npx wrangler pages functions build --outdir worker/functions",
 		"check": "npm run check:functions && npm run check:astro",
 		"check:astro": "npm run sync && astro check",
-		"check:functions": "tsc --noEmit -p ./functions/tsconfig.json",
-		"dev": "astro dev",
-		"format": "prettier --write \"**/*.{js,jsx,ts,tsx,mjs,astro,css,json,yaml,yml}\"",
-		"postinstall": "patch-package && npm run sync",
-		"preview": "astro preview",
-		"start": "astro dev",
-		"sync": "astro sync"
+		"check:functions": "npx tsc --noEmit -p ./functions/tsconfig.json",
+		"dev": "npx astro dev",
+		"format": "npx prettier --write \"**/*.{js,jsx,ts,tsx,mjs,astro,css,json,yaml,yml}\"",
+		"postinstall": "npx patch-package && npm run sync",
+		"preview": "npx astro preview",
+		"start": "npx astro dev",
+		"sync": "npx astro sync"
 	},
 	"devDependencies": {
 		"@astro-community/astro-embed-youtube": "^0.5.3",


### PR DESCRIPTION
### Summary

Move package.json scripts to use npx to prevent conflicts with locally installed binaries that have the same name (i.e https://www.astronomer.io/docs/astro)