### PR TITLE
[Docs Site] Disable smartypants processing

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -73,8 +73,8 @@ const autolinkConfig: rehypeAutolinkHeadingsOptions = {
 // https://astro.build/config
 export default defineConfig({
 	site: "https://developers.cloudflare.com",
-	smartypants: false,
 	markdown: {
+		smartypants: false,
 		rehypePlugins: [
 			[
 				rehypeMermaid,


### PR DESCRIPTION
### Summary

Closes https://github.com/cloudflare/cloudflare-docs/issues/18083

The configuration option was added pre-migration but in the incorrect place.