### PR TITLE
[Docs Site] Fix anchor link headings

### DIFF
--- a/plugins/rehype/heading-slugs.ts
+++ b/plugins/rehype/heading-slugs.ts
@@ -28,10 +28,10 @@ export default function () {
 						const text = element.children.at(-2) as MdxTextExpression;
 						text.value = text.value.trimEnd();
 						element.children.with(-2, text);
-					} else {
-						if (!element.properties.id) {
-							element.properties.id = slugs.slug(toString(element));
-						}
+					}
+				} else {
+					if (!element.properties.id) {
+						element.properties.id = slugs.slug(toString(element));
 					}
 				}
 			}


### PR DESCRIPTION
### Summary

Fixes anchor link headings

The `else` was accidentally included inside the `if` block.