### PR TITLE
Add rpxy to pqc-support.mdx

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -15,6 +15,7 @@ Cloudflare's deployment of post-quantum [hybrid key agreements](/ssl/post-quantu
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 - [rustls-post-quantum 0.2.0+](https://crates.io/crates/rustls-post-quantum) ([blog](https://www.memorysafety.org/blog/pq-key-exchange/))
+- Default for [rpxy 0.9.4+](https://github.com/junkurihara/rust-rpxy)
 
 ## X25519Kyber768Draft00
 


### PR DESCRIPTION
### Summary

rpxy, a Rust-based reverse proxy, enables hybrid post-quantum key exchange for TLS and QUIC with X25519MLKEM768 by default as of 0.9.4

https://github.com/junkurihara/rust-rpxy/releases/tag/0.9.4

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
