### PR TITLE
[Queues] add r2 event notifications disclaimer in src/content/docs/queues/get-started.mdx

### DIFF
--- a/src/content/docs/queues/get-started.mdx
+++ b/src/content/docs/queues/get-started.mdx
@@ -20,7 +20,7 @@ To use Queues, you will need:
 
 ## 1. Create a Worker project
 
-You will access your queue from a Worker, the producer Worker. You must create at least one producer Worker to publish messages onto your queue.
+You will access your queue from a Worker, the producer Worker. You must create at least one producer Worker to publish messages onto your queue. If you are using [R2 Bucket Event Notifications](/r2/buckets/event-notifications/), then you do not need a producer Worker.
 
 To create a producer Worker, run:
 


### PR DESCRIPTION
### Summary

This PR adds a disclaimer to the queues get started documentation. The documentation currently states that:
> You must create at least one producer Worker to publish messages onto your queue.

However, if you are using [R2 Bucket Event Notifications](https://developers.cloudflare.com/r2/buckets/event-notifications/), then you do not need a producer Worker. It does not state this in either the Queues or the Event Notifications documentation as far as I can tell.

### Screenshots (optional)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
