### PR TITLE
update CF fundamentals for Single Redirect token name

### DIFF
--- a/src/content/partials/fundamentals/zone-permissions-table.mdx
+++ b/src/content/partials/fundamentals/zone-permissions-table.mdx
@@ -59,7 +59,7 @@ import { Markdown } from "~/components"
 | Response Compression {props.one}          | Grants write access to [Response Compression](/rules/compression-rules/).                                                                  |
 | Sanitize Read                    | Grants read access to sanitization.                                                                                                        |
 | Sanitize {props.one}                      | Grants write access to sanitization.                                                                                                       |
-| Single Redirect        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
+| Single Redirect Read        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
 | Single Redirect {props.one}          | Grants write access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                             |
 | SSL and Certificates Read        | Grants read access to [SSL configuration and certificate management](/ssl/).                                                               |
 | SSL and Certificates {props.one}          | Grants write access to [SSL configuration and certificate management](/ssl/).                                                              |

--- a/src/content/partials/fundamentals/zone-permissions-table.mdx
+++ b/src/content/partials/fundamentals/zone-permissions-table.mdx
@@ -35,8 +35,6 @@ import { Markdown } from "~/components"
 | DMARC Management {props.one}              | Grants write access to [DMARC Management](/dmarc-management/).                                                                             |
 | DNS Read                         | Grants read access to [DNS](/dns/).                                                                                                        |
 | DNS Write                        | Grants write access to [DNS](/dns/).                                                                                                       |
-| Dynamic URL Redirect Read        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
-| Dynamic URL Redirect {props.one}          | Grants write access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                             |
 | Email Routing Rules Read         | Grants read access to [Email Routing Rules](/email-routing/setup/email-routing-addresses/).                                                |
 | Email Routing Rules {props.one}           | Grants write access to [Email Routing Rules](/email-routing/setup/email-routing-addresses/).                                               |
 | Firewall Services Read           | Grants read access to Firewall resources.                                                                                                  |
@@ -61,6 +59,8 @@ import { Markdown } from "~/components"
 | Response Compression {props.one}          | Grants write access to [Response Compression](/rules/compression-rules/).                                                                  |
 | Sanitize Read                    | Grants read access to sanitization.                                                                                                        |
 | Sanitize {props.one}                      | Grants write access to sanitization.                                                                                                       |
+| Single Redirect        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
+| Single Redirect {props.one}          | Grants write access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                             |
 | SSL and Certificates Read        | Grants read access to [SSL configuration and certificate management](/ssl/).                                                               |
 | SSL and Certificates {props.one}          | Grants write access to [SSL configuration and certificate management](/ssl/).                                                              |
 | Transform Rules Read             | Grants read access to [Transform Rules](/rules/transform/).                                                                                |


### PR DESCRIPTION
'Dynamic URL Redirect' was the old name, it's not longer available in the dashboard, 'Single Redirect' is the new one

### Summary

### Screenshots (optional)

old name: 
<img width="670" alt="Screenshot 2024-12-09 at 20 12 34" src="https://github.com/user-attachments/assets/6f8f491d-b9d3-4d59-91ff-c9a550d98c42">



### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

