### PR TITLE
Ensure lower case for AI model name search comparison

### DIFF
--- a/src/components/ModelCatalog.jsx
+++ b/src/components/ModelCatalog.jsx
@@ -70,7 +70,7 @@ const ModelCatalog = ({ models }) => {
 		}
 
 		if (filters.search) {
-			if (!model.name.includes(filters.search)) {
+			if (!model.name.toLowerCase().includes(filters.search.toLowerCase())) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This PR is a quick fix for ignoring casing when doing client-side searches on AI model names.