### PR TITLE
Fix code example for `NonRetryableError`

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -103,7 +103,7 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
 	  await step.do("some step", async () => {
 			  if !(event.data) {
-					throw NonRetryableError("event.data did not contain the expected payload")
+					throw new NonRetryableError("event.data did not contain the expected payload")
 				}
 			})
 	}


### PR DESCRIPTION
### Summary

Missing `new` in an example of throwing `NonRetryableError`.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
