### PR TITLE
Clarify how to add HTTP headers in the dashboard

### DIFF
--- a/src/content/docs/logs/get-started/enable-destinations/http.mdx
+++ b/src/content/docs/logs/get-started/enable-destinations/http.mdx
@@ -19,7 +19,7 @@ Note that when using Logpush to HTTP endpoints, Cloudflare customers are expecte
 5. In **Select a destination**, choose **HTTP destination**.
 
 6. Enter the **HTTP endpoint** where you want to send the logs to, and select **Continue**.
-		* You can use `"header_*"` URL parameters to set request headers (for example, to pass an authentication token to your HTTP endpoint).
+		- You can use `"header_*"` URL parameters to set request headers, for example, to pass an authentication token to your HTTP endpoint.
 
 7. Select the dataset to push to the storage service.
 

--- a/src/content/docs/logs/get-started/enable-destinations/http.mdx
+++ b/src/content/docs/logs/get-started/enable-destinations/http.mdx
@@ -19,6 +19,7 @@ Note that when using Logpush to HTTP endpoints, Cloudflare customers are expecte
 5. In **Select a destination**, choose **HTTP destination**.
 
 6. Enter the **HTTP endpoint** where you want to send the logs to, and select **Continue**.
+		* You can use `"header_*"` URL parameters to set request headers (for example, to pass an authentication token to your HTTP endpoint).
 
 7. Select the dataset to push to the storage service.
 


### PR DESCRIPTION
Minor update to clarify that HTTP Headers can be configured not only via API but also in the dashboard by passing specifically formatted url parameters.