### PR TITLE
Updated docs to make backlog count clear

### DIFF
--- a/src/content/docs/queues/configuration/pull-consumers.mdx
+++ b/src/content/docs/queues/configuration/pull-consumers.mdx
@@ -140,6 +140,7 @@ This will return an array of messages (up to the specified `batch_size`) in the 
 	"errors": [],
 	"messages": [],
 	"result": {
+		"message_backlog_count": 10,
 		"messages": [
 			{
 				"body": "hello",


### PR DESCRIPTION
Add message backlog count in the response body, in Queues HTTP pull consumers documentation.