### PR TITLE
[Style guide] Properly spell `variable`

### DIFF
--- a/src/content/docs/style-guide/components/markdown.mdx
+++ b/src/content/docs/style-guide/components/markdown.mdx
@@ -18,4 +18,4 @@ If you have a variable that needs to be formatted in any special way (for exampl
 <Markdown text={props.foo} />
 ```
 
-Note that you need to wrap your variabble in curly braces, as well as use `text=` or this will not work.
+Note that you need to wrap your variable in curly braces, as well as use `text=` or this will not work.


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `variabble`.

Similar to #19500.
