### PR TITLE
remove unnecessary config for email worker

### DIFF
--- a/src/content/docs/email-routing/email-workers/send-email-workers.mdx
+++ b/src/content/docs/email-routing/email-workers/send-email-workers.mdx
@@ -16,7 +16,7 @@ import { WranglerConfig } from "~/components";
 
 ```toml
 send_email = [
-    {type = "send_email", name = "<NAME_FOR_BINDING>", destination_address = "<YOUR_EMAIL>@example.com"},
+    {name = "<NAME_FOR_BINDING>", destination_address = "<YOUR_EMAIL>@example.com"},
 ]
 ```
 


### PR DESCRIPTION
### Summary

A small fix that removes an unnecessary field when configuring a send email worker 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
