### PR TITLE
Update wrangler workers site to recommend workers static assets

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1121,7 +1121,7 @@ upload_source_maps = true
 
 ## Workers Sites
 
-<Render file="workers_sites" />
+<Render file="workers_sites"/>
 
 [Workers Sites](/workers/configuration/sites/) allows you to host static websites, or dynamic websites using frameworks like Vue or React, on Workers.
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1121,10 +1121,7 @@ upload_source_maps = true
 
 ## Workers Sites
 
-:::note[Cloudflare Pages]
-
-Consider using [Cloudflare Pages](/pages/) for hosting static applications instead of Workers Sites.
-:::
+<Render file="workers_sites" />
 
 [Workers Sites](/workers/configuration/sites/) allows you to host static websites, or dynamic websites using frameworks like Vue or React, on Workers.
 


### PR DESCRIPTION
### Summary

The following recommends Cloudflare Pages over Workers Sites, which is inconsistent with other documentation that recommends Workers Static Assets

https://developers.cloudflare.com/workers/wrangler/configuration/#workers-sites

### Screenshots (optional)

Now the section looks like:

![image](https://github.com/user-attachments/assets/7f6aaee3-89d0-4f55-96dd-7778767e4a70)


