### PR TITLE
Updates dns docs to not use unimplemented method

### DIFF
--- a/src/content/changelogs-next/2025-01-28-nodejs-compat-improvements.mdx
+++ b/src/content/changelogs-next/2025-01-28-nodejs-compat-improvements.mdx
@@ -53,10 +53,9 @@ You can use [`node:dns`](https://nodejs.org/api/dns.html) for name resolution vi
 
 <TypeScriptExample filename="index.ts">
 ```ts
-import dns from "node:dns";
+import dns from 'node:dns';
 
-dns.lookup("example.org", (_err: any, address: string, ipFamily: number) =>
-	console.log(`address: ${address} family: IPv${ipFamily}`));
+let responese = await dns.promises.resolve4('cloudflare.com', 'NS');
 ````
 
 </TypeScriptExample>

--- a/src/content/docs/workers/runtime-apis/nodejs/dns.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/dns.mdx
@@ -12,12 +12,13 @@ You can use [`node:dns`](https://nodejs.org/api/dns.html) for name resolution vi
 
 <TypeScriptExample filename="index.ts">
 ```ts
-import dns from "node:dns";
+import dns from 'node:dns';
 
-dns.lookup("example.org", (_err: any, address: string, ipFamily: number) =>
-	console.log(`address: ${address} family: IPv${ipFamily}`));
+let responese = await dns.promises.resolve4('cloudflare.com', 'NS');
 ```
 </TypeScriptExample>
+
+All `node:dns` functions are available, except `lookup`, `lookupService`, and `resolve` which throw "Not implemented" errors when called.
 
 :::note
 


### PR DESCRIPTION
### Summary

Accidentally used `lookup` in my example even tho it's not implemented 🤦 .

Using the resolve4 promise because it works and the promise UX seems slightly nicer IMO.

Confirmed that this works with latest wrangler.
