### PR TITLE
[LP/ZT] Create 'First network policy' page

### DIFF
--- a/src/content/docs/cloudflare-one/policies/gateway/network-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/network-policies/common-policies.mdx
@@ -6,10 +6,9 @@ sidebar:
 head:
   - tag: title
     content: Common network policies
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 The following policies are commonly used to secure network traffic.
 
@@ -23,12 +22,7 @@ Refer to the [network policies page](/cloudflare-one/policies/gateway/network-po
 
 Require devices to have certain software installed or other configuration attributes. For instructions on enabling a device posture check, refer to the [device posture section](/cloudflare-one/identity/devices/).
 
-In the following example, users can only access an application if they connect from a company device.
-
-| Selector                     | Operator | Value                   | Logic | Action |
-| ---------------------------- | -------- | ----------------------- | ----- | ------ |
-| Passed Device Posture Checks | not in   | `Device serial numbers` | And   | Block  |
-| SNI Domain                   | is       | `internalapp.com`       |       |        |
+<Render file="gateway/policies/enforce-device-posture" />
 
 ## Enforce session duration
 

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-dns-policies/create-policy.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-dns-policies/create-policy.mdx
@@ -9,25 +9,19 @@ import { Render } from "~/components";
 
 DNS policies determine how Gateway should handle a DNS request. When a user sends a DNS request, Gateway matches the request against your filters and either allows the query to resolve, blocks the query, or responds to the query with a different IP.
 
-You can filter DNS traffic based on query or response parameters (such as domain, source IP, or geolocation). You can also filter by user identity if you connect your devices to Gateway with the [WARP client or Cloudflare One Agent](/learning-paths/secure-internet-traffic/connect-devices/install-agent/). To learn more, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).
+You can filter DNS traffic based on query or response parameters (such as domain, source IP, or geolocation). You can also filter by user identity if you connect your devices to Gateway with the [WARP client or Cloudflare One Agent](/learning-paths/secure-internet-traffic/connect-devices/install-agent/).
 
 To create a new DNS policy:
 
 1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Gateway** > **Firewall policies**.
-
 2. In the **DNS** tab, select **Add a policy**.
-
 3. Name the policy.
