### PR TITLE
[Docs Site] Fix fetch-depth and last updated on pages with updated frontmatter.

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,6 +15,8 @@ jobs:
     name: Publish Preview
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -11,6 +11,8 @@ jobs:
     name: Publish Production
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -152,6 +152,7 @@ export default defineConfig({
 				Footer: "./src/components/overrides/Footer.astro",
 				Head: "./src/components/overrides/Head.astro",
 				Hero: "./src/components/overrides/Hero.astro",
+				LastUpdated: "./src/components/overrides/LastUpdated.astro",
 				MarkdownContent: "./src/components/overrides/MarkdownContent.astro",
 				Sidebar: "./src/components/overrides/Sidebar.astro",
 				PageSidebar: "./src/components/overrides/PageSidebar.astro",

--- a/src/components/overrides/LastUpdated.astro
+++ b/src/components/overrides/LastUpdated.astro
@@ -1,0 +1,12 @@
+---
+import type { Props } from "@astrojs/starlight/props";
+import Default from "@astrojs/starlight/components/LastUpdated.astro";
+
+// Disable lastUpdated in footer if `updated` is present,
+// since this will show the date in PageTitle.astro instead.
+if (Astro.props.entry.data.updated) {
+	Astro.props.lastUpdated = undefined;
+}
+---
+
+<Default {...Astro.props} />


### PR DESCRIPTION
### Summary

Fix fetch-depth and last updated on pages with updated frontmatter.

This shows the real last updated times (vs. the time of build) as well as removes the duplicate dates on pages with explicit `updated` frontmatter dates.