### PR TITLE
[Docs Site] Support individual pages in ProductChangelog component

### DIFF
--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -97,7 +97,7 @@ if (!changelogs) {
 						</div>
 					);
 				} else {
-					description = marked.parse(entry.description);
+					description = marked.parse(entry.description as string);
 					return (
 						<AnchorHeading depth={2} title={date} />
 						<div data-product={entry.product.toLowerCase()}>

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -85,7 +85,7 @@ if (!changelogs) {
 					return (
 						<div data-product={entry.product.toLowerCase()}>
 							<a href={entry.individual_page} class="no-underline">
-								<strong>{page.data.title}</strong>
+								<AnchorHeading depth={2} title={page.data.title} />
 							</a>
 							<p class="text-xs">{entry.date}</p>
 							{page.data.changelog_product_area_name && (

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -3,6 +3,7 @@ import { getEntry, type CollectionEntry } from "astro:content";
 import { marked } from "marked";
 import { getChangelogs } from "~/util/changelogs";
 import AnchorHeading from "~/components/AnchorHeading.astro";
+import { entryToString } from "~/util/container";
 
 const page = await getEntry("docs", Astro.params.slug!);
 
@@ -62,18 +63,55 @@ if (!changelogs) {
 {
 	changelogs.map(([date, entries]) => (
 		<div data-date={date}>
-			<AnchorHeading depth={2} title={date} />
-			{(entries ?? []).map((entry) => (
-				<div data-product={entry.product.toLowerCase()}>
-					{page.data.changelog_product_area_name && (
-						<h3 class="!mt-4">
-							<a href={entry.productLink}>{entry.product}</a>
-						</h3>
-					)}
-					{entry.title && <strong>{entry.title}</strong>}
-					<Fragment set:html={marked.parse(entry.description ?? "")} />
-				</div>
-			))}
+			{(entries ?? []).map(async (entry) => {
+				let description;
+				if (entry.individual_page) {
+					const link = entry.individual_page;
+
+					if (!link)
+						throw new Error(
+							`Changelog entry points to individual page but no link is provided`,
+						);
+
+					const page = await getEntry("docs", link.slice(1, -1));
+
+					if (!page)
+						throw new Error(
+							`Changelog entry points to ${link.slice(1, -1)} but unable to find entry with that slug`,
+						);
+
+					description = (await entryToString(page)) ?? page.body;
+
+					return (
+						<div data-product={entry.product.toLowerCase()}>
+							<a href={entry.individual_page} class="no-underline">
+								<strong>{page.data.title}</strong>
+							</a>
+							<p class="text-xs">{entry.date}</p>
+							{page.data.changelog_product_area_name && (
+								<h3 class="!mt-4">
+									<a href={entry.productLink}>{entry.product}</a>
+								</h3>
+							)}
+							{<Fragment set:html={description} />}
+						</div>
+					);
+				} else {
+					description = marked.parse(entry.description);
+					return (
+						<AnchorHeading depth={2} title={date} />
+						<div data-product={entry.product.toLowerCase()}>
+							{page.data.changelog_product_area_name && (
+								<h3 class="!mt-4">
+									<a href={entry.productLink}>{entry.product}</a>
+								</h3>
+							)}
+							{entry.title && <strong>{entry.title}</strong>}
+							{<Fragment set:html={description} />}
+						</div>
+					);
+				}
+			})}
 		</div>
 	))
 }

--- a/src/content/changelogs/workers.yaml
+++ b/src/content/changelogs/workers.yaml
@@ -11,7 +11,7 @@ entries:
   - publish_date: "2024-09-19"
     description: |-
       -  Revamped Workers and Pages UI settings to simplify the creation and management of project configurations. For bugs and general feedback, please submit this [form](https://forms.gle/XXqhRGbZmuzninuN9).
-  - publish_date: '2024-09-16'
+  - publish_date: "2024-09-16"
     description: |-
       - Updated v8 to version 12.9.
   - publish_date: "2024-08-19"

--- a/src/schemas/changelogs.ts
+++ b/src/schemas/changelogs.ts
@@ -10,20 +10,11 @@ export const changelogsSchema = z.object({
 		.object({
 			publish_date: z.string(),
 			title: z.string().optional(),
+			description: z.string().optional(),
+			individual_page: z.boolean().optional(),
+			link: z.string().optional(),
 			scheduled: z.boolean().optional(),
 			scheduled_date: z.string().optional(),
 		})
-		.and(
-			z
-				.object({
-					individual_page: z.boolean(),
-					link: z.string(),
-				})
-				.or(
-					z.object({
-						description: z.string(),
-					}),
-				),
-		)
 		.array(),
 });

--- a/src/schemas/changelogs.ts
+++ b/src/schemas/changelogs.ts
@@ -10,11 +10,20 @@ export const changelogsSchema = z.object({
 		.object({
 			publish_date: z.string(),
 			title: z.string().optional(),
-			description: z.string().optional(),
-			individual_page: z.boolean().optional(),
-			link: z.string().optional(),
 			scheduled: z.boolean().optional(),
 			scheduled_date: z.string().optional(),
 		})
+		.and(
+			z
+				.object({
+					individual_page: z.boolean(),
+					link: z.string(),
+				})
+				.or(
+					z.object({
+						description: z.string(),
+					}),
+				),
+		)
 		.array(),
 });

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -39,6 +39,7 @@ export async function getChangelogs(opts?: {
 				productLink: product.data.productLink,
 				productAreaName: product.data.productArea,
 				productAreaLink: product.data.productAreaLink,
+				individual_page: entry.link,
 			};
 		});
 	});

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -39,7 +39,7 @@ export async function getChangelogs(opts?: {
 				productLink: product.data.productLink,
 				productAreaName: product.data.productArea,
 				productAreaLink: product.data.productAreaLink,
-				individual_page: entry.link,
+				individual_page: entry.individual_page && entry.link,
 			};
 		});
 	});


### PR DESCRIPTION
### Summary

Supports individual_page usage in the ProductChangelog component.

### Screenshots (optional)

```yaml
entries:
  - publish_date: "2024-10-29"
    individual_page: true
    link: "/workers/demos/"
```

![image](https://github.com/user-attachments/assets/28ca80bf-1187-4232-bb5e-f2d6afa2dac7)