### PR TITLE
[Rules] Update edit-expressions.mdx

### DIFF
--- a/src/content/docs/ruleset-engine/rules-language/expressions/edit-expressions.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/expressions/edit-expressions.mdx
@@ -70,7 +70,7 @@ Only the Expression Editor supports nested expressions such as the one above. If
 
 :::note
 
-String comparison in rule expressions is case sensitive. To account for possible variations of string capitalization in an expression, you can use the [`lower()`](/ruleset-engine/rules-language/functions/#lower) function and compare the result with a lowercased string, like in the following example:
+String comparison in rule expressions is case-sensitive. To account for possible variations of string capitalization in an expression, you can use the [`lower()`](/ruleset-engine/rules-language/functions/#lower) function and compare the result with a lowercased string, like in the following example:
 
 ```txt
 lower(http.request.uri.path) contains "/wp-login.php"


### PR DESCRIPTION
It is a compound adjective, and the hyphen is used to clarify that the two words function together to modify the noun that follows.

### Summary

It is a compound adjective, and the hyphen is used to clarify that the two words function together to modify the noun that follows.
Thanks.