### PR TITLE
Clarifiy that allow_custom_ports flag affects WebSockets

### DIFF
--- a/src/content/compatibility-dates/allow-custom-ports.md
+++ b/src/content/compatibility-dates/allow-custom-ports.md
@@ -25,3 +25,4 @@ const response = await fetch("https://example.com:8000");
 With allow_custom_ports the above example would fetch `https://example.com:8000` rather than
 `https://example.com:443`.
 
+Note that creating a WebSocket client with a call to `new WebSocket(url)` will also obey this flag.


### PR DESCRIPTION
Clarify that creating a WebSocket client with a call to `new WebSocket(url)` will also obey the `allow_custom_ports` or `ignore_custom_ports` flags, which I have verified through testing.

I haven't created an issue as this is not a "significant change" as described in CONTRIBUTING.md.