### PR TITLE
Fix incorrect parameter description for fetch

### DIFF
--- a/src/content/docs/workers/runtime-apis/fetch.mdx
+++ b/src/content/docs/workers/runtime-apis/fetch.mdx
@@ -62,7 +62,7 @@ async function eventHandler(event) {
 
 
 
-* <code>fetch(resource, options optional)</code> : Promise`<Response>`
+* <code>fetch(request, options optional)</code> : Promise`<Response>`
 
   * Fetch returns a promise to a Response.
 
@@ -72,7 +72,7 @@ async function eventHandler(event) {
 
 
 
-* [`resource`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#resource) Request | string | URL
+* [`request`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#request) Request | string | URL
 
 * `options` options
 	* `cache` `undefined | 'no-store'` optional


### PR DESCRIPTION
### Summary

The first parameter of fetch is request instead of resource.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
