### PR TITLE
workflows: `step.sleep` takes the number argument as milliseconds

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -26,7 +26,7 @@ Use `step.sleep` to have a Workflow sleep for a relative period of time:
 await step.sleep("sleep for a bit", "1 hour")
 ```
 
-The second argument to `step.sleep` accepts both `number` (seconds) or a human-readable format, such as "1 minute" or "26 hours". The accepted units for `step.sleep` when used this way are as follows:
+The second argument to `step.sleep` accepts both `number` (milliseconds) or a human-readable format, such as "1 minute" or "26 hours". The accepted units for `step.sleep` when used this way are as follows:
 
 ```ts
 | "second"

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -26,7 +26,7 @@ Use `step.sleep` to have a Workflow sleep for a relative period of time:
 await step.sleep("sleep for a bit", "1 hour")
 ```
 
-The second argument to `step.sleep` accepts both `number` (milliseconds) or a human-readable format, such as "1 minute" or "26 hours". The accepted units for `step.sleep` when used this way are as follows:
+The second argument to `step.sleep` accepts both `number` (milliseconds) or a human-readable format, such as "1 minute" or "26 hours". The accepted units for `step.sleep` when used this way are:
 
 ```ts
 | "second"


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

The `step.sleep` method for Workflows takes the number argument as milliseconds, instead of seconds as previously documented.
I tested and noticed this issue.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
