### PR TITLE
Clarify O2O no longer being ENT-only

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -4,7 +4,7 @@ title: Shopify
 head:
   - tag: title
     content: Shopify | Provider guides
-description: Learn how to configure your Enterprise zone with Shopify.
+description: Learn how to configure your zone with Shopify.
 
 ---
 


### PR DESCRIPTION
### Summary

Removed the word `Enterprise` from the Shopify SaaS page's description to clarify that O2O is no longer just for enterprise zones
<!-- Add context such as the type of documentation being updated or added -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
