### PR TITLE
[Area 1] Clarify Gmail BCC instructions

### DIFF
--- a/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
+++ b/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
@@ -22,11 +22,11 @@ import { Render } from "~/components"
 7. In **If the above expressions match, do the following**:
     1. Select **Modify message**.
     2. Ensure that **Envelope recipient** > **Change envelope recipient** is unselected, to ensure that emails will not be dropped as an unintended consequence. You will select this option at a later stage.
-    2. Go to **Also deliver to**, select **Add more recipients** > **ADD** > Choose **Advanced**.
-    3. Under **Envelope recipient**, select **Change envelope recipient** > **Replace recipient** > Enter the email of the recipient.
-    4. Under **Spam and delivery options**, select **Suppress bounces from this recipient**.
-    5. Under **Headers**, select **Add X-Gm-Spam and X-Gm-Phishy headers**.
-    6. Select **SAVE**.
+    3. Go to **Also deliver to**, select **Add more recipients** > **ADD** > Choose **Advanced**.
+    4. Under **Envelope recipient**, select **Change envelope recipient** > **Replace recipient** > Enter the email of the recipient.
+    5. Under **Spam and delivery options**, select **Suppress bounces from this recipient**.
+    6. Under **Headers**, select **Add X-Gm-Spam and X-Gm-Phishy headers**.
+    7. Select **SAVE**.
 8. In **Account types to affect**, select **Users** and **Groups**.
 9. Select **SAVE**.
 

--- a/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
+++ b/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
@@ -19,7 +19,7 @@ import { Render } from "~/components"
     5. In **Match type**, select **Matches regex**.
     6. In **Regexp** input `.*`. You can customize the regex as needed and test within the admin page or on sites like [Regexr](https://regexr.com/).
     7. Select **SAVE**.
-7. In **If the above expressions match, do the following**:
+6. In **If the above expressions match, do the following**:
     1. Select **Modify message**.
     2. Ensure that **Envelope recipient** > **Change envelope recipient** is unselected, to ensure that emails will not be dropped as an unintended consequence. You will select this option at a later stage.
     3. Go to **Also deliver to**, select **Add more recipients** > **ADD** > Choose **Advanced**.
@@ -27,8 +27,8 @@ import { Render } from "~/components"
     5. Under **Spam and delivery options**, select **Suppress bounces from this recipient**.
     6. Under **Headers**, select **Add X-Gm-Spam and X-Gm-Phishy headers**.
     7. Select **SAVE**.
-8. In **Account types to affect**, select **Users** and **Groups**.
-9. Select **SAVE**.
+7. In **Account types to affect**, select **Users** and **Groups**.
+8. Select **SAVE**.
 
 ## Next steps
 

--- a/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
+++ b/src/content/docs/email-security/deployment/api/setup/gsuite-bcc-setup/bcc-rules-to-area1.mdx
@@ -11,20 +11,24 @@ import { Render } from "~/components"
 2. Go to **Content Compliance** > Select **Edit**.
 3. Add a **Content Compliance** filter, and name it `Email Security (Area 1) - BCC`.
 4. In **Email messages to affect**, select **Inbound**.
-5. Select the recipients you want to send emails to Email Security (formerly Area 1) via BCC:
-    1. Select **Add** to configure the expression.
-    2. Select **Advanced content match**.
-    3. In **Location**, select **Headers + Body**.
-    4. In **Match type**, select **Matches regex**.
-    5. In **Regexp** input `.*`. You can customize the regex as needed and test within the admin page or on sites like [Regexr](https://regexr.com/).
+5. Select the recipients you want to send emails to Email Security (formerly Area 1) via BCC. Under **Add expressions that describe the content you want to search for in each message**:
+    1. Select **If ANY of the following match the message**.
+    2. Select **Add** to configure the expression.
+    3. Select **Advanced content match**.
+    4. In **Location**, select **Headers + Body**.
+    5. In **Match type**, select **Matches regex**.
+    6. In **Regexp** input `.*`. You can customize the regex as needed and test within the admin page or on sites like [Regexr](https://regexr.com/).
+    7. Select **SAVE**.
+7. In **If the above expressions match, do the following**:
+    1. Select **Modify message**.
+    2. Ensure that **Envelope recipient** > **Change envelope recipient** is unselected, to ensure that emails will not be dropped as an unintended consequence. You will select this option at a later stage.
+    2. Go to **Also deliver to**, select **Add more recipients** > **ADD** > Choose **Advanced**.
+    3. Under **Envelope recipient**, select **Change envelope recipient** > **Replace recipient** > Enter the email of the recipient.
+    4. Under **Spam and delivery options**, select **Suppress bounces from this recipient**.
+    5. Under **Headers**, select **Add X-Gm-Spam and X-Gm-Phishy headers**.
     6. Select **SAVE**.
-6. In **If the above expressions match, do the following**, select **Modify message**, select **Add more recipients** > Select **ADD** > Choose **Advanced**:
-    1. Under **Envelope recipient**, select **Change envelope recipient** > **Replace recipient** > Enter the email of the recipient.
-    2. Under **Spam and delivery options**, select **Suppress bounces from this recipient**.
-    3. Under **Headers**, select **Add X-Gm-Spam and X-Gm-Phishy headers**.
-    4. Select **SAVE**.
-7. In **Account types to affect**, select **Users** and **Groups**.
-8. Select **SAVE**.
+8. In **Account types to affect**, select **Users** and **Groups**.
+9. Select **SAVE**.
 
 ## Next steps
 


### PR DESCRIPTION
This PR aims at:

- Simplifying steps for Gmail BCC setup (adding steps on multiple lines).
- Clarifying that users should not select Envelope recipient (which appears twice) the first time.