### PR TITLE
Fixes Typo in Workflows Quick Start Command

### DIFF
--- a/src/content/docs/workflows/get-started/cli-quick-start.mdx
+++ b/src/content/docs/workflows/get-started/cli-quick-start.mdx
@@ -39,7 +39,7 @@ Workflows are defined as part of a Worker script.
 To create a Workflow, use the `create cloudflare` (C3) CLI tool, specifying the Workflows starter template:
 
 ```sh
-npm create cloudflare@latest workflows-starter -- --template "cloudflare/workflows-starter"
+npm create cloudflare@latest workflows-starter --template "cloudflare/workflows-starter"
 ```
 
 This will create a new folder called `workflows-tutorial`, which contains two files:


### PR DESCRIPTION
### Summary

The command listed in the quick start guide for Workflows has an extra `--`.

```sh
npm create cloudflare@latest workflows-starter -- --template "cloudflare/workflows-starter"
```

This PR removes it.