### PR TITLE
[DO] Renaming "Walkthrough" to "Tutorial"

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -399,6 +399,7 @@
 /durable-objects/api/transactional-storage-api/ /durable-objects/api/storage-api/ 301
 /durable-objects/platform/changelog/ /durable-objects/changelog/ 301
 /durable-objects/glossary/ /durable-objects/reference/glossary/ 301
+/durable-objects/get-started/walkthrough/ /durable-objects/get-started/tutorial/ 301
 
 # email-routing
 /email-routing/enable-email-routing/ /email-routing/get-started/enable-email-routing/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -399,7 +399,7 @@
 /durable-objects/api/transactional-storage-api/ /durable-objects/api/storage-api/ 301
 /durable-objects/platform/changelog/ /durable-objects/changelog/ 301
 /durable-objects/glossary/ /durable-objects/reference/glossary/ 301
-/durable-objects/get-started/walkthrough/ /durable-objects/get-started/tutorial/ 301
+/durable-objects/get-started/tutorial/ /durable-objects/get-started/tutorial/ 301
 
 # email-routing
 /email-routing/enable-email-routing/ /email-routing/get-started/enable-email-routing/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -399,7 +399,7 @@
 /durable-objects/api/transactional-storage-api/ /durable-objects/api/storage-api/ 301
 /durable-objects/platform/changelog/ /durable-objects/changelog/ 301
 /durable-objects/glossary/ /durable-objects/reference/glossary/ 301
-/durable-objects/get-started/tutorial/ /durable-objects/get-started/tutorial/ 301
+/durable-objects/get-started/walkthrough/ /durable-objects/get-started/tutorial/ 301
 
 # email-routing
 /email-routing/enable-email-routing/ /email-routing/get-started/enable-email-routing/ 301

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -217,7 +217,7 @@ export class WebSocketServer extends DurableObject {
 
 </TabItem> </Tabs>
 
-To execute this code, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
+To execute this code, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
 
 ```toml title="wrangler.toml"
 name = "websocket-server"
@@ -355,7 +355,7 @@ export class WebSocketHibernationServer extends DurableObject {
 
 </TabItem> </Tabs>
 
-Similar to the WebSocket Standard API example, to execute this code, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
+Similar to the WebSocket Standard API example, to execute this code, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
 
 ```toml title="wrangler.toml"
 name = "websocket-hibernation-server"

--- a/src/content/docs/durable-objects/examples/alarms-api.mdx
+++ b/src/content/docs/durable-objects/examples/alarms-api.mdx
@@ -74,7 +74,7 @@ export class Batcher extends DurableObject {
 
 The `alarm()` handler will be called once every 10 seconds. If an unexpected error terminates the Durable Object, the `alarm()` handler will be re-instantiated on another machine. Following a short delay, the `alarm()` handler will run from the beginning on the other machine.
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/build-a-counter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-counter.mdx
@@ -170,7 +170,7 @@ export class Counter extends DurableObject {
 
 </TabItem> </Tabs>
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
@@ -264,7 +264,7 @@ export class RateLimiter extends DurableObject {
 </TabItem>
 </Tabs>
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -70,7 +70,7 @@ New Location: ${request.cf.city}`);
 }
 ```
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/durable-object-ttl.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-ttl.mdx
@@ -100,7 +100,7 @@ export default {
 
 </TabItem> </Tabs>
 
-To test and deploy this example, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+To test and deploy this example, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
@@ -177,7 +177,7 @@ export class WebSocketHibernationServer extends DurableObject {
 
 </TabItem> </Tabs>
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the namespace and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/examples/websocket-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-server.mdx
@@ -187,7 +187,7 @@ export class WebSocketServer extends DurableObject {
 
 </TabItem> </Tabs>
 
-Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/walkthrough/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
+Finally, configure your Wrangler file to include a Durable Object [binding](/durable-objects/get-started/tutorial/#5-configure-durable-object-bindings) and [migration](/durable-objects/reference/durable-objects-migrations/) based on the <GlossaryTooltip term="namespace">namespace</GlossaryTooltip> and class name chosen previously.
 
 <WranglerConfig>
 

--- a/src/content/docs/durable-objects/get-started/tutorial.mdx
+++ b/src/content/docs/durable-objects/get-started/tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: Walkthrough
+title: Tutorial
 pcx_content_type: get-started
 sidebar:
   order: 1

--- a/src/content/docs/durable-objects/index.mdx
+++ b/src/content/docs/durable-objects/index.mdx
@@ -32,7 +32,7 @@ A Durable Object is a special kind of [Worker](/workers/). Like a Worker, it is 
 
 Thus, Durable Objects enable **stateful** serverless applications.
 
-<LinkButton href="/durable-objects/get-started/walkthrough/">Get started</LinkButton>
+<LinkButton href="/durable-objects/get-started/tutorial/">Get started</LinkButton>
 
 :::note[SQLite in Durable Objects Beta]
 

--- a/src/content/docs/kv/concepts/kv-bindings.mdx
+++ b/src/content/docs/kv/concepts/kv-bindings.mdx
@@ -78,7 +78,7 @@ kv_namespaces = [
 
 ## Access KV from Durable Objects and Workers using ES modules format
 
-[Durable Objects](/durable-objects/) use ES modules format. Instead of a global variable, bindings are available as properties of the `env` parameter [passed to the constructor](/durable-objects/get-started/walkthrough/#3-write-a-durable-object-class).
+[Durable Objects](/durable-objects/) use ES modules format. Instead of a global variable, bindings are available as properties of the `env` parameter [passed to the constructor](/durable-objects/get-started/tutorial/#3-write-a-durable-object-class).
 
 An example might look like:
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Currently the "Get started" section for DO is looking a bit messy. We have 

- Walkthrough
- Tutorial with SQL API
- Video series

`Walkthrough` and `Tutorial with SQL API` are identical with the exception of which backend storage API it uses. This PR unifies the naming convention for consistency.

We may wish to consider a separate PR to position the video series in a different location.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
