### PR TITLE
[Docs Site] Remove unnecessary ts-expect-error directives

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,6 @@ export default [
 		rules: {
 			"no-var": "error",
 			"@typescript-eslint/no-explicit-any": "off",
-			"@typescript-eslint/triple-slash-reference": "off",
 			"@typescript-eslint/no-unused-vars": [
 				"error",
 				{ ignoreRestSiblings: true },

--- a/src/components/ListExamples.astro
+++ b/src/components/ListExamples.astro
@@ -1,16 +1,17 @@
 ---
 import { z } from "astro:schema";
-import { getCollection } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import { marked } from "marked";
 
 import { CardGrid } from "@astrojs/starlight/components";
 import LinkTitleCard from "~/components/LinkTitleCard.astro";
 
 type Props = z.infer<typeof props>;
+type Data = keyof CollectionEntry<"docs">["data"];
 
 const props = z.object({
 	directory: z.string().optional(),
-	filters: z.string().array().optional(),
+	filters: z.custom<Data>().array().optional(),
 	additionalProducts: z.string().array().optional(),
 });
 
@@ -36,13 +37,15 @@ const examples = await getCollection("docs", (entry) => {
 });
 
 const filterValues: Record<string, string[]> = {};
+
 if (filters) {
 	for (const filter of filters) {
 		const values = examples.flatMap((x) =>
-			// @ts-expect-error indexing frontmatter with string
 			filter in x.data ? x.data[filter] : [],
 		);
-		const unique = [...new Set(values)];
+
+		const unique = [...new Set(values.flatMap((v) => v?.toString() ?? []))];
+
 		filterValues[filter] = unique;
 	}
 }
@@ -79,16 +82,14 @@ if (filters) {
 			examples
 				.sort((a, b) => a.data.title.localeCompare(b.data.title))
 				.map((example) => {
-					const filterAttributes = {};
+					const filterAttributes: { [index: string]: any } = {};
+
 					if (filters) {
 						for (const filter of filters) {
 							const hasFilterableProperty = filter in example.data;
 
 							if (hasFilterableProperty) {
-								// @ts-expect-error can't use TS generics inside JSX
-								filterAttributes[`data-${filter}`] =
-									// @ts-expect-error indexing frontmatter with string
-									example.data[filter];
+								filterAttributes[`data-${filter}`] = example.data[filter];
 							}
 						}
 					}

--- a/src/components/ListTutorials.astro
+++ b/src/components/ListTutorials.astro
@@ -27,13 +27,20 @@ const tutorials = await getCollection("docs", (entry) => {
 });
 
 type VideoEntry = InferEntrySchema<"videos">["entries"][number];
+
 type FinalTutorials = {
 	slug?: string;
-	data: InferEntrySchema<"docs"> | VideoEntry;
+	data:
+		| ({ type: "docs" } & InferEntrySchema<"docs">)
+		| ({ type: "videos" } & VideoEntry);
 }[];
+
 const finalTutorials: FinalTutorials = tutorials.map((x) => ({
 	slug: x.id,
-	data: x.data,
+	data: {
+		type: "docs",
+		...x.data,
+	},
 }));
 
 const videos = await getEntry("videos", "index");
@@ -49,7 +56,14 @@ const filteredVideos = videos.data.entries.filter((x) =>
 );
 
 if (filteredVideos) {
-	filteredVideos.forEach((x) => finalTutorials.push({ data: x }));
+	filteredVideos.forEach((x) =>
+		finalTutorials.push({
+			data: {
+				type: "videos",
+				...x,
+			},
+		}),
+	);
 }
 
 finalTutorials.sort((a, b) => Number(b.data.updated) - Number(a.data.updated));
@@ -72,8 +86,10 @@ const timeAgo = (date?: Date) => {
 	<tbody>
 		{
 			finalTutorials.map((tutorial) => {
-				// @ts-expect-error TODO: improve types
-				const href = tutorial.slug ? `/${tutorial.slug}` : tutorial.data.link;
+				const href =
+					tutorial.data.type === "docs"
+						? `/${tutorial.slug}/`
+						: tutorial.data.link;
 				return (
 					<tr>
 						<td>

--- a/src/components/Plan.astro
+++ b/src/components/Plan.astro
@@ -27,15 +27,13 @@ const props = z
 		}),
 	);
 
-// @ts-expect-error plans are not typed
-const { id, type } = props.parse(Astro.props);
+const input = props.parse(Astro.props);
 
 let availability;
-if (type) {
-	// @ts-expect-error plans are not typed
-	availability = mappings[type];
+if ("type" in input) {
+	availability = mappings[input.type];
 } else {
-	availability = await indexPlans(id);
+	availability = await indexPlans(input.id);
 }
 ---
 

--- a/src/components/WorkersArchitectureDiagram.astro
+++ b/src/components/WorkersArchitectureDiagram.astro
@@ -1,1147 +1,1064 @@
----
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck xmlns in SVGs makes Astro very upset, so we'll just ignore this file
----
-
 <svg
 	xmlns="http://www.w3.org/2000/svg"
-	xmlns:xlink="http://www.w3.org/1999/xlink"
-	version="1.1"
-	width="701px"
-	height="863px"
-	viewBox="-0.5 -0.5 701 863"
+	width="701"
+	height="863"
 	class="dark:invert"
-	><defs></defs><g
-		><rect
-			x="140"
-			y="200"
-			width="350"
-			height="660"
-			fill="transparent"
-			stroke="#000000"
-			stroke-width="4"
-			pointer-events="none"></rect><rect
-			x="160"
-			y="240"
-			width="310"
-			height="330"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><path
-			d="M 240 398.24 L 240 415 L 195 415 L 195 431.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 240 392.24 L 244 400.24 L 240 398.24 L 236 400.24 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 195 437.76 L 191 429.76 L 195 431.76 L 199 429.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 268 398.24 L 268 415 L 255 415 L 255 431.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 268 392.24 L 272 400.24 L 268 398.24 L 264 400.24 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 255 437.76 L 251 429.76 L 255 431.76 L 259 429.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 390 398.24 L 390 415 L 435 415 L 435 431.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 390 392.24 L 394 400.24 L 390 398.24 L 386 400.24 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 435 437.76 L 431 429.76 L 435 431.76 L 439 429.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 363 398.24 L 363 415 L 375 415 L 375 431.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 363 392.24 L 367 400.24 L 363 398.24 L 359 400.24 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 375 437.76 L 371 429.76 L 375 431.76 L 379 429.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 410 330 L 421.76 330"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 427.76 330 L 419.76 334 L 421.76 330 L 419.76 326 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 360 270 L 360 168.24"
-			fill="none"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 360 162.24 L 364 170.24 L 360 168.24 L 356 170.24 Z"
-			fill="#6c8ebf"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="220"
-			y="270"
-			width="190"
-			height="120"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(232.5,321.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="164"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 165px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Scheduling and routing
-						</div>
-					</div></foreignObject
-				><text
-					x="82"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Scheduling and routing</text
-				></switch
-			></g
-		><path
-			d="M 470 330 L 501.76 330"
-			fill="none"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 507.76 330 L 499.76 334 L 501.76 330 L 499.76 326 Z"
-			fill="#b85450"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="390"
-			y="310"
-			width="120"
-			height="40"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,450,330)"
-			pointer-events="none"></rect><g
-			transform="translate(408.5,321.5)rotate(-90,41.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="83"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 84px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							HTTP client
-						</div>
-					</div></foreignObject
-				><text
-					x="42"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">HTTP client</text
-				></switch
-			></g
-		><path
-			d="M 200 330 L 211.76 330"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 217.76 330 L 209.76 334 L 211.76 330 L 209.76 326 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="120"
-			y="310"
-			width="120"
-			height="40"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,180,330)"
-			pointer-events="none"></rect><g
-			transform="translate(134.5,321.5)rotate(-90,45,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="90"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 91px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							HTTP server
-						</div>
-					</div></foreignObject
-				><text
-					x="45"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">HTTP server</text
-				></switch
-			></g
-		><path
-			d="M 120 330 L 151.76 330"
-			fill="none"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 157.76 330 L 149.76 334 L 151.76 330 L 149.76 326 Z"
-			fill="#b85450"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 60 270 L 60 40 L 271.76 40"
-			fill="none"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 277.76 40 L 269.76 44 L 271.76 40 L 269.76 36 Z"
-			fill="#000000"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="0"
-			y="270"
-			width="120"
-			height="120"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(17.5,311.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="85"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 86px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Inbound<br style="font-size: 16px" />HTTP proxy<br
-								style="font-size: 16px"
-							/>
-						</div>
-					</div></foreignObject
-				><text
-					x="43"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 570 270 L 570 40 L 448.24 40"
-			fill="none"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 442.24 40 L 450.24 36 L 448.24 40 L 450.24 44 Z"
-			fill="#000000"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="510"
-			y="270"
-			width="120"
-			height="120"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(527.5,311.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="85"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 86px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Outbound<br style="font-size: 16px" />HTTP proxy<br
-								style="font-size: 16px"
-							/>
-						</div>
-					</div></foreignObject
-				><text
-					x="43"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 280 140 L 238.24 140"
-			fill="none"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 232.24 140 L 240.24 136 L 238.24 140 L 240.24 144 Z"
-			fill="#000000"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 360 120 L 360 88.24"
-			fill="none"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 360 82.24 L 364 90.24 L 360 88.24 L 356 90.24 Z"
-			fill="#000000"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="280"
-			y="120"
-			width="160"
-			height="40"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(321.5,131.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="76"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 77px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Supervisor<br style="font-size: 16px" />
-						</div>
-					</div></foreignObject
-				><text
-					x="38"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><g transform="translate(171.5,246.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="161"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 162px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Main Runtime Process
-						</div>
-					</div></foreignObject
-				><text
-					x="81"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Main Runtime Process</text
-				></switch
-			></g
-		><g transform="translate(161.5,211.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="108"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 109px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Outer Sandbox
-						</div>
-					</div></foreignObject
-				><text
-					x="54"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Outer Sandbox</text
-				></switch
-			></g
-		><path
-			d="M 170 116 C 170 94.67 230 94.67 230 116 L 230 164 C 230 185.33 170 185.33 170 164 Z"
-			fill="transparent"
-			stroke="#000000"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 170 116 C 170 132 230 132 230 116"
-			fill="none"
-			stroke="#000000"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(184.5,142.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="31"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 32px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Disk
-						</div>
-					</div></foreignObject
-				><text
-					x="16"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Disk</text
-				></switch
-			></g
-		><path
-			d="M 320 20 C 288 20 280 40 305.6 44 C 280 52.8 308.8 72 329.6 64 C 344 80 392 80 408 64 C 440 64 440 48 420 40 C 440 24 408 8 380 16 C 360 4 328 4 320 20 Z"
-			fill="transparent"
-			stroke="#000000"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(312.5,31.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="95"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 96px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Control plane<br style="font-size: 16px" />
-						</div>
-					</div></foreignObject
-				><text
-					x="48"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 520 460 L 551.76 460"
-			fill="none"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 557.76 460 L 549.76 464 L 551.76 460 L 549.76 456 Z"
-			fill="#b85450"
-			stroke="#b85450"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(566.5,451.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="42"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 43px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: left ; font-size: 16px">
-								<span style="font-size: 16px">HTTP</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="21"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 520 490 L 551.76 490"
-			fill="none"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 557.76 490 L 549.76 494 L 551.76 490 L 549.76 486 Z"
-			fill="#6c8ebf"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(566.5,481.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="122"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 123px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: left ; font-size: 16px">
-								<span style="font-size: 16px">Cap'n Proto RPC</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="61"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 520 520 L 551.76 520"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 557.76 520 L 549.76 524 L 551.76 520 L 549.76 516 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(566.5,511.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="111"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 112px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: left ; font-size: 16px">
-								<span style="font-size: 16px">In-process calls</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="56"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 520 550 L 551.76 550"
-			fill="none"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 557.76 550 L 549.76 554 L 551.76 550 L 549.76 546 Z"
-			fill="#000000"
-			stroke="#000000"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><g transform="translate(566.5,541.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="40"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 41px; white-space: nowrap; overflow-wrap: normal;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: left ; font-size: 16px">
-								<span style="font-size: 16px">Other</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="20"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="135"
-			y="475"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,195,500)"
-			pointer-events="none"></rect><g
-			transform="translate(159.5,491.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="195"
-			y="475"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,255,500)"
-			pointer-events="none"></rect><g
-			transform="translate(219.5,491.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="315"
-			y="475"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,375,500)"
-			pointer-events="none"></rect><g
-			transform="translate(339.5,491.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="375"
-			y="475"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,435,500)"
-			pointer-events="none"></rect><g
-			transform="translate(399.5,491.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="340"
-			y="580"
-			width="130"
-			height="270"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(373.5,586.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="63"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 64px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Process<br />Sandbox<br style="font-size: 16px" />
-						</div>
-					</div></foreignObject
-				><text
-					x="32"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="345"
-			y="750"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,405,775)"
-			pointer-events="none"></rect><g
-			transform="translate(369.5,766.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 405 690 L 405 706.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 405 712.76 L 401 704.76 L 405 706.76 L 409 704.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="350"
-			y="630"
-			width="110"
-			height="60"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(351.5,641.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="106"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 106px; white-space: normal; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Scheduling and routing
-						</div>
-					</div></foreignObject
-				><text
-					x="53"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Scheduling and routing</text
-				></switch
-			></g
-		><rect
-			x="160"
-			y="580"
-			width="130"
-			height="270"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(193.5,586.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="63"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 64px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Process<br />Sandbox<br style="font-size: 16px" />
-						</div>
-					</div></foreignObject
-				><text
-					x="32"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><rect
-			x="165"
-			y="750"
-			width="120"
-			height="50"
-			fill="transparent"
-			stroke="#000000"
-			transform="rotate(-90,225,775)"
-			pointer-events="none"></rect><g
-			transform="translate(189.5,766.5)rotate(-90,35.5,8.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="71"
-					height="17"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 72px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							<div style="text-align: center ; font-size: 16px">
-								<span style="font-size: 16px">V8 Isolate</span>
-							</div>
-						</div>
-					</div></foreignObject
-				><text
-					x="36"
-					y="17"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">[Not supported by viewer]</text
-				></switch
-			></g
-		><path
-			d="M 225 690 L 225 706.76"
-			fill="none"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 225 712.76 L 221 704.76 L 225 706.76 L 229 704.76 Z"
-			fill="#82b366"
-			stroke="#82b366"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><rect
-			x="170"
-			y="630"
-			width="110"
-			height="60"
-			fill="transparent"
-			stroke="#000000"
-			pointer-events="none"></rect><g transform="translate(171.5,641.5)"
-			><switch
-				><foreignObject
-					style="overflow:visible;"
-					pointer-events="all"
-					width="106"
-					height="36"
-					requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
-					><div
-						xmlns="http://www.w3.org/1999/xhtml"
-						style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 106px; white-space: normal; overflow-wrap: normal; text-align: center;"
-					>
-						<div
-							xmlns="http://www.w3.org/1999/xhtml"
-							style="display:inline-block;text-align:inherit;text-decoration:inherit;"
-						>
-							Scheduling and routing
-						</div>
-					</div></foreignObject
-				><text
-					x="53"
-					y="26"
-					fill="#000000"
-					text-anchor="middle"
-					font-size="16px"
-					font-family="Helvetica">Scheduling and routing</text
-				></switch
-			></g
-		><path
-			d="M 310 390 L 310 660 L 288.24 660"
-			fill="none"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 282.24 660 L 290.24 656 L 288.24 660 L 290.24 664 Z"
-			fill="#6c8ebf"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 320 390 L 320 660 L 341.76 660"
-			fill="none"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path><path
-			d="M 347.76 660 L 339.76 664 L 341.76 660 L 339.76 656 Z"
-			fill="#6c8ebf"
-			stroke="#6c8ebf"
-			stroke-width="2"
-			stroke-miterlimit="10"
-			pointer-events="none"></path></g
-	></svg
+	viewBox="-0.5 -0.5 701 863"
 >
+	<path
+		fill="transparent"
+		stroke="#000"
+		stroke-width="4"
+		d="M140 200h350v660H140z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M160 240h310v330H160z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M240 398v17h-45v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m240 392 4 8-4-2-4 2ZM195 438l-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M268 398v17h-13v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m268 392 4 8-4-2-4 2ZM255 438l-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M390 398v17h45v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m390 392 4 8-4-2-4 2ZM435 438l-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M363 398v17h12v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m363 392 4 8-4-2-4 2ZM375 438l-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M410 330h12"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m428 330-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M360 270V168"
+		pointer-events="none"></path>
+	<path
+		fill="#6c8ebf"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m360 162 4 8-4-2-4 2Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M220 270h190v120H220z"
+		pointer-events="none"></path>
+	<switch transform="translate(233 322)">
+		<foreignObject
+			width="164"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:165px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Scheduling and routing
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="82"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Scheduling and routing</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M470 330h32"
+		pointer-events="none"></path>
+	<path
+		fill="#b85450"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m508 330-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M430 390V270h40v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 407 -35)">
+		<foreignObject
+			width="83"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:84px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					HTTP client
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="42"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">HTTP client</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M200 330h12"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m218 330-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M160 390V270h40v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 273 102)">
+		<foreignObject
+			width="90"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:91px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					HTTP server
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="45"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">HTTP server</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M120 330h32"
+		pointer-events="none"></path>
+	<path
+		fill="#b85450"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m158 330-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M60 270V40h212"
+		pointer-events="none"></path>
+	<path
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m278 40-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M0 270h120v120H0z"
+		pointer-events="none"></path>
+	<switch transform="translate(18 312)">
+		<foreignObject
+			width="85"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:86px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Inbound
+					<br style="font-size:16px" />
+					HTTP proxy
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="43"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M570 270V40H448"
+		pointer-events="none"></path>
+	<path
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m442 40 8-4-2 4 2 4Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M510 270h120v120H510z"
+		pointer-events="none"></path>
+	<switch transform="translate(528 312)">
+		<foreignObject
+			width="85"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:86px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Outbound
+					<br style="font-size:16px" />
+					HTTP proxy
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="43"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M280 140h-42"
+		pointer-events="none"></path>
+	<path
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m232 140 8-4-2 4 2 4Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M360 120V88"
+		pointer-events="none"></path>
+	<path
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m360 82 4 8-4-2-4 2Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M280 120h160v40H280z"
+		pointer-events="none"></path>
+	<switch transform="translate(322 132)">
+		<foreignObject
+			width="76"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:77px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Supervisor
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="38"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<switch transform="translate(172 247)">
+		<foreignObject
+			width="161"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:162px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Main Runtime Process
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="81"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Main Runtime Process</text
+		>
+	</switch>
+	<switch transform="translate(162 212)">
+		<foreignObject
+			width="108"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:109px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Outer Sandbox
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="54"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Outer Sandbox</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		stroke-miterlimit="10"
+		d="M170 116c0-21 60-21 60 0v48c0 21-60 21-60 0Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		d="M170 116c0 16 60 16 60 0"
+		pointer-events="none"></path>
+	<switch transform="translate(185 143)">
+		<foreignObject
+			width="31"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:32px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Disk
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="16"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Disk</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		stroke-miterlimit="10"
+		d="M320 20c-32 0-40 20-14 24-26 9 3 28 24 20 14 16 62 16 78 0 32 0 32-16 12-24 20-16-12-32-40-24-20-12-52-12-60 4Z"
+		pointer-events="none"></path>
+	<switch transform="translate(313 32)">
+		<foreignObject
+			width="95"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:96px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Control plane
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="48"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M520 460h32"
+		pointer-events="none"></path>
+	<path
+		fill="#b85450"
+		stroke="#b85450"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m558 460-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<switch transform="translate(567 452)">
+		<foreignObject
+			width="42"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:43px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:left;font-size:16px">
+						<span style="font-size:16px"> HTTP </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="21"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M520 490h32"
+		pointer-events="none"></path>
+	<path
+		fill="#6c8ebf"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m558 490-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<switch transform="translate(567 482)">
+		<foreignObject
+			width="122"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:123px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:left;font-size:16px">
+						<span style="font-size:16px"> Cap&apos;n Proto RPC </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="61"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M520 520h32"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m558 520-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<switch transform="translate(567 512)">
+		<foreignObject
+			width="111"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:112px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:left;font-size:16px">
+						<span style="font-size:16px"> In-process calls </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="56"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M520 550h32"
+		pointer-events="none"></path>
+	<path
+		stroke="#000"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m558 550-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+	<switch transform="translate(567 542)">
+		<foreignObject
+			width="40"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:41px;white-space:nowrap;overflow-wrap:normal"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:left;font-size:16px">
+						<span style="font-size:16px"> Other </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="20"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M170 560V440h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 361 174)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M230 560V440h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 391 144)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M350 560V440h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 451 84)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M410 560V440h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 481 54)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M340 580h130v270H340z"
+		pointer-events="none"></path>
+	<switch transform="translate(374 587)">
+		<foreignObject
+			width="63"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:64px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Process
+					<br />
+					Sandbox
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="32"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M380 835V715h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 604 207)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M405 690v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m405 713-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M350 630h110v60H350z"
+		pointer-events="none"></path>
+	<switch transform="translate(352 642)">
+		<foreignObject
+			width="106"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:106px;white-space:normal;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Scheduling and routing
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="53"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Scheduling and routing</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M160 580h130v270H160z"
+		pointer-events="none"></path>
+	<switch transform="translate(194 587)">
+		<foreignObject
+			width="63"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:64px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Process
+					<br />
+					Sandbox
+					<br style="font-size:16px" />
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="32"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M200 835V715h50v120z"
+		pointer-events="none"></path>
+	<switch transform="rotate(-90 514 297)">
+		<foreignObject
+			width="71"
+			height="17"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:72px;white-space:nowrap;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					<div style="text-align:center;font-size:16px">
+						<span style="font-size:16px"> V8 Isolate </span>
+					</div>
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="36"
+			y="17"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">[Not supported by viewer]</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M225 690v17"
+		pointer-events="none"></path>
+	<path
+		fill="#82b366"
+		stroke="#82b366"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m225 713-4-8 4 2 4-2Z"
+		pointer-events="none"></path>
+	<path
+		fill="transparent"
+		stroke="#000"
+		d="M170 630h110v60H170z"
+		pointer-events="none"></path>
+	<switch transform="translate(172 642)">
+		<foreignObject
+			width="106"
+			height="36"
+			pointer-events="all"
+			requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+			style="overflow:visible"
+		>
+			<div
+				style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;vertical-align:top;width:106px;white-space:normal;overflow-wrap:normal;text-align:center"
+			>
+				<div
+					style="display:inline-block;text-align:inherit;text-decoration:inherit"
+				>
+					Scheduling and routing
+				</div>
+			</div>
+		</foreignObject>
+		<text
+			x="53"
+			y="26"
+			font-family="Helvetica"
+			font-size="16"
+			text-anchor="middle">Scheduling and routing</text
+		>
+	</switch>
+	<path
+		fill="none"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M310 390v270h-22"
+		pointer-events="none"></path>
+	<path
+		fill="#6c8ebf"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m282 660 8-4-2 4 2 4Z"
+		pointer-events="none"></path>
+	<path
+		fill="none"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="M320 390v270h22"
+		pointer-events="none"></path>
+	<path
+		fill="#6c8ebf"
+		stroke="#6c8ebf"
+		stroke-miterlimit="10"
+		stroke-width="2"
+		d="m348 660-8 4 2-4-2-4Z"
+		pointer-events="none"></path>
+</svg>

--- a/src/content/docs/src/env.d.ts
+++ b/src/content/docs/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../.astro/types.d.ts" />

--- a/src/plugins/rehype/heading-slugs.ts
+++ b/src/plugins/rehype/heading-slugs.ts
@@ -16,7 +16,8 @@ export default function () {
 			if (/^h[1-6]$/.test(element.tagName)) {
 				const last = element.children.at(-1);
 
-				// @ts-expect-error this is added by mdast-util-mdx-expression
+				if (!last) return;
+
 				if (last.type === "mdxTextExpression") {
 					const lastElement = last as MdxTextExpression;
 					if (


### PR DESCRIPTION
### Summary

Removes unnecessary ts-expect-error directives by improving types - all visual or functional behaviour should be identical.