### PR TITLE
r2: clarify bucket ops limits

### DIFF
--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -18,7 +18,7 @@ import { Render } from "~/components";
 | Maximum upload parts                                                | 10,000                       |
 
 <sup>1</sup> Bucket management operations include creating, deleting, listing,
-and configuring buckets.
+and configuring buckets. This limit does _not_ apply to reading or writing objects to a bucket.
 <br /> <sup>2</sup> The object size limit is 5 GiB less than 5 TiB, so 4.995
 TiB.
 <br /> <sup>3</sup> The max upload size is 5 MiB less than 5 GiB, so 4.995 GiB.


### PR DESCRIPTION
Clarify that R2 bucket ops limits do not apply to reads/writes.