### PR TITLE
[Workers] fix: update supported vitest version

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
@@ -30,7 +30,7 @@ First, you will need to uninstall the old environment and install the new pool. 
 
 ```sh
 npm uninstall vitest-environment-miniflare
-npm install --save-dev --save-exact vitest@2.1.5
+npm install --save-dev --save-exact vitest@2.1.8
 npm install --save-dev @cloudflare/vitest-pool-workers
 ```
 

--- a/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
@@ -30,7 +30,7 @@ First, you will need to uninstall the old environment and install the new pool. 
 
 ```sh
 npm uninstall vitest-environment-miniflare
-npm install --save-dev --save-exact vitest@2.0.5
+npm install --save-dev --save-exact vitest@2.1.6
 npm install --save-dev @cloudflare/vitest-pool-workers
 ```
 

--- a/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2.mdx
@@ -30,7 +30,7 @@ First, you will need to uninstall the old environment and install the new pool. 
 
 ```sh
 npm uninstall vitest-environment-miniflare
-npm install --save-dev --save-exact vitest@2.1.6
+npm install --save-dev --save-exact vitest@2.1.5
 npm install --save-dev @cloudflare/vitest-pool-workers
 ```
 

--- a/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
@@ -32,7 +32,7 @@ The above commands will add the packages to your `package.json` file and install
 
 :::note
 
-Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 2.1.x.
+Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 2.1.8.
 
 :::
 

--- a/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
@@ -24,7 +24,7 @@ This guide will instruct you through installing and setting up the `@cloudflare/
 Open a terminal window and make sure you are in your project's root directory. Once you have confirmed that, run:
 
 ```sh
-npm install vitest@2.1.6 --save-dev --save-exact
+npm install vitest@2.1.8 --save-dev --save-exact
 npm install @cloudflare/vitest-pool-workers --save-dev
 ```
 

--- a/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/get-started/write-your-first-test.mdx
@@ -24,7 +24,7 @@ This guide will instruct you through installing and setting up the `@cloudflare/
 Open a terminal window and make sure you are in your project's root directory. Once you have confirmed that, run:
 
 ```sh
-npm install vitest@2.0.5 --save-dev --save-exact
+npm install vitest@2.1.6 --save-dev --save-exact
 npm install @cloudflare/vitest-pool-workers --save-dev
 ```
 
@@ -32,7 +32,7 @@ The above commands will add the packages to your `package.json` file and install
 
 :::note
 
-Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.5.
+Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 2.1.x.
 
 :::
 


### PR DESCRIPTION
### Summary

This simply updates the supported vitest version to 2.1.8. The Workers vitest integrations works with `2.0.x - 2.1.x`.

Paired with https://github.com/cloudflare/workers-sdk/pull/7384