### PR TITLE
[Docs Site] Various changelog improvements

### DIFF
--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -68,7 +68,9 @@ if (!changelogs) {
 {
 	page.data.pcx_content_type === "changelog" && (
 		<p>
-			<a href={`/${page.slug}/index.xml`}>Subscribe to RSS</a>
+			<a href={`/${page.slug}/index.xml`} target="_blank">
+				Subscribe to RSS
+			</a>
 		</p>
 	)
 }

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -66,6 +66,13 @@ if (!changelogs) {
 ---
 
 {
+	page.data.pcx_content_type === "changelog" && (
+		<p>
+			<a href={`/${page.slug}/index.xml`}>Subscribe to RSS</a>
+		</p>
+	)
+}
+{
 	changelogs.map(([date, entries]) => (
 		<div data-date={date}>
 			{(entries ?? []).map(async (entry) => {
@@ -104,16 +111,18 @@ if (!changelogs) {
 				} else {
 					description = marked.parse(entry.description as string);
 					return (
-						<AnchorHeading depth={2} title={date} />
-						<div data-product={entry.product.toLowerCase()}>
-							{page.data.changelog_product_area_name && (
-								<h3 class="!mt-4">
-									<a href={entry.productLink}>{entry.product}</a>
-								</h3>
-							)}
-							{entry.title && <strong>{entry.title}</strong>}
-							{<Fragment set:html={description} />}
-						</div>
+						<>
+							<AnchorHeading depth={2} title={date} />
+							<div data-product={entry.product.toLowerCase()}>
+								{page.data.changelog_product_area_name && (
+									<h3 class="!mt-4">
+										<a href={entry.productLink}>{entry.product}</a>
+									</h3>
+								)}
+								{entry.title && <strong>{entry.title}</strong>}
+								{<Fragment set:html={description} />}
+							</div>
+						</>
 					);
 				}
 			})}

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -4,6 +4,7 @@ import { Aside } from "~/components";
 import { marked } from "marked";
 import { format } from "date-fns";
 import { getChangelogs } from "~/util/changelogs";
+import { getEntry } from "astro:content";
 
 const { products, productAreas, changelogs } = await getChangelogs();
 ---
@@ -52,42 +53,43 @@ const { products, productAreas, changelogs } = await getChangelogs();
 					<h4 class="text-nowrap">{format(date, "do MMMM yyyy")}</h4>
 				</div>
 				<div class="!mt-0">
-					{entries?.map((entry) => (
-						<div
-							data-product={entry.product.toLowerCase()}
-							data-productArea={entry.productAreaName.toLowerCase()}
-						>
-							<h3>
-								<a href={entry.link}>{entry.product}</a>
-							</h3>
-							{["WAF", "DDoS protection"].includes(entry.product) && (
-								<p
-									set:html={marked.parse(
-										entry.scheduled
-											? "**" +
-													"Scheduled changes for " +
-													(entry.date ?? "") +
-													"**"
-											: "**" + (entry.date ?? "") + "**",
-									)}
-								/>
-							)}
-							{entry.title && (
-								<p set:html={marked.parse("**" + (entry.title ?? "") + "**")} />
-							)}
-							{["WAF", "DDoS protection"].includes(entry.product) ? (
-								<p
-									set:html={marked.parse(
-										"For more details, refer to the [changelog page](" +
-											entry.link +
-											").",
-									)}
-								/>
-							) : (
-								<p set:html={marked.parse(entry.description ?? "")} />
-							)}
-						</div>
-					))}
+					{entries?.map(async (entry) => {
+						let title = entry.title;
+						let description = entry.description || "";
+
+						if (entry.individual_page) {
+							const page = await getEntry(
+								"docs",
+								entry.individual_page.slice(1, -1),
+							);
+
+							if (!page) {
+								throw new Error(
+									`[Changelog] Unable to load page ${entry.individual_page}.`,
+								);
+							}
+
+							title = `${entry.product} - ${page.data.title}`;
+							description = `For more details, refer to the dedicated page for [${title}](${entry.individual_page}).`;
+						}
+
+						return (
+							<div
+								data-product={entry.product.toLowerCase()}
+								data-productArea={entry.productAreaName.toLowerCase()}
+							>
+								<h3>
+									<a href={entry.productLink}>{entry.product}</a>
+								</h3>
+								{title && (
+									<p>
+										<strong>{title}</strong>
+									</p>
+								)}
+								<Fragment set:html={marked.parse(description)} />
+							</div>
+						);
+					})}
 				</div>
 			</div>
 		))

--- a/src/util/changelogs.ts
+++ b/src/util/changelogs.ts
@@ -61,7 +61,7 @@ export async function getWranglerChangelog(): Promise<
 	CollectionEntry<"changelogs">
 > {
 	const response = await fetch(
-		"https://api.github.com/repos/cloudflare/workers-sdk/releases",
+		"https://api.github.com/repos/cloudflare/workers-sdk/releases?per_page=100",
 	);
 
 	if (!response.ok) {


### PR DESCRIPTION
### Summary

- Points to the correct product landing in the `h3`
- Points to the correct individual page for DDoS and WAF
- Adds "Subscribe to RSS" link in `ProductChangelog`
- Increases `per_page` when fetching Wrangler changelogs to 100.

Before:

<img width="1348" alt="image" src="https://github.com/user-attachments/assets/87e943b1-b378-4cde-b511-5bd62a8adbc9" />

After:

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/7c2847f2-b376-4355-9fa2-47152c77f8f0" />