### PR TITLE
[Docs Site] Adjust feedback prompt on pages with no ToC

### DIFF
--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -61,7 +61,13 @@ const { tableOfContents } = Astro.props.entry.data;
 
 		&:not([data-has-toc]) {
 			.feedback-prompt-content {
-				display: block;	
+				display: block;
+			}
+		}
+
+		&[data-has-hero] {
+			.feedback-prompt-content {
+				display: none;
 			}
 		}
 	}

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -43,11 +43,29 @@ const { tableOfContents } = Astro.props.entry.data;
 <ImageZoom />
 <div class="sl-markdown-content">
     <slot />
-	<div class="!mt-[1.5em] block min-[1152px]:hidden">
+	<div class="feedback-prompt-content">
 		<FeedbackPrompt />
 	</div>
 </div>
 <style>
+	html {
+		.feedback-prompt-content {
+			margin-top: 1.5em !important;
+
+			@media (min-width: 1152px) {
+				& {
+					display: none;
+				}
+			}
+		}
+
+		&:not([data-has-toc]) {
+			.feedback-prompt-content {
+				display: block;	
+			}
+		}
+	}
+
 	/* Custom styles for heading anchor links. */
 	.sl-markdown-content :global(.heading-wrapper) {
 		--icon-size: 0.75em;


### PR DESCRIPTION
### Summary

Adjust feedback prompt on pages with no ToC.

It should always show at the bottom of the content if there is no ToC, and only when the ToC is hidden due to smaller viewports otherwise.