### PR TITLE
Fix outdated property `event.params` in Workflows guide

### DIFF
--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -62,7 +62,7 @@ type Params = {
 export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
 		// Can access bindings on `this.env`
-		// Can access params on `event.params`
+		// Can access params on `event.payload`
 
 		const files = await step.do('my first step', async () => {
 			// Fetch a list of files from $SOME_SERVICE


### PR DESCRIPTION
### Summary

The Workflows guide contains a comment:

```
// Can access params on `event.params`
```

I guess the API had changed, and it should be `event.payload`.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
