### PR TITLE
Remove beta note from Gradual Deployments

### DIFF
--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -17,14 +17,6 @@ Using versions and deployments is useful if:
 - You want to monitor for performance differences when deploying new versions of your Worker.
 - You have a CI/CD pipeline configured for Workers but want to cut manual releases.
 
-:::note
-
-Versions and deployments are in **beta and under active development**. Refer to [Limits](/workers/configuration/versions-and-deployments/#limits) before using these features.
-
-Provide your feedback on versions and deployments through the [feedback form](https://www.cloudflare.com/lp/developer-week-deployments).
-
-:::
-
 ## Versions
 
 A version is defined by the state of code as well as the state of configuration in a Worker's [`wrangler.toml`](/workers/wrangler/configuration/) file. Versions track historical changes to [bundled code](/workers/wrangler/bundling/), [static assets](/workers/static-assets/) and changes to configuration like [bindings](/workers/runtime-apis/bindings/) and [compatibility date and compatibility flags](/workers/configuration/compatibility-dates/) over time.


### PR DESCRIPTION
### Summary

Gradual deployments is GA but we missed removing this beta note and it's causing confusion.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
