### PR TITLE
[Rules] Fix broken anchor

### DIFF
--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -35,7 +35,7 @@ Cloud Connector rules are evaluated last in the request evaluation workflow. Whe
 Cloud Connector will perform the following configurations automatically, depending on the cloud provider:
 
 - Modify the `Host` header.
-- Adjust SSL/TLS for bucket-related traffic ([Amazon S3 website endpoints](/rules/cloud-connector/providers/#ssl-connections-for-aws-s3-endpoints) only).
+- Adjust SSL/TLS for bucket-related traffic ([AWS S3 website endpoints](/rules/cloud-connector/providers/#ssl-connections-to-aws-s3-endpoints) only).
 
 ## Availability
 


### PR DESCRIPTION
### Summary

Fixes a broken anchor and updates `Amazon` >> `AWS`.
