### PR TITLE
[cloudflare-docs] fix misspelling of the word practices in websocket.mdx 

### DIFF
--- a/src/content/docs/network/websockets.mdx
+++ b/src/content/docs/network/websockets.mdx
@@ -62,7 +62,7 @@ Once a WebSocket connection is closed, you can view your aggregated WebSocket us
 
 When Cloudflare releases new code to its global network, we may restart servers, which terminates WebSockets connections.
 
-### Best practises
+### Best practices
 
 - Implement a [keepalive](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets).
 - Review and then remove or extend timeout settings on the origin and/or on the client.


### PR DESCRIPTION
### Summary

 - Correcting the misspelling of `practices` in websockets.mdx

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/cdf821da-d9bf-4f35-b58c-b708917ac8bd)


### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
