### PR TITLE
[ZT] Browser proxy should support DNS policies

### DIFF
--- a/src/content/docs/reference-architecture/architectures/sase.mdx
+++ b/src/content/docs/reference-architecture/architectures/sase.mdx
@@ -434,7 +434,7 @@ The following table summarizes SWG capabilities for the various methods of forwa
 | ------------------------------ | ------------------------------------- | --------------------------------- | -------------- | ------------- | ---------------- |
 | Types of traffic forwarded     | TCP/UDP                               | TPC/UDP                           | HTTP           | HTTP          | DNS              |
 | **Policy types**               |                                       |                                   |                |               |                  |
-| DNS                            | Yes                                   | Yes                               | Yes            | No            | Yes              |
+| DNS                            | Yes                                   | Yes                               | Yes            | Yes           | Yes              |
 | HTTP/S<sup>\*2</sup>           | Yes                                   | Yes                               | Yes            | Yes           | N/A              |
 | Network (L3/L4 parameter)      | Yes                                   | Yes                               | Yes            | Yes           | No               |
 | **Data available in policies** |                                       |                                   |                |               |                  |


### PR DESCRIPTION
PCX-14904

--
According to this docs, the browser proxy should support DNS policies

https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/agentless/pac-files/#gateway-dns-and-resolver-policies
>Gateway DNS and resolver policies will always apply to traffic proxied via PAC files, regardless of device configuration.