### PR TITLE
[DRAFT][Magic WAN] update Azure instructions

### DIFF
--- a/src/content/docs/magic-wan/configuration/manually/third-party/azure.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/azure.mdx
@@ -5,10 +5,6 @@ title: Microsoft Azure
 
 This tutorial provides information on how to connect Cloudflare Magic WAN to your Azure Virtual Network, using the Azure Virtual Network Gateway.
 
-:::note
-This configuration guide applies to Azure Virtual Network Gateway in an Active/Standby configuration. Active/Active configuration is not currently supported.
-:::
-
 ## Prerequisites
 
 You will need to have an existing Resource group, Virtual Network, and Virtual Machine created in your Azure account. Refer to [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/virtual-network/) to learn more on how to create these.
@@ -32,6 +28,20 @@ The Virtual Network Gateway is used to form the tunnel to the devices on your pr
 This configuration guide applies to Azure Virtual Network Gateway which includes the functionality found in the Azure VPN Gateway.
 :::
 
+:::note
+Active/Active and Active/Standby configurations are both supported. Two Azure public IP addresses, and two Magic WAN IPsec tunnels, are required for the Active/Active configuration.
+:::
+
+#### Active/Active connfiguration
+
+1. Create a Virtual Network Gateway.
+2. Create two new public IP addresses or use an existing IPs. Take note of the public IP addresses assigned to the Virtual Network Gateway as these will be the **Customer endpoint** for Magic WAN's IPsec tunnels configuration.
+3. Select the resource group and VNET you have already created.
+4. In **Configuration**, enable **Active-active mode** and disable **Gateway Private IPs**.
+5. Select **Create**.
+
+#### Active/Standby connfiguration
+
 1. Create a Virtual Network Gateway.
 2. Create a new public IP address or use an existing IP. Take note of the public IP address assigned to the Virtual Network Gateway as this will be the **Customer endpoint** for Magic WAN's IPsec tunnels configuration.
 3. Select the resource group and VNET you have already created.
@@ -53,6 +63,10 @@ We recommend creating a Local Network Gateway for your Cloudflare IPsec tunnel.
 3. In **Address space(s)**, specify the address range of any subnets you wish to access remotely through the Magic WAN connection. For example, if you want to reach a network with an IP range of `192.168.1.0/24`, and this network is connected to your Magic WAN tenant, you would add `192.168.1.0/24` to the local network gateway address space.
 4. Go to the **Advanced** tab > **BGP settings**, and make sure you select **No**.
 
+:::note
+A single Cloudflare anycast address must be used in both Active/Active and Active/Standby configurations.
+:::
+
 ### 4. Configure Local Network Gateway for Magic IPsec tunnel health checks
 
 Magic WAN uses [Tunnel Health Checks](/magic-wan/reference/tunnel-health-checks/) to ensure the tunnel is available.
@@ -62,14 +76,14 @@ Tunnel health checks make use of ICMP probes sent from the Cloudflare side of th
 There is an important distinction between how to configure Cloudflare and Azure to support the health checks:
 
 - Magic IPsec Tunnel configuration settings requires specifying a discrete IP address (`/31` netmask recommended)
