### PR TITLE
Update warp-to-warp.mdx - Split tunnel Exclude mode

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-to-warp.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-to-warp.mdx
@@ -34,8 +34,11 @@ This guide covers how to:
 3. Enable **Warp-to-Warp**. This allows Cloudflare to route traffic to the <GlossaryTooltip term="CGNAT IP">CGNAT IP</GlossaryTooltip> space.
 4. In your [Split Tunnel configuration](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/), ensure that traffic to `100.96.0.0/12` is going through WARP:
 
-- If using **Exclude** mode, remove `100.96.0.0/12` from your list.
-- If using **Include** mode, add `100.96.0.0/12` to your list.
+- If using **Exclude** mode:
+	- Remove `100.96.0.0/12` from your list.
+	- Re-add `100.64.0.0/11` and `100.112.0.0/12`.
+- If using **Include** mode:
+	- Add `100.96.0.0/12` to your list.
 
 This will instruct WARP to begin proxying any traffic destined for a `100.96.0.0/12` IP address to Cloudflare for routing and policy enforcement.
 

--- a/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-to-warp.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/private-net/warp-to-warp.mdx
@@ -34,11 +34,8 @@ This guide covers how to:
 3. Enable **Warp-to-Warp**. This allows Cloudflare to route traffic to the <GlossaryTooltip term="CGNAT IP">CGNAT IP</GlossaryTooltip> space.
 4. In your [Split Tunnel configuration](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/split-tunnels/), ensure that traffic to `100.96.0.0/12` is going through WARP:
 
-- If using **Exclude** mode:
-	- Remove `100.96.0.0/12` from your list.
-	- Re-add `100.64.0.0/11` and `100.112.0.0/12`.
-- If using **Include** mode:
-	- Add `100.96.0.0/12` to your list.
+- If using **Exclude** mode, delete `100.64.0.0/10` from the list and re-add `100.64.0.0/11` and `100.112.0.0/12`.
+- If using **Include** mode, add `100.96.0.0/12` to your list.
 
 This will instruct WARP to begin proxying any traffic destined for a `100.96.0.0/12` IP address to Cloudflare for routing and policy enforcement.
 


### PR DESCRIPTION
### Summary

Instead of simply excluding 100.96.0.0/12 from split tunneling in Exclude mode, this removes only the CGNAT IP range that CloudFlare WARP needs. Info taken from another page on the CloudFlare documentation.

https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/private-net/warp-connector/user-to-site/#3-route-cgnat-ips-through-cloudflare

### Documentation checklist
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
