### PR TITLE
Update client-errors.mdx - Update Happy Eyeballs failure error message name and add a condition (device revocation)

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors.mdx
@@ -138,7 +138,7 @@ The device failed to present a [valid mTLS certificate](/cloudflare-one/connecti
 1. Ensure that there are no admin restrictions on certificate installation.
 2. Re-install the client certificate on the device.
 
-## CF\_HAPPY\_EYEBALLS\_FAILURE
+## CF\_HAPPY\_EYEBALLS\_MITM\_FAILURE
 
 ### Symptoms
 
@@ -149,9 +149,10 @@ The device failed to present a [valid mTLS certificate](/cloudflare-one/connecti
 A router, firewall, antivirus software, or other third-party security product is blocking UDP on the WARP ports.
 
 ### Resolution
-
+ 
 1. Configure the third-party security product to allow the [WARP ingress IPs and ports](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#warp-ingress-ip).
 2. Ensure that your Internet router is working properly and try rebooting the router.
+3. Check that the device is not revoked in the [devices page of the dashboard](https://one.dash.cloudflare.com?to=/:account/team/devices). 
 
 ## CF\_HOST\_UNREACHABLE\_CHECK
 

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors.mdx
@@ -152,7 +152,7 @@ A router, firewall, antivirus software, or other third-party security product is
  
 1. Configure the third-party security product to allow the [WARP ingress IPs and ports](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#warp-ingress-ip).
 2. Ensure that your Internet router is working properly and try rebooting the router.
-3. Check that the device is not revoked in the [devices page of the dashboard](https://one.dash.cloudflare.com?to=/:account/team/devices). 
+3. Check that the device is not revoked by going to **My team** > **Devices**. 
 
 ## CF\_HOST\_UNREACHABLE\_CHECK
 


### PR DESCRIPTION

### Summary

The error message is actually:   "CF_HAPPY_EYEBALLS_MITM_FAILURE" 

The Happy Eyeballs error can also be seen when a device is revoked. 

When users run into Happy Eyeball errors, they should also check form the dashboard that the particular device is not revoked.

### Screenshots (optional)

Example error message of a device that has been revoked.  

![revoked](https://github.com/user-attachments/assets/75c23a99-2231-4814-baa6-80954d04847d)

### Documentation checklist

<!-- Remove items that do not apply -->

- [ x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
