### PR TITLE
Update react pages guide and react build-configuration not to use/mention `create-react-app`

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
@@ -7,7 +7,7 @@ import { PagesBuildPreset, Render, PackageManagers } from "~/components";
 
 [React](https://reactjs.org/) is a popular framework for building reactive and powerful front-end applications, built by the open-source team at Facebook.
 
-In this guide, you will create a new React application and deploy it using Cloudflare Pages. You will use `create-react-app`, a batteries-included tool for generating new React applications.
+In this guide, you will create a new React application and deploy it using Cloudflare Pages.
 
 ## Setting up a new project
 
@@ -51,11 +51,11 @@ npm start
 
 <div>
 
-<PagesBuildPreset framework="create-react-app" />
+<PagesBuildPreset framework="react" />
 
 </div>
 
-After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `create-react-app`, your project dependencies, and building your site, before deploying it.
+After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `react`, your project dependencies, and building your site, before deploying it.
 
 :::note
 

--- a/src/content/pages-framework-presets/index.yaml
+++ b/src/content/pages-framework-presets/index.yaml
@@ -1,8 +1,8 @@
 build_configs:
-  create-react-app:
-    display_name: Create React App
+  react:
+    display_name: React (Vite)
     build_command: npm run build
-    build_output_directory: build
+    build_output_directory: dist
     icon: /icons/framework-icons/logo-react.svg
   gatsby:
     display_name: Gatsby


### PR DESCRIPTION
partially addresses #16379

### Summary

`create-cloudflare` does not use `create-react-app` so our React pages guide mentioning that `create-react-app` is being used is incorrect, in this PR I am removing such outdated/incorrect reference.

Moreover I am also updating the react build configuration not to use `create-react-app` since it is no longer (and hasn't been for a while) the recommended too for creating react applications.