### PR TITLE
Workflows: add new changelog entries during January 2025 and February 2025

### DIFF
--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -6,9 +6,9 @@ productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2025-02-11"
-    title: "Performance improvements"
+    title: "Behavior improvements"
     description: |-
-      Improved Workflows execution mechanism that prevents Workflows instances to get stuck.
+      Improved Workflows execution that prevents Workflows instances from getting stuck, and allows stuck instances to become unstuck.
   - publish_date: "2025-01-23"
     title: "Major bugfixes and improvements"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -24,7 +24,7 @@ entries:
     description: |-
       Previously, in local dev, the output field would return the list of successful steps outputs in the workflow. This is not expected behavior compared to production workflows (where the output is the actual return of the run function).
 
-      This release makes it so that output is equal to production behavior.
+      This release aligns the local dev output field behavior with the production behavior.
   - publish_date: "2024-12-19"
     title: "Better instance control, improved queued logic, and step limit increased"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -5,6 +5,10 @@ productLink: "/workflows/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2025-02-11"
+    title: "Performance improvements"
+    description: |-
+      Improved Workflows execution mechanism that prevents Workflows instances to get stuck.
   - publish_date: "2025-01-23"
     title: "Major bugfixes and improvements"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -10,7 +10,7 @@ entries:
     description: |-
       Improved Workflows execution that prevents Workflows instances from getting stuck, and allows stuck instances to become unstuck.
 
-      Also, improved reliability of Workflows step retry counts, and improved Instance ID validation.
+      Also, improved the reliability of Workflows step retry counts, and improved Instance ID validation.
   - publish_date: "2025-01-23"
     title: "Major bugfixes and improvements"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -12,8 +12,7 @@ entries:
         * `event.timestamp` is now `Date`, fixing a regression
         *  Fixed issue where instances without metadata were not terminated as expected
 
-      Also, this release brings the following improvements:
-        * More reliable Engine for loaded accounts
+      Also, this release makes Workflows execution more reliable for accounts with high loads.
   - publish_date: "2025-01-09"
     title: "Improved Wrangler local dev experience for step's output, matching production"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -20,7 +20,7 @@ entries:
 
       Also, this release makes Workflows execution more reliable for accounts with high loads.
   - publish_date: "2025-01-09"
-    title: "Improved Wrangler local dev experience for step's output, matching production"
+    title: "Improved Wrangler local dev experience for steps' output, matching production"
     description: |-
       Previously, in local dev, the output field would return the list of successful steps outputs in the workflow. This is not expected behavior compared to production workflows (where the output is the actual return of the run function).
 

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -9,6 +9,8 @@ entries:
     title: "Behavior improvements"
     description: |-
       Improved Workflows execution that prevents Workflows instances from getting stuck, and allows stuck instances to become unstuck.
+
+      Also, improved reliability of Workflows step retry counts, and improved Instance ID validation.
   - publish_date: "2025-01-23"
     title: "Major bugfixes and improvements"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -10,7 +10,7 @@ entries:
     description: |-
       With this release, some bug were fixed:
         * `event.timestamp` is now `Date`, fixing a regression
-        *  Fixed issue where instances without metadata are not terminated as expected
+        *  Fixed issue where instances without metadata were not terminated as expected
 
       Also, this release brings the following improvements:
         * More reliable Engine for loaded accounts

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -15,8 +15,8 @@ entries:
     title: "Major bugfixes and improvements"
     description: |-
       With this release, some bug were fixed:
-        * `event.timestamp` is now `Date`, fixing a regression
-        *  Fixed issue where instances without metadata were not terminated as expected
+        * `event.timestamp` is now `Date`, fixing a regression.
+        *  Fixed issue where instances without metadata were not terminated as expected.
 
       Also, this release makes Workflows execution more reliable for accounts with high loads.
   - publish_date: "2025-01-09"

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -5,6 +5,21 @@ productLink: "/workflows/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2025-01-23"
+    title: "Major bugfixes and improvements"
+    description: |-
+      With this release, some bug were fixed:
+        * `event.timestamp` is now Date, fixing a regression
+        *  Fixed issue where instances without metadata are not terminated as expected
+
+      Also, this release brings the following improvements:
+        * More reliable Engine for loaded accounts
+  - publish_date: "2025-01-09"
+    title: "Improved Wrangler local dev experience for step's output, matching production"
+    description: |-
+      Previously, in local dev, the output field would return the list of successful steps outputs in the workflow. This is not expected behavior compared to production workflows (where the output is the actual return of the run function).
+
+      This release makes it so that output is equal to production behavior.
   - publish_date: "2024-12-19"
     title: "Better instance control, improved queued logic, and step limit increased"
     description: |-

--- a/src/content/changelogs/workflows.yaml
+++ b/src/content/changelogs/workflows.yaml
@@ -9,7 +9,7 @@ entries:
     title: "Major bugfixes and improvements"
     description: |-
       With this release, some bug were fixed:
-        * `event.timestamp` is now Date, fixing a regression
+        * `event.timestamp` is now `Date`, fixing a regression
         *  Fixed issue where instances without metadata are not terminated as expected
 
       Also, this release brings the following improvements:


### PR DESCRIPTION
### Summary

Add new changelog entries for Workflows during January 2025 and February 2025