### PR TITLE
[DNS] New cf-proxied tag and use in import/export

### DIFF
--- a/src/content/docs/dns/cname-flattening/set-up-cname-flattening.mdx
+++ b/src/content/docs/dns/cname-flattening/set-up-cname-flattening.mdx
@@ -47,7 +47,7 @@ Make a `PATCH` request to the [Update DNS Settings](/api/resources/dns/subresour
 
 Paid zones also have the option of flattening specific `CNAME` records.
 
-If you use this option, a special [tag](/dns/manage-dns-records/reference/record-attributes/) `cf-flatten` will be added to the respective flattened `CNAME` records in your zone file, allowing you to [export and import records](/dns/manage-dns-records/how-to/import-and-export/) without losing this configuration.
+If you use this option, a special [tag](/dns/manage-dns-records/reference/record-attributes/) `cf-flatten-cname` will be added to the respective flattened `CNAME` records in your zone file, allowing you to [export and import records](/dns/manage-dns-records/how-to/import-and-export/) without losing this configuration.
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 

--- a/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
@@ -94,6 +94,13 @@ g.example.com.  60  IN  A   1.1.1.1
 
 When exporting and importing, special tags starting by `cf-` allow you to control specific Cloudflare configurations. On export, these tags are automatically added to reflect the current configuration for each record on your zone.
 
+```txt title="Records with cf- tags example"
+;; CNAME Records
+a.cloudflaredocs.com.	1	IN	CNAME	example.com. ; cf_tags=test:1,cf-flatten-cname
+b.cloudflaredocs.com.	1	IN	CNAME	example.com. ; cf_tags=cf-proxied:false
+c.cloudflaredocs.com.	1	IN	CNAME	example.com. ; cf_tags=tag-without-value,cf-proxied:true
+```
+
 #### cf-proxied
 
 On export, [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/#proxied-records) will present a tag `cf-proxied:true` while DNS-only records will have this tag set to `cf-proxied:false`.

--- a/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
@@ -90,9 +90,10 @@ f.example.com.  60  IN  A   1.1.1.1 ; this is the comment cf_tags=tag1:value1,ta
 g.example.com.  60  IN  A   1.1.1.1
 ```
 
-### cf-flatten tag
+### Reserved cf- tags
 
-If you are on a paid zone and want to use [Per-record CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/#per-record), use the tag `cf-flatten` next to each flattened CNAME record in your zone file. On export, this tag is automatically added to reflect the record configuration that you have on your zone.
+- **cf-proxied**:
+- **cf-flatten-cname**: If you are on a paid zone and want to use [Per-record CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/#per-record), use the tag `cf-flatten-cname` next to each flattened CNAME record in your zone file. On export, this tag is automatically added to reflect the record configuration that you have on your zone.
 
 ## DNS zone file directives
 

--- a/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
@@ -19,7 +19,7 @@ Use import and export to have more control over your DNS records and make proces
 
 Create a [BIND zone file](https://en.wikipedia.org/wiki/Zone_file) for your domain. If you need help, use a [third-party tool](https://pgl.yoyo.org/as/bind-zone-file-creator.php).
 
-If you are using certain record types — for example, `CNAME`, `DNAME`, `MX`, `NS`, `PTR`, or `SRV` records — make sure that the **content** of those records contains fully qualified domain names (which end in a trailing period like `example.com.`). For more details, refer to [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-5.1) or this [post on Stack Exchange](https://superuser.com/questions/348282/fqdn-format-in-bind-zone#348284).
+If you are using certain record types — for example, `CNAME`, `DNAME`, `MX`, `NS`, `PTR`, or `SRV` records — make sure that the **content** of those records contains fully qualified domain names ending in a trailing period (as in `example.com.`). For more details, refer to [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-5.1) or this [post on Stack Exchange](https://superuser.com/questions/348282/fqdn-format-in-bind-zone#348284).
 
 ### Import zone file to Cloudflare
 

--- a/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/import-and-export.mdx
@@ -92,8 +92,20 @@ g.example.com.  60  IN  A   1.1.1.1
 
 ### Reserved cf- tags
 
-- **cf-proxied**:
-- **cf-flatten-cname**: If you are on a paid zone and want to use [Per-record CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/#per-record), use the tag `cf-flatten-cname` next to each flattened CNAME record in your zone file. On export, this tag is automatically added to reflect the record configuration that you have on your zone.
+When exporting and importing, special tags starting by `cf-` allow you to control specific Cloudflare configurations. On export, these tags are automatically added to reflect the current configuration for each record on your zone.
+
+#### cf-proxied
+
+On export, [proxied DNS records](/dns/manage-dns-records/reference/proxied-dns-records/#proxied-records) will present a tag `cf-proxied:true` while DNS-only records will have this tag set to `cf-proxied:false`.
+
+When importing zone files, the value in the `cf-proxied` tag will take precedence in determining whether a record should be proxied. This means that:
+
+- If the tag is present, its value will be considered for the respective record regardless of the **Proxy imported DNS records** option being selected (via dashboard), or the `proxied` parameter being generally set to `true` or `false` (via API).
+- If the tag is absent, the proxied status will fall back to the general import option, meaning **Proxy imported DNS records** selected or not (via dashboard)  or the `proxied` parameter set to `true` or `false` (via API).
+
+#### cf-flatten-cname
+
+If you are on a paid zone and want to use [Per-record CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/#per-record), use the tag `cf-flatten-cname` next to each flattened CNAME record in your zone file. On export, this tag is automatically added to reflect the record configuration that you have on your zone.
 
 ## DNS zone file directives
 

--- a/src/content/docs/dns/manage-dns-records/reference/record-attributes.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/record-attributes.mdx
@@ -51,7 +51,7 @@ Create or edit record attributes just like any other aspect of DNS records, whet
 
 You can also add or edit attributes by [exporting and re-importing](/dns/manage-dns-records/how-to/import-and-export/#dns-record-attributes) your records, or using the [Batch record changes API](/dns/manage-dns-records/how-to/batch-record-changes/#use-the-api).
 
-When exporting and importing, a special tag `cf-flatten` allows you to control [CNAME flattening for individual records](/dns/cname-flattening/set-up-cname-flattening/#per-record). On export, this tag is automatically added to reflect the record configuration you have on your zone.
+When exporting and importing, special tags starting by `cf-` allow you to control specific Cloudflare configurations. On export, these tags are automatically added to reflect the current configuration for each record on your zone. Refer to [reserved cf- tags](/dns/manage-dns-records/how-to/import-and-export/#reserved-cf--tags) for details.
 
 ***
 

--- a/src/content/docs/dns/troubleshooting/faq.mdx
+++ b/src/content/docs/dns/troubleshooting/faq.mdx
@@ -61,15 +61,7 @@ If you are an Enterprise customer and require more DNS records, contact your acc
 
 ## Which record types does Cloudflare not proxy?
 
-Cloudflare does not proxy the following record types:
-
-- `LOC`
-- `MX`
-- `NS`
-- `SPF`
-- `TXT`
-- `SRV`
-- `CAA`
+Only `A`, `AAAA`, and `CNAME` records can be proxied. Cloudflare will not proxy any other [DNS record types](/dns/manage-dns-records/reference/dns-record-types/).
 
 ---
 

--- a/src/content/partials/dns/limitations.mdx
+++ b/src/content/partials/dns/limitations.mdx
@@ -7,26 +7,9 @@ import { Render } from "~/components"
 
 #### Proxy eligibility
 
-By default, `A`, `AAAA`, and `CNAME` DNS records that serve `HTTP/HTTPS` traffic can be proxied.
+Only `A`, `AAAA`, and `CNAME` DNS records can be proxied.
 
 If you encounter a `CNAME` record that you cannot proxy — usually associated with another CDN provider — a proxied version of that record will cause connectivity errors. Cloudflare is purposely preventing that record from being proxied to protect you from a misconfiguration.
-
-The following types of DNS records may be in your DNS configuration, but cannot be proxied:
-
-* `CAA`
-* `DKIM`
-* `DMARC`
-* `DNSKEY`
-* `DS`
-* `HTTPS`
-* `MX`
-* `NS`
-* `PTR`
-* `SOA`
-* `SPF`
-* `SRV`
-* `SVCB`
-* `TXT`
 
 #### Ports and protocols
 
@@ -47,5 +30,5 @@ For enhanced security, we recommend rolling your origin IP addresses at your hos
 
 #### Windows authentication
 
-Because Microsoft Integrated Windows Authentication, NTLM, and Kerberos violate HTTP/1.1 specifications, they are not compatible with proxied DNS records. 
+Because Microsoft Integrated Windows Authentication, NTLM, and Kerberos violate HTTP/1.1 specifications, they are not compatible with proxied DNS records.
 :::


### PR DESCRIPTION
### Summary

PCX-15087: Document new behavior of cf-proxied tag for zone file import / exports
PCX-14642 sub-task: List the record types that can be proxied and explicitly say all other types cannot be proxied