### PR TITLE
Document Wrangler's OS & Node support policy

### DIFF
--- a/src/content/docs/workers/wrangler/install-and-update.mdx
+++ b/src/content/docs/workers/wrangler/install-and-update.mdx
@@ -21,9 +21,9 @@ Wrangler is installed locally into each of your projects. This allows you and yo
 
 <Details header="Wrangler System Requirements">
 
-Wrangler supports the [Current, Active, and Maintenance](https://nodejs.org/en/about/previous-releases) versions of Node.js. We aim not to break older versions of Node.js, but occasionally will due to features that are unavailable in older version of Node.js or security patches.
+We support running the Wrangler CLI with the [Current, Active, and Maintenance](https://nodejs.org/en/about/previous-releases) versions of Node.js. Your Worker will always be executed in `workerd`, the open source Cloudflare Workers runtime.
 
-For most Wrangler features to work, your operating system needs to support `workerd`, the open source Cloudflare Workers runtime. `workerd`'s OS support policy is listed in it's [GitHub README](https://github.com/cloudflare/workerd?tab=readme-ov-file#running-workerd).
+Wrangler is only supported on macOS 13.5+, Windows 11, and Linux distros that support glib 2.31. This follows [`workerd`'s OS support policy](https://github.com/cloudflare/workerd?tab=readme-ov-file#running-workerd).
 
 </Details>
 

--- a/src/content/docs/workers/wrangler/install-and-update.mdx
+++ b/src/content/docs/workers/wrangler/install-and-update.mdx
@@ -18,6 +18,16 @@ To install [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packag
 
 Wrangler is installed locally into each of your projects. This allows you and your team to use the same Wrangler version, control Wrangler versions for each project, and roll back to an earlier version of Wrangler, if needed.
 
+
+<Details header="Wrangler System Requirements">
+
+Wrangler supports the [Current, Active, and Maintenance](https://nodejs.org/en/about/previous-releases) versions of Node.js. We aim not to break older versions of Node.js, but occasionally will due to features that are unavailable in older version of Node.js or security patches.
+
+For most Wrangler features to work, your operating system needs to support `workerd`, the open source Cloudflare Workers runtime. `workerd`'s OS support policy is listed in it's [GitHub README](https://github.com/cloudflare/workerd?tab=readme-ov-file#running-workerd).
+
+</Details>
+
+
 To install Wrangler within your Worker project, run:
 
 <Render file="install_wrangler" />

--- a/src/content/docs/workers/wrangler/install-and-update.mdx
+++ b/src/content/docs/workers/wrangler/install-and-update.mdx
@@ -14,7 +14,7 @@ Wrangler is a command-line tool for building with Cloudflare developer products.
 
 ## Install Wrangler
 
-To install [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [Node.js](https://nodejs.org/en/) and [npm](https://docs.npmjs.com/getting-started) installed, preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to change Node.js versions. Wrangler requires a Node version of `16.17.0` or later.
+To install [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [Node.js](https://nodejs.org/en/) and [npm](https://docs.npmjs.com/getting-started) installed, preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to change Node.js versions.
 
 Wrangler is installed locally into each of your projects. This allows you and your team to use the same Wrangler version, control Wrangler versions for each project, and roll back to an earlier version of Wrangler, if needed.
 


### PR DESCRIPTION
### Summary

This adds a documented OS and Node version support policy for Wrangler, which we didn't previously have explicitly documented.

The Node version support policy is potentially controversial.