### PR TITLE
[wrangler] update wrangler global flags and `secret:bulk` -> `secret bulk`

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -27,7 +27,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`r2 bucket`](#r2-bucket) - Manage Workers R2 buckets.
 - [`r2 object`](#r2-object) - Manage Workers R2 objects.
 - [`secret`](#secret) - Manage the secret variables for a Worker.
-- [`secret:bulk`](#secretbulk) - Manage multiple secret variables for a Worker.
+- [`secret bulk`](#secretbulk) - Manage multiple secret variables for a Worker.
 - [`workflows`](#workflows) - Manage and configure Workflows.
 - [`tail`](#tail) - Start a session to livestream logs from a deployed Worker.
 - [`pages`](#pages) - Configure Cloudflare Pages.
@@ -730,12 +730,12 @@ npx wrangler secret list
 
 ---
 
-## `secret:bulk`
+## `secret bulk`
 
 Upload multiple secrets for a Worker at once.
 
 ```txt
-wrangler secret:bulk [<FILENAME>] [OPTIONS]
+wrangler secret bulk [<FILENAME>] [OPTIONS]
 ```
 
 - `FILENAME` <Type text="string" /> <MetaInfo text="optional" />
@@ -758,7 +758,7 @@ The following is an example of uploading secrets from a JSON file redirected to 
 ```
 
 ```sh
-npx wrangler secret:bulk < secrets.json
+npx wrangler secret bulk < secrets.json
 ```
 
 ```sh output

--- a/src/content/partials/workers/wrangler-commands/global-flags.mdx
+++ b/src/content/partials/workers/wrangler-commands/global-flags.mdx
@@ -8,9 +8,5 @@ The following global flags work on every command:
 
 - `--help` <Type text="boolean" />
   - Show help.
-- `--version` <Type text="boolean" />
-  - Show version number.
 - `--config` <Type text="string" /> (not supported by Pages)
-  - Path to `.toml` configuration file.
-- `--experimental-json-config` <Type text="boolean" /> (not supported by Pages)
-  - ⚠️ This is an experimental command. Read configuration from a `wrangler.json` or `wrangler.jsonc` file, instead of `wrangler.toml`. In this case the config file is parsed as [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments).
+  - Path to `wrangler.json` or `wrangler.toml` configuration file.


### PR DESCRIPTION
### Summary

`--experimental-json-config` has been deprecated as it is no longer necessary - wrangler.json is supported by default
`--version` doesn't appear to do anything
`secret:bulk` has been deprecated for a while in favour of `secret bulk`, and will be removed in v4 

