### PR TITLE
[Docs Site] Move deprecations to new page, move date header on changelogs

### DIFF
--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,6 +1,6 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
-import { Badge } from "~/components";
+import { Aside, Badge } from "~/components";
 import { marked } from "marked";
 import { getChangelogs } from "~/util/changelogs";
 
@@ -8,9 +8,11 @@ const { products, productAreas, changelogs } = await getChangelogs();
 ---
 
 <StarlightPage frontmatter={{ title: "Changelogs", template: "splash" }}>
-	<Badge text="Beta" variant="caution" size="medium" />
-	<br />
-	<br />
+	<Aside>
+		Looking for API deprecations? They can be found on our <a
+			href="/deprecations/">dedicated deprecations page.</a
+		>
+	</Aside>
 	<p id="productDescription">
 		Subscribe to all Changelog posts via <a href="/changelog/index.xml">RSS</a>.
 	</p>
@@ -44,43 +46,48 @@ const { products, productAreas, changelogs } = await getChangelogs();
 	</select>
 	{
 		changelogs.map(([date, entries]) => (
-			<div style="overflow-anchor: none;" data-date={date}>
-				<h2>{date}</h2>
-				{entries?.map((entry) => (
-					<div
-						data-product={entry.product.toLowerCase()}
-						data-productArea={entry.productAreaName.toLowerCase()}
-					>
-						<h3>
-							<a href={entry.link}>{entry.product}</a>
-						</h3>
-						{["WAF", "DDoS protection"].includes(entry.product) ? (
-							<p
-								set:html={marked.parse(
-									entry.scheduled
-										? "**" +
-												"Scheduled changes for " +
-												(entry.date ?? "") +
-												"**"
-										: "**" + (entry.date ?? "") + "**",
-								)}
-							/>
-						) : (
-							<p set:html={marked.parse("**" + (entry.title ?? "") + "**")} />
-						)}
-						{["WAF", "DDoS protection"].includes(entry.product) ? (
-							<p
-								set:html={marked.parse(
-									"For more details, refer to the [changelog page](" +
-										entry.link +
-										").",
-								)}
-							/>
-						) : (
-							<p set:html={marked.parse(entry.description ?? "")} />
-						)}
-					</div>
-				))}
+			<div class="md:grid md:grid-cols-[20%_80%]" data-date={date}>
+				<div>
+					<h2 class="text-nowrap">{date}</h2>
+				</div>
+				<div class="!mt-0">
+					{entries?.map((entry) => (
+						<div
+							data-product={entry.product.toLowerCase()}
+							data-productArea={entry.productAreaName.toLowerCase()}
+						>
+							<h3>
+								<a href={entry.link}>{entry.product}</a>
+							</h3>
+							{["WAF", "DDoS protection"].includes(entry.product) && (
+								<p
+									set:html={marked.parse(
+										entry.scheduled
+											? "**" +
+													"Scheduled changes for " +
+													(entry.date ?? "") +
+													"**"
+											: "**" + (entry.date ?? "") + "**",
+									)}
+								/>
+							)}
+							{entry.title && (
+								<p set:html={marked.parse("**" + (entry.title ?? "") + "**")} />
+							)}
+							{["WAF", "DDoS protection"].includes(entry.product) ? (
+								<p
+									set:html={marked.parse(
+										"For more details, refer to the [changelog page](" +
+											entry.link +
+											").",
+									)}
+								/>
+							) : (
+								<p set:html={marked.parse(entry.description ?? "")} />
+							)}
+						</div>
+					))}
+				</div>
 			</div>
 		))
 	}
@@ -94,7 +101,9 @@ const { products, productAreas, changelogs } = await getChangelogs();
 	);
 	const navHeightPx = Number(navHeightRem.split("rem")[0]) * 16 + 16;
 
-	const headers = document.querySelectorAll<HTMLElement>("[data-date] > h2");
+	const headers = document.querySelectorAll<HTMLElement>(
+		"[data-date] > div > h2",
+	);
 	headers.forEach(
 		(header) => new StickyHeader(header, { offset: 0 - navHeightPx }),
 	);

--- a/src/pages/deprecations/index.astro
+++ b/src/pages/deprecations/index.astro
@@ -1,0 +1,34 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import { marked } from "marked";
+import { getChangelogs } from "~/util/changelogs";
+
+const { changelogs } = await getChangelogs({
+	deprecationsOnly: true,
+});
+---
+
+<StarlightPage frontmatter={{ title: "Deprecations", template: "splash" }}>
+	<p>
+		Unless otherwise noted, all dates refer to the release date of the change.
+	</p>
+	<br />
+	{
+		changelogs.map(([date, entries]) => (
+			<div>
+				<h2>{date}</h2>
+				{entries?.map((entry) => (
+					<div
+						data-product={entry.product.toLowerCase()}
+						data-productArea={entry.productAreaName.toLowerCase()}
+					>
+						<h3>
+							<a href={entry.link}>{entry.product}</a>
+						</h3>
+						<p set:html={marked.parse(entry.description ?? "")} />
+					</div>
+				))}
+			</div>
+		))
+	}
+</StarlightPage>

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -5,6 +5,7 @@ import { type CollectionEntry } from "astro:content";
 export async function getChangelogs(opts?: {
 	filter?: Parameters<typeof getCollection<"changelogs">>[1];
 	wranglerOnly?: boolean;
+	deprecationsOnly?: boolean;
 }) {
 	let changelogs;
 
@@ -20,6 +21,12 @@ export async function getChangelogs(opts?: {
 		throw new Error(
 			`[getChangelogs] Unable to find any changelogs with ${JSON.stringify(opts)}`,
 		);
+	}
+
+	if (opts?.deprecationsOnly) {
+		changelogs = changelogs.filter((x) => x.id === "api-deprecations");
+	} else {
+		changelogs = changelogs.filter((x) => x.id !== "api-deprecations");
 	}
 
 	const products = [...new Set(changelogs.flatMap((x) => x.data.productName))];


### PR DESCRIPTION
### Summary

Move deprecations to new page, move date header on changelogs

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/456c6105-17cf-456c-9e82-b378df125e8b)
![image](https://github.com/user-attachments/assets/2e19d11a-3ec2-464c-bd07-7a43a7c0a71b)
![image](https://github.com/user-attachments/assets/2dc0e04d-10cc-43a0-964a-8215f940c5c6)
