### PR TITLE
[DO] Properly spell `accessible`

### DIFF
--- a/src/content/docs/durable-objects/get-started/tutorial-with-sql-api.mdx
+++ b/src/content/docs/durable-objects/get-started/tutorial-with-sql-api.mdx
@@ -138,7 +138,7 @@ export class MyDurableObject extends DurableObject {
 In the code above, you have:
 
 1. Defined a RPC method, `sayHello()`, that can be called by a Worker to communicate with a Durable Object.
-2. Accessed a Durable Object's attached storage, which is a private SQLite database only accesible to the object, using [SQL API](/durable-objects/api/sql-storage/#exec) methods (`sql.exec()`) available on `ctx.storage` .
+2. Accessed a Durable Object's attached storage, which is a private SQLite database only accessible to the object, using [SQL API](/durable-objects/api/sql-storage/#exec) methods (`sql.exec()`) available on `ctx.storage` .
 3. Returned an object representing the single row query result using `one()`, which checks that the query result has exactly one row.
 4. Return the `greeting` column from the row object result.
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `accesible`.

Similar to #19500.
