### PR TITLE
workflows: clarify get throws

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -194,7 +194,24 @@ Get a specific Workflow instance by ID.
 
   * `id` - the ID of the Workflow instance.
 
-Returns a `WorkflowInstance`.
+Returns a `WorkflowInstance`. Throws an exception if the instance ID does not exist.
+
+```ts
+// Fetch an existing Workflow instance by ID:
+try {
+  let instance = await env.MY_WORKFLOW.get(id)
+  return Response.json({
+	  id: instance.id,
+	  details: await instance.status(),
+  });
+} catch (e: any) {
+  // Handle errors
+  // .get will throw an exception if the ID doesn't exist or is invalid.
+  const msg = `failed to get instance ${id}: ${e.message}`
+  console.error(msg)
+  return Response.json({error: msg}, { status: 400 })
+}
+```
 
 ## WorkflowInstanceCreateOptions
 


### PR DESCRIPTION
Clarify that get throws and add an example of catching the error. 