### PR TITLE
[Rules] Cloud Connector: Terraform documentation

### DIFF
--- a/src/content/docs/rules/cloud-connector/create-terraform.mdx
+++ b/src/content/docs/rules/cloud-connector/create-terraform.mdx
@@ -1,0 +1,68 @@
+---
+title: Configure Cloud Connector using Terraform
+pcx_content_type: how-to
+sidebar:
+  order: 4
+  label: Configure using Terraform
+head:
+  - tag: title
+    content: Configure Cloud Connector using Terraform
+---
+
+You can create Cloud Connector using the [Terraform Cloudflare provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest).
+
+To get started with Terraform for Cloudflare configuration, refer to [Terraform: Get started](/terraform/installing/).
+
+## Example configuration
+
+Below is an example Terraform configuration that demonstrates creating Cloud Connectors for various [supported providers](/rules/cloud-connector/providers/) to route traffic between them based on URI paths:
+
+```tf
+resource "cloudflare_cloud_connector_rules" "cloud_connector_rules" {
+  zone_id = "<ZONE_ID>"
+
+  rules {
+    description = "Route /data to GCP bucket"
+    enabled     = true
+    expression  = "(http.request.uri.path wildcard \"*/data/*\")"
+    provider    = "gcp_storage"
+    parameters {
+      host = "mystorage.storage.googleapis.com"
+    }
+  }
+
+  rules {
+    description = "Route /resources to AWS bucket"
+    enabled     = true
+    expression  = "(http.request.uri.path wildcard \"*/resources/*\")"
+    provider    = "aws_s3"
+    parameters {
+      host = "mystorage.s3.ams.amazonaws.com"
+    }
+  }
+
+  rules {
+    description = "Route /files to Azure bucket"
+    enabled     = true
+    expression  = "(http.request.uri.path wildcard \"*/files/*\")"
+    provider    = "azure_storage"
+    parameters {
+      host = "mystorage.blob.core.windows.net"
+    }
+  }
+
+  rules {
+    description = "Route /images to R2 bucket"
+    enabled     = true
+    expression  = "(http.request.uri.path wildcard \"*/images/*\")"
+    provider    = "cloudflare_r2"
+    parameters {
+      host = "mybucketcustomdomain.example.com"
+    }
+  }
+}
+```
+
+## More resources
+
+Refer to the [Terraform Cloudflare provider documentation](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) for more information on the `cloudflare_cloud_connector_rules` resource.


### PR DESCRIPTION
### Summary
Adding generic Terraform documentation for Cloud Connector on top of the existing example at https://developers.cloudflare.com/rules/cloud-connector/examples/route-images-to-aws-s3-using-terraform/.