### PR TITLE
[Images] Add details to supported ANS notification types

### DIFF
--- a/src/content/notifications/index.yaml
+++ b/src/content/notifications/index.yaml
@@ -583,3 +583,17 @@ entries:
     associatedProducts: Web Analytics
     nextSteps: No action is needed. This notification is a weekly summary with reports from your Web Analytics account. Refer to [Notifications](https://dash.cloudflare.com/?to=/:account/notifications) in the Cloudflare dashboard to refine your notifications settings.
     otherFilters: None.
+
+  - name: Image Notifications
+    audience: Customers using [Direct creator uploads](/images/upload-images/direct-creator-upload/) to upload images.
+    availability: Cloudflare images subscription.
+    associatedProducts: Cloudflare Images
+    nextSteps: No action is needed.
+    otherFilters: None.
+
+  - name: Image Transformation Notifications
+    audience: Customers who are using free image transformations and want to be notified if they exceed their free quota.
+    availability: All Cloudflare plans.
+    associatedProducts: Cloudflare Images
+    nextSteps: No action is needed.
+    otherFilters: None.


### PR DESCRIPTION
### Summary

Cloudflare Images now supports two additional notifications:
- Image Notifications - this allows customers to get notifications when a user uses Direct Upload on success/failure
- Image Transformation Notifications - this gives users a notification when they've exceeded their the free tier limits for transformations.

This adds the appropriate documentation.

### Screenshots (optional)

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/575727c0-3f3e-4596-beb5-86038d2ac8d4">
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/455a4760-0b7c-4d4d-8138-3264cc76a481">

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
