### PR TITLE
fixed templates link

### DIFF
--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -166,7 +166,7 @@ bun create cloudflare@latest [--] [<DIRECTORY>] [OPTIONS] [-- <NESTED ARGS...>]
     - `wrangler.toml`
     - `src/` containing a worker script referenced from `wrangler.toml`
 
-    See the [templates folder](https://github.com/cloudflare/workers-sdk/tree/main/templates) of this repo for more examples.
+    See the [templates folder](https://github.com/cloudflare/workers-sdk/tree/main/packages/create-cloudflare/templates) of this repo for more examples.
 
 - `--deploy` boolean (default: true) optional
 


### PR DESCRIPTION
The templates link goes to a 404 page. I replaced the link to:

https://github.com/cloudflare/workers-sdk/tree/main/packages/create-cloudflare/templates

### Summary

Replaced a link URL.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
