### PR TITLE
Add deprecation notice for resolver.cloudflare-eth.com

### DIFF
--- a/src/content/changelogs/api-deprecations.yaml
+++ b/src/content/changelogs/api-deprecations.yaml
@@ -5,6 +5,17 @@ productLink: "/fundamentals/"
 productArea: Core platform
 productAreaLink: /fundamentals/reference/changelog/platform/
 entries:
+  - publish_date: "2025-07-01"
+    title: Cloudflare DWeb Resolver
+    description: |-
+      Deprecation date: July 1, 2025
+      
+      The Cloudflare DWeb Resolver experiment is ending.
+      
+      Deprecated APIs:
+      
+      - DoH resolver on resolver.cloudflare-eth.com
+
   - publish_date: "2025-03-23"
     title: "Eligible Zones For Account Custom Nameservers"
     description: |-


### PR DESCRIPTION
### Summary
resolver.cloudflare-eth.com was setup as part of the distributed name resolver experiment.
The experiment is ending, and we are deprecating the associated DoH resolver.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
