### PR TITLE
Update "dynamic"/"deterministic" usage in rules-of-workflows.mdx

### DIFF
--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -227,15 +227,15 @@ export class MyWorkflow extends WorkflowEntrypoint {
 
 ### Name steps deterministically
 
-Steps should be named deterministically (even if dynamic). This  ensures that their state is cached, and prevents the step from being rerun unnecessarily. Step names act as the "cache key" in your Workflow.
+Steps should be named deterministically (ie, not using the current date/time, randomness, etc). This  ensures that their state is cached, and prevents the step from being rerun unnecessarily. Step names act as the "cache key" in your Workflow.
 
 
 ```ts
 export class MyWorkflow extends WorkflowEntrypoint {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
-		// 🔴 Bad: Dynamically naming the step prevents it from being cached
+		// 🔴 Bad: Naming the step non-deterministically prevents it from being cached
 		// This will cause the step to be re-run if subsequent steps fail.
-		await step.do(`step #1 running at: ${Date.now}`, async () => {
+		await step.do(`step #1 running at: ${Date.now()}`, async () => {
 		    let userData = await env.KV.get(event.user)
 				event.data = userData
 		})


### PR DESCRIPTION
Dynamic is fine. Non-deterministic is not. Clarifying the latter.

Also fixed a minor bug. (`Date.now` when stringified is actually deterministic – it always outputs `"[Function: now]"` – it's `Date.now()` that's the problem!)