### PR TITLE
[Docs Site] Fix isCurrent sidebar item on custom pages and nested hideChildren pages

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -95,7 +95,7 @@ async function handleGroup(group: Group): Promise<SidebarEntry> {
 			label: group.label,
 			order: group.order,
 			attrs: {},
-			isCurrent: indexLink.href.slice(1, -1) === Astro.params.slug,
+			isCurrent: Astro.url.pathname.startsWith(indexLink.href),
 		} as Link;
 	}
 


### PR DESCRIPTION
### Summary

Fix isCurrent sidebar item on custom pages and nested hideChildren pages.

`Astro.params.slug` is `undefined` on custom pages, such as those used by Workers AI models.

Some pages do not exist on the sidebar, i.e those in a `hideChildren` folder, and this will still highlight the parent page.

### Screenshots (optional)

Before:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/344947be-01ac-4bea-92a9-c83615be19ca" />
<img width="786" alt="image" src="https://github.com/user-attachments/assets/f146ce6d-a775-4173-8b76-a6c9458d5a2a" />

After:
![image](https://github.com/user-attachments/assets/4159e12d-704b-4abf-9ca3-8bf89890a7e0)
![image](https://github.com/user-attachments/assets/a9e2f717-d05d-4668-9607-1eaf0d832cf7)