### PR TITLE
SPEED-1066: Update Speed Brain rejected response code from 503 to 406

### DIFF
--- a/src/content/docs/speed/optimization/content/speed-brain.mdx
+++ b/src/content/docs/speed/optimization/content/speed-brain.mdx
@@ -55,7 +55,7 @@ The configuration looks like this:
 }
 ```
 
-This configuration instructs the browser to initiate prefetch requests for future navigations. These prefetch requests will include the `sec-purpose: prefetch` HTTP request header. Prefetches that are not successful will respond with a `503` status code. Prefetches that are successful will respond with a `200` status code.
+This configuration instructs the browser to initiate prefetch requests for future navigations. These prefetch requests will include the `sec-purpose: prefetch` HTTP request header. Prefetches that are not successful will respond with a `406` status code (used to be `503`). Prefetches that are successful will respond with a `200` status code.
 
 ## Test Speed Brain
 


### PR DESCRIPTION
### Summary

This commit is changing the public documentation about Speed Brain rejecting speculation requests with the newly decided 406 response code instead of the current 503, which was introduced during the initial release of the Speed Brain product during Birthday Week '24.

### Screenshots (optional)

N/A

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.