### PR TITLE
[R2] Document the max number of keys that may be deleted at a time

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-reference.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-reference.mdx
@@ -87,6 +87,7 @@ export default {
 
   - Deletes the given <code>values</code> and metadata under the associated <code>keys</code>. Once the delete succeeds, returns <code>void</code>.
   - R2 deletes are strongly consistent. Once the Promise resolves, all subsequent read operations will no longer see the provided key value pairs globally.
+  - Up to 1000 keys may be deleted per call.
 
 - `list` <Type text="(options?: R2ListOptions): Promise<R2Objects>" />
 


### PR DESCRIPTION
### Summary

It's confusing that R2's `delete()` method in Workers does not document the maximum number of keys that can be deleted at once.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
