### PR TITLE
[Docs] Exclude false positives from unused images audit

### DIFF
--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -21,7 +21,7 @@ jobs:
         id: find-files
         run: |
           # Find all .png and .svg files, but only look in the ./src/assets/images directory
-          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*")
+          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg")
 
           # Check if files are referenced in any markdown file
           UNUSED_FILES=""

--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -21,7 +21,7 @@ jobs:
         id: find-files
         run: |
           # Find all .png and .svg files, but only look in the ./src/assets/images directory
-          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg")
+          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg" -not -path "./src/assets/images/workers/ai/*.png")
 
           # Check if files are referenced in any markdown file
           UNUSED_FILES=""

--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -21,7 +21,7 @@ jobs:
         id: find-files
         run: |
           # Find all .png and .svg files, but only look in the ./src/assets/images directory
-          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg" -not -path "./src/assets/images/workers/ai/*.png")
+          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg" -not -path "./src/assets/images/workers/ai/*.png" -not -path "./src/assets/images/changelog-next/*")
 
           # Check if files are referenced in any markdown file
           UNUSED_FILES=""


### PR DESCRIPTION
### Summary

We have a few false positives that keep appearing in unused images audits. For example, in this one: #18978

These images are not used in MDX files, but they are are imported in TypeScript/Astro files:
* [Logos of AI models](https://github.com/cloudflare/cloudflare-docs/blob/production/src/components/models/data.ts?plain=1)
* [Images for AI assistant](https://github.com/cloudflare/cloudflare-docs/blob/production/src/pages/workers/ai.astro?plain=1)
* [Changelog Next images](https://github.com/cloudflare/cloudflare-docs/blob/production/src/components/changelog-next/Header.astro?plain=1)
