### PR TITLE
Changed value for resolved to allow DNS over TLS for systemd-resolved

### DIFF
--- a/src/content/docs/1.1.1.1/setup/linux.mdx
+++ b/src/content/docs/1.1.1.1/setup/linux.mdx
@@ -51,6 +51,12 @@ sudo <EDITOR> /etc/systemd/resolved.conf
 
 ```txt
 [Resolve]
+DNS=1.1.1.1
+```
+To use DNS over TLS, add `#one.one.one.one` as in the following example:
+
+```txt
+[Resolve]
 DNS=1.1.1.1#one.one.one.one
 ```
 

--- a/src/content/docs/1.1.1.1/setup/linux.mdx
+++ b/src/content/docs/1.1.1.1/setup/linux.mdx
@@ -53,11 +53,12 @@ sudo <EDITOR> /etc/systemd/resolved.conf
 [Resolve]
 DNS=1.1.1.1
 ```
-To use DNS over TLS, add `#one.one.one.one` as in the following example:
+To use DNS over TLS, add `#one.one.one.one` and set `DNSOverTLS` to `yes`, as in the following example:
 
 ```txt
 [Resolve]
 DNS=1.1.1.1#one.one.one.one
+DNSOverTLS=yes
 ```
 
 ## Use graphical user interface (GUI)

--- a/src/content/docs/1.1.1.1/setup/linux.mdx
+++ b/src/content/docs/1.1.1.1/setup/linux.mdx
@@ -51,7 +51,7 @@ sudo <EDITOR> /etc/systemd/resolved.conf
 
 ```txt
 [Resolve]
-DNS=1.1.1.1
+DNS=1.1.1.1#one.one.one.one
 ```
 
 ## Use graphical user interface (GUI)


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Please also update the website: https://one.one.one.one

Changed value for resolved to allow DNS over TLS for systemd-resolved as described below.
https://man.archlinux.org/man/resolved.conf.5#OPTIONS
