### PR TITLE
Add `default` to export for Service Binding example.

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -60,7 +60,7 @@ main = "./src/workerB.js"
 ```js
 import { WorkerEntrypoint } from "cloudflare:workers";
 
-export class WorkerB extends WorkerEntrypoint {
+export default class WorkerB extends WorkerEntrypoint {
   // Currently, entrypoints without a named handler are not supported
   async fetch() { return new Response(null, {status: 404}); }
 


### PR DESCRIPTION
This is required to make the code sample work.

This partially addresses issue #17421 but does not expand the example as requested in the issue.
