### PR TITLE
[Images]Update troubleshooting.mdx

### DIFF
--- a/src/content/docs/images/reference/troubleshooting.mdx
+++ b/src/content/docs/images/reference/troubleshooting.mdx
@@ -51,6 +51,7 @@ When resizing fails, the response body contains an error message explaining the 
 
 * Maximum image size is 100 megapixels (meaning 10.000×10.000 pixels large). Maximum file size is 100 MB. GIF/WebP animations are limited to 50 megapixels total (sum of sizes of all frames).
 * Image Resizing is not compatible with [Bringing Your Own IPs (BYOIP)](/byoip/).
+* When Polish can't optimize an image the Response Header `Warning: cf-images 299 "original is smaller"` is returned.
 
 ***
 


### PR DESCRIPTION
Hello team, 

### Summary

Can we publicly document the following?

* Sometimes when Polish can't optimize an image and the original is still smaller,  the Response Header `Warning: cf-images 299 "original is smaller"` is returned.

Sample URL:

https://editorialist.com/thumbnail/600/2025/1/034/032/300/34032300~white_1736188056063_0.webp?width=100&quality=100

<img width="1270" alt="Screenshot 2025-01-17 at 14 36 16" src="https://github.com/user-attachments/assets/ec754f95-26f4-4f9e-a1f8-545b13d5c511" />



Thanks!