### PR TITLE
[CF1] Properly spell `visibility`

### DIFF
--- a/src/content/docs/cloudflare-one/insights/dex/ip-visibility.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/ip-visibility.mdx
@@ -50,7 +50,7 @@ DEX's IP visibility allows you to review an event log of a device's IP history f
 
 Refer to [Available metrics](/cloudflare-one/insights/dex/fleet-status/#available-metrics) to review **Status** and **Mode** descriptions.
 
-## Troubleshoot with IP visbility
+## Troubleshoot with IP visibility
 
 While IP visibility allows you to inspect a device's IP information, use [DEX's live analytics](/cloudflare-one/insights/dex/fleet-status/#available-metrics) to review which Cloudflare data center the device is connected to. When traffic leaves a WARP-connected end-user device, it will hit a [Cloudflare data center](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#identify-the-cloudflare-data-center-serving-your-request).
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `visbility`.

Similar to #19500.
