### PR TITLE
Add dev spotlight product category to  new spotlight contributions

### DIFF
--- a/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
@@ -8,6 +8,7 @@ products:
   - Workers
   - Workers AI
   - Durable Objects
+  - Developer Spotlight
 spotlight:
   author: Vasyl
   author_bio_link: https://github.com/berezovyy

--- a/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
+++ b/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
@@ -7,6 +7,7 @@ title: Automate analytics reporting with Cloudflare Workers and email routing
 products:
   - Workers
   - Email Routing
+  - Developer Spotlight
 spotlight:
   author: Aleksej Komnenovic
   author_bio_link: https://www.linkedin.com/in/komnenovic/


### PR DESCRIPTION
### Summary

Add Developer Spotlight product category to two new contributions so they appear in the Developer Spotlight space on docs.