### PR TITLE
[D1] Properly spell `misspelling`

### DIFF
--- a/src/content/docs/d1/observability/debug-d1.mdx
+++ b/src/content/docs/d1/observability/debug-d1.mdx
@@ -43,7 +43,7 @@ To capture exceptions, log the `Error.message` value. For example, the code belo
 
 ```js
 try {
-    // This is an intentional mispelling
+    // This is an intentional misspelling
     await db.exec("INSERTZ INTO my_table (name, employees) VALUES ()");
 } catch (e: any) {
     console.error({


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `mispelling`.

Similar to #19500.
