### PR TITLE
[Turnstile] Properly spell `encounter`

### DIFF
--- a/src/content/docs/turnstile/concepts/widget.mdx
+++ b/src/content/docs/turnstile/concepts/widget.mdx
@@ -104,4 +104,4 @@ The widget expires when a token was issued but the user did not solve the challe
 
 ![Unsupported browser](~/assets/images/turnstile/unsupported-browser.png)
 
-Visitors with outdated browsers or unsupported browsers will encouter this widget state. Refer to [Supported browsers](/waf/reference/cloudflare-challenges/#browser-support) for more information regarding supported browsers.
+Visitors with outdated browsers or unsupported browsers will encounter this widget state. Refer to [Supported browsers](/waf/reference/cloudflare-challenges/#browser-support) for more information regarding supported browsers.


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `encouter`.

Similar to #19500.
