### PR TITLE
[Vectorize] Allow reuse of index names

### DIFF
--- a/src/content/changelogs/vectorize.yaml
+++ b/src/content/changelogs/vectorize.yaml
@@ -5,10 +5,15 @@ productLink: "/vectorize/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2024-12-20"
+    title: Added support for index name reuse
+    description: |-
+      Vectorize now supports the reuse of index names within the account. An index can be created using the same name as an index that is in a deleted state.
+
   - publish_date: "2024-12-19"
     title: Added support for range queries in metadata filters
     description: |-
-      Vectorize now supports `$lt`, `$lte`, `$gt`, and `$gte` clauses in [metadata filters](/vectorize/reference/metadata-filtering/). 
+      Vectorize now supports `$lt`, `$lte`, `$gt`, and `$gte` clauses in [metadata filters](/vectorize/reference/metadata-filtering/).
 
   - publish_date: "2024-11-13"
     title: Added support for $in and $nin metadata filters

--- a/src/content/docs/vectorize/best-practices/create-indexes.mdx
+++ b/src/content/docs/vectorize/best-practices/create-indexes.mdx
@@ -15,7 +15,7 @@ Creating an index requires three inputs:
 - The (fixed) [dimension size](#dimensions) of each vector, for example 384 or 1536.
 - The (fixed) [distance metric](#distance-metrics) to use for calculating vector similarity.
 
-An index cannot be created using the same name as an index previously deleted on your account. We are in the process of addressing this limitation.
+An index cannot be created using the same name as an index that is currently active on your account. However, an index can be created with a name that belonged to an index that has been deleted.
 
 The configuration of an index cannot be changed after creation.
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -209,7 +209,7 @@ npx wrangler vectorize create <INDEX_NAME> [--dimensions=<NUM_DIMENSIONS>] [--me
 ```
 
 - `INDEX_NAME` <Type text="string" /> <MetaInfo text="required" />
-  - The name of the new index to create. Must be unique for an account and cannot be changed after creation or reused after the deletion of an index.
+  - The name of the new index to create. Must be unique for an account and cannot be changed after creation.
 - `--dimensions` <Type text="number" /> <MetaInfo text="required" />
   - The vector dimension width to configure the index for. Cannot be changed after creation.
 - `--metric` <Type text="string" /> <MetaInfo text="required" />


### PR DESCRIPTION
### Summary

Context: Vectorize indexes had a limitation where the index names (the primary identifier for an index) were unique and could not be reused even after the deletion of an index. 

We have now addressed that limitation and have enabled the reuse of index names.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
