### PR TITLE
workflows: changelog multi workflows

### DIFF
--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -5,6 +5,12 @@ productLink: "/workflows/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2024-11-22"
+    title: "Multiple Workflows in local development now supported"
+    description: |-
+      Local development with `wrangler dev` now correctly supports multiple Workflow definitions per script.
+
+      There is no change to production Workflows, where multiple Workflow definitions per Worker script was already supported.
   - publish_date: "2024-10-23"
     title: "Workflows is now in public beta!"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -6,7 +6,7 @@ productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2024-11-21"
-    title: "Worker bindings "
+    title: "Fixed create instance API in Workers bindings"
     description: |-
       You can now call `create()` without any arguments when using the [Workers API](/workflows/build/workers-api/#create) for Workflows. Workflows will automatically generate the ID of the Workflow on your behalf.
 

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -5,7 +5,13 @@ productLink: "/workflows/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
-  - publish_date: "2024-11-22"
+  - publish_date: "2024-11-21"
+    title: "Worker bindings "
+    description: |-
+      You can now call `create()` without any arguments when using the [Workers API](/workflows/build/workers-api/#create) for Workflows. Workflows will automatically generate the ID of the Workflow on your behalf.
+
+      This addresses a bug that caused calls to `create()` to fail when provided with no arguments.
+  - publish_date: "2024-11-20"
     title: "Multiple Workflows in local development now supported"
     description: |-
       Local development with `wrangler dev` now correctly supports multiple Workflow definitions per script.


### PR DESCRIPTION
Updates the Workflows changelog to reflect the latest updates:

- [x] Fixes multiple Workflows in local dev
- [x] Fixes the empty `create` binding bug
