### PR TITLE
[Vectorize] Update v2 limits for GA

### DIFF
--- a/src/content/docs/vectorize/platform/limits.mdx
+++ b/src/content/docs/vectorize/platform/limits.mdx
@@ -7,22 +7,22 @@ sidebar:
 
 The following limits apply to accounts, indexes and vectors (as specified):
 
-| Feature                                                       | Current Limit                                                    |
-| ------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Indexes per account                                           | 100 indexes                                                      |
-| Maximum dimensions per vector                                 | 1536 dimensions                                                  |
-| Maximum vector ID length                                      | 64 bytes                                                         |
-| Metadata per vector                                           | 10KiB                                                            |
-| Maximum returned results (`topK`) with values or metadata     | 20                                                               |
-| Maximum returned results (`topK`) without values and metadata | 100                                                              |
-| Maximum upsert batch size (per batch)                         | 1000 (Workers) / 5000 (HTTP API)                                 |
-| Maximum index name length                                     | 64 bytes                                                         |
-| Maximum vectors per index                                     | 5,000,000                                                        |
-| Maximum namespaces per index                                  | 1000 namespaces                                                  |
-| Maximum namespace name length                                 | 64 bytes                                                         |
-| Maximum vectors upload size                                   | 100 MB                                                           |
-| Maximum metadata indexes per Vectorize index                  | 10                                                               |
-| Maximum indexed data per metadata index per vector            | 64 bytes                                                         |
+| Feature                                                       | Current Limit                       |
+| ------------------------------------------------------------- | ----------------------------------- |
+| Indexes per account                                           | 50,000 (Workers Paid) / 100 (Free)  |
+| Maximum dimensions per vector                                 | 1536 dimensions                     |
+| Maximum vector ID length                                      | 64 bytes                            |
+| Metadata per vector                                           | 10KiB                               |
+| Maximum returned results (`topK`) with values or metadata     | 20                                  |
+| Maximum returned results (`topK`) without values and metadata | 100                                 |
+| Maximum upsert batch size (per batch)                         | 1000 (Workers) / 5000 (HTTP API)    |
+| Maximum index name length                                     | 64 bytes                            |
+| Maximum vectors per index                                     | 5,000,000                           |
+| Maximum namespaces per index                                  | 50,000 (Workers Paid) / 1000 (Free) |
+| Maximum namespace name length                                 | 64 bytes                            |
+| Maximum vectors upload size                                   | 100 MB                              |
+| Maximum metadata indexes per Vectorize index                  | 10                                  |
+| Maximum indexed data per metadata index per vector            | 64 bytes                            |
 
 ## Limits V1 (deprecated)
 


### PR DESCRIPTION
Increased Vectorize v2 limits after GA: 
| Feature                                                       | Current Limit                       |
| ------------------------------------------------------------- | ----------------------------------- |
| Indexes per account                                           | 50,000 (Workers Paid) / 100 (Free)  |
| Maximum namespaces per index                                  | 50,000 (Workers Paid) / 1000 (Free) |