### PR TITLE
[Workers Assets] Update Static Assets page to reflect new `wrangler dev --remote` support

### DIFF
--- a/src/content/docs/workers/static-assets/compatibility-matrix.mdx
+++ b/src/content/docs/workers/static-assets/compatibility-matrix.mdx
@@ -35,13 +35,13 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 | [Preview URLs](/workers/configuration/previews)                                     | ✅      | ✅      |
 | [Testing tools](/workers/testing)                                                   | ✅      | ✅      |
 | [Local Development](/workers/testing/local-development/)                            | ✅      | ✅      |
-| [Remote Development (`--remote`)](/workers/wrangler/commands/)                      | ✅ [^1] | ❌      |
+| [Remote Development (`--remote`)](/workers/wrangler/commands/)                      | ✅      | ❌      |
 | [Quick Editor in Dashboard](https://blog.cloudflare.com/improved-quick-edit)        | ✅      | ❌      |
 | **Static Assets**                                                                   |         |         |
 | [Early Hints](/pages/configuration/early-hints/)                                    | ❌      | ✅      |
-| [Custom HTTP headers for static assets](/pages/configuration/headers/)              | 🟡 [^2] | ✅      |
-| [Middleware](/pages/functions/middleware/)                                          | 🟡 [^3] | ✅      |
-| [Redirects](/pages/configuration/redirects/)                                        | 🟡 [^4] | ✅      |
+| [Custom HTTP headers for static assets](/pages/configuration/headers/)              | 🟡 [^1] | ✅      |
+| [Middleware](/pages/functions/middleware/)                                          | 🟡 [^2] | ✅      |
+| [Redirects](/pages/configuration/redirects/)                                        | 🟡 [^3] | ✅      |
 | [Smart Placement](/workers/configuration/smart-placement/)                          | ✅      | ✅      |
 | **Observability**                                                                   |         |         |
 | [Workers Logs](/workers/observability/)                                             | ✅      | ❌      |
@@ -50,7 +50,7 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 | [Real-time logs](/workers/observability/logs/real-time-logs/)                       | ✅      | ✅      |
 | **Runtime APIs & Compute Models**                                                   |         |         |
 | [Node.js Compatibility Mode](/workers/runtime-apis/nodejs/)                         | ✅      | ✅      |
-| [Durable Objects](/durable-objects/api/)                                            | ✅      | 🟡 [^5] |
+| [Durable Objects](/durable-objects/api/)                                            | ✅      | 🟡 [^4] |
 | [Cron Triggers](/workers/configuration/cron-triggers/)                              | ✅      | ❌      |
 | **Bindings**                                                                        |         |         |
 | [AI](/workers-ai/get-started/workers-wrangler/#2-connect-your-worker-to-workers-ai) | ✅      | ✅      |
@@ -78,19 +78,17 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 | [Branch Deploy Controls](/pages/configuration/branch-build-controls/)               | ❌      | ✅      |
 | [Custom Branch Aliases](/pages/how-to/custom-branch-aliases/)                       | ❌      | ✅      |
 | **Pages Functions**                                                                 |         |         |
-| [File-based Routing](/pages/functions/routing/)                                     | ❌ [^6] | ✅      |
-| [Pages Plugins](/pages/functions/plugins/)                                          | ❌ [^7] | ✅      |
+| [File-based Routing](/pages/functions/routing/)                                     | ❌ [^5] | ✅      |
+| [Pages Plugins](/pages/functions/plugins/)                                          | ❌ [^6] | ✅      |
 
-[^1]: Does not currently support Workers with static assets. For more details on which bindings are supported in remote development, [refer to the docs](/workers/testing/local-development/#supported-resource-bindings-in-different-environments).
+[^1]: Similar to <sup>3</sup>, to customize the HTTP headers that are returned by static assets, you can use [Service bindings](/workers/runtime-apis/bindings/service-bindings/) to connect a Worker in front of the Worker with assets.
 
-[^2]: Similar to <sup>3</sup>, to customize the HTTP headers that are returned by static assets, you can use [Service bindings](/workers/runtime-apis/bindings/service-bindings/) to connect a Worker in front of the Worker with assets.
+[^2]: If you need to run a Worker before serving static assets, you can create a separate Worker that acts as middleware, and then use [Service bindings](/workers/runtime-apis/bindings/service-bindings/) to forward the request to the Worker with assets. We plan to explore additional configuration to support more complex routing in the future.
 
-[^3]: If you need to run a Worker before serving static assets, you can create a separate Worker that acts as middleware, and then use [Service bindings](/workers/runtime-apis/bindings/service-bindings/) to forward the request to the Worker with assets. We plan to explore additional configuration to support more complex routing in the future.
+[^3]: You can handle redirects by adding code to your Worker (a [community package](https://npmjs.com/package/redirects-in-workers) is available for `_redirects` support), or you can use [Bulk Redirects](/rules/url-forwarding/bulk-redirects/).
 
-[^4]: You can handle redirects by adding code to your Worker (a [community package](https://npmjs.com/package/redirects-in-workers) is available for `_redirects` support), or you can use [Bulk Redirects](/rules/url-forwarding/bulk-redirects/).
+[^4]: To [use Durable Objects with your Cloudflare Pages project](/pages/functions/bindings/#durable-objects), you must create a separate Worker with a Durable Object and then declare a binding to it in both your Production and Preview environments. Using Durable Objects with Workers is simpler and recommended.
 
-[^5]: To [use Durable Objects with your Cloudflare Pages project](/pages/functions/bindings/#durable-objects), you must create a separate Worker with a Durable Object and then declare a binding to it in both your Production and Preview environments. Using Durable Objects with Workers is simpler and recommended.
+[^5]: Workers [supports popular frameworks](/workers/frameworks/), many of which implement file-based routing.
 
-[^6]: Workers [supports popular frameworks](/workers/frameworks/), many of which implement file-based routing.
-
-[^7]: Everything that is possible with Pages Functions can also be achieved by adding code to your Worker or by using framework-specific plugins for relevant third party tools.
+[^6]: Everything that is possible with Pages Functions can also be achieved by adding code to your Worker or by using framework-specific plugins for relevant third party tools.

--- a/src/content/docs/workers/testing/local-development.mdx
+++ b/src/content/docs/workers/testing/local-development.mdx
@@ -34,7 +34,7 @@ npx wrangler dev
 | Product                             | Local Dev Supported | Remote Dev Supported |
 | ----------------------------------- | ------------------- | -------------------- |
 | AI                                  | ✅[^1]              | ✅                   |
-| Assets                              | ✅                  | ❌                   |
+| Assets                              | ✅                  | ✅                   |
 | Analytics Engine                    | ❌                  | ✅                   |
 | Browser Rendering                   | ❌                  | ✅                   |
 | D1                                  | ✅                  | ✅                   |


### PR DESCRIPTION
### Summary

`wrangler dev --remote` has added support for Workers + Assets. This PR updates all remote mode + Workers static assets references to reflect the newly added support.


### Screenshots (optional)
<img width="499" alt="Screenshot 2024-11-28 at 16 43 49" src="https://github.com/user-attachments/assets/fce8c432-e774-4dac-8761-313d1da2c0d2">

<img width="769" alt="Screenshot 2024-11-28 at 16 45 33" src="https://github.com/user-attachments/assets/08f7295f-d2f8-4d5e-b6b9-41a4bef5c43d">


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
