### PR TITLE
[D1] Adding two more projects into the Community projects page.

### DIFF
--- a/src/content/docs/d1/reference/community-projects.mdx
+++ b/src/content/docs/d1/reference/community-projects.mdx
@@ -27,7 +27,7 @@ Sutando is an ORM designed for Node.js. With Sutando, each table in a database h
 
 ### knex-cloudflare-d1
 
-knex-cloudflare-d1 is the Cloudflare D1 dialect for Knex.js.
+knex-cloudflare-d1 is the Cloudflare D1 dialect for Knex.js. Note that this is not an official dialect provided by Knex.js.
 
 - [GitHub](https://github.com/kiddyuchina/knex-cloudflare-d1)
 

--- a/src/content/docs/d1/reference/community-projects.mdx
+++ b/src/content/docs/d1/reference/community-projects.mdx
@@ -18,6 +18,19 @@ Community projects are not maintained by the Cloudflare D1 team. They are manage
 
 ## Projects
 
+### Sutando ORM
+
+Sutando is an ORM designed for Node.js. It maps databases to JavaScript models, and supports multiple databases.
+
+- [GitHub](https://github.com/sutandojs/sutando)
+- [D1 with Sutando ORM Example](https://github.com/sutandojs/sutando-examples/tree/main/typescript/rest-hono-cf-d1)
+
+### knex-cloudflare-d1
+
+knex-cloudflare-d1 is the Cloudflare D1 dialect for Knex.js.
+
+- [GitHub](https://github.com/kiddyuchina/knex-cloudflare-d1)
+
 ### Prisma ORM
 
 [Prisma ORM](https://www.prisma.io/orm) is a next-generation JavaScript and TypeScript ORM that unlocks a new level of developer experience when working with databases thanks to its intuitive data model, automated migrations, type-safety and auto-completion.

--- a/src/content/docs/d1/reference/community-projects.mdx
+++ b/src/content/docs/d1/reference/community-projects.mdx
@@ -20,7 +20,7 @@ Community projects are not maintained by the Cloudflare D1 team. They are manage
 
 ### Sutando ORM
 
-Sutando is an ORM designed for Node.js. It maps databases to JavaScript models, and supports multiple databases.
+Sutando is an ORM designed for Node.js. With Sutando, each table in a database has a corresponding model that handles CRUD (Create, Read, Update, Delete) operations.
 
 - [GitHub](https://github.com/sutandojs/sutando)
 - [D1 with Sutando ORM Example](https://github.com/sutandojs/sutando-examples/tree/main/typescript/rest-hono-cf-d1)


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Adding `Sutando ORM` and `knex-cloudflare-d1` projects into D1's Community projects page.

Related to: issue https://github.com/cloudflare/cloudflare-docs/issues/14088

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
