### PR TITLE
[DO] Add missing imports to DurableObject examples

### DIFF
--- a/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
+++ b/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
@@ -20,8 +20,9 @@ By default, a Durable Object class leverages a key-value storage backend. New Du
 
 A common pattern is to initialize a Durable Object from [persistent storage](/durable-objects/api/storage-api/) and set instance variables the first time it is accessed. Since future accesses are routed to the same Durable Object, it is then possible to return any initialized values without making further calls to persistent storage.
 
-
 ```ts
+import { DurableObject } from "cloudflare:workers";
+
 export class Counter extends DurableObject {
   value: number;
 

--- a/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
@@ -205,6 +205,8 @@ While the token bucket algorithm is popular for implementing rate limiting and u
 <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
+import { DurableObject } from "cloudflare:workers";
+
 // Durable Object
 export class RateLimiter extends DurableObject {
   static milliseconds_per_request = 1;
@@ -232,6 +234,8 @@ export class RateLimiter extends DurableObject {
 <TabItem label="TypeScript" icon="seti:typescript">
 
 ```ts title="index.ts"
+import { DurableObject } from "cloudflare:workers";
+
 // Durable Object
 export class RateLimiter extends DurableObject {
   static milliseconds_per_request = 1;

--- a/src/content/docs/durable-objects/get-started/walkthrough.mdx
+++ b/src/content/docs/durable-objects/get-started/walkthrough.mdx
@@ -71,7 +71,9 @@ Your `MyDurableObject` class will have a constructor with two parameters. The fi
 <Tabs> <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
-export class MyDurableObject extends DurableObject{
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
 	constructor(state, env) {}
 }
 ```
@@ -79,7 +81,9 @@ export class MyDurableObject extends DurableObject{
 </TabItem> <TabItem label="TypeScript" icon="seti:typescript">
 
 ```ts
-export class MyDurableObject extends DurableObject{
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
 	constructor(state: DurableObjectState, env: Env) {}
 }
 ```
@@ -93,7 +97,9 @@ Your file should now look like:
 <Tabs> <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
-export class MyDurableObject extends DurableObject{
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
 	constructor(state, env) {}
 
 	async fetch(request) {
@@ -105,7 +111,9 @@ export class MyDurableObject extends DurableObject{
 </TabItem> <TabItem label="TypeScript" icon="seti:typescript">
 
 ```ts
-export class MyDurableObject extends DurableObject{
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
 	constructor(state: DurableObjectState, env: Env) {}
 
 	async fetch(request: Request) {
@@ -222,7 +230,7 @@ new_classes = ["MyDurableObject"] # Array of new classes
 
 :::note[SQLite in Durable Objects Beta]
 
-New beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. SQL storage is opt-in during beta; otherwise, a Durable Object class has the standard, private key-value storage. Objects can access long-lived durable storage with the [Storage API](/durable-objects/api/storage-api/). 
+New beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. SQL storage is opt-in during beta; otherwise, a Durable Object class has the standard, private key-value storage. Objects can access long-lived durable storage with the [Storage API](/durable-objects/api/storage-api/).
 
 :::
 

--- a/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
+++ b/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
@@ -302,6 +302,8 @@ For this tutorial, the function creates an identical seating plan for all the fl
 Replace the `Flight` class with the following code:
 
 ```ts title="src/index.ts"
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
 	sql = this.ctx.storage.sql;
 
@@ -341,6 +343,8 @@ export class Flight extends DurableObject {
 3. Add a `fetch` handler to the `Flight` class. This handler will return a text response. In [Step 5](#5-handle-websocket-connections) You will update the `fetch` handler to handle the WebSocket connection.
 
 ```ts title="src/index.ts" {3-5}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
   ...
   async fetch(request: Request): Promise<Response> {
@@ -379,6 +383,8 @@ Using the flight ID, from the query parameter, a unique Durable Object is create
 1. Add the `getSeats()` function to the `Flight` class. This function returns all the seats in the table.
 
 ```ts title="src/index.ts" {8-22}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
     ...
 
@@ -407,6 +413,8 @@ export class Flight extends DurableObject {
 2. Add the `assignSeat()` function to the `Flight` class. This function will assign a seat to a passenger. It takes the seat number and the passenger name as parameters.
 
 ```ts title="src/index.ts" {13-48}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
 	...
 
@@ -467,6 +475,8 @@ All the clients will connect to the Durable Object using WebSockets. The Durable
 1. Add the `handleWebSocket()` function to the `Flight` class. This function handles the WebSocket connections.
 
 ```ts title="src/index.ts" {18-26}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
 	...
 
@@ -499,6 +509,8 @@ export class Flight extends DurableObject {
 2. Add the `broadcastSeats()` function to the `Flight` class. This function will broadcast the updated seats to all the connected clients.
 
 ```ts title="src/index.ts" {22-24}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
 	...
 
@@ -529,6 +541,8 @@ export class Flight extends DurableObject {
 3. Next, update the `fetch` handler in the `Flight` class. This handler will handle all the incoming requests from the Worker and handle the WebSocket connections using the `handleWebSocket()` method.
 
 ```ts title="src/index.ts" {26-28}
+import { DurableObject } from "cloudflare:workers";
+
 export class Flight extends DurableObject {
 	...
 

--- a/src/content/partials/durable-objects/durable-objects-sql.mdx
+++ b/src/content/partials/durable-objects/durable-objects-sql.mdx
@@ -7,7 +7,9 @@ import { Details } from "~/components"
 [SQL API](/durable-objects/api/storage-api/#sqlexec) examples below use the following SQL schema:
 
 ```ts
-export class MyDurableObject extends DurableObject{
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
   sql: SqlStorage
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);


### PR DESCRIPTION
### Summary

When extending a DurableObject, users must first import the class from `cloudflare:workers`. If they don't, they get a confusing error message saying DurableObject is an interface, not a class:

![CleanShot 2024-10-02 at 03 12 41@2x](https://github.com/user-attachments/assets/9f4cbbc3-5ae4-40ee-ace6-cdb0c4d0c08b)

source: I was trying to follow these examples and got confused about why it didn't work.

Any time we show examples where we extend `DurableObject`, we should make sure we show that you need to import the class first.

### Screenshots (optional)


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
