### PR TITLE
[Workers Logs] Properly spell `visibility`

### DIFF
--- a/src/content/docs/workers/observability/logs/index.mdx
+++ b/src/content/docs/workers/observability/logs/index.mdx
@@ -17,7 +17,7 @@ Automatically ingest, filter, and analyze logs emitted from Cloudflare Workers i
 
 ## [Real-time logs](/workers/observability/logs/real-time-logs)
 
-Access log events in near real-time. Real-time logs provide immediate feedback and visiblity into the health of your Cloudflare Worker.
+Access log events in near real-time. Real-time logs provide immediate feedback and visibility into the health of your Cloudflare Worker.
 
 ## [Tail Workers](/workers/observability/logs/tail-workers) <Badge text="Beta" size="large"/>
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `visiblity`.

Similar to #19500.
