### PR TITLE
feat: [workflows] clarify when dynamic step names can be used

### DIFF
--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -229,6 +229,8 @@ export class MyWorkflow extends WorkflowEntrypoint {
 
 Dynamically naming a step will prevent it from being cached, and cause the step to be re-run unnecessarily. Step names act as the "cache key" in your Workflow.
 
+Note that, step names can be formed dynamically as long they are deterministic across steps and/or Workflow restarts.
+
 ```ts
 export class MyWorkflow extends WorkflowEntrypoint {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
@@ -243,7 +245,20 @@ export class MyWorkflow extends WorkflowEntrypoint {
 		// Return dynamic values in your state, or log them instead.
 		let state = await step.do("fetch user data from KV", async () => {
 		    let userData = await env.KV.get(event.user)
-				console.log(`fetched at ${Date.now})
+				console.log(`fetched at ${Date.now}`)
 				return userData
 		})
+
+		// ✅ Good: steps that are dynamically named are constructed in a deterministic way.
+		// In this case, `catList` is a step output, which is stable, and `catList` is
+		// traversed in a deterministic fashion (no shuffles or random accesses) so,
+		// it's fine to dynamically name steps (e.g: create a step per list entry).
+		let catList = await step.do("get cat list from KV", async () => {
+			return await env.KV.get("cat-list")
+		})
+		for(const cat of carList) {
+			await step.do(`get cat: ${cat}`, async () => {
+				return await env.KV.get(cat)
+			})
+		}
 ```

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -227,9 +227,8 @@ export class MyWorkflow extends WorkflowEntrypoint {
 
 ### Name steps deterministically
 
-Dynamically naming a step will prevent it from being cached, and cause the step to be re-run unnecessarily. Step names act as the "cache key" in your Workflow.
+Steps should be named deterministically (even if dynamic). This  ensures that their state is cached, and prevents the step from being rerun unnecessarily. Step names act as the "cache key" in your Workflow.
 
-Note that, step names can be formed dynamically as long they are deterministic across steps and/or Workflow restarts.
 
 ```ts
 export class MyWorkflow extends WorkflowEntrypoint {


### PR DESCRIPTION
### Summary

Add more context on when dynamic step names might work. They always do as long they are built in a deterministic manner, this wasn't very explicit before and caused some confusion in users.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
