### PR TITLE
Add instructions for restoring original visitor IPs when using Caddy

### DIFF
--- a/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
+++ b/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
@@ -456,7 +456,7 @@ For more details, refer to [Custom header original IP detection extension](https
 
 ### Caddy
 
-If you are running an application behind [Caddy](https://caddyserver.com/) that relies on the `X-Forwarded-For` header, you can configure Caddy to override the header with Cloudflare's [CF-Connecting-IP header](/fundamentals/reference/http-request-headers/#cf-connecting-ip).
+If you are running an application behind [Caddy](https://caddyserver.com/) that relies on the `X-Forwarded-For` header, you can configure Caddy to override the header with Cloudflare's [CF-Connecting-IP header](/fundamentals/reference/http-headers/#cf-connecting-ip).
 
 It is advised that you also only accept traffic from [Cloudflare's IP addresses](https://www.cloudflare.com/ips/); otherwise, the header could be spoofed. That's why, in the second example, we handle this as part of the Caddy configuration. Alternatively, you can handle this at the firewall level, which is usually easier to automate. If you already have a firewall or other measure in place to ensure this, your Caddyfile could look like this:
 ```txt title="Caddyfile"

--- a/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
+++ b/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
@@ -454,6 +454,42 @@ clientIPDetection:
 
 For more details, refer to [Custom header original IP detection extension](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/http/original_ip_detection/custom_header/v3/custom_header.proto).
 
+### Caddy
+
+If you are running an application behind [Caddy](https://caddyserver.com/) that relies on the `X-Forwarded-For` header, you can configure Caddy to override the header with Cloudflare's [CF-Connecting-IP header](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip).
+
+It is advised that you also only accept traffic from [Cloudflare's IP addresses](https://www.cloudflare.com/ips/); otherwise, the header could be spoofed. That's why, in the second example, we handle this as part of the Caddy configuration. Alternatively, you can handle this at the firewall level, which is usually easier to automate. If you already have a firewall or other measure in place to ensure this, your Caddyfile could look like this:
+```txt title="Caddyfile"
+https://example.com {
+    reverse_proxy localhost:8080 {
+				# Sets X-Forwarded-For as the value Cloudflare gives us for CF-Connecting-IP.
+				header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
+		}
+}
+```
+
+If you want Caddy to handle only accepting traffic from [Cloudflare's IP addresses](https://www.cloudflare.com/ips/), you can use a configuration like this one:
+```txt title="Caddyfile"
+https://example.com {
+    # Restrict access to Cloudflare IPs (https://www.cloudflare.com/ips/)
+    @cloudflare {
+        remote_ip 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
+    }
+
+    # Process requests from Cloudflare IPs
+    handle @cloudflare {
+        reverse_proxy localhost:8080 {
+            # Sets X-Forwarded-For as the value Cloudflare gives us for CF-Connecting-IP.
+            header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
+        }
+    }
+
+    # Deny requests from non-Cloudflare IPs
+    handle {
+        respond "Access Denied" 403
+    }
+}
+```
 ---
 
 ## Related Resources

--- a/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
+++ b/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
@@ -456,7 +456,7 @@ For more details, refer to [Custom header original IP detection extension](https
 
 ### Caddy
 
-If you are running an application behind [Caddy](https://caddyserver.com/) that relies on the `X-Forwarded-For` header, you can configure Caddy to override the header with Cloudflare's [CF-Connecting-IP header](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip).
+If you are running an application behind [Caddy](https://caddyserver.com/) that relies on the `X-Forwarded-For` header, you can configure Caddy to override the header with Cloudflare's [CF-Connecting-IP header](/fundamentals/reference/http-request-headers/#cf-connecting-ip).
 
 It is advised that you also only accept traffic from [Cloudflare's IP addresses](https://www.cloudflare.com/ips/); otherwise, the header could be spoofed. That's why, in the second example, we handle this as part of the Caddy configuration. Alternatively, you can handle this at the firewall level, which is usually easier to automate. If you already have a firewall or other measure in place to ensure this, your Caddyfile could look like this:
 ```txt title="Caddyfile"


### PR DESCRIPTION
### Summary

This adds a section to the [Restoring Visitor IPs](https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/ ) documentation for the [Caddy](https://caddyserver.com/) web server/reverse proxy.

Caddy is an increasingly popular alternative to Nginx and Apache which already have guides on there so I figured as I had to do my research to be able to handle the problem, that I'd share my solution with other users potentially seeking to solve the same problem.

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/a8153569-7e61-45a6-816d-8f027d2dd823)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
