### PR TITLE
fix: bedrock example code

### DIFF
--- a/src/content/docs/ai-gateway/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/providers/bedrock.mdx
@@ -89,7 +89,7 @@ export default {
 			response.headers.get("content-type")?.includes("application/json")
 		) {
 			const data = await response.json();
-			return new Response(JSON.stringify(response));
+			return new Response(JSON.stringify(data));
 		} else {
 			return new Response("Invalid response", { status: 500 });
 		}


### PR DESCRIPTION
### Summary

While going through the example code for the bedrock implementation, I noticed that the return is returning the full response rather than the JSON data.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
