### PR TITLE
[Docs Site] Trim product area suffix from titles in TroubleshootingList

### DIFF
--- a/src/components/TroubleshootingList.astro
+++ b/src/components/TroubleshootingList.astro
@@ -50,9 +50,12 @@ const resources = await getCollection("docs", (entry) => {
 					location.push(title);
 				}
 
+				// Use the custom title from the `head` frontmatter, minus
+				// the product area suffix, if present.
 				const title =
-					resource.data.head.find((x) => x.tag === "title")?.content ??
-					resource.data.title;
+					resource.data.head
+						.find((x) => x.tag === "title")
+						?.content.split(" · ")[0] ?? resource.data.title;
 
 				return (
 					<tr>


### PR DESCRIPTION
### Summary

Trim product area suffix from titles in TroubleshootingList

### Screenshots (optional)

Before:

<img width="366" alt="image" src="https://github.com/user-attachments/assets/cc1381bf-82f1-499b-98db-065c584fa696">

After:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/dde9df10-2167-4b5c-800b-057df8cdef70">
