### PR TITLE
[D1] Adding `migrations_dir` in Wrangler config chapter.

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -400,9 +400,9 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
   - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
 
-- `migration_dir` <Type text="string" /> <MetaInfo text="optional" />
+- `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
 
-  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).
+  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).
 
 :::note
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -402,7 +402,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
 - `migration_dir` <Type text="string" /> <MetaInfo text="optional" />
 
-  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migration](/d1/reference/migrations/).
+  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).
 
 :::note
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -400,6 +400,10 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
   - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
 
+- `migration_dir` <Type text="string" /> <MetaInfo text="optional" />
+
+  - The migration directory containing the `ALTER` table. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create).
+
 :::note
 
 When using Wrangler in the default local development mode, files will be written to local storage instead of the preview or production database. Refer to [Local development and testing](/workers/testing/local-development/) for more details.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -402,7 +402,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
 - `migration_dir` <Type text="string" /> <MetaInfo text="optional" />
 
-  - The migration directory containing the `ALTER` table. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create).
+  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migration_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migration](/d1/reference/migrations/).
 
 :::note
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -402,7 +402,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
 - `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
 
-  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migration` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).
+  - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migrations` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).
 
 :::note
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Adding info that `migrations_dir` is a possible binding when migrating a database.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
