### PR TITLE
[Docs Site] Downgrade DOMPurify to 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"astro-icon": "^1.1.1",
 				"astro-live-code": "^0.0.3",
 				"date-fns": "^3.6.0",
-				"dompurify": "^3.1.7",
+				"dompurify": "3.1.6",
 				"dot-prop": "^9.0.0",
 				"github-slugger": "^2.0.0",
 				"hastscript": "^9.0.0",
@@ -5440,9 +5440,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+			"integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)"
 		},

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"astro-icon": "^1.1.1",
 		"astro-live-code": "^0.0.3",
 		"date-fns": "^3.6.0",
-		"dompurify": "^3.1.7",
+		"dompurify": "3.1.6",
 		"dot-prop": "^9.0.0",
 		"github-slugger": "^2.0.0",
 		"hastscript": "^9.0.0",


### PR DESCRIPTION
### Summary

Downgrade DOMPurify to 3.1.6

This is to fix a MermaidJS incompatibility.