### PR TITLE
Fix aws-sdk-js-v3 code example for version 3.729.0 or later

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -26,6 +26,8 @@ const S3 = new S3Client({
 		accessKeyId: ACCESS_KEY_ID,
 		secretAccessKey: SECRET_ACCESS_KEY,
 	},
+	requestChecksumCalculation: 'WHEN_REQUIRED',
+	responseChecksumValidation: 'WHEN_REQUIRED'
 });
 
 console.log(await S3.send(new ListBucketsCommand({})));


### PR DESCRIPTION
### Summary

The latest release of `@aws-sdk/client-s3` (3.729.0) introduced a breaking change with R2. Many commands, such as `PutObject` are now failing with error `501: NotImplemented: Header 'x-amz-checksum-crc32' with value (***) not implemented` because AWS is now enforcing checksums.

The workaround is to set the `requestChecksumCalculation` and `responseChecksumValidation` properties to `WHEN_REQUIRED` when initializing the client.

It would be best if Cloudflare could support this new header as there's no telling how long AWS will allow this setting to be disabled.

See https://github.com/aws/aws-sdk-js-v3/issues/6810 for more info.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.