### PR TITLE
[Analytics] Remove link to video tutorial

### DIFF
--- a/src/content/docs/analytics/network-analytics/get-started.mdx
+++ b/src/content/docs/analytics/network-analytics/get-started.mdx
@@ -29,5 +29,3 @@ Use the [GraphQL Analytics API](/analytics/graphql-api/) to query data using the
 ## Send Network Analytics logs to a third-party service
 
 [Create a Logpush job](/logs/get-started/enable-destinations/) that sends Network analytics logs to your storage service, <GlossaryTooltip term="SIEM">SIEM solution</GlossaryTooltip>, or log management provider.
-
-For a video tutorial, refer to [Send Network Analytics Logs to Splunk](/analytics/analytics-integrations/splunk/#video-tutorial-send-network-analytics-logs-to-splunk).


### PR DESCRIPTION
### Summary

The video tutorial was removed from Dev Docs (it was outdated), but we were still linking to the section that was removed.
