### PR TITLE
Update shopify.mdx to identify plan restriction and enablement flag

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -22,22 +22,24 @@ For more details about how O2O is different than other Cloudflare setups, refer 
 
 ## Enable
 
-You can enable O2O on any Cloudflare zone plan.
+An Enterprise zone plan is required for O2O to a Shopify origin.
 
-To enable O2O on your account, [create](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) a `CNAME` DNS record.
+:::note  
+Setting up your zone with O2O with a Shopify origin currently requires a Support Case due to a provider limitation in the Cloudflare for SaaS platform.  
+We are working to improve this experience. Please submit a Support Case to request O2O enablement for your zone.  
+:::  
+
+Once enabled by Support, set up O2O on your zone by [creating a `CNAME` DNS record.](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records)
 
 | Type    | Name                 | Target                | Proxy status |
 | ------- | -------------------- | --------------------- | ------------ |
 | `CNAME` | `<YOUR_SHOP_DOMAIN>` | `shops.myshopify.com` | Proxied      |
 
-:::note
+Be sure that you are using `shops.myshopify.com`. Using your store-specific url (for example `trinketstore.myshopify.com`) will not work; it is not the Shopify SaaS domain.
 
-
-For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).
-
-If you cannot activate your domain using [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/), reach out to your account team or the [Cloudflare Community](https://community.cloudflare.com).
-
-
+:::note  
+For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).  
+If you cannot activate your domain using [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/), reach out to your account team or the [Cloudflare Community](https://community.cloudflare.com).  
 :::
 
 ## Product compatibility

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -35,7 +35,7 @@ Once enabled by Support, set up O2O on your zone by [creating a `CNAME` DNS reco
 | ------- | -------------------- | --------------------- | ------------ |
 | `CNAME` | `<YOUR_SHOP_DOMAIN>` | `shops.myshopify.com` | Proxied      |
 
-Be sure that you are using `shops.myshopify.com`. Using your store-specific url (for example `trinketstore.myshopify.com`) will not work; it is not the Shopify SaaS domain.
+Be sure that you are using `shops.myshopify.com`. Using your store-specific URL (for example `trinketstore.myshopify.com`) will not work; it is not the Shopify SaaS domain.
 
 :::note  
 For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).  


### PR DESCRIPTION
### Summary

Shopify currently does not support O2O without a feature flag that Support/SE must set. Due to this restriction, O2O to Shopify is currently restricted to Enterprise plan levels.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
