### PR TITLE
[API Shield] Minor tweaks to Transform Rules section

### DIFF
--- a/src/content/docs/api-shield/security/jwt-validation/transform-rules.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/transform-rules.mdx
@@ -26,12 +26,12 @@ lookup_json_string(http.request.jwt.claims["<TOKEN_CONFIGURATION_ID>"][0], "clai
 
 ## Create a Transform Rule
 
-As an example, to send the header `x-send-jwt-claim-user` request header to the origin, you must create a Transform Rule:
+As an example, to send the `x-send-jwt-claim-user` request header to the origin, you must create a Transform Rule:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account and domain.
 2. Go to **Rules** > **Transform Rules**.
 3. Select **Modify Request Header** > **Create rule**.
 4. Enter a rule name and a filter expression, if applicable.
 5. Choose **Set dynamic**.
-6. Set the header name.
+6. Set the header name to `x-send-jwt-claim-user`.
 7. Set the value to `lookup_json_string(http.request.jwt.claims["<TOKEN_CONFIGURATION_ID>"][0], "claim_name")`, where `<TOKEN_CONFIGURATION_ID>` is your token configuration ID found in JWT Validation and `claim_name` is the [JWT claim](/ruleset-engine/rules-language/fields/dynamic-fields/#json-web-tokens-validation-claims) you want to add to the header.


### PR DESCRIPTION
### Summary

Removes repeated word.
Specifies header name according to example intro.
