### PR TITLE
Update Assets syntax to more standardised table

### DIFF
--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -72,7 +72,10 @@ compatibility_date = "2024-09-19"
 main = "src/index.ts"
  # The following configuration unconditionally invokes the Worker script at
  # `src/index.ts`, which can programatically fetch assets via the ASSETS binding
-assets = { directory = "./public/", binding = "ASSETS", experimental_serve_directly = false }
+[assets]
+directory = "./public/"
+binding = "ASSETS"
+experimental_serve_directly = false
 ```
 
 </WranglerConfig>
@@ -88,7 +91,9 @@ name = "my-worker"
 main = "./src/index.js"
 compatibility_date = "2024-09-19"
 
-assets = { directory = "./public/", binding = "ASSETS" }
+[assets]
+directory = "./public/"
+binding = "ASSETS"
 ```
 
 </WranglerConfig>
@@ -113,8 +118,8 @@ Your dynamic code can make new, or forward incoming, requests to your project's 
 
 Take the following example that configures a Worker script to return a response under all requests headed for `/api/`. Otherwise, the Worker script will pass the incoming request through to the asset binding. In this case, because a Worker script is only invoked when the requested route has not matched any static assets, this will always evaluate [`not_found_handling`](/workers/static-assets/routing/#routing-configuration) behavior.
 
-<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
-
+<Tabs>
+<TabItem label="JavaScript" icon="seti:javascript">
 ```js
 export default {
 	async fetch(request, env) {
@@ -129,9 +134,8 @@ export default {
 	},
 };
 ```
-
-</TabItem> <TabItem label="TypeScript" icon="seti:typescript">
-
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
 ```ts
 interface Env {
 	ASSETS: Fetcher;
@@ -150,8 +154,8 @@ export default {
 	},
 } satisfies ExportedHandler<Env>;
 ```
-
-</TabItem> </Tabs>
+</TabItem>
+</Tabs>
 
 ## Routing configuration
 

--- a/src/content/docs/workers/static-assets/index.mdx
+++ b/src/content/docs/workers/static-assets/index.mdx
@@ -67,17 +67,17 @@ Requests to a project with static assets can either return static assets or invo
 
 **Requests to static assets are free and unlimited**. Requests to the Worker script (e.g. in the case of SSR content) are billed according to Workers pricing. Refer to [pricing](/workers/platform/pricing/#example-2) for an example.
 
-There's no additional cost for storing Assets. 
+There's no additional cost for storing Assets.
 
 ### Troubleshooting
 
-- `assets.bucket is a required field` — if you see this error, you need to update Wrangler to at least `3.78.10` or later. `bucket` is not a required field.
+- `assets.bucket is a required field` — if you see this error, you need to update Wrangler to at least `3.78.10` or later. `bucket` is not a required field.
 
 ### Limitations
 
 The following limitations apply for Workers with static assets:
 
-- There is a 20,000 file count limit per [Worker version](/workers/configuration/versions-and-deployments/), and a 25 MiB individual file size limit. This matches the [limits in Cloudflare Pages](/pages/platform/limits/) today. 
+- There is a 20,000 file count limit per [Worker version](/workers/configuration/versions-and-deployments/), and a 25 MiB individual file size limit. This matches the [limits in Cloudflare Pages](/pages/platform/limits/) today.
 - You cannot upload static assets to [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) [user workers](/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works/). This is a temporary limitation, we are working to remove it.
 - In local development, you cannot make [Service Binding RPC calls](/workers/runtime-apis/bindings/service-bindings/rpc/) to a Worker with static assets. This is a temporary limitation, we are working to remove it.
 - Workers with assets cannot run on a [route or domain](/workers/configuration/routing/) with a path component. For example, `example.com/*` is an acceptable route, but `example.com/foo/*` is not. Wrangler and the Cloudflare dashboard will throw an error when you try and add a route with a path component.


### PR DESCRIPTION
### Summary

`assets = {}` syntax is easy to get wrong in TOML land, we've seen this time and time again with things like `kv_namespaces`. We have standardised on [xxxx] & [[xxxx]] across our docs. Let's make sure assets is following the same pattern here too.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
