### PR TITLE
[worker] Document response stream disconnected error

### DIFF
--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -231,10 +231,6 @@ Runtime errors will occur within the runtime, do not throw up an error page, and
 | `Memory limit`<br/>`would be exceeded`<br/> `before EOF` | Trying to read a stream or buffer that would take you over the [memory limit](/workers/platform/limits/#memory). |
 | `daemonDown`                                             | A temporary problem invoking the Worker.                                                                         |
 
-### Response Stream Disconnected
-
-A `responseStreamDisconnected` event `outcome` occurs when one end of the connection hangs up during the deferred proxying stage of a Worker request flow. This is regarded as an error for request metrics, and presents in logs as a non-error log entry. It commonly appears for longer lived connections such as WebSockets.
-
 ## Identify errors: Workers Metrics
 
 To review whether your application is experiencing any downtime or returning any errors:
@@ -242,6 +238,8 @@ To review whether your application is experiencing any downtime or returning any
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. In **Account Home**, select **Workers & Pages**.
 3. In **Overview**, select your Worker and review your Worker's metrics.
+
+A `responseStreamDisconnected` event `outcome` occurs when one end of the connection hangs up during the deferred proxying stage of a Worker request flow. This is regarded as an error for request metrics, and presents in logs as a non-error log entry. It commonly appears for longer lived connections such as WebSockets.
 
 ## Debug exceptions
 

--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -233,7 +233,7 @@ Runtime errors will occur within the runtime, do not throw up an error page, and
 
 ### Response Stream Disconnected
 
-A `responseStreamDisconnected` event `outcome` occurs when one end of the connection hangs up during the deferred proxying stage of a Worker request flow. This is regarded as an error for request metrics, and presents in logs as a non-error log entry. Commonly appears for longer lived connections such as websockets.
+A `responseStreamDisconnected` event `outcome` occurs when one end of the connection hangs up during the deferred proxying stage of a Worker request flow. This is regarded as an error for request metrics, and presents in logs as a non-error log entry. It commonly appears for longer lived connections such as WebSockets.
 
 ## Identify errors: Workers Metrics
 

--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -231,6 +231,10 @@ Runtime errors will occur within the runtime, do not throw up an error page, and
 | `Memory limit`<br/>`would be exceeded`<br/> `before EOF` | Trying to read a stream or buffer that would take you over the [memory limit](/workers/platform/limits/#memory). |
 | `daemonDown`                                             | A temporary problem invoking the Worker.                                                                         |
 
+### Response Stream Disconnected
+
+A `responseStreamDisconnected` event `outcome` occurs when one end of the connection hangs up during the deferred proxying stage of a Worker request flow. This is regarded as an error for request metrics, and presents in logs as a non-error log entry. Commonly appears for longer lived connections such as websockets.
+
 ## Identify errors: Workers Metrics
 
 To review whether your application is experiencing any downtime or returning any errors:

--- a/src/content/docs/workers/runtime-apis/handlers/tail.mdx
+++ b/src/content/docs/workers/runtime-apis/handlers/tail.mdx
@@ -101,6 +101,7 @@ export default {
     * `exceededMemory`: The Worker invocation exceeded memory limits.
     * `scriptNotFound`: An internal error from difficulty retrieving the Worker script.
     * `canceled`: The worker invocation was canceled before it completed. Commonly because the client disconnected before a response could be sent.
+    * `responseStreamDisconnected`: The response stream was disconnected during deferred proxying. Happens when either the client or server hangs up early.
 
 
 


### PR DESCRIPTION
### Summary

This change documents the `responseStreamDisconnected` event `outcome` seen in CloudFlare worker logs and error metrics.

Previously, this outcome doesn't appear to be documented, but presents as an error in metrics and presents as a non-error entry in the CloudFlare Worker Logs. This change aims to reduce confusion going forward.

Changes introducing `responseStreamDisconnected`: https://github.com/cloudflare/workerd/pull/2503

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
