### PR TITLE
Clarify target and infra app setup

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
@@ -20,8 +20,6 @@ import { Tabs, TabItem, Badge, Render } from "~/components";
 
 2. In the **Private Networks** tab for the tunnel, enter the private IP address of your server (or a range that includes the server IP).
 
-<Render file="tunnel/warp-to-tunnel-route-ips" />
-
 ## 2. Set up the client
 
 To connect your devices to Cloudflare:

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
@@ -20,6 +20,8 @@ import { Tabs, TabItem, Badge, Render } from "~/components";
 
 2. In the **Private Networks** tab for the tunnel, enter the private IP address of your server (or a range that includes the server IP).
 
+<Render file="tunnel/warp-to-tunnel-route-ips" />
+
 ## 2. Set up the client
 
 To connect your devices to Cloudflare:
@@ -62,7 +64,7 @@ Next, configure your SSH server to trust the Cloudflare SSH CA. This allows Acce
 
 ## 8. Connect as a user
 
-Users can use any SSH client to connect to the target, as long as they are logged into the WARP client on their device. Users do not need to modify any SSH configs on their device. For example, to SSH from a terminal:
+Users can use any SSH client to connect to the target, as long as they are logged into the WARP client on their device. If the target is located within a particular virtual network, ensure that the WARP client is connected to that virtual network before initiating the connection. Users do not need to modify any SSH configs on their device. For example, to SSH from a terminal:
 
 ```sh
 ssh <username>@<target IP>

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access.mdx
@@ -49,6 +49,11 @@ To connect your devices to Cloudflare:
 Next, configure your SSH server to trust the Cloudflare SSH CA. This allows Access to authenticate using short-lived certificates instead of traditional SSH keys.
 
 ### Generate a Cloudflare SSH CA
+
+<Render file="ssh/ssh-proxy-ca-note" />
+
+To generate a Cloudflare SSH CA and get its public key:
+
 <Render file="ssh/ssh-proxy-ca" />
 
 ### Save the public key
@@ -62,7 +67,7 @@ Next, configure your SSH server to trust the Cloudflare SSH CA. This allows Acce
 
 ## 8. Connect as a user
 
-Users can use any SSH client to connect to the target, as long as they are logged into the WARP client on their device. If the target is located within a particular virtual network, ensure that the WARP client is connected to that virtual network before initiating the connection. Users do not need to modify any SSH configs on their device. For example, to SSH from a terminal:
+Users can use any SSH client to connect to the target, as long as they are logged into the WARP client on their device. If the target is located within a particular virtual network, ensure that the WARP client is [connected to that virtual network](/cloudflare-one/connections/connect-networks/private-net/cloudflared/tunnel-virtual-networks/#connect-to-a-virtual-network) before initiating the connection. Users do not need to modify any SSH configs on their device. For example, to SSH from a terminal:
 
 ```sh
 ssh <username>@<target IP>

--- a/src/content/docs/cloudflare-one/policies/gateway/network-policies/ssh-logging.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/network-policies/ssh-logging.mdx
@@ -31,10 +31,7 @@ Cloudflare Gateway will take the identity from a token and, using short-lived ce
 
 Instead of traditional SSH keys, Gateway uses short-lived certificates to authenticate traffic between Cloudflare and your origin.
 
-:::note
-
-Other short-lived CAs, such as those used to [secure SSH servers behind Cloudflare Access](/cloudflare-one/applications/non-http/short-lived-certificates-legacy/), are incompatible with the Gateway SSH proxy. For SSH logging to work, you must create a new CA using the `gateway_ca` API endpoint.
-:::
+<Render file="ssh/ssh-proxy-ca-note" />
 
 To generate a Gateway SSH proxy CA and get its public key:
 

--- a/src/content/partials/cloudflare-one/access/add-target.mdx
+++ b/src/content/partials/cloudflare-one/access/add-target.mdx
@@ -20,7 +20,7 @@ To create a new target:
 			- Contain only alphanumeric characters, `-`, or `.` (no spaces allowed)
 			- Start and end with an alphanumeric character
 	</Details>
