### PR TITLE
Update cache-reserve.mdx

### DIFF
--- a/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
+++ b/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
@@ -46,6 +46,7 @@ Not all assets are eligible for Cache Reserve. To be admitted into Cache Reserve
 - Be cacheable, according to Cloudflare's standard [cacheability factors](/cache),
 - Have a freshness time-to-live (TTL) of at least 10 hours (set by any means such as Cache-Control / [CDN-Cache-Control](/cache/concepts/cache-control/) origin response headers, [Edge Cache TTL](/cache/how-to/edge-browser-cache-ttl/#edge-cache-ttl), [Cache TTL By Status](/cache/how-to/configure-cache-status-code/), or [Cache Rules](/cache/how-to/cache-rules/)),
 - Have a Content-Length response header.
+- Come from an origin in the eyeball zone, and not from an [O2O](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) origin.
 - When using [Image transformations](/images/manage-images/create-variants/), original files are eligible for Cache Reserve, but resized file variants are not eligible because transformations happen after Cache Reserve in the response flow.
 
 ## Limits


### PR DESCRIPTION
Added O2O caveat, as per cache team review here:
https://chat.google.com/room/AAAAw8D9k0s/m8bhqCpQ10g/m8bhqCpQ10g?cls=10

While Tiered Cache is moving in front of O2O, Cache Reserve is still behind O2O.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
