### PR TITLE
[Docs Site] Set eslint in CI to use filter_mode: nofilter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          fail_level: "error"
+          fail_level: error
+          filter_mode: nofilter
 
       - run: npm run format:core:check
       ## TODO: content formatting checks

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -6,8 +6,6 @@ import { marked } from "marked";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
 
-import { Badge } from "@astrojs/starlight/components";
-
 import Description from "~/components/Description.astro";
 import SpotlightAuthorDetails from "~/components/SpotlightAuthorDetails.astro";
 import LastReviewed from "~/components/LastReviewed.astro";


### PR DESCRIPTION
### Summary

Set eslint in CI to use filter_mode: nofilter. This stops errors from getting past reviewdog which would later be caught by `npx eslint .` locally.