### PR TITLE
remove incorrect information

### DIFF
--- a/src/content/docs/ssl/edge-certificates/ech.mdx
+++ b/src/content/docs/ssl/edge-certificates/ech.mdx
@@ -56,8 +56,6 @@ ECH is enabled by default on Free zones. Other plans can turn it on or off follo
 
 Some enterprise or regional networks may need to audit or apply filtering policies to traffic that traverses their network. These policies are expressed in terms of domain names, not IP addresses. Consequently, they are best applied at the local DNS resolver in response to the `A` and `AAAA` queries for the individual domain names.
 
-However, for settings wherein DNS-based filtering is not applicable, there are two ways in which networks can disable ECH to allow existing filtering mechanisms to continue working as expected.
+However, for settings wherein DNS-based filtering is not applicable, there are ways in which networks can disable ECH to allow existing filtering mechanisms to continue working as expected.
 
 The most reliable way is via the local or recursive DNS resolver itself, by dropping ECH configurations from HTTPS resource records returned to clients, or, preferably, by returning a “no error no answer” or NXDOMAIN response to HTTPS queries. This prevents clients from obtaining the necessary information to use ECH. Note that modifying HTTPS resource records may cause failures for clients that perform DNSSEC validation, so dropping HTTPS responses may be the preferred approach. This will prevent browsers, such as Chrome from using ECH.
-
-The second way to disable ECH is via a network canary domain. In particular, your network’s DNS resolver can return a “no error no answer” or an NXDOMAIN response to queries made to the `use-application-dns.net` [canary domain](https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet). This will prevent browsers, such as Firefox from using ECH. For more information, see Firefox's [frequently asked questions page](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello#w_how-will-ech-interact-with-dohs-opt-outs) for Encrypted Client Hello.


### PR DESCRIPTION
### Summary

The "use-application-dns.net" canary domain is only used to disable DNS over HTTPS (DoH), not to disable ECH (see [documentation](https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet)). Originally, Firefox required DoH to be enabled in order for ECH to function. Since Firefox 129, ECH is enabled even if DoH is disabled (see [here](https://wiki.mozilla.org/Security/Encrypted_Client_Hello#Dependency_on_DoH ))

Other browsers have always ignored the canary domain (see [here](https://www.chromium.org/developers/dns-over-https/#faq)).

