### PR TITLE
ci: skip all /api/ links for the validation

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -177,27 +177,27 @@ export default defineConfig({
 			plugins: [
 				...(runLinkCheck
 					? [
-							starlightLinksValidator({
-								errorOnInvalidHashes: false,
-								errorOnLocalLinks: false,
-								exclude: [
-									"/api/",
-									"/api/operations/**",
-									"/changelog/",
-									"/http/resources/**",
-									"{props.*}",
-									"/",
-									"**/glossary/?term=**",
-									"/products/?product-group=*",
-									"/products/",
-									"/rules/snippets/examples/?operation=*",
-									"/rules/transform/examples/?operation=*",
-									"/workers/examples/?languages=*",
-									"/workers/examples/?tags=*",
-									"/workers-ai/models/**",
-								],
-							}),
-						]
+						starlightLinksValidator({
+							errorOnInvalidHashes: false,
+							errorOnLocalLinks: false,
+							exclude: [
+								"/api/",
+								"/api/**",
+								"/changelog/",
+								"/http/resources/**",
+								"{props.*}",
+								"/",
+								"**/glossary/?term=**",
+								"/products/?product-group=*",
+								"/products/",
+								"/rules/snippets/examples/?operation=*",
+								"/rules/transform/examples/?operation=*",
+								"/workers/examples/?languages=*",
+								"/workers/examples/?tags=*",
+								"/workers-ai/models/**",
+							],
+						}),
+					]
 					: []),
 				starlightDocSearch({
 					appId: "D32WIYFTUF",


### PR DESCRIPTION
The CI step gives a false positive that these URLs are invalid despite them being correct; they just live outside of the developer docs.