### PR TITLE
[Rules] Cloud Connector: clarify SSL to AWS S3

### DIFF
--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -35,7 +35,7 @@ Cloud Connector rules are evaluated last in the request evaluation workflow. Whe
 Cloud Connector will perform the following configurations automatically, depending on the cloud provider:
 
 - Modify the `Host` header.
-- Adjust SSL/TLS for bucket-related traffic ([Amazon S3 website endpoints](./providers/#ssl-connections-for-aws-s3-endpoints) only).
+- Adjust SSL/TLS for bucket-related traffic ([Amazon S3 website endpoints](/rules/cloud-connector/providers/#ssl-connections-for-aws-s3-endpoints) only).
 
 ## Availability
 

--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -35,7 +35,7 @@ Cloud Connector rules are evaluated last in the request evaluation workflow. Whe
 Cloud Connector will perform the following configurations automatically, depending on the cloud provider:
 
 - Modify the `Host` header.
-- Adjust SSL/TLS for bucket-related traffic (AWS S3 only).
+- Adjust SSL/TLS for bucket-related traffic ([Amazon S3 website endpoints](./providers/#ssl-connections-for-aws-s3-endpoints) only).
 
 ## Availability
 

--- a/src/content/docs/rules/cloud-connector/providers.mdx
+++ b/src/content/docs/rules/cloud-connector/providers.mdx
@@ -31,9 +31,9 @@ Cloud Connector supports both subdomain and URI path-style URLs:
 - **Subdomain-style URLs**: Set the hostname to `<BUCKET_NAME>.s3.amazonaws.com`. In this case, your files are accessible directly under the root of the bucket. For example, `https://example.com/index.html` will map to `https://<BUCKET_NAME>.s3.amazonaws.com/index.html`.
 - **URI path-style URLs**: Set the hostname to `s3.amazonaws.com`. Here, your bucket name must be part of the URI path in your requests. For example, if your bucket name is `<BUCKET_NAME>`, files will be available on paths like `https://example.com/<BUCKET_NAME>/index.html`, and your Cloud Connector rule should filter traffic based on the URI path starting with `/<BUCKET_NAME>`.
 
-### SSL Connections to AWS S3 Endpoints
+### SSL connections to AWS S3 endpoints
 
-The SSL setting applied for requests between Cloud Connector and AWS S3 depends on the type of S3 endpoint you use:
+The SSL setting applied to requests between Cloud Connector and AWS S3 depends on the type of S3 endpoint you use:
 
 - **HTTPS-supported endpoints**: For hostnames like `*s3.<REGION>.amazonaws.com` and `*s3.amazonaws.com`, Cloudflare will connect to AWS S3 over HTTPS if you set your zone's SSL/TLS mode to **Full** or **Full (Strict)**.
 - **Non-HTTPS endpoints**: For website-style hostnames such as `*s3-website.<REGION>.amazonaws.com` or `*s3-website-<REGION>.amazonaws.com`, which do not support HTTPS, Cloudflare will default to **Flexible SSL**.

--- a/src/content/docs/rules/cloud-connector/providers.mdx
+++ b/src/content/docs/rules/cloud-connector/providers.mdx
@@ -22,14 +22,21 @@ Support for Cloudflare R2 will be added soon.
 The hostname of your S3 bucket URL must have one of the following formats (where `*` is a wildcard character):
 
 - `*s3.amazonaws.com`
-- `*s3-website.<REGION>.amazonaws.com`
 - `*s3.<REGION>.amazonaws.com`
+- `*s3-website.<REGION>.amazonaws.com`
 - `*s3-website-<REGION>.amazonaws.com`
 
 Cloud Connector supports both subdomain and URI path-style URLs:
 
 - **Subdomain-style URLs**: Set the hostname to `<BUCKET_NAME>.s3.amazonaws.com`. In this case, your files are accessible directly under the root of the bucket. For example, `https://example.com/index.html` will map to `https://<BUCKET_NAME>.s3.amazonaws.com/index.html`.
 - **URI path-style URLs**: Set the hostname to `s3.amazonaws.com`. Here, your bucket name must be part of the URI path in your requests. For example, if your bucket name is `<BUCKET_NAME>`, files will be available on paths like `https://example.com/<BUCKET_NAME>/index.html`, and your Cloud Connector rule should filter traffic based on the URI path starting with `/<BUCKET_NAME>`.
+
+### SSL Connections to AWS S3 Endpoints
+
+The SSL setting applied for requests between Cloud Connector and AWS S3 depends on the type of S3 endpoint you use:
+
+- **HTTPS-supported endpoints**: For hostnames like `*s3.<REGION>.amazonaws.com` and `*s3.amazonaws.com`, Cloudflare will connect to AWS S3 over HTTPS if you set your zone's SSL/TLS mode to **Full** or **Full (Strict)**.
+- **Non-HTTPS endpoints**: For website-style hostnames such as `*s3-website.<REGION>.amazonaws.com` or `*s3-website-<REGION>.amazonaws.com`, which do not support HTTPS, Cloudflare will default to **Flexible SSL**.
 
 ### Get the bucket URL
 


### PR DESCRIPTION
### Summary

Cloud Connector applies different SSL settings based on the type of S3 endpoints.