### PR TITLE
AI Schema Formatting & Updates

### DIFF
--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -7,7 +7,7 @@ fetch("https://ai.cloudflare.com/api/models")
 			const fileName = model.name.split("/")[2];
 			fs.writeFileSync(
 				`./src/content/workers-ai-models/${fileName}.json`,
-				JSON.stringify(model),
+				JSON.stringify(model, null, 4),
 				"utf-8",
 			);
 		});

--- a/src/content/workers-ai-models/bart-large-cnn.json
+++ b/src/content/workers-ai-models/bart-large-cnn.json
@@ -1,1 +1,48 @@
-{"id":"19bd38eb-bcda-4e53-bec2-704b4689b43a","source":1,"name":"@cf/facebook/bart-large-cnn","description":"BART is a transformer encoder-encoder (seq2seq) model with a bidirectional (BERT-like) encoder and an autoregressive (GPT-like) decoder. You can use this model for text summarization.","task":{"id":"6f4e65d8-da0f-40d2-9aa4-db582a5a04fd","name":"Summarization","description":"Summarization is the task of producing a shorter version of a document while preserving its important information. Some models can extract text from the original input, while other models can generate entirely new text."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"type":"object","properties":{"input_text":{"type":"string","minLength":1,"description":"The text that you want the model to summarize"},"max_length":{"type":"integer","default":1024,"description":"The maximum length of the generated summary in tokens"}},"required":["input_text"]},"output":{"type":"object","contentType":"application/json","properties":{"summary":{"type":"string","description":"The summarized version of the input text"}}}}}
+{
+    "id": "19bd38eb-bcda-4e53-bec2-704b4689b43a",
+    "source": 1,
+    "name": "@cf/facebook/bart-large-cnn",
+    "description": "BART is a transformer encoder-encoder (seq2seq) model with a bidirectional (BERT-like) encoder and an autoregressive (GPT-like) decoder. You can use this model for text summarization.",
+    "task": {
+        "id": "6f4e65d8-da0f-40d2-9aa4-db582a5a04fd",
+        "name": "Summarization",
+        "description": "Summarization is the task of producing a shorter version of a document while preserving its important information. Some models can extract text from the original input, while other models can generate entirely new text."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "input_text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The text that you want the model to summarize"
+                },
+                "max_length": {
+                    "type": "integer",
+                    "default": 1024,
+                    "description": "The maximum length of the generated summary in tokens"
+                }
+            },
+            "required": [
+                "input_text"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "The summarized version of the input text"
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/bge-base-en-v1.5.json
+++ b/src/content/workers-ai-models/bge-base-en-v1.5.json
@@ -1,1 +1,82 @@
-{"id":"429b9e8b-d99e-44de-91ad-706cf8183658","source":1,"name":"@cf/baai/bge-base-en-v1.5","description":"BAAI general embedding (bge) models transform any given text into a compact vector","task":{"id":"0137cdcf-162a-4108-94f2-1ca59e8c65ee","name":"Text Embeddings","description":"Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://huggingface.co/BAAI/bge-base-en-v1.5"},{"property_id":"max_input_tokens","value":"512"},{"property_id":"output_dimensions","value":"768"}],"schema":{"input":{"type":"object","properties":{"text":{"oneOf":[{"type":"string","description":"The text to embed","minLength":1},{"type":"array","description":"Batch of text values to embed","items":{"type":"string","description":"The text to embed","minLength":1},"maxItems":100}]}},"required":["text"]},"output":{"type":"object","contentType":"application/json","properties":{"shape":{"type":"array","items":{"type":"number"}},"data":{"type":"array","description":"Embeddings of the requested text values","items":{"type":"array","description":"Floating point embedding representation shaped by the embedding model","items":{"type":"number"}}}}}}}
+{
+    "id": "429b9e8b-d99e-44de-91ad-706cf8183658",
+    "source": 1,
+    "name": "@cf/baai/bge-base-en-v1.5",
+    "description": "BAAI general embedding (bge) models transform any given text into a compact vector",
+    "task": {
+        "id": "0137cdcf-162a-4108-94f2-1ca59e8c65ee",
+        "name": "Text Embeddings",
+        "description": "Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/BAAI/bge-base-en-v1.5"
+        },
+        {
+            "property_id": "max_input_tokens",
+            "value": "512"
+        },
+        {
+            "property_id": "output_dimensions",
+            "value": "768"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "The text to embed",
+                            "minLength": 1
+                        },
+                        {
+                            "type": "array",
+                            "description": "Batch of text values to embed",
+                            "items": {
+                                "type": "string",
+                                "description": "The text to embed",
+                                "minLength": 1
+                            },
+                            "maxItems": 100
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "shape": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "data": {
+                    "type": "array",
+                    "description": "Embeddings of the requested text values",
+                    "items": {
+                        "type": "array",
+                        "description": "Floating point embedding representation shaped by the embedding model",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/bge-large-en-v1.5.json
+++ b/src/content/workers-ai-models/bge-large-en-v1.5.json
@@ -1,1 +1,82 @@
-{"id":"01bc2fb0-4bca-4598-b985-d2584a3f46c0","source":1,"name":"@cf/baai/bge-large-en-v1.5","description":"BAAI general embedding (bge) models transform any given text into a compact vector","task":{"id":"0137cdcf-162a-4108-94f2-1ca59e8c65ee","name":"Text Embeddings","description":"Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://huggingface.co/BAAI/bge-base-en-v1.5"},{"property_id":"max_input_tokens","value":"512"},{"property_id":"output_dimensions","value":"1024"}],"schema":{"input":{"type":"object","properties":{"text":{"oneOf":[{"type":"string","description":"The text to embed","minLength":1},{"type":"array","description":"Batch of text values to embed","items":{"type":"string","description":"The text to embed","minLength":1},"maxItems":100}]}},"required":["text"]},"output":{"type":"object","contentType":"application/json","properties":{"shape":{"type":"array","items":{"type":"number"}},"data":{"type":"array","description":"Embeddings of the requested text values","items":{"type":"array","description":"Floating point embedding representation shaped by the embedding model","items":{"type":"number"}}}}}}}
+{
+    "id": "01bc2fb0-4bca-4598-b985-d2584a3f46c0",
+    "source": 1,
+    "name": "@cf/baai/bge-large-en-v1.5",
+    "description": "BAAI general embedding (bge) models transform any given text into a compact vector",
+    "task": {
+        "id": "0137cdcf-162a-4108-94f2-1ca59e8c65ee",
+        "name": "Text Embeddings",
+        "description": "Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/BAAI/bge-base-en-v1.5"
+        },
+        {
+            "property_id": "max_input_tokens",
+            "value": "512"
+        },
+        {
+            "property_id": "output_dimensions",
+            "value": "1024"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "The text to embed",
+                            "minLength": 1
+                        },
+                        {
+                            "type": "array",
+                            "description": "Batch of text values to embed",
+                            "items": {
+                                "type": "string",
+                                "description": "The text to embed",
+                                "minLength": 1
+                            },
+                            "maxItems": 100
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "shape": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "data": {
+                    "type": "array",
+                    "description": "Embeddings of the requested text values",
+                    "items": {
+                        "type": "array",
+                        "description": "Floating point embedding representation shaped by the embedding model",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/bge-small-en-v1.5.json
+++ b/src/content/workers-ai-models/bge-small-en-v1.5.json
@@ -1,1 +1,82 @@
-{"id":"57fbd08a-a4c4-411c-910d-b9459ff36c20","source":1,"name":"@cf/baai/bge-small-en-v1.5","description":"BAAI general embedding (bge) models transform any given text into a compact vector","task":{"id":"0137cdcf-162a-4108-94f2-1ca59e8c65ee","name":"Text Embeddings","description":"Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://huggingface.co/BAAI/bge-base-en-v1.5"},{"property_id":"max_input_tokens","value":"512"},{"property_id":"output_dimensions","value":"384"}],"schema":{"input":{"type":"object","properties":{"text":{"oneOf":[{"type":"string","description":"The text to embed","minLength":1},{"type":"array","description":"Batch of text values to embed","items":{"type":"string","description":"The text to embed","minLength":1},"maxItems":100}]}},"required":["text"]},"output":{"type":"object","contentType":"application/json","properties":{"shape":{"type":"array","items":{"type":"number"}},"data":{"type":"array","description":"Embeddings of the requested text values","items":{"type":"array","description":"Floating point embedding representation shaped by the embedding model","items":{"type":"number"}}}}}}}
+{
+    "id": "57fbd08a-a4c4-411c-910d-b9459ff36c20",
+    "source": 1,
+    "name": "@cf/baai/bge-small-en-v1.5",
+    "description": "BAAI general embedding (bge) models transform any given text into a compact vector",
+    "task": {
+        "id": "0137cdcf-162a-4108-94f2-1ca59e8c65ee",
+        "name": "Text Embeddings",
+        "description": "Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/BAAI/bge-base-en-v1.5"
+        },
+        {
+            "property_id": "max_input_tokens",
+            "value": "512"
+        },
+        {
+            "property_id": "output_dimensions",
+            "value": "384"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "The text to embed",
+                            "minLength": 1
+                        },
+                        {
+                            "type": "array",
+                            "description": "Batch of text values to embed",
+                            "items": {
+                                "type": "string",
+                                "description": "The text to embed",
+                                "minLength": 1
+                            },
+                            "maxItems": 100
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "shape": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "data": {
+                    "type": "array",
+                    "description": "Embeddings of the requested text values",
+                    "items": {
+                        "type": "array",
+                        "description": "Floating point embedding representation shaped by the embedding model",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/deepseek-coder-6.7b-base-awq.json
+++ b/src/content/workers-ai-models/deepseek-coder-6.7b-base-awq.json
@@ -1,1 +1,383 @@
-{"id":"7f180530-2e16-4116-9d26-f49fbed9d372","source":2,"name":"@hf/thebloke/deepseek-coder-6.7b-base-awq","description":"Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "7f180530-2e16-4116-9d26-f49fbed9d372",
+    "source": 2,
+    "name": "@hf/thebloke/deepseek-coder-6.7b-base-awq",
+    "description": "Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/deepseek-coder-6.7b-instruct-awq.json
+++ b/src/content/workers-ai-models/deepseek-coder-6.7b-instruct-awq.json
@@ -1,1 +1,383 @@
-{"id":"60474554-f03b-4ff4-8ecc-c1b7c71d7b29","source":2,"name":"@hf/thebloke/deepseek-coder-6.7b-instruct-awq","description":"Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://huggingface.co/TheBloke/deepseek-coder-6.7B-instruct-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "60474554-f03b-4ff4-8ecc-c1b7c71d7b29",
+    "source": 2,
+    "name": "@hf/thebloke/deepseek-coder-6.7b-instruct-awq",
+    "description": "Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://huggingface.co/TheBloke/deepseek-coder-6.7B-instruct-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/deepseek-math-7b-instruct.json
+++ b/src/content/workers-ai-models/deepseek-math-7b-instruct.json
@@ -1,1 +1,387 @@
-{"id":"4c3a544e-da47-4336-9cea-c7cbfab33f16","source":1,"name":"@cf/deepseek-ai/deepseek-math-7b-instruct","description":"DeepSeekMath-Instruct 7B is a mathematically instructed tuning model derived from DeepSeekMath-Base 7B. DeepSeekMath is initialized with DeepSeek-Coder-v1.5 7B and continues pre-training on math-related tokens sourced from Common Crawl, together with natural language and code data for 500B tokens.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/deepseek-ai/deepseek-math-7b-instruct"},{"property_id":"terms","value":"https://github.com/deepseek-ai/DeepSeek-Math/blob/main/LICENSE-MODEL"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "4c3a544e-da47-4336-9cea-c7cbfab33f16",
+    "source": 1,
+    "name": "@cf/deepseek-ai/deepseek-math-7b-instruct",
+    "description": "DeepSeekMath-Instruct 7B is a mathematically instructed tuning model derived from DeepSeekMath-Base 7B. DeepSeekMath is initialized with DeepSeek-Coder-v1.5 7B and continues pre-training on math-related tokens sourced from Common Crawl, together with natural language and code data for 500B tokens.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/deepseek-ai/deepseek-math-7b-instruct"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/deepseek-ai/DeepSeek-Math/blob/main/LICENSE-MODEL"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/detr-resnet-50.json
+++ b/src/content/workers-ai-models/detr-resnet-50.json
@@ -1,1 +1,82 @@
-{"id":"cc34ce52-3059-415f-9a48-12aa919d37ee","source":1,"name":"@cf/facebook/detr-resnet-50","description":"DEtection TRansformer (DETR) model trained end-to-end on COCO 2017 object detection (118k annotated images).","task":{"id":"9c178979-90d9-49d8-9e2c-0f1cf01815d4","name":"Object Detection","description":"Object detection models can detect instances of objects like persons, faces, license plates, or others in an image. This task takes an image as input and returns a list of detected objects, each one containing a label, a probability score, and its surrounding box coordinates."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary","description":"The image to use for detection"},{"type":"object","properties":{"image":{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255 (unsigned 8bit)"}}}}]},"output":{"type":"array","contentType":"application/json","description":"An array of detected objects within the input image","items":{"type":"object","properties":{"score":{"type":"number","description":"Confidence score indicating the likelihood that the detection is correct"},"label":{"type":"string","description":"The class label or name of the detected object"},"box":{"type":"object","description":"Coordinates defining the bounding box around the detected object","properties":{"xmin":{"type":"number","description":"The x-coordinate of the top-left corner of the bounding box"},"ymin":{"type":"number","description":"The y-coordinate of the top-left corner of the bounding box"},"xmax":{"type":"number","description":"The x-coordinate of the bottom-right corner of the bounding box"},"ymax":{"type":"number","description":"The y-coordinate of the bottom-right corner of the bounding box"}}}}}}}}
+{
+    "id": "cc34ce52-3059-415f-9a48-12aa919d37ee",
+    "source": 1,
+    "name": "@cf/facebook/detr-resnet-50",
+    "description": "DEtection TRansformer (DETR) model trained end-to-end on COCO 2017 object detection (118k annotated images).",
+    "task": {
+        "id": "9c178979-90d9-49d8-9e2c-0f1cf01815d4",
+        "name": "Object Detection",
+        "description": "Object detection models can detect instances of objects like persons, faces, license plates, or others in an image. This task takes an image as input and returns a list of detected objects, each one containing a label, a probability score, and its surrounding box coordinates."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The image to use for detection"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "array",
+                            "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                            "items": {
+                                "type": "number",
+                                "description": "A value between 0 and 255 (unsigned 8bit)"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "output": {
+            "type": "array",
+            "contentType": "application/json",
+            "description": "An array of detected objects within the input image",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "score": {
+                        "type": "number",
+                        "description": "Confidence score indicating the likelihood that the detection is correct"
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "The class label or name of the detected object"
+                    },
+                    "box": {
+                        "type": "object",
+                        "description": "Coordinates defining the bounding box around the detected object",
+                        "properties": {
+                            "xmin": {
+                                "type": "number",
+                                "description": "The x-coordinate of the top-left corner of the bounding box"
+                            },
+                            "ymin": {
+                                "type": "number",
+                                "description": "The y-coordinate of the top-left corner of the bounding box"
+                            },
+                            "xmax": {
+                                "type": "number",
+                                "description": "The x-coordinate of the bottom-right corner of the bounding box"
+                            },
+                            "ymax": {
+                                "type": "number",
+                                "description": "The y-coordinate of the bottom-right corner of the bounding box"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/discolm-german-7b-v1-awq.json
+++ b/src/content/workers-ai-models/discolm-german-7b-v1-awq.json
@@ -1,1 +1,383 @@
-{"id":"9d2ab560-065e-4d0d-a789-d4bc7468d33e","source":1,"name":"@cf/thebloke/discolm-german-7b-v1-awq","description":"DiscoLM German 7b is a Mistral-based large language model with a focus on German-language applications. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/TheBloke/DiscoLM_German_7b_v1-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "9d2ab560-065e-4d0d-a789-d4bc7468d33e",
+    "source": 1,
+    "name": "@cf/thebloke/discolm-german-7b-v1-awq",
+    "description": "DiscoLM German 7b is a Mistral-based large language model with a focus on German-language applications. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/TheBloke/DiscoLM_German_7b_v1-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/distilbert-sst-2-int8.json
+++ b/src/content/workers-ai-models/distilbert-sst-2-int8.json
@@ -1,1 +1,55 @@
-{"id":"eaf31752-a074-441f-8b70-d593255d2811","source":1,"name":"@cf/huggingface/distilbert-sst-2-int8","description":"Distilled BERT model that was finetuned on SST-2 for sentiment classification","task":{"id":"19606750-23ed-4371-aab2-c20349b53a60","name":"Text Classification","description":"Sentiment analysis or text classification is a common NLP task that classifies a text input into labels or classes."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://huggingface.co/Intel/distilbert-base-uncased-finetuned-sst-2-english-int8-static"}],"schema":{"input":{"type":"object","properties":{"text":{"type":"string","minLength":1,"description":"The text that you want to classify"}},"required":["text"]},"output":{"type":"array","contentType":"application/json","description":"An array of classification results for the input text","items":{"type":"object","properties":{"score":{"type":"number","description":"Confidence score indicating the likelihood that the text belongs to the specified label"},"label":{"type":"string","description":"The classification label assigned to the text (e.g., 'POSITIVE' or 'NEGATIVE')"}}}}}}
+{
+    "id": "eaf31752-a074-441f-8b70-d593255d2811",
+    "source": 1,
+    "name": "@cf/huggingface/distilbert-sst-2-int8",
+    "description": "Distilled BERT model that was finetuned on SST-2 for sentiment classification",
+    "task": {
+        "id": "19606750-23ed-4371-aab2-c20349b53a60",
+        "name": "Text Classification",
+        "description": "Sentiment analysis or text classification is a common NLP task that classifies a text input into labels or classes."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/Intel/distilbert-base-uncased-finetuned-sst-2-english-int8-static"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The text that you want to classify"
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "output": {
+            "type": "array",
+            "contentType": "application/json",
+            "description": "An array of classification results for the input text",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "score": {
+                        "type": "number",
+                        "description": "Confidence score indicating the likelihood that the text belongs to the specified label"
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "The classification label assigned to the text (e.g., 'POSITIVE' or 'NEGATIVE')"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/dreamshaper-8-lcm.json
+++ b/src/content/workers-ai-models/dreamshaper-8-lcm.json
@@ -1,1 +1,99 @@
-{"id":"7912c0ab-542e-44b9-b9ee-3113d226a8b5","source":1,"name":"@cf/lykon/dreamshaper-8-lcm","description":"Stable Diffusion model that has been fine-tuned to be better at photorealism without sacrificing range.","task":{"id":"3d6e1f35-341b-4915-a6c8-9a7142a9033a","name":"Text-to-Image","description":"Generates images from input text. These models can be used to generate and modify images based on text prompts."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/Lykon/DreamShaper"}],"schema":{"input":{"type":"object","properties":{"prompt":{"type":"string","minLength":1,"description":"A text description of the image you want to generate"},"negative_prompt":{"type":"string","description":"Text describing elements to avoid in the generated image"},"height":{"type":"integer","minimum":256,"maximum":2048,"description":"The height of the generated image in pixels"},"width":{"type":"integer","minimum":256,"maximum":2048,"description":"The width of the generated image in pixels"},"image":{"type":"array","description":"For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"image_b64":{"type":"string","description":"For use with img2img tasks. A base64-encoded string of the input image"},"mask":{"type":"array","description":"An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"num_steps":{"type":"integer","default":20,"maximum":20,"description":"The number of diffusion steps; higher values can improve quality but take longer"},"strength":{"type":"number","default":1,"description":"A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"},"guidance":{"type":"number","default":7.5,"description":"Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"},"seed":{"type":"integer","description":"Random seed for reproducibility of the image generation"}},"required":["prompt"]},"output":{"type":"string","contentType":"image/png","format":"binary","description":"The generated image in PNG format"}}}
+{
+    "id": "7912c0ab-542e-44b9-b9ee-3113d226a8b5",
+    "source": 1,
+    "name": "@cf/lykon/dreamshaper-8-lcm",
+    "description": "Stable Diffusion model that has been fine-tuned to be better at photorealism without sacrificing range.",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/Lykon/DreamShaper"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate"
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "Text describing elements to avoid in the generated image"
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The height of the generated image in pixels"
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The width of the generated image in pixels"
+                },
+                "image": {
+                    "type": "array",
+                    "description": "For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "image_b64": {
+                    "type": "string",
+                    "description": "For use with img2img tasks. A base64-encoded string of the input image"
+                },
+                "mask": {
+                    "type": "array",
+                    "description": "An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "num_steps": {
+                    "type": "integer",
+                    "default": 20,
+                    "maximum": 20,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer"
+                },
+                "strength": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"
+                },
+                "guidance": {
+                    "type": "number",
+                    "default": 7.5,
+                    "description": "Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed for reproducibility of the image generation"
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "string",
+            "contentType": "image/png",
+            "format": "binary",
+            "description": "The generated image in PNG format"
+        }
+    }
+}

--- a/src/content/workers-ai-models/falcon-7b-instruct.json
+++ b/src/content/workers-ai-models/falcon-7b-instruct.json
@@ -1,1 +1,383 @@
-{"id":"48dd2443-0c61-43b2-8894-22abddf1b081","source":1,"name":"@cf/tiiuae/falcon-7b-instruct","description":"Falcon-7B-Instruct is a 7B parameters causal decoder-only model built by TII based on Falcon-7B and finetuned on a mixture of chat/instruct datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/tiiuae/falcon-7b-instruct"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "48dd2443-0c61-43b2-8894-22abddf1b081",
+    "source": 1,
+    "name": "@cf/tiiuae/falcon-7b-instruct",
+    "description": "Falcon-7B-Instruct is a 7B parameters causal decoder-only model built by TII based on Falcon-7B and finetuned on a mixture of chat/instruct datasets.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/tiiuae/falcon-7b-instruct"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/flux-1-schnell.json
+++ b/src/content/workers-ai-models/flux-1-schnell.json
@@ -1,42 +1,49 @@
 {
-  "id": "9e087485-23dc-47fa-997d-f5bfafc0c7cc",
-  "source": 1,
-  "name": "@cf/black-forest-labs/flux-1-schnell",
-  "description": "FLUX.1 [schnell] is a 12 billion parameter rectified flow transformer capable of generating images from text descriptions. ",
-  "task": {
-    "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
-    "name": "Text-to-Image",
-    "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
-  },
-  "tags": [],
-  "properties": [{ "property_id": "beta", "value": "true" }],
-  "schema": {
-    "input": {
-      "type": "object",
-      "properties": {
-        "prompt": {
-          "type": "string",
-          "minLength": 1,
-          "description": "A text description of the image you want to generate"
-        },
-        "num_steps": {
-          "type": "integer",
-          "default": 4,
-          "maximum": 8,
-          "description": "The number of diffusion steps; higher values can improve quality but take longer"
-        }
-      },
-      "required": ["prompt"]
+    "id": "9e087485-23dc-47fa-997d-f5bfafc0c7cc",
+    "source": 1,
+    "name": "@cf/black-forest-labs/flux-1-schnell",
+    "description": "FLUX.1 [schnell] is a 12 billion parameter rectified flow transformer capable of generating images from text descriptions. ",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
     },
-    "output": {
-      "type": "object",
-      "contentType": "application/json",
-      "properties": {
-        "image": {
-          "type": "string",
-          "description": "The generated image in Base64 format."
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
         }
-      }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate."
+                },
+                "steps": {
+                    "type": "integer",
+                    "default": 4,
+                    "maximum": 8,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer."
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "description": "The generated image in Base64 format."
+                }
+            }
+        }
     }
-  }
 }

--- a/src/content/workers-ai-models/flux-1-schnell.json
+++ b/src/content/workers-ai-models/flux-1-schnell.json
@@ -22,6 +22,7 @@
                 "prompt": {
                     "type": "string",
                     "minLength": 1,
+                    "maxLength": 2048,
                     "description": "A text description of the image you want to generate."
                 },
                 "steps": {

--- a/src/content/workers-ai-models/gemma-2b-it-lora.json
+++ b/src/content/workers-ai-models/gemma-2b-it-lora.json
@@ -1,1 +1,383 @@
-{"id":"e8e8abe4-a372-4c13-815f-4688ba655c8e","source":1,"name":"@cf/google/gemma-2b-it-lora","description":"This is a Gemma-2B base model that Cloudflare dedicates for inference with LoRA adapters. Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"lora","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "e8e8abe4-a372-4c13-815f-4688ba655c8e",
+    "source": 1,
+    "name": "@cf/google/gemma-2b-it-lora",
+    "description": "This is a Gemma-2B base model that Cloudflare dedicates for inference with LoRA adapters. Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/gemma-7b-it-lora.json
+++ b/src/content/workers-ai-models/gemma-7b-it-lora.json
@@ -1,1 +1,383 @@
-{"id":"337170b7-bd2f-4631-9a57-688b579cf6d3","source":1,"name":"@cf/google/gemma-7b-it-lora","description":"  This is a Gemma-7B base model that Cloudflare dedicates for inference with LoRA adapters. Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"lora","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "337170b7-bd2f-4631-9a57-688b579cf6d3",
+    "source": 1,
+    "name": "@cf/google/gemma-7b-it-lora",
+    "description": "  This is a Gemma-7B base model that Cloudflare dedicates for inference with LoRA adapters. Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/gemma-7b-it.json
+++ b/src/content/workers-ai-models/gemma-7b-it.json
@@ -1,1 +1,403 @@
-{"id":"0f002249-7d86-4698-aabf-8529ed86cefb","source":2,"name":"@hf/google/gemma-7b-it","description":"Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://ai.google.dev/gemma/docs"},{"property_id":"lora","value":"true"},{"property_id":"max_batch_prefill_tokens","value":"2048"},{"property_id":"max_input_length","value":"1512"},{"property_id":"max_total_tokens","value":"2048"},{"property_id":"terms","value":"https://ai.google.dev/gemma/terms"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "0f002249-7d86-4698-aabf-8529ed86cefb",
+    "source": 2,
+    "name": "@hf/google/gemma-7b-it",
+    "description": "Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://ai.google.dev/gemma/docs"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        },
+        {
+            "property_id": "max_batch_prefill_tokens",
+            "value": "2048"
+        },
+        {
+            "property_id": "max_input_length",
+            "value": "1512"
+        },
+        {
+            "property_id": "max_total_tokens",
+            "value": "2048"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://ai.google.dev/gemma/terms"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
+++ b/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
@@ -1,1 +1,387 @@
-{"id":"44774b85-08c8-4bb8-8d2a-b06ebc538a79","source":2,"name":"@hf/nousresearch/hermes-2-pro-mistral-7b","description":"Hermes 2 Pro on Mistral 7B is the new flagship 7B Hermes! Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"function_calling","value":"true"},{"property_id":"info","value":"https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "44774b85-08c8-4bb8-8d2a-b06ebc538a79",
+    "source": 2,
+    "name": "@hf/nousresearch/hermes-2-pro-mistral-7b",
+    "description": "Hermes 2 Pro on Mistral 7B is the new flagship 7B Hermes! Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-2-13b-chat-awq.json
+++ b/src/content/workers-ai-models/llama-2-13b-chat-awq.json
@@ -1,1 +1,383 @@
-{"id":"85c5a3c6-24b0-45e7-b23a-023182578822","source":2,"name":"@hf/thebloke/llama-2-13b-chat-awq","description":"Llama 2 13B Chat AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Llama 2 variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/TheBloke/Llama-2-13B-chat-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "85c5a3c6-24b0-45e7-b23a-023182578822",
+    "source": 2,
+    "name": "@hf/thebloke/llama-2-13b-chat-awq",
+    "description": "Llama 2 13B Chat AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Llama 2 variant.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/TheBloke/Llama-2-13B-chat-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
@@ -1,1 +1,387 @@
-{"id":"ca54bcd6-0d98-4739-9b3b-5c8b4402193d","source":1,"name":"@cf/meta/llama-2-7b-chat-fp16","description":"Full precision (fp16) generative text model with 7 billion parameters from Meta","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://ai.meta.com/llama/"},{"property_id":"terms","value":"https://ai.meta.com/resources/models-and-libraries/llama-downloads/"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "ca54bcd6-0d98-4739-9b3b-5c8b4402193d",
+    "source": 1,
+    "name": "@cf/meta/llama-2-7b-chat-fp16",
+    "description": "Full precision (fp16) generative text model with 7 billion parameters from Meta",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://ai.meta.com/llama/"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://ai.meta.com/resources/models-and-libraries/llama-downloads/"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-2-7b-chat-hf-lora.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-hf-lora.json
@@ -1,1 +1,383 @@
-{"id":"7ed8d8e8-6040-4680-843a-aef402d6b013","source":1,"name":"@cf/meta-llama/llama-2-7b-chat-hf-lora","description":"This is a Llama2 base model that Cloudflare dedicated for inference with LoRA adapters. Llama 2 is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. This is the repository for the 7B fine-tuned model, optimized for dialogue use cases and converted for the Hugging Face Transformers format. ","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"lora","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "7ed8d8e8-6040-4680-843a-aef402d6b013",
+    "source": 1,
+    "name": "@cf/meta-llama/llama-2-7b-chat-hf-lora",
+    "description": "This is a Llama2 base model that Cloudflare dedicated for inference with LoRA adapters. Llama 2 is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. This is the repository for the 7B fine-tuned model, optimized for dialogue use cases and converted for the Hugging Face Transformers format. ",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-2-7b-chat-int8.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-int8.json
@@ -1,1 +1,374 @@
-{"id":"9c95c39d-45b3-4163-9631-22f0c0dc3b14","source":1,"name":"@cf/meta/llama-2-7b-chat-int8","description":"Quantized (int8) generative text model with 7 billion parameters from Meta","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "9c95c39d-45b3-4163-9631-22f0c0dc3b14",
+    "source": 1,
+    "name": "@cf/meta/llama-2-7b-chat-int8",
+    "description": "Quantized (int8) generative text model with 7 billion parameters from Meta",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
@@ -1,1 +1,387 @@
-{"id":"31097538-a3ff-4e6e-bb56-ad0e1f428b61","source":1,"name":"@cf/meta/llama-3-8b-instruct-awq","description":"Quantized (int4) generative text model with 8 billion parameters from Meta.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://llama.meta.com"},{"property_id":"terms","value":"https://llama.meta.com/llama3/license/#"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "31097538-a3ff-4e6e-bb56-ad0e1f428b61",
+    "source": 1,
+    "name": "@cf/meta/llama-3-8b-instruct-awq",
+    "description": "Quantized (int4) generative text model with 8 billion parameters from Meta.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://llama.meta.com"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://llama.meta.com/llama3/license/#"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "info",
             "value": "https://llama.meta.com"
         },

--- a/src/content/workers-ai-models/llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct.json
@@ -1,1 +1,387 @@
-{"id":"e11d8f45-7b08-499a-9eeb-71d4d3c8cbf9","source":1,"name":"@cf/meta/llama-3-8b-instruct","description":"Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://llama.meta.com"},{"property_id":"terms","value":"https://llama.meta.com/llama3/license/#"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "e11d8f45-7b08-499a-9eeb-71d4d3c8cbf9",
+    "source": 1,
+    "name": "@cf/meta/llama-3-8b-instruct",
+    "description": "Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://llama.meta.com"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://llama.meta.com/llama3/license/#"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "info",
             "value": "https://llama.meta.com"
         },

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
@@ -1,1 +1,383 @@
-{"id":"3dcb4f2d-26a8-412b-b6e3-2a368beff66b","source":1,"name":"@cf/meta/llama-3.1-8b-instruct-awq","description":"Quantized (int4) generative text model with 8 billion parameters from Meta.\n","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "3dcb4f2d-26a8-412b-b6e3-2a368beff66b",
+    "source": 1,
+    "name": "@cf/meta/llama-3.1-8b-instruct-awq",
+    "description": "Quantized (int4) generative text model with 8 billion parameters from Meta.\n",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
@@ -1,1 +1,383 @@
-{"id":"9b9c87c6-d4b7-494c-b177-87feab5904db","source":1,"name":"@cf/meta/llama-3.1-8b-instruct-fp8","description":"Llama 3.1 8B quantized to FP8 precision","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "9b9c87c6-d4b7-494c-b177-87feab5904db",
+    "source": 1,
+    "name": "@cf/meta/llama-3.1-8b-instruct-fp8",
+    "description": "Llama 3.1 8B quantized to FP8 precision",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct.json
@@ -1,1 +1,383 @@
-{"id":"41975cc2-c82e-4e98-b7b8-88ffb186a545","source":1,"name":"@cf/meta/llama-3.1-8b-instruct","description":"The Meta Llama 3.1 collection of multilingual large language models (LLMs) is a collection of pretrained and instruction tuned generative models. The Llama 3.1 instruction tuned text only models are optimized for multilingual dialogue use cases and outperform many of the available open source and closed chat models on common industry benchmarks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "41975cc2-c82e-4e98-b7b8-88ffb186a545",
+    "source": 1,
+    "name": "@cf/meta/llama-3.1-8b-instruct",
+    "description": "The Meta Llama 3.1 collection of multilingual large language models (LLMs) is a collection of pretrained and instruction tuned generative models. The Llama 3.1 instruction tuned text only models are optimized for multilingual dialogue use cases and outperform many of the available open source and closed chat models on common industry benchmarks.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.2-11b-vision-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-11b-vision-instruct.json
@@ -1,1 +1,417 @@
-{"id":"2cbc033b-ded8-4e02-bbb2-47cf05d5cfe5","source":1,"name":"@cf/meta/llama-3.2-11b-vision-instruct","description":" The Llama 3.2-Vision instruction-tuned models are optimized for visual recognition, image reasoning, captioning, and answering general questions about an image.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "2cbc033b-ded8-4e02-bbb2-47cf05d5cfe5",
+    "source": 1,
+    "name": "@cf/meta/llama-3.2-11b-vision-instruct",
+    "description": " The Llama 3.2-Vision instruction-tuned models are optimized for visual recognition, image reasoning, captioning, and answering general questions about an image.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "image": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                                    "items": {
+                                        "type": "number",
+                                        "description": "A value between 0 and 255"
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "format": "binary",
+                                    "description": "Binary string representing the image contents."
+                                }
+                            ]
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "image": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                                    "items": {
+                                        "type": "number",
+                                        "description": "A value between 0 and 255"
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "format": "binary",
+                                    "description": "Binary string representing the image contents."
+                                }
+                            ]
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.2-11b-vision-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-11b-vision-instruct.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.2-1b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-1b-instruct.json
@@ -1,1 +1,383 @@
-{"id":"906a57fd-b018-4d6c-a43e-a296d4cc5839","source":1,"name":"@cf/meta/llama-3.2-1b-instruct","description":"The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "906a57fd-b018-4d6c-a43e-a296d4cc5839",
+    "source": 1,
+    "name": "@cf/meta/llama-3.2-1b-instruct",
+    "description": "The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.2-1b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-1b-instruct.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.2-3b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-3b-instruct.json
@@ -1,1 +1,383 @@
-{"id":"d9dc8363-66f4-4bb0-8641-464ee7bfc131","source":1,"name":"@cf/meta/llama-3.2-3b-instruct","description":"The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "d9dc8363-66f4-4bb0-8641-464ee7bfc131",
+    "source": 1,
+    "name": "@cf/meta/llama-3.2-3b-instruct",
+    "description": "The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llama-3.2-3b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-3b-instruct.json
@@ -11,10 +11,6 @@
     "tags": [],
     "properties": [
         {
-            "property_id": "beta",
-            "value": "true"
-        },
-        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
         }

--- a/src/content/workers-ai-models/llamaguard-7b-awq.json
+++ b/src/content/workers-ai-models/llamaguard-7b-awq.json
@@ -1,1 +1,379 @@
-{"id":"d9b7a55c-cefa-4208-8ab3-11497a2b046c","source":2,"name":"@hf/thebloke/llamaguard-7b-awq","description":"Llama Guard is a model for classifying the safety of LLM prompts and responses, using a taxonomy of safety risks.\n","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "d9b7a55c-cefa-4208-8ab3-11497a2b046c",
+    "source": 2,
+    "name": "@hf/thebloke/llamaguard-7b-awq",
+    "description": "Llama Guard is a model for classifying the safety of LLM prompts and responses, using a taxonomy of safety risks.\n",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/llava-1.5-7b-hf.json
+++ b/src/content/workers-ai-models/llava-1.5-7b-hf.json
@@ -1,1 +1,81 @@
-{"id":"af274959-cb47-4ba8-9d8e-5a0a58b6b402","source":1,"name":"@cf/llava-hf/llava-1.5-7b-hf","description":"LLaVA is an open-source chatbot trained by fine-tuning LLaMA/Vicuna on GPT-generated multimodal instruction-following data. It is an auto-regressive language model, based on the transformer architecture.","task":{"id":"882a91d1-c331-4eec-bdad-834c919942a8","name":"Image-to-Text","description":"Image to text models output a text from a given image. Image captioning or optical character recognition can be considered as the most common applications of image to text."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary","description":"Binary string representing the image contents."},{"type":"object","properties":{"temperature":{"type":"number","description":"Controls the randomness of the output; higher values produce more random results."},"prompt":{"type":"string","description":"The input text prompt for the model to generate a response."},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"max_tokens":{"type":"integer","default":512,"description":"The maximum number of tokens to generate in the response."}},"required":["image"]}]},"output":{"type":"object","contentType":"application/json","properties":{"description":{"type":"string"}}}}}
+{
+    "id": "af274959-cb47-4ba8-9d8e-5a0a58b6b402",
+    "source": 1,
+    "name": "@cf/llava-hf/llava-1.5-7b-hf",
+    "description": "LLaVA is an open-source chatbot trained by fine-tuning LLaMA/Vicuna on GPT-generated multimodal instruction-following data. It is an auto-regressive language model, based on the transformer architecture.",
+    "task": {
+        "id": "882a91d1-c331-4eec-bdad-834c919942a8",
+        "name": "Image-to-Text",
+        "description": "Image to text models output a text from a given image. Image captioning or optical character recognition can be considered as the most common applications of image to text."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Binary string representing the image contents."
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "temperature": {
+                            "type": "number",
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "image": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                                    "items": {
+                                        "type": "number",
+                                        "description": "A value between 0 and 255"
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "format": "binary",
+                                    "description": "Binary string representing the image contents."
+                                }
+                            ]
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 512,
+                            "description": "The maximum number of tokens to generate in the response."
+                        }
+                    },
+                    "required": [
+                        "image"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "description": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/m2m100-1.2b.json
+++ b/src/content/workers-ai-models/m2m100-1.2b.json
@@ -1,1 +1,65 @@
-{"id":"617e7ec3-bf8d-4088-a863-4f89582d91b5","source":1,"name":"@cf/meta/m2m100-1.2b","description":"Multilingual encoder-decoder (seq-to-seq) model trained for Many-to-Many multilingual translation","task":{"id":"f57d07cb-9087-487a-bbbf-bc3e17fecc4b","name":"Translation","description":"Translation models convert a sequence of text from one language to another."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://github.com/facebookresearch/fairseq/tree/main/examples/m2m_100"},{"property_id":"languages","value":"english, chinese, french, spanish, arabic, russian, german, japanese, portuguese, hindi"},{"property_id":"terms","value":"https://github.com/facebookresearch/fairseq/blob/main/LICENSE"}],"schema":{"input":{"type":"object","properties":{"text":{"type":"string","minLength":1,"description":"The text to be translated"},"source_lang":{"type":"string","default":"en","description":"The language code of the source text (e.g., 'en' for English). Defaults to 'en' if not specified"},"target_lang":{"type":"string","description":"The language code to translate the text into (e.g., 'es' for Spanish)"}},"required":["text","target_lang"]},"output":{"type":"object","contentType":"application/json","properties":{"translated_text":{"type":"string","description":"The translated text in the target language"}}}}}
+{
+    "id": "617e7ec3-bf8d-4088-a863-4f89582d91b5",
+    "source": 1,
+    "name": "@cf/meta/m2m100-1.2b",
+    "description": "Multilingual encoder-decoder (seq-to-seq) model trained for Many-to-Many multilingual translation",
+    "task": {
+        "id": "f57d07cb-9087-487a-bbbf-bc3e17fecc4b",
+        "name": "Translation",
+        "description": "Translation models convert a sequence of text from one language to another."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://github.com/facebookresearch/fairseq/tree/main/examples/m2m_100"
+        },
+        {
+            "property_id": "languages",
+            "value": "english, chinese, french, spanish, arabic, russian, german, japanese, portuguese, hindi"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/facebookresearch/fairseq/blob/main/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The text to be translated"
+                },
+                "source_lang": {
+                    "type": "string",
+                    "default": "en",
+                    "description": "The language code of the source text (e.g., 'en' for English). Defaults to 'en' if not specified"
+                },
+                "target_lang": {
+                    "type": "string",
+                    "description": "The language code to translate the text into (e.g., 'es' for Spanish)"
+                }
+            },
+            "required": [
+                "text",
+                "target_lang"
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "translated_text": {
+                    "type": "string",
+                    "description": "The translated text in the target language"
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/meta-llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/meta-llama-3-8b-instruct.json
@@ -1,1 +1,374 @@
-{"id":"1a7b6ad6-9987-4bd3-a329-20ee8de93296","source":2,"name":"@hf/meta-llama/meta-llama-3-8b-instruct","description":"Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.\t","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "1a7b6ad6-9987-4bd3-a329-20ee8de93296",
+    "source": 2,
+    "name": "@hf/meta-llama/meta-llama-3-8b-instruct",
+    "description": "Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.\t",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.1-awq.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.1-awq.json
@@ -1,1 +1,383 @@
-{"id":"980ec5e9-33c2-483a-a2d8-cd092fdf273f","source":2,"name":"@hf/thebloke/mistral-7b-instruct-v0.1-awq","description":"Mistral 7B Instruct v0.1 AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Mistral variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "980ec5e9-33c2-483a-a2d8-cd092fdf273f",
+    "source": 2,
+    "name": "@hf/thebloke/mistral-7b-instruct-v0.1-awq",
+    "description": "Mistral 7B Instruct v0.1 AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Mistral variant.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
@@ -1,1 +1,387 @@
-{"id":"c907d0f9-d69d-4e93-b501-4daeb4fd69eb","source":1,"name":"@cf/mistral/mistral-7b-instruct-v0.1","description":"Instruct fine-tuned version of the Mistral-7b generative text model with 7 billion parameters","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://mistral.ai/news/announcing-mistral-7b/"},{"property_id":"lora","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "c907d0f9-d69d-4e93-b501-4daeb4fd69eb",
+    "source": 1,
+    "name": "@cf/mistral/mistral-7b-instruct-v0.1",
+    "description": "Instruct fine-tuned version of the Mistral-7b generative text model with 7 billion parameters",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://mistral.ai/news/announcing-mistral-7b/"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.2-lora.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.2-lora.json
@@ -1,1 +1,383 @@
-{"id":"c58c317b-0c15-4bda-abb6-93e275f282d9","source":1,"name":"@cf/mistral/mistral-7b-instruct-v0.2-lora","description":"The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"lora","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "c58c317b-0c15-4bda-abb6-93e275f282d9",
+    "source": 1,
+    "name": "@cf/mistral/mistral-7b-instruct-v0.2-lora",
+    "description": "The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
@@ -1,1 +1,399 @@
-{"id":"b97d7069-48d9-461c-80dd-445d20a632eb","source":2,"name":"@hf/mistral/mistral-7b-instruct-v0.2","description":"The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2. Mistral-7B-v0.2 has the following changes compared to Mistral-7B-v0.1: 32k context window (vs 8k context in v0.1), rope-theta = 1e6, and no Sliding-Window Attention.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2"},{"property_id":"lora","value":"true"},{"property_id":"max_batch_prefill_tokens","value":"8192"},{"property_id":"max_input_length","value":"3072"},{"property_id":"max_total_tokens","value":"4096"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "b97d7069-48d9-461c-80dd-445d20a632eb",
+    "source": 2,
+    "name": "@hf/mistral/mistral-7b-instruct-v0.2",
+    "description": "The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2. Mistral-7B-v0.2 has the following changes compared to Mistral-7B-v0.1: 32k context window (vs 8k context in v0.1), rope-theta = 1e6, and no Sliding-Window Attention.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2"
+        },
+        {
+            "property_id": "lora",
+            "value": "true"
+        },
+        {
+            "property_id": "max_batch_prefill_tokens",
+            "value": "8192"
+        },
+        {
+            "property_id": "max_input_length",
+            "value": "3072"
+        },
+        {
+            "property_id": "max_total_tokens",
+            "value": "4096"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/neural-chat-7b-v3-1-awq.json
+++ b/src/content/workers-ai-models/neural-chat-7b-v3-1-awq.json
@@ -1,1 +1,379 @@
-{"id":"d2ba5c6b-bbb7-49d6-b466-900654870cd6","source":2,"name":"@hf/thebloke/neural-chat-7b-v3-1-awq","description":"This model is a fine-tuned 7B parameter LLM on the Intel Gaudi 2 processor from the mistralai/Mistral-7B-v0.1 on the open source dataset Open-Orca/SlimOrca.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "d2ba5c6b-bbb7-49d6-b466-900654870cd6",
+    "source": 2,
+    "name": "@hf/thebloke/neural-chat-7b-v3-1-awq",
+    "description": "This model is a fine-tuned 7B parameter LLM on the Intel Gaudi 2 processor from the mistralai/Mistral-7B-v0.1 on the open source dataset Open-Orca/SlimOrca.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/openchat-3.5-0106.json
+++ b/src/content/workers-ai-models/openchat-3.5-0106.json
@@ -1,1 +1,383 @@
-{"id":"081054cd-a254-4349-855e-6dc0996277fa","source":1,"name":"@cf/openchat/openchat-3.5-0106","description":"OpenChat is an innovative library of open-source language models, fine-tuned with C-RLFT - a strategy inspired by offline reinforcement learning.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/openchat/openchat-3.5-0106"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "081054cd-a254-4349-855e-6dc0996277fa",
+    "source": 1,
+    "name": "@cf/openchat/openchat-3.5-0106",
+    "description": "OpenChat is an innovative library of open-source language models, fine-tuned with C-RLFT - a strategy inspired by offline reinforcement learning.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/openchat/openchat-3.5-0106"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/openhermes-2.5-mistral-7b-awq.json
+++ b/src/content/workers-ai-models/openhermes-2.5-mistral-7b-awq.json
@@ -1,1 +1,379 @@
-{"id":"673c56cc-8553-49a1-b179-dd549ec9209a","source":2,"name":"@hf/thebloke/openhermes-2.5-mistral-7b-awq","description":"OpenHermes 2.5 Mistral 7B is a state of the art Mistral Fine-tune, a continuation of OpenHermes 2 model, which trained on additional code datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "673c56cc-8553-49a1-b179-dd549ec9209a",
+    "source": 2,
+    "name": "@hf/thebloke/openhermes-2.5-mistral-7b-awq",
+    "description": "OpenHermes 2.5 Mistral 7B is a state of the art Mistral Fine-tune, a continuation of OpenHermes 2 model, which trained on additional code datasets.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/phi-2.json
+++ b/src/content/workers-ai-models/phi-2.json
@@ -1,1 +1,383 @@
-{"id":"1d933df3-680f-4280-940d-da87435edb07","source":1,"name":"@cf/microsoft/phi-2","description":"Phi-2 is a Transformer-based model with a next-word prediction objective, trained on 1.4T tokens from multiple passes on a mixture of Synthetic and Web datasets for NLP and coding.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/microsoft/phi-2"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "1d933df3-680f-4280-940d-da87435edb07",
+    "source": 1,
+    "name": "@cf/microsoft/phi-2",
+    "description": "Phi-2 is a Transformer-based model with a next-word prediction objective, trained on 1.4T tokens from multiple passes on a mixture of Synthetic and Web datasets for NLP and coding.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/microsoft/phi-2"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/qwen1.5-0.5b-chat.json
+++ b/src/content/workers-ai-models/qwen1.5-0.5b-chat.json
@@ -1,1 +1,383 @@
-{"id":"f8703a00-ed54-4f98-bdc3-cd9a813286f3","source":1,"name":"@cf/qwen/qwen1.5-0.5b-chat","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-0.5b-chat"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "f8703a00-ed54-4f98-bdc3-cd9a813286f3",
+    "source": 1,
+    "name": "@cf/qwen/qwen1.5-0.5b-chat",
+    "description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/qwen/qwen1.5-0.5b-chat"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/qwen1.5-1.8b-chat.json
+++ b/src/content/workers-ai-models/qwen1.5-1.8b-chat.json
@@ -1,1 +1,383 @@
-{"id":"3222ddb3-e211-4fd9-9a6d-79a80e47b3a6","source":1,"name":"@cf/qwen/qwen1.5-1.8b-chat","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-1.8b-chat"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "3222ddb3-e211-4fd9-9a6d-79a80e47b3a6",
+    "source": 1,
+    "name": "@cf/qwen/qwen1.5-1.8b-chat",
+    "description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/qwen/qwen1.5-1.8b-chat"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/qwen1.5-14b-chat-awq.json
+++ b/src/content/workers-ai-models/qwen1.5-14b-chat-awq.json
@@ -1,1 +1,383 @@
-{"id":"09d113a9-03c4-420e-b6f2-52ad4b3bed45","source":1,"name":"@cf/qwen/qwen1.5-14b-chat-awq","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-14b-chat-awq"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "09d113a9-03c4-420e-b6f2-52ad4b3bed45",
+    "source": 1,
+    "name": "@cf/qwen/qwen1.5-14b-chat-awq",
+    "description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/qwen/qwen1.5-14b-chat-awq"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/qwen1.5-7b-chat-awq.json
+++ b/src/content/workers-ai-models/qwen1.5-7b-chat-awq.json
@@ -1,1 +1,383 @@
-{"id":"90a20ae7-7cf4-4eb3-8672-8fc4ee580635","source":1,"name":"@cf/qwen/qwen1.5-7b-chat-awq","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-7b-chat-awq"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "90a20ae7-7cf4-4eb3-8672-8fc4ee580635",
+    "source": 1,
+    "name": "@cf/qwen/qwen1.5-7b-chat-awq",
+    "description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/qwen/qwen1.5-7b-chat-awq"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/resnet-50.json
+++ b/src/content/workers-ai-models/resnet-50.json
@@ -1,1 +1,66 @@
-{"id":"7f9a76e1-d120-48dd-a565-101d328bbb02","source":1,"name":"@cf/microsoft/resnet-50","description":"50 layers deep image classification CNN trained on more than 1M images from ImageNet","task":{"id":"00cd182b-bf30-4fc4-8481-84a3ab349657","name":"Image Classification","description":"Image classification models take an image input and assigns it labels or classes."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://www.microsoft.com/en-us/research/blog/microsoft-vision-model-resnet-50-combines-web-scale-data-and-multi-task-learning-to-achieve-state-of-the-art/"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary","description":"The image to classify"},{"type":"object","properties":{"image":{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255 (unsigned 8bit)"}}},"required":["image"]}]},"output":{"type":"array","contentType":"application/json","items":{"type":"object","properties":{"score":{"type":"number","description":"A confidence value, between 0 and 1, indicating how certain the model is about the predicted label"},"label":{"type":"string","description":"The predicted category or class for the input image based on analysis"}}}}}}
+{
+    "id": "7f9a76e1-d120-48dd-a565-101d328bbb02",
+    "source": 1,
+    "name": "@cf/microsoft/resnet-50",
+    "description": "50 layers deep image classification CNN trained on more than 1M images from ImageNet",
+    "task": {
+        "id": "00cd182b-bf30-4fc4-8481-84a3ab349657",
+        "name": "Image Classification",
+        "description": "Image classification models take an image input and assigns it labels or classes."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://www.microsoft.com/en-us/research/blog/microsoft-vision-model-resnet-50-combines-web-scale-data-and-multi-task-learning-to-achieve-state-of-the-art/"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The image to classify"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "array",
+                            "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                            "items": {
+                                "type": "number",
+                                "description": "A value between 0 and 255 (unsigned 8bit)"
+                            }
+                        }
+                    },
+                    "required": [
+                        "image"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "type": "array",
+            "contentType": "application/json",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "score": {
+                        "type": "number",
+                        "description": "A confidence value, between 0 and 1, indicating how certain the model is about the predicted label"
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "The predicted category or class for the input image based on analysis"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/sqlcoder-7b-2.json
+++ b/src/content/workers-ai-models/sqlcoder-7b-2.json
@@ -1,1 +1,387 @@
-{"id":"1dc9e589-df6b-4e66-ac9f-ceff42d64983","source":1,"name":"@cf/defog/sqlcoder-7b-2","description":"This model is intended to be used by non-technical users to understand data inside their SQL databases. ","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/defog/sqlcoder-7b-2"},{"property_id":"terms","value":"https://creativecommons.org/licenses/by-sa/4.0/deed.en"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "1dc9e589-df6b-4e66-ac9f-ceff42d64983",
+    "source": 1,
+    "name": "@cf/defog/sqlcoder-7b-2",
+    "description": "This model is intended to be used by non-technical users to understand data inside their SQL databases. ",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/defog/sqlcoder-7b-2"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://creativecommons.org/licenses/by-sa/4.0/deed.en"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/stable-diffusion-v1-5-img2img.json
+++ b/src/content/workers-ai-models/stable-diffusion-v1-5-img2img.json
@@ -1,1 +1,103 @@
-{"id":"19547f04-7a6a-4f87-bf2c-f5e32fb12dc5","source":1,"name":"@cf/runwayml/stable-diffusion-v1-5-img2img","description":"Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images. Img2img generate a new image from an input image with Stable Diffusion. ","task":{"id":"3d6e1f35-341b-4915-a6c8-9a7142a9033a","name":"Text-to-Image","description":"Generates images from input text. These models can be used to generate and modify images based on text prompts."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/runwayml/stable-diffusion-v1-5"},{"property_id":"terms","value":"https://github.com/runwayml/stable-diffusion/blob/main/LICENSE"}],"schema":{"input":{"type":"object","properties":{"prompt":{"type":"string","minLength":1,"description":"A text description of the image you want to generate"},"negative_prompt":{"type":"string","description":"Text describing elements to avoid in the generated image"},"height":{"type":"integer","minimum":256,"maximum":2048,"description":"The height of the generated image in pixels"},"width":{"type":"integer","minimum":256,"maximum":2048,"description":"The width of the generated image in pixels"},"image":{"type":"array","description":"For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"image_b64":{"type":"string","description":"For use with img2img tasks. A base64-encoded string of the input image"},"mask":{"type":"array","description":"An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"num_steps":{"type":"integer","default":20,"maximum":20,"description":"The number of diffusion steps; higher values can improve quality but take longer"},"strength":{"type":"number","default":1,"description":"A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"},"guidance":{"type":"number","default":7.5,"description":"Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"},"seed":{"type":"integer","description":"Random seed for reproducibility of the image generation"}},"required":["prompt"]},"output":{"type":"string","contentType":"image/png","format":"binary","description":"The generated image in PNG format"}}}
+{
+    "id": "19547f04-7a6a-4f87-bf2c-f5e32fb12dc5",
+    "source": 1,
+    "name": "@cf/runwayml/stable-diffusion-v1-5-img2img",
+    "description": "Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images. Img2img generate a new image from an input image with Stable Diffusion. ",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/runwayml/stable-diffusion-v1-5"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/runwayml/stable-diffusion/blob/main/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate"
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "Text describing elements to avoid in the generated image"
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The height of the generated image in pixels"
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The width of the generated image in pixels"
+                },
+                "image": {
+                    "type": "array",
+                    "description": "For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "image_b64": {
+                    "type": "string",
+                    "description": "For use with img2img tasks. A base64-encoded string of the input image"
+                },
+                "mask": {
+                    "type": "array",
+                    "description": "An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "num_steps": {
+                    "type": "integer",
+                    "default": 20,
+                    "maximum": 20,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer"
+                },
+                "strength": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"
+                },
+                "guidance": {
+                    "type": "number",
+                    "default": 7.5,
+                    "description": "Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed for reproducibility of the image generation"
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "string",
+            "contentType": "image/png",
+            "format": "binary",
+            "description": "The generated image in PNG format"
+        }
+    }
+}

--- a/src/content/workers-ai-models/stable-diffusion-v1-5-inpainting.json
+++ b/src/content/workers-ai-models/stable-diffusion-v1-5-inpainting.json
@@ -1,1 +1,103 @@
-{"id":"a9abaef0-3031-47ad-8790-d311d8684c6c","source":1,"name":"@cf/runwayml/stable-diffusion-v1-5-inpainting","description":"Stable Diffusion Inpainting is a latent text-to-image diffusion model capable of generating photo-realistic images given any text input, with the extra capability of inpainting the pictures by using a mask.","task":{"id":"3d6e1f35-341b-4915-a6c8-9a7142a9033a","name":"Text-to-Image","description":"Generates images from input text. These models can be used to generate and modify images based on text prompts."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/runwayml/stable-diffusion-inpainting"},{"property_id":"terms","value":"https://github.com/runwayml/stable-diffusion/blob/main/LICENSE"}],"schema":{"input":{"type":"object","properties":{"prompt":{"type":"string","minLength":1,"description":"A text description of the image you want to generate"},"negative_prompt":{"type":"string","description":"Text describing elements to avoid in the generated image"},"height":{"type":"integer","minimum":256,"maximum":2048,"description":"The height of the generated image in pixels"},"width":{"type":"integer","minimum":256,"maximum":2048,"description":"The width of the generated image in pixels"},"image":{"type":"array","description":"For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"image_b64":{"type":"string","description":"For use with img2img tasks. A base64-encoded string of the input image"},"mask":{"type":"array","description":"An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"num_steps":{"type":"integer","default":20,"maximum":20,"description":"The number of diffusion steps; higher values can improve quality but take longer"},"strength":{"type":"number","default":1,"description":"A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"},"guidance":{"type":"number","default":7.5,"description":"Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"},"seed":{"type":"integer","description":"Random seed for reproducibility of the image generation"}},"required":["prompt"]},"output":{"type":"string","contentType":"image/png","format":"binary","description":"The generated image in PNG format"}}}
+{
+    "id": "a9abaef0-3031-47ad-8790-d311d8684c6c",
+    "source": 1,
+    "name": "@cf/runwayml/stable-diffusion-v1-5-inpainting",
+    "description": "Stable Diffusion Inpainting is a latent text-to-image diffusion model capable of generating photo-realistic images given any text input, with the extra capability of inpainting the pictures by using a mask.",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/runwayml/stable-diffusion-inpainting"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/runwayml/stable-diffusion/blob/main/LICENSE"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate"
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "Text describing elements to avoid in the generated image"
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The height of the generated image in pixels"
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The width of the generated image in pixels"
+                },
+                "image": {
+                    "type": "array",
+                    "description": "For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "image_b64": {
+                    "type": "string",
+                    "description": "For use with img2img tasks. A base64-encoded string of the input image"
+                },
+                "mask": {
+                    "type": "array",
+                    "description": "An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "num_steps": {
+                    "type": "integer",
+                    "default": 20,
+                    "maximum": 20,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer"
+                },
+                "strength": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"
+                },
+                "guidance": {
+                    "type": "number",
+                    "default": 7.5,
+                    "description": "Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed for reproducibility of the image generation"
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "string",
+            "contentType": "image/png",
+            "format": "binary",
+            "description": "The generated image in PNG format"
+        }
+    }
+}

--- a/src/content/workers-ai-models/stable-diffusion-xl-base-1.0.json
+++ b/src/content/workers-ai-models/stable-diffusion-xl-base-1.0.json
@@ -1,1 +1,103 @@
-{"id":"6d52253a-b731-4a03-b203-cde2d4fae871","source":1,"name":"@cf/stabilityai/stable-diffusion-xl-base-1.0","description":"Diffusion-based text-to-image generative model by Stability AI. Generates and modify images based on text prompts.","task":{"id":"3d6e1f35-341b-4915-a6c8-9a7142a9033a","name":"Text-to-Image","description":"Generates images from input text. These models can be used to generate and modify images based on text prompts."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://stability.ai/stable-diffusion"},{"property_id":"terms","value":"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md"}],"schema":{"input":{"type":"object","properties":{"prompt":{"type":"string","minLength":1,"description":"A text description of the image you want to generate"},"negative_prompt":{"type":"string","description":"Text describing elements to avoid in the generated image"},"height":{"type":"integer","minimum":256,"maximum":2048,"description":"The height of the generated image in pixels"},"width":{"type":"integer","minimum":256,"maximum":2048,"description":"The width of the generated image in pixels"},"image":{"type":"array","description":"For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"image_b64":{"type":"string","description":"For use with img2img tasks. A base64-encoded string of the input image"},"mask":{"type":"array","description":"An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"num_steps":{"type":"integer","default":20,"maximum":20,"description":"The number of diffusion steps; higher values can improve quality but take longer"},"strength":{"type":"number","default":1,"description":"A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"},"guidance":{"type":"number","default":7.5,"description":"Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"},"seed":{"type":"integer","description":"Random seed for reproducibility of the image generation"}},"required":["prompt"]},"output":{"type":"string","contentType":"image/png","format":"binary","description":"The generated image in PNG format"}}}
+{
+    "id": "6d52253a-b731-4a03-b203-cde2d4fae871",
+    "source": 1,
+    "name": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+    "description": "Diffusion-based text-to-image generative model by Stability AI. Generates and modify images based on text prompts.",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://stability.ai/stable-diffusion"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate"
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "Text describing elements to avoid in the generated image"
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The height of the generated image in pixels"
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The width of the generated image in pixels"
+                },
+                "image": {
+                    "type": "array",
+                    "description": "For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "image_b64": {
+                    "type": "string",
+                    "description": "For use with img2img tasks. A base64-encoded string of the input image"
+                },
+                "mask": {
+                    "type": "array",
+                    "description": "An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "num_steps": {
+                    "type": "integer",
+                    "default": 20,
+                    "maximum": 20,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer"
+                },
+                "strength": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"
+                },
+                "guidance": {
+                    "type": "number",
+                    "default": 7.5,
+                    "description": "Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed for reproducibility of the image generation"
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "string",
+            "contentType": "image/png",
+            "format": "binary",
+            "description": "The generated image in PNG format"
+        }
+    }
+}

--- a/src/content/workers-ai-models/stable-diffusion-xl-lightning.json
+++ b/src/content/workers-ai-models/stable-diffusion-xl-lightning.json
@@ -1,1 +1,99 @@
-{"id":"7f797b20-3eb0-44fd-b571-6cbbaa3c423b","source":1,"name":"@cf/bytedance/stable-diffusion-xl-lightning","description":"SDXL-Lightning is a lightning-fast text-to-image generation model. It can generate high-quality 1024px images in a few steps.","task":{"id":"3d6e1f35-341b-4915-a6c8-9a7142a9033a","name":"Text-to-Image","description":"Generates images from input text. These models can be used to generate and modify images based on text prompts."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/ByteDance/SDXL-Lightning"}],"schema":{"input":{"type":"object","properties":{"prompt":{"type":"string","minLength":1,"description":"A text description of the image you want to generate"},"negative_prompt":{"type":"string","description":"Text describing elements to avoid in the generated image"},"height":{"type":"integer","minimum":256,"maximum":2048,"description":"The height of the generated image in pixels"},"width":{"type":"integer","minimum":256,"maximum":2048,"description":"The width of the generated image in pixels"},"image":{"type":"array","description":"For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"image_b64":{"type":"string","description":"For use with img2img tasks. A base64-encoded string of the input image"},"mask":{"type":"array","description":"An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"num_steps":{"type":"integer","default":20,"maximum":20,"description":"The number of diffusion steps; higher values can improve quality but take longer"},"strength":{"type":"number","default":1,"description":"A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"},"guidance":{"type":"number","default":7.5,"description":"Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"},"seed":{"type":"integer","description":"Random seed for reproducibility of the image generation"}},"required":["prompt"]},"output":{"type":"string","contentType":"image/png","format":"binary","description":"The generated image in PNG format"}}}
+{
+    "id": "7f797b20-3eb0-44fd-b571-6cbbaa3c423b",
+    "source": 1,
+    "name": "@cf/bytedance/stable-diffusion-xl-lightning",
+    "description": "SDXL-Lightning is a lightning-fast text-to-image generation model. It can generate high-quality 1024px images in a few steps.",
+    "task": {
+        "id": "3d6e1f35-341b-4915-a6c8-9a7142a9033a",
+        "name": "Text-to-Image",
+        "description": "Generates images from input text. These models can be used to generate and modify images based on text prompts."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/ByteDance/SDXL-Lightning"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A text description of the image you want to generate"
+                },
+                "negative_prompt": {
+                    "type": "string",
+                    "description": "Text describing elements to avoid in the generated image"
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The height of the generated image in pixels"
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 2048,
+                    "description": "The width of the generated image in pixels"
+                },
+                "image": {
+                    "type": "array",
+                    "description": "For use with img2img tasks. An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "image_b64": {
+                    "type": "string",
+                    "description": "For use with img2img tasks. A base64-encoded string of the input image"
+                },
+                "mask": {
+                    "type": "array",
+                    "description": "An array representing An array of integers that represent mask image data for inpainting constrained to 8-bit unsigned integer values",
+                    "items": {
+                        "type": "number",
+                        "description": "A value between 0 and 255"
+                    }
+                },
+                "num_steps": {
+                    "type": "integer",
+                    "default": 20,
+                    "maximum": 20,
+                    "description": "The number of diffusion steps; higher values can improve quality but take longer"
+                },
+                "strength": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "A value between 0 and 1 indicating how strongly to apply the transformation during img2img tasks; lower values make the output closer to the input image"
+                },
+                "guidance": {
+                    "type": "number",
+                    "default": 7.5,
+                    "description": "Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt"
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed for reproducibility of the image generation"
+                }
+            },
+            "required": [
+                "prompt"
+            ]
+        },
+        "output": {
+            "type": "string",
+            "contentType": "image/png",
+            "format": "binary",
+            "description": "The generated image in PNG format"
+        }
+    }
+}

--- a/src/content/workers-ai-models/starling-lm-7b-beta.json
+++ b/src/content/workers-ai-models/starling-lm-7b-beta.json
@@ -1,1 +1,395 @@
-{"id":"e5ca943b-720f-4e66-aa8f-40e3d2770933","source":2,"name":"@hf/nexusflow/starling-lm-7b-beta","description":"We introduce Starling-LM-7B-beta, an open large language model (LLM) trained by Reinforcement Learning from AI Feedback (RLAIF). Starling-LM-7B-beta is trained from Openchat-3.5-0106 with our new reward model Nexusflow/Starling-RM-34B and policy optimization method Fine-Tuning Language Models from Human Preferences (PPO).","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/Nexusflow/Starling-LM-7B-beta"},{"property_id":"max_batch_prefill_tokens","value":"8192"},{"property_id":"max_input_length","value":"3072"},{"property_id":"max_total_tokens","value":"4096"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "e5ca943b-720f-4e66-aa8f-40e3d2770933",
+    "source": 2,
+    "name": "@hf/nexusflow/starling-lm-7b-beta",
+    "description": "We introduce Starling-LM-7B-beta, an open large language model (LLM) trained by Reinforcement Learning from AI Feedback (RLAIF). Starling-LM-7B-beta is trained from Openchat-3.5-0106 with our new reward model Nexusflow/Starling-RM-34B and policy optimization method Fine-Tuning Language Models from Human Preferences (PPO).",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/Nexusflow/Starling-LM-7B-beta"
+        },
+        {
+            "property_id": "max_batch_prefill_tokens",
+            "value": "8192"
+        },
+        {
+            "property_id": "max_input_length",
+            "value": "3072"
+        },
+        {
+            "property_id": "max_total_tokens",
+            "value": "4096"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/tinyllama-1.1b-chat-v1.0.json
+++ b/src/content/workers-ai-models/tinyllama-1.1b-chat-v1.0.json
@@ -1,1 +1,383 @@
-{"id":"bf6ddd21-6477-4681-bbbe-24c3d5423e78","source":1,"name":"@cf/tinyllama/tinyllama-1.1b-chat-v1.0","description":"The TinyLlama project aims to pretrain a 1.1B Llama model on 3 trillion tokens. This is the chat model finetuned on top of TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "bf6ddd21-6477-4681-bbbe-24c3d5423e78",
+    "source": 1,
+    "name": "@cf/tinyllama/tinyllama-1.1b-chat-v1.0",
+    "description": "The TinyLlama project aims to pretrain a 1.1B Llama model on 3 trillion tokens. This is the chat model finetuned on top of TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/uform-gen2-qwen-500m.json
+++ b/src/content/workers-ai-models/uform-gen2-qwen-500m.json
@@ -1,1 +1,85 @@
-{"id":"3dca5889-db3e-4973-aa0c-3a4a6bd22d29","source":1,"name":"@cf/unum/uform-gen2-qwen-500m","description":"UForm-Gen is a small generative vision-language model primarily designed for Image Captioning and Visual Question Answering. The model was pre-trained on the internal image captioning dataset and fine-tuned on public instructions datasets: SVIT, LVIS, VQAs datasets.","task":{"id":"882a91d1-c331-4eec-bdad-834c919942a8","name":"Image-to-Text","description":"Image to text models output a text from a given image. Image captioning or optical character recognition can be considered as the most common applications of image to text."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://www.unum.cloud/"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary","description":"Binary string representing the image contents."},{"type":"object","properties":{"temperature":{"type":"number","description":"Controls the randomness of the output; higher values produce more random results."},"prompt":{"type":"string","description":"The input text prompt for the model to generate a response."},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"max_tokens":{"type":"integer","default":512,"description":"The maximum number of tokens to generate in the response."}},"required":["image"]}]},"output":{"type":"object","contentType":"application/json","properties":{"description":{"type":"string"}}}}}
+{
+    "id": "3dca5889-db3e-4973-aa0c-3a4a6bd22d29",
+    "source": 1,
+    "name": "@cf/unum/uform-gen2-qwen-500m",
+    "description": "UForm-Gen is a small generative vision-language model primarily designed for Image Captioning and Visual Question Answering. The model was pre-trained on the internal image captioning dataset and fine-tuned on public instructions datasets: SVIT, LVIS, VQAs datasets.",
+    "task": {
+        "id": "882a91d1-c331-4eec-bdad-834c919942a8",
+        "name": "Image-to-Text",
+        "description": "Image to text models output a text from a given image. Image captioning or optical character recognition can be considered as the most common applications of image to text."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://www.unum.cloud/"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Binary string representing the image contents."
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "temperature": {
+                            "type": "number",
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "image": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "description": "An array of integers that represent the image data constrained to 8-bit unsigned integer values",
+                                    "items": {
+                                        "type": "number",
+                                        "description": "A value between 0 and 255"
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "format": "binary",
+                                    "description": "Binary string representing the image contents."
+                                }
+                            ]
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 512,
+                            "description": "The maximum number of tokens to generate in the response."
+                        }
+                    },
+                    "required": [
+                        "image"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "description": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/content/workers-ai-models/una-cybertron-7b-v2-bf16.json
+++ b/src/content/workers-ai-models/una-cybertron-7b-v2-bf16.json
@@ -1,1 +1,379 @@
-{"id":"b7fe7ad2-aeaf-47d2-8bfa-7a5ae22a2ab4","source":1,"name":"@cf/fblgit/una-cybertron-7b-v2-bf16","description":"Cybertron 7B v2 is a 7B MistralAI based model, best on it's series. It was trained with SFT, DPO and UNA (Unified Neural Alignment) on multiple datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "b7fe7ad2-aeaf-47d2-8bfa-7a5ae22a2ab4",
+    "source": 1,
+    "name": "@cf/fblgit/una-cybertron-7b-v2-bf16",
+    "description": "Cybertron 7B v2 is a 7B MistralAI based model, best on it's series. It was trained with SFT, DPO and UNA (Unified Neural Alignment) on multiple datasets.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/whisper-tiny-en.json
+++ b/src/content/workers-ai-models/whisper-tiny-en.json
@@ -1,1 +1,78 @@
-{"id":"2169496d-9c0e-4e49-8399-c44ee66bff7d","source":1,"name":"@cf/openai/whisper-tiny-en","description":"Whisper is a pre-trained model for automatic speech recognition (ASR) and speech translation. Trained on 680k hours of labelled data, Whisper models demonstrate a strong ability to generalize to many datasets and domains without the need for fine-tuning. This is the English-only version of the Whisper Tiny model which was trained on the task of speech recognition.","task":{"id":"dfce1c48-2a81-462e-a7fd-de97ce985207","name":"Automatic Speech Recognition","description":"Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."},"tags":[],"properties":[{"property_id":"beta","value":"true"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary"},{"type":"object","properties":{"audio":{"type":"array","description":"An array of integers that represent the audio data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"source_lang":{"type":"string","description":"The language of the recorded audio"},"target_lang":{"type":"string","description":"The language to translate the transcription into. Currently only English is supported."}},"required":["audio"]}]},"output":{"type":"object","contentType":"application/json","properties":{"text":{"type":"string","description":"The transcription"},"word_count":{"type":"number"},"words":{"type":"array","items":{"type":"object","properties":{"word":{"type":"string"},"start":{"type":"number","description":"The second this word begins in the recording"},"end":{"type":"number","description":"The ending second when the word completes"}}}},"vtt":{"type":"string"}},"required":["text"]}}}
+{
+	"id": "2169496d-9c0e-4e49-8399-c44ee66bff7d",
+	"source": 1,
+	"name": "@cf/openai/whisper-tiny-en",
+	"description": "Whisper is a pre-trained model for automatic speech recognition (ASR) and speech translation. Trained on 680k hours of labelled data, Whisper models demonstrate a strong ability to generalize to many datasets and domains without the need for fine-tuning. This is the English-only version of the Whisper Tiny model which was trained on the task of speech recognition.",
+	"task": {
+		"id": "dfce1c48-2a81-462e-a7fd-de97ce985207",
+		"name": "Automatic Speech Recognition",
+		"description": "Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."
+	},
+	"tags": [],
+	"properties": [
+		{
+			"property_id": "beta",
+			"value": "true"
+		}
+	],
+	"schema": {
+		"input": {
+			"oneOf": [
+				{
+					"type": "string",
+					"format": "binary"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"audio": {
+							"type": "array",
+							"description": "An array of integers that represent the audio data constrained to 8-bit unsigned integer values",
+							"items": {
+								"type": "number",
+								"description": "A value between 0 and 255"
+							}
+						}
+					},
+					"required": ["audio"]
+				}
+			]
+		},
+		"output": {
+			"type": "object",
+			"contentType": "application/json",
+			"properties": {
+				"text": {
+					"type": "string",
+					"description": "The transcription"
+				},
+				"word_count": {
+					"type": "number"
+				},
+				"words": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"word": {
+								"type": "string"
+							},
+							"start": {
+								"type": "number",
+								"description": "The second this word begins in the recording"
+							},
+							"end": {
+								"type": "number",
+								"description": "The ending second when the word completes"
+							}
+						}
+					}
+				},
+				"vtt": {
+					"type": "string"
+				}
+			},
+			"required": ["text"]
+		}
+	}
+}

--- a/src/content/workers-ai-models/whisper-tiny-en.json
+++ b/src/content/workers-ai-models/whisper-tiny-en.json
@@ -1,78 +1,82 @@
 {
-	"id": "2169496d-9c0e-4e49-8399-c44ee66bff7d",
-	"source": 1,
-	"name": "@cf/openai/whisper-tiny-en",
-	"description": "Whisper is a pre-trained model for automatic speech recognition (ASR) and speech translation. Trained on 680k hours of labelled data, Whisper models demonstrate a strong ability to generalize to many datasets and domains without the need for fine-tuning. This is the English-only version of the Whisper Tiny model which was trained on the task of speech recognition.",
-	"task": {
-		"id": "dfce1c48-2a81-462e-a7fd-de97ce985207",
-		"name": "Automatic Speech Recognition",
-		"description": "Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."
-	},
-	"tags": [],
-	"properties": [
-		{
-			"property_id": "beta",
-			"value": "true"
-		}
-	],
-	"schema": {
-		"input": {
-			"oneOf": [
-				{
-					"type": "string",
-					"format": "binary"
-				},
-				{
-					"type": "object",
-					"properties": {
-						"audio": {
-							"type": "array",
-							"description": "An array of integers that represent the audio data constrained to 8-bit unsigned integer values",
-							"items": {
-								"type": "number",
-								"description": "A value between 0 and 255"
-							}
-						}
-					},
-					"required": ["audio"]
-				}
-			]
-		},
-		"output": {
-			"type": "object",
-			"contentType": "application/json",
-			"properties": {
-				"text": {
-					"type": "string",
-					"description": "The transcription"
-				},
-				"word_count": {
-					"type": "number"
-				},
-				"words": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"word": {
-								"type": "string"
-							},
-							"start": {
-								"type": "number",
-								"description": "The second this word begins in the recording"
-							},
-							"end": {
-								"type": "number",
-								"description": "The ending second when the word completes"
-							}
-						}
-					}
-				},
-				"vtt": {
-					"type": "string"
-				}
-			},
-			"required": ["text"]
-		}
-	}
+    "id": "2169496d-9c0e-4e49-8399-c44ee66bff7d",
+    "source": 1,
+    "name": "@cf/openai/whisper-tiny-en",
+    "description": "Whisper is a pre-trained model for automatic speech recognition (ASR) and speech translation. Trained on 680k hours of labelled data, Whisper models demonstrate a strong ability to generalize to many datasets and domains without the need for fine-tuning. This is the English-only version of the Whisper Tiny model which was trained on the task of speech recognition.",
+    "task": {
+        "id": "dfce1c48-2a81-462e-a7fd-de97ce985207",
+        "name": "Automatic Speech Recognition",
+        "description": "Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "audio": {
+                            "type": "array",
+                            "description": "An array of integers that represent the audio data constrained to 8-bit unsigned integer values",
+                            "items": {
+                                "type": "number",
+                                "description": "A value between 0 and 255"
+                            }
+                        }
+                    },
+                    "required": [
+                        "audio"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The transcription"
+                },
+                "word_count": {
+                    "type": "number"
+                },
+                "words": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "word": {
+                                "type": "string"
+                            },
+                            "start": {
+                                "type": "number",
+                                "description": "The second this word begins in the recording"
+                            },
+                            "end": {
+                                "type": "number",
+                                "description": "The ending second when the word completes"
+                            }
+                        }
+                    }
+                },
+                "vtt": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text"
+            ]
+        }
+    }
 }

--- a/src/content/workers-ai-models/whisper.json
+++ b/src/content/workers-ai-models/whisper.json
@@ -1,1 +1,86 @@
-{"id":"c1c12ce4-c36a-4aa6-8da4-f63ba4b8984d","source":1,"name":"@cf/openai/whisper","description":"Whisper is a general-purpose speech recognition model. It is trained on a large dataset of diverse audio and is also a multitasking model that can perform multilingual speech recognition, speech translation, and language identification.","task":{"id":"dfce1c48-2a81-462e-a7fd-de97ce985207","name":"Automatic Speech Recognition","description":"Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."},"tags":[],"properties":[{"property_id":"beta","value":"false"},{"property_id":"info","value":"https://openai.com/research/whisper"}],"schema":{"input":{"oneOf":[{"type":"string","format":"binary"},{"type":"object","properties":{"audio":{"type":"array","description":"An array of integers that represent the audio data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},"source_lang":{"type":"string","description":"The language of the recorded audio"},"target_lang":{"type":"string","description":"The language to translate the transcription into. Currently only English is supported."}},"required":["audio"]}]},"output":{"type":"object","contentType":"application/json","properties":{"text":{"type":"string","description":"The transcription"},"word_count":{"type":"number"},"words":{"type":"array","items":{"type":"object","properties":{"word":{"type":"string"},"start":{"type":"number","description":"The second this word begins in the recording"},"end":{"type":"number","description":"The ending second when the word completes"}}}},"vtt":{"type":"string"}},"required":["text"]}}}
+{
+    "id": "c1c12ce4-c36a-4aa6-8da4-f63ba4b8984d",
+    "source": 1,
+    "name": "@cf/openai/whisper",
+    "description": "Whisper is a general-purpose speech recognition model. It is trained on a large dataset of diverse audio and is also a multitasking model that can perform multilingual speech recognition, speech translation, and language identification.",
+    "task": {
+        "id": "dfce1c48-2a81-462e-a7fd-de97ce985207",
+        "name": "Automatic Speech Recognition",
+        "description": "Automatic speech recognition (ASR) models convert a speech signal, typically an audio input, to text."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "false"
+        },
+        {
+            "property_id": "info",
+            "value": "https://openai.com/research/whisper"
+        }
+    ],
+    "schema": {
+        "input": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "binary"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "audio": {
+                            "type": "array",
+                            "description": "An array of integers that represent the audio data constrained to 8-bit unsigned integer values",
+                            "items": {
+                                "type": "number",
+                                "description": "A value between 0 and 255"
+                            }
+                        }
+                    },
+                    "required": [
+                        "audio"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "type": "object",
+            "contentType": "application/json",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The transcription"
+                },
+                "word_count": {
+                    "type": "number"
+                },
+                "words": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "word": {
+                                "type": "string"
+                            },
+                            "start": {
+                                "type": "number",
+                                "description": "The second this word begins in the recording"
+                            },
+                            "end": {
+                                "type": "number",
+                                "description": "The ending second when the word completes"
+                            }
+                        }
+                    }
+                },
+                "vtt": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text"
+            ]
+        }
+    }
+}

--- a/src/content/workers-ai-models/zephyr-7b-beta-awq.json
+++ b/src/content/workers-ai-models/zephyr-7b-beta-awq.json
@@ -1,1 +1,383 @@
-{"id":"3976bab8-3810-4ad8-8580-ab1e22de7823","source":2,"name":"@hf/thebloke/zephyr-7b-beta-awq","description":"Zephyr 7B Beta AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Zephyr model variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"info","value":"https://huggingface.co/TheBloke/zephyr-7B-beta-AWQ"}],"schema":{"input":{"type":"object","oneOf":[{"title":"Prompt","properties":{"prompt":{"type":"string","minLength":1,"maxLength":131072,"description":"The input text prompt for the model to generate a response."},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"raw":{"type":"boolean","default":false,"description":"If true, a chat template is not applied and you must adhere to the specific model's expected formatting."},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally using SSE, Server Sent Events."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."},"lora":{"type":"string","description":"Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."}},"required":["prompt"]},{"title":"Messages","properties":{"messages":{"type":"array","description":"An array of message objects representing the conversation history.","items":{"type":"object","properties":{"role":{"type":"string","description":"The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."},"content":{"type":"string","maxLength":131072,"description":"The content of the message as a string."}},"required":["role","content"]}},"image":{"oneOf":[{"type":"array","description":"An array of integers that represent the image data constrained to 8-bit unsigned integer values","items":{"type":"number","description":"A value between 0 and 255"}},{"type":"string","format":"binary","description":"Binary string representing the image contents."}]},"functions":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"string"}},"required":["name","code"]}},"tools":{"type":"array","description":"A list of tools available for the assistant to use.","items":{"type":"object","oneOf":[{"properties":{"name":{"type":"string","description":"The name of the tool. More descriptive the better."},"description":{"type":"string","description":"A brief description of what the tool does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the tool.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]},{"properties":{"type":{"type":"string","description":"Specifies the type of tool (e.g., 'function')."},"function":{"type":"object","description":"Details of the function tool.","properties":{"name":{"type":"string","description":"The name of the function."},"description":{"type":"string","description":"A brief description of what the function does."},"parameters":{"type":"object","description":"Schema defining the parameters accepted by the function.","properties":{"type":{"type":"string","description":"The type of the parameters object (usually 'object')."},"required":{"type":"array","description":"List of required parameter names.","items":{"type":"string"}},"properties":{"type":"object","description":"Definitions of each parameter.","additionalProperties":{"type":"object","properties":{"type":{"type":"string","description":"The data type of the parameter."},"description":{"type":"string","description":"A description of the expected parameter."}},"required":["type","description"]}}},"required":["type","properties"]}},"required":["name","description","parameters"]}},"required":["type","function"]}]}},"stream":{"type":"boolean","default":false,"description":"If true, the response will be streamed back incrementally."},"max_tokens":{"type":"integer","default":256,"description":"The maximum number of tokens to generate in the response."},"temperature":{"type":"number","default":0.6,"minimum":0,"maximum":5,"description":"Controls the randomness of the output; higher values produce more random results."},"top_p":{"type":"number","minimum":0,"maximum":2,"description":"Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."},"top_k":{"type":"integer","minimum":1,"maximum":50,"description":"Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."},"seed":{"type":"integer","minimum":1,"maximum":9999999999,"description":"Random seed for reproducibility of the generation."},"repetition_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Penalty for repeated tokens; higher values discourage repetition."},"frequency_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Decreases the likelihood of the model repeating the same lines verbatim."},"presence_penalty":{"type":"number","minimum":0,"maximum":2,"description":"Increases the likelihood of the model introducing new topics."}},"required":["messages"]}]},"output":{"oneOf":[{"type":"object","contentType":"application/json","properties":{"response":{"type":"string","description":"The generated text response from the model"},"tool_calls":{"type":"array","description":"An array of tool calls requests made during the response generation","items":{"type":"object","properties":{"arguments":{"type":"object","description":"The arguments passed to be passed to the tool call request"},"name":{"type":"string","description":"The name of the tool to be called"}}}}}},{"type":"string","contentType":"text/event-stream","format":"binary"}]}}}
+{
+    "id": "3976bab8-3810-4ad8-8580-ab1e22de7823",
+    "source": 2,
+    "name": "@hf/thebloke/zephyr-7b-beta-awq",
+    "description": "Zephyr 7B Beta AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Zephyr model variant.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "beta",
+            "value": "true"
+        },
+        {
+            "property_id": "info",
+            "value": "https://huggingface.co/TheBloke/zephyr-7B-beta-AWQ"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 131072,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 131072,
+                                        "description": "The content of the message as a string."
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### Summary

This PR updates formatting of JSON schema files for AI models to assist human-readability in changes. It also updates Text Generation schemas to only show `image` parameters if the model supports them, and updates Automatic Speech Recognition schemas to only show `source_lang` and `target_lang` fields if the model supports them.

Sorry for the formatting noise!