### PR TITLE
[Access for SaaS] Properly spell `consumer`

### DIFF
--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/atlassian-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/atlassian-saas.mdx
@@ -56,7 +56,7 @@ This guide covers how to configure [Atlassian Cloud](https://support.atlassian.c
 
 1. In your open Zero Trust window, fill in the following fields:
    * **Entity ID**: Service provider entity URL from Atlassian Cloud SAML SSO set-up.
-   * **Assertion Consumer Service URL**: Service provider assertion comsumer service URL from Atlassian Cloud SAML SSO set-up.
+   * **Assertion Consumer Service URL**: Service provider assertion consumer service URL from Atlassian Cloud SAML SSO set-up.
    * **Name ID format**: *Email*
 2. Configure [Access policies](/cloudflare-one/policies/access/) for the application.
 3. Save the application.


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `comsumer`.

Similar to #19500.
