### PR TITLE
[wrangler]: add `wrangler telemetry` commands and update existing info on telemetry collection

### DIFF
--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -296,7 +296,7 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
+  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 - `limits` Limits optional
 

--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -296,7 +296,7 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
+  - Whether Wrangler should send usage data to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 - `limits` Limits optional
 

--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -296,7 +296,7 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project.
+  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
 
 - `limits` Limits optional
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2613,7 +2613,9 @@ wrangler telemetry enable
 
 ### `status`
 
-Check whether telemetry collection is currently enabled. This will resolve the global status set by `wrangler telemetry disable / enable`, the environment variable [`WRANGLER_SEND_METRICS`](/workers/wrangler/system-environment-variables/#supported-environment-variables) and the [`send_metrics`](/workers/wrangler/configuration/#top-level-only-keys) key in `wrangler.toml`.
+Check whether telemetry collection is currently enabled. The return result is specific to the directory where you have run the command.
+
+This will resolve the global status set by `wrangler telemetry disable / enable`, the environment variable [`WRANGLER_SEND_METRICS`](/workers/wrangler/system-environment-variables/#supported-environment-variables), and the [`send_metrics`](/workers/wrangler/configuration/#top-level-only-keys) key in `wrangler.toml`.
 
 ```txt
 wrangler telemetry status

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2591,7 +2591,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
 
 ## `telemetry`
 
-Cloudflare collects anonymous usage data to improve Wrangler. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
+Cloudflare collects anonymous usage data to improve Wrangler. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 You can opt-out of sharing telemetry data at any time using these commands.
 
@@ -2603,12 +2603,6 @@ Disable telemetry collection for Wrangler.
 wrangler telemetry disable
 ```
 
-:::note
-
-You can also disable telemetry collection on a specific project by setting the environment variable `WRANGLER_SEND_METRICS=false`.
-
-:::
-
 ### `enable`
 
 Enable telemetry collection for Wrangler.
@@ -2616,12 +2610,6 @@ Enable telemetry collection for Wrangler.
 ```txt
 wrangler telemetry enable
 ```
-
-:::note
-
-You can also enable telemetry for a specific project by setting the environment variable `WRANGLER_SEND_METRICS=true`.
-
-:::
 
 ### `status`
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -41,7 +41,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`dispatch-namespace`](#dispatch-namespace) - Interact with a [dispatch namespace](/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works/#dispatch-namespace).
 - [`mtls-certificate`](#mtls-certificate) - Manage certificates used for mTLS connections.
 - [`types`](#types) - Generate types from bindings and module rules in configuration.
-- [`telemetry`](#telemetry) - Configure whether Wrangler can collect anonymous usage telemetry
+- [`telemetry`](#telemetry) - Configure whether Wrangler can collect anonymous usage data.
 
 :::note
 
@@ -2593,7 +2593,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
 
 Cloudflare collects anonymous usage data to improve Wrangler. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
-You can opt-out of sharing telemetry data at any time using these commands.
+You can manage sharing of usage data at any time using these commands.
 
 ### `disable`
 
@@ -2613,7 +2613,7 @@ wrangler telemetry enable
 
 ### `status`
 
-Check whether telemetry collection is currently enabled.
+Check whether telemetry collection is currently enabled. This will resolve the global status set by `wrangler telemetry disable / enable`, the environment variable [`WRANGLER_SEND_METRICS`](/workers/wrangler/system-environment-variables/#supported-environment-variables) and the [`send_metrics`](/workers/wrangler/configuration/#top-level-only-keys) key in `wrangler.toml`.
 
 ```txt
 wrangler telemetry status

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -41,6 +41,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`dispatch-namespace`](#dispatch-namespace) - Interact with a [dispatch namespace](/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works/#dispatch-namespace).
 - [`mtls-certificate`](#mtls-certificate) - Manage certificates used for mTLS connections.
 - [`types`](#types) - Generate types from bindings and module rules in configuration.
+- [`telemetry`](#telemetry) - Configure whether Wrangler can collect anonymous usage telemetry
 
 :::note
 
@@ -2585,3 +2586,47 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - A custom path must have a `d.ts` extension.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+## `telemetry`
+
+Cloudflare collects anonymous usage data to improve Wrangler. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
+
+You can opt-out of sharing telemetry data at any time using these commands.
+
+### `disable`
+
+Disable telemetry collection for Wrangler.
+
+```txt
+wrangler telemetry disable
+```
+
+:::note
+
+You can also disable telemetry collection on a specific project by setting the environment variable `WRANGLER_SEND_METRICS=false`.
+
+:::
+
+### `enable`
+
+Enable telemetry collection for Wrangler.
+
+```txt
+wrangler telemetry enable
+```
+
+:::note
+
+You can also enable telemetry for a specific project by setting the environment variable `WRANGLER_SEND_METRICS=true`.
+
+:::
+
+### `status`
+
+Check whether telemetry collection is currently enabled.
+
+```txt
+wrangler telemetry status
+```

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -69,7 +69,7 @@ Top-level keys apply to the Worker as a whole (and therefore all environments). 
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
+  - Whether Wrangler should send usage data to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 - `site` <Type text="object" /> <MetaInfo text="optional deprecated" />
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -69,7 +69,7 @@ Top-level keys apply to the Worker as a whole (and therefore all environments). 
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
+  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 - `site` <Type text="object" /> <MetaInfo text="optional deprecated" />
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -69,7 +69,7 @@ Top-level keys apply to the Worker as a whole (and therefore all environments). 
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Whether Wrangler should send usage metrics to Cloudflare for this project.
+  - Whether Wrangler should send usage metrics to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
 
 - `site` <Type text="object" /> <MetaInfo text="optional deprecated" />
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -40,7 +40,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_SEND_METRICS` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Options for this are `true` and `false`, the default behavior is `true`. Controls whether Wrangler can send anonymous usage metrics to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
+  * Options for this are `true` and `false`, the default behavior is `true`. Controls whether Wrangler can send anonymous usage metrics to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 * `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>`<Type text="string" /> <MetaInfo text="optional" />
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -40,7 +40,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_SEND_METRICS` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Options for this are `true` and `false`, the default behavior is `true`. Controls whether Wrangler can send anonymous usage metrics to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
+  * Options for this are `true` and `false`. Defaults to `true`. Controls whether Wrangler can send anonymous usage data to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 * `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>`<Type text="string" /> <MetaInfo text="optional" />
 
@@ -52,7 +52,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_LOG` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`. Levels are case-insensitive and default to `"log"`. If an invalid level is specified, Wrangler will fallback to the default.
+  * Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`. Levels are case-insensitive and default to `"log"`. If an invalid level is specified, Wrangler will fallback to the default. Logs can include requests to Cloudflare's API, any usage data being collected, and more verbose error logs.
 
 * `FORCE_COLOR` <Type text="string" /> <MetaInfo text="optional" />
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -40,7 +40,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_SEND_METRICS` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Options for this are `true` and `false`, the default behavior is `false`.
+  * Options for this are `true` and `false`, the default behavior is `true`. Controls whether Wrangler can send anonymous usage metrics to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/telemetry.md).
 
 * `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>`<Type text="string" /> <MetaInfo text="optional" />
 


### PR DESCRIPTION
### Summary

Wrangler will be enabling telemetry collection by default for new users (see https://github.com/cloudflare/workers-sdk/pull/7291).

This PR documents the new `wrangler telemetry enable/disable/status` commands that have been added in the process, and updates existing references to telemetry collection in Wrangler, including adding links to our data policy.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.