### PR TITLE
Remove --category option from C3 docs because it does not work

### DIFF
--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -98,17 +98,6 @@ bun create cloudflare@latest [--] [<DIRECTORY>] [OPTIONS] [-- <NESTED ARGS...>]
 
   - CLI arguments to pass to eventual third party CLIs C3 might invoke (in the case of full-stack applications).
 
-- `--category` <Type text="string" /> <MetaInfo text="optional" />
-
-  - The kind of templates that should be created.
-
-  - The possible values for this option are:
-
-    - `hello-world`: Hello World example
-    - `web-framework`: Framework Starter
-    - `demo`: Application Starter
-    - `remote-template`: Template from a GitHub repo
-
 - `--type` <Type text="string" /> <MetaInfo text="optional" />
 
   - The type of application that should be created.


### PR DESCRIPTION
```
> npm create cloudflare -- --category web-framework
.......

Unrecognized option: category
````

<img width="752" alt="Screenshot 2024-12-13 at 3 42 44 PM" src="https://github.com/user-attachments/assets/b274e4f2-16b3-4e44-8eb6-fca1180b4f40" />

https://developers.cloudflare.com/pages/get-started/c3/#cli-arguments

https://github.com/cloudflare/workers-sdk/blob/6cac35131c0bdf93995f317b977cfdb2e9a4902c/packages/create-cloudflare/src/templates.ts#L233-L235