### PR TITLE
Remove `--experimental-json-config` flag

### DIFF
--- a/src/content/partials/workers/wrangler-commands/global-flags.mdx
+++ b/src/content/partials/workers/wrangler-commands/global-flags.mdx
@@ -12,5 +12,3 @@ The following global flags work on every command:
   - Show version number.
 - `--config` <Type text="string" /> (not supported by Pages)
   - Path to `.toml` configuration file.
-- `--experimental-json-config` <Type text="boolean" /> (not supported by Pages)
-  - ⚠️ This is an experimental command. Read configuration from a `wrangler.json` file, instead of `wrangler.toml`. `wrangler.json` is a [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) file.


### PR DESCRIPTION
This is now on by default and can't be set