### PR TITLE
[Wrangler] Removed duplicate line in D1 Bindings section

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -433,8 +433,6 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
   - The preview ID of this D1 database. If provided, `wrangler dev` will use this ID. Otherwise, it will use `database_id`. This option is required when using `wrangler dev --remote`.
 
-  - The ID of the database. The database ID is available when you first use `wrangler d1 create` or when you call `wrangler d1 list`, and uniquely identifies your database.
-
 - `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
 
   - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files. For more information, refer to [D1 Wrangler `migrations` commands](/workers/wrangler/commands/#migrations-create) and [D1 migrations](/d1/reference/migrations/).

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -431,7 +431,7 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
 
 - `preview_database_id` <Type text="string" /> <MetaInfo text="optional" />
 
-  - The preview ID of this D1 database. If provided, `wrangler dev` will use this ID. Otherwise, it will use `database_id`. This option is required when using `wrangler dev --remote`.
+  - The preview ID of this D1 database. If provided, `wrangler dev` uses this ID. Otherwise, it uses `database_id`. This option is required when using `wrangler dev --remote`.
 
 - `migrations_dir` <Type text="string" /> <MetaInfo text="optional" />
 


### PR DESCRIPTION
### Summary

Looks like a line from `database_id` was mistakenly kept in `preview_database_id` too:
https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases

### Screenshots

![image](https://github.com/user-attachments/assets/9ca09628-8931-4b71-ab67-3ff64291e971)
