### PR TITLE
fix markdown syntax in developer-spotlight/index.mdx

### DIFF
--- a/src/content/docs/developer-spotlight/index.mdx
+++ b/src/content/docs/developer-spotlight/index.mdx
@@ -9,7 +9,7 @@ import { LinkTitleCard } from "~/components";
 
 Find examples of how our community of developers are getting the most out of our products.
 
-Applications are currently open until Thursday, the 24th of October 2024. To apply, please read the (application guide)[/developer-spotlight/application-guide/]
+Applications are currently open until Thursday, the 24th of October 2024. To apply, please read the [application guide](/developer-spotlight/application-guide/)
 
 ## View latest contributions
 


### PR DESCRIPTION
`[]()` not `()[]`