### PR TITLE
clarify that wildcards are not allowed in redirect-to-custom-domain.mdx

### DIFF
--- a/src/content/docs/pages/how-to/redirect-to-custom-domain.mdx
+++ b/src/content/docs/pages/how-to/redirect-to-custom-domain.mdx
@@ -1,18 +1,18 @@
 ---
 pcx_content_type: how-to
-title: Redirecting *.pages.dev to a Custom Domain
+title: Redirecting <deploy-id>.pages.dev to a Custom Domain
 
 ---
 
 import { Example } from "~/components"
 
-Learn how to use [Bulk Redirects](/rules/url-forwarding/bulk-redirects/) to redirect your `*.pages.dev` subdomain to your [custom domain](/pages/configuration/custom-domains/).
+Learn how to use [Bulk Redirects](/rules/url-forwarding/bulk-redirects/) to redirect `<deploy-id>.pages.dev` subdomain to your [custom domain](/pages/configuration/custom-domains/).
 
-You may want to do this to ensure that your site's content is served only on the custom domain, and not the `*.pages.dev` site automatically generated on your first Pages deployment.
+You may want to do this to ensure that your site's content is served only on the custom domain, and not `<deploy-id>.pages.dev` site automatically generated on your first Pages deployment.
 
 ## Setup
 
-To redirect a `*.pages.dev` subdomain to your custom domain:
+To redirect `<deploy-id>.pages.dev` subdomain to your custom domain:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/domains), and select your account.
 2. Select **Workers & Pages** and select your Pages application.
@@ -24,13 +24,13 @@ To redirect a `*.pages.dev` subdomain to your custom domain:
 
 | Source URL    | Target URL            | Status | Parameters                                                                                                               |
 | ------------- | --------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `*.pages.dev` | `https://example.com` | `301`  | <ul><li>Preserve query string</li><li>Subpath matching</li><li>Preserve path suffix</li><li>Include subdomains</li></ul> |
+| `<deploy-id>.pages.dev` | `https://example.com` | `301`  | <ul><li>Preserve query string</li><li>Subpath matching</li><li>Preserve path suffix</li><li>Include subdomains</li></ul> |
 
 </Example>
 
 6. [Create a bulk redirect rule](/rules/url-forwarding/bulk-redirects/create-dashboard/#2-create-a-bulk-redirect-rule) using the list you just created.
 
-To test that your redirect worked, go to your `*.pages.dev` domain. If the URL is now set to your custom domain, then the rule has propagated.
+To test that your redirect worked, go to your `<deploy-id>.pages.dev` domain. If the URL is now set to your custom domain, then the rule has propagated.
 
 ## Related resources
 


### PR DESCRIPTION
As far as I can tell wildcards (`*`) are not supported for bulk redirect rules, so mentioning the `*` so prominently confuses a bit.

The `<deploy-id>` placeholder is debatable. If possible please offer a better suggestion. Or please explain if I overlooked something, I am still learning the Cloudflare API.
