### PR TITLE
[Workers] Document preview_urls config

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -65,9 +65,42 @@ You must press enter after you input your Application domain for it to save. You
 10. Go to the next page.
 11. Add application.
 
-## Making Preview URLs inaccessible
+## Disabling Preview URLs
 
-Preview URLs run on your [`workers.dev` subdomain](/workers/configuration/routing/workers-dev/). To make preview URLs inaccessible, you must disable your Workers `workers.dev` subdomain. Learn how to [disable your Workers `workers.dev` subdomain](/workers/configuration/routing/workers-dev/#disabling-workersdev).
+### Disabling Preview URLs in the dashboard
+
+To disable the `workers.dev` route for a Worker:
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
+2. Go to **Workers & Pages** and in **Overview**, select your Worker.
+3. Go to **Settings** > **Domains & Routes**.
+4. On "Preview URLs" click "Disable".
+5. Confirm you want to disable.
+
+### Disabling Preview URLs in `wrangler.toml`
+
+::note
+Wrangler 3.91.0 or higher is required to use this feature.
+::
+
+To disable Preview URLs for a Worker, include the following in your Worker's `wrangler.toml` file:
+
+import { WranglerConfig } from "~/components";
+
+<WranglerConfig>
+
+```toml
+preview_urls = false
+```
+
+</WranglerConfig>
+
+When you redeploy your Worker with this change, Preview URLs will be disabled.
+
+:::caution
+
+If you disable Preview URLs in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `preview_urls = false`, then Preview URLs will be re-enabled the next time you publish your Worker with wrangler.
+:::
 
 ## Limitations
 

--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -69,7 +69,7 @@ You must press enter after you input your Application domain for it to save. You
 
 ### Disabling Preview URLs in the dashboard
 
-To disable the `workers.dev` route for a Worker:
+To disable Preview URLs for a Worker:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **Workers & Pages** and in **Overview**, select your Worker.
@@ -79,9 +79,9 @@ To disable the `workers.dev` route for a Worker:
 
 ### Disabling Preview URLs in `wrangler.toml`
 
-::note
+:::note
 Wrangler 3.91.0 or higher is required to use this feature.
-::
+:::
 
 To disable Preview URLs for a Worker, include the following in your Worker's `wrangler.toml` file:
 
@@ -99,7 +99,7 @@ When you redeploy your Worker with this change, Preview URLs will be disabled.
 
 :::caution
 
-If you disable Preview URLs in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `preview_urls = false`, then Preview URLs will be re-enabled the next time you publish your Worker with wrangler.
+If you disable Preview URLs in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `preview_urls = false`, then Preview URLs will be re-enabled the next time you deploy your Worker with Wrangler.
 :::
 
 ## Limitations

--- a/src/content/docs/workers/configuration/routing/routes.mdx
+++ b/src/content/docs/workers/configuration/routing/routes.mdx
@@ -43,8 +43,8 @@ To set up a route in the dashboard:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **Workers & Pages** and in **Overview**, select your Worker.
-3. Go to **Settings** > **Triggers** > **Routes** > **Add route**.
-4. Enter the route and select the zone it applies to.
+3. Go to **Settings** > **Domains & Routes** > **Add** > **Route**.
+4. Select the zone and enter the route pattern.
 5. Select **Add route**.
 
 ### Set up a route in `wrangler.toml`

--- a/src/content/docs/workers/configuration/routing/workers-dev.mdx
+++ b/src/content/docs/workers/configuration/routing/workers-dev.mdx
@@ -43,13 +43,13 @@ workers_dev = false
 
 </WranglerConfig>
 
-When you redeploy your Worker with this change, the `workers.dev` route will be disabled. Disabling your `workers.dev` route not disable Preview URLs. Learn how to [disable Preview URLs](/workers/configuration/previews/#disabling-preview-urls).
+When you redeploy your Worker with this change, the `workers.dev` route will be disabled. Disabling your `workers.dev` route does not disable Preview URLs. Learn how to [disable Preview URLs](/workers/configuration/previews/#disabling-preview-urls).
 
 If you do not specify `workers_dev = false` but add a [`routes` component](/workers/wrangler/configuration/#routes) to your `wrangler.toml`, the value of `workers_dev` will be inferred as `false` on the next deploy.
 
 :::caution
 
-If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you publish your Worker with wrangler.
+If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you publish your Worker with Wrangler.
 :::
 
 ## Limitations

--- a/src/content/docs/workers/configuration/routing/workers-dev.mdx
+++ b/src/content/docs/workers/configuration/routing/workers-dev.mdx
@@ -49,7 +49,7 @@ If you do not specify `workers_dev = false` but add a [`routes` component](/work
 
 :::caution
 
-If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you publish your Worker with Wrangler.
+If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you deploy your Worker with Wrangler.
 :::
 
 ## Limitations

--- a/src/content/docs/workers/configuration/routing/workers-dev.mdx
+++ b/src/content/docs/workers/configuration/routing/workers-dev.mdx
@@ -19,7 +19,17 @@ All Workers are assigned a `workers.dev` route when they are created or renamed 
 
 ## Disabling `workers.dev`
 
-Review your `workers.dev` route in your Worker > **Settings** > **Domains & Routes**.
+### Disabling `workers.dev` in the dashboard
+
+To disable the `workers.dev` route for a Worker:
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
+2. Go to **Workers & Pages** and in **Overview**, select your Worker.
+3. Go to **Settings** > **Domains & Routes**.
+4. On `workers.dev` click "Disable".
+5. Confirm you want to disable.
+
+### Disabling `workers.dev` in `wrangler.toml`
 
 To disable the `workers.dev` route for a Worker, include the following in your Worker's `wrangler.toml` file:
 
@@ -33,13 +43,13 @@ workers_dev = false
 
 </WranglerConfig>
 
-When you redeploy your Worker with this change, the `workers.dev` route will be disabled. Disabling your `workers.dev` subdomain will also make [preview URLs](/workers/configuration/previews) inaccessible.
+When you redeploy your Worker with this change, the `workers.dev` route will be disabled. Disabling your `workers.dev` route not disable Preview URLs. Learn how to [disable Preview URLs](/workers/configuration/previews/#disabling-preview-urls).
 
 If you do not specify `workers_dev = false` but add a [`routes` component](/workers/wrangler/configuration/#routes) to your `wrangler.toml`, the value of `workers_dev` will be inferred as `false` on the next deploy.
 
 :::caution
 
-If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will re-enable the next time you publish your Worker.
+If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's `wrangler.toml` file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you publish your Worker with wrangler.
 :::
 
 ## Limitations

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -113,7 +113,11 @@ At a minimum, the `name`, `main` and `compatibility_date` keys are required to d
 
 - `workers_dev` <Type text="boolean" /> <MetaInfo text="optional" />
 
-  - Enables use of `*.workers.dev` subdomain to test and deploy your Worker. If you have a Worker that is only for `scheduled` events, you can set this to `false`. Defaults to `true`.
+  - Enables use of `*.workers.dev` subdomain to deploy your Worker. If you have a Worker that is only for `scheduled` events, you can set this to `false`. Defaults to `true`. Refer to [types of routes](#types-of-routes).
+
+- `preview_urls` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  - Enables use of Preview URLs to test your Worker. Defaults to `true`. Refer to [Preview URLs](/workers/configuration/previews).
 
 - `route` <Type text="Route" /> <MetaInfo text="optional" />
 


### PR DESCRIPTION
### Summary

Preview URL (beta) config was split from `workers.dev` in https://github.com/cloudflare/workers-sdk/pull/7227 but never documented.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

ps. I rediscovered https://github.com/cloudflare/cloudflare-docs/pull/18173 after making this pr. We can merge either?