### PR TITLE
Add local development section to Hyperdrive Pages Functions binding

### DIFF
--- a/src/content/docs/pages/functions/bindings.mdx
+++ b/src/content/docs/pages/functions/bindings.mdx
@@ -681,7 +681,7 @@ The local runtime will attempt to connect to your database using the connection 
 
 :::note
 
-For more information about using Hyperdrive locally, see [this page](/hyperdrive/configuration/local-development/).
+For more information about using Hyperdrive locally, see the [local development configuration guide](/hyperdrive/configuration/local-development/).
 
 :::
 

--- a/src/content/docs/pages/functions/bindings.mdx
+++ b/src/content/docs/pages/functions/bindings.mdx
@@ -670,6 +670,21 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
 </TabItem> </Tabs>
 
+### Interact with your Hyperdrive configs locally
+
+You can interact with your Hyperdrive config bindings locally in one of two ways:
+
+- Give you Hyperdrive binding a `localConnectionString` value in your Pages project's `wrangler.toml` file.
+- **Recommended** Export the `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>` environment variable with the connection string to your database.
+
+The local runtime will attempt to connect to your database using the connection string you provide with one of the two options above.
+
+:::note
+
+For more information about using Hyperdrive locally, see [this page](/hyperdrive/configuration/local-development/).
+
+:::
+
 ## Analytics Engine
 
 The [Analytics Engine](/analytics/analytics-engine/) binding enables you to write analytics within your Pages Function.


### PR DESCRIPTION
### Summary

Add tiny section to the Hyperdrive section or the Pages Functions Bindings page providing information on how to use the Hyperdrive binding in local development.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
