### PR TITLE
Remove from Free plan section tab no longer available in Free plan

### DIFF
--- a/src/content/docs/analytics/account-and-zone-analytics/zone-analytics.mdx
+++ b/src/content/docs/analytics/account-and-zone-analytics/zone-analytics.mdx
@@ -49,7 +49,7 @@ Below is a summary of each Analytics app tab.
 
 These metrics include legitimate user requests as well as crawlers and threats. The Traffic tab features the following panels: 
 
-* **Web Traffic** - Displays metrics for *Requests*, *Bandwidth*, *Unique Visitors*, and [*Status Codes*](/analytics/account-and-zone-analytics/status-codes/). If you are using Cloudflare Workers, subrequests data will not be visible in zone Traffic Analytics. Instead, you can find subrequests analytics under the **Workers & Pages** tab in the **Overview** section. Refer to [Worker Analytics](/analytics/account-and-zone-analytics/analytics-with-workers/#worker-analytics) for more information.
+* **Web Traffic** - Displays metrics for *Requests*, *Bandwidth*, and *Unique Visitors*. If you are using Cloudflare Workers, subrequests data will not be visible in zone Traffic Analytics. Instead, you can find subrequests analytics under the **Workers & Pages** tab in the **Overview** section. Refer to [Worker Analytics](/analytics/account-and-zone-analytics/analytics-with-workers/#worker-analytics) for more information.
 * **Web Traffic Requests by Country** - Is an interactive map that breaks down the number of requests by country.  This panel also includes a data table for **Top Traffic Countries / Regions** that display the countries with the most number of requests (up to five, if the data exists).
 * **Share Your Stats -** Lets you share actual site statistics on social media (Twitter) for: *Bytes saved,* *SSL requests served*, and *attacks blocked*.
 


### PR DESCRIPTION
### Summary

In the 'Free plan' section there is a reference to 'Status Codes' which is a tab no longer available on the Free plan.

### Screenshots (optional)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
