### PR TITLE
[Docs Site] Move pagination buttons above footer links

### DIFF
--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -129,14 +129,14 @@ if (
 				<FeedbackPrompt client:idle />
 			</div>
 			<Default {...Astro.props} />
-			<div id="footer-links" class="flex flex-wrap items-center">
+			<div id="footer-links" class="mt-6 flex flex-wrap items-center space-x-4">
 				{Object.entries(links).map(([text, href]) => (
-					<a href={href} class="mx-2 my-2 text-xs text-black decoration-accent">
+					<a href={href} class="text-xs text-black decoration-accent">
 						<span>{text}</span>
 					</a>
 				))}
 				{isProduction && (
-					<div class="mx-2 my-2 text-xs text-black [&>button]:underline [&>button]:decoration-accent">
+					<div class="text-xs text-black [&>button]:underline [&>button]:decoration-accent">
 						<OneTrust />
 					</div>
 				)}
@@ -146,6 +146,18 @@ if (
 }
 
 <style>
+	:global(footer) {
+		flex-direction: column-reverse;
+	}
+
+	:global(.meta) {
+		margin-top: 0;
+	}
+
+	:global(.pagination-links) {
+		margin-top: 3rem;
+	}
+
 	.feedback-prompt {
 		h2 {
 			color: var(--sl-color-white);

--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -147,15 +147,15 @@ if (
 
 <style>
 	:global(footer) {
-		flex-direction: column-reverse;
+		flex-direction: column-reverse !important;
 	}
 
 	:global(.meta) {
-		margin-top: 0;
+		margin-top: 0 !important;
 	}
 
 	:global(.pagination-links) {
-		margin-top: 3rem;
+		margin-top: 3rem !important;
 	}
 
 	.feedback-prompt {


### PR DESCRIPTION
### Summary

Move pagination buttons above footer links

### Screenshots (optional)

Before:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/f226dbac-290f-405f-874f-d181928b9432" />

After:

<img width="774" alt="image" src="https://github.com/user-attachments/assets/a3053865-3577-4717-9d7f-71312f0f0f33" />