### PR TITLE
[ZT] - Give More information into how to format tokens

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
@@ -170,20 +170,22 @@ Assigns a unique identifier to the device for the [device UUID posture check](/c
 
 ### `auth_client_id`
 
-Enrolls the device in your Zero Trust organization using a [service token](/cloudflare-one/connections/connect-devices/warp/deployment/device-enrollment/#check-for-service-token). Requires the `auth_client_secret` parameter.
+Enrolls the device in your Zero Trust organization using a [service token](/cloudflare-one/connections/connect-devices/warp/deployment/device-enrollment/#check-for-service-token).
+Requires the `auth_client_secret` parameter. 
 
 **Value Type:** `string`
 
-**Value:** `Client ID` of the service token.
-
+**Value:** `Client ID` of the service token. Expects everything after `CF-Access-Client-Id: ` and includes `.access` 
+The String should be everything after `CF-Access-Client-Id: ` and includes `.access` 
 ### `auth_client_secret`
 
-Enrolls the device in your Zero Trust organization using a [service token](/cloudflare-one/connections/connect-devices/warp/deployment/device-enrollment/#check-for-service-token). Requires the `auth_client_id` parameter.
+Enrolls the device in your Zero Trust organization using a [service token](/cloudflare-one/connections/connect-devices/warp/deployment/device-enrollment/#check-for-service-token). 
+Requires the `auth_client_id` parameter.
 
 **Value Type:** `string`
 
 **Value:** `Client Secret` of the service token.
-
+The String should be just the value after `CF-Access-Client-Secret: ` 
 ### `display_name`
 
 When WARP is deployed with [multiple organizations or configurations](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations/), this parameter is used to identify each configuration in the GUI.

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
@@ -179,12 +179,12 @@ Requires the `auth_client_secret` parameter.
 
 Example configuration:
 
-  ```xml
-  <key>auth_client_id</key>
-  <string>88bf3b6d86161464f6509f7219099e57.access</string>
-  <key>auth_client_secret</key>
-  <string>bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5</string>
-  ```
+```xml
+<key>auth_client_id</key>
+<string>88bf3b6d86161464f6509f7219099e57.access</string>
+<key>auth_client_secret</key>
+<string>bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5</string>
+```
 
 ### `auth_client_secret`
 

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters.mdx
@@ -175,8 +175,17 @@ Requires the `auth_client_secret` parameter.
 
 **Value Type:** `string`
 
-**Value:** `Client ID` of the service token. Expects everything after `CF-Access-Client-Id: ` and includes `.access` 
-The String should be everything after `CF-Access-Client-Id: ` and includes `.access` 
+**Value:** Client ID of the service token.
+
+Example configuration:
+
+  ```xml
+  <key>auth_client_id</key>
+  <string>88bf3b6d86161464f6509f7219099e57.access</string>
+  <key>auth_client_secret</key>
+  <string>bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5</string>
+  ```
+
 ### `auth_client_secret`
 
 Enrolls the device in your Zero Trust organization using a [service token](/cloudflare-one/connections/connect-devices/warp/deployment/device-enrollment/#check-for-service-token). 
@@ -184,8 +193,8 @@ Requires the `auth_client_id` parameter.
 
 **Value Type:** `string`
 
-**Value:** `Client Secret` of the service token.
-The String should be just the value after `CF-Access-Client-Secret: ` 
+**Value:** Client Secret of the service token.
+
 ### `display_name`
 
 When WARP is deployed with [multiple organizations or configurations](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations/), this parameter is used to identify each configuration in the GUI.


### PR DESCRIPTION

### Summary
When using a service token, CloudFlare Zero Trust formats the token to include  
`CF-Access-Client-Id: `
`CF-Access-Client-Secret: `

If you directly paste these into a Cloudflare Warp `mdm.xml` it will fail as a invalid token. 

I've added a bit of clarity to this to describe what the value expects.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
