### PR TITLE
Workflows: Added pause and resume commands to manage Workflows and removed the delete command

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1360,7 +1360,7 @@ wrangler workflows describe <WORKFLOW_NAME> [OPTIONS]
 
 Trigger (create) a Workflow instance.
 ```sh
-wrangler workflows describe <WORKFLOW_NAME> <PARAMS> [OPTIONS]
+wrangler workflows trigger <WORKFLOW_NAME> <PARAMS> [OPTIONS]
 ```
 
 - `WORKFLOW_NAME` <Type text="string" /> <MetaInfo text="required" />
@@ -1370,7 +1370,7 @@ wrangler workflows describe <WORKFLOW_NAME> <PARAMS> [OPTIONS]
 
  ```sh
  # Pass optional params to the Workflow.
- wrangler workflows instances trigger my-workflow '{"hello":"world"}'
+ wrangler workflows trigger my-workflow '{"hello":"world"}'
  ```
 
 ### `delete`
@@ -1383,6 +1383,10 @@ wrangler workflows delete <WORKFLOW_NAME> [OPTIONS]
 
 - `WORKFLOW_NAME` <Type text="string" /> <MetaInfo text="required" />
   - The name of a registered Workflow.
+
+:::caution
+This command is not yet implemented.
+:::
 
 ## `tail`
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1373,6 +1373,8 @@ wrangler workflows trigger <WORKFLOW_NAME> <PARAMS> [OPTIONS]
  wrangler workflows trigger my-workflow '{"hello":"world"}'
  ```
 
+{/*
+
 ### `delete`
 
 Delete (unregister) a Workflow.
@@ -1384,9 +1386,7 @@ wrangler workflows delete <WORKFLOW_NAME> [OPTIONS]
 - `WORKFLOW_NAME` <Type text="string" /> <MetaInfo text="required" />
   - The name of a registered Workflow.
 
-:::caution
-This command is not yet implemented.
-:::
+*/}
 
 ## `tail`
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1321,7 +1321,6 @@ wrangler workflows instances terminate <WORKFLOW_NAME> <ID> [OPTIONS]
 - `ID` <Type text="string" /> <MetaInfo text="required" />
   - The ID of a Workflow instance.
 
-{/*
 ### `instances pause`
 
 Pause (until resumed) a Workflow instance.
@@ -1347,8 +1346,6 @@ wrangler workflows instances resume <WORKFLOW_NAME> <ID> [OPTIONS]
   - The name of a registered Workflow.
 - `ID` <Type text="string" /> <MetaInfo text="required" />
   - The ID of a Workflow instance.
-
-*/}
 
 ### `describe`
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -70,7 +70,7 @@ const defaultConfig: WorkflowStepConfig = {
 When providing your own `StepConfig`, you can configure:
 
 * The total number of attempts to make for a step
-* The delay between attempts (accepts both number (ms) or a human-readable format)
+* The delay between attempts (accepts both `number` (ms) or a human-readable format)
 * What backoff algorithm to apply between each attempt: any of `constant`, `linear`, or `exponential`
 * When to timeout (in duration) before considering the step as failed (including during a retry attempt)
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -70,7 +70,7 @@ const defaultConfig: WorkflowStepConfig = {
 When providing your own `StepConfig`, you can configure:
 
 * The total number of attempts to make for a step
-* The delay between attempts
+* The delay between attempts (accepts both number (ms) or a human-readable format)
 * What backoff algorithm to apply between each attempt: any of `constant`, `linear`, or `exponential`
 * When to timeout (in duration) before considering the step as failed (including during a retry attempt)
 

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -62,20 +62,20 @@ interface Env {
 
 export default {
 	async fetch(req: Request, env: Env) {
-        //
-        const instanceId = new URL(req.url).searchParams.get("instanceId")
+    // Get instanceId from query parameters
+    const instanceId = new URL(req.url).searchParams.get("instanceId")
 
-        // If an ?instanceId=<id> query parameter is provided, fetch the status
-        // of an existing Workflow by its ID.
-        if (instanceId) {
-            let instance = await env.MY_WORKFLOW.get(instanceId);
+    // If an ?instanceId=<id> query parameter is provided, fetch the status
+    // of an existing Workflow by its ID.
+    if (instanceId) {
+      let instance = await env.MY_WORKFLOW.get(instanceId);
 			return Response.json({
 				status: await instance.status(),
 			});
-        }
+    }
 
-        // Else, create a new instance of our Workflow, passing in any (optional) params
-        // and return the ID.
+    // Else, create a new instance of our Workflow, passing in any (optional)
+    // params and return the ID.
 		const newId = await crypto.randomUUID();
 		let instance = await env.MY_WORKFLOW.create({ id: newId });
 		return Response.json({

--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -507,6 +507,8 @@ curl -s https://workflows-starter.YOUR_WORKERS_SUBDOMAIN.workers.dev/
 {"id":"16ac31e5-db9d-48ae-a58f-95b95422d0fa","details":{"status":"queued","error":null,"output":null}}
 ```
 
+{/*
+
 ## 7. (Optional) Clean up
 
 You can optionally delete the Workflow, which will prevent the creation of any (all) instances by using `wrangler`:
@@ -516,6 +518,8 @@ npx wrangler workflows delete my-workflow
 ```
 
 Re-deploying the Workers script containing your Workflow code will re-create the Workflow.
+
+*/}
 
 ---
 


### PR DESCRIPTION
### Summary

Added pause and resume commands to manage Workflows. Also commented out the delete command, as it is not yet implemented in our API.

Finally, took the chance to fix some indentation issues on a script file.

Related Wrangler PR:
https://github.com/cloudflare/workers-sdk/pull/7121