### PR TITLE
Update the Rust & WebAssembly book link

### DIFF
--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -229,4 +229,4 @@ Finally, `worker-bundle` automatically invokes [`wasm-opt`](https://github.com/b
 
 ## Related resources
 
-- [Rust Wasm Book](https://rustwasm.github.io/book/introduction.html)
+- [Rust Wasm Book](https://rustwasm.github.io/docs/book/)


### PR DESCRIPTION
### Summary

The old link points to the unpublished version of the book. It is published now, as indicated by the banner on the webpage. 

This commit replaces the link with the published book URL.

### Screenshots (optional)

Current URL:
![screenshot-2025-01-24-at-03 41 46PM@2x](https://github.com/user-attachments/assets/b14881c0-a708-4937-8202-87cf2db1291b)

New:

![screenshot-2025-01-24-at-03 42 00PM@2x](https://github.com/user-attachments/assets/3394a11e-202d-4570-bf60-f3dcfb87738b)


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
