### PR TITLE
[Workers] Clarify service binding pricing for deprecated usage models

### DIFF
--- a/src/content/docs/workers/platform/pricing.mdx
+++ b/src/content/docs/workers/platform/pricing.mdx
@@ -101,7 +101,7 @@ If you had a Worker on the Bundled usage model prior to the migration to Standar
 
 :::note
 
-Some Workers Enterprise customers maintain the ability to change usage models. 
+Some Workers Enterprise customers maintain the ability to change usage models.
 
 Usage models may be changed at the individual Worker level:
 
@@ -202,7 +202,7 @@ For example, if Worker A makes a subrequest to Worker B via a Service Binding, o
 - The total amount of CPU time used across both Worker A and Worker B
 
 :::note[Only available on Workers Standard pricing]
-If your Worker is on the deprecated [Bundled](/workers/platform/pricing/#example-pricing-bundled-usage-model) or [Unbound](/workers/platform/pricing/#example-pricing-unbound-usage-model) pricing plans, subrequests and RPC calls made via Service Bindings are charged as if they are request from the Internet. In the example above, you would be charged for two requests, one to Worker A, and one to Worker B.
+If your Worker is on the deprecated Bundled or Unbound pricing plans, incoming requests from Service Bindings are charged the same as requests from the Internet. In the example above, you would be charged for two requests, one to Worker A, and one to Worker B.
 :::
 
 ## Fine Print


### PR DESCRIPTION
- Customer was reading current documentation as "subrequests ... are charged as if they are requests from the Internet"
  - This isn't true, we never charge for subrequests
- Reword to clarify that _incoming_ requests from service bindings are what we're charging for
- Remove dead links to old usage model docs

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
