### PR TITLE
update frontmatter description for workers/sites page

### DIFF
--- a/src/content/docs/workers/configuration/sites/index.mdx
+++ b/src/content/docs/workers/configuration/sites/index.mdx
@@ -2,9 +2,7 @@
 pcx_content_type: navigation
 title: Workers Sites
 head: []
-description: Use [Cloudflare Pages](/pages/) for hosting full-stack applications
-  instead of Workers Sites. Do not use Workers Sites for new projects.
-
+description: Use [Workers Static Assets](/workers/static-assets/) to host full-stack applications instead of Workers Sites. Do not use Workers Sites for new projects.
 ---
 
 import { Render } from "~/components"


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

The Workers sites page frontmatter description suggests people to use Pages instead, however the pages itself suggests to use Workers Static Assets, this PR is realigning the two.

Related to #18119
