### PR TITLE
Add Source Maps to Workers / Pages Compat Matrix

### DIFF
--- a/src/content/docs/workers/static-assets/compatibility-matrix.mdx
+++ b/src/content/docs/workers/static-assets/compatibility-matrix.mdx
@@ -48,6 +48,7 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 | [Logpush](/workers/observability/logs/logpush/)                                     | ✅      | ❌      |
 | [Tail Workers](/workers/observability/logs/tail-workers/)                           | ✅      | ❌      |
 | [Real-time logs](/workers/observability/logs/real-time-logs/)                       | ✅      | ✅      |
+| [Source Maps](/workers/observability/source-maps/)                                  | ✅      | ❌      |
 | **Runtime APIs & Compute Models**                                                   |         |         |
 | [Node.js Compatibility Mode](/workers/runtime-apis/nodejs/)                         | ✅      | ✅      |
 | [Durable Objects](/durable-objects/api/)                                            | ✅      | 🟡 [^5] |


### PR DESCRIPTION
Pretty sure this does not work with Pages

(but if you add `upload_source_maps = true` then run `wrangler pages deploy` we don't warn you)