### PR TITLE
Removed confusing self-referential link

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -10,7 +10,7 @@ description: Facilitate Worker-to-Worker communication.
 
 ## About Service bindings
 
-Service bindings allow one worker to call into another, without going through a publicly-accessible URL. A Service binding allows Worker A to call a method on Worker B, or to forward a request from Worker A to Worker B.
+Service bindings allow one Worker to call into another, without going through a publicly-accessible URL. A Service binding allows Worker A to call a method on Worker B, or to forward a request from Worker A to Worker B.
 
 Service bindings provide the separation of concerns that microservice or service-oriented architectures provide, without configuration pain, performance overhead or need to learn RPC protocols.
 

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -10,7 +10,7 @@ description: Facilitate Worker-to-Worker communication.
 
 ## About Service bindings
 
-[Service bindings](/workers/runtime-apis/bindings/service-bindings/) allow one worker to call into another, without going through a publicly-accessible URL. A Service binding allows Worker A to call a method on Worker B, or to forward a request from Worker A to Worker B.
+Service bindings allow one worker to call into another, without going through a publicly-accessible URL. A Service binding allows Worker A to call a method on Worker B, or to forward a request from Worker A to Worker B.
 
 Service bindings provide the separation of concerns that microservice or service-oriented architectures provide, without configuration pain, performance overhead or need to learn RPC protocols.
 


### PR DESCRIPTION
### Summary

The self-referential link was confusing, as it appeared to lead to a different page but redirected to the same one. Updated the link behavior to improve user navigation and provide a clearer experience.

### Screenshots (optional)

<img width="788" alt="image" src="https://github.com/user-attachments/assets/8ed08e8c-c67a-428f-844f-60af80387b22" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
