### PR TITLE
[Rules] Use wildcard in URI scheme

### DIFF
--- a/src/content/docs/rules/cloud-connector/create-dashboard.mdx
+++ b/src/content/docs/rules/cloud-connector/create-dashboard.mdx
@@ -26,10 +26,10 @@ To configure a Cloud Connector rule in the dashboard:
 
 6. Under **If**, select **Custom filter expression** and [enter an expression](/ruleset-engine/rules-language/expressions/edit-expressions/) to define the traffic that will be redirected to the bucket. For example:
 
-   - To route all requests under `https://example.com/images/*` you could enter the following expression:<br/>
-     `http.request.full_uri wildcard "https://example.com/images/*"`
-   - To route all requests under `https://images.example.com/*` you could enter the following expression:<br/>
-     `http.request.full_uri wildcard "https://images.example.com/*"`
+   - To route all requests matching `http*://example.com/images/*` (HTTPS and HTTP requests) you could enter the following expression:<br/>
+     `http.request.full_uri wildcard "http*://example.com/images/*"`
+   - To route all requests matching `http*://images.example.com/*` (HTTPS and HTTP requests) you could enter the following expression:<br/>
+     `http.request.full_uri wildcard "http*://images.example.com/*"`
 
    Alternatively, select **All incoming requests** to redirect all incoming traffic for your zone to the storage bucket you selected.
 

--- a/src/content/docs/rules/cloud-connector/examples/route-images-to-s3.mdx
+++ b/src/content/docs/rules/cloud-connector/examples/route-images-to-s3.mdx
@@ -16,10 +16,10 @@ To route requests to `/images` on your domain to an AWS S3 bucket:
    - **Subdomain-style URL**: Set the hostname to `<BUCKET_NAME>.s3.amazonaws.com`. In this case, your files should be organized in the root of the bucket, meaning the URI path will map directly to the file. For example, `https://<YOUR_HOSTNAME>/images/file.jpg` will map to `https://<BUCKET_NAME>.s3.amazonaws.com/images/file.jpg`.
    - **URI path-style URL**: Set the hostname to `s3.amazonaws.com`. Here, your bucket must include a folder named `images`, and files should be placed inside this folder. The URI path will then include the bucket name, like `https://<YOUR_HOSTNAME>/<BUCKET_NAME>/images/file.jpg` mapping to `https://s3.amazonaws.com/<BUCKET_NAME>/images/file.jpg`.
 5. _(Optional)_ Use the [Rewrite URL](/rules/transform/url-rewrite/) feature of [Transform Rules](/rules/transform/) to adjust the URL structure. For example, you can [create a URL rewrite](/rules/transform/url-rewrite/create-dashboard/) that changes `/images` to `/<BUCKET_NAME>/images` to match the URI path-style URL structure.
-6. Click **Next** and enter a descriptive name like "Route images to S3" in Cloud Connector name.
-7. Under **If**, select **Custom filter expression** and enter the following expression:
-   `http.request.full_uri wildcard "https://<YOUR_HOSTNAME>/images/*"`<br />
+6. Click **Next** and enter a descriptive name like `Route images to S3` in **Cloud Connector name**.
+7. Under **If**, select **Custom filter expression** and enter the following expression:<br />
+   `http.request.full_uri wildcard "http*://<YOUR_HOSTNAME>/images/*"`<br />
    Replace `<YOUR_HOSTNAME>` with desired hostname.
 8. Select **Deploy** to activate the rule.
 
-This setup will route all traffic to `https://<YOUR_HOSTNAME>/images/*` directly to your S3 bucket. Make sure to replace `<YOUR_HOSTNAME>` with your actual hostname and adjust the example paths according to your setup.
+This setup will route all traffic matching `http*://<YOUR_HOSTNAME>/images/*` (HTTPS and HTTP requests) to your S3 bucket. Make sure to replace `<YOUR_HOSTNAME>` with your actual hostname and adjust the example paths according to your setup.

--- a/src/content/docs/rules/cloud-connector/examples/serve-static-assets-from-azure.mdx
+++ b/src/content/docs/rules/cloud-connector/examples/serve-static-assets-from-azure.mdx
@@ -15,9 +15,9 @@ To serve static assets from an Azure Blob Storage container:
 4. Enter the bucket URL. Here’s how to structure it:
    - **Subdomain-style URL**: Set the hostname to `<BUCKET_NAME>.blob.core.windows.net`. In this case, your bucket should include a folder named `static-assets`, and files should be placed inside this folder. For example, `https://<YOUR_HOSTNAME>/static-assets/style.css` will map to `https://<BUCKET_NAME>.blob.core.windows.net/static-assets/style.css`.
 5. _(Optional)_ Use the [Rewrite URL](/rules/transform/url-rewrite/) feature of [Transform Rules](/rules/transform/) to adjust the URL structure. For example, you can [create a URL rewrite](/rules/transform/url-rewrite/create-dashboard/) that changes `/static-assets` to `/my-pages-project/static-assets` to match the file structure of your object storage bucket.
-6. Click **Next** and enter a descriptive name like "Serve static assets from Azure" in Cloud Connector name.
+6. Click **Next** and enter a descriptive name like `Serve static assets from Azure` in **Cloud Connector name**.
 7. Under **If**, select **Custom filter expression** and enter the following expression:
