### PR TITLE
Update metadata-filtering.mdx

### DIFF
--- a/src/content/docs/vectorize/reference/metadata-filtering.mdx
+++ b/src/content/docs/vectorize/reference/metadata-filtering.mdx
@@ -60,13 +60,13 @@ Both [namespaces](/vectorize/best-practices/insert-vectors/#namespaces) and meta
 #### Explicit operator
 
 ```json
-{ "someKey": { "$ne": true } }
+{ "someKey": { "$ne": "hbo" } }
 ```
 
 #### Implicit logical `AND` with multiple keys
 
 ```json
-{ "pandas.nice": 42, "someKey": { "$ne": true } }
+{ "pandas.nice": 42, "someKey": { "$ne": "someValue" } }
 ```
 
 #### Keys define nesting with `.` (dot)


### PR DESCRIPTION
I was a bit confused with the example `{ "$ne": true }`, it seemed like one should put `true` specifically, and then provide the actual value elsewhere. Unless I misunderstood again, perhaps this small change would make it clearer how the operators work.

### Summary

Vectorize → Reference → Metadata filtering article.

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
