### PR TITLE
workflows: remove script_name references

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -43,9 +43,6 @@ name = "workflows-tutorial"
 # be how you call (run) your Workflow from your other Workers handlers or
 # scripts.
 binding = "MY_WORKFLOW"
- # script_name is required during for the beta.
- # Must match the "name" of your Worker at the top of wrangler.toml
-script_name = "workflows-tutorial"
 # Must match the class defined in your code that extends the Workflow class
 class_name = "MyWorkflow"
 ```

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -120,9 +120,6 @@ name = "workflows-starter"
 binding = "MY_WORKFLOW"
 # this is class that extends the Workflow class in src/index.ts
 class_name = "MyWorkflow"
-# script_name is required during for the beta.
-# Must match the "name" of your Worker at the top of wrangler.toml
-script_name = "workflows-starter"
 ```
 
 ## Workflow

--- a/src/content/docs/workflows/get-started/cli-quick-start.mdx
+++ b/src/content/docs/workflows/get-started/cli-quick-start.mdx
@@ -180,9 +180,6 @@ name = "workflows-starter"
 binding = "MY_WORKFLOW"
 # this is class that extends the Workflow class in src/index.ts
 class_name = "MyWorkflow"
-# script_name is required during for the beta.
-# Must match the "name" of your Worker at the top of wrangler.toml
-script_name = "workflows-starter"
 ```
 
 You can then invoke the methods on this binding directly from your Worker script's `env` parameter. The `Workflow` type has methods for:

--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -198,9 +198,6 @@ name = "workflows-starter"
 binding = "MY_WORKFLOW"
 # this is class that extends the Workflow class in src/index.ts
 class_name = "MyWorkflow"
-# script_name is required during the beta.
-# Must match the "name" of your Worker at the top of wrangler.toml
-script_name = "workflows-starter"
 ```
 
 :::note


### PR DESCRIPTION
No longer a requirement.