### PR TITLE
[Docs] Use ubuntu-22.04 image for API crawler

### DIFF
--- a/.github/workflows/api-links-crawl.yml
+++ b/.github/workflows/api-links-crawl.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   compile:
     name: Compiles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Summary

Got [an error](https://github.com/cloudflare/cloudflare-docs/actions/runs/12816585634/job/35737869751#step:7:9) after updating the crawler to work with the new API reference site:

```
Error: Failed to launch the browser process!
[2031:2031:0116/1[9](https://github.com/cloudflare/cloudflare-docs/actions/runs/12816585634/job/35737869751#step:7:10)5750.719457:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

Regular puppeteer installations have some issues in Ubuntu 24.04 (`ubuntu-latest`). 
Switching to the previous Ubuntu version for a quick fix.

Context:
https://github.com/puppeteer/puppeteer/issues/12818
