### PR TITLE
Update commands.mdx

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -460,6 +460,8 @@ wrangler d1 migrations apply <DATABASE_NAME> [OPTIONS]
 
 - `DATABASE_NAME` <Type text="string" /> <MetaInfo text="required" />
   - The name of the D1 database you wish to apply your migrations on.
+- `--env` <Type text="string" /> <MetaInfo text="optional" />
+  - Specify which environment configuration to use for d1 dinding
 - `--local` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
   - Execute any unapplied migrations on your locally persisted D1 database.
 - `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -461,7 +461,7 @@ wrangler d1 migrations apply <DATABASE_NAME> [OPTIONS]
 - `DATABASE_NAME` <Type text="string" /> <MetaInfo text="required" />
   - The name of the D1 database you wish to apply your migrations on.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
-  - Specify which environment configuration to use for d1 dinding
+  - Specify which environment configuration to use for D1 binding
 - `--local` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
   - Execute any unapplied migrations on your locally persisted D1 database.
 - `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />


### PR DESCRIPTION
### Summary

There is no mention that if you have multiple environments and separate db names for each in wrangler.toml, to use proper binding you must set --env parameter. It's supported, but not documented.

Without this parameter there will be error:

> Couldn't find a D1 DB with the name or binding 'some-db-production' in wrangler.toml.


Where 'some-db-production' is in:
[env.production]
[[env.production.d1_databases]]
binding = "DB"
database_name = "some-db-production"
database_id = "00000000-0000-0000-0000-000000000000"

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