-   `http.request.full_uri wildcard "https://<YOUR_HOSTNAME>/static-assets/*"`<br />
+   `http.request.full_uri wildcard "http*://<YOUR_HOSTNAME>/static-assets/*"`<br />
 8. Select **Deploy** to activate the rule.
 
-This setup ensures that all traffic to `https://<YOUR_HOSTNAME>/static-assets/*` is served from your Azure Blob Storage container. Make sure to replace `<YOUR_HOSTNAME>` with your actual hostname and adjust the example paths according to your setup.
+This setup ensures that all traffic matching `http*://<YOUR_HOSTNAME>/static-assets/*` (HTTPS and HTTP requests) is served from your Azure Blob Storage container. Make sure to replace `<YOUR_HOSTNAME>` with your actual hostname and adjust the example paths according to your setup.

--- a/src/content/docs/rules/transform/url-rewrite/create-dashboard.mdx
+++ b/src/content/docs/rules/transform/url-rewrite/create-dashboard.mdx
@@ -54,7 +54,7 @@ If you choose to deploy your rewrite URL rule, the new rule will be enabled. If 
 
 The Cloudflare dashboard offers a simplified user interface for creating URL rewrites based on wildcard matching and replacement. When you select **Wildcard pattern**, you will have the following parameters available:
 
-- **Request URL**: Enter the [wildcard pattern](/ruleset-engine/rules-language/operators/#wildcard-matching) using the asterisk (`*`) character to match multiple requests. For example, `https://*.example.com/*`.
+- **Request URL**: Enter the [wildcard pattern](/ruleset-engine/rules-language/operators/#wildcard-matching) using the asterisk (`*`) character to match multiple requests. For example, `http*://*.example.com/*`.
 
 - **Then rewrite the path and/or query**: Define the [URL rewrite settings](/rules/transform/url-rewrite/reference/parameters/) including:
   - **Path** > **Target path**: Enter the URI path to match, which can include wildcards (for example, `/oldpath/*`).

--- a/src/content/docs/rules/url-forwarding/single-redirects/create-dashboard.mdx
+++ b/src/content/docs/rules/url-forwarding/single-redirects/create-dashboard.mdx
@@ -14,8 +14,9 @@ import { Render } from "~/components";
 4. (Optional) Select one of the rule templates that address common use cases. Then, review and adjust the proposed rule configuration.
 5. Enter a descriptive name for the rule in **Rule name**.
 6. Under **When incoming requests match**, select one of the following options:
+
    - **Wildcard pattern**: The rule will only apply to traffic matching the wildcard pattern.
-     - **Request URL**: Enter the [wildcard pattern](/ruleset-engine/rules-language/operators/#wildcard-matching) using the asterisk (`*`) character to match multiple requests. For example, `https://*.example.com/files/*`.
+     - **Request URL**: Enter the [wildcard pattern](/ruleset-engine/rules-language/operators/#wildcard-matching) using the asterisk (`*`) character to match multiple requests. For example, `http*://*.example.com/files/*`.
      - **Then**: Define the [URL redirect settings](/rules/url-forwarding/single-redirects/settings/) including:
        - **Target URL**: Enter the target URL, which can be static (for example, `https://example.com`) or dynamic (for example, `https://example.com/${1}/files/${2}`). Use [wildcard replacement](/ruleset-engine/rules-language/functions/#wildcard_replace) such as `${1}` and `${2}` to define dynamic target URLs.
        - **Status code**: Select the status code for the redirect (for example, `301`).
@@ -24,6 +25,7 @@ import { Render } from "~/components";
      - **Then**: Define the [URL redirect settings](/rules/url-forwarding/single-redirects/settings/) for all incoming requests.
    - **Custom filter expression**: The rule will only apply to traffic matching a custom expression. Define the [rule expression](/ruleset-engine/rules-language/expressions/edit-expressions/) to configure which requests should be redirected.
      - **Then**: Define the [URL redirect settings](/rules/url-forwarding/single-redirects/settings/) for requests matching the custom rule expression.
+
 7. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
 
 <Render

--- a/src/content/docs/ruleset-engine/rules-language/operators.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/operators.mdx
@@ -197,10 +197,11 @@ When using the `wildcard`/`strict wildcard` operator, the entire field value mus
 
 ```txt title="Example A"
 # The following expression:
-http.request.full_uri wildcard "https://example.com/a/*"
+http.request.full_uri wildcard "http*://example.com/a/*"
 
 # Would match the following URIs:
 # - https://example.com/a/           (the '*' matches zero characters)
+# - http://example.com/a/
 # - https://example.com/a/page.html
 # - https://example.com/a/sub/folder/?name=value
 
@@ -233,7 +234,7 @@ http.request.full_uri wildcard "*.example.com/*/page.html"
 
 ```txt
 # The following expression:
-http.request.full_uri wildcard "*.example.com/*" or http.request.full_uri wildcard "example.com/*"
+http.request.full_uri wildcard "*.example.com/*" or http.request.full_uri wildcard "http*://example.com/*"
 
 # Would match the following URIs:
 # - https://example.com/folder/list.htm


### PR DESCRIPTION
### Summary

Uses `*` metacharacter in the URI scheme when using the `wildcard` operator and we're not redirecting from HTTP to HTTPS.

Closes #17945.

