### PR TITLE
[ZT] Change ProgramData to the upper case

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/automated-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/automated-deployment.mdx
@@ -82,7 +82,7 @@ To access the installed certificate in Windows:
 2. Enter `certlm.msc`.
 3. Go to **Trusted Root Certification Authority** > **Certificates**. The default Cloudflare certificate name is **Gateway CA - Cloudflare Managed G1**.
 
-The WARP client will also place the certificate in `%ProgramData%\Cloudflare\installed_cert.pem` for reference by scripts or tools.
+The WARP client will also place the certificate in `%PROGRAMDATA%\Cloudflare\installed_cert.pem` for reference by scripts or tools.
 
 ### Linux
 


### PR DESCRIPTION
`%ProgramData%` path does not work for the device posture as the file check.

Can you change it to `%PROGRAMDATA%` so that we can use it for the device posture as the file check?
