### PR TITLE
docs: increase free-tier Worker size limit from 1MB to 3MB

### DIFF
--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -205,7 +205,7 @@ Specific error cases include but are not limited to:
 
 #### Worker exceeded the upload size limit
 
-A Worker can be up to 10 MB in size after compression on the Workers Paid plan, and up to 1 MB on the Workers Free plan.
+A Worker can be up to 10 MB in size after compression on the Workers Paid plan, and up to 3 MB on the Workers Free plan.
 
 To reduce the upload size of a Worker, you should consider removing unnecessary dependencies and/or using Workers KV, a D1 database or R2 to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code.
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -17,7 +17,7 @@ import { Render } from "~/components";
 | [Simultaneous outgoing<br/>connections/request](#simultaneous-open-connections)  | 6            | 6                                                                                                                                                                                                                                                                  |
 | [Environment variables](#environment-variables)                                  | 64/Worker    | 128/Worker                                                                                                                                                                                                                                                         |
 | [Environment variable<br/>size](#environment-variables)                          | 5 KB         | 5 KB                                                                                                                                                                                                                                                               |
-| [Worker size](#worker-size)                                                      | 1 MB         | 10 MB                                                                                                                                                                                                                                                              |
+| [Worker size](#worker-size)                                                      | 3 MB         | 10 MB                                                                                                                                                                                                                                                              |
 | [Worker startup time](#worker-startup-time)                                      | 400 ms       | 400 ms                                                                                                                                                                                                                                                             |
 | [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500                                                                                                                                                                                                                                                                |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250                                                                                                                                                                                                                                                                |
@@ -245,7 +245,7 @@ Each environment variable has a size limitation of 5 KB.
 
 ## Worker size
 
-A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan, and up to 1 MB on the Workers Free plan.
+A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan, and up to 3 MB on the Workers Free plan.
 
 You can assess the size of your Worker bundle after compression by performing a dry-run with `wrangler` and reviewing the final compressed (`gzip`) size output by `wrangler`:
 

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -14,7 +14,7 @@ Many limits are inherited from those applied to Workers scripts and as documente
 
 | Feature                                   | Workers Free            | Workers Paid          |
 | ----------------------------------------- | ----------------------- | --------------------- |
-| Workflow class definitions per script     | 1MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits) | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)
+| Workflow class definitions per script     | 3MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits) | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)
 | Total scripts per account                 | 100 | 500 (shared with [Worker script limits](/workers/platform/limits/#account-plan-limits) |
 | Compute time per step [^3]                | 10 seconds | 30 seconds of [active CPU time](/workers/platform/limits/#cpu-time) |
 | Duration (wall clock) per step [^3]       | Unlimited | Unlimited - for example, waiting on network I/O calls or querying a database |


### PR DESCRIPTION
### Summary

Updates free-tier Worker size limit from 1MB to 3MB.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
