### PR TITLE
Adding information to format of caPool option

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/configure-tunnels/origin-configuration.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/configure-tunnels/origin-configuration.mdx
@@ -26,6 +26,8 @@ Hostname that `cloudflared` should expect from your origin server certificate. I
 
 Path to the certificate authority (CA) for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
 
+*Format:* The CA Pool option typically expects a path to a certificate store file or a bundle file in .pem or .crt format. This file should contain one or more trusted root CA certificates. It’s usually not a URL; rather, it’s a local file path where your trusted certificates are stored.
+
 ### noTLSVerify
 
 | Default | UI name       |

--- a/src/content/docs/cloudflare-one/connections/connect-networks/configure-tunnels/origin-configuration.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/configure-tunnels/origin-configuration.mdx
@@ -24,9 +24,7 @@ Hostname that `cloudflared` should expect from your origin server certificate. I
 | ------- | -------------------------- |
 | `""`    | Certificate Authority Pool |
 
-Path to the certificate authority (CA) for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
-
-*Format:* The CA Pool option typically expects a path to a certificate store file or a bundle file in .pem or .crt format. This file should contain one or more trusted root CA certificates. It’s usually not a URL; rather, it’s a local file path where your trusted certificates are stored.
+Local file path to the certificate authority (CA) for your origin server certificate (for example, `/root/certs/ca.pem`). The path should point to a certificate store file or a bundle file in `.pem` or `.crt` format that contains one or more trusted root CA certificates. You should only configure this setting if your certificate is not signed by Cloudflare.
 
 ### noTLSVerify
 


### PR DESCRIPTION
The current information for the caPool option is a bit vauge on what to actually enter here.

Added information provided by another CF Employee to the doc.

### Summary

Added this line "*Format:* The CA Pool option typically expects a path to a certificate store file or a bundle file in .pem or .crt format. This file should contain one or more trusted root CA certificates. It’s usually not a URL; rather, it’s a local file path where your trusted certificates are stored."

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
