### PR TITLE
[Docs Site] add prettierOptions to `detype`

### DIFF
--- a/src/components/TypeScriptExample.astro
+++ b/src/components/TypeScriptExample.astro
@@ -58,7 +58,11 @@ if (!code) {
 
 code = code.replace(/\u007f/g, "\n");
 
-const js = await transform(code, "placeholder.ts");
+const js = await transform(code, "placeholder.ts", {
+	prettierOptions: {
+		useTabs: true,
+	},
+});
 
 const TabsWrapper = tabsWrapper ? Tabs : Fragment;
 ---


### PR DESCRIPTION
### Summary

Aligns `detype` prettier options with the rest of the repo, and what's generated by `create-cloudflare`, by using tabs for indentation.