### PR TITLE
[Magic Cloud] Clarify catalog export title

### DIFF
--- a/src/content/docs/magic-cloud-networking/manage-resources.mdx
+++ b/src/content/docs/magic-cloud-networking/manage-resources.mdx
@@ -28,9 +28,9 @@ To browse the resources in your catalog:
 5. Select **Save** when you are finished.
 6. (Optional) You can also select **Delete** to delete your cloud integration.
 
-## Download cloud integrations catalog
+## Download cloud resource catalog
 
-You can download a JSON file containing the information about all your cloud resources:
+You can download a JSON file containing metadata and configuration for all your cloud resources:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/), and select your account.
 2. Select **Manage Account** > **Cloud integrations**.


### PR DESCRIPTION
Updates subtitle for the MCN cloud resource catalog export feature to clarify that the export contains information about cloud resources, not about cloud integrations.