### PR TITLE
update `getPlatformProxy` docs by generalizing wrangler.toml references and adding assets bindings support

### DIFF
--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -252,7 +252,7 @@ const platform = await getPlatformProxy(options);
 
       The path to the config file to use.
 
-      If no path is specified the default behavior is to search from the current directory up the filesystem for a[Wrangler configuration file](/workers/wrangler/configuration/) to use.
+      If no path is specified the default behavior is to search from the current directory up the filesystem for a [Wrangler configuration file](/workers/wrangler/configuration/) to use.
 
       **Note:** this field is optional but if a path is specified it must point to a valid file on the filesystem.
 
@@ -342,8 +342,6 @@ The bindings supported by `getPlatformProxy` are:
 
     For example, you might have the following file read by `getPlatformProxy`.
 
-
-
     <WranglerConfig>
 
     ```toml
@@ -364,6 +362,8 @@ The bindings supported by `getPlatformProxy` are:
 - [Queue bindings](/queues/configuration/javascript-apis/)
 
 - [D1 database bindings](/d1/worker-api/)
+
+- [Static Asset bindings](/workers/static-assets/binding/#binding)
 
 - [Hyperdrive bindings](/hyperdrive)
 

--- a/src/content/docs/workers/wrangler/api.mdx
+++ b/src/content/docs/workers/wrangler/api.mdx
@@ -252,7 +252,7 @@ const platform = await getPlatformProxy(options);
 
       The path to the config file to use.
 
-      If no path is specified the default behavior is to search from the current directory up the filesystem for a `wrangler.toml` to use.
+      If no path is specified the default behavior is to search from the current directory up the filesystem for a[Wrangler configuration file](/workers/wrangler/configuration/) to use.
 
       **Note:** this field is optional but if a path is specified it must point to a valid file on the filesystem.
 
@@ -295,7 +295,7 @@ const platform = await getPlatformProxy(options);
 
 ### Usage
 
-The `getPlatformProxy` function uses bindings found in `wrangler.toml`. For example, if you have an [environment variable](/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) configuration set up in `wrangler.toml`:
+The `getPlatformProxy` function uses bindings found in [Wrangler configuration files](/workers/wrangler/configuration/). For example, if you have such an [environment variable](/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) in your configuration:
 
 import { WranglerConfig } from "~/components";
 
@@ -326,7 +326,7 @@ This will print the following output: `MY_VARIABLE = test`.
 
 ### Supported bindings
 
-All supported bindings found in your `wrangler.toml` are available to you via `env`.
+All supported bindings found in your [Wrangler configuration](/workers/wrangler/configuration/) are available to you via `env`.
 
 The bindings supported by `getPlatformProxy` are:
 


### PR DESCRIPTION
Note: assets bindings support has been introduced in [`wrangler@3.104.0`](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/CHANGELOG.md#31040)

> [!Warning]
> The change was reverted https://github.com/cloudflare/workers-sdk/pull/7866, so this PR  needs to wait for the feature to be re-introduced