### PR TITLE
docs: add missing flag to d1 migrations list

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -435,6 +435,8 @@ wrangler d1 migrations list <DATABASE_NAME> [OPTIONS]
   - The name of the D1 database you wish to list unapplied migrations for.
 - `--local` <Type text="boolean" /> <MetaInfo text="optional" />
   - Show the list of unapplied migration files on your locally persisted D1 database.
+- `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
+  - Execute any unapplied migrations on your remote D1 database.
 - `--persist-to` <Type text="string" /> <MetaInfo text="optional" />
   - Specify directory to use for local persistence (for use in combination with `--local`).
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -436,7 +436,7 @@ wrangler d1 migrations list <DATABASE_NAME> [OPTIONS]
 - `--local` <Type text="boolean" /> <MetaInfo text="optional" />
   - Show the list of unapplied migration files on your locally persisted D1 database.
 - `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
-  - Execute any unapplied migrations on your remote D1 database.
+  - Show the list of unapplied migration files on your remote D1 database.
 - `--persist-to` <Type text="string" /> <MetaInfo text="optional" />
   - Specify directory to use for local persistence (for use in combination with `--local`).
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />


### PR DESCRIPTION
### Summary

Adds missing flag to d1 migrations list command docs

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
