### PR TITLE
Remove outdated note about max_age and stale_while_revalidate support from hyperdrive docs

### DIFF
--- a/src/content/docs/hyperdrive/configuration/query-caching.mdx
+++ b/src/content/docs/hyperdrive/configuration/query-caching.mdx
@@ -34,12 +34,6 @@ SELECT LASTVAL(), * FROM articles LIMIT 50;
 
 ## Default cache settings
 
-:::note
-
-Hyperdrive will support configuring both the `max_age` and `stale_while_revalidate` values in the near future.
-
-:::
-
 The default caching behaviour for Hyperdrive is defined as below:
 
 - `max_age` = 60 seconds (1 minute)


### PR DESCRIPTION
- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [X] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [X] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
