### PR TITLE
Indicate required fields for Workers AI model inputs

### DIFF
--- a/src/components/models/SchemaRow.astro
+++ b/src/components/models/SchemaRow.astro
@@ -12,8 +12,15 @@ const { node, root } = Astro.props;
 		node.title ? (
 			<span class="mr-2 font-bold">{node.title}</span>
 		) : (
-			<code class="mr-2 !pr-0 font-mono rounded-md bg-gray-100">
+			<code class="mr-2 rounded-md bg-gray-100 !pr-0 font-mono">
 				{node.subpath[node.subpath.length - 1]}
+				{node.parent.fragment?.required?.includes(
+					node.subpath[node.subpath.length - 1],
+				) ? (
+					<span class="font-semibold text-red-500">*</span>
+				) : (
+					""
+				)}
 			</code>
 		)
 	}
@@ -46,7 +53,7 @@ const { node, root } = Astro.props;
 
 	{
 		node.children && (
-			<ul class="!list-none m-0 p-0 ml-4">
+			<ul class="m-0 ml-4 !list-none p-0">
 				{node.children.map((node: SchemaNode) => (
 					<Astro.self node={node} />
 				))}

--- a/src/pages/workers-ai/models/[name].astro
+++ b/src/pages/workers-ai/models/[name].astro
@@ -208,6 +208,7 @@ const starlightPageProps = {
 	}
 
 	<h2 id="Parameters">Parameters</h2>
+	<p><span class="text-red-500">*</span> indicates a required field</p>
 	<h3 id="Input">Input</h3>
 	<SchemaViewer schema={model.schema.input} />
 


### PR DESCRIPTION
### Summary

This change adds a red * to required fields within the Workers AI model input documentation. 

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/d9635bb7-d63f-4e8d-9f84-0afb77f639af)
![image](https://github.com/user-attachments/assets/cf5980e2-6ef2-427a-94fb-7823edb0c617)

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.