### PR TITLE
R2 data location remove event notification limitation

### DIFF
--- a/src/content/docs/r2/reference/data-location.mdx
+++ b/src/content/docs/r2/reference/data-location.mdx
@@ -146,7 +146,6 @@ During the beta, the following services will not interact with R2 resources with
 
 * [Super Slurper](/r2/data-migration/)
 * [Logpush](/logs/get-started/enable-destinations/r2/)
-* [Event Notifications](/r2/buckets/event-notifications/)
 
 ### Additional considerations
 


### PR DESCRIPTION
### Summary

Removes the limitation on event notifications in the R2 data location section.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
