### PR TITLE
[Queues] Fix broken code blocks

### DIFF
--- a/src/content/docs/queues/configuration/javascript-apis.mdx
+++ b/src/content/docs/queues/configuration/javascript-apis.mdx
@@ -92,7 +92,7 @@ type MessageSendRequest<Body = unknown> = {
   * The body of the message.
   * The body can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types), as long as its size is less than 128 KB.
 
-* <code>optionsQueueSendOptions</code>
+* <code>options</code> QueueSendOptions
 
   * Options to apply to the current message, including content type and message delay settings.
 
@@ -102,13 +102,13 @@ type MessageSendRequest<Body = unknown> = {
 
 Optional configuration that applies when sending a message to a queue.
 
-* <code>contentTypeQueuesContentType</code>
+* <code>contentType</code> QueuesContentType
 
   * The explicit content type of a message so it can be previewed correctly with the [List messages from the dashboard](/queues/examples/list-messages-from-dash/) feature. Optional argument.
   * As of now, this option is for internal use. In the future, `contentType` will be used by alternative consumer types to explicitly mark messages as serialized so they can be consumed in the desired type.
   * See [QueuesContentType](#queuescontenttype) for possible values.
 
-* <code>delaySecondsnumber</code>
+* <code>delaySeconds</code> number
 
   * The number of seconds to [delay a message](/queues/configuration/batching-retries/) for within the queue, before it can be delivered to a consumer.
   * Must be an integer between 0 and 43200 (12 hours). Setting this value to zero will explicitly prevent the message from being delayed, even if there is a global (default) delay at the queue level.
@@ -117,7 +117,7 @@ Optional configuration that applies when sending a message to a queue.
 
 Optional configuration that applies when sending a batch of messages to a queue.
 
-* <code>delaySecondsnumber</code>
+* <code>delaySeconds</code> number
 
   * The number of seconds to [delay messages](/queues/configuration/batching-retries/) for within the queue, before it can be delivered to a consumer.
   * Must be a positive integer.
@@ -291,7 +291,7 @@ declare interface QueueRetryOptions {
 }
 ```
 
-* <code>delaySecondsnumber</code>
+* <code>delaySeconds</code> number
 
   * The number of seconds to [delay a message](/queues/configuration/batching-retries/) for within the queue, before it can be delivered to a consumer.
   * Must be a positive integer.


### PR DESCRIPTION
### Summary

Fixed broken code blocks in the Queues JavaScript API documentation.

### Screenshots (optional)

#### Before

![CleanShot 2024-11-08 at 00 35 36@2x](https://github.com/user-attachments/assets/2da304eb-50c8-4b36-9e7d-4b5a81049770)

#### After

![CleanShot 2024-11-08 at 00 34 52@2x](https://github.com/user-attachments/assets/a11243a2-bddc-4e82-9202-ddef2795534a)
