### PR TITLE
[ZT] Add quotes to Mermaid connections

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/agentless/dns/locations/dns-resolver-ips.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/agentless/dns/locations/dns-resolver-ips.mdx
@@ -28,10 +28,10 @@ flowchart TB
 
     gateway-->query{{"Is the DNS query sent over HTTPS?"}}
 
-    query--Yes-->hostname["Look up location by<br />unique hostname"]
+    query--"Yes"-->hostname["Look up location by<br />unique hostname"]
     query--"No"-->ipv4{{"Is it over IPv4?"}}
 
-    ipv4--Yes-->source["Look up location by<br />source IPv4 address"]
+    ipv4--"Yes"-->source["Look up location by<br />source IPv4 address"]
     ipv4--"No"-->destination["Look up location by<br />destination IPv6 address"]
 ```
 

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/captive-portals.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/captive-portals.mdx
@@ -3,7 +3,6 @@ pcx_content_type: concept
 title: Captive portal detection
 sidebar:
   order: 3
-
 ---
 
 Captive portals are used by public Wi-Fi networks (such as airports, coffee shops, and hotels) to make a user agree to their Terms of Service or provide payment before allowing access to the Internet. When a user connects to the Wi-Fi, the captive portal blocks all HTTPS traffic until the user completes a captive portal login flow in their browser. This prevents the WARP client from connecting to Cloudflare. At the same time, WARP creates [firewall rules](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#ip-traffic) on the device to send all traffic to Cloudflare. The user is therefore unable to access the captive portal login screen unless they temporarily disable WARP.
@@ -14,13 +13,13 @@ To allow users to connect through a captive portal, administrators can configure
 
 ### No user interaction required
 
-* Enable [Captive portal detection](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#captive-portal-detection). This allows WARP to temporarily turn off when it detects a captive portal on the network. For more details, refer to [how captive portal detection works](#how-captive-portal-detection-works) and its [limitations](#limitations).
-* Set [Device tunnel protocol](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#device-tunnel-protocol) to **MASQUE**. When using MASQUE, WARP traffic will look like standard HTTPS traffic and is therefore less likely to be blocked by captive portals.
+- Enable [Captive portal detection](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#captive-portal-detection). This allows WARP to temporarily turn off when it detects a captive portal on the network. For more details, refer to [how captive portal detection works](#how-captive-portal-detection-works) and its [limitations](#limitations).
+- Set [Device tunnel protocol](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#device-tunnel-protocol) to **MASQUE**. When using MASQUE, WARP traffic will look like standard HTTPS traffic and is therefore less likely to be blocked by captive portals.
 
 ### User interaction required
 
-* Enable [Lock WARP switch](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#lock-warp-switch) and enable [Admin override](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#admin-override). Users can contact the IT administrator for a one-time code that allows them to manually turn off WARP and connect to a portal.
-* For employees who travel, disable [Lock WARP switch](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#lock-warp-switch) and set an [Auto connect](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#auto-connect) duration. This allows the user to manually turn off WARP without contacting IT.
+- Enable [Lock WARP switch](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#lock-warp-switch) and enable [Admin override](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#admin-override). Users can contact the IT administrator for a one-time code that allows them to manually turn off WARP and connect to a portal.
+- For employees who travel, disable [Lock WARP switch](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#lock-warp-switch) and set an [Auto connect](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#auto-connect) duration. This allows the user to manually turn off WARP without contacting IT.
 
 ## How captive portal detection works
 
@@ -28,8 +27,8 @@ If WARP cannot establish a connection to Cloudflare, it will:
 
 1. Temporarily open the [system firewall](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#ip-traffic) so that the device can send traffic outside of the WARP tunnel. The firewall only allows the following traffic:
 
-   * HTTP/HTTPS on TCP ports `80`, `443`, `8080`, and `8443`
-   * DNS on UDP port `53`
+   - HTTP/HTTPS on TCP ports `80`, `443`, `8080`, and `8443`
+   - DNS on UDP port `53`
 
 2. Send a series of requests to the [captive portal test URLs](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#captive-portal). If the HTTPS request is intercepted, WARP assumes the network is behind a captive portal.
 
@@ -42,18 +41,18 @@ flowchart TB
 accTitle: Captive portal detection
 
 
-A[Send DNS request] --Succeed--> B[Send HTTPS request]--Fail--> C[Send HTTP request] --Succeed--> D[Captive portal detected]--Receive HTTP redirect-->I[Redirect to captive portal login]
-A --Fail--> F(CF_NO_NETWORK error)
-C --Fail--> F
-B --Succeed--> G[No captive portal]--> H[Retry connection to Cloudflare]
+A[Send DNS request] -- Succeed --> B[Send HTTPS request]-- Fail --> C[Send HTTP request] -- Succeed --> D[Captive portal detected]-- Receive HTTP redirect -->I[Redirect to captive portal login]
+A -- Fail --> F(CF_NO_NETWORK error)
+C -- Fail --> F
+B -- Succeed --> G[No captive portal]--> H[Retry connection to Cloudflare]
 ```
 
 ## Limitations
 
