### PR TITLE
[Docs Site] Remove docs-tag lines from rendered output in GitHubCode

### DIFF
--- a/src/components/GitHubCode.astro
+++ b/src/components/GitHubCode.astro
@@ -33,12 +33,11 @@ if (!res.ok) {
 	throw new Error(`[GitHubCode] Received ${res.status} from Worker.`);
 }
 
-let content = await res.text();
+const content = await res.text();
+let contentLines = content.split("\n");
 
 if (lines) {
 	const [start, end] = lines;
-
-	const contentLines = content.split("\n");
 
 	if (contentLines.length < end - 1) {
 		throw new Error(
@@ -46,10 +45,8 @@ if (lines) {
 		);
 	}
 
-	content = contentLines.slice(start - 1, end).join("\n");
+	contentLines = contentLines.slice(start - 1, end);
 } else if (tag) {
-	const contentLines = content.split("\n");
-
 	const startTag = contentLines.findIndex((x) =>
 		x.includes(`<docs-tag name="${tag}">`),
 	);
@@ -61,8 +58,12 @@ if (lines) {
 		throw new Error(`[GitHubCode] Unable to find a region using tag "${tag}".`);
 	}
 
-	content = contentLines.slice(startTag + 1, endTag).join("\n");
+	contentLines = contentLines.slice(startTag + 1, endTag);
 }
+
+contentLines = contentLines.filter(
+	(line) => !/<[\/]?docs-tag name=".*">/.test(line),
+);
 ---
 
-<Code code={content} lang={lang} />
+<Code code={contentLines.join("\n")} lang={lang} />

--- a/src/content/docs/style-guide/components/github-code.mdx
+++ b/src/content/docs/style-guide/components/github-code.mdx
@@ -18,10 +18,10 @@ import { GitHubCode } from "~/components";
 import { GitHubCode } from "~/components";
 
 <GitHubCode
-    repo="cloudflare/workers-rs"
-    file="templates/hello-world/src/lib.rs"
-    commit="ab3951b5c95329a600a7baa9f9bb1a7a95f1aeaa"
-    lang="rs"
+    repo="cloudflare/workflows-starter"
+    file="src/index.ts"
+    commit="a844e629ec80968118d4b116d4b26f5dcb107137"
+    lang="ts"
 />
 ```
 


### PR DESCRIPTION
### Summary

Remove docs-tag lines from rendered output in GitHubCode

### Screenshots (optional)

Before:

<img width="716" alt="image" src="https://github.com/user-attachments/assets/f2bed83b-e85b-4d62-a7e7-5aef01c09cbc">

After:

<img width="776" alt="image" src="https://github.com/user-attachments/assets/6e2d2118-6b75-47f1-b1ba-330117f824a8">
