### PR TITLE
[DO] Relocating the limit increase box away from the footnotes for clarity.

### DIFF
--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -26,7 +26,7 @@ Durable Objects are only available on the [Workers Paid plan](/workers/platform/
 
 [^2]: Durable Objects both bills and measures storage based on a gigabyte <br/> (1 GB = 1,000,000,000 bytes) and not a gibibyte (GiB). <br/>
 
-[^3]: Will be raised to 10GB for general availability.
+[^3]: Will be raised to 10 GB for general availability.
 
 [^4]: Each incoming HTTP request or WebSocket *message* resets the remaining available CPU time to 30 seconds. This allows the Durable Object to consume up to 30 seconds of compute after each incoming network request, with each new network request resetting the timer. If you consume more than 30 seconds of compute between incoming network requests, there is a heightened chance that the individual Durable Object is evicted and reset.
 

--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -10,25 +10,25 @@ import { Render } from "~/components";
 
 Durable Objects are only available on the [Workers Paid plan](/workers/platform/pricing/#workers). Durable Objects limits are the same as [Workers Limits](/workers/platform/limits/), as well as the following limits that are specific to Durable Objects:
 
-| Feature                                  | Limit for class with key-value storage backend                   | Limit for class with SQite storage backend <sup>1</sup> |
-| ---------------------------------        | ---------------------------------------------------------------- | --------------------------------------------- |
+| Feature                                  | Limit for class with key-value storage backend                   | Limit for class with SQite storage backend [^1] |
+| ---------------------------------        | ---------------------------------------------------------------- | ----------------------------------------------- |
 | Number of Objects                        | Unlimited (within an account or of a given class)                | Unlimited (within an account or of a given class)                |
 | Maximum Durable Object namespaces        | 500 (identical to the [script limit](/workers/platform/limits/)) | 500 (identical to the [script limit](/workers/platform/limits/)) |
-| Storage per account                      | 50 GB (can be raised by contacting Cloudflare) <sup>2</sup>      | 50 GB (can be raised by contacting Cloudflare) <sup>2</sup>      |
+| Storage per account                      | 50 GB (can be raised by contacting Cloudflare) [^2]              | 50 GB (can be raised by contacting Cloudflare) [^2]              |
 | Storage per class                        | Unlimited                                                        | Unlimited                                                        |
-| Storage per Durable Object               | Unlimited                                                        | 1 GB <sup>4</sup>                                                |
+| Storage per Durable Object               | Unlimited                                                        | 1 GB [^3]                                                        |
 | Key size                                 | 2 KiB (2048 bytes)                                               | Key and value combined cannot exceed 2 MB                        |
 | Value size                               | 128 KiB (131072 bytes)                                           | Key and value combined cannot exceed 2 MB                        |
 | WebSocket message size                   | 1 MiB (only for received messages)                               | 1 MiB (only for received messages)                               |
-| CPU per request                          | 30s (including WebSocket messages) <sup>3</sup>                  | 30s (including WebSocket messages) <sup>3</sup>                  |
+| CPU per request                          | 30s (including WebSocket messages) [^4]                          | 30s (including WebSocket messages) [^4]                          |
 
-<sup>1</sup> The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When creating a Durabe Object class, users can [opt-in to using SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sql-storage-on-create-durable-object-class-migration).
+[^1]: The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When creating a Durable Object class, users can [opt-in to using SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sql-storage-on-create-durable-object-class-migration).
 
-<sup>2</sup> Durable Objects both bills and measures storage based on a gigabyte <br/> (1 GB = 1,000,000,000 bytes) and not a gibibyte (GiB). <br/>
+[^2]: Durable Objects both bills and measures storage based on a gigabyte <br/> (1 GB = 1,000,000,000 bytes) and not a gibibyte (GiB). <br/>
 
-<sup>3</sup> Each incoming HTTP request or WebSocket *message* resets the remaining available CPU time to 30 seconds. This allows the Durable Object to consume up to 30 seconds of compute after each incoming network request, with each new network request resetting the timer. If you consume more than 30 seconds of compute between incoming network requests, there is a heightened chance that the individual Durable Object is evicted and reset.
+[^3]: Will be raised to 10GB for general availability.
 
-<sup>4</sup> Will be raised to 10GB for general availability.
+[^4]: Each incoming HTTP request or WebSocket *message* resets the remaining available CPU time to 30 seconds. This allows the Durable Object to consume up to 30 seconds of compute after each incoming network request, with each new network request resetting the timer. If you consume more than 30 seconds of compute between incoming network requests, there is a heightened chance that the individual Durable Object is evicted and reset.
 
 For Durable Object classes with [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) these SQL limits apply:
 

--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -30,8 +30,6 @@ Durable Objects are only available on the [Workers Paid plan](/workers/platform/
 
 <sup>4</sup> Will be raised to 10GB for general availability.
 
-<Render file="limits_increase" product="workers" />
-
 For Durable Object classes with [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) these SQL limits apply:
 
 | SQL                                                      | Limit |
@@ -43,6 +41,8 @@ For Durable Object classes with [SQLite storage backend](/durable-objects/best-p
 | Maximum bound parameters per query                       | 100 |
 | Maximum arguments per SQL function                       | 32 |
 | Maximum characters (bytes) in a `LIKE` or `GLOB` pattern | 50 bytes |
+
+<Render file="limits_increase" product="workers" />
 
 ## How much work can a single Durable Object do?
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Relocating the limit increase note box away from the footnotes for less confusion (we won't be increasing the limit on a per-account basis)
2. Using the new footnote component. Technically, this solves 1 as well, but have relocated the box away anyway.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
