### PR TITLE
Add docs for experimental C3 Workers + Assets template for Vue

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/vue.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/vue.mdx
@@ -1,0 +1,63 @@
+---
+pcx_content_type: how-to
+title: Vue
+head: []
+description: Create a Vue application and deploy it to Cloudflare Workers with Workers Assets.
+---
+
+import {
+	Badge,
+	Description,
+	InlineBadge,
+	Render,
+	PackageManagers,
+} from "~/components";
+
+In this guide, you will create a new [Vue](https://vuejs.org/)) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+
+## 1. Set up a new project
+
+Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Vue's official setup tool, and provide the option to deploy instantly.
+
+To use `create-cloudflare` to create a new Vue project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+
+<PackageManagers
+	type="create"
+	pkg="cloudflare@latest my-vue-app"
+	args={"--framework=vue --experimental"}
+/>
+
+<Render
+	file="c3-post-run-steps"
+	product="workers"
+	params={{
+		category: "web-framework",
+		framework: "vue",
+	}}
+/>
+
+After setting up your project, change your directory by running the following command:
+
+```sh
+cd my-vue-app
+```
+
+## 2. Develop locally
+
+After you have created your project, run the following command in the project directory to start a local server. This will allow you to preview your project locally during development.
+
+<PackageManagers type="run" args={"dev"} />
+
+## 3. Deploy your Project
+
+Your project can be deployed to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), from your own machine or from any CI/CD system, including [Cloudflare's own](/workers/ci-cd/builds/).
+
+The following command will build and deploy your project. If you're using CI, ensure you update your ["deploy command"](/workers/ci-cd/builds/configuration/#build-settings) configuration appropriately.
+
+<PackageManagers type="run" args={"deploy"} />
+
+---
+
+## Static assets
+
+You can serve static assets your Vue application by placing them in the [`./public/` directory](https://vite.dev/guide/assets.html). This can be useful for resource files such as images, stylesheets, fonts, and manifests.

--- a/src/content/docs/workers/frameworks/framework-guides/vue.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/vue.mdx
@@ -61,3 +61,5 @@ The following command will build and deploy your project. If you're using CI, en
 ## Static assets
 
 You can serve static assets your Vue application by placing them in the [`./public/` directory](https://vite.dev/guide/assets.html). This can be useful for resource files such as images, stylesheets, fonts, and manifests.
+
+<Render file="workers-assets-routing-summary" />

--- a/src/content/docs/workers/frameworks/framework-guides/vue.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/vue.mdx
@@ -13,7 +13,7 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Vue](https://vuejs.org/)) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Vue](https://vuejs.org/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 


### PR DESCRIPTION
### Summary

Adds a docs page corresponding to a new C3 experimental template for Vue with Workers Static Assets.
See https://github.com/cloudflare/workers-sdk/pull/7480

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
