### PR TITLE
add `--strict-vars` option to the `wrangler types` command

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2287,6 +2287,10 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - Leave the path blank to use the default option, e.g. `npx wrangler types --x-include-runtime`
   - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
   - A custom path must have a `d.ts` extension.
+- `--loose-vars` <Type text="boolean" /> <MetaInfo text="optional (default: false)" />
+  - Flag used to generate "loose"/generic types instead of literal and union types for variables (e.g. `myEnv: string` instead of `myEnv: 'my env variable'`)
+  - Useful when environment variables can often change (especially with multiple environments involved)
+
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2287,10 +2287,9 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - Leave the path blank to use the default option, e.g. `npx wrangler types --x-include-runtime`
   - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
   - A custom path must have a `d.ts` extension.
-- `--loose-vars` <Type text="boolean" /> <MetaInfo text="optional (default: false)" />
-  - Flag used to generate "loose"/generic types instead of literal and union types for variables (e.g. `myEnv: string` instead of `myEnv: 'my env variable'`)
-  - Useful when environment variables can often change (especially with multiple environments involved)
-
+- `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
+  - Flag to opt out of the default generation of literal and union types for variables in favour of more generic types (e.g. to generate `myEnv: string` instead of `myEnv: 'my env variable'`)
+  - Useful when environment variables can often change (especially with multiple environments are involved)
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2289,8 +2289,8 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - A custom path must have a `d.ts` extension.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
   - Control the types that Wrangler generates for `vars` bindings.
-  - If true (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
-  - If false, Wrangler generates generic types (e.g. `myEnv: string`).
+  - If `true` (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
+  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`).
   - Useful when environment variables can often change (especially with multiple environments are involved)
 
 <Render file="wrangler-commands/global-flags" product="workers" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2288,7 +2288,9 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - A custom path must be relative to the project root, e.g. `./my-runtime-types.d.ts`
   - A custom path must have a `d.ts` extension.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
-  - Flag to opt out of the default generation of literal and union types for variables in favour of more generic types (e.g. to generate `myEnv: string` instead of `myEnv: 'my env variable'`)
+  - Control the types that Wrangler generates for `vars` bindings.
+  - If true (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
+  - If false, Wrangler generates generic types (e.g. `myEnv: string`).
   - Useful when environment variables can often change (especially with multiple environments are involved)
 
 <Render file="wrangler-commands/global-flags" product="workers" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2289,7 +2289,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
   - A custom path must have a `d.ts` extension.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
   - Control the types that Wrangler generates for `vars` bindings.
-  - If `true` (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
+  - If `true`, (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
   - If `false`, Wrangler generates generic types (e.g. `myEnv: string`).
   - Useful when environment variables can often change (especially with multiple environments are involved)
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2290,7 +2290,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
   - Control the types that Wrangler generates for `vars` bindings.
   - If `true`, (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
-  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`) (useful when environment variables can often change especially when multiple environments are used).
+  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`). This is useful when variables change frequently, such as when working across multiple environments.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2290,8 +2290,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
   - Control the types that Wrangler generates for `vars` bindings.
   - If `true`, (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
-  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`).
-  - Useful when environment variables can often change (especially with multiple environments are involved)
+  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`) (useful when environment variables can often change especially when multiple environments are used).
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -2290,7 +2290,7 @@ The minimum required Wrangler version to use this command is 3.66.0.
 - `--strict-vars` <Type text="boolean" /> <MetaInfo text="optional (default: true)" />
   - Control the types that Wrangler generates for `vars` bindings.
   - If `true`, (the default) Wrangler generates literal and union types for bindings (e.g. `myEnv: 'my dev variable' | 'my prod variable'`).
-  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`). This is useful when variables change frequently, such as when working across multiple environments.
+  - If `false`, Wrangler generates generic types (e.g. `myEnv: string`). This is useful when variables change frequently, especially when working across multiple environments.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 


### PR DESCRIPTION
### Summary

Add info regarding the newly introduced `--strict-vars` option for the `wrangler types` command

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
