### PR TITLE
Fix typo in system-environment-variables.mdx

### DIFF
--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -26,7 +26,7 @@ Wrangler supports the following environment variables:
 
   * The [account ID](/fundamentals/setup/find-account-and-zone-ids/) for the Workers related account.
 
-* `CLOUDFLARE_API_TOKEN` <`Type text="string" /> <MetaInfo text="optional" />
+* `CLOUDFLARE_API_TOKEN` <Type text="string" /> <MetaInfo text="optional" />
 
   * The [API token](/fundamentals/api/get-started/create-token/) for your Cloudflare account, can be used for authentication for situations like CI/CD, and other automation.
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -26,7 +26,7 @@ Wrangler supports the following environment variables:
 
   * The [account ID](/fundamentals/setup/find-account-and-zone-ids/) for the Workers related account.
 
-* `CLOUDFLARE_API_TOKEN` `Type text="string" /> <MetaInfo text="optional" />
+* `CLOUDFLARE_API_TOKEN` <`Type text="string" /> <MetaInfo text="optional" />
 
   * The [API token](/fundamentals/api/get-started/create-token/) for your Cloudflare account, can be used for authentication for situations like CI/CD, and other automation.
 


### PR DESCRIPTION
### Summary

My change fixes a typo (missing `<` at the beginning of a `Type` element) on the https://developers.cloudflare.com/workers/wrangler/system-environment-variables page.

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/d66420e9-36ea-4bb7-9639-26824ef18927)
_The typo is underlined in red_.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
