### PR TITLE
Fix incorrect expression for Zone Lockdown example

### DIFF
--- a/src/content/docs/waf/tools/zone-lockdown.mdx
+++ b/src/content/docs/waf/tools/zone-lockdown.mdx
@@ -19,7 +19,7 @@ Cloudflare recommends that you create [WAF custom rules](/waf/custom-rules/) ins
 For example, a custom rule equivalent to the Zone Lockdown [example rule](#example-rule) provided in this page could have the following configuration:
 
 - **Description**: `Block all traffic to staging and wiki unless it comes from HQ or branch offices`
-- **Expression**: `((http.host eq "staging.example.com") or (http.host eq "staging.example.com" and starts_with(http.request.uri.path, "/wiki/")) and not ip.src in {192.0.2.0/24 2001:DB8::/64 203.0.133.1}`
+- **Expression**: `((http.host eq "staging.example.com") or (http.host eq "example.com" and starts_with(http.request.uri.path, "/wiki/")) and not ip.src in {192.0.2.0/24 2001:DB8::/64 203.0.133.1}`
 - **Action**: _Block_
 
 :::


### PR DESCRIPTION
This is a minor change that ensures that the expression matches the example on the page. Given how little I’ve changed, it naturally adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).