### PR TITLE
[D1] Adding info on resolving 'statement too long' errors while importing.

### DIFF
--- a/src/content/docs/d1/build-with-d1/import-export-data.mdx
+++ b/src/content/docs/d1/build-with-d1/import-export-data.mdx
@@ -165,6 +165,34 @@ If you receive an error when trying to import an existing schema and/or dataset 
 - If you have foreign key relationships between tables, ensure you are importing the tables in the right order. You cannot refer to a table that does not yet exist.
 - If you receive a `"cannot start a transaction within a transaction"` error, make sure you have removed `BEGIN TRANSACTION` and `COMMIT` from your dumped SQL statements.
 
+### Resolve `Statement too long` error:
+
+If you encounter a `Statement too long` error when trying to import a large SQL file into D1, it means that one of the SQL statements in your file exceeds the maximum allowed length. To resolve this issue, try one of the following approaches:
+
+1. Convert a single large INSERT statement into multiple smaller INSERT statements. For example:
+
+```sql
+INSERT INTO users (id, full_name, created_on)
+VALUES
+  ('01GREFXCN9519NRVXWTPG0V0BF', 'Catlaina Harbar', '2022-08-20 05:39:52'),
+  ('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13'),
+  ...
+  ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
+```
+
+2. Break it into multiple INSERT statements:
+
+```sql
+INSERT INTO users (id, full_name, created_on)
+VALUES
+('01GREFXCN9519NRVXWTPG0V0BF', 'Catlaina Harbar', '2022-08-20 05:39:52');
+INSERT INTO users (id, full_name, created_on)
+VALUES
+('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13');
+```
+
+3. If you have a single large INSERT statement with many rows, break it into smaller chunks. For example, instead of inserting 1000 rows in one statement, try splitting that into 250 rows.
+
 ## Next Steps
 
 - Read the SQLite [`CREATE TABLE`](https://www.sqlite.org/lang_createtable.html) documentation.

--- a/src/content/docs/d1/build-with-d1/import-export-data.mdx
+++ b/src/content/docs/d1/build-with-d1/import-export-data.mdx
@@ -169,7 +169,7 @@ If you receive an error when trying to import an existing schema and/or dataset 
 
 If you encounter a `Statement too long` error when trying to import a large SQL file into D1, it means that one of the SQL statements in your file exceeds the maximum allowed length. To resolve this issue, try one of the following approaches:
 
-1. Convert a single large `INSERT` statement into multiple smaller `INSERT` statements. For example:
+- Convert a single large `INSERT` statement into multiple smaller `INSERT` statements. For example:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -180,7 +180,7 @@ VALUES
   ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
 ```
 
-2. Break it into multiple `INSERT` statements:
+- Break it into multiple `INSERT` statements:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -191,7 +191,7 @@ VALUES
 ('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13');
 ```
 
-3. If you have a single large `INSERT` statement with many rows, break it into smaller chunks. For example, instead of inserting 1,000 rows in one statement, try splitting that into 250 rows.
+- If you have a single large `INSERT` statement with many rows, break it into smaller chunks. For example, instead of inserting 1,000 rows in one statement, try splitting that into 250 rows.
 
 ## Next Steps
 

--- a/src/content/docs/d1/build-with-d1/import-export-data.mdx
+++ b/src/content/docs/d1/build-with-d1/import-export-data.mdx
@@ -169,7 +169,7 @@ If you receive an error when trying to import an existing schema and/or dataset 
 
 If you encounter a `Statement too long` error when trying to import a large SQL file into D1, it means that one of the SQL statements in your file exceeds the maximum allowed length. To resolve this issue, try one of the following approaches:
 
-1. Convert a single large INSERT statement into multiple smaller INSERT statements. For example:
+1. Convert a single large `INSERT` statement into multiple smaller `INSERT` statements. For example:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -180,7 +180,7 @@ VALUES
   ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
 ```
 
-2. Break it into multiple INSERT statements:
+2. Break it into multiple `INSERT` statements:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -191,7 +191,7 @@ VALUES
 ('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13');
 ```
 
-3. If you have a single large INSERT statement with many rows, break it into smaller chunks. For example, instead of inserting 1000 rows in one statement, try splitting that into 250 rows.
+3. If you have a single large `INSERT` statement with many rows, break it into smaller chunks. For example, instead of inserting 1,000 rows in one statement, try splitting that into 250 rows.
 
 ## Next Steps
 

--- a/src/content/docs/d1/build-with-d1/import-export-data.mdx
+++ b/src/content/docs/d1/build-with-d1/import-export-data.mdx
@@ -165,11 +165,11 @@ If you receive an error when trying to import an existing schema and/or dataset 
 - If you have foreign key relationships between tables, ensure you are importing the tables in the right order. You cannot refer to a table that does not yet exist.
 - If you receive a `"cannot start a transaction within a transaction"` error, make sure you have removed `BEGIN TRANSACTION` and `COMMIT` from your dumped SQL statements.
 
-### Resolve `Statement too long` error:
+### Resolve `Statement too long` error
 
 If you encounter a `Statement too long` error when trying to import a large SQL file into D1, it means that one of the SQL statements in your file exceeds the maximum allowed length. To resolve this issue, try one of the following approaches:
 
-1. Convert a single large INSERT statement into multiple smaller INSERT statements. For example:
+- Convert a single large INSERT statement into multiple smaller INSERT statements. For example:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -180,7 +180,7 @@ VALUES
   ('01GREFXCNF67KV7FPPSEJVJMEW', 'Riane Zamora', '2022-12-24 06:49:04');
 ```
 
-2. Break it into multiple INSERT statements:
+- Break it into multiple INSERT statements:
 
 ```sql
 INSERT INTO users (id, full_name, created_on)
@@ -191,7 +191,7 @@ VALUES
 ('01GREFXCNBYBGX2GC6ZGY9FMP4', 'Hube Bilverstone', '2022-12-15 21:56:13');
 ```
 
-3. If you have a single large INSERT statement with many rows, break it into smaller chunks. For example, instead of inserting 1000 rows in one statement, try splitting that into 250 rows.
+- If you have a single large INSERT statement with many rows, break it into smaller chunks. For example, instead of inserting 1000 rows in one statement, try splitting that into 250 rows.
 
 ## Next Steps
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Adding docs on workarounds for resolving 'Statement too long' errors.

Regenerating PR after migration.

- Original PR: https://github.com/cloudflare/cloudflare-docs/pull/15051
- Original Issue: https://github.com/cloudflare/cloudflare-docs/issues/14798

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
