### PR TITLE
Update dns-record-types.mdx

### DIFF
--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -322,10 +322,10 @@ A start of authority (SOA) record stores information about your domain such as a
 
 If you are using Cloudflare for your [authoritative DNS](/dns/zone-setups/full-setup/), you do not need to create an SOA record. Cloudflare creates this record automatically when you start using Cloudflare's authoritative nameservers.
 
-If you have an Enterprise account, you can change the SOA record values that Cloudflare will use:
+With Enterprise accounts, you also have the option to change the SOA record values that Cloudflare will use:
 
-- As a DNS zone default (applicable to all zone plans): define the SOA record values that Cloudflare will use for all new zones added to your account. Refer to [Configure DNS zone defaults](/dns/additional-options/dns-zone-defaults/) for step-by-step guidance.
-- For existing Enterprise zones: override the defaults or Cloudflare-generated values by going to **DNS** > **Records** > **DNS record options**.
+- As a DNS zone default: Define the SOA record values that Cloudflare will use for all new zones added to your account. Refer to [Configure DNS zone defaults](/dns/additional-options/dns-zone-defaults/) for step-by-step guidance.
+- For existing zones: Override the defaults or Cloudflare-generated values by going to **DNS** > **Records** > **DNS record options**.
 
 :::note
 If you are an Enterprise customer and these options are not displayed on your Cloudflare dashboard, reach out to your account team.

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -322,9 +322,14 @@ A start of authority (SOA) record stores information about your domain such as a
 
 If you are using Cloudflare for your [authoritative DNS](/dns/zone-setups/full-setup/), you do not need to create an SOA record. Cloudflare creates this record automatically when you start using Cloudflare's authoritative nameservers.
 
-If you have an Enterprise zone, you also have the option to change the SOA record values that Cloudflare will use.
-You can do that for existing zones by going to **DNS** > **Records** > **DNS record options**, or you can configure your own [DNS zone defaults](/dns/additional-options/dns-zone-defaults/) and define the SOA record values that Cloudflare will use for all new zones added to your account.
-If these options are not displayed in your Cloudflare Dashboard, you may need to reach out to your account team to have them enabled.
+If you have an Enterprise account, you can change the SOA record values that Cloudflare will use:
+
+- As a DNS zone default (applicable to all zone plans): define the SOA record values that Cloudflare will use for all new zones added to your account. Refer to [Configure DNS zone defaults](/dns/additional-options/dns-zone-defaults/) for step-by-step guidance.
+- For existing Enterprise zones: override the defaults or Cloudflare-generated values by going to **DNS** > **Records** > **DNS record options**.
+
+:::note
+If you are an Enterprise customer and these options are not displayed on your Cloudflare dashboard, reach out to your account team.
+:::
 
 Refer to the following list for information about each SOA record field:
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -324,7 +324,7 @@ If you are using Cloudflare for your [authoritative DNS](/dns/zone-setups/full-s
 
 If you have an Enterprise zone, you also have the option to change the SOA record values that Cloudflare will use.
 You can do that for existing zones by going to **DNS** > **Records** > **DNS record options**, or you can configure your own [DNS zone defaults](/dns/additional-options/dns-zone-defaults/) and define the SOA record values that Cloudflare will use for all new zones added to your account.
-If these options are not displayed in your Cloudflare Dashboard, you may need to reach out to [Cloudflare Support](https://developers.cloudflare.com/support/contacting-cloudflare-support/) to have them enabled.
+If these options are not displayed in your Cloudflare Dashboard, you may need to reach out to your account team to have them enabled.
 
 Refer to the following list for information about each SOA record field:
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -322,8 +322,9 @@ A start of authority (SOA) record stores information about your domain such as a
 
 If you are using Cloudflare for your [authoritative DNS](/dns/zone-setups/full-setup/), you do not need to create an SOA record. Cloudflare creates this record automatically when you start using Cloudflare's authoritative nameservers.
 
-If you have an Enterprise account, you also have the option to change the SOA record values that Cloudflare will use.
+If you have an Enterprise zone, you also have the option to change the SOA record values that Cloudflare will use.
 You can do that for existing zones by going to **DNS** > **Records** > **DNS record options**, or you can configure your own [DNS zone defaults](/dns/additional-options/dns-zone-defaults/) and define the SOA record values that Cloudflare will use for all new zones added to your account.
+If these options are not displayed in your Cloudflare Dashboard, you may need to reach out to [Cloudflare Support](https://developers.cloudflare.com/support/contacting-cloudflare-support/) to have them enabled.
 
 Refer to the following list for information about each SOA record field:
 


### PR DESCRIPTION
SOA records require an Account Entitlement for ENT customers, not enabled by default: Authoritative DNS - Custom SOA Record Allowed, so customers may need to reach out to support or their account teams to enable it

### Summary

<!-- Add context such as the type of documentation being updated or added -->

Customer in ticket 01217536 tried to edit RNAME in SOA and got errors. Troubleshooting it led to find that this entitlement needed to be enabled, but neither the customer or the owner TSE knew about it

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
