### PR TITLE
[Cache] Remove note that R2 is not supported in tiered-cache.mdx

### DIFF
--- a/src/content/docs/cache/how-to/tiered-cache.mdx
+++ b/src/content/docs/cache/how-to/tiered-cache.mdx
@@ -48,14 +48,6 @@ Custom Tiered cache allows you to work with Cloudflare’s support team to set a
 
 <FeatureTable id="cache.tiered_cache" />
 
-:::note
-
-
-Tiered Cache currently is not compatible with responses from [R2](/r2). These responses will act as if Tiered Cache is not configured.
-
-
-:::
-
 ## Bandwidth Alliance
 
 Enterprise customers can override Bandwidth Alliance configuration with Tiered Cache. For all other users, the Bandwidth Alliance takes precedence. Tiered Cache is still a valuable option to enable because the Bandwidth Alliance may not always be an available option, and in those instances, the Tiered Cache configuration will be used.


### PR DESCRIPTION
### Summary

Follow up on PR #18301 for Cache removing note that R2 is not supported in tiered-cache.mdx
