### PR TITLE
Adding description as an argument when creating rule for event notifications

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -945,6 +945,8 @@ wrangler r2 bucket notification create <NAME> [OPTIONS]
   - The prefix that an object must match to emit event notifications (note: regular expressions are not supported).
 - `--suffix` <Type text="string" /> <MetaInfo text="optional" />
   - The suffix that an object must match to emit event notifications (note: regular expressions are not supported).
+- `--description` <Type text="string" /> <MetaInfo text="optional" />
+  - A description that can be used to identify the event notification rule after creation.
 
 ### `notification delete`
 


### PR DESCRIPTION
### Summary

Updating docs to add new Wrangler argument for options when creating an R2 event notification rule

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->
![Screenshot from 2024-10-18 13-28-11](https://github.com/user-attachments/assets/6a96dcfb-8610-422f-b7c6-b08e560e5e24)


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
