### PR TITLE
Fix required API token permissions for origin rules

### DIFF
--- a/src/content/docs/rules/origin-rules/create-api.mdx
+++ b/src/content/docs/rules/origin-rules/create-api.mdx
@@ -242,4 +242,4 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id} \
 
 The API token used in API requests to manage origin rules must have at least the following permission:
 
-- _Origin_ > _Edit_
+- _Zone_ > _Origin Rules_ > _Edit_


### PR DESCRIPTION
The permission name is actually `Origin Rules`, not `Origin`
