### PR TITLE
fix incorrect `response` identifier used in text-to-image code snippet

### DIFF
--- a/src/components/models/code/TextToImageCode.astro
+++ b/src/components/models/code/TextToImageCode.astro
@@ -28,7 +28,7 @@ export default {
       inputs
     );
 
-    return new Response(response, {
+    return new Response(stream, {
       headers: {
         "content-type": "image/jpg",
       },


### PR DESCRIPTION
### Summary

In the [Stable diffusion code snippet](https://developers.cloudflare.com/workers-ai/models/stable-diffusion-xl-base-1.0) the result of `AI.run` is assigned to a variable called `steam`, however the next line incorrectly uses `response` instead of `stream` (there is no `response` variable anywhere in the code snippet):
![Screenshot 2024-10-31 at 00 48 08](https://github.com/user-attachments/assets/9262a18c-1b1b-4b3f-a9cf-5f69de18eeae)

This PR is addressing this by using the correct `stream` variable name.