### PR TITLE
Update and simplify AI image inference pricing

### DIFF
--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -51,16 +51,12 @@ Standard models are large image models such as `@cf/stabilityai/stable-diffusion
 Fast models are usually smaller image models that require fewer steps to generate an image, such as `@cf/black-forest-labs/flux-1-schnell` and `@cf/bytedance/stable-diffusion-xl-lightning`
 We take the maximum of the image height and width to calculate pricing. For example, and image of 1024x768 would fall under 1024x1024 pricing.
 
-| Image Size   | Model Type | Price                 |
-| ------------ | ---------- | --------------------- |
-| \<=256x256   | Standard   | $0.00125 per 25 steps |
-| \<=256x256   | Fast       | $0.00025 per 5 steps  |
-| \<=512x512   | Standard   | $0.0025 per 25 steps  |
-| \<=512x512   | Fast       | $0.0005 per 5 steps   |
-| \<=1024x1024 | Standard   | $0.005 per 25 steps   |
-| \<=1024x1024 | Fast       | $0.001 per 5 steps    |
-| \<=2048x2048 | Standard   | $0.01 per 25 steps    |
-| \<=2048x2048 | Fast       | $0.002 per 5 steps    |
+| Image Size   | Price                 |
+| ------------ | --------------------- |
+| \<=256x256   | $0.00025 per 5 steps  |
+| \<=512x512   | $0.0005 per 5 steps   |
+| \<=1024x1024 | $0.001 per 5 steps    |
+| \<=2048x2048 | $0.002 per 5 steps    |
 
 ## Speech-to-text
 Speech-to-text models like `@cf/openai/whisper` are billed on minutes of audio input.


### PR DESCRIPTION
### Summary

Fast and Standard Image Generation models have the same per-step pricing, so we should simplify the docs.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
