### PR TITLE
Remove R2 "Maximum object name length" limit 

### DIFF
--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -21,7 +21,6 @@ Managed public bucket access through an `r2.dev` subdomain is not intended for p
 | Object key length                 | 1,024 bytes                  |
 | Object metadata size              | 8,192 bytes                  |
 | Object size                       | 5 TiB per object<sup>1</sup> |
-| Maximum object name length        | 1024 bytes                   |
 | Maximum upload size<sup>3</sup>   | 5 GiB<sup>2</sup>            |
 | Maximum upload parts              | 10,000                       |
 | Maximum custom domains per bucket | 50                           |


### PR DESCRIPTION

### Summary

Remove R2 "Maximum object name length" limit because it's already listed more correctly as "object key length".

