### PR TITLE
[Durable Objects] call out currently unsupported locations for hints

### DIFF
--- a/src/content/docs/durable-objects/reference/data-location.mdx
+++ b/src/content/docs/durable-objects/reference/data-location.mdx
@@ -92,4 +92,8 @@ Hints are a best effort and not a guarantee. Unlike with jurisdictions, Durable 
 
 <sup>1</sup> Dynamic relocation of existing Durable Objects is planned for the
 future.
-<sup>2</sup> Durable Objects currently do not spawn in this location. Instead, the Durable Object will spawn in a nearby location which does support Durable Objects. For example, Durable Objects hinted to South America spawn in Eastern North America instead.
+
+<sup>2</sup> Durable Objects currently do not spawn in this location. Instead,
+the Durable Object will spawn in a nearby location which does support Durable
+Objects. For example, Durable Objects hinted to South America spawn in Eastern
+North America instead.

--- a/src/content/docs/durable-objects/reference/data-location.mdx
+++ b/src/content/docs/durable-objects/reference/data-location.mdx
@@ -78,17 +78,18 @@ Hints are a best effort and not a guarantee. Unlike with jurisdictions, Durable 
 
 ### Supported locations
 
-| Parameter | Location              |
-| --------- | --------------------- |
-| wnam      | Western North America |
-| enam      | Eastern North America |
-| sam       | South America         |
-| weur      | Western Europe        |
-| eeur      | Eastern Europe        |
-| apac      | Asia-Pacific          |
-| oc        | Oceania               |
-| afr       | Africa                |
-| me        | Middle East           |
+| Parameter | Location                   |
+| --------- | -------------------------- |
+| wnam      | Western North America      |
+| enam      | Eastern North America      |
+| sam       | South America <sup>2</sup> |
+| weur      | Western Europe             |
+| eeur      | Eastern Europe             |
+| apac      | Asia-Pacific               |
+| oc        | Oceania                    |
+| afr       | Africa <sup>2</sup>        |
+| me        | Middle East <sup>2</sup>   |
 
 <sup>1</sup> Dynamic relocation of existing Durable Objects is planned for the
 future.
+<sup>2</sup> Durable Objects currently do not spawn in this location. Instead, the Durable Object will spawn in a nearby location which does support Durable Objects. For example, Durable Objects hinted to South America spawn in Eastern North America instead.


### PR DESCRIPTION
### Summary

Closes #18471

This pull request includes updates to the `src/content/docs/durable-objects/reference/data-location.mdx` file to clarify the supported locations for Durable Objects and provide additional information about certain regions.

Updates to supported locations:

* Clarified that Durable Objects currently do not spawn in certain locations (South America, Africa, Middle East) by adding a footnote explaining that they will spawn in a nearby supported location instead.
* Added `<sup>2</sup>` notation to the South America, Africa, and Middle East entries in the supported locations table to reference the new footnote.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
