### PR TITLE
[Analytics] Document that GraphQL query inputs cannot exceed 25KB

### DIFF
--- a/content/analytics/graphql-api/limits/index.md
+++ b/content/analytics/graphql-api/limits/index.md
@@ -24,6 +24,7 @@ limits:
 
 These limits are applied to every query for every plan:
 
+* GraphQL inputs cannot be larger than **25KB**
 * A zone-scoped query can include up to **10 zones**
 * An account-scoped query can include only **1 account**
 


### PR DESCRIPTION
We're imposing a limit on the sizes of GraphQL queries - that is, the input data, and not the output. This commit documents that change. I wasn't sure how best to convey that it isn't the response that is being limited. Ideas for rephrasing are welcome.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
