### PR TITLE
Add Customer Support team as codeowner for Support section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,7 +203,7 @@
 
 # Support
 
-/src/content/docs/support/ @shanecloudflare @zeinjaber @TracyCloudflare @ngayerie @cloudflare/pcx-technical-writing
+/src/content/docs/support/ @shanecloudflare @zeinjaber @TracyCloudflare @ngayerie @cloudflare/pcx-technical-writing @cloudflare/customer-support
 
 # Turnstile
 


### PR DESCRIPTION
### Summary

Adding group containing supportability and training teams to enable more efficient review of content in the support section.