### PR TITLE
ci: remove semgrep on each PR creation

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request: {}
   workflow_dispatch: {}
   schedule:
     - cron: "0 4 * * *"


### PR DESCRIPTION
The semgrep setup is slow on large repositories. Move it to a once a day task instead.
