### PR TITLE
Added notes for cache request hostnames

### DIFF
--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -51,12 +51,13 @@ await myCache.match(request);
 ```
 When using the cache API, avoid overriding the hostname in cache requests, as this can lead to unnecessary DNS lookups and cache inefficiencies. Always use the hostname that matches the domain associated with your Worker.
 
-```async fetch(request, env, ctx) {
-    // avoid overriding the request URL or passing a new request into the cache API
-    request.url = "https://some-overridden-value.com";
+```js
+async fetch(request, env, ctx) {
+// avoid overriding the request URL or passing a new request into the cache API
+request.url = "https://some-overridden-value.com";
 
-    let myCache = await caches.open('custom:cache');
-    await myCache.match(request);
+let myCache = await caches.open('custom:cache');
+await myCache.match(request);
 },
 ```
 ***

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -49,7 +49,16 @@ You may create and manage additional Cache instances via the [`caches.open`](htt
 let myCache = await caches.open('custom:cache');
 await myCache.match(request);
 ```
+When using the cache API, avoid overriding the hostname in cache requests, as this can lead to unnecessary DNS lookups and cache inefficiencies. Always use the hostname that matches the domain associated with your Worker.
 
+```async fetch(request, env, ctx) {
+    // avoid overriding the request URL or passing a new request into the cache API
+    request.url = "https://some-overridden-value.com";
+
+    let myCache = await caches.open('custom:cache');
+    await myCache.match(request);
+},
+```
 ***
 
 ## Headers
@@ -105,14 +114,6 @@ cache.put(request, response);
 
 
 The `stale-while-revalidate` and `stale-if-error` directives are not supported when using the `cache.put` or `cache.match` methods.
-
-
-:::
-
-:::note
-To avoid unnecessary DNS lookups and cache inefficiencies, do not override the hostname in cache requests. Always use the hostname that matches the domain associated with your Worker.
-:::
-
 #### Parameters
 
 
@@ -156,14 +157,6 @@ cache.match(request, options);
 
 
 The `stale-while-revalidate` and `stale-if-error` directives are not supported when using the `cache.put` or `cache.match` methods.
-
-
-:::
-
-:::note
-To avoid unnecessary DNS lookups and cache inefficiencies, do not override the hostname in cache requests. Always use the hostname that matches the domain associated with your Worker.
-:::
-
 #### Parameters
 
 

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -109,6 +109,10 @@ The `stale-while-revalidate` and `stale-if-error` directives are not supported w
 
 :::
 
+:::note
+Do not use dynamic or invalid hostnames in cache requests. This can cause DNS cache failures and latency.
+:::
+
 #### Parameters
 
 
@@ -154,6 +158,10 @@ cache.match(request, options);
 The `stale-while-revalidate` and `stale-if-error` directives are not supported when using the `cache.put` or `cache.match` methods.
 
 
+:::
+
+:::note
+Do not use dynamic or invalid hostnames in cache requests. This can cause DNS cache failures and latency.
 :::
 
 #### Parameters

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -161,7 +161,7 @@ The `stale-while-revalidate` and `stale-if-error` directives are not supported w
 :::
 
 :::note
-Do not use dynamic or invalid hostnames in cache requests. This can cause DNS cache failures and latency.
+To avoid unnecessary DNS lookups and cache inefficiencies, do not override the hostname in cache requests. Always use the hostname that matches the domain associated with your Worker.
 :::
 
 #### Parameters

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -110,7 +110,7 @@ The `stale-while-revalidate` and `stale-if-error` directives are not supported w
 :::
 
 :::note
-Do not use dynamic or invalid hostnames in cache requests. This can cause DNS cache failures and latency.
+To avoid unnecessary DNS lookups and cache inefficiencies, do not override the hostname in cache requests. Always use the hostname that matches the domain associated with your Worker.
 :::
 
 #### Parameters

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -49,17 +49,17 @@ You may create and manage additional Cache instances via the [`caches.open`](htt
 let myCache = await caches.open('custom:cache');
 await myCache.match(request);
 ```
+:::note
 When using the cache API, avoid overriding the hostname in cache requests, as this can lead to unnecessary DNS lookups and cache inefficiencies. Always use the hostname that matches the domain associated with your Worker.
 
 ```js
-async fetch(request, env, ctx) {
-// avoid overriding the request URL or passing a new request into the cache API
-request.url = "https://some-overridden-value.com";
+// avoid overriding the URL in request or passing a new request into the cache API
+request.url = "https://some-overridden-value.com/";
 
 let myCache = await caches.open('custom:cache');
-await myCache.match(request);
-},
+let response = await myCache.match(request);
 ```
+:::
 ***
 
 ## Headers

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -53,8 +53,8 @@ await myCache.match(request);
 When using the cache API, avoid overriding the hostname in cache requests, as this can lead to unnecessary DNS lookups and cache inefficiencies. Always use the hostname that matches the domain associated with your Worker.
 
 ```js
-// Do not do this
-request.url = "https://some-overridden-value.com/";
+// recommended approach: use your Worker hostname to ensure efficient caching
+request.url = "https://your-Worker-hostname.com/";
 
 let myCache = await caches.open('custom:cache');
 let response = await myCache.match(request);

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -53,7 +53,7 @@ await myCache.match(request);
 When using the cache API, avoid overriding the hostname in cache requests, as this can lead to unnecessary DNS lookups and cache inefficiencies. Always use the hostname that matches the domain associated with your Worker.
 
 ```js
-// avoid overriding the URL in request or passing a new request into the cache API
+// Do not do this
 request.url = "https://some-overridden-value.com/";
 
 let myCache = await caches.open('custom:cache');


### PR DESCRIPTION
Added notes - Do not use dynamic or invalid hostnames in cache requests. This can cause DNS cache failures and latency. 