### PR TITLE
[Hyperdrive] Update wrangler command documentation for hyperdrive

### DIFF
--- a/src/content/partials/workers/wrangler-commands/hyperdrive.mdx
+++ b/src/content/partials/workers/wrangler-commands/hyperdrive.mdx
@@ -16,22 +16,22 @@ wrangler hyperdrive create <CONFIG_NAME> [OPTIONS]
   - The name of the Hyperdrive configuration to create.
 - `--connection-string` <Type text="string" /> <MetaInfo text="optional" />
   - The database connection string in the form `postgres://user:password@hostname:port/database`.
-- `--host` <Type text="string" /> <MetaInfo text="optional" />
+- `--origin-host` <Type text="string" /> <MetaInfo text="optional" />
   - The hostname or IP address Hyperdrive should connect to.
-- `--port` <Type text="number" /> <MetaInfo text="optional" />
+- `--origin-port` <Type text="number" /> <MetaInfo text="optional" />
   - The database port to connect to.
-- `--scheme` <Type text="string" /> <MetaInfo text="optional" />
+- `--origin-scheme` <Type text="string" /> <MetaInfo text="optional" />
   - The scheme used to connect to the origin database, for example, postgresql or postgres.
 - `--database` <Type text="string" /> <MetaInfo text="optional" />
   - The database (name) to connect to. For example, Postgres or defaultdb.
-- `--user` <Type text="string" /> <MetaInfo text="optional" />
+- `--origin-user` <Type text="string" /> <MetaInfo text="optional" />
   - The username used to authenticate to the database.
-- `--password` <Type text="string" /> <MetaInfo text="optional" />
+- `--origin-password` <Type text="string" /> <MetaInfo text="optional" />
   - The password used to authenticate to the database.
 - `--access-client-id` <Type text="string" /> <MetaInfo text="optional" />
-  - The Client ID of the Access token to use when connecting to the origin database, must be set with a Client Access Secret. Mutually exclusive with `port`.
+  - The Client ID of the Access token to use when connecting to the origin database, must be set with a Client Access Secret. Mutually exclusive with `origin-port`.
 - `--access-client-secret` <Type text="string" /> <MetaInfo text="optional" />
-  - The Client Secret of the Access token to use when connecting to the origin database, must be set with a Client Access ID. Mutually exclusive with `port`.
+  - The Client Secret of the Access token to use when connecting to the origin database, must be set with a Client Access ID. Mutually exclusive with `origin-port`.
 - `--caching-disabled` <Type text="boolean" /> <MetaInfo text="optional" />
   - Disables the caching of SQL responses.
 - `--max-age` <Type text="number" /> <MetaInfo text="optional" />
@@ -51,10 +51,14 @@ wrangler hyperdrive update <ID> [OPTIONS]
   - The ID of the Hyperdrive configuration to update.
 - `--name` <Type text="string" /> <MetaInfo text="optional" />
   - The new name of the Hyperdrive configuration.
+- `--connection-string` <Type text="string" /> <MetaInfo text="optional" />
+  - The database connection string in the form `postgres://user:password@hostname:port/database`.
 - `--origin-host` <Type text="string" /> <MetaInfo text="optional" />
   - The new database hostname or IP address Hyperdrive should connect to.
 - `--origin-port` <Type text="string" /> <MetaInfo text="optional" />
   - The new database port to connect to.
+- `--origin-scheme` <Type text="string" /> <MetaInfo text="optional" />
+  - The scheme used to connect to the origin database, for example, postgresql or postgres.
 - `--database` <Type text="string" /> <MetaInfo text="optional" />
   - The new database (name) to connect to. For example, Postgres or defaultdb.
 - `--origin-user` <Type text="string" /> <MetaInfo text="optional" />


### PR DESCRIPTION
### Summary

The `wrangler hyperdrive create` command had support for individual parameters added with different names then `wrangler hyperdrive update` -- the correct names were added as the primary names for the parameters, with the original names as aliases for backwards compatibility.

The `wrangler hyperdrive update` command can now be passed a connection string.
