### PR TITLE
chore: drop deprecated `@types/dompurify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 				"@iarna/toml": "^2.2.5",
 				"@iconify-json/material-symbols": "^1.2.12",
 				"@stoplight/json-schema-tree": "^4.0.0",
-				"@types/dompurify": "^3.2.0",
 				"@types/hast": "^3.0.4",
 				"@types/he": "^1.2.3",
 				"@types/node": "^22.10.5",
@@ -6031,16 +6030,6 @@
 			"resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.1.tgz",
 			"integrity": "sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==",
 			"dev": true
-		},
-		"node_modules/@types/dompurify": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-			"integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-			"deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"dompurify": "*"
-			}
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 		"@iarna/toml": "^2.2.5",
 		"@iconify-json/material-symbols": "^1.2.12",
 		"@stoplight/json-schema-tree": "^4.0.0",
-		"@types/dompurify": "^3.2.0",
 		"@types/hast": "^3.0.4",
 		"@types/he": "^1.2.3",
 		"@types/node": "^22.10.5",


### PR DESCRIPTION
### Summary

As indicated by build logs:

```
 WARN  deprecated @types/dompurify@3.2.0: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
```

`dompurify` does not need type definition any more.
