### PR TITLE
Version error info added

### DIFF
--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
@@ -12,6 +12,7 @@ import { Render } from "~/components";
 ## Install
 
 ### Install with `npm`
+#### This package is for Wrangler v1.x and is no longer supported. Please visit https://www.npmjs.com/package/wrangler for Wrangler v2+.
 
 ```sh
 npm i @cloudflare/wrangler -g

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
@@ -12,7 +12,6 @@ import { Render } from "~/components";
 ## Install
 
 ### Install with `npm`
-#### This package is for Wrangler v1.x and is no longer supported. Please visit https://www.npmjs.com/package/wrangler for Wrangler v2+.
 
 ```sh
 npm i @cloudflare/wrangler -g

--- a/src/content/partials/workers/wrangler-v1-deprecation.mdx
+++ b/src/content/partials/workers/wrangler-v1-deprecation.mdx
@@ -6,7 +6,8 @@
 :::caution
 
 
-This page is for Wrangler v1, which has now been deprecated. Access documentation for the current version of Wrangler by visiting the [Wrangler homepage](/workers/wrangler). Refer to the [Migration guide](/workers/wrangler/migration/v1-to-v2/) for instructions on how to migrate to the latest version.
+This page is for Wrangler v1, which has been deprecated.
+[Learn how to update to the latest version of Wrangler](/workers/wrangler/migration/v1-to-v2/).
 
 
 :::


### PR DESCRIPTION
npm update -g @cloudflare/wrangler

npm warn deprecated @cloudflare/wrangler@1.21.0: This package is for Wrangler v1.x  and is no longer supported. Please visit https://www.npmjs.com/package/wrangler for Wrangler v2+.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
