### PR TITLE
[Docs Site] Append product meta suffix to custom titles

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -14,12 +14,30 @@ if (currentSection) {
 
 	if (product) {
 		if (product.data.meta.title) {
-			const title = `${Astro.props.entry.data.title} | ${product.data.meta.title}`;
-			Astro.props.entry.data.head.push({
-				tag: "title",
-				attrs: {},
-				content: title,
-			});
+			const titleIdx = Astro.props.entry.data.head.findIndex(
+				(x) => x.tag === "title",
+			);
+
+			let title: string;
+
+			if (titleIdx !== -1) {
+				const existingTitle = Astro.props.entry.data.head[titleIdx].content;
+				title = `${existingTitle} · ${product.data.meta.title}`;
+
+				Astro.props.entry.data.head[titleIdx] = {
+					tag: "title",
+					attrs: {},
+					content: title,
+				};
+			} else {
+				title = `${Astro.props.entry.data.title} · ${product.data.meta.title}`;
+				Astro.props.entry.data.head.push({
+					tag: "title",
+					attrs: {},
+					content: title,
+				});
+			}
+
 			Astro.props.entry.data.head.push({
 				tag: "meta",
 				attrs: { property: "og:title", content: title },

--- a/src/content/docs/aegis/index.mdx
+++ b/src/content/docs/aegis/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare Aegis docs
+    content: Overview
 ---
 
 import { CardGrid, Description, GlossaryTooltip, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/china-network/index.mdx
+++ b/src/content/docs/china-network/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare China Network
+    content: Overview
 ---
 
 import { Stream } from "~/components"

--- a/src/content/docs/page-shield/index.mdx
+++ b/src/content/docs/page-shield/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare Page Shield
+    content: Overview
 description: Page Shield is a comprehensive client-side security and privacy
   solution that allows you to ensure the safety of your website visitors'
   browsing environment.

--- a/src/content/docs/rules/index.mdx
+++ b/src/content/docs/rules/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare Rules
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/ruleset-engine/index.mdx
+++ b/src/content/docs/ruleset-engine/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 head:
   - tag: title
-    content: Overview | Cloudflare Ruleset Engine
+    content: Overview
 ---
 
 import { LinkButton } from "~/components";

--- a/src/content/docs/ssl/index.mdx
+++ b/src/content/docs/ssl/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare SSL/TLS docs
+    content: Overview
 description: Cloudflare SSL/TLS offers free Universal SSL alongside advanced and enterprise features to meet your encryption and certificate management needs.
 ---
 

--- a/src/content/docs/waf/index.mdx
+++ b/src/content/docs/waf/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Overview | Cloudflare Web Application Firewall
+    content: Overview
 description: The Cloudflare Web Application Firewall (WAF) provides automatic
   protection from vulnerabilities and the flexibility to create custom rules.
 ---


### PR DESCRIPTION
### Summary

Append product meta suffix to custom titles

Page:

```yaml
head:
  - tag: title
    content: Troubleshooting | Custom certificates
```

Before:

```html
<meta property="og:title" content="Troubleshooting | Cloudflare SSL/TLS docs">
```

After:

```html
<meta property="og:title" content="Troubleshooting | Custom certificates · Cloudflare SSL/TLS docs">
```