### PR TITLE
fix: misspelt date in /warp/user-side-certificates/

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/automated-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/automated-deployment.mdx
@@ -6,7 +6,7 @@ sidebar:
 head: []
 description: Automatically deploy a root certificate on desktop devices.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-17-10, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/automated-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/automated-deployment.mdx
@@ -6,7 +6,7 @@ sidebar:
 head: []
 description: Automatically deploy a root certificate on desktop devices.
 banner:
-  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/custom-certificate.mdx
@@ -7,7 +7,7 @@ head: []
 description: Configure WARP to use a custom root certificate instead of the
   Cloudflare certificate.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-17-10, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Render, Tabs, TabItem } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/custom-certificate.mdx
@@ -7,7 +7,7 @@ head: []
 description: Configure WARP to use a custom root certificate instead of the
   Cloudflare certificate.
 banner:
-  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Render, Tabs, TabItem } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/index.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/index.mdx
@@ -4,7 +4,7 @@ title: User-side certificates
 sidebar:
   order: 4
 banner:
-  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 Advanced security features such as [HTTPS traffic inspection](/cloudflare-one/policies/gateway/http-policies/tls-decryption/), [Data Loss Prevention](/cloudflare-one/policies/data-loss-prevention/), [anti-virus scanning](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/), [Access for Infrastructure](/cloudflare-one/applications/non-http/infrastructure-apps/), and [Browser Isolation](/cloudflare-one/policies/browser-isolation/) require users to install and trust a root certificate on their device. You can either install the certificate provided by Cloudflare (default option), or generate your own custom certificate and upload it to Cloudflare.

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/index.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/index.mdx
@@ -4,7 +4,7 @@ title: User-side certificates
 sidebar:
   order: 4
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-17-10, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 Advanced security features such as [HTTPS traffic inspection](/cloudflare-one/policies/gateway/http-policies/tls-decryption/), [Data Loss Prevention](/cloudflare-one/policies/data-loss-prevention/), [anti-virus scanning](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/), [Access for Infrastructure](/cloudflare-one/applications/non-http/infrastructure-apps/), and [Browser Isolation](/cloudflare-one/policies/browser-isolation/) require users to install and trust a root certificate on their device. You can either install the certificate provided by Cloudflare (default option), or generate your own custom certificate and upload it to Cloudflare.

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/manual-deployment.mdx
@@ -7,7 +7,7 @@ head: []
 description: Manually add a Cloudflare certificate to mobile devices and
   individual applications.
 banner:
-  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details, Render, TabItem, Tabs } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/user-side-certificates/manual-deployment.mdx
@@ -7,7 +7,7 @@ head: []
 description: Manually add a Cloudflare certificate to mobile devices and
   individual applications.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-17-10, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on February 2nd, 2024. If you installed the default Cloudflare certificate before October 10th, 2024, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details, Render, TabItem, Tabs } from "~/components";


### PR DESCRIPTION
### Summary
Really wierd way to pronounce "Oct 17th, 2024".

It should've look like this: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/user-side-certificates/#activate-a-root-certificate 

### Screenshots (optional)

![img-110824](https://github.com/user-attachments/assets/346ed8c8-e27e-4d14-87ec-676b76b2e85c)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
