### PR TITLE
[Workers] Properly spell `manage`

### DIFF
--- a/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
+++ b/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
@@ -161,7 +161,7 @@ The integration creates a new Fauna authentication key and stores the key's secr
 
 :::note
 
-You can mange the generated Fauna key in the Fauna Dashboard. See the [Clouflare Fauna integration docs](/workers/databases/native-integrations/fauna).
+You can manage the generated Fauna key in the Fauna Dashboard. See the [Clouflare Fauna integration docs](/workers/databases/native-integrations/fauna).
 
 :::
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `mange`.

Similar to #19500.
