### PR TITLE
Add missing link to reference architecture diagram

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/storage/event-notifications-for-storage.mdx
+++ b/src/content/docs/reference-architecture/diagrams/storage/event-notifications-for-storage.mdx
@@ -21,7 +21,7 @@ Event notifications function by sending messages to a [queue](/queues/) whenever
 
 For instance, you can configure a notification to trigger when new images are uploaded to your R2 bucket. This notification can then automatically start an AI workload that performs an action on the image, such as converting the image to text.
 
-Consider the example below of push-based post-processing: when a user uploads a new object into R2, we want to log and store that event into a separate R2 bucket. You can create this scenario yourself by following this tutorial: Log and store upload events in R2 with event notifications.
+Consider the example below of push-based post-processing: when a user uploads a new object into R2, we want to log and store that event into a separate R2 bucket. You can create this scenario yourself by following this tutorial: [Log and store upload events in R2 with event notifications](/r2/tutorials/upload-logs-event-notifications/).
 
 ![Figure 1: Push-Based R2 Event Notifications](~/assets/images/reference-architecture/event-notifications-for-storage/pushed-based-event-notification.svg "Figure 1: Push-Based R2 Event Notifications")
 


### PR DESCRIPTION
### Summary

Add a missing link to the event notifications reference architecture diagram. 

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
