### PR TITLE
Typo in R2 event notifications documentation page

### DIFF
--- a/src/content/docs/r2/buckets/event-notifications.mdx
+++ b/src/content/docs/r2/buckets/event-notifications.mdx
@@ -231,5 +231,5 @@ Queue consumers receive notifications as [Messages](/queues/configuration/javasc
 
 ## Notes
 
-- Event notifications are not available for buckets with [jursdictional restrictions](/r2/reference/data-location/#jurisdictional-restrictions) (_coming soon_).
+- Event notifications are not available for buckets with [jurisdictional restrictions](/r2/reference/data-location/#jurisdictional-restrictions) (_coming soon_).
 - Queues [per-queue message throughput](/queues/platform/limits/) is currently 5,000 messages per second. If your workload produces more than 5,000 notifications per second, we recommend splitting notification rules across multiple queues.


### PR DESCRIPTION
### Summary

A small typo in the word `jurisdictional`.


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
