### PR TITLE
[Access for SaaS] Properly spell `prerequisites`

### DIFF
--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/google-cloud-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/google-cloud-saas.mdx
@@ -19,7 +19,7 @@ When configuring Google Cloud with Access, the following limitations apply:
 - The integration of Access as a single sign-on provider for your Google Cloud account does not work for Google super admins. It will work for other users.
   :::
 
-## Prerequistes
+## Prerequisites
 
 - An [identity provider](/cloudflare-one/identity/idp-integration/) configured in Cloudflare Zero Trust
 - Admin access to a Google Workspace account

--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/google-workspace-saas.mdx
@@ -16,7 +16,7 @@ The integration of Access as a single sign-on provider for your Google Workspace
 
 :::
 
-## Prerequistes
+## Prerequisites
 
 - An [identity provider](/cloudflare-one/identity/idp-integration/) configured in Cloudflare Zero Trust
 - Admin access to a Google Workspace account


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `prerequistes`.

Similar to #19500.
