### PR TITLE
[Docs Site] Fix api-deprecations in ProductChangelog

### DIFF
--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -43,6 +43,11 @@ if (page.data.changelog_product_area_name) {
 			wranglerOnly: true,
 		};
 		({ changelogs } = await getChangelogs(opts));
+	} else if (name === "api-deprecations") {
+		const opts = {
+			deprecationsOnly: true,
+		};
+		({ changelogs } = await getChangelogs(opts));
 	} else {
 		const opts = {
 			filter: (entry: CollectionEntry<"changelogs">) => {


### PR DESCRIPTION
### Summary

Fixes the `api-deprecations` changelog not appearing in the `ProductChangelog` component.