### PR TITLE
[Zero-Trust] Fixed OS typo in install-cert-with-warp.mdx

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cert-with-warp.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cert-with-warp.mdx
@@ -63,7 +63,7 @@ The certificate is also placed in `%ProgramData%\Cloudflare\installed_cert.pem` 
 
 ### macOS
 
-To access the installed certificate in Windows:
+To access the installed certificate in macOS:
 
 1. Open Keychain Access.
 2. In **System Keychains**, go to **System** > **Certificates**.


### PR DESCRIPTION
- Small typo fixed, changed "Windows" to "macOS"

### Summary

In the Zero-Trust documentation for [Install certificate using WARP](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/user-side-certificates/install-cert-with-warp/#macos), the section for macOS incorrectly refers to that section as the directions for accessing certificates on Windows.

### Screenshot
<img width="368" alt="image" src="https://github.com/user-attachments/assets/b39f0c2f-e003-4a3b-a201-bb55531e0c94">

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
