### PR TITLE
[C3] Consistently use full official full stack framework names

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -829,6 +829,8 @@
 /pages/how-to/deploy-a-vue-application/ /pages/framework-guides/deploy-a-vue-site/ 301
 /pages/functions/plugins/mailchannels/ /workers/tutorials/send-emails-with-resend/ 301
 /pages/framework-guides/deploy-a-vue-application/ /pages/framework-guides/deploy-a-vue-site 301
+/pages/framework-guides/deploy-a-solid-site/ /pages/framework-guides/deploy-a-solid-start-site/ 301
+/pages/framework-guides//pages/framework-guides/deploy-a-svelte-site/ /pages/framework-guides/deploy-a-svelte-kit-site/ 301
 /pages/how-to/deploy-a-zola-site/ /pages/framework-guides/deploy-a-zola-site/ 301
 /pages/how-to/elderjs/ /pages/framework-guides/deploy-an-elderjs-site/ 301
 /pages/configuration/language-support-and-tools/ /pages/configuration/build-image/ 301

--- a/src/content/docs/d1/examples/d1-and-sveltekit.mdx
+++ b/src/content/docs/d1/examples/d1-and-sveltekit.mdx
@@ -19,7 +19,7 @@ import { TabItem, Tabs } from "~/components"
 
 To set up a new SvelteKit site on Cloudflare Pages that can query D1:
 
