### PR TITLE
Update R2 limits docs to reflect default bucket limit of 1 million

### DIFF
--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -1,36 +1,38 @@
 ---
 title: Limits
 pcx_content_type: concept
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
-## Rate limiting on managed public buckets through `r2.dev`
+| Feature                                                             | Limit                        |
+| ------------------------------------------------------------------- | ---------------------------- |
+| Data storage per bucket                                             | Unlimited                    |
+| Maximum number of buckets per account                               | 1,000,000                    |
+| Maximum rate of bucket management operations per bucket<sup>1</sup> | 50 per second                |
+| Number of custom domains per bucket                                 | 50                           |
+| Object key length                                                   | 1,024 bytes                  |
+| Object metadata size                                                | 8,192 bytes                  |
+| Object size                                                         | 5 TiB per object<sup>2</sup> |
+| Maximum upload size<sup>4</sup>                                     | 5 GiB<sup>3</sup>            |
+| Maximum upload parts                                                | 10,000                       |
 
-Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a rate limit applied to it. If you exceed the rate limit, requests through your `r2.dev` subdomain will be temporarily throttled and you will receive a `429 Too Many Requests` response. For production use cases, consider linking a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket.
-
-## Account plan limits
-
-
-
-| Feature                           | Limit                        |
-| --------------------------------- | ---------------------------- |
-| Bucket                            | 1000 buckets per account     |
-| Data storage per bucket           | Unlimited                    |
-| Object key length                 | 1,024 bytes                  |
-| Object metadata size              | 8,192 bytes                  |
-| Object size                       | 5 TiB per object<sup>1</sup> |
-| Maximum upload size<sup>3</sup>   | 5 GiB<sup>2</sup>            |
-| Maximum upload parts              | 10,000                       |
-| Maximum custom domains per bucket | 50                           |
-
-
-
-<sup>1</sup> The object size limit is 5 GiB less than 5 TiB, so 4.995 TiB.<br/> <sup>2</sup> The max upload size is 5 MiB less than 5 GiB, so 4.995 GiB.<br/> <sup>3</sup> Max upload size applies to uploading a file via one request, uploading a part of a multipart upload, or copying into a part of a multipart upload. If you have a Worker, its inbound request size is
-constrained by [Workers request limits](/workers/platform/limits#request-limits). The max upload size limit does not apply to subrequests.<br/>
-Review the [Examples](/r2/examples/) on how to use the SDKs.<br/>
+<sup>1</sup> Bucket management operations include creating, deleting, listing,
+and configuring buckets.
+<br /> <sup>2</sup> The object size limit is 5 GiB less than 5 TiB, so 4.995
+TiB.
+<br /> <sup>2</sup> The max upload size is 5 MiB less than 5 GiB, so 4.995 GiB.
+<br /> <sup>4</sup> Max upload size applies to uploading a file via one request,
+uploading a part of a multipart upload, or copying into a part of a multipart
+upload. If you have a Worker, its inbound request size is constrained by
+[Workers request limits](/workers/platform/limits#request-limits). The max
+upload size limit does not apply to subrequests.
+<br />
 
 Limits specified in MiB (mebibyte), GiB (gibibyte), or TiB (tebibyte) are storage units of measurement based on base-2. 1 GiB (gibibyte) is equivalent to 2<sup>30</sup> bytes (or 1024<sup>3</sup> bytes). This is distinct from 1 GB (gigabyte), which is 10<sup>9</sup> bytes (or 1000<sup>3</sup> bytes).
 
 <Render file="limits_increase" product="workers" />
+
+## Rate limiting on managed public buckets through `r2.dev`
+
+Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a rate limit applied to it. If you exceed the rate limit, requests through your `r2.dev` subdomain will be temporarily throttled and you will receive a `429 Too Many Requests` response. For production use cases, consider linking a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket.


### PR DESCRIPTION
Update R2 limits docs to reflect default bucket limit of 1 million