-4. In **IP addresses**, enter the private IPv4 and/or IPv6 address of the target resource. If the IP address overlaps across multiple private networks, select the [virtual network](/cloudflare-one/connections/connect-networks/private-net/cloudflared/tunnel-virtual-networks/) where the resource is located. Targets may not point to the same IP address and virtual network pairings.
+4. In **IP addresses**, enter the private IPv4 and/or IPv6 address of the target resource. If the IP address overlaps across multiple private networks, select the [virtual network](/cloudflare-one/connections/connect-networks/private-net/cloudflared/tunnel-virtual-networks/) where the resource is located. This IP address and virtual network pairing is now assigned to this target and cannot be reused in another target by design.
 :::note[IP address requirements]
 - Public IPs are not currently supported.
 - The IP address must be reachable through Cloudflare Tunnel.

--- a/src/content/partials/cloudflare-one/access/add-target.mdx
+++ b/src/content/partials/cloudflare-one/access/add-target.mdx
@@ -13,14 +13,14 @@ To create a new target:
 <TabItem label="Dashboard">
 1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Network** > **Targets**.
 2. Select **Add a target**.
-3. In **Target hostname**, enter a user-friendly name for the target resource. We recommend using the server hostname, for example `production-server`. The hostname does not need to be unique and can be reused for multiple targets.
+3. In **Target hostname**, enter a user-friendly name for the target resource. We recommend using the server hostname, for example `production-server`. The hostname does not need to be unique and can be reused for multiple targets. Hostnames are used to define the subset of targets included in an infrastructure application and are not used in DNS address resolution.
 	<Details header="Format restrictions">
 			- Case insensitive
 			- Contain no more than 255 characters
 			- Contain only alphanumeric characters, `-`, or `.` (no spaces allowed)
 			- Start and end with an alphanumeric character
 	</Details>
-4. In **IP addresses**, enter the private IPv4 and/or IPv6 address of the target resource. If the IP address overlaps across multiple private networks, select the [virtual network](/cloudflare-one/connections/connect-networks/private-net/cloudflared/tunnel-virtual-networks/) where the resource is located.
+4. In **IP addresses**, enter the private IPv4 and/or IPv6 address of the target resource. If the IP address overlaps across multiple private networks, select the [virtual network](/cloudflare-one/connections/connect-networks/private-net/cloudflared/tunnel-virtual-networks/) where the resource is located. Targets may not point to the same IP address and virtual network pairings.
 :::note[IP address requirements]
 - Public IPs are not currently supported.
 - The IP address must be reachable through Cloudflare Tunnel.

--- a/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca-note.mdx
+++ b/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca-note.mdx
@@ -1,0 +1,9 @@
+---
+{}
+
+---
+
+:::note
+
+Other short-lived CAs, such as those used to [secure SSH servers behind Cloudflare Access](/cloudflare-one/applications/non-http/short-lived-certificates-legacy/), are incompatible with the Gateway SSH proxy. For SSH logging to work, you must create a new CA using the `gateway_ca` API endpoint.
+:::

--- a/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
+++ b/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
@@ -5,11 +5,6 @@
 
 import { Render } from "~/components"
 
-:::note
-
-Other short-lived CAs, such as those used to [secure SSH servers behind Cloudflare Access](/cloudflare-one/applications/non-http/short-lived-certificates-legacy/), are incompatible with the Gateway SSH proxy. For SSH logging to work, you must create a new CA using the `gateway_ca` API endpoint.
-:::
-
 1. Make a `POST` request to the Cloudflare API with your email address and [API key](/fundamentals/api/get-started/keys/) as request headers.
 
    ```bash

--- a/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
+++ b/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
@@ -5,6 +5,11 @@
 
 import { Render } from "~/components"
 
+:::note
+
+Other short-lived CAs, such as those used to [secure SSH servers behind Cloudflare Access](/cloudflare-one/applications/non-http/short-lived-certificates-legacy/), are incompatible with the Gateway SSH proxy. For SSH logging to work, you must create a new CA using the `gateway_ca` API endpoint.
+:::
+
 1. Make a `POST` request to the Cloudflare API with your email address and [API key](/fundamentals/api/get-started/keys/) as request headers.
 
    ```bash


### PR DESCRIPTION
### Summary

Clarifying target and app creation setup. Specifically calling out: 
- Target hostnames are not used in DNS address resolution.
- Targets cannot have the same IP address and VNET pairings.
- Users must switch to the VNET the target is located within before they execute an SSH connection request.
- Clarify details around Gateway SSH proxy certificate vs. other short-lived certificates.
- Adding in specific section for split tunnel gotcha for allowing connections to addresses under RFC 1918.
