### PR TITLE
Cleaned up the Hostname priority

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/remove-custom-hostnames.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/remove-custom-hostnames.mdx
@@ -26,7 +26,7 @@ If the custom hostname is in a **Moved** state for seven days, it will transitio
 
 If your customer's domain is not using Cloudflare, you must remove a customer's custom hostname from your zone if they decide to churn.
 
-This is especially important if your end customers are using Cloudflare because if the custom hostname changes the DNS target to point away from your SaaS zone, the custom hostname will continue to route to your service. This is a result of the [custom hostname priority logic](/ssl/reference/certificate-and-hostname-priority/#hostname-priority-cloudflare-for-saas).
+This is especially important if your end customers are using Cloudflare because if the custom hostname changes the DNS target to point away from your SaaS zone, the custom hostname will continue to route to your service. This is a result of the [custom hostname priority logic](/ssl/reference/certificate-and-hostname-priority/#hostname-priority).
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
@@ -33,7 +33,7 @@ There are three main causes of error 1016:
 
 1. Custom Hostname ownership validation is not complete. To check validation status, run an API call to [search for a certificate by hostname](/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls/) and check the verification error field: `"verification_errors": ["custom hostname does not CNAME to this zone."]`.
 2. Fallback Origin is not [correctly set](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#1-create-fallback-origin). Confirm that you have created a DNS record for the fallback origin and also set the fallback origin.
-3. A Wildcard Custom Hostname has been created, but the requested hostname is associated with a domain that exists in Cloudflare as a standalone zone. In this case, the [hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority-cloudflare-for-saas) for the standalone zone will take precedence over the wildcard custom hostname. This behavior applies even if there is no DNS record for this standalone zone hostname.
+3. A Wildcard Custom Hostname has been created, but the requested hostname is associated with a domain that exists in Cloudflare as a standalone zone. In this case, the [hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority) for the standalone zone will take precedence over the wildcard custom hostname. This behavior applies even if there is no DNS record for this standalone zone hostname.
 
 In this scenario each hostname that needs to be served by the Cloudflare for SaaS parent zone needs to be added as an individual Custom Hostname.
 

--- a/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
+++ b/src/content/docs/ssl/reference/certificate-and-hostname-priority.mdx
@@ -57,21 +57,21 @@ Cloudflare uses the following order to determine the certificate and settings us
 
 ***
 
-## Hostname priority (Cloudflare for SaaS)
+## Hostname priority
 
-When multiple proxied DNS records exist for a zone — usually with Cloudflare for SaaS — only one record can control the zone settings and associated origin server.
+When multiple proxied DNS records exist for a hostname, in multiple zones — usually due to Cloudflare for SaaS — only one record will control the zone settings and associated origin server.
 
-Cloudflare determines this priority in the following order (assuming each record exists and is proxied (orange-clouded)):
+Cloudflare determines this priority in the following order, assuming each record exists and is proxied (orange-clouded):
 
 1. **Exact hostname match**:
 
    1. [New custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/) (belonging to a SaaS provider)
    2. [Legacy custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/reference/versioning/) (belonging to a SaaS provider)
-   3. [DNS](/dns/manage-dns-records/reference/proxied-dns-records/) (Belonging to the logical DNS zone)
+   3. [DNS](/dns/manage-dns-records/reference/proxied-dns-records/) (belonging to the logical DNS zone)
 
 2. **Wildcard hostname match**:
 
-   1. DNS (Belonging to the logical DNS zone)
+   1. DNS (belonging to the logical DNS zone)
    2. New custom hostname (belonging to a SaaS provider)
 
 If a hostname resource record is not proxied (gray-clouded) for a zone on Cloudflare, that zone's settings are not applied and any settings configured at the associated origin are applied instead. This origin could be another zone on Cloudflare or any other server.
@@ -90,6 +90,6 @@ Customer1 uses Cloudflare as authoritative DNS for the zone `shop.example.com`. 
 
 A customer has a [proxied](/dns/manage-dns-records/reference/proxied-dns-records/) DNS record for their domain. The customer's zone on Cloudflare is using a Free plan.
 
-This customer is also using a SaaS provider that utilizes Cloudflare for SaaS. The SaaS provider is using a Cloudflare Enterprise plan.
+This customer is also using a SaaS provider that uses Cloudflare for SaaS. The SaaS provider is using a Cloudflare Enterprise plan.
 
 If the provider is using a wildcard custom hostname, then the original customer's plan limits will take precedence over the provider's plan limits (Cloudflare will treat the zone as a Free zone). To apply the Enterprise limits through Cloudflare for SaaS, the original customer's zone would need to either use a [DNS-only](/dns/manage-dns-records/reference/proxied-dns-records/) record or the SaaS provider would need to use an exact hostname match.

--- a/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
+++ b/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
@@ -9,6 +9,6 @@
 4. Click **Add Custom Hostname**.
 5. Add your customer's hostname `app.customer.com` and set the relevant options, including:
    * Choosing the [Validation method](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/).
-   * Whether you want to **Enable wildcard**, which adds a `*.<custom-hostname>` SAN to the custom hostname certificate. For more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority-cloudflare-for-saas).
+   * Whether you want to **Enable wildcard**, which adds a `*.<custom-hostname>` SAN to the custom hostname certificate. For more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority).
    * Choosing a value for [Custom origin server](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/).
 6. Click **Add Custom Hostname**.

--- a/src/content/partials/cloudflare-for-platforms/get-started-prereqs.mdx
+++ b/src/content/partials/cloudflare-for-platforms/get-started-prereqs.mdx
@@ -11,7 +11,7 @@ Before you start creating custom hostnames:
 
 1. [Add](/fundamentals/setup/manage-domains/add-site/) your zone to Cloudflare {props.one}
 2. [Enable](/cloudflare-for-platforms/cloudflare-for-saas/start/enable/) Cloudflare for SaaS for your zone.
-3. Review the [Hostname prioritization guidelines](/ssl/reference/certificate-and-hostname-priority/#hostname-priority-cloudflare-for-saas). Wildcard custom hostnames behave differently than an exact hostname match.
+3. Review the [Hostname prioritization guidelines](/ssl/reference/certificate-and-hostname-priority/#hostname-priority). Wildcard custom hostnames behave differently than an exact hostname match.
 4. (optional) Review the following documentation:
 
 * [API documentation](/fundamentals/api/) (if you have not worked with the Cloudflare API before).


### PR DESCRIPTION
I wanted to make sure readers would not overlook this "Hostname priority" section, hence I removed (Cloudflare for SaaS) because it gives a false impression it's not needed to read it for a standard customer. In the end, it's very often the case that, somewhere, a customer have a hostname covered by Cloudflare for SaaS, but customer isn't aware of it.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
