### PR TITLE
Add link to FAQ page in Zaraz documentation

### DIFF
--- a/src/content/docs/zaraz/get-started.mdx
+++ b/src/content/docs/zaraz/get-started.mdx
@@ -39,7 +39,7 @@ If you need to programmatically start actions in your tools, Cloudflare Zaraz pr
 
 ## Troubleshooting
 
-If you suspect that something is not working the way it should, or if you want to verify the operation of tools on your website, read more about [Debug Mode](/zaraz/web-api/debug-mode/) and [Zaraz Monitoring](/zaraz/monitoring/). Also, check the FAQ page to see if your question was already answered there.
+If you suspect that something is not working the way it should, or if you want to verify the operation of tools on your website, read more about [Debug Mode](/zaraz/web-api/debug-mode/) and [Zaraz Monitoring](/zaraz/monitoring/). Also, check the [FAQ](/zaraz/faq/) page to see if your question was already answered there.
 
 ## Platform plugins
 


### PR DESCRIPTION
### Summary

This PR updates the Zaraz documentation by adding a link to the FAQ page (/zaraz/faq/). This change ensures users can directly access the FAQ page to find answers to their questions, improving the usability of the documentation.


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.  
