### PR TITLE
[Docs Site] Always use current origin in search results

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -136,10 +136,7 @@ export default defineConfig({
 						]
 					: []),
 				starlightDocSearch({
-					appId: "D32WIYFTUF",
-					apiKey: "5cec275adc19dd3bc17617f7d9cf312a",
-					indexName: "prod_devdocs",
-					insights: true,
+					clientOptionsModule: "./src/plugins/docsearch/index.ts",
 				}),
 				starlightImageZoom(),
 			],

--- a/src/plugins/docsearch/index.ts
+++ b/src/plugins/docsearch/index.ts
@@ -1,0 +1,21 @@
+import type { DocSearchClientOptions } from "@astrojs/starlight-docsearch";
+
+export default {
+	appId: "D32WIYFTUF",
+	apiKey: "5cec275adc19dd3bc17617f7d9cf312a",
+	indexName: "prod_devdocs",
+	insights: true,
+	// Replace URL with the current origin so search
+	// can be used in local development and previews.
+	transformItems(items) {
+		return items.map((item) => {
+			const path = new URL(item.url).pathname;
+			const url = new URL(path, window.origin);
+
+			return {
+				...item,
+				url: url.toString(),
+			};
+		});
+	},
+} satisfies DocSearchClientOptions;


### PR DESCRIPTION
### Summary

Always use current origin in search results.

Currently, when using the search, all results will go to `https://developers.cloudflare.com/...`. This makes it use the current origin, so local development would go to `http://localhost:1111/...` or preview URLs would go to `https://foo.cloudflare-docs-7ou.pages.dev/...`.