### PR TITLE
[Docs Site] Shrink codeblock buttons on mobile to desktop size

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -164,9 +164,9 @@ export default defineConfig({
 			sidebar: await autogenSections(),
 			customCss: [
 				"./src/asides.css",
+				"./src/code.css",
 				"./src/headings.css",
 				"./src/input.css",
-				"./src/kbd.css",
 				"./src/littlefoot.css",
 				"./src/mermaid.css",
 				"./src/table.css",

--- a/src/code.css
+++ b/src/code.css
@@ -1,0 +1,8 @@
+/*
+    This is normally set to 2.5rem the user is unable to hover (i.e mobile)
+    and 2rem otherwise, we would like it to always be 2rem.
+*/
+.expressive-code .copy button {
+	width: 2rem !important;
+	height: 2rem !important;
+}

--- a/src/code.css
+++ b/src/code.css
@@ -1,5 +1,5 @@
 /*
-    This is normally set to 2.5rem the user is unable to hover (i.e mobile)
+    This is normally set to 2.5rem if the user is unable to hover (i.e mobile)
     and 2rem otherwise, we would like it to always be 2rem.
 */
 .expressive-code .copy button {


### PR DESCRIPTION
### Summary

EC sets the copy button to be `2.5rem` on mobile and `2rem` on desktop, this change means it will always be `2rem`.

### Screenshots (optional)

Before:
<img width="316" alt="image" src="https://github.com/user-attachments/assets/0006b8d8-2fa4-4ff6-92a5-9415819efcc1" />

After:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/828b9b0c-ab7b-4b00-a3a3-87c96c808167" />