### PR TITLE
[DO] Runtime API rename, cleaning up Storage API chapter

### DIFF
--- a/src/content/changelogs/durable-objects.yaml
+++ b/src/content/changelogs/durable-objects.yaml
@@ -17,7 +17,7 @@ entries:
   - publish_date: "2024-09-26"
     title: (Beta) SQLite storage backend & SQL API available on new Durable Object classes
     description: |-
-      The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
+      The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/sql-storage/#point-in-time-recovery), part of Durable Objects Storage API.
 
       You cannot enable a SQLite storage backend on an existing, deployed Durable Object class. Automatic migration of deployed classes from their key-value storage backend to SQLite storage backend will be available in the future.
 

--- a/src/content/changelogs/durable-objects.yaml
+++ b/src/content/changelogs/durable-objects.yaml
@@ -17,7 +17,7 @@ entries:
   - publish_date: "2024-09-26"
     title: (Beta) SQLite storage backend & SQL API available on new Durable Object classes
     description: |-
-      The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
+      The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
 
       You cannot enable a SQLite storage backend on an existing, deployed Durable Object class. Automatic migration of deployed classes from their key-value storage backend to SQLite storage backend will be available in the future.
 

--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -29,20 +29,20 @@ Alarms can be used to build distributed primitives, like queues or batching of w
 
 ## Storage methods
 
-### getAlarm
+### `getAlarm`
 
 - <code>getAlarm()</code>: <Type text="number | null" />
 
   - If there is an alarm set, then return the currently set alarm time as the number of milliseconds elapsed since the UNIX epoch. Otherwise, return `null`.
 
-### setAlarm
+### `setAlarm`
 
 - <code>{" "}setAlarm(scheduledTimeMs <Type text="number" />)</code>
   : <Type text="void" />
 
   - Set the time for the alarm to run. Specify the time as the number of milliseconds elapsed since the UNIX epoch.
 
-### deleteAlarm
+### `deleteAlarm`
 
 - `deleteAlarm()`: <Type text='void' />
 
@@ -52,7 +52,7 @@ Alarms can be used to build distributed primitives, like queues or batching of w
 
 ## Handler methods
 
-### alarm
+### `alarm`
 
 - `alarm()`: <Type text='void' />
 

--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -2,7 +2,7 @@
 title: Alarms
 pcx_content_type: concept
 sidebar:
-  order: 6
+  order: 7
 ---
 
 import { Type, GlossaryTooltip } from "~/components";

--- a/src/content/docs/durable-objects/api/index.mdx
+++ b/src/content/docs/durable-objects/api/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Runtime APIs
+title: Worker Binding API
 pcx_content_type: navigation
 sidebar:
   order: 4

--- a/src/content/docs/durable-objects/api/index.mdx
+++ b/src/content/docs/durable-objects/api/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Worker Binding API
+title: Workers Binding API
 pcx_content_type: navigation
 sidebar:
   order: 4

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Render, Type, MetaInfo, GlossaryTooltip } from "~/components";
 
-The `SqlStorage` interface encapsulates methods that modify the SQLite database embedded within a Durable Object.
+The `SqlStorage` interface encapsulates methods that modify the SQLite database embedded within a Durable Object. The `SqlStorage` interface is accessible via the `sql` property of `DurableObjectStorage` class.
 
 For example, using `sql.exec()`, a user can create a table, then insert rows into the table.
 
@@ -33,11 +33,11 @@ export class MyDurableObject extends DurableObject {
 }
 ```
 
-The `SqlStorage` interface is accessible via the `sql` property of `DurableObjectStorage` class.
-
 :::note[SQLite in Durable Objects Beta]
 SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
 :::
+
+Specifically for Durable Object classes with SQLite storage backend, KV operations ([`get`](/durable-objects/api/storage-api/#get), [`put`](/durable-objects/api/storage-api/#put), [`delete`](/durable-objects/api/storage-api/#delete), [`deleteAll`](/durable-objects/api/storage-api/#deleteall), [`list`](/durable-objects/api/storage-api/#list)) are synchronous, even though they return promises. These methods will have completed their operations before they return the promise.
 
 ## Methods
 

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -8,6 +8,33 @@ sidebar:
 
 import { Render, Type, MetaInfo, GlossaryTooltip } from "~/components";
 
+The `SqlStorage` interface encapsulates methods that modify the SQLite database embedded within a Durable Object.
+
+For example, using `sql.exec()`, a user can create a table, then insert rows into the table.
+
+```js
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDurableObject extends DurableObject {
+  sql: SqlStorage
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+
+    this.sql.exec(`CREATE TABLE IF NOT EXISTS artist(
+      artistid    INTEGER PRIMARY KEY,
+      artistname  TEXT
+    );INSERT INTO artist (artistid, artistname) VALUES
+      (123, 'Alice'),
+      (456, 'Bob'),
+      (789, 'Charlie');`
+    );
+  }
+}
+```
+
+The `SqlStorage` interface is accessible via the `sql` property of `DurableObjectStorage` class.
+
 :::note[SQLite in Durable Objects Beta]
 SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
 :::

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -37,7 +37,7 @@ export class MyDurableObject extends DurableObject {
 SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
 :::
 
-Specifically for Durable Object classes with SQLite storage backend, KV operations ([`get`](/durable-objects/api/storage-api/#get), [`put`](/durable-objects/api/storage-api/#put), [`delete`](/durable-objects/api/storage-api/#delete), [`deleteAll`](/durable-objects/api/storage-api/#deleteall), [`list`](/durable-objects/api/storage-api/#list)) are synchronous, even though they return promises. These methods will have completed their operations before they return the promise.
+Specifically for Durable Object classes with SQLite storage backend, KV operations which were previously asynchronous (for example, [`get`](/durable-objects/api/storage-api/#get), [`put`](/durable-objects/api/storage-api/#put), [`delete`](/durable-objects/api/storage-api/#delete), [`deleteAll`](/durable-objects/api/storage-api/#deleteall), [`list`](/durable-objects/api/storage-api/#list)) are synchronous, even though they return promises. These methods will have completed their operations before they return the promise.
 
 ## Methods
 

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -14,7 +14,7 @@ SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Obj
 
 ## Methods
 
-### exec
+### `exec`
 
 <code>exec(query: <Type text='string'/>, ...bindings: <Type text='any[]'/>)</code>: <Type text='SqlStorageCursor' />
 
@@ -69,7 +69,7 @@ Note that `sql.exec()` cannot execute transaction-related statements like `BEGIN
 
 <Render file="durable-objects-sql" />
 
