### PR TITLE
Fix tooltip text

### DIFF
--- a/src/content/docs/rules/snippets/index.mdx
+++ b/src/content/docs/rules/snippets/index.mdx
@@ -13,7 +13,7 @@ head:
 
 import { FeatureTable, GlossaryTooltip, Render } from "~/components";
 
-Cloudflare Snippets (beta) provide a powerful and flexible way to customize the behavior of your website or application using short pieces of JavaScript code. With Snippets, you can modify HTTP response headers, implement <GlossaryTooltip term="JSON web token (JWT)" prepend="JSON web token (JWT) is ">JWT</GlossaryTooltip> validation, perform complex <GlossaryTooltip term="redirect">redirects,</GlossaryTooltip> and much more.
+Cloudflare Snippets (beta) provide a powerful and flexible way to customize the behavior of your website or application using short pieces of JavaScript code. With Snippets, you can modify HTTP response headers, implement <GlossaryTooltip term="JSON web token (JWT)" prepend="JSON web token (JWT) is ">JWT</GlossaryTooltip> validation, perform complex <GlossaryTooltip term="redirect">redirects</GlossaryTooltip>, and much more.
 
 For code samples addressing common use cases, please refer to the [Examples](/rules/snippets/examples/) section.
 


### PR DESCRIPTION
### Summary

Small fix, moved a single comma outside the tooltip link.
