### PR TITLE
[Docs] Fix anchors with links or badges

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-sessions.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-sessions.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Render, Badge } from "~/components";
 
-Cloudflare Zero Trust enforces WARP client reauthentication on a per-application basis, unlike legacy VPNs which treat it as a global setting. You can configure WARP session timeouts for your [Access applications](#configure-warp-sessions-in-access-) or as part of your [Gateway policies](#configure-warp-sessions-in-gateway).
+Cloudflare Zero Trust enforces WARP client reauthentication on a per-application basis, unlike legacy VPNs which treat it as a global setting. You can configure WARP session timeouts for your [Access applications](#configure-warp-sessions-in-access) or as part of your [Gateway policies](#configure-warp-sessions-in-gateway).
 
 <Render file="warp/warp-sessions-intro" />
 

--- a/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
@@ -38,7 +38,7 @@ Cloudflare Browser Isolation runs a headless, Chromium-based browser for your us
 
 ## Network on-ramps
 
-The primary ways to source multi-device or network traffic to Cloudflare Gateway are via Magic WAN using GRE or IPsec tunnels, the [WARP Connector](#warp-connector-) as a software-defined all-ports traffic proxy, or via upstream DNS for a whole network using [DNS filtering locations](#dns-filtering-locations).
+The primary ways to source multi-device or network traffic to Cloudflare Gateway are via Magic WAN using GRE or IPsec tunnels, the [WARP Connector](#warp-connector) as a software-defined all-ports traffic proxy, or via upstream DNS for a whole network using [DNS filtering locations](#dns-filtering-locations).
 
 ### Magic WAN
 

--- a/src/content/docs/waf/analytics/security-analytics.mdx
+++ b/src/content/docs/waf/analytics/security-analytics.mdx
@@ -120,7 +120,7 @@ The main chart displays the following data for the selected time frame, accordin
 
 Security Analytics shows request logs for the selected time frame and applied filters, along with detailed information and security analyses of those requests.
 
-By default, Security Analytics uses sampled logs for the logs table. If you are subscribed to [Log Explorer](/logs/log-explorer/), you may also have access to [raw logs](#raw-logs-).
+By default, Security Analytics uses sampled logs for the logs table. If you are subscribed to [Log Explorer](/logs/log-explorer/), you may also have access to [raw logs](#raw-logs).
 
 #### Sampled logs
 


### PR DESCRIPTION
### Summary

Before we fixed it in https://github.com/cloudflare/cloudflare-docs/pull/19331, some headings had a trailing dash in their anchor names due to links or badges. This is no longer the case, so this PR removes those extra dashes.
