### PR TITLE
[Docs Site] Disable feedback submission until a reason is ticked

### DIFF
--- a/src/components/FeedbackPrompt.astro
+++ b/src/components/FeedbackPrompt.astro
@@ -62,7 +62,7 @@ import { AstroIcon } from "~/components";
 						name="info"
 					/>
 				</div>
-				<input type="submit" value="Submit" />
+				<input type="submit" value="Submit" disabled />
 			</fieldset>
 		</form>
 	</div>
@@ -109,7 +109,7 @@ import { AstroIcon } from "~/components";
 						name="info"
 					/>
 				</div>
-				<input type="submit" value="Submit" />
+				<input type="submit" value="Submit" disabled />
 			</fieldset>
 		</form>
 	</div>
@@ -184,6 +184,28 @@ import { AstroIcon } from "~/components";
 					const form = questionsDiv.querySelector("form");
 
 					if (!form) return;
+
+					const reasons = form.querySelectorAll<HTMLInputElement>(
+						"input[type='radio']",
+					);
+
+					if (!reasons) return;
+
+					const submit = form.querySelector<HTMLInputElement>(
+						"input[type='submit']",
+					);
+
+					if (!submit) return;
+
+					reasons.forEach((reason) =>
+						reason.addEventListener(
+							"change",
+							() => {
+								submit.disabled = false;
+							},
+							{ once: true },
+						),
+					);
 
 					form.addEventListener("submit", async (e) => {
 						e.preventDefault();


### PR DESCRIPTION
### Summary

Disable feedback submission until a reason is ticked.

We already validated a reason was provided on the backend, this just stops invalid feedback from being submitted.

### Screenshots (optional)

<img width="272" alt="image" src="https://github.com/user-attachments/assets/b5beff38-ca5b-416b-ac83-11498cc04821">

<img width="262" alt="image" src="https://github.com/user-attachments/assets/836df4e2-acc2-4a35-a1e3-06e75f9366a5">
