### PR TITLE
[DLS] Adds instructions to send logs to an EU R2 bucket via an S3-Compatible endpoint

### DIFF
--- a/src/content/docs/data-localization/how-to/r2.mdx
+++ b/src/content/docs/data-localization/how-to/r2.mdx
@@ -6,6 +6,8 @@ sidebar:
 
 ---
 
+import { Details } from "~/components"
+
 In the following sections, we will give you some details about how to configure R2 with Regional Services and Customer Metadata Boundary.
 
 ## Regional Services
@@ -19,6 +21,75 @@ To configure Regional Services for hostnames [proxied](/dns/manage-dns-records/r
 5. Run the [API POST](/data-localization/regional-services/get-started/#configure-regional-services-via-api) command on the configured bucket custom domain to create a `regional_hostnames` with a specific region.
 
 Regional Services only applies to the custom domain configured for an R2 Bucket.
+
+### Send logs to an EU R2 bucket via an S3-Compatible endpoint
+
+The following instructions will show you how to set up a Logpush job using an S3-Compatible endpoint to store logs in an R2 bucket with EU jurisdiction.
+
+1. Create an [R2 bucket](/r2/get-started/) in your Cloudflare account and set EU as the jurisdiction.
+
+2. Generate an API token for your R2 bucket. You have these two options available:
+
+<Details header="Generate a token for a specific bucket (recommended)">
+
+Go to the R2 section of your Cloudflare dashboard and select **Manage R2 API Tokens** to generate a token directly tied to your specific bucket. You can follow the instructions in the [Authentication](/r2/api/s3/tokens/) section. 
+
+</Details>
+
+<Details header="Generate a token for all buckets">
+
+You can generate a API token in **Manage Account** > **Account API Tokens** or you can create a user-specific token:
+
+1. Go to **My Profile** > **API Tokens** 
+2. Select **Create Token** > **Create Custom Token**
+3. Choose **Account** > **Workers R2 Storage** > **Edit** to set permissions.
+4. To test your token, copy the `curl` command and paste it into a terminal.
+
+```bash
+curl "https://api.cloudflare.com/client/v4/user/tokens/verify" \
+--header "Authorization: Bearer <API_TOKEN>"
+```
+
+The result:
+
+```json
+{
+  "result": {
+    "id": "325xxxxcd",
+    "status": "active"
+  },
+  "success": true,
+  "errors": [],
+  "messages": [
+    {
+      "code": 10000,
+      "message": "This API Token is valid and active",
+      "type": null
+    }
+  ]
+}
+```
+
+5. Generate a SHA-256 hash of the token:
+      
+```bash
+echo -n "<token>" | shasum -a 256
+```
+
+This command will output a hash similar to `dxxxx391b`. 
+
+</Details>
+
+3. Set up a Logpush destination using [S3-Compatible endpoint](/logs/get-started/enable-destinations/s3-compatible-endpoints/) and fill in the required fields as follows:
+
+- **Bucket**: Enter the name of the R2 bucket you created with the EU jurisdiction.
+- **Path** (optional): If you want, you can specify a folder path to organize your logs.
+- **Endpoint URL**: Provide the S3 API endpoint for your bucket in the format `<account-id>.eu.r2.cloudflarestorage.com`. Do not include the bucket name, as it was set in the first field.
+- **Bucket Region**: Use `WEUR` to specify the EU region.
+- **Access Key ID**: Enter the Token ID created previously (`325xxxxcd`).
+- **Secret Access Key**: Use the SHA-256 hash of the token (`dxxxx391b`).
+
+End the configuration by selecting the fields you want to push to your R2 bucket.
 
 ## Customer Metadata Boundary
 

--- a/src/content/docs/data-localization/how-to/r2.mdx
+++ b/src/content/docs/data-localization/how-to/r2.mdx
@@ -22,13 +22,13 @@ To configure Regional Services for hostnames [proxied](/dns/manage-dns-records/r
 
 Regional Services only applies to the custom domain configured for an R2 Bucket.
 
-### Send logs to an EU R2 bucket via an S3-Compatible endpoint
+### Send logs to an EU R2 bucket via an S3-compatible endpoint
 
-The following instructions will show you how to set up a Logpush job using an S3-Compatible endpoint to store logs in an R2 bucket with EU jurisdiction.
+The following instructions will show you how to set up a Logpush job using an S3-compatible endpoint to store logs in an R2 bucket with EU jurisdiction.
 
 1. Create an [R2 bucket](/r2/get-started/) in your Cloudflare account and set EU as the jurisdiction.
 
-2. Generate an API token for your R2 bucket. You have these two options available:
+2. Generate an API token for your R2 bucket. You have the following two options:
 
 <Details header="Generate a token for a specific bucket (recommended)">
 
@@ -80,7 +80,7 @@ This command will output a hash similar to `dxxxx391b`.
 
 </Details>
 
-3. Set up a Logpush destination using [S3-Compatible endpoint](/logs/get-started/enable-destinations/s3-compatible-endpoints/) and fill in the required fields as follows:
+3. Set up a Logpush destination using [S3-compatible endpoint](/logs/get-started/enable-destinations/s3-compatible-endpoints/) and fill in the required fields as follows:
 
 - **Bucket**: Enter the name of the R2 bucket you created with the EU jurisdiction.
 - **Path** (optional): If you want, you can specify a folder path to organize your logs.
@@ -89,7 +89,7 @@ This command will output a hash similar to `dxxxx391b`.
 - **Access Key ID**: Enter the Token ID created previously (`325xxxxcd`).
 - **Secret Access Key**: Use the SHA-256 hash of the token (`dxxxx391b`).
 
-End the configuration by selecting the fields you want to push to your R2 bucket.
+Complete the configuration by selecting the fields you want to push to your R2 bucket.
 
 ## Customer Metadata Boundary
 


### PR DESCRIPTION
### Summary

Adds instructions to set up a Logpush using an S3-Compatible endpoint to store logs in an R2 bucket with EU jurisdiction.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

