### PR TITLE
[Docs Site] Fix GitHubCode tag conditional

### DIFF
--- a/src/components/GitHubCode.astro
+++ b/src/components/GitHubCode.astro
@@ -57,7 +57,7 @@ if (lines) {
 		x.includes(`</docs-tag name="${tag}">`),
 	);
 
-	if (!startTag || !endTag) {
+	if (startTag === -1 || endTag === -1) {
 		throw new Error(`[GitHubCode] Unable to find a region using tag "${tag}".`);
 	}
 


### PR DESCRIPTION
### Summary

Fix GitHubCode tag conditional since a tag on the first line would return `0` which is falsy, we should check for `-1`.