-* Due to [how captive portal detection works](#how-captive-portal-detection-works), it may be possible for an employee to spoof a captive portal in order to turn off WARP.
-* Some captive portals, particularly those on airlines, may be slow to respond and exceed the captive portal detection timeout. Users will likely see a [CF\_CAPTIVE\_PORTAL\_TIMED\_OUT](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_captive_portal_timed_out) error when they try to connect.
-* WARP may not be able to detect multi-stage captive portals, which redirect the user to different networks during the login process. Users will need to manually turn off WARP to get through the captive portal.
-* Some public Wi-Fi networks are incompatible with running WARP:
+- Due to [how captive portal detection works](#how-captive-portal-detection-works), it may be possible for an employee to spoof a captive portal in order to turn off WARP.
+- Some captive portals, particularly those on airlines, may be slow to respond and exceed the captive portal detection timeout. Users will likely see a [CF_CAPTIVE_PORTAL_TIMED_OUT](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_captive_portal_timed_out) error when they try to connect.
+- WARP may not be able to detect multi-stage captive portals, which redirect the user to different networks during the login process. Users will need to manually turn off WARP to get through the captive portal.
+- Some public Wi-Fi networks are incompatible with running WARP:
 
-  * Captive portals that intercept all DNS traffic will block WARP's [DoH connection](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#overview). Users will likely see a [CF\_NO\_NETWORK](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_no_network) error after they login to the captive portal.
-  * Captive portals that only allow HTTPS traffic will block WARP's [Wireguard UDP connection](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#overview). Users will likely see a [CF\_HAPPY\_EYEBALLS\_MITM\_FAILURE](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_happy_eyeballs_failure) error after they login to the captive portal.
+  - Captive portals that intercept all DNS traffic will block WARP's [DoH connection](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#overview). Users will likely see a [CF_NO_NETWORK](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_no_network) error after they login to the captive portal.
+  - Captive portals that only allow HTTPS traffic will block WARP's [Wireguard UDP connection](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/warp-architecture/#overview). Users will likely see a [CF_HAPPY_EYEBALLS_MITM_FAILURE](/cloudflare-one/connections/connect-devices/warp/troubleshooting/client-errors/#cf_happy_eyeballs_failure) error after they login to the captive portal.

--- a/src/content/docs/cloudflare-one/policies/gateway/order-of-enforcement.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/order-of-enforcement.mdx
@@ -3,10 +3,9 @@ pcx_content_type: concept
 title: Order of enforcement
 sidebar:
   order: 12
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 With Cloudflare Gateway, you can [enable and configure](/cloudflare-one/policies/gateway/initial-setup/) any combination of DNS, network, and HTTP policies.
 

--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -1,9 +1,8 @@
 ---
 {}
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 ```mermaid
 flowchart TB
@@ -14,20 +13,20 @@ flowchart TB
     %% In with user traffic
     start(["Traffic"])-->dns0[/"DNS query"/]-->dns1
     start-->http0{{"HTTP(S) request on port 80 or 443?"}}
-    http0--Yes-->http1
-    http0--No-->network0
+    http0-- "Yes" -->http1
+    http0-- "No" -->network0
 
     %% DNS policies
     subgraph DNS
     dns1["DNS policies"]
     style DNS text-align:left
-    dns1--Resolved by-->dns2["1.1.1.1"]
+    dns1-- "Resolved by" -->dns2["1.1.1.1"]
     dns1-.->dns3
 
         %% DNS resolution
         subgraph Resolution
         dns2["1.1.1.1"]
-        dns3["Resolver policies <br />(Enterprise users only)"]--Resolved by-->dns4["Custom resolver"]
+        dns3["Resolver policies <br />(Enterprise users only)"]-- "Resolved by" -->dns4["Custom resolver"]
         end
 
     end
@@ -46,7 +45,7 @@ flowchart TB
     http2-->http3["Allow, Block, Do Not Scan policies"]
     end
 
-    http1--Do Not Inspect-->network0
+    http1-- "Do Not Inspect" -->network0
     http3-->network0
     network0[/"Network connections"/]-->network1
 
@@ -62,8 +61,8 @@ flowchart TB
     end
 
     %% Finish
-    network1--Egress with Cloudflare IP-->internet([Internet])
-    egress1--Egress with dedicated IP-->internet
+    network1-- "Egress with Cloudflare IP" -->internet([Internet])
+    egress1-- "Egress with dedicated IP" -->internet
 ```
 
 ## Priority between policy builders
@@ -103,7 +102,7 @@ When DNS queries are received, Gateway evaluates policies with pre-resolution se
 | 1          | Resolved Country IP Geolocation | is       | United States | Allow  |
 | 2          | Domain                          | is       | `example.com` | Block  |
 
-Despite an explicit Allow policy ordered first, policy 2 takes precedence because the *Domain* selector is evaluated before DNS resolution.
+Despite an explicit Allow policy ordered first, policy 2 takes precedence because the _Domain_ selector is evaluated before DNS resolution.
 
 If a policy contains both pre-resolution and post-resolution selectors, Gateway will evaluate the entire policy after DNS resolution. For information on when each selector is evaluated, refer to the [list of DNS selectors](/cloudflare-one/policies/gateway/dns-policies/#selectors).
 
@@ -123,7 +122,7 @@ This order of enforcement allows Gateway to first determine whether decryption s
 
 :::note
 
-The only exception is if you are using [Clientless Web Isolation](/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation/) — all sites within the clientless remote browser are implicitly isolated even if they match a Do Not Inspect policy. 
+The only exception is if you are using [Clientless Web Isolation](/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation/) — all sites within the clientless remote browser are implicitly isolated even if they match a Do Not Inspect policy.
 :::
 
 Next, Gateway checks decrypted traffic against your Isolate policies. When a user makes a request which triggers an Isolate policy, the request will be rerouted to a [remote browser](/cloudflare-one/policies/browser-isolation/).
@@ -132,29 +131,33 @@ Lastly, Gateway evaluates all Allow, Block, and Do Not Scan policies. These poli
 
 ### Order of precedence
 
-<Render file="gateway/order-of-precedence" product="cloudflare-one" params={{ one: "DNS, network, or HTTP" }} />
+<Render
+	file="gateway/order-of-precedence"
+	product="cloudflare-one"
+	params={{ one: "DNS, network, or HTTP" }}
+/>
 
 :::caution[Terraform precedence limitation]
 
-To avoid conflicts, Terraform applies a hash calculation to precedences. For example, a precedence of `1000` may become `1000901`. This can cause errors when reordering policies. To avoid this issue, manually set the precedence of your policies via the [Cloudflare API](/api/operations/zero-trust-gateway-rules-update-zero-trust-gateway-rule). 
+To avoid conflicts, Terraform applies a hash calculation to precedences. For example, a precedence of `1000` may become `1000901`. This can cause errors when reordering policies. To avoid this issue, manually set the precedence of your policies via the [Cloudflare API](/api/operations/zero-trust-gateway-rules-update-zero-trust-gateway-rule).
 :::
 
 ## Example
 
 Suppose you have a list of policies arranged in the following order of precedence:
 
-* DNS policies: <Render file="gateway/order-of-precedence-dns" product="cloudflare-one" />
-* HTTP policies:
-  | Precedence | Selector | Operator | Value               | Action         |
+- DNS policies: <Render file="gateway/order-of-precedence-dns" product="cloudflare-one" />
+- HTTP policies:
+  | Precedence | Selector | Operator | Value | Action |
   | ---------- | -------- | -------- | ------------------- | -------------- |
-  | 1          | Host     | is       | `example.com`       | Block          |
-  | 2          | Host     | is       | `test2.example.com` | Do Not Inspect |
-* Network policies:
-  | Precedence | Selector         | Operator | Value              | Action |
+  | 1 | Host | is | `example.com` | Block |
+  | 2 | Host | is | `test2.example.com` | Do Not Inspect |
+- Network policies:
+  | Precedence | Selector | Operator | Value | Action |
   | ---------- | ---------------- | -------- | ------------------ | ------ |
-  | 1          | Destination Port | is       | `80`               | Block  |
-  | 2          | Destination port | is       | `443`              | Allow  |
-  | 3          | SNI Domain       | is       | `test.example.com` | Block  |
+  | 1 | Destination Port | is | `80` | Block |
+  | 2 | Destination port | is | `443` | Allow |
+  | 3 | SNI Domain | is | `test.example.com` | Block |
 
 When a user goes to `https://test.example.com`, Gateway performs the following operations:
 


### PR DESCRIPTION
Recent changes to Mermaid have made certain label for node connections (specifically `No`) to not display correctly. Best practice would be to surround each connection label with double quotes and/or spaces.