### PR TITLE
Update kubernetes.mdx

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/kubernetes.mdx
@@ -89,7 +89,7 @@ spec:
       labels:
         pod: cloudflared
     spec:
-			securityContext:
+      securityContext:
         sysctls:
           - name: net.ipv4.ping_group_range
             value: "65532 65532"

--- a/src/content/docs/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/kubernetes.mdx
@@ -89,6 +89,10 @@ spec:
       labels:
         pod: cloudflared
     spec:
+			securityContext:
+        sysctls:
+          - name: net.ipv4.ping_group_range
+            value: "65532 65532"
       containers:
         - command:
             - cloudflared


### PR DESCRIPTION
### Summary

This PR updates the Cloudflare Zero Trust [Kubernetes Deployment Manifests](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/kubernetes/#routing-with-cloudflare-tunnel) to address the warning:  
`WRN The user running cloudflared process has a GID (group ID) that is not within ping_group_range. You might need to add that user to a group within that range, or instead update the range to encompass a group the user is already in by modifying /proc/sys/net/ipv4/ping_group_range. Otherwise cloudflared will not be able to ping this network error="Group ID 65532 is not between ping group 1 to 0"`  

The change adds a `securityContext` with a `sysctls` configuration to explicitly set `net.ipv4.ping_group_range` to `"65532 65532"`.  
This configuration ensures that the warning no longer appears when running the deployment.

### Screenshots (optional)

_N/A_

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page - an issue has been opened in relation to any incorrect or out-of-date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
