### PR TITLE
Restoring nextjs tutorial to pages

### DIFF
--- a/src/content/docs/pages/framework-guides/nextjs/index.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/index.mdx
@@ -11,4 +11,8 @@ import { DirectoryListing, Stream } from "~/components"
 
 [Next.js](https://nextjs.org) is an open-source React framework for creating websites and applications.
 
+### Video Tutorial
+
+<Stream videoId="0b28fdd5938c4929bd7fdedcd167044d" videoTitle="Deploy NextJS to your Workers Application" thumbnailTimeOrURL="2.5s" />
+
 <DirectoryListing />


### PR DESCRIPTION
### Summary

Restoring nextjs tutorial to pages

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/e08530e2-9a7b-45b1-bbcf-f3bb76c97c77)