### PR TITLE
[Docs Site] Add hashes back into entrypoint filenames, disable hoisting.

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
 	experimental: {
 		contentIntellisense: true,
 		contentLayer: true,
+		directRenderScript: true,
 	},
 	server: {
 		port: 1111,
@@ -223,13 +224,4 @@ export default defineConfig({
 		}),
 		react(),
 	],
-	vite: {
-		build: {
-			rollupOptions: {
-				output: {
-					entryFileNames: "_astro/[name].js",
-				},
-			},
-		},
-	},
 });


### PR DESCRIPTION
### Summary

Add hashes back into entrypoint filenames, disable hoisting.

The `hoisted.js` file is present in the `<head>` of every page built, but the content hashes were changing as the scripts imports were identical but the ordering was not.

[`directRenderScript`](https://docs.astro.build/en/reference/configuration-reference/#experimentaldirectrenderscript) will be the default in Astro 5 and removes the need for hoisting in the first place, so we're happy to enable it now.