### PR TITLE
Update set-caching-levels.mdx

### DIFF
--- a/src/content/docs/cache/how-to/set-caching-levels.mdx
+++ b/src/content/docs/cache/how-to/set-caching-levels.mdx
@@ -18,7 +18,7 @@ You can adjust the caching level from the dashboard under **Caching** > **Config
 :::note[Note]
 
 
-Ignore Query String only disregards the query string for static file extensions. For example, Cloudflare serves the `style.css resource` to requests for either `style.css?this` or `style.css?that`.
+Ignore Query String only disregards the query string for static file extensions. For example, Cloudflare serves the `style.css` resource to requests for either `style.css?this` or `style.css?that`.
 
 
 :::


### PR DESCRIPTION
### Summary

The word "resource" seems should be outside of the backtick on page https://developers.cloudflare.com/cache/how-to/set-caching-levels/. 🤔

### Screenshots (optional)

![](https://github.com/user-attachments/assets/103cc71f-668f-435a-b124-a631065c0e94)


<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist
