### PR TITLE
[Pages] Fix typo in build-image.mdx

### DIFF
--- a/src/content/docs/pages/configuration/build-image.mdx
+++ b/src/content/docs/pages/configuration/build-image.mdx
@@ -54,7 +54,7 @@ To override default versions of languages and tools in the build system, you can
 To set the version using environment variables, you can:
 
 1. Find the environment variable name for the language or tool in [this table](/pages/configuration/build-image/#supported-languages-and-tools).
-2. Add the environment variable on the dashboard by going to **Settings** > **Environmnet variables** in your Pages project, or [add the environment variable via Wrangler](/workers/configuration/environment-variables/#add-environment-variables-via-wrangler).
+2. Add the environment variable on the dashboard by going to **Settings** > **Environment variables** in your Pages project, or [add the environment variable via Wrangler](/workers/configuration/environment-variables/#add-environment-variables-via-wrangler).
 
 Or, to set the version by adding a file to your project, you can:
 


### PR DESCRIPTION
### Summary

Fix a typo `Environmnet` => `Environment`