### PR TITLE
fix broken link in qr-code-generator tutorial

### DIFF
--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -150,7 +150,7 @@ async function generateQRCode(request) {
 }
 ```
 
-The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ("nodejs_compat_v2" compatibility flag)(/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
+The `qr-image` package you installed depends on Node.js APIs. For this to work, you need to set the ["nodejs_compat_v2" compatibility flag](/workers/runtime-apis/nodejs/#enable-nodejs-with-workers) in your Wrangler configuration file:
 
 ```toml
 compatibility_flags = [ "nodejs_compat_v2"]


### PR DESCRIPTION
Just fixing this broken link:
![Screenshot 2024-10-08 at 17 43 56](https://github.com/user-attachments/assets/db281df9-913f-4156-964e-8f77e3591958)