-1. **Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)**.
+1. **Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-kit-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)**.
 2. Install the Cloudflare adapter within your SvelteKit project: `npm i -D @sveltejs/adapter-cloudflare`.
 3. Bind a D1 database [to your Pages Function](/pages/functions/bindings/#d1-databases).
 4. Pass the `--d1 BINDING_NAME=DATABASE_ID` flag to `wrangler dev` when developing locally. `BINDING_NAME` should match what call in your code, and `DATABASE_ID` should match the `database_id` defined in your wrangler.toml: for example, `--d1 DB=xxxx-xxxx-xxxx-xxxx-xxxx`.

--- a/src/content/docs/d1/examples/d1-and-sveltekit.mdx
+++ b/src/content/docs/d1/examples/d1-and-sveltekit.mdx
@@ -19,7 +19,7 @@ import { TabItem, Tabs } from "~/components"
 
 To set up a new SvelteKit site on Cloudflare Pages that can query D1:
 
-1. **Refer to [the Svelte guide](/pages/framework-guides/deploy-a-svelte-kit-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)**.
+1. **Refer to [the SvelteKit guide](/pages/framework-guides/deploy-a-svelte-kit-site/) and Svelte's [Cloudflare adapter](https://kit.svelte.dev/docs/adapter-cloudflare)**.
 2. Install the Cloudflare adapter within your SvelteKit project: `npm i -D @sveltejs/adapter-cloudflare`.
 3. Bind a D1 database [to your Pages Function](/pages/functions/bindings/#d1-databases).
 4. Pass the `--d1 BINDING_NAME=DATABASE_ID` flag to `wrangler dev` when developing locally. `BINDING_NAME` should match what call in your code, and `DATABASE_ID` should match the `database_id` defined in your wrangler.toml: for example, `--d1 DB=xxxx-xxxx-xxxx-xxxx-xxxx`.

--- a/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: how-to
-title: Solid
+title: SolidStart
 ---
 
 import { Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-svelte-kit-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-svelte-kit-site.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: how-to
 title: SvelteKit
-description: Learn how to use Cloudflare's features with SvelteKit
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
@@ -5,7 +5,7 @@ title: Elder.js
 
 import { PagesBuildPreset, Render } from "~/components";
 
-[Elder.js](https://elderguide.com/tech/elderjs/) is an SEO-focused framework for building static sites with [Svelte](/pages/framework-guides/deploy-a-svelte-site/).
+[Elder.js](https://elderguide.com/tech/elderjs/) is an SEO-focused framework for building static sites with [Svelte](/pages/framework-guides/deploy-a-svelte-kit-site/).
 
 In this guide, you will create a new Elder.js application and deploy it using Cloudflare Pages.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
@@ -5,7 +5,7 @@ title: Elder.js
 
 import { PagesBuildPreset, Render } from "~/components";
 
-[Elder.js](https://elderguide.com/tech/elderjs/) is an SEO-focused framework for building static sites with [Svelte](/pages/framework-guides/deploy-a-svelte-kit-site/).
+[Elder.js](https://elderguide.com/tech/elderjs/) is an SEO-focused framework for building static sites with [SvelteKit](/pages/framework-guides/deploy-a-svelte-kit-site/).
 
 In this guide, you will create a new Elder.js application and deploy it using Cloudflare Pages.
 

--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -37,8 +37,8 @@ If you choose the "Framework Starter" option, you will be prompted to choose a f
 - [Qwik](/pages/framework-guides/deploy-a-qwik-site/)
 - [React](/pages/framework-guides/deploy-a-react-site/)
 - [Remix](/pages/framework-guides/deploy-a-remix-site/)
-- [Solid](/pages/framework-guides/deploy-a-solid-site/)
-- [Svelte](/pages/framework-guides/deploy-a-svelte-site/)
+- [SolidStart](/pages/framework-guides/deploy-a-solid-start-site/)
+- [SvelteKit](/pages/framework-guides/deploy-a-svelte-kit-site/)
 - [Vue](/pages/framework-guides/deploy-a-vue-site/)
 
 When you use a framework, `npm create cloudflare` directly uses the framework's own command for generating a new projects, which may prompt additional questions. This ensures that the project you create is up-to-date with the latest version of the framework, and you have all the same options when creating you project via `npm create cloudflare` that you would if you created your project using the framework's tooling directly.

--- a/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
+++ b/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
@@ -23,7 +23,7 @@ cloudflared version 2021.5.9 (built 2021-05-21-1541 UTC)
 
 ## Run a local service
 
-The easiest way to get up and running with Cloudflare Tunnel is to have an application running locally, such as a [React](/pages/framework-guides/deploy-a-react-site/) or [Svelte](/pages/framework-guides/deploy-a-svelte-site/) site. When you are developing an application with these frameworks, they will often make use of a `npm run develop` script, or something similar, which mounts the application and runs it on a `localhost` port. For example, the popular `vite` tool runs your in-development React application on port `5173`, making it accessible at the `http://localhost:5173` address.
+The easiest way to get up and running with Cloudflare Tunnel is to have an application running locally, such as a [React](/pages/framework-guides/deploy-a-react-site/) or [Svelte](/pages/framework-guides/deploy-a-svelte-kit-site/) site. When you are developing an application with these frameworks, they will often make use of a `npm run develop` script, or something similar, which mounts the application and runs it on a `localhost` port. For example, the popular `vite` tool runs your in-development React application on port `5173`, making it accessible at the `http://localhost:5173` address.
 
 ## Start a Cloudflare Tunnel
 

--- a/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
+++ b/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
@@ -23,7 +23,7 @@ cloudflared version 2021.5.9 (built 2021-05-21-1541 UTC)
 
 ## Run a local service
 
-The easiest way to get up and running with Cloudflare Tunnel is to have an application running locally, such as a [React](/pages/framework-guides/deploy-a-react-site/) or [Svelte](/pages/framework-guides/deploy-a-svelte-kit-site/) site. When you are developing an application with these frameworks, they will often make use of a `npm run develop` script, or something similar, which mounts the application and runs it on a `localhost` port. For example, the popular `vite` tool runs your in-development React application on port `5173`, making it accessible at the `http://localhost:5173` address.
+The easiest way to get up and running with Cloudflare Tunnel is to have an application running locally, such as a [React](/pages/framework-guides/deploy-a-react-site/) or [SvelteKit](/pages/framework-guides/deploy-a-svelte-kit-site/) site. When you are developing an application with these frameworks, they will often make use of a `npm run develop` script, or something similar, which mounts the application and runs it on a `localhost` port. For example, the popular `vite` tool runs your in-development React application on port `5173`, making it accessible at the `http://localhost:5173` address.
 
 ## Start a Cloudflare Tunnel
 


### PR DESCRIPTION
Update the C3 guides to, instead of using shortened names for the various full stack frameworks use their full official names

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

___

> [!Note]
> Not completely necessary but ideally this should be merged after https://github.com/cloudflare/workers-sdk/pull/7608 is merged