### PR TITLE
Update learning path typo index.mdx

### DIFF
--- a/src/content/docs/learning-paths/application-security/account-security/index.mdx
+++ b/src/content/docs/learning-paths/application-security/account-security/index.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ---
 
-Make sure your zone's basics are configured properly.
+Make sure your account's security basics are configured properly.
 
 ## Objectives
 


### PR DESCRIPTION
Replacing incorrect word 'zone' with 'account'.

