### PR TITLE
Add CSUP to Support images CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -204,6 +204,7 @@
 # Support
 
 /src/content/docs/support/ @shanecloudflare @zeinjaber @TracyCloudflare @ngayerie @cloudflare/pcx-technical-writing @cloudflare/customer-support
+/src/assets/images/support/ @shanecloudflare @zeinjaber @TracyCloudflare @ngayerie @cloudflare/pcx-technical-writing @cloudflare/customer-support
 
 # Turnstile
 


### PR DESCRIPTION
### Summary

Support own their docs but currently adding images make PCX required approvers. 