### PR TITLE
KV get-started syntax fix

### DIFF
--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -164,7 +164,7 @@ To bind your KV namespace to your Worker:
 1. In your `wrangler.toml` file, add the following with the values generated in your terminal from [step 2](/kv/get-started/#2-create-a-kv-namespace):
 
 	```toml
-	[[kv_namespaces]] =
+	[[kv_namespaces]]
 	binding = "<BINDING_NAME>"
 	id = "<BINDING_ID>"
 


### PR DESCRIPTION
### Summary

Removed equal sign from the wrangler.toml snippet, it's not supposed to be there.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.