### PR TITLE
easier to understand Tail Worker doc

### DIFF
--- a/src/content/docs/workers/observability/logs/tail-workers.mdx
+++ b/src/content/docs/workers/observability/logs/tail-workers.mdx
@@ -24,7 +24,7 @@ A Tail Worker is automatically invoked after the invocation of a producer Worker
 To configure a Tail Worker:
 
 1. [Create a Worker](/workers/get-started/guide) to serve as the Tail Worker.
-2. Add a [`tail()`](/workers/runtime-apis/handlers/tail/) handler to your Worker. The `tail()` handler is invoked every time the producer Worker a Tail Worker is connected to is invoked. The following Worker code is a Tail Worker that sends its data to an HTTP endpoint:
+2. Add a [`tail()`](/workers/runtime-apis/handlers/tail/) handler to your Worker. The `tail()` handler is invoked every time the producer Worker to which a Tail Worker is connected is invoked. The following Worker code is a Tail Worker that sends its data to an HTTP endpoint:
 
 ```js
 export default {


### PR DESCRIPTION
### Summary

In tail worker docs, a particular attributive clause sentence in English is hard to parse. Why not make it clearer 

### Screenshots (optional)

<img width="758" alt="image" src="https://github.com/user-attachments/assets/30b783f4-22ac-4b44-b70e-8e8bcd3ef271" />


### Documentation checklist