### PR TITLE
[Reference Architecture] Cleaning up Overview pages

### DIFF
--- a/src/content/docs/reference-architecture/architectures/index.mdx
+++ b/src/content/docs/reference-architecture/architectures/index.mdx
@@ -2,6 +2,8 @@
 title: Reference Architectures
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 4
 ---
 

--- a/src/content/docs/reference-architecture/design-guides/index.mdx
+++ b/src/content/docs/reference-architecture/design-guides/index.mdx
@@ -2,6 +2,8 @@
 title: Design Guides
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 6
 ---
 

--- a/src/content/docs/reference-architecture/diagrams/ai/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/ai/index.mdx
@@ -2,6 +2,8 @@
 title: Artificial Intelligence (AI)
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/bots/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/bots/index.mdx
@@ -2,6 +2,8 @@
 title: Bots
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 ---
 

--- a/src/content/docs/reference-architecture/diagrams/content-delivery/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/content-delivery/index.mdx
@@ -2,6 +2,8 @@
 title: Content Delivery
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/index.mdx
@@ -2,6 +2,8 @@
 title: Reference Architecture Diagrams
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 5
 ---
 

--- a/src/content/docs/reference-architecture/diagrams/iot/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/iot/index.mdx
@@ -2,6 +2,8 @@
 title: Internet of Things (IoT)
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 ---
 

--- a/src/content/docs/reference-architecture/diagrams/network/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/network/index.mdx
@@ -2,6 +2,8 @@
 title: Network
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/sase/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/sase/index.mdx
@@ -2,6 +2,8 @@
 title: Secure Access Service Edge (SASE)
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/security/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/security/index.mdx
@@ -2,6 +2,8 @@
 title: Security
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/serverless/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/serverless/index.mdx
@@ -2,6 +2,8 @@
 title: Serverless
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/diagrams/storage/index.mdx
+++ b/src/content/docs/reference-architecture/diagrams/storage/index.mdx
@@ -2,6 +2,8 @@
 title: Storage
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 2
 
 ---

--- a/src/content/docs/reference-architecture/implementation-guides/application-security/index.mdx
+++ b/src/content/docs/reference-architecture/implementation-guides/application-security/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: Application Security
 pcx_content_type: navigation
+sidebar:
+  group:
+    hideIndex: true
 ---
 
 import { Description, DirectoryListing, Render } from "~/components";

--- a/src/content/docs/reference-architecture/implementation-guides/index.mdx
+++ b/src/content/docs/reference-architecture/implementation-guides/index.mdx
@@ -2,6 +2,8 @@
 title: Implementation Guides
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 7
 ---
 

--- a/src/content/docs/reference-architecture/implementation-guides/zero-trust/index.mdx
+++ b/src/content/docs/reference-architecture/implementation-guides/zero-trust/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: Zero Trust
 pcx_content_type: navigation
+sidebar:
+  group:
+    hideIndex: true
 ---
 
 import { Description, DirectoryListing, Render } from "~/components";


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Currently, in the Reference Architecture in dev docs, there are 3 types of `Overview` pages.

1. The main Overview page. This is fine as it is, and has not been modified.
2. Overview pages which purely contain links to the items available on the sidebar. **These have been hidden.**
3. Overview pages which has links + explanation. **These have also been hidden.** The existing text did not really provide much meaningful information beyond the "Overview" and "How to use" pages.

Note that the hidden pages still exist. For example, currently, the links in the "How to use" page directs users to the hidden "Overview" pages. We can further update the links to land on a different page.

If these Overview pages are really important, we should consider adding more meaningful information.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
