### PR TITLE
[Docs Site] Cache Astro assets in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-
-      - uses: actions/cache@v4
-        id: npm-cache
+          cache: "npm"
+      - uses: actions/cache/restore@v4
         with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: |
+            node_modules/.astro/_astro
+            node_modules/.astro/assets
+          key: static
 
       - run: npm ci
       - run: npm run check
@@ -43,6 +37,13 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=4192"
           RUN_LINK_CHECK: true
+
+      - uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules/.astro/_astro
+            node_modules/.astro/assets
+          key: static
 
       - name: Check - Validate redirects (infinite loops, sources with fragment)
         run: npx tsm bin/validate-redirects.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static
 
       - run: npm ci
@@ -41,8 +40,7 @@ jobs:
       - uses: actions/cache/save@v4
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static
 
       - name: Check - Validate redirects (infinite loops, sources with fragment)

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -23,8 +23,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static
       - run: npx astro build
         env:
@@ -42,6 +41,5 @@ jobs:
         if: always()
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static
       - run: npx astro build
         env:
@@ -34,6 +33,5 @@ jobs:
         if: always()
         with:
           path: |
-            node_modules/.astro/_astro
-            node_modules/.astro/assets
+            node_modules/.astro
           key: static


### PR DESCRIPTION
### Summary

Cache Astro assets (resized images) like we do in publish-production and publish-preview.

Explicit NPM cache step is unnecessary, v4 will handle this.