### PR TITLE
Fix typo in Next.js workers guide

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -133,7 +133,7 @@ npm run preview:worker
 ```
 
 This command will build your OpenNext application, also creating, if not already present, an `open-next.configs.ts` file for you.
-This if necessary if you want to deploy your application with a GibHub/GitLab integration as presented in the next step.
+This is necessary if you want to deploy your application with a GibHub/GitLab integration as presented in the next step.
 
 ### 7. Deploy to Cloudflare Workers
 


### PR DESCRIPTION
fixes #19359

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.