### PR TITLE
[Gateway] Update HTTP/3 guidance

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/agentless/pac-files.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/agentless/pac-files.mdx
@@ -201,7 +201,9 @@ You can now use the Proxy Endpoint selector in [network](/cloudflare-one/policie
 
 ### Traffic limitations
 
-At this time, the agentless HTTP proxy does not support [identity-based policies](/cloudflare-one/policies/gateway/identity-selectors/), mTLS authentication, or UDP traffic. To enforce HTTP policies for UDP traffic, you must [disable QUIC](/cloudflare-one/policies/gateway/http-policies/http3/#prevent-inspection-bypass) in your users' browsers.
+The agentless HTTP proxy does not support [identity-based policies](/cloudflare-one/policies/gateway/identity-selectors/) or mTLS authentication.
+
+To enforce HTTP policies for UDP traffic, you must turn on the [Gateway proxy for UDP](/cloudflare-one/policies/gateway/http-policies/http3/#enable-http3-inspection).
 
 ### Gateway DNS and resolver policies
 

--- a/src/content/docs/cloudflare-one/policies/gateway/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/egress-policies/dedicated-egress-ips.mdx
@@ -22,8 +22,9 @@ To start routing traffic through dedicated egress IPs:
 
 1. Contact your account team to obtain a dedicated egress IP.
 2. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Network**.
-3. Turn on **Proxy** for TCP.
-4. (Optional) Select **UDP**. This will allow HTTP/3 traffic to egress with your dedicated IPs.
+3. In **Firewall**, turn on **Proxy**.
+4. Select **TCP**.
+5. (Optional) Select **UDP**. This will allow HTTP/3 traffic to egress with your dedicated IPs.
 
 Dedicated egress IPs are now turned on for all network and HTTP traffic proxied by Gateway. To selectively turn on dedicated egress IPs for a subset of your traffic, refer to [egress policies](/cloudflare-one/policies/gateway/egress-policies/).
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
@@ -24,17 +24,11 @@ To enable HTTP/3 inspection, turn on the Gateway proxy for UDP:
 
 Gateway can inspect HTTP/3 traffic from Mozilla Firefox and Microsoft Edge, as well as other HTTP applications, such as cURL.
 
-By default, the following browsers do not support HTTP/3 inspection unless you [disable QUIC](#prevent-inspection-bypass):
-
-- Google Chrome
-- Safari
-- Firefox
-
-If the [UDP proxy](#enable-http3-inspection) is enabled in Zero Trust, Gateway will force all HTTP/3 traffic in these browsers to fall back to HTTP/2, allowing you to enforce your HTTP policies. If the UDP proxy is not enabled, HTTP/3 traffic will bypass inspection.
+If the UDP proxy is enabled in Zero Trust, Google Chrome will force all HTTP/3 traffic to fall back to HTTP/2, allowing you to enforce your HTTP policies. If the UDP proxy is not enabled, HTTP/3 traffic from Chrome will bypass inspection.
 
 ## Prevent inspection bypass
 
-To prevent HTTP/3 traffic from bypassing inspection, disable QUIC in your users' browsers.
+If you do not want to use Gateway to proxy UDP traffic but still want to apply HTTP policies, disable QUIC in your users' browsers.
 
 <Details header="Google Chrome">
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-title: HTTP/3
+title: HTTP/3 inspection
 sidebar:
   order: 3
 ---
@@ -13,10 +13,10 @@ Gateway applies HTTP policies to HTTP/3 traffic last. For more information, refe
 
 ## Enable HTTP/3 inspection
 
-To enable HTTP/3 inspection, turn on the Gateway proxy for UDP:
+To enable HTTP/3 inspection, turn on the [Gateway proxy](/cloudflare-one/policies/gateway/proxy/) for UDP:
 
 1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Network**.
-2. Under **Firewall**, turn on **Proxy**.
+2. In **Firewall**, turn on **Proxy**.
 3. Select **TCP** and **UDP**.
 4. Turn on **TLS decryption**.
 
@@ -26,9 +26,9 @@ Gateway can inspect HTTP/3 traffic from Mozilla Firefox and Microsoft Edge, as w
 
 If the UDP proxy is enabled in Zero Trust, Google Chrome will force all HTTP/3 traffic to fall back to HTTP/2, allowing you to enforce your HTTP policies. If the UDP proxy is not enabled, HTTP/3 traffic from Chrome will bypass inspection.
 
-## Prevent inspection bypass
+## Force HTTP/2 traffic
 
-If you do not want to use Gateway to proxy UDP traffic but still want to apply HTTP policies, disable QUIC in your users' browsers.
+To apply Gateway policies to HTTP traffic without turning on the UDP proxy, you must disable QUIC in your users' browsers to ensure only HTTP/2 traffic reaches Gateway.
 
 <Details header="Google Chrome">
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/http3.mdx
@@ -13,15 +13,16 @@ Gateway applies HTTP policies to HTTP/3 traffic last. For more information, refe
 
 ## Enable HTTP/3 inspection
 
-To enable HTTP/3 inspection:
+To enable HTTP/3 inspection, turn on the Gateway proxy for UDP:
 
 1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Network**.
-2. Under **Firewall**, enable **Proxy** and select **UDP**.
-3. Enable **TLS decryption**.
+2. Under **Firewall**, turn on **Proxy**.
+3. Select **TCP** and **UDP**.
+4. Turn on **TLS decryption**.
 
 ### Application limitations
 
-Gateway can inspect HTTP/3 traffic from Microsoft Edge, as well as other HTTP applications, such as cURL.
+Gateway can inspect HTTP/3 traffic from Mozilla Firefox and Microsoft Edge, as well as other HTTP applications, such as cURL.
 
 By default, the following browsers do not support HTTP/3 inspection unless you [disable QUIC](#prevent-inspection-bypass):
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
@@ -101,7 +101,7 @@ By default, TLS decryption can use both TLS version 1.2 and 1.3. However, some e
 
 When FIPS compliance is enabled, Gateway will only choose [FIPS-compliant cipher suites](#cipher-suites) when connecting to the origin. If the origin does not support FIPS-compliant ciphers, the request will fail.
 
-FIPS-compliant traffic defaults to HTTP/3. Gateway does not inspect HTTP/3 traffic from most browsers, including Chrome, Firefox, and Safari. To enforce your HTTP policies for this HTTP/3 traffic, you must [disable QUIC](/cloudflare-one/policies/gateway/http-policies/http3/#prevent-inspection-bypass) in your users' browsers.
+FIPS-compliant traffic defaults to [HTTP/3](/cloudflare-one/policies/gateway/http-policies/http3/). To enforce HTTP policies for UDP traffic, you must turn on the [Gateway proxy for UDP](/cloudflare-one/policies/gateway/http-policies/http3/#enable-http3-inspection).
 
 ### Cipher suites
 

--- a/src/content/docs/cloudflare-one/policies/gateway/proxy.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/proxy.mdx
@@ -3,10 +3,9 @@ pcx_content_type: concept
 title: Proxy
 sidebar:
   order: 14
-
 ---
 
-import { Badge } from "~/components"
+import { Badge } from "~/components";
 
 You can forward [HTTP](/cloudflare-one/policies/gateway/initial-setup/http/) and [network](/cloudflare-one/policies/gateway/initial-setup/network/) traffic to Gateway for logging and filtering. Gateway can proxy both outbound traffic and traffic directed to resources connected via a Cloudflare Tunnel, GRE tunnel, or IPsec tunnel.
 
@@ -36,8 +35,9 @@ The ICMP proxy forwards traffic for diagnostic tools such as `ping` and `tracero
 Gateway cannot log or filter ICMP traffic.
 :::
 
-## Enable the Gateway proxy
+## Turn on the Gateway proxy
 
 1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Settings** > **Network**.
-2. Enable **Proxy** for TCP.
-3. (Optional) Depending on your use case, you can enable **UDP** and/or **ICMP**.
+2. In **Firewall**, turn on **Proxy**.
+3. Select **TCP**.
+4. (Optional) Depending on your use case, you can select **UDP** and/or **ICMP**.

--- a/src/content/partials/cloudflare-one/tunnel/enable-gateway-proxy.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/enable-gateway-proxy.mdx
@@ -5,7 +5,7 @@
 import { Tabs, TabItem } from "~/components";
 
 1. Go to **Settings** > **Network**.
-2. Turn on **Proxy**.
+2. In **Firewall**, turn on **Proxy**.
 3. Select **TCP**.
 4. (Recommended) To proxy traffic to internal DNS resolvers, select **UDP**.
 5. (Recommended) To proxy traffic for diagnostic tools such as `ping` and `traceroute`, select **ICMP**. You may also need to update your system to allow ICMP traffic through `cloudflared`:


### PR DESCRIPTION
Gateway supports HTTP/3 inspection for some browsers. Update our guidance and add context for why you might disable QUIC.

PCX-14865