### PR TITLE
Simplify verification in nodes with jose

### DIFF
--- a/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
+++ b/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
@@ -252,9 +252,7 @@ if __name__ == '__main__':
 
 ```javascript
 const express = require('express');
-const cookieParser = require('cookie-parser');
-const jwksClient = require('jwks-rsa');
-const jwt = require('jsonwebtoken');
+const jose = require('jose');
 
 // The Application Audience (AUD) tag for your application
 const AUD = process.env.POLICY_AUD;
@@ -263,44 +261,37 @@ const AUD = process.env.POLICY_AUD;
 const TEAM_DOMAIN = process.env.TEAM_DOMAIN;
 const CERTS_URL = `${TEAM_DOMAIN}/cdn-cgi/access/certs`;
 
-const client = jwksClient({
-  jwksUri: CERTS_URL
-});
-
-const getKey = (header, callback) => {
-  client.getSigningKey(header.kid, function(err, key) {
-    callback(err, key?.getPublicKey());
-  });
-}
+const JWKS = jose.createRemoteJWKSet(new URL(CERTS_URL));
 
 // verifyToken is a middleware to verify a CF authorization token
-const verifyToken = (req, res, next) => {
-  const token = req.cookies['CF_Authorization'];
+const verifyToken = async (req, res, next) => {
+  const token = req.headers['cf-access-jwt-assertion'];
 
   // Make sure that the incoming request has our token header
   if (!token) {
-    return res.status(403).send({ status: false, message: 'missing required cf authorization token' });
+    return res.status(403).send({
+      status: false,
+      message: 'missing required cf authorization token',
+    });
   }
 
-  jwt.verify(token, getKey, { audience: AUD }, (err, decoded) => {
-    if (err) {
-      return res.status(403).send({ status: false, message: 'invalid token' });
-    }
-
-    req.user = decoded;
-    next();
+  const result = await jose.jwtVerify(token, JWKS, {
+    issuer: TEAM_DOMAIN,
+    audience: AUD,
   });
-}
+
+  req.user = result.payload;
+  next();
+};
 
 const app = express();
 
-app.use(cookieParser());
 app.use(verifyToken);
 
 app.get('/', (req, res) => {
   res.send('Hello World!');
 });
 
-app.listen(3333)
+app.listen(3333);
 
 ```


### PR DESCRIPTION
This switches the verification from using `jsonwebtoken` and other libraries to using `Jose`. The verification step is simpler and the keys are automatically selected. Also removes the dependence on cookies. `jose` has [zero dependencies](https://github.com/panva/jose?tab=readme-ov-file#dependencies-0) and supports [CF Workers](https://github.com/panva/jose?tab=readme-ov-file#supported-runtimes).

### Summary

Updating the [Javascript example](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/#javascript-example) of the docs to validate JWT.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

