### PR TITLE
[DNS] The max number of linked peers per zone

### DIFF
--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
@@ -85,6 +85,10 @@ To create a peer DNS server using the API, send a [POST](/api/resources/dns/subr
 
 If you previously [created a peer DNS server](#2-create-peer-dns-server-optional), you should link it to your primary zone.
 
+:::note
+<Render file="linked-peers-limit" />
+:::
+
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 To link a primary zone to a peer using the dashboard:
@@ -104,10 +108,6 @@ To link a primary zone to a peer using the API, send a [POST](/api/resources/dns
 
 :::caution[Multiple peers and TSIG]
 If you link more than one peer to a zone and at least one of them has TSIG configured, all peers are expected to also use the same TSIG.
-:::
-
-:::note[The max number of linked peers per zone]
-You cannot have more than 30 peers linked to the zone.
 :::
 
 ## 4. Update your secondary DNS provider

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
@@ -106,6 +106,10 @@ To link a primary zone to a peer using the API, send a [POST](/api/resources/dns
 If you link more than one peer to a zone and at least one of them has TSIG configured, all peers are expected to also use the same TSIG.
 :::
 
+:::note[The max number of linked peers per zone]
+You cannot have more than 30 peers linked to the zone.
+:::
+
 ## 4. Update your secondary DNS provider
 
 Your secondary DNS provider should send zone transfer requests (via AXFR or IXFR) to [this IP](/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses/#transfer-ip) on port 53 and from the IP address specified in your [peer configuration](#2-create-peer-dns-server-optional).

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
@@ -81,6 +81,9 @@ To create a secondary zone using the dashboard:
    Cloudflare will not use the REFRESH value inside the SOA record that is served by your primary provider. Instead the value of zone refresh configured for your secondary zone on Cloudflare will be used to determine the interval after which the SOA serial of the primary zone will be checked for changes.
    :::
 7. Select the peer server you [previously created](#2-create-peer-server). If needed, you can link more than one peer server to a zone.
+   :::note[The max number of linked peers per zone]
+   You cannot have more than 30 peers linked to the zone.
+   :::
 8. Click **Continue**.
 9. Review the list of transferred records and click **Continue**.
    :::note

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
@@ -81,8 +81,8 @@ To create a secondary zone using the dashboard:
    Cloudflare will not use the REFRESH value inside the SOA record that is served by your primary provider. Instead the value of zone refresh configured for your secondary zone on Cloudflare will be used to determine the interval after which the SOA serial of the primary zone will be checked for changes.
    :::
 7. Select the peer server you [previously created](#2-create-peer-server). If needed, you can link more than one peer server to a zone.
-   :::note[The max number of linked peers per zone]
-   You cannot have more than 30 peers linked to the zone.
+   :::note
+   <Render file="linked-peers-limit" />
    :::
 8. Click **Continue**.
 9. Review the list of transferred records and click **Continue**.

--- a/src/content/docs/dns/zone-setups/zone-transfers/index.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/index.mdx
@@ -9,6 +9,8 @@ head:
 
 ---
 
+import { Render } from "~/components";
+
 To increase availability and fault tolerance, you can use one or more DNS provider(s) alongside Cloudflare in case one provider becomes unavailable (known as a [peer DNS server](#peer-dns-server)). Your providers will then transfer DNS records between themselves using authoritative ([AXFR](https://datatracker.ietf.org/doc/html/rfc5936)) or incremental ([IXFR](https://datatracker.ietf.org/doc/html/rfc1995)) zone transfers.
 
 With AXFR, the entire zone will be transferred from the primary to the secondary provider, even if only one record changes. With IXFR, only the changes will be transferred. Cloudflare supports both protocols.
@@ -21,6 +23,8 @@ With zone transfers, you have two configuration options:
 ## Peer DNS server
 
 Peer DNS servers can be used as primary and secondary external DNS servers. The same peer can be linked to multiple primary and secondary zones. Each peer can be associated with only one Transaction Signature (TSIG).
+
+<Render file="linked-peers-limit" />
 
 You can manage peers via the [API](/api/resources/dns/subresources/zone_transfers/subresources/peers/methods/list/) or the dashboard by going to **Manage Account** > **Configurations** > **DNS Zone Transfers**.
 

--- a/src/content/partials/dns/linked-peers-limit.mdx
+++ b/src/content/partials/dns/linked-peers-limit.mdx
@@ -1,0 +1,6 @@
+---
+{}
+
+---
+
+The maximum number of linked peers per zone is 30.


### PR DESCRIPTION
PCX-15247
--
The max number of linked peers per zone.
You cannot have more than 30 peers linked to the zone. 