### PR TITLE
[Docs Site] Support paths with and without trailing slash in local dev

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -44,7 +44,6 @@ const runLinkCheck = process.env.RUN_LINK_CHECK || false;
 // https://astro.build/config
 export default defineConfig({
 	site: "https://developers.cloudflare.com",
-	trailingSlash: "always",
 	markdown: {
 		smartypants: false,
 		rehypePlugins: [

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -44,6 +44,7 @@ const runLinkCheck = process.env.RUN_LINK_CHECK || false;
 // https://astro.build/config
 export default defineConfig({
 	site: "https://developers.cloudflare.com",
+	trailingSlash: "always",
 	markdown: {
 		smartypants: false,
 		rehypePlugins: [

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -5,7 +5,7 @@ import Default from "@astrojs/starlight/components/Sidebar.astro";
 import { Icon as AstroIcon } from "astro-icon/components";
 import { lookupProductTitle } from "~/util/sidebar";
 
-const [product, module] = Astro.url.pathname.split("/").slice(1, -1);
+const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 ---
 
 <a

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -16,7 +16,7 @@ const sidebars = new Map<string, Group>();
 
 export async function getSidebar(context: AstroGlobal<Props>) {
 	const pathname = context.url.pathname;
-	const segments = pathname.split("/").slice(1, -1);
+	const segments = pathname.split("/").filter(Boolean);
 
 	const product = segments.at(0);
 
@@ -96,9 +96,14 @@ function setSidebarCurrentEntry(
 	pathname: string,
 ): boolean {
 	for (const entry of sidebar) {
-		if (entry.type === "link" && entry.href === pathname) {
-			entry.isCurrent = true;
-			return true;
+		if (entry.type === "link") {
+			const href = entry.href;
+
+			// Compare with and without trailing slash
+			if (href === pathname || href.slice(0, -1) === href) {
+				entry.isCurrent = true;
+				return true;
+			}
 		}
 
 		if (


### PR DESCRIPTION
### Summary

This was highlighted by a chance in our sidebar logic - we shouldn't "support" links like `/workers` and should direct people to `/workers/` as all links and redirects written should use the trailing slash.