### PR TITLE
[Static Assets] Rename experimental_serve_directly to run_worker_first

### DIFF
--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -59,9 +59,9 @@ _headers
 
 Now Wrangler will not upload these files as client-side assets when deploying the Worker.
 
-## `experimental_serve_directly`
+## `run_worker_first`
 
-Controls whether assets will be served first on a matching request. `experimental_serve_directly = true` ([default](/workers/static-assets/routing/#default-behavior)) will serve any static asset matching a request, while `experimental_serve_directly = false` will unconditionally [invoke your Worker script](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets).
+Controls whether to invoke the Worker script regardless of a request which would have otherwise matched an asset. `run_worker_first = false` ([default](/workers/static-assets/routing/#default-behavior)) will serve any static asset matching a request, while `run_worker_first = true` will unconditionally [invoke your Worker script](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets).
 
 <WranglerConfig>
 
@@ -74,7 +74,7 @@ main = "src/index.ts"
 [assets]
 directory = "./public/"
 binding = "ASSETS"
-experimental_serve_directly = false
+run_worker_first = true
 ```
 
 </WranglerConfig>
@@ -166,16 +166,16 @@ For the various static asset routing configuration options, refer to [Routing](/
 
 ### Smart Placement with Worker Code First
 
-If you desire to run your [Worker code ahead of assets](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets) by setting `experimental_serve_directly=false`, all requests must first travel to your Smart-Placed Worker. As a result, you may experience increased latency for asset requests.
+If you desire to run your [Worker code ahead of assets](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets) by setting `run_worker_first=true`, all requests must first travel to your Smart-Placed Worker. As a result, you may experience increased latency for asset requests.
 
-Use Smart Placement with `experimental_serve_directly=false` when you need to integrate with other backend services, authenticate requests before serving any assets, or if your want to make modifications to your assets before serving them.
+Use Smart Placement with `run_worker_first=true` when you need to integrate with other backend services, authenticate requests before serving any assets, or if your want to make modifications to your assets before serving them.
 
 If you want some assets served as quickly as possible to the user, but others to be served behind a smart-placed Worker, considering splitting your app into multiple Workers and [using service bindings to connect them](/workers/configuration/smart-placement/#best-practices).
 
 ### Smart Placement with Assets First
 
-Enabling Smart Placement with `experimental_serve_directly=true` lets you serve assets from as close as possible to your users, but moves your Worker logic to run most efficiently (such as near a database).
+Enabling Smart Placement with `run_worker_first=false` (or not specifying it) lets you serve assets from as close as possible to your users, but moves your Worker logic to run most efficiently (such as near a database).
 
-Use Smart Placement with `experimental_serve_directly=true` when prioritizing fast asset delivery.
+Use Smart Placement with `run_worker_first=false` (or not specifying it) when prioritizing fast asset delivery.
 
 This will not impact the [default routing behavior](/workers/static-assets/routing/#default-behavior).

--- a/src/content/docs/workers/static-assets/compatibility-matrix.mdx
+++ b/src/content/docs/workers/static-assets/compatibility-matrix.mdx
@@ -40,7 +40,7 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 | **Static Assets**                                                                   |         |         |
 | [Early Hints](/pages/configuration/early-hints/)                                    | ❌      | ✅      |
 | [Custom HTTP headers for static assets](/pages/configuration/headers/)              | 🟡 [^1] | ✅      |
-| [Middleware](/workers/static-assets/binding/#experimental_serve_directly)           | ✅ [^2] | ✅      |
+| [Middleware](/workers/static-assets/binding/#run_worker_first)                      | ✅ [^2] | ✅      |
 | [Redirects](/pages/configuration/redirects/)                                        | 🟡 [^3] | ✅      |
 | [Smart Placement](/workers/configuration/smart-placement/)                          | ✅      | ✅      |
 | [Serve assets on a path](/workers/static-assets/routing/)                           | ✅      | ❌      |
@@ -85,7 +85,7 @@ We plan to bridge the gaps between Workers and Pages and provide ways to migrate
 
 [^1]: Similar to <sup>3</sup>, to customize the HTTP headers that are returned by static assets, you can use [Service bindings](/workers/runtime-apis/bindings/service-bindings/) to connect a Worker in front of the Worker with assets.
 
-[^2]: Middleware can be configured via the [`experimental_serve_directly`](/workers/static-assets/binding/#experimental_serve_directly) option, but is charged as a normal Worker invocation. We plan to explore additional related options in the future.
+[^2]: Middleware can be configured via the [`run_worker_first`](/workers/static-assets/binding/#run_worker_first) option, but is charged as a normal Worker invocation. We plan to explore additional related options in the future.
 
 [^3]: You can handle redirects by adding code to your Worker (a [community package](https://npmjs.com/package/redirects-in-workers) is available for `_redirects` support), or you can use [Bulk Redirects](/rules/url-forwarding/bulk-redirects/).
 

--- a/src/content/docs/workers/static-assets/routing.mdx
+++ b/src/content/docs/workers/static-assets/routing.mdx
@@ -15,7 +15,7 @@ import {
 	Render,
 	TabItem,
 	Tabs,
-	WranglerConfig
+	WranglerConfig,
 } from "~/components";
 
 ## Default behavior
@@ -38,7 +38,7 @@ In this example, a request to `example.com/api` doesn't match a static asset so 
 
 ## Invoking Worker Script Ahead of Assets
 
-You may wish to run code before assets are served. This is often the case when implementing authentication, logging, personalization, internationalization, or other similar functions. [`experimental_serve_directly`](/workers/static-assets/binding/#experimental_serve_directly) is a configuration option available in the `wrangler.toml / wrangler.json` file which controls this behavior. When disabled, `experimental_serve_directly = false` will invoke your Worker's code, regardless of any assets that would have otherwise matched.
+You may wish to run code before assets are served. This is often the case when implementing authentication, logging, personalization, internationalization, or other similar functions. [`run_worker_first`](/workers/static-assets/binding/#run_worker_first) is a configuration option available in `wrangler.toml / wrangler.json` which controls this behavior. When enabled, `run_worker_first = true` will invoke your Worker's code, regardless of any assets that would have otherwise matched.
 
 Take the following directory structure, `wrangler.toml / wrangler.json` file, and user Worker code:
 
@@ -59,7 +59,7 @@ Take the following directory structure, `wrangler.toml / wrangler.json` file, an
 name = "my-worker"
 compatibility_date = "2024-09-19"
 main = "src/index.ts"
-assets = { directory = "./public/", binding = "ASSETS", experimental_serve_directly = false }
+assets = { directory = "./public/", binding = "ASSETS", run_worker_first = true }
 ```
 
 </WranglerConfig>
@@ -90,7 +90,7 @@ export default {
 };
 ```
 
-In this example, any request will be routed to our user Worker, due to `experimental_serve_directly` being disabled. As a result, any request being made `/supersecret.txt` without an `Authorization` header will result in a 403.
+In this example, any request will be routed to our user Worker, due to `run_worker_first` being enabled. As a result, any request being made `/supersecret.txt` without an `Authorization` header will result in a 403.
 
 ## Routing configuration
 
@@ -321,3 +321,4 @@ In this example, requests to `example.com/blog/` will serve the `index.html` fil
 
 If you have a file outside the configured path, it will not be served. For example, if you have a `home.html` file in the root of your asset directory, it will not be served when requesting `example.com/blog/home`.
 However, if needed, these files can still be manually fetched over [the binding](/workers/static-assets/binding/#binding).
+```

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -984,9 +984,9 @@ The following options are available under the `assets` key.
 
   - The binding name used to refer to the assets. Optional, and only useful when a Worker script is set with `main`.
 
-- `experimental_serve_directly` <Type text="boolean" /> <MetaInfo text="optional, defaults to true" />
+- `run_worker_first` <Type text="boolean" /> <MetaInfo text="optional, defaults to false" />
 
-  - Controls whether static assets are fetched directly, or a Worker script is invoked. Learn more about fetching assets when using [`experimental_serve_directly`](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets).
+  - Controls whether static assets are fetched directly, or a Worker script is invoked. Learn more about fetching assets when using [`run_worker_first`](/workers/static-assets/routing/#invoking-worker-script-ahead-of-assets).
 
 - `html_handling`: <Type text={'"auto-trailing-slash" | "force-trailing-slash" | "drop-trailing-slash" | "none"'} /> <MetaInfo text={'optional, defaults to "auto-trailing-slash"'} />
 


### PR DESCRIPTION
Updates the naming for the Worker-first configuration.

### Summary

Provides rename for `experimental_serve_directly`.

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
