### PR TITLE
[Worker/D1] Adding note on the limit of D1 when choosing storage product.

### DIFF
--- a/src/content/docs/workers/platform/storage-options.mdx
+++ b/src/content/docs/workers/platform/storage-options.mdx
@@ -136,6 +136,10 @@ To get started with D1:
 - Follow the [Get started guide](/d1/get-started/) to provision your first D1 database.
 - Review the [D1 client API](/d1/build-with-d1/d1-client-api/).
 
+:::note
+If your working data size exceeds 10 GB (the maximum size for a D1 database), consider splitting the database to multiple, smaller D1 databases.
+:::
+
 ## Queues
 
 Cloudflare Queues allows developers to send and receive messages with guaranteed delivery. It integrates with [Cloudflare Workers](/workers) and offers at-least once delivery, message batching, and does not charge for egress bandwidth.

--- a/src/content/docs/workers/platform/storage-options.mdx
+++ b/src/content/docs/workers/platform/storage-options.mdx
@@ -137,7 +137,7 @@ To get started with D1:
 - Review the [D1 client API](/d1/build-with-d1/d1-client-api/).
 
 :::note
-If your working data size exceeds 10 GB (the maximum size for a D1 database), consider splitting the database to multiple, smaller D1 databases.
+If your working data size exceeds 10 GB (the maximum size for a D1 database), consider splitting the database into multiple, smaller D1 databases.
 :::
 
 ## Queues


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Adding a note about the 10 GB limit of D1 in the page to allow users to better choose their storage option.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
