### PR TITLE
[D1] Renaming "Terminology" to "Bookmarks"

### DIFF
--- a/src/content/docs/d1/reference/time-travel.mdx
+++ b/src/content/docs/d1/reference/time-travel.mdx
@@ -21,7 +21,7 @@ To understand which storage subsystem your database uses, run `wrangler d1 info 
 
 :::
 
-## Terminology
+## Bookmarks
 
 Time Travel introduces the concept of a "bookmark" to D1. A bookmark represents the state of a database at a specific point in time, and is effectively an append-only log.
 

--- a/src/content/docs/d1/reference/time-travel.mdx
+++ b/src/content/docs/d1/reference/time-travel.mdx
@@ -9,7 +9,7 @@ Time Travel is D1's approach to backups and point-in-time-recovery, and allows y
 
 - You do not need to enable Time Travel. It is always on.
 - Database history and restoring a database incur no additional costs.
-- Time Travel automatically creates [bookmarks](#terminology) on your behalf. You do not need to manually trigger or remember to initiate a backup.
+- Time Travel automatically creates [bookmarks](#bookmarks) on your behalf. You do not need to manually trigger or remember to initiate a backup.
 
 By not having to rely on scheduled backups and/or manually initiated backups, you can go back in time and restore a database prior to a failed migration or schema change, a `DELETE` or `UPDATE` statement without a specific `WHERE` clause, and in the future, fork/copy a production database directly.
 
@@ -95,7 +95,7 @@ Note that:
 
 - Timestamps are converted to a deterministic, stable bookmark. The same timestamp will always represent the same bookmark.
 - Queries in flight will be cancelled, and an error returned to the client.
-- The restore operation will return a [bookmark](#terminology) that allows you to [undo](#undo-a-restore) and revert the database.
+- The restore operation will return a [bookmark](#bookmarks) that allows you to [undo](#undo-a-restore) and revert the database.
 
 ## Undo a restore
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Renaming `/d1/reference/time-travel/#terminology` to `/d1/reference/time-travel/#bookmarks`, as this better reflects the content being discussed in the heading.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
