### PR TITLE
docs: add FlareBase Expo D1 to community projects

### DIFF
--- a/src/content/docs/d1/reference/community-projects.mdx
+++ b/src/content/docs/d1/reference/community-projects.mdx
@@ -92,7 +92,6 @@ Instead of running the `wrangler d1 execute` command in your terminal every time
 
 * [GitHub](https://github.com/renoki-co/l1)
 * [Packagist](https://packagist.org/packages/renoki-co/l1)
-
 ### Staff Directory - a D1-based demo
 
 Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/honox), and [Cloudflare Pages](/pages/). It uses D1 to store employee data, and is an example of a full-stack application built on top of D1.
@@ -109,6 +108,12 @@ Staff Directory is a demo project using D1, [HonoX](https://github.com/honojs/ho
 * [GitHub](https://github.com/nuxt-hub/core)
 * [Documentation](https://hub.nuxt.com)
 * [Example](https://github.com/Atinux/nuxt-todos-edge)
+
+### FlareBase Expo D1
+
+FlareBase Expo D1 is a modern web dashboard for managing Cloudflare D1 databases. It provides a clean interface for executing queries, viewing table structures, and monitoring database metrics with zero setup required.
+
+* [GitHub](https://github.com/malithonline/flareBaseExpoD1)
 
 ## Feedback
 


### PR DESCRIPTION
Added FlareBase Expo D1 to D1 community projects:
- Modern web dashboard for D1
- Zero setup required
- Built with Next.js
- Includes CORS worker example

### Summary
Added FlareBase Expo D1 to the community projects section in D1 documentation. This project helps users manage their D1 databases through a modern web interface.

### Screenshots
![Database Overview](https://raw.githubusercontent.com/malithonline/flareBaseExpoD1/main/screenshots/pic0.png)
![Table Management](https://raw.githubusercontent.com/malithonline/flareBaseExpoD1/main/screenshots/pic1.png)

### Documentation checklist
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
