### PR TITLE
Add a warning about remaining IPv6 addresses

### DIFF
--- a/src/content/docs/byoip/service-bindings/magic-transit-with-cdn.mdx
+++ b/src/content/docs/byoip/service-bindings/magic-transit-with-cdn.mdx
@@ -45,6 +45,13 @@ Once a service binding is created (or deleted), it will take **four** to **six**
 This guide assumes that the prefix is tied to a single Cloudflare account that has both Magic Transit and CDN properties. If you are using [prefix delegations](/byoip/concepts/prefix-delegations/), the service bindings must be [created](#2-create-service-binding) on the parent account.
 :::
 
+{{<Aside type="warning">}}
+
+As of december 2024, a Magic Transit BYOIP pool is made of IPv4 addresses. When carving out IPv4 addresses for CDN or Spectrum, DNS A records will resolve to these new IPv4 addresses. DNS AAAA records will contine to resolve to Cloudflare-owned IPv6 addresses.
+You'd need to import a /48 IPv6 range to assign customer-owned IPv6 addresses as well.
+
+{{</Aside>}}
+
 ## 1. Get account information
 
 1. Log in to your Cloudflare account and get your [account ID](/fundamentals/setup/find-account-and-zone-ids/) and [API token](/fundamentals/api/get-started/create-token/). The token permissions should include `Account` - `IP Prefixes` - `Edit`.


### PR DESCRIPTION
As per discussion with Erfi, I'm adding a preliminary draft message to convey that, although IPv4 addresses are used for A records, the Cloudflare-owned IPv6 will continue to be used. Which may defeat the purpose of Static IPs for CDN/Spectrum.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
