### PR TITLE
[Docs Site] Hide Cursor illustration on small-medium viewports

### DIFF
--- a/src/pages/workers/ai.astro
+++ b/src/pages/workers/ai.astro
@@ -8,7 +8,7 @@ import CursorLight from "~/assets/images/workers/ai/cursor-light.png";
 
 <StarlightPage frontmatter={{ title: "AI Assistant", tableOfContents: false }}>
 	<section id="assistant-header">
-		<div class="not-content">
+		<div class="not-content max-lg:hidden">
 			<Image
 				src={CursorDark}
 				alt="Cursor illustration"
@@ -24,9 +24,14 @@ import CursorLight from "~/assets/images/workers/ai/cursor-light.png";
 		</div>
 		<div id="text">
 			<h1>
-				<div class="illustration"></div>
 				Meet your AI assistant, Cursor
-				<div class="alpha">AI Preview</div>
+				<div>
+					<span
+						class="ml-1 rounded-full bg-orange-200 px-2 py-0.5 text-xs text-orange-900"
+					>
+						AI Preview
+					</span>
+				</div>
 			</h1>
 			<p>
 				Cursor is an experimental AI assistant, trained to answer questions


### PR DESCRIPTION
### Summary

Hides Cursor illustration on small-medium viewports and updates the `AI Preview` pill.

### Screenshots (optional)

<img width="341" alt="image" src="https://github.com/user-attachments/assets/295e9d1a-3d5b-4a9e-9322-2cdc61e3bdbf" />