-### databaseSize
+### `databaseSize`
 
 `databaseSize`: <Type text ='number' />
 
@@ -80,3 +80,36 @@ The current SQLite database size in bytes.
   let size = ctx.storage.sql.databaseSize;
 ```
 
+## Point in time recovery
+
+For [Durable Objects classes with SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration), the following point-in-time-recovery (PITR) API methods are available to restore a Durable Object's embedded SQLite database to any point in time in the past 30 days. These methods apply to the entire SQLite database contents, including both the object's stored SQL data and stored key-value data using the key-value `put()` API. The PITR API is not supported in local development because a durable log of data changes is not stored locally.
+
+The PITR API represents points in times using "bookmarks". A bookmark is a mostly alphanumeric string like `0000007b-0000b26e-00001538-0c3e87bb37b3db5cc52eedb93cd3b96b`. Bookmarks are designed to be lexically comparable: a bookmark representing an earlier point in time compares less than one representing a later point, using regular string comparison.
+
+### `getCurrentBookmark`
+
+<code>ctx.storage.getCurrentBookmark()</code>: <Type text='Promise<string>' />
+
+  * Returns a bookmark representing the current point in time in the object's history.
+
+### `getBookmarkForTime`
+
+<code>ctx.storage.getBookmarkForTime(timestamp: <Type text='number'/> | <Type text='Date'/>)</code>: <Type text='Promise<string>' />
+
+  * Returns a bookmark representing approximately the given point in time, which must be within the last 30 days. If the timestamp is represented as a number, it is converted to a date as if using `new Date(timestamp)`.
+
+### `onNextSessionRestoreBookmark`
+
+<code>ctx.storage.onNextSessionRestoreBookmark(bookmark: <Type text='string'/>)</code>: <Type text='Promise<string>' />
+
+  * Configure the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
+
+  This method returns a special bookmark representing the point in time immediately before the recovery takes place (even though that point in time is still technically in the future). Thus, after the recovery completes, it can be undone by performing a second recovery to this bookmark.
+
+
+```ts
+  let now = new Date();
+  // restore to 2 days ago
+  let bookmark = ctx.storage.getBookmarkForTime(now - 2);
+  ctx.storage.onNextSessionRestoreBookmark(bookmark);
+```

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -16,7 +16,7 @@ SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Obj
 
 ### exec
 
-<code>ctx.storage.sql.exec(query: <Type text='string'/>, ...bindings: <Type text='any[]'/>)</code>: <Type text='SqlStorageCursor' />
+<code>exec(query: <Type text='string'/>, ...bindings: <Type text='any[]'/>)</code>: <Type text='SqlStorageCursor' />
 
 #### Parameters
 
@@ -71,7 +71,7 @@ Note that `sql.exec()` cannot execute transaction-related statements like `BEGIN
 
 ### databaseSize
 
