### PR TITLE
Workflows: reflect that step.sleep do not count towards max step limits

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -69,6 +69,12 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
   * `name` - the name of the step.
   * `timestamp` - a JavaScript `Date` object or seconds from the Unix epoch to sleep the Workflow instance until.
 
+:::note
+
+`step.sleep` and `step.sleepUntil` methods do not count towards the maximum Workflow steps limit. More information is available [here](/workflows/reference/limits/) regarding the limits imposed to Workflow.
+
+:::
+
 ## WorkflowStepConfig
 
 ```ts

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -71,7 +71,7 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 
 :::note
 
-`step.sleep` and `step.sleepUntil` methods do not count towards the maximum Workflow steps limit. More information is available [here](/workflows/reference/limits/) regarding the limits imposed to Workflow.
+step.sleep and step.sleepUntil methods do not count towards the maximum Workflow steps limit. More information about the limits imposed on Workflow can be found in the [Workflow Limits Reference](/workflows/reference/limits/).
 
 :::
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -71,7 +71,9 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 
 :::note
 
-step.sleep and step.sleepUntil methods do not count towards the maximum Workflow steps limit. More information about the limits imposed on Workflow can be found in the [Workflow Limits Reference](/workflows/reference/limits/).
+`step.sleep` and `step.sleepUntil` methods do not count towards the maximum Workflow steps limit. 
+
+More information about the limits imposed on Workflow can be found in the [Workflows limits documentation](/workflows/reference/limits/).
 
 :::
 

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -21,7 +21,7 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum persisted state per step          | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum state that can be persisted per Workflow instance | 100MB | 1GB |
 | Maximum `step.sleep` duration             | 365 days (1 year) [^1] | 365 days (1 year) [^1] |
-| Maximum steps per Workflow                | 512 [^1] | 512 [^1] |
+| Maximum steps per Workflow [^5]           | 512 [^1] | 512 [^1] |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |
 | Concurrent Workflow instances (executions)   | 25 | 100 [^1] |
 | Retention limit for completed Workflow state | 3 days | 30 days [^2] |
@@ -34,5 +34,7 @@ Many limits are inherited from those applied to Workers scripts and as documente
 [^3]: A Workflow instance can run forever, as long as each step does not take more than the CPU time limit and the maximum number of steps per Workflow is not reached.
 
 [^4]: Match pattern: _```^[a-zA-Z0-9_][a-zA-Z0-9-_]*$```_
+
+[^5]: `step.sleep` do not count towards the max. steps limit
 
 <Render file="limits_increase" product="workers" />


### PR DESCRIPTION
### Summary

Added info that step sleep do not count towards steps limit.

