### PR TITLE
Add clarification on onRequest call fall-through

### DIFF
--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -14,7 +14,7 @@ The following methods can be used to configure your Pages Function.
 
 ### `onRequests`
 
-`onRequest` will be called unless a more specific `onRequestVerb` method is exported. For example, if both `onRequest` and `onRequestGet` are exported, only `onRequestGet` will be called for `GET` requests.
+The `onRequest` method will be called unless a more specific `onRequestVerb` method is exported. For example, if both `onRequest` and `onRequestGet` are exported, only `onRequestGet` will be called for `GET` requests.
 
 * <code>onRequest(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
   * This function will be invoked on all requests no matter what the request method is, as long as no specific request verb (like one of the methods below) is exported. It also won't be invoked if `next(context.request)` is called from a `onRequestVerb` function.

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -14,7 +14,7 @@ The following methods can be used to configure your Pages Function.
 
 ### `onRequests`
 
-`onRequest` will be called *unless* a more specific `onRequestVerb` method is exported. For example if both `onRequest` and `onRequestGet` are exported, the `onRequest` method will not be called for matching `GET` requests.
+`onRequest` will be called unless a more specific `onRequestVerb` method is exported. For example, if both `onRequest` and `onRequestGet` are exported, only `onRequestGet` will be called for `GET` requests.
 
 * <code>onRequest(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
   * This function will be invoked on all requests no matter the request method, if no specific request verb method below is exported. It will not be called if `next(context.request)` is called from a `onRquestVerb function`.

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -17,7 +17,7 @@ The following methods can be used to configure your Pages Function.
 `onRequest` will be called unless a more specific `onRequestVerb` method is exported. For example, if both `onRequest` and `onRequestGet` are exported, only `onRequestGet` will be called for `GET` requests.
 
 * <code>onRequest(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
-  * This function will be invoked on all requests no matter the request method, if no specific request verb method below is exported. It will not be called if `next(context.request)` is called from a `onRquestVerb function`.
+  * This function will be invoked on all requests no matter what the request method is, as long as no specific request verb (like one of the methods below) is exported. It also won't be invoked if `next(context.request)` is called from a `onRequestVerb` function.
 * <code>onRequestGet(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
   * This function will be invoked on all `GET` requests.
 * <code>onRequestPost(context[EventContext](#eventcontext))</code> Response | Promise\<Response>

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -17,7 +17,7 @@ The following methods can be used to configure your Pages Function.
 The `onRequest` method will be called unless a more specific `onRequestVerb` method is exported. For example, if both `onRequest` and `onRequestGet` are exported, only `onRequestGet` will be called for `GET` requests.
 
 * <code>onRequest(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
-  * This function will be invoked on all requests no matter what the request method is, as long as no specific request verb (like one of the methods below) is exported. It also won't be invoked if `next(context.request)` is called from a `onRequestVerb` function.
+  * This function will be invoked on all requests no matter what the request method is, as long as no specific request verb (like one of the methods below) is exported.
 * <code>onRequestGet(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
   * This function will be invoked on all `GET` requests.
 * <code>onRequestPost(context[EventContext](#eventcontext))</code> Response | Promise\<Response>

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -14,10 +14,10 @@ The following methods can be used to configure your Pages Function.
 
 ### `onRequests`
 
-
+`onRequest` will be called *unless* a more specific `onRequestVerb` method is exported. For example if both `onRequest` and `onRequestGet` are exported, the `onRequest` method will not be called for matching `GET` requests.
 
 * <code>onRequest(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
-  * This function will be invoked on all requests no matter the request method.
+  * This function will be invoked on all requests no matter the request method, if no specific request verb method below is exported. It will not be called if `next(context.request)` is called from a `onRquestVerb function`.
 * <code>onRequestGet(context[EventContext](#eventcontext))</code> Response | Promise\<Response>
   * This function will be invoked on all `GET` requests.
 * <code>onRequestPost(context[EventContext](#eventcontext))</code> Response | Promise\<Response>


### PR DESCRIPTION
Adds clarification that the `onRequest` function will not be called if another matching function is found.

### Summary

Adds some additional information to clarify `onRequest` call flow and effects on exported definitions. An issue for this documentation/change request can be found at https://github.com/cloudflare/cloudflare-docs/pull/19289

### Screenshots (optional)

NA

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.