### PR TITLE
[Style guide] Properly spell `readability`

### DIFF
--- a/src/content/docs/style-guide/documentation-content-strategy/file-conventions.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/file-conventions.mdx
@@ -26,7 +26,7 @@ Filenames should:
 /src/assets/images/api-shield/API_Image_1.png
 ```
 
-These conventions are important for user readibility, SEO conventions, and making sure our GitHub actions do not break.
+These conventions are important for user readability, SEO conventions, and making sure our GitHub actions do not break.
 
 ## Folders
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `readibility`.

Similar to #19500.
