### PR TITLE
[Docs Site] Use |= instead of ^= in footnotes fnref selector

### DIFF
--- a/src/scripts/footnotes.ts
+++ b/src/scripts/footnotes.ts
@@ -10,7 +10,7 @@ if (footnotes) {
 			const content = note.querySelector("p") as HTMLParagraphElement;
 
 			const fnrefs = document.querySelectorAll<HTMLAnchorElement>(
-				`a[id^='${note.id.replace("fn", "fnref")}']`,
+				`a[id|='${note.id.replace("fn", "fnref")}']`,
 			);
 
 			for (const fnref of fnrefs) {


### PR DESCRIPTION
### Summary

Use |= instead of ^= in footnotes fnref selector.

`^=` matches `1` and `1-1`, as desired, but also `11` which we don't want. `|=` will only match `1` and `1-1`.