### PR TITLE
Clarifying anycast vs local prefixes

### DIFF
--- a/src/content/docs/network-interconnect/classic-cni/set-up/configure-bgp-bfd.mdx
+++ b/src/content/docs/network-interconnect/classic-cni/set-up/configure-bgp-bfd.mdx
@@ -36,7 +36,7 @@ If you have a virtual link via Megaport, the IP provisioning may fail if you hav
 
 After you provision the IPs and the ping tests confirm the connection, accept the routes from the BGP session Cloudflare configured. Configuring the BGP session on both the Cloudflare and user sides requires a BGP call and an approximately two hour maintenance window that you provide to Cloudflare.
 
-Cloudflare advertises all of its available anycast prefixes including [BYOIP](/byoip/) prefixes over CNI, but this can exclude other location-specific prefixes that may not be available at that datacenter, and the BGP session occurs over a private link from Cloudflare to the customer data center.
+Cloudflare advertises all of its available anycast prefixes, including [BYOIP](/byoip/) prefixes, over a private CNI link between Cloudflare and the customer data center. However, this can exclude other location-specific prefixes that may not be available at that datacenter.
 
 :::note
 Your CNI needs to accept all of Cloudflare's prefixes to ensure it is fully utilized, and traffic routed from the data centers back to the CNI is secure, fast, and reliable.

--- a/src/content/docs/network-interconnect/classic-cni/set-up/configure-bgp-bfd.mdx
+++ b/src/content/docs/network-interconnect/classic-cni/set-up/configure-bgp-bfd.mdx
@@ -36,7 +36,7 @@ If you have a virtual link via Megaport, the IP provisioning may fail if you hav
 
 After you provision the IPs and the ping tests confirm the connection, accept the routes from the BGP session Cloudflare configured. Configuring the BGP session on both the Cloudflare and user sides requires a BGP call and an approximately two hour maintenance window that you provide to Cloudflare.
 
-Cloudflare advertises all of its anycast prefixes including [BYOIP](/byoip/) prefixes over CNI, but the process occurs over a private link from Cloudflare to the customer data center.
+Cloudflare advertises all of its available anycast prefixes including [BYOIP](/byoip/) prefixes over CNI, but this can exclude other location-specific prefixes that may not be available at that datacenter, and the BGP session occurs over a private link from Cloudflare to the customer data center.
 
 :::note
 Your CNI needs to accept all of Cloudflare's prefixes to ensure it is fully utilized, and traffic routed from the data centers back to the CNI is secure, fast, and reliable.


### PR DESCRIPTION
### Summary

Clarified the difference between anycast prefixes and local prefixes.

The documentation was correct as is, because it indicated anycast prefixes explicitly. This just further clarifies that local prefixes can potentially not be available due to being associated with a specific location.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.