### PR TITLE
Fix model name typo

### DIFF
--- a/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
+++ b/src/content/docs/workers-ai/get-started/workers-wrangler.mdx
@@ -87,7 +87,7 @@ export default {
 } satisfies ExportedHandler<Env>;
 ```
 
-Up to this point, you have created an AI binding for your Worker and configured your Worker to be able to execute the Llama 2 model. You can now test your project locally before you deploy globally.
+Up to this point, you have created an AI binding for your Worker and configured your Worker to be able to execute the Llama 3.1 model. You can now test your project locally before you deploy globally.
 
 ## 4. Develop locally with Wrangler
 


### PR DESCRIPTION
### Summary

Fix model name typo, it should be Llama 3.1 instead of Llama 2

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.