### PR TITLE
[Workflows] Properly spell `your`

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -45,7 +45,7 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 The `WorkflowEvent` type accepts an optional [type parameter](https://www.typescriptlang.org/docs/handbook/2/generics.html#working-with-generic-type-variables) that allows you to provide a type for the `payload` property within the `WorkflowEvent`.
 
-Refer to the [events and parameters](/workflows/build/events-and-parameters/) documentation for how to handle events within yur Workflow code.
+Refer to the [events and parameters](/workflows/build/events-and-parameters/) documentation for how to handle events within your Workflow code.
 
 ## WorkflowEvent
 
@@ -63,7 +63,7 @@ export type WorkflowEvent<T> = {
   * `timestamp` - a `Date` object set to the time the Workflow instance was created (triggered).
   * `instanceId` - the ID of the associated instance.
 
-Refer to the [events and parameters](/workflows/build/events-and-parameters/) documentation for how to handle events within yur Workflow code.
+Refer to the [events and parameters](/workflows/build/events-and-parameters/) documentation for how to handle events within your Workflow code.
 
 ## WorkflowStep
 


### PR DESCRIPTION
### Summary

This PR fixes a typo. There are no other occurrences of `yur`.

Similar to #19500.
