### PR TITLE
Workflows: NonRetryableErrors Section Improvement

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -132,7 +132,7 @@ try {
 		// work not to be retried
         throw new NonRetryableError('oh no');
     });
-} catch {
+} catch(e as Error) {
     console.log('error was thrown');
 }
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -114,7 +114,9 @@ The Workflow instance itself will fail immediately, no further steps will be inv
 
 ## Catch Workflow errors
 
-Any uncaught exceptions that propagate to the top level, or any steps that reach their retry limit, will cause the Workflow to end execution in an Errored state. However, this may not be intended, as for example, a cleanup of previous step executions may be required.
+Any uncaught exceptions that propagate to the top level, or any steps that reach their retry limit, will cause the Workflow to end execution in an `Errored` state.
+
+If you want to avoid this, you can catch exceptions emitted by a `step`. This can be useful if you need to trigger clean-up tasks or have conditional logic that triggers additional steps.
 
 To allow the Workflow to continue its execution, surround the intended steps that are allowed to fail with a try/catch.
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -87,7 +87,7 @@ let someState = step.do("call an API", {
 }, async () => { /* Step code goes here /* }
 ```
 
-## Force a Workflow to fail
+## Force a Workflow Instance to fail
 
 You can also force a Workflow instance to fail and _not_ retry by throwing a `NonRetryableError` from within the step.
 
@@ -111,3 +111,5 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 ```
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
+
+Users can catch this error if they intend to continue the Workflow execution. Otherwise, the Workflow will fail.

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -112,4 +112,4 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
 
-Users can catch this error if they intend to continue the Workflow execution. Otherwise, the Workflow will fail.
+Like other Errors, any uncaught exceptions that propagate to the top level will cause the Workflow to end execution in an Errored state. Catch the `NonRetryableError` to continue Workflow execution.

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -120,7 +120,6 @@ If you want to avoid this, you can catch exceptions emitted by a `step`. This ca
 
 To allow the Workflow to continue its execution, surround the intended steps that are allowed to fail with a `try-catch` block.
 
-Simple example of a Worflow with a cleanup step:
 
 ```ts
 ...

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -133,7 +133,10 @@ try {
         throw new NonRetryableError('oh no');
     });
 } catch(e as Error) {
-    console.log('error was thrown');
+    console.log(`Step failed: ${e.message}`);
+    await step.do('clean up', async () => {
+      // Clean up code here
+    }
 }
 
 // the Workflow will not fail and will continue its execution

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -112,4 +112,22 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
 
-Like other Errors, any uncaught exceptions that propagate to the top level will cause the Workflow to end execution in an Errored state. Catch the `NonRetryableError` to continue Workflow execution.
+Like other Errors, any uncaught exceptions that propagate to the top level will cause the Workflow to end execution in an Errored state. Catch the `NonRetryableError` to continue Workflow execution:
+
+```ts
+...
+try {
+    await step.do('task', async () => {
+		// work not to be retried
+        throw new NonRetryableError('oh no');
+    });
+} catch {
+    console.log('error was thrown');
+}
+
+// the Workflow will not fail and can continue its execution
+
+await step.do(next task, async() => {
+	// more work to be done
+});
+```

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -112,7 +112,7 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
 
-## Avoid a Workflow instance to fail
+## Catch Workflow errors
 
 Any uncaught exceptions that propagate to the top level, or any steps that reach their retry limit, will cause the Workflow to end execution in an Errored state. However, this may not be intended, as for example, a cleanup of previous step executions may be required.
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -125,9 +125,10 @@ try {
     console.log('error was thrown');
 }
 
-// the Workflow will not fail and can continue its execution
+// the Workflow will not fail and will continue its execution
 
-await step.do(next task, async() => {
+await step.do('next-task', async() => {
 	// more work to be done
 });
+...
 ```

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -87,7 +87,7 @@ let someState = step.do("call an API", {
 }, async () => { /* Step code goes here /* }
 ```
 
-## Force a Workflow Instance to fail
+## Force a Workflow instance to fail
 
 You can also force a Workflow instance to fail and _not_ retry by throwing a `NonRetryableError` from within the step.
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -134,15 +134,15 @@ try {
     });
 } catch(e as Error) {
     console.log(`Step failed: ${e.message}`);
-    await step.do('clean up', async () => {
+    await step.do('clean-up-task', async () => {
       // Clean up code here
-    }
+    });
 }
 
 // the Workflow will not fail and will continue its execution
 
-await step.do('cleanup-task', async() => {
-	// cleanup work, revert execution from 'task' step
+await step.do('next-task', async() => {
+	// more work to be done
 });
 ...
 ```

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -118,7 +118,7 @@ Any uncaught exceptions that propagate to the top level, or any steps that reach
 
 If you want to avoid this, you can catch exceptions emitted by a `step`. This can be useful if you need to trigger clean-up tasks or have conditional logic that triggers additional steps.
 
-To allow the Workflow to continue its execution, surround the intended steps that are allowed to fail with a try/catch.
+To allow the Workflow to continue its execution, surround the intended steps that are allowed to fail with a `try-catch` block.
 
 Simple example of a Worflow with a cleanup step:
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -112,12 +112,22 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
 
-Like other Errors, any uncaught exceptions that propagate to the top level will cause the Workflow to end execution in an Errored state. Catch the `NonRetryableError` to continue Workflow execution:
+## Avoid a Workflow instance to fail
+
+Any uncaught exceptions that propagate to the top level, or any steps that reach their retry limit, will cause the Workflow to end execution in an Errored state. However, this may not be intended, as for example, a cleanup of previous step executions may be required.
+
+To allow the Workflow to continue its execution, surround the intended steps that are allowed to fail with a try/catch.
+
+Simple example of a Worflow with a cleanup step:
 
 ```ts
 ...
+await step.do('task', async () => {
+	// work to be done
+});
+
 try {
-    await step.do('task', async () => {
+    await step.do('non-retryable-task', async () => {
 		// work not to be retried
         throw new NonRetryableError('oh no');
     });
@@ -127,8 +137,8 @@ try {
 
 // the Workflow will not fail and will continue its execution
 
-await step.do('next-task', async() => {
-	// more work to be done
+await step.do('cleanup-task', async() => {
+	// cleanup work, revert execution from 'task' step
 });
 ...
 ```


### PR DESCRIPTION
### Summary

Reenforce that for NonRetryableErrors, users need to manage the error or the Workflow will fail
