### PR TITLE
Fix batch image upload endpoint from v2 to v1

### DIFF
--- a/src/content/docs/images/upload-images/images-batch.mdx
+++ b/src/content/docs/images/upload-images/images-batch.mdx
@@ -27,12 +27,12 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/images/v1/batch
 
 After getting your token, you can use it to make requests for:
 
-- [Upload an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/create/) - `POST /images/v1`
-- [Delete an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/delete/) - `DELETE /images/v1/{identifier}`
-- [Image details](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/get/) - `GET /images/v1/{identifier}`
-- [Update image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/edit/) - `PATCH /images/v1/{identifier}`
-- [List images V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/methods/list/) - `GET /images/v2`
-- [Direct upload V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/subresources/direct_uploads/methods/create/) - `POST /images/v2/direct_upload`
+- [Upload an image](/api/resources/images/subresources/v1/methods/create/) - `POST /images/v1`
+- [Delete an image](/api/resources/images/subresources/v1/methods/delete/) - `DELETE /images/v1/{identifier}`
+- [Image details](/api/resources/images/subresources/v1/methods/get/) - `GET /images/v1/{identifier}`
+- [Update image](/api/resources/images/subresources/v1/methods/edit/) - `PATCH /images/v1/{identifier}`
+- [List images V2](/api/resources/images/subresources/v2/methods/list/) - `GET /images/v2`
+- [Direct upload V2](/api/resources/images/subresources/v2/subresources/direct_uploads/methods/create/) - `POST /images/v2/direct_upload`
 
 These options use a different host and a different path with the same method, request, and response bodies.
 

--- a/src/content/docs/images/upload-images/images-batch.mdx
+++ b/src/content/docs/images/upload-images/images-batch.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: reference
 title: Upload via batch API
-
 ---
 
 The Images batch API lets you make several requests in sequence while bypassing Cloudflare’s global API rate limits.
@@ -28,12 +27,12 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/images/v1/batch
 
 After getting your token, you can use it to make requests for:
 
-* [Upload an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/create/) - `POST /images/v1`
-* [Delete an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/delete/) - `DELETE /images/v1/{identifier}`
-* [Image details](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/get/) - `GET /images/v1/{identifier}`
-* [Update image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/edit/) - `PATCH /images/v1/{identifier}`
-* [List images V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/methods/list/) - `GET /images/v2`
-* [Direct upload V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/subresources/direct_uploads/methods/create/) - `POST /images/v2/direct_upload`
+- [Upload an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/create/) - `POST /images/v1`
+- [Delete an image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/delete/) - `DELETE /images/v1/{identifier}`
+- [Image details](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/get/) - `GET /images/v1/{identifier}`
+- [Update image](https://developers.cloudflare.com/api/resources/images/subresources/v1/methods/edit/) - `PATCH /images/v1/{identifier}`
+- [List images V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/methods/list/) - `GET /images/v2`
+- [Direct upload V2](https://developers.cloudflare.com/api/resources/images/subresources/v2/subresources/direct_uploads/methods/create/) - `POST /images/v2/direct_upload`
 
 These options use a different host and a different path with the same method, request, and response bodies.
 
@@ -43,6 +42,6 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/images/v2" \
 ```
 
 ```bash title="Example request using a batch token"
-curl "https://batch.imagedelivery.net/images/v2" \
+curl "https://batch.imagedelivery.net/images/v1" \
 --header "Authorization: Bearer <BATCH_TOKEN>"
 ```

--- a/src/content/docs/images/upload-images/images-batch.mdx
+++ b/src/content/docs/images/upload-images/images-batch.mdx
@@ -25,7 +25,7 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/images/v1/batch
 }
 ```
 
-After getting your token, you can use it to make requests for:
+After getting your token, use it to make requests for:
 
 - [Upload an image](/api/resources/images/subresources/v1/methods/create/) - `POST /images/v1`
 - [Delete an image](/api/resources/images/subresources/v1/methods/delete/) - `DELETE /images/v1/{identifier}`


### PR DESCRIPTION
### Summary

<!-- This pull request fixes the incorrect endpoint URL for the batch image upload in the documentation. The endpoint in the curl command has been changed from https://batch.imagedelivery.net/images/v2 to https://batch.imagedelivery.net/images/v1 -->


References

Issue #18929: [Cloudflare Batch Image Upload Endpoint](https://github.com/cloudflare/cloudflare-docs/issues/18929)

Code that is changed:

"curl "https://batch.imagedelivery.net/images/v1" \
--header "Authorization: Bearer <BATCH_TOKEN>"


