### PR TITLE
[API Shield] Update session identifier type note

### DIFF
--- a/src/content/partials/api-shield/set-up-session-identifiers.mdx
+++ b/src/content/partials/api-shield/set-up-session-identifiers.mdx
@@ -10,10 +10,9 @@
 5. Choose the type of session identifier (cookie, HTTP header, or JWT claim).
 
 :::note
+The session identifier cookie must comply with RFC 6265. Otherwise, it will be rejected.
 
-If you are using a JWT claim, choose the [Token Configuration](/api-shield/security/jwt-validation/configure/#token-configurations) that will verify the JWT. Token Configurations are required to use JWT claims as session identifiers.
-
-Refer to [JWT Validation](/api-shield/security/jwt-validation/) for more information. 
+If you are using a JWT claim, choose the [Token Configuration](/api-shield/security/jwt-validation/configure/#token-configurations) that will verify the JWT. Token Configurations are required to use JWT claims as session identifiers. Refer to [JWT Validation](/api-shield/security/jwt-validation/) for more information. 
 :::
 
 6. Enter the name of the session identifier.


### PR DESCRIPTION
### Summary

Update the note on session identifier type to include requirement that choosing to use a cookie will need to comply with RFC6265

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

