### PR TITLE
experimental_assets no longer works

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -66,7 +66,7 @@ main = ".worker-next/index.mjs"
 name = "my-app"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
-experimental_assets = { directory = ".worker-next/assets", binding = "ASSETS" }
+assets = { directory = ".worker-next/assets", binding = "ASSETS" }
 ```
 
 :::note


### PR DESCRIPTION
### Summary

From trial and error, I found that `experimental_assets` fails silently (it doesn't do anything). By comparing the [official @opennextjs/cloudflare instructions](https://opennext.js.org/cloudflare/get-started#2-install-wrangler-and-add-a-wranglertoml-file), I realized that it must be `assets`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

