### PR TITLE
Update deploy-a-hugo-site.mdx

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
@@ -82,7 +82,7 @@ echo "theme = 'ananke'" >> hugo.toml
 Create a new post to give your Hugo site some initial content. Run the `hugo new` command in your terminal to generate a new post:
 
 ```sh
-hugo new content posts/hello-world.md
+hugo new content/posts/hello-world.md
 ```
 
 Inside of `hello-world.md`, add some initial content to create your post. Remove the `draft` line in your post's frontmatter when you are ready to publish the post. Any posts with `draft: true` set will be skipped by Hugo's build process.


### PR DESCRIPTION


### Summary
Fix command for creating a new post in documentation
Corrected the command in the "Create a Post" section from: hugo new content posts/hello-world.md
to:
hugo new content/posts/hello-world.md

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

