### PR TITLE
Update local-development.mdx for Vectorize support

### DIFF
--- a/src/content/docs/workers/testing/local-development.mdx
+++ b/src/content/docs/workers/testing/local-development.mdx
@@ -53,7 +53,7 @@ With any bindings that are not supported locally, you will need to use the `--re
 
 [^1]: Using Workers AI always accesses your Cloudflare account in order to run AI models and will incur usage charges even in local development.
 
-[^2]: Using Vectorize always accesses your Cloudflare account in order to run queries and will incur usage charges even in local development.
+[^2]: Using Vectorize always accesses your Cloudflare account to run queries, and will incur usage charges even in local development.
 
 ## Work with local data
 

--- a/src/content/docs/workers/testing/local-development.mdx
+++ b/src/content/docs/workers/testing/local-development.mdx
@@ -47,11 +47,13 @@ npx wrangler dev
 | R2                                  | ✅                  | ✅                   |
 | Rate Limiting                       | ✅                  | ✅                   |
 | Service Bindings (multiple workers) | ✅                  | ✅                   |
-| Vectorize                           | ❌                  | ✅                   |
+| Vectorize                           | ✅[^2]              | ✅                   |
 
 With any bindings that are not supported locally, you will need to use the `--remote` command in wrangler, such as `wrangler dev --remote`.
 
 [^1]: Using Workers AI always accesses your Cloudflare account in order to run AI models and will incur usage charges even in local development.
+
+[^2]: Using Vectorize always accesses your Cloudflare account in order to run queries and will incur usage charges even in local development.
 
 ## Work with local data
 


### PR DESCRIPTION
Local development support for Vectorize seems to have been added as part of the most recent Wrangler update https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%403.84.0