-- Azure Local Network Gateway settings require specifying a subnet (in CIDR notation)
+- Azure Local Network Gateway settings require specifying the Cloudflare Magic WAN Interface Addresss in CIDR notation using a `/32` netmask
 
 Cloudflare recommends customers select a unique `/31` subnet ([RFC 1918 - Address Allocation for Private Internets](https://datatracker.ietf.org/doc/html/rfc1918)) for each IPsec tunnel which is treated as a Point-to-Point Link and provides the ideal addressing scheme to satisfy both requirements.
 
 Example:
 
 ```txt
-10.252.3.54/31 - Define as the subnet (in CIDR notation) in Azure Local Network Gateway in the Azure Portal.
+10.252.3.55/32 - Define as the subnet (in CIDR notation) in Azure Local Network Gateway in the Azure Portal.
 10.252.3.55/31 - Define as the discrete IP Address assigned to the Interface Address (VTI - Virtual Tunnel Interface) of the Magic IPsec Tunnel in the Cloudflare Dashboard (see Configure Magic WAN below).
 ```
 
@@ -85,8 +99,13 @@ To configure the Address Space for the Local Network Gateway to support Tunnel H
 
 1. Edit the Local Network Gateway configured in the previous section.
 2. Select **Connections**.
-3. Add the`/31` subnet in CIDR notation (for example, `10.252.3.54/31`) under **Address Space(s)**.
+3. Add the Interface Address of the Magic IPsec Tunnel from the Cloudflare Dashboard in CIDR notation (for example, `10.252.3.55/32`) under **Address Space(s)**.
+4. If using an Active/Active configuration, add the Interface Address of the second Magic IPsec Tunnel from the Cloudflare Dashboard in CIDR notation (for example, `10.252.3.55/32`) under **Address Space(s)**.
 4. Select **Save**.
+
+:::note
+The Magic IPsec Tunnel Interface Address should be entered as a `/31` in the Cloudflare Dashboard, but as a `/32` when configuring the Local Network Gateway Address Space(s) in the Azure portal.
+:::
 
 ### 5. Create an IPsec VPN Connection
 
@@ -165,10 +184,13 @@ ICMP (ping/traceroute) will work to remote Magic WAN sites, but is not forwarded
    3. **Cloudflare endpoint**: Use the Cloudflare anycast address you have received from your account team. This will also be the IP address corresponding to the Local Network Gateway in Azure. For example, `162.xxx.xxx.xxx`.
    4. **Health check rate**: Leave the default option (Medium) selected.
    5. **Health check type**: Leave the default option (Reply) selected.
-   6. **Health check direction**: Leave default option.
-   7. **Add pre-shared key later**: Select this option to create a PSK that will be used later in Azure.
-   8. **Replay protection**: **Enable**.
-3. Create static routes for your Azure Virtual Network subnets, specifying the newly created tunnel as the next hop.
+   6. **Health check direction**: Leave default option (Bidirectional) selected.
+   7. **Health check target**: Select **Custom**.
+   8. **Target address**: Enter the same address that is used in the **Customer endpoint** field.
+   9. **Add pre-shared key later**: Select this option to create a PSK that will be used later in Azure.
+   10. **Replay protection**: **Enable**.
+3. If using the Active/Active configuration, repeat step 2 to create the secoind Magic WAN IPsec tunnel.
+4. Create static routes for your Azure Virtual Network subnets, specifying the newly created tunnel as the next hop.
 
 ## Validate connectivity and disable Azure Virtual Network Gateway anti-replay protection
 
@@ -354,20 +376,6 @@ curl --location --request PUT \
 ```
 
 6. Leave the replay protection setting checked in the Cloudflare dashboard, and wait several minutes before validating connectivity again.
-
-## Tunnel health checks and Azure
-
-We have identified cases where the IPsec Tunnels configured on the Azure Virtual Network Gateway need to be restarted one time before the tunnel health checks start passing.
-
-### Restart Azure tunnels
-
-1. Open the Virtual Network Gateway.
-2. Go to **Settings** > **Connections**.
-3. Open the properties of the tunnel.
-4. Go to **Help** > **Reset**.
-5. Select **Reset**.
-
-It may take several minutes for the tunnels to reset from the Azure side. Monitor the [tunnel health checks section](/magic-wan/configuration/common-settings/check-tunnel-health-dashboard/) in the Cloudflare dashboard to determine the status.
 
 :::note
 Tunnel Health Check percentages are calculated over a one hour period.


### PR DESCRIPTION
This updates the Azure instructions to: 
- use the Active/Active configuration on the Azure Virtual Gateway
- use bidirectional health checks with a custom target equal to the Customer endpoint

These changes are unlocked by the completion of RM-19633.   (The work is done, and shipped, even if the RM is not yet closed)

### Summary

https://developers.cloudflare.com/magic-wan/configuration/manually/third-party/azure/

### Screenshots (optional)


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
