### PR TITLE
Add missing product to footnote Renders

### DIFF
--- a/src/content/docs/fundamentals/setup/manage-members/manage.mdx
+++ b/src/content/docs/fundamentals/setup/manage-members/manage.mdx
@@ -6,10 +6,9 @@ sidebar:
 head:
   - tag: title
     content: Manage account members
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Granting access to others on your account is done with several sets of data principles:
 
@@ -22,7 +21,9 @@ When assigning a new user, you can assign a policy to them directly. If multiple
 Learn how to add new account members, edit or revoke their access, and resend verification emails.
 
 :::note
- <Render file="account-member-manage-limitation" product="fundamentals" /> 
+
+<Render file="account-member-manage-limitation" product="fundamentals" />
+
 :::
 
 ## View account members
@@ -53,11 +54,8 @@ Learn how to add new account members, edit or revoke their access, and resend ve
 
 <Render file="remove-account-members" product="fundamentals" />
 
-[^1]: <Render file="account-member-manage-limitation" />
-
 :::note
-
-If you have been invited to an account and want to remove yourself from the account, go to **Manage Account** > **Members**. Under your email address, select **Leave**. 
+If you have been invited to an account and want to remove yourself from the account, go to **Manage Account** > **Members**. Under your email address, select **Leave**.
 :::
 
 ## Super Administrator access

--- a/src/content/docs/learning-paths/application-security/account-security/add-other-members.mdx
+++ b/src/content/docs/learning-paths/application-security/account-security/add-other-members.mdx
@@ -42,4 +42,4 @@ Learn how to add new account members, edit or revoke their permissions and acces
 
 <Render file="remove-account-members" product="fundamentals" />
 
-[^1]: <Render file="account-member-manage-limitation" />
+[^1]: <Render file="account-member-manage-limitation" product="fundamentals" />

--- a/src/content/docs/learning-paths/application-security/account-security/add-other-members.mdx
+++ b/src/content/docs/learning-paths/application-security/account-security/add-other-members.mdx
@@ -3,15 +3,16 @@ title: Add and manage other members
 pcx_content_type: overview
 sidebar:
   order: 2
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Learn how to add new account members, edit or revoke their permissions and access, and resend verifications emails.
 
 :::note
- <Render file="account-member-manage-limitation" product="fundamentals" /> 
+
+<Render file="account-member-manage-limitation" product="fundamentals" />
+
 :::
 
 ## View account members
@@ -41,5 +42,3 @@ Learn how to add new account members, edit or revoke their permissions and acces
 <Render file="account-member-manage-limitation" product="fundamentals" />
 
 <Render file="remove-account-members" product="fundamentals" />
-
-[^1]: <Render file="account-member-manage-limitation" product="fundamentals" />

--- a/src/content/docs/learning-paths/get-started/account-setup/add-other-members.mdx
+++ b/src/content/docs/learning-paths/get-started/account-setup/add-other-members.mdx
@@ -42,4 +42,4 @@ Learn how to add new account members, edit or revoke their permissions and acces
 
 <Render file="remove-account-members" product="fundamentals" />
 
-[^1]: <Render file="account-member-manage-limitation" />
+[^1]: <Render file="account-member-manage-limitation" product="fundamentals" />

--- a/src/content/docs/learning-paths/get-started/account-setup/add-other-members.mdx
+++ b/src/content/docs/learning-paths/get-started/account-setup/add-other-members.mdx
@@ -3,15 +3,16 @@ title: Add and manage other members
 pcx_content_type: overview
 sidebar:
   order: 5
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 Learn how to add new account members, edit or revoke their permissions and access, and resend verifications emails.
 
 :::note
- <Render file="account-member-manage-limitation" product="fundamentals" /> 
+
+<Render file="account-member-manage-limitation" product="fundamentals" />
+
 :::
 
 ## View account members
@@ -41,5 +42,3 @@ Learn how to add new account members, edit or revoke their permissions and acces
 <Render file="account-member-manage-limitation" product="fundamentals" />
 
 <Render file="remove-account-members" product="fundamentals" />
-
-[^1]: <Render file="account-member-manage-limitation" product="fundamentals" />

--- a/src/content/partials/fundamentals/resend-member-invitation.mdx
+++ b/src/content/partials/fundamentals/resend-member-invitation.mdx
@@ -1,11 +1,15 @@
 ---
 {}
-
 ---
+
+import { Render } from "~/components";
 
 If you invited a member to your account but they cannot find the invitation or the invitation expires, you can resend the invitation through the Cloudflare dashboard:
 
-1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account\[^1].
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account[^1].
 2. Go to **Manage Account** > **Members**.
 3. Select a member record where their **Status** is **Invite Pending**.
 4. Select **Resend invite**.
+
+{/* prettier-ignore */}
+[^1]: <Render file="account-member-manage-limitation" product="fundamentals" />


### PR DESCRIPTION
### Summary

A couple of `Render` components are missing the right `product` attributes. This adds them in.