### PR TITLE
clarify r2 lifecycle rule conflict behavior

### DIFF
--- a/src/content/docs/r2/buckets/object-lifecycles.mdx
+++ b/src/content/docs/r2/buckets/object-lifecycles.mdx
@@ -16,6 +16,7 @@ For example, you can create an object lifecycle rule to delete objects after 90 
 - An object is no longer billable once it has been deleted.
 - Buckets have a default lifecycle rule to expire multipart uploads seven days after initiation.
 - When an object is transitioned from Standard storage to Infrequent Access storage, a [Class A operation](/r2/pricing/#class-a-operations) is incurred.
+- When rules conflict and specify both a storage class transition and expire transition within a 24 hour period, the expire (or delete) lifecycle transition takes precedence over transitioning storage class. 
 
 ## Configure lifecycle rules for your bucket
 


### PR DESCRIPTION
### Summary

Clarifying behavior of object lifecycles in R2 when rules conflict with each other. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
