### PR TITLE
Add note re. discard IP

### DIFF
--- a/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
+++ b/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
@@ -6,11 +6,13 @@ title: Redirect one domain to another
 
 import { Render } from "~/components"
 
-If you have an alias domain that only forwards traffic to another domain, you can set up redirects directly within Cloudflare.
+If you have an alias domain that only forwards traffic to another domain (that is, it doesn't have an origin server of its own), you can set up redirects directly within Cloudflare.
 
 1. [Add](/fundamentals/setup/manage-domains/#add-a-domain-to-cloudflare) your alias domain (for example, `previous.com`) to Cloudflare.
 
 2. Make sure that your alias domain has a proxied [DNS A or CNAME record](/dns/manage-dns-records/how-to/create-dns-records/) that properly resolves DNS queries. You may also want to include a record for the `www` subdomain.
+
+*You should use the IP address `192.0.2.1` as it will discard traffic but fulfil the function we require. `100::` is the equivalent for an `AAAA` record.*
 
    | **Type** | **Name** | **IPv4 address** | **Proxy status** |
    | -------- | -------- | ---------------- | ---------------- |

--- a/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
+++ b/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
@@ -12,7 +12,7 @@ If you have an alias domain that only forwards traffic to another domain (that i
 
 2. Make sure that your alias domain has a proxied [DNS A or CNAME record](/dns/manage-dns-records/how-to/create-dns-records/) that properly resolves DNS queries. You may also want to include a record for the `www` subdomain.
 
-*You should use the IP address `192.0.2.1` as it will discard traffic but fulfil the function we require. `100::` is the equivalent for an `AAAA` record.*
+   Use the IP address `192.0.2.1` for the `A` record. This address does not route traffic to an origin server but allows Cloudflare to apply rules, redirects, and Workers to incoming traffic. The equivalent IP address for an `AAAA` record is `100::`.
 
    | **Type** | **Name** | **IPv4 address** | **Proxy status** |
    | -------- | -------- | ---------------- | ---------------- |

--- a/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
+++ b/src/content/docs/fundamentals/setup/manage-domains/redirect-domain.mdx
@@ -6,7 +6,7 @@ title: Redirect one domain to another
 
 import { Render } from "~/components"
 
-If you have an alias domain that only forwards traffic to another domain (that is, it doesn't have an origin server of its own), you can set up redirects directly within Cloudflare.
+If you have an alias domain that only forwards traffic to another domain (that is, the domain does not have an associated origin server of its own), you can set up redirects directly within Cloudflare.
 
 1. [Add](/fundamentals/setup/manage-domains/#add-a-domain-to-cloudflare) your alias domain (for example, `previous.com`) to Cloudflare.
 


### PR DESCRIPTION
### Summary

Adds a note to avoid the misconception that `192.0.2.1` is illustrative for the documentation (as is the usual convention) and not intended to be replaced by the actual IP of the origin server.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

