### PR TITLE
Add deprecation to DNS Records API - Remove eligible zones for custom nameservers endpoint

### DIFF
--- a/src/content/changelogs/api-deprecations.yaml
+++ b/src/content/changelogs/api-deprecations.yaml
@@ -5,6 +5,16 @@ productLink: "/fundamentals/"
 productArea: Core platform
 productAreaLink: /fundamentals/reference/changelog/platform/
 entries:
+  - publish_date: "2025-03-23"
+    title: "Eligible Zones For Account Custom Nameservers"
+    description: |-
+      Deprecation date: March 23, 2025
+
+      Users can now add custom nameservers that are not part of a zone managed within their account. As a result, any zone is eligible for custom nameservers, regardless of whether it is managed by Cloudflare. Given this change, an endpoint to check for eligible zones is no longer relevant and is therefore being deprecated.
+
+      Deprecated APIs:
+      - `GET /accounts/:account_id/custom_ns/availability`
+
   - publish_date: "2024-12-09"
     title: "Access applications: self_hosted_domains"
     description: |-


### PR DESCRIPTION
### Summary

This add a DNS records API deprecation to remove the  `GET /accounts/:account_id/custom_ns/availability` endpoint.
It is now possible for users to add custom nameservers that are not part of a zone managed within their account. As a result,  an endpoint to check for eligible zones is no longer relevant.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

cc @hannes-cf 