### PR TITLE
[Docs Site] Only show child units in LP when present

### DIFF
--- a/src/components/LearningPath.astro
+++ b/src/components/LearningPath.astro
@@ -64,17 +64,19 @@ if (!firstModule)
 						<LinkButton href={"/" + module.slug + "/"} variant="secondary">
 							Start module
 						</LinkButton>
-						<Details header={`Contains ${units.length} units`} open>
-							<Steps>
-								<ol>
-									{units.map((unit) => (
-										<li>
-											<a href={"/" + unit.slug + "/"}>{unit.data.title}</a>
-										</li>
-									))}
-								</ol>
-							</Steps>
-						</Details>
+						{units.length > 0 && (
+							<Details header={`Contains ${units.length} units`} open>
+								<Steps>
+									<ol>
+										{units.map((unit) => (
+											<li>
+												<a href={"/" + unit.slug + "/"}>{unit.data.title}</a>
+											</li>
+										))}
+									</ol>
+								</Steps>
+							</Details>
+						)}
 					</li>
 				);
 			})


### PR DESCRIPTION
### Summary

Only show child units in LP when present

### Screenshots (optional)

Before:

<img width="355" alt="image" src="https://github.com/user-attachments/assets/c3cc1567-7229-4921-b6bc-a8f3359a9ba7">

After:

<img width="346" alt="image" src="https://github.com/user-attachments/assets/f0977aa9-1950-4a86-ab5d-ec4d2f05a5b2">