-
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block.
-
 5. Choose an **Action** to take when traffic matches the logical expression. For example, we recommend adding a policy to block all [security categories](/cloudflare-one/policies/gateway/domain-categories/#security-categories):
-
    <Render
    	file="gateway/policies/block-security-categories"
    	product="cloudflare-one"
    />
-
 6. Select **Create policy**.
 
 For more information, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
@@ -7,9 +7,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-DNS policies determine how Gateway should handle a DNS request. When a user sends a DNS request, Gateway matches the request against your filters and either allows the query to resolve, blocks the query, or responds to the query with a different IP.
-
-You can filter DNS traffic based on query or response parameters (such as domain, source IP, or geolocation). You can also filter by user identity if you connect your devices to Gateway with the [WARP client or Cloudflare One Agent](/learning-paths/secure-internet-traffic/connect-devices/install-agent/). To learn more, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).
+You can control network-level traffic by filtering requests by selectors such as IP addresses and ports. You can also integrate network policies with an [identity provider](/cloudflare-one/identity/idp-integration/) to apply identity-based filtering.
 
 To create a new network policy:
 

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
@@ -1,0 +1,33 @@
+---
+title: Create your first DNS policy
+pcx_content_type: learning-unit
+sidebar:
+  order: 1
+---
+
+import { Render } from "~/components";
+
+DNS policies determine how Gateway should handle a DNS request. When a user sends a DNS request, Gateway matches the request against your filters and either allows the query to resolve, blocks the query, or responds to the query with a different IP.
+
+You can filter DNS traffic based on query or response parameters (such as domain, source IP, or geolocation). You can also filter by user identity if you connect your devices to Gateway with the [WARP client or Cloudflare One Agent](/learning-paths/secure-internet-traffic/connect-devices/install-agent/). To learn more, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).
+
+To create a new network policy:
+
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Gateway** > **Firewall policies**.
+
+2. In the **Network** tab, select **Add a policy**.
+
+3. Name the policy.
+
+4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block.
+
+5. Choose an **Action** to take when traffic matches the logical expression. For example, we recommend adding a policy to block all [security categories](/cloudflare-one/policies/gateway/domain-categories/#security-categories):
+
+   <Render
+   	file="gateway/policies/block-security-categories"
+   	product="cloudflare-one"
+   />
+
+6. Select **Create policy**.
+
+For more information, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/create-policy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create your first DNS policy
+title: Create your first network policy
 pcx_content_type: learning-unit
 sidebar:
   order: 1
@@ -14,20 +14,14 @@ You can filter DNS traffic based on query or response parameters (such as domain
 To create a new network policy:
 
 1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Gateway** > **Firewall policies**.
-
 2. In the **Network** tab, select **Add a policy**.
-
 3. Name the policy.
-
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block.
-
-5. Choose an **Action** to take when traffic matches the logical expression. For example, we recommend adding a policy to block all [security categories](/cloudflare-one/policies/gateway/domain-categories/#security-categories):
-
+5. Choose an **Action** to take when traffic matches the logical expression.
    <Render
-   	file="gateway/policies/block-security-categories"
+   	file="gateway/policies/enforce-device-posture"
    	product="cloudflare-one"
    />
-
 6. Select **Create policy**.
 
-For more information, refer to [DNS policies](/cloudflare-one/policies/gateway/dns-policies/).
+For more information, refer to [network policies](/cloudflare-one/policies/gateway/network-policies/).

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/index.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/index.mdx
@@ -3,7 +3,6 @@ title: Build network security policies
 pcx_content_type: overview
 sidebar:
   order: 8
-
 ---
 
 After creating policies for security based on DNS resolution, we can layer in additional security controls with the Gateway network firewall, which operates at Layer 4 of the OSI model. The Gateway network firewall allows you to build specific policies to block users or services' ability to connect to endpoints at specific IPs or on specific ports. You can also use [Protocol Detection](https://developers.cloudflare.com/cloudflare-one/policies/gateway/network-policies/protocol-detection/) to block proxying specific protocols.
@@ -12,4 +11,5 @@ After creating policies for security based on DNS resolution, we can layer in ad
 
 By the end of this module, you will be able to:
 
-* Add recommended network security policies.
+- Creat your first Gateway network policy.
+- Add recommended network security policies.

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/recommended-network-policies.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-network-policies/recommended-network-policies.mdx
@@ -2,7 +2,7 @@
 title: Recommended network policies
 pcx_content_type: learning-unit
 sidebar:
-  order: 1
+  order: 2
 ---
 
 import { Details, GlossaryTooltip, Render } from "~/components";

--- a/src/content/partials/cloudflare-one/gateway/policies/enforce-device-posture.mdx
+++ b/src/content/partials/cloudflare-one/gateway/policies/enforce-device-posture.mdx
@@ -2,7 +2,7 @@
 {}
 ---
 
-In the following example, users can only access an application if they connect from a company device:
+In the following example, you can use a list of [device serial numbers](/cloudflare-one/identity/devices/warp-client-checks/corp-device/) to ensure users can only access an application if they connect with the WARP client from a company device:
 
 | Selector                     | Operator | Value                   | Logic | Action |
 | ---------------------------- | -------- | ----------------------- | ----- | ------ |

--- a/src/content/partials/cloudflare-one/gateway/policies/enforce-device-posture.mdx
+++ b/src/content/partials/cloudflare-one/gateway/policies/enforce-device-posture.mdx
@@ -1,0 +1,10 @@
+---
+{}
+---
+
+In the following example, users can only access an application if they connect from a company device:
+
+| Selector                     | Operator | Value                   | Logic | Action |
+| ---------------------------- | -------- | ----------------------- | ----- | ------ |
+| Passed Device Posture Checks | not in   | _Device serial numbers_ | And   | Block  |
+| SNI Domain                   | is       | `internalapp.com`       |       |        |


### PR DESCRIPTION
Add 'Create your first network policy' page in Secure your Internet Traffic implementation guide to reach parity with DNS and HTTP policies.

PCX-14344