### PR TITLE
[Docs Site] fix: update algolia index for Workflows to match other products

### DIFF
--- a/src/content/products/workflows.yaml
+++ b/src/content/products/workflows.yaml
@@ -9,7 +9,7 @@ product:
 meta:
   title: Cloudflare Workflows docs
   description: Build durable, multi-step applications using the Workers platform
-  author: '@cloudflare'
+  author: "@cloudflare"
 
 resources:
   community: https://community.cloudflare.com/c/developers/workers/40
@@ -28,6 +28,6 @@ externals:
     url: https://discord.cloudflare.com
 
 algolia:
-  index: developers-cloudflare2
+  index: TEST - Re-dev docs
   apikey: 4edb0a6cef3338ff4bcfbc6b3d2db56b
   product: workflows


### PR DESCRIPTION
### Summary

Fixes Workflows using the old `developers-cloudflare2` algolia index instead of the one used by other products, `TEST - Re-dev docs`. I'm not sure if this is the _only_ thing needed to make it show up in search, but it'll definitely help.

Every other product points at `index: TEST - Re-dev docs` for reference.