### PR TITLE
[Workers] Point users to the npm package for workers-types instead of the archived repo

### DIFF
--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -99,7 +99,7 @@ An object containing Cloudflare-specific properties that can be set on the `Requ
 fetch(event.request, { cf: { scrapeShield: false } })
 ```
 
-Invalid or incorrectly-named keys in the `cf` object will be silently ignored. Consider using TypeScript and [`@cloudflare/workers-types`](https://github.com/cloudflare/workerd/tree/main/npm/workers-types) to ensure proper use of the `cf` object.
+Invalid or incorrectly-named keys in the `cf` object will be silently ignored. Consider using TypeScript and [`@cloudflare/workers-types`](https://www.npmjs.com/package/@cloudflare/workers-types) to ensure proper use of the `cf` object.
 
 
 

--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -99,7 +99,7 @@ An object containing Cloudflare-specific properties that can be set on the `Requ
 fetch(event.request, { cf: { scrapeShield: false } })
 ```
 
-Invalid or incorrectly-named keys in the `cf` object will be silently ignored. Consider using TypeScript and [`@cloudflare/workers-types`](https://github.com/cloudflare/workers-types) to ensure proper use of the `cf` object.
+Invalid or incorrectly-named keys in the `cf` object will be silently ignored. Consider using TypeScript and [`@cloudflare/workers-types`](https://github.com/cloudflare/workerd/tree/main/npm/workers-types) to ensure proper use of the `cf` object.
 
 
 


### PR DESCRIPTION
### Summary

This PR updates the link for workers-types from the archived repo, to the npm package.
