### PR TITLE
[Docs Site] changelog-next padding fixes

### DIFF
--- a/src/pages/changelog-next/[...slug].astro
+++ b/src/pages/changelog-next/[...slug].astro
@@ -40,7 +40,7 @@ const props = {
 
 <StarlightPage {...props}>
 	<Header />
-	<div class="w-full max-w-[50rem] justify-self-center">
+	<div class="w-full max-w-[50rem] justify-self-center px-4">
 		<div class="!mt-0 mb-10">
 			<a href="/changelog-next/" class="no-underline">
 				<span class="text-accent">← </span>

--- a/src/pages/changelog-next/index.astro
+++ b/src/pages/changelog-next/index.astro
@@ -50,7 +50,7 @@ const props = {
 						</div>
 						<Steps>
 							<ol class="!mt-0 overflow-x-auto" data-products={productIds}>
-								<li class="mb-16">
+								<li class="!pb-16">
 									<div>
 										<a
 											href={`/changelog-next/${entry.slug}/`}


### PR DESCRIPTION
### Summary

changelog-next padding fixes

### Screenshots (optional)

Before:

<img width="422" alt="image" src="https://github.com/user-attachments/assets/90809045-7913-419f-9099-ef29c690e574" />
<br/>
<img width="370" alt="image" src="https://github.com/user-attachments/assets/44adffdc-b4df-4c22-83e3-0b65d16f4079" />


After:

<img width="380" alt="image" src="https://github.com/user-attachments/assets/c21edcb2-6df6-464e-b325-66702d63ccad" />
<br/>
<img width="362" alt="image" src="https://github.com/user-attachments/assets/0946c302-00aa-4bbd-a34b-5b37bb9ea9d7" />
