### PR TITLE
[Access for SaaS] Properly spell `metadata`

### DIFF
--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/tableau-saml-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/tableau-saml-saas.mdx
@@ -34,7 +34,7 @@ This guide covers how to configure [Tableau Cloud](https://help.tableau.com/curr
 1. In Tableau Cloud, go to **Settings** > **Authentication**.
 2. Turn on **Enable an additional authentication method**. For **select authentication type**, select *SAML*.
 3. Under **1. Get Tableau Cloud metadata**, copy the **Tableau Cloud entity ID** and **Tableau Cloud ACS URL**.
-4. Under **4. Upload metatdata to Tableau**, select **Choose a file**, and upload the `.xml` file created in step [2. Download the metadata file](#2-download-the-metadata-file)
+4. Under **4. Upload metadata to Tableau**, select **Choose a file**, and upload the `.xml` file created in step [2. Download the metadata file](#2-download-the-metadata-file)
 5. Under **5. Map attributes**, turn on **Full name**. For **Name (full name)**, enter `name`.
 6. (Optional) Choose whether users who are accessing embedded views will **Authenticate in a separate pop-up window** or **Authenticate using an inline frame**.
 7. Select **Save Changes**.


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `metatdata`.

Similar to #19500.
