### PR TITLE
[Docs Site] Add privacy group to Key Transparency and Privacy Gateway

### DIFF
--- a/src/content/products/key-transparency.yaml
+++ b/src/content/products/key-transparency.yaml
@@ -4,6 +4,7 @@ product:
   title: Key Transparency Auditor
   url: /key-transparency/
   group: Application security
+  additional_groups: [Privacy]
 
 meta:
   title: Key Transparency Auditor

--- a/src/content/products/privacy-gateway.yml
+++ b/src/content/products/privacy-gateway.yml
@@ -5,6 +5,7 @@ product:
   title: Privacy Gateway
   url: /privacy-gateway/
   group: Developer platform
+  additional_groups: [Privacy]
 
 meta:
   title: Cloudflare Privacy Gateway


### PR DESCRIPTION
### Summary

Add privacy group to Key Transparency and Privacy Gateway

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/7bdbd2d0-8567-40ac-84b5-2f6524db5cf9" />
