### PR TITLE
r2: clarify r2.dev limits

### DIFF
--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -40,4 +40,4 @@ Managed public bucket access through an `r2.dev` subdomain is not intended for p
 * If you exceed the rate limit (hundreds of requests/second), requests to your `r2.dev` endpoint will be temporarily throttled and you will receive a `429 Too Many Requests` response.
 * Bandwidth (throughput) may also be throttled when using the `r2.dev` endpoint.
 
-For production use cases, connect a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket. Custom domains allow you to serve content from a domain you control (e.g. `assets.example.com`), configure fine-grained caching, set up redirect and rewrite rules, mutate content via [Cloudflare Workers](/workers/), and get detailed URL-level analytics for content served from your R2 bucket.
+For production use cases, connect a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket. Custom domains allow you to serve content from a domain you control (for example, `assets.example.com`), configure fine-grained caching, set up redirect and rewrite rules, mutate content via [Cloudflare Workers](/workers/), and get detailed URL-level analytics for content served from your R2 bucket.

--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -35,7 +35,7 @@ Limits specified in MiB (mebibyte), GiB (gibibyte), or TiB (tebibyte) are storag
 
 ## Rate limiting on managed public buckets through `r2.dev`
 
-Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a variable rate limit applied to it. The `r2.dev` endpoint for your bucket is designed to enable testing: 
+Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a variable rate limit applied to it. The `r2.dev` endpoint for your bucket is designed to enable testing.
 
 * If you exceed the rate limit (hundreds of requests/second), requests to your `r2.dev` endpoint will be temporarily throttled and you will receive a `429 Too Many Requests` response.
 * Bandwidth (throughput) may also be throttled when using the `r2.dev` endpoint.

--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -35,4 +35,9 @@ Limits specified in MiB (mebibyte), GiB (gibibyte), or TiB (tebibyte) are storag
 
 ## Rate limiting on managed public buckets through `r2.dev`
 
-Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a rate limit applied to it. If you exceed the rate limit, requests through your `r2.dev` subdomain will be temporarily throttled and you will receive a `429 Too Many Requests` response. For production use cases, consider linking a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket.
+Managed public bucket access through an `r2.dev` subdomain is not intended for production usage and has a variable rate limit applied to it. The `r2.dev` endpoint for your bucket is designed to enable testing: 
+
+* If you exceed the rate limit (hundreds of requests/second), requests to your `r2.dev` endpoint will be temporarily throttled and you will receive a `429 Too Many Requests` response.
+* Bandwidth (throughput) may also be throttled when using the `r2.dev` endpoint.
+
+For production use cases, connect a [custom domain](/r2/buckets/public-buckets/#custom-domains) to your bucket. Custom domains allow you to serve content from a domain you control (e.g. `assets.example.com`), configure fine-grained caching, set up redirect and rewrite rules, mutate content via [Cloudflare Workers](/workers/), and get detailed URL-level analytics for content served from your R2 bucket.


### PR DESCRIPTION
Clarify existing `r2.dev` limits and expand on the custom domain benefits.