### PR TITLE
[DOCS]: Update Incorrect Parameter Descriptions in KV Commands Page

### DIFF
--- a/src/content/partials/workers/wrangler-commands/kv.mdx
+++ b/src/content/partials/workers/wrangler-commands/kv.mdx
@@ -173,9 +173,9 @@ This command requires a `--binding` or `--namespace-id` flag.
 - `--path` <MetaInfo text="optional" />
   - When defined, the value is loaded from the file at `--path` rather than reading it from the `VALUE` argument. This is ideal for security-sensitive operations because it avoids saving keys and values into your terminal history.
 - `--binding` string
-  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete.
+  - The binding name of the namespace, as stored in the `wrangler.toml` file, to write to.
 - `--namespace-id` <Type text="string" />
-  - The ID of the namespace to delete.
+  - The ID of the namespace to write to.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific environment.
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />
@@ -245,9 +245,9 @@ This command requires `--binding` or `--namespace-id`.
 :::
 
 - `--binding` <Type text="string" />
-  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete.
+  - The binding name of the namespace, as stored in the `wrangler.toml` file, to list from.
 - `--namespace-id` <Type text="string" />
-  - The ID of the namespace to delete.
+  - The ID of the namespace to list from.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific environment.
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />
@@ -333,9 +333,9 @@ Exactly one of `--binding` or `--namespace-id` is required.
 - `KEY` <Type text="string" /> <MetaInfo text="required" />
   - The key value to get.
 - `--binding` <Type text="string" />
-  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete.
+  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete from.
 - `--namespace-id` <Type text="string" />
-  - The ID of the namespace to delete.
+  - The ID of the namespace to delete from.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific environment.
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />
@@ -385,9 +385,9 @@ This command requires `--binding` or `--namespace-id`.
 - `FILENAME` <Type text="string" /> <MetaInfo text="required" />
   - The JSON file containing an array of key-value pairs to write to the namespace.
 - `--binding` <Type text="string" />
-  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete.
+  - The binding name of the namespace, as stored in the `wrangler.toml` file, to write to.
 - `--namespace-id` <Type text="string" />
-  - The ID of the namespace to delete.
+  - The ID of the namespace to write to.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific environment.
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />
@@ -467,9 +467,9 @@ This command requires `--binding` or `--namespace-id`.
 - `FILENAME` <Type text="string" /> <MetaInfo text="required" />
   - The JSON file containing an array of keys to delete from the namespace.
 - `--binding` <Type text="string" />
-  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete.
+  - The binding name of the namespace, as stored in the `wrangler.toml` file, to delete from.
 - `--namespace-id` <Type text="string" />
-  - The ID of the namespace to delete.
+  - The ID of the namespace to delete from.
 - `--env` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific environment.
 - `--preview` <Type text="boolean" /> <MetaInfo text="optional" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
The documentation page at https://developers.cloudflare.com/kv/reference/kv-commands/, detailing the KV commands, had incorrect parameter descriptions in some places. This pr aims to fix that.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
