### PR TITLE
[Docs Site] Sort Glossary table by term

### DIFF
--- a/src/components/Glossary.astro
+++ b/src/components/Glossary.astro
@@ -11,6 +11,8 @@ const { product } = Astro.props;
 
 let terms = await getGlossaryEntries(product);
 
+terms = terms.sort((a, b) => a.term.localeCompare(b.term));
+
 const INITIAL_VISIBLE_ROWS = 20;
 ---
 


### PR DESCRIPTION
### Summary

Sort Glossary table by term

### Screenshots (optional)

Before:
<img width="825" alt="image" src="https://github.com/user-attachments/assets/0d063aed-e684-465d-a776-33c9d9070b40">

After:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/d9b2ffa8-5db6-4731-8b2f-515858c095b0">
