### PR TITLE
R2 event notifications can be used with jurisdictions

### DIFF
--- a/src/content/docs/r2/buckets/event-notifications.mdx
+++ b/src/content/docs/r2/buckets/event-notifications.mdx
@@ -231,5 +231,4 @@ Queue consumers receive notifications as [Messages](/queues/configuration/javasc
 
 ## Notes
 
-- Event notifications are not available for buckets with [jurisdictional restrictions](/r2/reference/data-location/#jurisdictional-restrictions) (_coming soon_).
 - Queues [per-queue message throughput](/queues/platform/limits/) is currently 5,000 messages per second. If your workload produces more than 5,000 notifications per second, we recommend splitting notification rules across multiple queues.


### PR DESCRIPTION
### Summary

Removes the note saying that R2 event notifications are not allowed in buckets with jurisdiction restrictions.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
