### PR TITLE
Update guide.mdx

### DIFF
--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -75,10 +75,10 @@ npm create cloudflare@latest -- --template <SOURCE>
 - `bitbucket:user/repo` (Bitbucket)
 - `gitlab:user/repo` (GitLab)
 
-At a minimum, template folders must contain the following:
+It's likely that you have an existing project that isn't configured as a Cloudflare template. Before your project can qualify as a valid template, the folder must contain the following files at least:
 
 - `package.json`
-- `wrangler.toml`
+- `wrangler.toml` [See this](/workers/wrangler/configuration/#sample-wranglertoml-configuration) for an example of a Wrangler configuration file
 - `src/` containing a worker script referenced from `wrangler.toml`
 
 </Details>

--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -58,7 +58,7 @@ In your project directory, C3 will have generated the following:
 
 <Details header="What if I already have a project in a git repository?">
 
-In addition to creating new projects from C3 templates, C3 also supports creating new projects from Git repositories. To create a new project from a Git repository, open your terminal and run:
+In addition to creating new projects from C3 templates, C3 also supports creating new projects from existing Git repositories. To create a new project from an existing Git repository, open your terminal and run:
 
 ```sh
 npm create cloudflare@latest -- --template <SOURCE>
@@ -75,10 +75,10 @@ npm create cloudflare@latest -- --template <SOURCE>
 - `bitbucket:user/repo` (Bitbucket)
 - `gitlab:user/repo` (GitLab)
 
-It's likely that you have an existing project that isn't configured as a Cloudflare template. Before your project can qualify as a valid template, the folder must contain the following files at least:
+Your existing template folder must contain the following files, at a minimum, to meet the requirements for Cloudflare Workers:
 
 - `package.json`
-- `wrangler.toml` [See this](/workers/wrangler/configuration/#sample-wranglertoml-configuration) for an example of a Wrangler configuration file
+- `wrangler.toml` [See sample Wrangler configuration](/workers/wrangler/configuration/#sample-wranglertoml-configuration)
 - `src/` containing a worker script referenced from `wrangler.toml`
 
 </Details>


### PR DESCRIPTION
### Summary
Make explicit the fact that when cloning your template, you can create your own Wrangler file to make your project compatible with Cloudflare as a template. 

I am making this edit because I was confused when reading the docs as to how to make take my NodeJS project and turn it into a worker without going through the fresh install to learn what config files I need.

I am editing step 1 of the Cloudflare Workers CLI Guide: https://developers.cloudflare.com/workers/get-started/guide/

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.