### PR TITLE
PCX-14416 adding crosslinking between RAD and tutorial on BQ + Workers AI

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/ai/bigquery-workers-ai.mdx
+++ b/src/content/docs/reference-architecture/diagrams/ai/bigquery-workers-ai.mdx
@@ -53,6 +53,7 @@ For periodic or longer workflows, you may opt for a batch approach. This diagram
 
 ## Related resources
 
+- [Tutorial: Using BigQuery with Workers AI](/workers-ai/tutorials/using-bigquery-with-workers-ai/)
 - [Workers AI: Get Started](/workers-ai/get-started/workers-wrangler/)
 - [Workers: Secrets](/workers/configuration/secrets/)
 - [Workers: Cron Triggers](/workers/runtime-apis/handlers/scheduled/)

--- a/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
@@ -677,7 +677,7 @@ Once you obtained the results, you formatted them to later be passed to generati
 
 ## Next Steps
 
-If, instead of displaying the results of ingesting the data to the AI model in a browser, your workflow requires fetching and store data (for example in [R2](/r2/) or [D1](/d1/)) on regular intervals, you may want to consider adding a [scheduled handler](/workers/runtime-apis/handlers/scheduled/) for this Worker. It allows triggering the Worker with a predefined cadence via a [Cron Trigger](/workers/configuration/cron-triggers/). Please consider reviewing the Reference Architecture Diagrams on [Ingesting BigQuery Data into Workers AI](/reference-architecture/diagrams/ai/bigquery-workers-ai/).
+If, instead of displaying the results of ingesting the data to the AI model in a browser, your workflow requires fetching and store data (for example in [R2](/r2/) or [D1](/d1/)) on regular intervals, you may want to consider adding a [scheduled handler](/workers/runtime-apis/handlers/scheduled/) for this Worker. It allows triggering the Worker with a predefined cadence via a [Cron Trigger](/workers/configuration/cron-triggers/). Consider reviewing the Reference Architecture Diagrams on [Ingesting BigQuery Data into Workers AI](/reference-architecture/diagrams/ai/bigquery-workers-ai/).
 
 A use case to ingest data from other sources, like you did in this tutorial, is to create a RAG system. If this sounds relevant to you, please check out the tutorial [Build a Retrieval Augmented Generation (RAG) AI](/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai/).
 

--- a/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
@@ -677,7 +677,7 @@ Once you obtained the results, you formatted them to later be passed to generati
 
 ## Next Steps
 
-If, instead of displaying the results of ingesting the data to the AI model in a browser, your workflow requires fetching and store data (for example in [R2](/r2/) or [D1](/d1/)) on regular intervals, you may want to consider adding a [scheduled handler](/workers/runtime-apis/handlers/scheduled/) for this Worker. It allows triggering the Worker with a predefined cadence via a [Cron Trigger](/workers/configuration/cron-triggers/).
+If, instead of displaying the results of ingesting the data to the AI model in a browser, your workflow requires fetching and store data (for example in [R2](/r2/) or [D1](/d1/)) on regular intervals, you may want to consider adding a [scheduled handler](/workers/runtime-apis/handlers/scheduled/) for this Worker. It allows triggering the Worker with a predefined cadence via a [Cron Trigger](/workers/configuration/cron-triggers/). Please consider reviewing the Reference Architecture Diagrams on [Ingesting BigQuery Data into Workers AI](/reference-architecture/diagrams/ai/bigquery-workers-ai/).
 
 A use case to ingest data from other sources, like you did in this tutorial, is to create a RAG system. If this sounds relevant to you, please check out the tutorial [Build a Retrieval Augmented Generation (RAG) AI](/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai/).
 


### PR DESCRIPTION
### Summary

Adds crosslinking between RAD and tutorial on BQ + Workers AI (/reference-architecture/diagrams/ai/bigquery-workers-ai/)  to tutorial (/workers-ai/tutorials/using-bigquery-with-workers-ai/) and viceversa.
