### PR TITLE
Adds streaming HTMLRewriter content docs and changelog

### DIFF
--- a/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
+++ b/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
@@ -1,19 +1,25 @@
 ---
-title: Rewrite HTML with streaming content
+title: Transform HTML quickly with streaming content
 description: HTMLRewiter now supports streamed content for more efficient replacement of HTML elements
 products:
   - workers
-date: 2025-01-31T10:00:00Z
+date: 2025-01-31T01:00:00Z
 ---
 
 import { Render, TypeScriptExample } from "~/components";
 
-[`HTMLRewriter`](/workers/runtime-apis/html-rewriter) now supports replacing HTML with content from a stream.
-[`Response`](/workers/runtime-apis/response/) and [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) values can now
-be passed as [`Content`](/workers/runtime-apis/html-rewriter/#global-types) into methods duch as
-`replace`, `append`, and `prepend`.
+You can now transform HTML elements with streamed content using [`HTMLRewriter`](/workers/runtime-apis/html-rewriter).
 
-This allows you to process HTML more efficiently, as content does not have to be loaded into memory before replacements are made.
+Methods like `replace`, `append`, and `prepend` now accept [`Response`](/workers/runtime-apis/response/) and [`ReadableStream`](/workers/runtime-apis/streams/readablestream/)
+values as [`Content`](/workers/runtime-apis/html-rewriter/#global-types).
+
+This can be helpful in a variety of situations. For instance, you may have a Worker in front of an origin,
+and want to replace an element with content from a different source. Prior to this change, if you wanted
+to replace an element with content from an upstream URL, you would have to load all of the content and convert
+it into a string before replacing the element. This slowed down overall response times.
+
+Now, you can pass the `Response` object directly into the `replace` method, and HTMLRewriter will immediately
+start replacing the content as it is streamed in. This makes responses faster.
 
 <TypeScriptExample filename="index.ts">
 ```ts

--- a/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
+++ b/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
@@ -14,9 +14,9 @@ Methods like `replace`, `append`, and `prepend` now accept [`Response`](/workers
 values as [`Content`](/workers/runtime-apis/html-rewriter/#global-types).
 
 This can be helpful in a variety of situations. For instance, you may have a Worker in front of an origin,
-and want to replace an element with content from a different source. Prior to this change, if you wanted
-to replace an element with content from an upstream URL, you would have to load all of the content and convert
-it into a string before replacing the element. This slowed down overall response times.
+and want to replace an element with content from a different source. Prior to this change, you would have to load
+all of the content from the upstream URL and convert it into a string before replacing the element. This slowed
+down overall response times.
 
 Now, you can pass the `Response` object directly into the `replace` method, and HTMLRewriter will immediately
 start replacing the content as it is streamed in. This makes responses faster.

--- a/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
+++ b/src/content/changelogs-next/2025-01-31-html-rewriter-streaming.mdx
@@ -3,18 +3,17 @@ title: Rewrite HTML with streaming content
 description: HTMLRewiter now supports streamed content for more efficient replacement of HTML elements
 products:
   - workers
-date: 2025-02-03T3:00:00Z
+date: 2025-01-31T10:00:00Z
 ---
 
 import { Render, TypeScriptExample } from "~/components";
 
 [`HTMLRewriter`](/workers/runtime-apis/html-rewriter) now supports replacing HTML with content from a stream.
-
-This allows you to process HTML more efficiently, as content does not have to be loaded into memory before replacements are made.
-
 [`Response`](/workers/runtime-apis/response/) and [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) values can now
 be passed as [`Content`](/workers/runtime-apis/html-rewriter/#global-types) into methods duch as
 `replace`, `append`, and `prepend`.
+
+This allows you to process HTML more efficiently, as content does not have to be loaded into memory before replacements are made.
 
 <TypeScriptExample filename="index.ts">
 ```ts

--- a/src/content/changelogs-next/2025-02-03-html-rewriter-streaming.mdx
+++ b/src/content/changelogs-next/2025-02-03-html-rewriter-streaming.mdx
@@ -1,0 +1,40 @@
+---
+title: Rewrite HTML with streaming content
+description: HTMLRewiter now supports streamed content for more efficient replacement of HTML elements
+products:
+  - workers
+date: 2025-02-03T3:00:00Z
+---
+
+import { Render, TypeScriptExample } from "~/components";
+
+[`HTMLRewriter`](/workers/runtime-apis/html-rewriter) now supports replacing HTML with content from a stream.
+
+This allows you to process HTML more efficiently, as content does not have to be loaded into memory before replacements are made.
+
+[`Response`](/workers/runtime-apis/response/) and [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) values can now
+be passed as [`Content`](/workers/runtime-apis/html-rewriter/#global-types) into methods duch as
+`replace`, `append`, and `prepend`.
+
+<TypeScriptExample filename="index.ts">
+```ts
+class ElementRewriter {
+	async element(element: any) {
+		// able to replace elements while streaming content
+		// the fetched body is not buffered into memory as part
+		// of the replace
+		let res = await fetch('https://upstream-content-provider.example');
+		element.replace(res);
+	}
+}
+
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		let response = await fetch('https://site-to-replace.com');
+		return new HTMLRewriter().on('[data-to-replace]', new ElementRewriter()).transform(response);
+	},
+} satisfies ExportedHandler<Env>;
+```
+</TypeScriptExample>
+
+For more information, see the [`HTMLRewriter` documentation](/workers/runtime-apis/html-rewriter).

--- a/src/content/docs/workers/runtime-apis/html-rewriter.mdx
+++ b/src/content/docs/workers/runtime-apis/html-rewriter.mdx
@@ -32,7 +32,7 @@ Throughout the `HTMLRewriter` API, there are a few consistent types that many pr
 
 * `Content` string | Response | ReadableStream
 
-  * Content inserted in the output stream should be a string, a [`Response`](/workers/runtime-apis/response/), or a [`ReadableStream`](/workers/runtime-apis/streams/readablestream/).
+  * Content inserted in the output stream should be a string, [`Response`](/workers/runtime-apis/response/), or [`ReadableStream`](/workers/runtime-apis/streams/readablestream/).
 
 * `ContentOptions` Object
 

--- a/src/content/docs/workers/runtime-apis/html-rewriter.mdx
+++ b/src/content/docs/workers/runtime-apis/html-rewriter.mdx
@@ -30,9 +30,9 @@ Throughout the `HTMLRewriter` API, there are a few consistent types that many pr
 
 
 
-* `Content` string
+* `Content` string | Response | ReadableStream
 
-  * Content inserted in the output stream should be a string.
+  * Content inserted in the output stream should be a string, a [`Response`](/workers/runtime-apis/response/), or a [`ReadableStream`](/workers/runtime-apis/streams/readablestream/).
 
 * `ContentOptions` Object
 


### PR DESCRIPTION
### Summary

Adds documentation and a changelog for recent updates to HTMLRewriter that allow for streamed content.

<img width="657" alt="Screenshot 2025-01-30 at 3 34 42 PM" src="https://github.com/user-attachments/assets/9f144c06-fd4e-4443-8573-0014c72912ae" />
