### PR TITLE
[Docs Site] Add dev-only middleware for /api/ links

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,18 @@
+import { defineMiddleware } from "astro:middleware";
+
+// `astro dev` only middleware so that `/api/...` links can be viewed.
+export const onRequest = defineMiddleware(async (context, next) => {
+	if (import.meta.env.DEV) {
+		if (context.url.pathname.startsWith("/api/")) {
+			const url = new URL(context.url.pathname, import.meta.env.SITE);
+
+			return fetch(url, {
+				headers: {
+					"accept-encoding": "identity",
+				},
+			});
+		}
+	}
+
+	return next();
+});


### PR DESCRIPTION
### Summary

Adds a dev-only middleware for /api/ links.