### PR TITLE
Update the Workers Routes configuration page to define "orange-clouded"

### DIFF
--- a/src/content/docs/workers/configuration/routing/routes.mdx
+++ b/src/content/docs/workers/configuration/routing/routes.mdx
@@ -21,7 +21,7 @@ To add a route, you must have:
 
 1. An [active Cloudflare zone](/dns/zone-setups/).
 2. A Worker to invoke.
-3. An orange-clouded DNS record set up for the [domain](/dns/manage-dns-records/how-to/create-zone-apex/) or [subdomain](/dns/manage-dns-records/how-to/create-subdomain/) you would like to route to.
+3. A DNS record set up for the [domain](/dns/manage-dns-records/how-to/create-zone-apex/) or [subdomain](/dns/manage-dns-records/how-to/create-subdomain/) proxied by Cloudflare (also known as orange-clouded) you would like to route to.
 
 :::caution
 


### PR DESCRIPTION
This PR updates the Workers Routes configuration page to define what an "orange-clouded" domain is before the term is used.

Resolves issue 17618