-`ctx.storage.sql.databaseSize`: <Type text ='number' />
+`databaseSize`: <Type text ='number' />
 
 #### Returns
 The current SQLite database size in bytes.

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -1,0 +1,82 @@
+---
+title: SQL Storage
+pcx_content_type: concept
+sidebar:
+  order: 5
+
+---
+
+import { Render, Type, MetaInfo, GlossaryTooltip } from "~/components";
+
+:::note[SQLite in Durable Objects Beta]
+SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
+:::
+
+## Methods
+
+### exec
+
+<code>ctx.storage.sql.exec(query: <Type text='string'/>, ...bindings: <Type text='any[]'/>)</code>: <Type text='SqlStorageCursor' />
+
+#### Parameters
+
+* `query`: <Type text ='string' />
+  * The SQL query string to be executed. `query` can contain `?` placeholders for parameter bindings. Multiple SQL statements, separated with a semicolon, can be executed in the `query`. With multiple SQL statements, any parameter bindings are applied to the last SQL statement in the `query`, and the returned cursor is only for the last SQL statement.
+* `bindings`: <Type text='any[]' /> <MetaInfo text='Optional' />
+  * Optional variable number of arguments that correspond to the `?` placeholders in `query`.
+
+#### Returns
+
+A cursor (`SqlStorageCursor`) to iterate over query row results as objects. `SqlStorageCursor` is a JavaScript [Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), which supports iteration using `for (let row of cursor)`. `SqlStorageCursor` is also a JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol), which supports iteration using `cursor.next()`.
+
+`SqlStorageCursor` supports the following methods:
+
+* `next()`
+  * Returns an object representing the next value of the cursor. The returned object has  `done` and `value` properties adhering to the JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol). `done` is set to `false` when a next value is present, and `value` is set to the next row object in the query result. `done` is set to `true` when the entire cursor is consumed, and no `value` is set.
+* `toArray()`
+  * Iterates through remaining cursor value(s) and returns an array of returned row objects.
+* `one()`
+  * Returns a row object if query result has exactly one row. If query result has zero rows or more than one row, `one()` throws an exception.
+* `raw()`: <Type text='Iterator' />
+  * Returns an Iterator over the same query results, with each row as an array of column values (with no column names) rather than an object.
+  * Returned Iterator supports `next()`, `toArray()`, and `one()` methods above.
+  * Returned cursor and `raw()` iterator iterate over the same query results and can be combined. For example:
+
+```ts
+  let cursor = this.sql.exec("SELECT * FROM artist ORDER BY artistname ASC;");
+  let rawResult = cursor.raw().next();
+
+  if (!rawResult.done) {
+    console.log(rawResult.value); // prints [ 123, 'Alice' ]
+  } else {
+    // query returned zero results
+  }
+
+  console.log(cursor.toArray()); // prints [{ artistid: 456, artistname: 'Bob' },{ artistid: 789, artistname: 'Charlie' }]
+```
+`SqlStorageCursor` had the following properties:
+
+* `columnNames`: <Type text='string[]' />
+  * The column names of the query in the order they appear in each row array returned by the `raw` iterator.
+*  `rowsRead`: <Type text='number' />
+  * The number of rows read so far as part of this SQL `query`. This may increase as you iterate the cursor. The final value is used for [SQL billing](/durable-objects/platform/pricing/#sqlite-storage-backend).
+*  `rowsWritten`: <Type text='number' />
+  * The number of rows written so far as part of this SQL `query`. This may increase as you iterate the cursor. The final value is used for [SQL billing](/durable-objects/platform/pricing/#sqlite-storage-backend).
+
+Note that `sql.exec()` cannot execute transaction-related statements like `BEGIN TRANSACTION` or `SAVEPOINT`. Instead, use the [`ctx.storage.transaction()`](#transaction) or [`ctx.storage.transactionSync()`](#transactionsync) APIs to start a transaction, and then execute SQL queries in your callback.
+
+#### Examples
+
+<Render file="durable-objects-sql" />
+
+### databaseSize
+
+`ctx.storage.sql.databaseSize`: <Type text ='number' />
+
+#### Returns
+The current SQLite database size in bytes.
+
+```ts
+  let size = ctx.storage.sql.databaseSize;
+```
+

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -111,7 +111,7 @@ The current SQLite database size in bytes.
 
 For [Durable Objects classes with SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration), the following point-in-time-recovery (PITR) API methods are available to restore a Durable Object's embedded SQLite database to any point in time in the past 30 days. These methods apply to the entire SQLite database contents, including both the object's stored SQL data and stored key-value data using the key-value `put()` API. The PITR API is not supported in local development because a durable log of data changes is not stored locally.
 
-The PITR API represents points in times using "bookmarks". A bookmark is a mostly alphanumeric string like `0000007b-0000b26e-00001538-0c3e87bb37b3db5cc52eedb93cd3b96b`. Bookmarks are designed to be lexically comparable: a bookmark representing an earlier point in time compares less than one representing a later point, using regular string comparison.
+The PITR API represents points in times using 'bookmarks'. A bookmark is a mostly alphanumeric string like `0000007b-0000b26e-00001538-0c3e87bb37b3db5cc52eedb93cd3b96b`. Bookmarks are designed to be lexically comparable: a bookmark representing an earlier point in time compares less than one representing a later point, using regular string comparison.
 
 ### `getCurrentBookmark`
 
@@ -129,7 +129,7 @@ The PITR API represents points in times using "bookmarks". A bookmark is a mostl
 
 <code>ctx.storage.onNextSessionRestoreBookmark(bookmark: <Type text='string'/>)</code>: <Type text='Promise<string>' />
 
-  * Configure the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
+  * Configures the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
 
   This method returns a special bookmark representing the point in time immediately before the recovery takes place (even though that point in time is still technically in the future). Thus, after the recovery completes, it can be undone by performing a second recovery to this bookmark.
 

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -131,9 +131,9 @@ The PITR API represents points in times using "bookmarks". A bookmark is a mostl
 
 <code>ctx.storage.onNextSessionRestoreBookmark(bookmark: <Type text='string'/>)</code>: <Type text='Promise<string>' />
 
-  * Configure the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
+* Configure the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this method, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
 
-  This method returns a special bookmark representing the point in time immediately before the recovery takes place (even though that point in time is still technically in the future). Thus, after the recovery completes, it can be undone by performing a second recovery to this bookmark.
+This method returns a special bookmark representing the point in time immediately before the recovery takes place (even though that point in time is still technically in the future). Thus, after the recovery completes, it can be undone by performing a second recovery to this bookmark.
 
 
 ```ts

--- a/src/content/docs/durable-objects/api/sql-storage.mdx
+++ b/src/content/docs/durable-objects/api/sql-storage.mdx
@@ -12,11 +12,11 @@ The `SqlStorage` interface encapsulates methods that modify the SQLite database 
 
 For example, using `sql.exec()`, a user can create a table, then insert rows into the table.
 
-```js
+```ts
 import { DurableObject } from "cloudflare:workers";
 
 export class MyDurableObject extends DurableObject {
-  sql: SqlStorage
+  sql: SqlStorage;
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
@@ -59,7 +59,7 @@ A cursor (`SqlStorageCursor`) to iterate over query row results as objects. `Sql
 `SqlStorageCursor` supports the following methods:
 
 * `next()`
-  * Returns an object representing the next value of the cursor. The returned object has  `done` and `value` properties adhering to the JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol). `done` is set to `false` when a next value is present, and `value` is set to the next row object in the query result. `done` is set to `true` when the entire cursor is consumed, and no `value` is set.
+  * Returns an object representing the next value of the cursor. The returned object has `done` and `value` properties adhering to the JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol). `done` is set to `false` when a next value is present, and `value` is set to the next row object in the query result. `done` is set to `true` when the entire cursor is consumed, and no `value` is set.
 * `toArray()`
   * Iterates through remaining cursor value(s) and returns an array of returned row objects.
 * `one()`
@@ -70,17 +70,18 @@ A cursor (`SqlStorageCursor`) to iterate over query row results as objects. `Sql
   * Returned cursor and `raw()` iterator iterate over the same query results and can be combined. For example:
 
 ```ts
-  let cursor = this.sql.exec("SELECT * FROM artist ORDER BY artistname ASC;");
-  let rawResult = cursor.raw().next();
+let cursor = this.sql.exec("SELECT * FROM artist ORDER BY artistname ASC;");
+let rawResult = cursor.raw().next();
 
-  if (!rawResult.done) {
-    console.log(rawResult.value); // prints [ 123, 'Alice' ]
-  } else {
-    // query returned zero results
-  }
+if (!rawResult.done) {
+  console.log(rawResult.value); // prints [ 123, 'Alice' ]
+} else {
+  // query returned zero results
+}
 
-  console.log(cursor.toArray()); // prints [{ artistid: 456, artistname: 'Bob' },{ artistid: 789, artistname: 'Charlie' }]
+console.log(cursor.toArray()); // prints [{ artistid: 456, artistname: 'Bob' },{ artistid: 789, artistname: 'Charlie' }]
 ```
+
 `SqlStorageCursor` had the following properties:
 
 * `columnNames`: <Type text='string[]' />
@@ -101,10 +102,11 @@ Note that `sql.exec()` cannot execute transaction-related statements like `BEGIN
 `databaseSize`: <Type text ='number' />
 
 #### Returns
+
 The current SQLite database size in bytes.
 
 ```ts
-  let size = ctx.storage.sql.databaseSize;
+let size = ctx.storage.sql.databaseSize;
 ```
 
 ## Point in time recovery
@@ -117,13 +119,13 @@ The PITR API represents points in times using "bookmarks". A bookmark is a mostl
 
 <code>ctx.storage.getCurrentBookmark()</code>: <Type text='Promise<string>' />
 
-  * Returns a bookmark representing the current point in time in the object's history.
+* Returns a bookmark representing the current point in time in the object's history.
 
 ### `getBookmarkForTime`
 
-<code>ctx.storage.getBookmarkForTime(timestamp: <Type text='number'/> | <Type text='Date'/>)</code>: <Type text='Promise<string>' />
+<code>ctx.storage.getBookmarkForTime(timestamp: <Type text='number | Date'/>)</code>: <Type text='Promise<string>' />
 
-  * Returns a bookmark representing approximately the given point in time, which must be within the last 30 days. If the timestamp is represented as a number, it is converted to a date as if using `new Date(timestamp)`.
+* Returns a bookmark representing approximately the given point in time, which must be within the last 30 days. If the timestamp is represented as a number, it is converted to a date as if using `new Date(timestamp)`.
 
 ### `onNextSessionRestoreBookmark`
 
@@ -135,8 +137,8 @@ The PITR API represents points in times using "bookmarks". A bookmark is a mostl
 
 
 ```ts
-  let now = new Date();
-  // restore to 2 days ago
-  let bookmark = ctx.storage.getBookmarkForTime(now - 2);
-  ctx.storage.onNextSessionRestoreBookmark(bookmark);
+let now = new Date();
+// restore to 2 days ago
+let bookmark = ctx.storage.getBookmarkForTime(now - 2);
+ctx.storage.onNextSessionRestoreBookmark(bookmark);
 ```

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -43,7 +43,7 @@ export class Counter {
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec). Otherwise, a Durable Object class has a key-value storage backend.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has a key-value storage backend.
 
 :::
 
@@ -193,7 +193,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * Provides access to the `put()`, `get()`, `delete()` and `list()` methods documented above to run in the current transaction context. In order to get transactional behavior within a transaction closure, you must call the methods on the `txn` Object instead of on the top-level `ctx.storage` Object.<br/><br/>Also supports a `rollback()` function that ensures any changes made during the transaction will be rolled back rather than committed. After `rollback()` is called, any subsequent operations on the `txn` Object will fail with an exception. `rollback()` takes no parameters and returns nothing to the caller.
 
-  * When using [the SQLite-backed storage engine](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend), the `txn` object is obsolete. Any storage operations performed directly on the `ctx.storage` object, including SQL queries using [`ctx.storage.sql.exec()`](#sqlexec), will be considered part of the transaction.
+  * When using [the SQLite-backed storage engine](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend), the `txn` object is obsolete. Any storage operations performed directly on the `ctx.storage` object, including SQL queries using [`ctx.storage.sql.exec()`](/durable-objects/api/sql-storage/#exec), will be considered part of the transaction.
 
 ### `transactionSync`
 
@@ -205,7 +205,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * If `callback()` throws an exception, the transaction will be rolled back.
 
-  * The callback must complete synchronously, that is, it should not be declared `async` nor otherwise return a Promise. Only synchronous storage operations can be part of the transaction. This is intended for use with SQL queries using [`ctx.storage.sql.exec()`](#sqlexec), which complete sychronously.
+  * The callback must complete synchronously, that is, it should not be declared `async` nor otherwise return a Promise. Only synchronous storage operations can be part of the transaction. This is intended for use with SQL queries using [`ctx.storage.sql.exec()`](/durable-objects/api/sql-storage/#exec), which complete sychronously.
 
 ### `sync`
 

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -233,7 +233,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
     <br/> If `setAlarm()` is called with a time equal to or before `Date.now()`, the alarm will be scheduled for asynchronous execution in the immediate future. If the alarm handler is currently executing in this case, it will not be canceled. Alarms can be set to millisecond granularity and will usually execute within a few milliseconds after the set time, but can be delayed by up to a minute due to maintenance or failures while failover takes place.
 
-### deleteAlarm
+### `deleteAlarm`
 
 * <code>deleteAlarm(options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text ='Promise' />
 

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Storage API
+title: Durable Object Storage
 pcx_content_type: concept
 sidebar:
   order: 4
@@ -243,76 +243,6 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 * `setAlarm()` and `deleteAlarm()` support the same options as [`put()`](/durable-objects/api/storage-api/#put), but without `noCache`.
 
-### sql.exec
-
-:::note[SQLite in Durable Objects Beta]
-
-SQL API methods accessed with `ctx.storage.sql` are only allowed on [Durable Object classes with SQLite storage backend](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration) and will return an error if called on Durable Object classes with a key-value storage backend.
-
-:::
-
-<code>ctx.storage.sql.exec(query: <Type text='string'/>, ...bindings: <Type text='any[]'/>)</code>: <Type text='SqlStorageCursor' />
-
-#### Parameters
-* `query`: <Type text ='string' />
-  * The SQL query string to be executed. `query` can contain `?` placeholders for parameter bindings. Multiple SQL statements, separated with a semicolon, can be executed in the `query`. With multiple SQL statements, any parameter bindings are applied to the last SQL statement in the `query`, and the returned cursor is only for the last SQL statement.
-* `bindings`: <Type text='any[]' /> <MetaInfo text='Optional' />
-  * Optional variable number of arguments that correspond to the `?` placeholders in `query`.
-
-#### Returns
-A cursor (`SqlStorageCursor`) to iterate over query row results as objects. `SqlStorageCursor` is a JavaScript [Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), which supports iteration using `for (let row of cursor)`. `SqlStorageCursor` is also a JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol), which supports iteration using `cursor.next()`.
-
-`SqlStorageCursor` supports the following methods:
-
-* `next()`
-  * Returns an object representing the next value of the cursor. The returned object has  `done` and `value` properties adhering to the JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol). `done` is set to `false` when a next value is present, and `value` is set to the next row object in the query result. `done` is set to `true` when the entire cursor is consumed, and no `value` is set.
-* `toArray()`
-  * Iterates through remaining cursor value(s) and returns an array of returned row objects.
-* `one()`
-  * Returns a row object if query result has exactly one row. If query result has zero rows or more than one row, `one()` throws an exception.
-* `raw()`: <Type text='Iterator' />
-  * Returns an Iterator over the same query results, with each row as an array of column values (with no column names) rather than an object.
-  * Returned Iterator supports `next()`, `toArray()`, and `one()` methods above.
-  * Returned cursor and `raw()` iterator iterate over the same query results and can be combined. For example:
-
-```ts
-  let cursor = this.sql.exec("SELECT * FROM artist ORDER BY artistname ASC;");
-  let rawResult = cursor.raw().next();
-
-  if (!rawResult.done) {
-    console.log(rawResult.value); // prints [ 123, 'Alice' ]
-  } else {
-    // query returned zero results
-  }
-
-  console.log(cursor.toArray()); // prints [{ artistid: 456, artistname: 'Bob' },{ artistid: 789, artistname: 'Charlie' }]
-```
-`SqlStorageCursor` had the following properties:
-
-* `columnNames`: <Type text='string[]' />
-  * The column names of the query in the order they appear in each row array returned by the `raw` iterator.
-*  `rowsRead`: <Type text='number' />
-  * The number of rows read so far as part of this SQL `query`. This may increase as you iterate the cursor. The final value is used for [SQL billing](/durable-objects/platform/pricing/#sqlite-storage-backend).
-*  `rowsWritten`: <Type text='number' />
-  * The number of rows written so far as part of this SQL `query`. This may increase as you iterate the cursor. The final value is used for [SQL billing](/durable-objects/platform/pricing/#sqlite-storage-backend).
-
-Note that `sql.exec()` cannot execute transaction-related statements like `BEGIN TRANSACTION` or `SAVEPOINT`. Instead, use the [`ctx.storage.transaction()`](#transaction) or [`ctx.storage.transactionSync()`](#transactionsync) APIs to start a transaction, and then execute SQL queries in your callback.
-
-#### Examples
-
-<Render file="durable-objects-sql" />
-
-### sql.databaseSize
-
-`ctx.storage.sql.databaseSize`: <Type text ='number' />
-
-#### Returns
-The current SQLite database size in bytes.
-
-```ts
-  let size = ctx.storage.sql.databaseSize;
-```
-
 ### Point in time recovery
 
 For [Durable Objects classes with SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration), the following point-in-time-recovery (PITR) API methods are available to restore a Durable Object's embedded SQLite database to any point in time in the past 30 days. These methods apply to the entire SQLite database contents, including both the object's stored SQL data and stored key-value data using the key-value `put()` API. The PITR API is not supported in local development because a durable log of data changes is not stored locally.
@@ -340,6 +270,12 @@ The PITR API represents points in times using "bookmarks". A bookmark is a mostl
   let bookmark = ctx.storage.getBookmarkForTime(now - 2);
   ctx.storage.onNextSessionRestoreBookmark(bookmark);
 ```
+
+### sql
+
+<code>ctx.storage.sql.METHOD</code>: <Type text="SqlStorage"/>
+
+- Allows you to access the `SqlStorage` methods.
 
 ### Related resources
 

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -8,13 +8,13 @@ sidebar:
 
 import { Render, Type, MetaInfo, GlossaryTooltip } from "~/components";
 
-The Storage API allows <GlossaryTooltip term="Durable Object">Durable Objects</GlossaryTooltip> to access transactional and strongly consistent storage. A Durable Object's attached storage is private to its unique instance and cannot be accessed by other objects.
+The Durable Object Storage API allows <GlossaryTooltip term="Durable Object">Durable Objects</GlossaryTooltip> to access transactional and strongly consistent storage. A Durable Object's attached storage is private to its unique instance and cannot be accessed by other objects.
 
-Durable Objects gain access to a persistent Storage API via `ctx.storage`, on the `ctx` parameter passed to the Durable Object constructor.
+Durable Objects gain access to a persistent Durable Object Storage API via `ctx.storage`, on the `ctx` parameter passed to the Durable Object constructor.
 
 While access to a Durable Object is single-threaded, request executions can still interleave with each other when they wait on I/O, such as when waiting on the promises returned by persistent storage methods or `fetch()` requests.
 
-The following code snippet shows you how to store and retrieve data using the Storage API.
+The following code snippet shows you how to store and retrieve data using the Durable Object Storage API.
 
 ```js
 export class Counter {
@@ -47,7 +47,7 @@ The new beta version of Durable Objects is available where each Durable Object h
 
 :::
 
-The Storage API comes with several methods, including key-value (KV) API, SQL API, and point-in-time-recovery (PITR) API.
+The Durable Object Storage API comes with several methods, including key-value (KV) API, SQL API, and point-in-time-recovery (PITR) API.
 
 - Durable Object classes with the default, key-value storage backend can use KV API.
 - Durable Object classes with the [SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) can use KV API, SQL API, and PITR API. KV API methods like `get()`, `put()`, `delete()`, or `list()` store data in a hidden SQLite table.

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -243,34 +243,6 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 * `setAlarm()` and `deleteAlarm()` support the same options as [`put()`](/durable-objects/api/storage-api/#put), but without `noCache`.
 
-### Point in time recovery
-
-For [Durable Objects classes with SQL storage](/durable-objects/reference/durable-objects-migrations/#enable-sqlite-storage-backend-on-new-durable-object-class-migration), the following point-in-time-recovery (PITR) API methods are available to restore a Durable Object's embedded SQLite database to any point in time in the past 30 days. These methods apply to the entire SQLite database contents, including both the object's stored SQL data and stored key-value data using the key-value `put()` API. The PITR API is not supported in local development because a durable log of data changes is not stored locally.
-
-The PITR API represents points in times using "bookmarks". A bookmark is a mostly alphanumeric string like `0000007b-0000b26e-00001538-0c3e87bb37b3db5cc52eedb93cd3b96b`. Bookmarks are designed to be lexically comparable: a bookmark representing an earlier point in time compares less than one representing a later point, using regular string comparison.
-
-`ctx.storage.getCurrentBookmark()`: <Type text='Promise<string>' />
-
-  * Returns a bookmark representing the current point in time in the object's history.
-
-<code>ctx.storage.getBookmarkForTime(timestamp: <Type text='number'/> | <Type text='Date'/>)</code>: <Type text='Promise<string>' />
-
-  * Returns a bookmark representing approximately the given point in time, which must be within the last 30 days. If the timestamp is represented as a number, it is converted to a date as if using `new Date(timestamp)`.
-
-<code>ctx.storage.onNextSessionRestoreBookmark(bookmark: <Type text='string'/>)</code>: <Type text='Promise<string>' />
-
-  * Configure the Durable Object so that the next time it restarts, it should restore its storage to exactly match what the storage contained at the given bookmark. After calling this, the application should typically invoke `ctx.abort()` to restart the Durable Object, thus completing the point-in-time recovery.
-
-  This method returns a special bookmark representing the point in time immediately before the recovery takes place (even though that point in time is still technically in the future). Thus, after the recovery completes, it can be undone by performing a second recovery to this bookmark.
-
-
-```ts
-  let now = new Date();
-  // restore to 2 days ago
-  let bookmark = ctx.storage.getBookmarkForTime(now - 2);
-  ctx.storage.onNextSessionRestoreBookmark(bookmark);
-```
-
 ### sql
 
 <code>ctx.storage.sql.METHOD</code>: <Type text="SqlStorage"/>

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -54,7 +54,7 @@ The Durable Object Storage API comes with several methods, including key-value (
 
 Each method is implicitly wrapped inside a transaction, such that its results are atomic and isolated from all other storage operations, even when accessing multiple key-value pairs.
 
-### get
+### `get`
 
 * <code>get(key <Type text='string' />, options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise<any>' />
 
@@ -74,7 +74,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
 
   * If true, then the key/value will not be inserted into the in-memory cache. If the key is already in the cache, the cached value will be returned, but its last-used time will not be updated. Use this when you expect this key will not be used again in the near future. This flag is only a hint. This flag will never change the semantics of your code, but it may affect performance.
 
-### put
+### `put`
 
 * <code>put(key <Type text='string' />, value <Type text='any' />, options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise' />
 
@@ -86,7 +86,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
   * Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types.
   * Supports up to 128 key-value pairs at a time. Each key is limited to a maximum size of 2,048 bytes and each value is limited to 128 KiB (131,072 bytes).
 
-### delete
+### `delete`
 
 * <code>delete(key <Type text='string' />, options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise<boolean>' />
 
@@ -96,7 +96,7 @@ Each method is implicitly wrapped inside a transaction, such that its results ar
 
   * Deletes the provided keys and their associated values. Supports up to 128 keys at a time. Returns a count of the number of key-value pairs deleted.
 
-### deleteAll
+### `deleteAll`
 
 * <code>deleteAll(options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise' />
 
@@ -136,7 +136,7 @@ If you invoke `put()` (or `delete()`) multiple times without performing any `awa
 The `put()` method returns a `Promise`, but most applications can discard this promise without using `await`. The `Promise` usually completes immediately, because `put()` writes to an in-memory write buffer that is flushed to disk asynchronously. However, if an application performs a large number of `put()` without waiting for any I/O, the write buffer could theoretically grow large enough to cause the isolate to exceed its 128 MB memory limit. To avoid this scenario, such applications should use `await` on the `Promise` returned by `put()`. The system will then apply backpressure onto the application, slowing it down so that the write buffer has time to flush. Using `await` will disable automatic write coalescing.
 :::
 
-### list
+### `list`
 
 * <code>list(options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text= 'Promise<Map<string, any>>' />
 
@@ -181,7 +181,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * Same as the option to `get()`, above.
 
-### transaction
+### `transaction`
 
 * `transaction(closureFunction(txn))`: <Type text='Promise' />
 
@@ -195,7 +195,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * When using [the SQLite-backed storage engine](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend), the `txn` object is obsolete. Any storage operations performed directly on the `ctx.storage` object, including SQL queries using [`ctx.storage.sql.exec()`](#sqlexec), will be considered part of the transaction.
 
-### transactionSync
+### `transactionSync`
 
 * `transactionSync(callback)`: <Type text='any' />
 
@@ -207,7 +207,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * The callback must complete synchronously, that is, it should not be declared `async` nor otherwise return a Promise. Only synchronous storage operations can be part of the transaction. This is intended for use with SQL queries using [`ctx.storage.sql.exec()`](#sqlexec), which complete sychronously.
 
-### sync
+### `sync`
 
 * `sync()` : <Type text='Promise' />
 
@@ -215,7 +215,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
   * This is similar to normal behavior from automatic write coalescing. If there are any pending writes in the write buffer (including those submitted with [the `allowUnconfirmed` option](/durable-objects/api/storage-api/#supported-options-1)), the returned promise will resolve when they complete. If there are no pending writes, the returned promise will be already resolved.
 
-### getAlarm
+### `getAlarm`
 
 * <code>getAlarm(options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise<Number | null>' />
 
@@ -225,7 +225,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 * Same options as [`get()`](/durable-objects/api/storage-api/#get), but without `noCache`.
 
-### setAlarm
+### `setAlarm`
 
 * <code>setAlarm(scheduledTime <Type text='Date | number' />, options <Type text='Object' /> <MetaInfo text='optional' />)</code>: <Type text='Promise' />
 
@@ -243,13 +243,13 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 * `setAlarm()` and `deleteAlarm()` support the same options as [`put()`](/durable-objects/api/storage-api/#put), but without `noCache`.
 
-### sql
+## Properties
 
-<code>ctx.storage.sql.METHOD</code>: <Type text="SqlStorage"/>
+### `sql`
 
-- Allows you to access the `SqlStorage` methods.
+`sql` is a readonly property of type `DurableObjectStorage` encapsulating the [SQL API](/durable-objects/api/sql-storage).
 
-### Related resources
+## Related resources
 
 * [Durable Objects: Easy, Fast, Correct – Choose Three](https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/).
 * [WebSockets API](/durable-objects/api/websockets/).

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -251,5 +251,5 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 ## Related resources
 
-* [Durable Objects: Easy, Fast, Correct – Choose Three](https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/).
-* [WebSockets API](/durable-objects/api/websockets/).
+* [Durable Objects: Easy, Fast, Correct – Choose Three](https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/)
+* [WebSockets API](/durable-objects/api/websockets/)

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -43,7 +43,7 @@ export class Counter {
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has a key-value storage backend.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) to access the new [SQL API](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has a key-value storage backend.
 
 :::
 
@@ -209,7 +209,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 ### `sync`
 
-* `sync()` : <Type text='Promise' />
+* `sync()`: <Type text='Promise' />
 
   * Synchronizes any pending writes to disk.
 
@@ -247,7 +247,7 @@ The `put()` method returns a `Promise`, but most applications can discard this p
 
 ### `sql`
 
-`sql` is a readonly property of type `DurableObjectStorage` encapsulating the [SQL API](/durable-objects/api/sql-storage).
+`sql` is a readonly property of type `DurableObjectStorage` encapsulating the [SQL API](/durable-objects/api/sql-storage/).
 
 ## Related resources
 

--- a/src/content/docs/durable-objects/api/webgpu.mdx
+++ b/src/content/docs/durable-objects/api/webgpu.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: configuration
 title: WebGPU
 sidebar:
-  order: 7
+  order: 8
 ---
 
 :::caution

--- a/src/content/docs/durable-objects/api/websockets.mdx
+++ b/src/content/docs/durable-objects/api/websockets.mdx
@@ -2,7 +2,7 @@
 title: WebSockets
 pcx_content_type: concept
 sidebar:
-  order: 5
+  order: 6
 ---
 
 import { Render, Type, MetaInfo, GlossaryTooltip } from "~/components";

--- a/src/content/docs/durable-objects/api/websockets.mdx
+++ b/src/content/docs/durable-objects/api/websockets.mdx
@@ -25,7 +25,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
 ## Extensions to WebSocket API
 
-### serializeAttachment
+### `serializeAttachment`
 
 - <code> serializeAttachment(value <Type text="any" />)</code>: <Type text="void" />
 
@@ -33,7 +33,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - If you modify `value` after calling this method, those changes will not be retained unless you call this method again. The serialized size of `value` is limited to 2,048 bytes, otherwise this method will throw an error. If you need larger values to survive hibernation, use the [Storage API](/durable-objects/api/storage-api/) and pass the corresponding key to this method so it can be retrieved later.
 
-### deserializeAttachment
+### `deserializeAttachment`
 
 - `deserializeAttachment()`: <Type text='any' />
 
@@ -41,7 +41,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
 ## State Methods
 
-### acceptWebSocket
+### `acceptWebSocket`
 
 - <code>acceptWebSocket(ws <Type text="WebSocket" />, tags{" "}<Type text="Array<string>" /> <MetaInfo text="optional" />)</code>: <Type text="void" />
 
@@ -53,7 +53,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - The WebSocket Hibernation API permits a maximum of 32,768 WebSocket connections per Durable Object, but the CPU and memory usage of a given workload may further limit the practical number of simultaneous connections.
 
-### getWebSockets
+### `getWebSockets`
 
 - <code>getWebSockets(tag <Type text="string" /> <MetaInfo text="optional" />)</code>: <Type text="Array<WebSocket>" />
 
@@ -66,13 +66,13 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
     `CLOSING` "readyState". The client might send more messages, so the
     WebSocket is technically not disconnected.
 
-### getTags
+### `getTags`
 
 - <code>getTags(ws <Type text="WebSocket" />)</code>: <Type text="Array<string>" />
 
   - Returns an Array of tags associated with the given WebSocket. Throws an error if you have not called `state.acceptWebSocket()` on the given WebSocket.
 
-### setWebSocketAutoResponse
+### `setWebSocketAutoResponse`
 
 - <code>setWebSocketAutoResponse(webSocketRequestResponsePair{" "}<Type text="WebSocketRequestResponsePair" /> <MetaInfo text="optional" />)</code>: <Type text="void" />
 
@@ -86,7 +86,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - If `state.setWebSocketAutoResponse()` is set without any argument, it will remove any previously set auto-response configuration. Setting `state.setWebSocketAutoResponse()` without any argument will stop a Durable Object from replying with `response` for a `request`. It will also stop updating the last timestamp of a `request`, but if there was any auto-response timestamp set, it will remain accessible with `state.getWebSocketAutoResponseTimestamp()`.
 
-### getWebSocketAutoResponse
+### `getWebSocketAutoResponse`
 
 - `getWebSocketAutoResponse()`: <Type text='Object | null' />
 
@@ -94,13 +94,13 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - Each <code>WebSocketRequestResponsePair(request <Type text='string'/>, response <Type text='string'/>)</code> Object provides methods for `getRequest()` and `getResponse()`.
 
-### getWebSocketAutoResponseTimestamp
+### `getWebSocketAutoResponseTimestamp`
 
 - <code>getWebSocketAutoResponseTimestamp(ws <Type text="WebSocket" />)</code>: <Type text="Date | null" />
 
   - Gets the most recent `Date` when the WebSocket received an auto-response request, or `null` if the given WebSocket never received an auto-response request.
 
-### setHibernatableWebSocketEventTimeout
+### `setHibernatableWebSocketEventTimeout`
 
 - <code>setHibernatableWebSocketEventTimeout(timeout <Type text="number" />{" "}<MetaInfo text="optional" />)</code>: <Type text="void" />
 
@@ -110,7 +110,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - The maximum value of `timeout` is 604,800,000 ms (7 days).
 
-### getHibernatableWebSocketEventTimeout
+### `getHibernatableWebSocketEventTimeout`
 
 - `getHibernatableWebSocketEventTimeout()`: <Type text='number | null' />
 
@@ -118,7 +118,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
 ## Handler Methods
 
-### webSocketMessage
+### `webSocketMessage`
 
 - <code> webSocketMessage(ws <Type text="WebSocket" />, message{" "} <Type text="string | ArrayBuffer" />)</code>: <Type text="void" />
 
@@ -128,7 +128,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - This method is not called for WebSocket control frames. The system will respond to an incoming [WebSocket protocol ping](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) automatically without interrupting hibernation.
 
-### webSocketClose
+### `webSocketClose`
 
 - <code> webSocketClose(ws <Type text="WebSocket" />, code <Type text="number" />,reason <Type text="string" />, wasClean <Type text="boolean" />)</code>: <Type text="void" />
 
@@ -136,7 +136,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
   - This method can be `async`.
 
-### webSocketError
+### `webSocketError`
 
 - <code> webSocketError(ws <Type text="WebSocket" />, error <Type text="any" />)</code> : <Type text="void" />
 

--- a/src/content/docs/durable-objects/api/websockets.mdx
+++ b/src/content/docs/durable-objects/api/websockets.mdx
@@ -43,7 +43,7 @@ To learn more about WebSocket Hibernation, refer to [Build a WebSocket server wi
 
 ### `acceptWebSocket`
 
-- <code>acceptWebSocket(ws <Type text="WebSocket" />, tags{" "}<Type text="Array<string>" /> <MetaInfo text="optional" />)</code>: <Type text="void" />
+- <code>acceptWebSocket(ws <Type text="WebSocket" />, tags <Type text="Array<string>" /> <MetaInfo text="optional" />)</code>: <Type text="void" />
 
   - Adds a WebSocket to the set attached to this Durable Object. `ws.accept()` must not have been called separately. Once called, any incoming messages will be delivered by calling the Durable Object's `webSocketMessage()` handler, and `webSocketClose()` will be invoked upon disconnect.
 

--- a/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
+++ b/src/content/docs/durable-objects/best-practices/access-durable-objects-storage.mdx
@@ -52,7 +52,7 @@ However if you ever write using [Storage API](/durable-objects/api/storage-api/)
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to a SQLite storage backend in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec). Otherwise, a Durable Object class has a key-value storage backend.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to a SQLite storage backend in order to access new [SQL API](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has a key-value storage backend.
 
 :::
 
@@ -64,7 +64,7 @@ tag = "v1" # Should be unique for each entry
 new_sqlite_classes = ["MyDurableObject"] # Array of new classes
 ```
 
-[SQL API](/durable-objects/api/storage-api/#sqlexec) is available on `ctx.storage.sql` parameter passed to the Durable Object constructor.
+[SQL API](/durable-objects/api/sql-storage/#exec) is available on `ctx.storage.sql` parameter passed to the Durable Object constructor.
 
 ### Examples
 

--- a/src/content/docs/durable-objects/get-started/tutorial-with-sql-api.mdx
+++ b/src/content/docs/durable-objects/get-started/tutorial-with-sql-api.mdx
@@ -16,7 +16,7 @@ This guide will instruct you through:
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec), part of Durable Objects Storage API.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec), part of Durable Objects Storage API.
 
 :::
 
@@ -132,7 +132,7 @@ export class MyDurableObject extends DurableObject {
 In the code above, you have:
 
 1. Defined a RPC method, `sayHello()`, that can be called by a Worker to communicate with a Durable Object.
-2. Accessed a Durable Object's attached storage, which is a private SQLite database only accesible to the object, using [SQL API](/durable-objects/api/storage-api/#sqlexec) methods (`sql.exec()`) available on `ctx.storage` .
+2. Accessed a Durable Object's attached storage, which is a private SQLite database only accesible to the object, using [SQL API](/durable-objects/api/sql-storage/#exec) methods (`sql.exec()`) available on `ctx.storage` .
 3. Returned an object representing the single row query result using `one()`, which checks that the query result has exactly one row.
 4. Return the `greeting` column from the row object result.
 

--- a/src/content/docs/durable-objects/index.mdx
+++ b/src/content/docs/durable-objects/index.mdx
@@ -27,7 +27,7 @@ Use Durable Objects to build collaborative editing tools, interactive chat, mult
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
 
 Storage API billing is not enabled for Durable Object classes using SQLite storage backend. SQLite-backed Durable Objects will incur [charges for requests and duration](/durable-objects/platform/pricing/#billing-metrics). We plan to enable Storage API billing for Durable Objects using SQLite storage backend in the first half of 2025 after advance notice with the following [pricing](/durable-objects/platform/pricing/#sql-storage-billing).
 

--- a/src/content/docs/durable-objects/index.mdx
+++ b/src/content/docs/durable-objects/index.mdx
@@ -27,7 +27,7 @@ Use Durable Objects to build collaborative editing tools, interactive chat, mult
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/storage-api/#point-in-time-recovery), part of Durable Objects Storage API.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec) and [point-in-time-recovery API](/durable-objects/api/sql-storage/#point-in-time-recovery), part of Durable Objects Storage API.
 
 Storage API billing is not enabled for Durable Object classes using SQLite storage backend. SQLite-backed Durable Objects will incur [charges for requests and duration](/durable-objects/platform/pricing/#billing-metrics). We plan to enable Storage API billing for Durable Objects using SQLite storage backend in the first half of 2025 after advance notice with the following [pricing](/durable-objects/platform/pricing/#sql-storage-billing).
 

--- a/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
+++ b/src/content/docs/durable-objects/reference/durable-objects-migrations.mdx
@@ -101,7 +101,7 @@ Note that `.toml` files do not allow line breaks in inline tables (the `{key = "
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to a SQLite storage backend in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec). Otherwise, a Durable Object class has a key-value storage backend.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to a SQLite storage backend in order to access new [SQL API](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has a key-value storage backend.
 
 :::
 

--- a/src/content/docs/workers/platform/storage-options.mdx
+++ b/src/content/docs/workers/platform/storage-options.mdx
@@ -209,7 +209,7 @@ To get started with Vectorize:
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to using SQL storage in order to access [Storage SQL API methods](/durable-objects/api/storage-api/#sqlexec). Otherwise, a Durable Object class has the standard, private key-value storage.
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can opt-in to using SQL storage in order to access [Storage SQL API methods](/durable-objects/api/sql-storage/#exec). Otherwise, a Durable Object class has the standard, private key-value storage.
 
 :::
 

--- a/src/content/partials/durable-objects/durable-objects-sql.mdx
+++ b/src/content/partials/durable-objects/durable-objects-sql.mdx
@@ -4,7 +4,7 @@
 
 import { Details } from "~/components"
 
-[SQL API](/durable-objects/api/storage-api/#sqlexec) examples below use the following SQL schema:
+[SQL API](/durable-objects/api/sql-storage/#exec) examples below use the following SQL schema:
 
 ```ts
 import { DurableObject } from "cloudflare:workers";

--- a/src/content/partials/workers/storage_api_pricing.mdx
+++ b/src/content/partials/workers/storage_api_pricing.mdx
@@ -34,7 +34,7 @@ Requests that hit the [Durable Objects in-memory cache](/durable-objects/referen
 
 :::note[SQLite in Durable Objects Beta]
 
-The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/storage-api/#sqlexec).
+The new beta version of Durable Objects is available where each Durable Object has a private, embedded SQLite database. When deploying a new Durable Object class, users can [opt-in to a SQLite storage backend](/durable-objects/best-practices/access-durable-objects-storage/#sqlite-storage-backend) in order to access new [SQL API](/durable-objects/api/sql-storage/#exec).
 
 During the initial beta, Storage API billing is not enabled for Durable Object classes using SQLite storage backend. SQLite-backed Durable Objects will incur [charges for requests and duration](/durable-objects/platform/pricing/#billing-metrics). We plan to enable Storage API billing for Durable Objects using SQLite storage backend in the first half of 2025 after advance notice with the below pricing.
 

--- a/src/content/partials/workers/storage_api_pricing.mdx
+++ b/src/content/partials/workers/storage_api_pricing.mdx
@@ -38,7 +38,7 @@ The new beta version of Durable Objects is available where each Durable Object h
 
 During the initial beta, Storage API billing is not enabled for Durable Object classes using SQLite storage backend. SQLite-backed Durable Objects will incur [charges for requests and duration](/durable-objects/platform/pricing/#billing-metrics). We plan to enable Storage API billing for Durable Objects using SQLite storage backend in the first half of 2025 after advance notice with the below pricing.
 
-You can introspect rows read and rows written using `cursor.rowsRead` and `cursor.rowsWritten` on the [cursor returned](/durable-objects/api/storage-api/#returns) by a SQL query and using [GraphQL analytics](/durable-objects/observability/graphql-analytics/#query-via-the-graphql-api). [`ctx.storage.sql.databaseSize`](/durable-objects/api/storage-api/#sqldatabaseSize) returns the current SQL database size for a Durable Object.
+You can introspect rows read and rows written using `cursor.rowsRead` and `cursor.rowsWritten` on the [cursor returned](/durable-objects/api/storage-api/#returns) by a SQL query and using [GraphQL analytics](/durable-objects/observability/graphql-analytics/#query-via-the-graphql-api). [`ctx.storage.sql.databaseSize`](/durable-objects/api/sql-storage/#sqldatabaseSize) returns the current SQL database size for a Durable Object.
 
 :::
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Renaming "Runtime API" to "Workers Binding API".
2. Splitting out "Storage API" into:
    - "Durable Object Storage"
    - "SQL Storage"

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
