### PR TITLE
Fix banner links to generate a new Cloudflare root certificate

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/automated-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/automated-deployment.mdx
@@ -6,7 +6,7 @@ sidebar:
 head: []
 description: Automatically deploy a root certificate on desktop devices.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="/cloudflare-one/connections/connect-devices/user-side-certificates/#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/custom-certificate.mdx
@@ -7,7 +7,7 @@ head: []
 description: Configure WARP to use a custom root certificate instead of the
   Cloudflare certificate.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="/cloudflare-one/connections/connect-devices/user-side-certificates/#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Render, Tabs, TabItem } from "~/components";

--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment.mdx
@@ -7,7 +7,7 @@ head: []
 description: Manually add a Cloudflare certificate to mobile devices and
   individual applications.
 banner:
-  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
+  content: The default global Cloudflare root certificate will expire on 2025-02-02. If you installed the default Cloudflare certificate before 2024-10-17, you must <a href="/cloudflare-one/connections/connect-devices/user-side-certificates/#generate-a-cloudflare-root-certificate">generate a new certificate</a> and activate it for your Zero Trust organization to avoid inspection errors.
 ---
 
 import { Details, Render, TabItem, Tabs } from "~/components";


### PR DESCRIPTION
Fixes various banner links to "generate a new Cloudflare root certificate" https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/user-side-certificates/#generate-a-cloudflare-root-certificate

This is crucial as the default global Cloudflare root certificate will expire on 2025-02-02.