### PR TITLE
[Docs] Update sitemap URL in API link crawler script

### DIFF
--- a/bin/crawl-api-links.js
+++ b/bin/crawl-api-links.js
@@ -28,7 +28,7 @@ async function checkLinks() {
 		else request.continue();
 	});
 
-	const sitemapUrl = "https://developers.cloudflare.com/sitemap.xml";
+	const sitemapUrl = "https://developers.cloudflare.com/sitemap-index.xml";
 	await page.goto(sitemapUrl, { timeout: navigationTimeout });
 
 	const sitemapLinks = await page.$$eval("url loc", (elements) =>


### PR DESCRIPTION
### Summary

Updates the sitemap URL — puppeteer doesn't seem to be following the redirect from `sitemap.xml` to `sitemap-index.xml`.
