### PR TITLE
[Pages] Update Hexo framework guides, solve the deployment failure issue

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
@@ -64,7 +64,7 @@ To deploy your site to Pages:
 | Configuration option | Value           |
 | -------------------- | --------------- |
 | Production branch    | `main`          |
-| Build command        | `hexo generate` |
+| Build command        | `npx hexo generate` |
 | Build directory      | `public`        |
 
 </div>

--- a/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
@@ -64,7 +64,7 @@ To deploy your site to Pages:
 | Configuration option | Value           |
 | -------------------- | --------------- |
 | Production branch    | `main`          |
-| Build command        | `npx hexo generate` |
+| Build command        | `npm run build` |
 | Build directory      | `public`        |
 
 </div>


### PR DESCRIPTION
### Summary
npm module executable "hexo" is no longer installed globally. Should migrate to using "npx hexo [args]"

Continuing to use `hexo generate` will result in deployment failure.

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
![image](https://github.com/user-attachments/assets/83dbe6ed-dd06-498b-a44d-e027191455bb)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
