### PR TITLE
Update limitations of allow local network

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/index.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/index.mdx
@@ -309,4 +309,4 @@ To turn on local network access in the WARP client:
 
 - WARP will only exclude local networks in the [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) address space. Other IP addresses such as CGNAT are not supported.
 - The maximum excluded subnet size is `/24`.
-- If a Windows device has multiple network interfaces with distinct local IP ranges, WARP will only exclude one of those networks. To access a specific local network, disable the other interfaces and disconnect/reconnect WARP.
+- If a device has multiple network interfaces with distinct local IP ranges, WARP will only exclude one of those networks. To access a specific local network, disable the other interfaces and disconnect/reconnect WARP.


### PR DESCRIPTION
Limitations originally specifically stated Windows would only exclude a single subnet if the device had multiple. Confirmed this limitation is on all OS's

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
