### PR TITLE
[Access for SaaS] Properly spell `metadata`

### DIFF
--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/jamf-pro-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/jamf-pro-saas.mdx
@@ -38,7 +38,7 @@ This guide covers how to configure [Jamf Pro](https://learn.jamf.com/en-US/bundl
 
 ## 3. Edit Access SAML Metadata
 
-1. Paste the **SAML Metdata endpoint** from application configuration in Cloudflare Zero Trust into a browser.
+1. Paste the **SAML Metadata endpoint** from application configuration in Cloudflare Zero Trust into a browser.
 2. Copy the file and paste it into a text editor.
 3. Change `WantAuthnRequestsSigned="true"` to `WantAuthnRequestsSigned="false"`.
 4. Set the file extension as `.xml` and save.


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `metdata`.

Similar to #19500.
