### PR TITLE
Update authentication.mdx to use correct auth header for OpenAI and V…

### DIFF
--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -41,7 +41,7 @@ const openai = new OpenAI({
 	apiKey: process.env.OPENAI_API_KEY,
 	baseURL: "https://gateway.ai.cloudflare.com/v1/account-id/gateway/openai",
 	defaultHeaders: {
-		"cf-aig-token": `Bearer {token}`,
+		"cf-aig-authorization": `Bearer {token}`,
 	},
 });
 ```
@@ -54,7 +54,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 const openai = createOpenAI({
 	baseURL: "https://gateway.ai.cloudflare.com/v1/account-id/gateway/openai",
 	headers: {
-		"cf-aig-token": `Bearer {token}`,
+		"cf-aig-authorization": `Bearer {token}`,
 	},
 });
 ```


### PR DESCRIPTION
…ercel SDKs

Using `cf-aig-token` results in Error: 401 [{"code":2009,"message":"Unauthorized"}]. From my tests this is fixed if we use header name `cf-aig-authorization` instead

### Summary

<!-- Add context such as the type of documentation being updated or added -->
Update authentication.mdx to use correct auth header for OpenAI and Vercel SDKs

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
