### PR TITLE
[Docs Site] Cache /_astro/* with immutable directive

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/_astro/*
+    Cache-Control: public, max-age=604800, immutable


### PR DESCRIPTION
### Summary

Adds `Cache-Control: public, max-age=604800, immutable` to files in the `/_astro/` directory - all of these assets (images, CSS, JS) have a content hash in the filename so browsers do not need to revalidate once they are cached.