### PR TITLE
Update deploy-an-angular-site.mdx

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -58,11 +58,8 @@ You will be asked to authorize access to your GitHub account if you have not alr
 
 <PagesBuildPreset framework="angular" />
 
-<<<<<<< HEAD
-:::caution[On Some Versions of Angular, You may need to:]
-=======
+
 :::caution[On some versions of Angular, You may need to:]
->>>>>>> e380ade1475f978746bc5c31b181a9d115204e7b
 Change the `Build command` to `npx ng build --output-path dist/cloudflare`\
 Change the `Build directory` to `dist/cloudflare/browser`
 :::

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -58,6 +58,10 @@ You will be asked to authorize access to your GitHub account if you have not alr
 
 <PagesBuildPreset framework="angular" />
 
+##On Some Versions of Angular You may need to:
+Change the Build Command to npx ng build --verbose --output-path dist/cloudflare
+Change the Build Directory to dist/cloudflare/browser
+
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 
 4. After completing configuration, select the **Save and Deploy**.

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -58,9 +58,10 @@ You will be asked to authorize access to your GitHub account if you have not alr
 
 <PagesBuildPreset framework="angular" />
 
-##On Some Versions of Angular You may need to:
-Change the Build Command to npx ng build --verbose --output-path dist/cloudflare
-Change the Build Directory to dist/cloudflare/browser
+:::caution[On Some Versions of Angular, You may need to:]
+Change the `Build command` to `npx ng build --output-path dist/cloudflare`\
+Change the `Build directory` to `dist/cloudflare/browser`
+:::
 
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -58,9 +58,10 @@ You will be asked to authorize access to your GitHub account if you have not alr
 
 <PagesBuildPreset framework="angular" />
 
-##On Some Versions of Angular You may need to:
-Change the Build Command to npx ng build --verbose --output-path dist/cloudflare
-Change the Build Directory to dist/cloudflare/browser
+:::caution[On some versions of Angular, You may need to:]
+Change the `Build command` to `npx ng build --output-path dist/cloudflare`\
+Change the `Build directory` to `dist/cloudflare/browser`
+:::
 
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -59,7 +59,7 @@ You will be asked to authorize access to your GitHub account if you have not alr
 <PagesBuildPreset framework="angular" />
 
 
-:::caution[On some versions of Angular, You may need to:]
+:::caution[On some versions of Angular, you may need to:]
 Change the `Build command` to `npx ng build --output-path dist/cloudflare`\
 Change the `Build directory` to `dist/cloudflare/browser`
 :::


### PR DESCRIPTION
Hotfix to Update Build Settings for Angular Deployment Tutorial. Fixed and working.

https://developers.cloudflare.com/pages/framework-guides/deploy-an-angular-site/
Following thie default project settings result in failed build.

Request to change PagesBuildPreset to this working solution or add instructions to 
change the ng build command in package.json.

Request to update the Angular preset on the dashboard to match. 

Seems like there are quite a few people with this issue.

See: https://github.com/cloudflare/workers-sdk/issues/5527
Also: https://stackoverflow.com/questions/78463333/fail-to-deploy-angular-project-on-cloudflare-pages/79151848#79151848 
And: https://community.cloudflare.com/t/angular-app-deployed-to-pages-is-unavailable-on-domain/632745