### PR TITLE
workflows: document payload size

### DIFF
--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -21,11 +21,12 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum persisted state per step          | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum event [payload size](/workflows/build/events-and-parameters/) | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum state that can be persisted per Workflow instance | 100MB | 1GB |
-| Maximum length of a Workflow ID [^4]         | 64 characters | 64 characters |
+| Maximum length of a Workflow ID [^4]      | 64 characters | 64 characters |
 | Maximum `step.sleep` duration             | 365 days (1 year) [^1] | 365 days (1 year) [^1] |
 | Maximum steps per Workflow [^5]           | 1024 [^1] | 1024 [^1] |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |
 | Concurrent Workflow instances (executions) per account   | 25 | 100 [^1] |
+| Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 [^1] | 100,000 [^1] | 
 | Retention limit for completed Workflow state | 3 days | 30 days [^2] |
 | Maximum length of a Workflow ID [^4]         | 64 characters | 64 characters |
 

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -19,7 +19,9 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Compute time per step [^3]                | 10 seconds | 30 seconds of [active CPU time](/workers/platform/limits/#cpu-time) |
 | Duration (wall clock) per step [^3]       | Unlimited | Unlimited - for example, waiting on network I/O calls or querying a database |
 | Maximum persisted state per step          | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
+| Maximum event [payload size](/workflows/build/events-and-parameters/) | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum state that can be persisted per Workflow instance | 100MB | 1GB |
+| Maximum length of a Workflow ID [^4]         | 64 characters | 64 characters |
 | Maximum `step.sleep` duration             | 365 days (1 year) [^1] | 365 days (1 year) [^1] |
 | Maximum steps per Workflow [^5]           | 1024 [^1] | 1024 [^1] |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |


### PR DESCRIPTION
This PR:

- [x] Documents the 1MiB (fixed bug that capped at 128KB) payload limit
- [x] The maximum number of queued instances for a given Workflow (beta)

