### PR TITLE
[Gateway] Remove archive limitation

### DIFF
--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/file-sandboxing.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/file-sandboxing.mdx
@@ -34,5 +34,3 @@ You can now create [Quarantine HTTP policies](/cloudflare-one/policies/gateway/h
 ### Non-scannable files
 
 <Render file="gateway/nonscannable-files" />
-
-- Archive files


### PR DESCRIPTION
File sandboxing supports zip and rar files, just not scanning the files within. ENG recommends removing any mention of archives in limitations.