### PR TITLE
Add note about minimum_file_size for configuring cache reserve in cache rule

### DIFF
--- a/src/content/docs/cache/how-to/cache-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/settings.mdx
@@ -246,6 +246,10 @@ This rule can also be used to specify Cache Reserve eligibility for website reso
 Cloudflare will still enforce the plan-based [cacheable file limits](/cache/concepts/default-cache-behavior/#customization-options-and-limits) when using this configuration. 
 :::
 
+:::note
+
+If `minimum_file_size` is omitted and `eligible` is true, Cloudflare will use 0 bytes by default.
+:::
 
 <Details header="API information">
 


### PR DESCRIPTION
### Summary

This is a small change to the API documentation for the `minimum_file_size` field of the `cache_reserve` setting in a ruleset.

There is a corresponding note in the Terraform documentation: https://registry.terraform.io/providers/cloudflare/cloudflare/4.43.0/docs/resources/ruleset#minimum_file_size

### Screenshots (optional)

N/A

### Documentation checklist

This is a minimal change. Please let me know if this change isn't compatible with a documentation requirement.
