### PR TITLE
[Docs Site] resolve bad import in D1 tutorial

### DIFF
--- a/src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx
+++ b/src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx
@@ -12,7 +12,7 @@ languages:
   - SQL
 ---
 
-import { Render, Detail, Steps } from "~/components";
+import { Render, Steps } from "~/components";
 
 In this tutorial, you will learn how to import a database into D1 using the [REST API](/api/operations/cloudflare-d1-import-database).
 


### PR DESCRIPTION
### Summary

Fixes the following warning when building the docs:
```
src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx (55:16): "Detail" is not exported by "src/components/index.ts", imported by "src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx".

```

This isn't ever used, so can just be removed from the import in this file.