### PR TITLE
Add MCP Server page to Agents documentation

### DIFF
--- a/src/content/docs/agents/capabilities/control-web-browsers.mdx
+++ b/src/content/docs/agents/capabilities/control-web-browsers.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Control Web Browsers (Browser Rendering API)
 external_link: /browser-rendering/
 sidebar:
-  order: 1
+  order: 2
 head: []
 description: The Workers Browser Rendering API allows developers to programmatically control and interact with a headless browser instance and create automation flows for their applications and products.
 

--- a/src/content/docs/agents/capabilities/mcp-server.mdx
+++ b/src/content/docs/agents/capabilities/mcp-server.mdx
@@ -18,7 +18,7 @@ Once deployed, your Worker becomes an MCP server that AI assistants (as long as 
 
 - **Minimal setup & built-in boilerplate:** The Worker automatically handles API routing, server management, and MCP protocol compliance. The [workers-mcp](https://www.npmjs.com/package/workers-mcp) package bootstraps your MCP server, allowing you to focus on your service logic.
 - **Automatic documentation:** Public methods annotated with JSDoc are automatically documented and exposed as MCP tools. This means AI assistants can quickly understand how to interact with your service, making tool discovery and integration much easier.
-- **Scalability & performance:** Deploy your MCP server on Cloudflare’s global edge network so that users can make fast, performant requests from their LLMs. Cloudflare will handle traffic spikes and high load, ensuring your service remains available and responsive. 
+- **Scalability & performance:** Deploy your MCP server on Cloudflare's global edge network so that users can make fast, performant requests from their LLMs. Cloudflare will handle traffic spikes and high load, ensuring your service remains available and responsive.
 - **Expand MCP server capabilities:** Easily connect to Workers AI, D1, Durable Objects, and other Cloudflare services to add more functionality to your MCP Server. 
 
 ## Get Started

--- a/src/content/docs/agents/capabilities/mcp-server.mdx
+++ b/src/content/docs/agents/capabilities/mcp-server.mdx
@@ -11,7 +11,7 @@ description: Build and deploy an MCP server on Cloudflare Workers
 
 ## Building an MCP Server on Cloudflare Workers
 
-Normally, setting up an MCP server requires handling infrastructure, API routing, and understanding the MCP protocol. But with [Cloudflare Workers](/workers/), all the heavy lifting is done for you, so all you need to do is define your service’s functionality.
+Normally, setting up an MCP server requires handling infrastructure, API routing, and understanding the MCP protocol. But with [Cloudflare Workers](/workers/), all the heavy lifting is done for you, so all you need to do is define your service's functionality.
 Once deployed, your Worker becomes an MCP server that AI assistants (as long as they support MCP) can connect to and use to interact with your service.
 
 ## Benefits

--- a/src/content/docs/agents/capabilities/mcp-server.mdx
+++ b/src/content/docs/agents/capabilities/mcp-server.mdx
@@ -1,0 +1,104 @@
+---
+pcx_content_type: tutorial
+title: Build MCP Server on Cloudflare Workers
+sidebar:
+  order: 1
+  group:
+    hideIndex: true
+description: Build and deploy an MCP server on Cloudflare Workers
+---
+
+# Building an MCP Server on Cloudflare Workers
+
+Model Context Protocol (MCP) is an open standard for interacting with AI services and applications. MCP is like a standardized interface that LLMs can use to connect to various data sources and tools. With Cloudflare Workers, you can easily build and deploy an MCP server that grants AI assistants access to your service’s functionality.
+
+## Why Build an MCP Server on Cloudflare Workers?
+
+Using Cloudflare Workers to run your MCP server offers several key benefits:
+
+- **Minimal setup & built-in boilerplate:** Workers automatically handle API routing, server management, and protocol compliance. The [workers-mcp](https://www.npmjs.com/package/workers-mcp) package bootstraps your MCP server, so you can focus on your service logic.
+- **Automatic documentation:** Public methods annotated with JSDoc are automatically documented and exposed as MCP tools. This means AI assistants can quickly understand how to interact with your service, making tool discovery and integration much easier.
+- **Scalability & performance:** Deploy your MCP server on Cloudflare’s global edge network so that users can make fast, performant requests from their LLMs. Cloudflare automatically handles traffic spikes and high load, ensuring your service remains responsive regardless of demand.
+- **Expand MCP Server capabilities:** Easily connect to Workers AI, D1 databases, Durable Objects, and other Cloudflare services to add more functionality to your MCP Server. 
+
+## Get Started
+
+Follow these steps to create and deploy your own MCP server on Cloudflare Workers.
+
+
+### 1. Create a New Worker Project
+
+If you haven't already, install [Wrangler](https://developers.cloudflare.com/workers/wrangler/) and log in:
+
+```bash
+npm install -g wrangler
+wrangler login
+```
+
+Initialize a new project:
+```bash
+wrangler init my-mcp-project
+cd my-mcp-project
+```
+
+### 2. Install the MCP Tooling
+Inside your project directory, install the workers-mcp package:
+
+```bash
+npm install workers-mcp
+```
+
+This package provides the tools needed to run your Worker as an MCP server.
+
+### 3. Set up the MCP Server on Workers
+Replace the contents of your src/index.ts (or index.js) with the following boilerplate code:
+
+<TypeScriptExample filename="index.ts">
+```ts
+import { WorkerEntrypoint } from 'cloudflare:workers';
+import { ProxyToSelf } from 'workers-mcp';
+
+/**
+ * Extend the Env interface to declare KV, secrets, or other bindings from your wrangler.toml.
+ */
+export interface Env {
+  // Example: MY_KV: KVNamespace
+}
+
+export default class MyWorker extends WorkerEntrypoint<Env> {
+  /**
+   * A warm, friendly greeting from your new MCP server.
+   * @param name {string} The name of the person to greet.
+   * @return {string} The greeting message.
+   */
+  sayHello(name: string) {
+    return `Hello from an MCP Worker, ${name}!`;
+  }
+
+  /**
+   * @ignore
+   */
+  async fetch(request: Request): Promise<Response> {
+    // ProxyToSelf handles MCP protocol compliance.
+    return new ProxyToSelf(this).fetch(request);
+  }
+}
+```
+</TypeScriptExample>
+
+**Note:** Every public method (like sayHello) that is annotated with JSDoc becomes an MCP tool that is discoverable by AI assistants.
+
+### 4. Deploy the MCP Server
+Update your wrangler.toml with the appropriate configuration then deploy your Worker:
+```bash
+wrangler deploy
+```
+
+Your MCP server is now deployed globally and all your public class methods are exposed as MCP tools that AI assistants can now interact with. 
+
+### Expanding the MCP Server capabilities
+Use existing Cloudflare products to expand the functionality of your MCP Server. You can: 
+- Send emails using [Email Routing](/email-routing/)
+- Capture and share website previews using [Browser Rendering](/browser-rendering/)
+- Store and manage sessions, user data, or other persistent information with [Durable Objects](/durable-objects/)
+- Query and update data using a [D1 database](/d1/)

--- a/src/content/docs/agents/capabilities/mcp-server.mdx
+++ b/src/content/docs/agents/capabilities/mcp-server.mdx
@@ -79,7 +79,7 @@ export default class MyWorker extends WorkerEntrypoint<Env> {
 
 This converts your Cloudflare Worker into an MCP server, enabling interactions with AI assistants. The key components are:
 - **WorkerEntrypoint:** The WorkerEntrypoint class handles all incoming request management and routing. This provides the structure needed to expose MCP tools within the Worker.
-- **Tool Definition:** Methods (e.g. sayHello) are annotated with JSDoc, which automatically registers the method it as an MCP tool. AI assistants can call this method dynamically, passing a name and receiving a greeting in response. Additional tools can be defined using the same pattern.
+- **Tool Definition:** Methods (for example, sayHello) are annotated with JSDoc, which automatically registers the method as an MCP tool. AI assistants can call this method dynamically, passing a name and receiving a greeting in response. Additional tools can be defined using the same pattern.
 - **ProxyToSelf:** MCP servers must follow a specific request/response format. ProxyToSelf ensures that incoming requests are properly routed to the correct MCP tools. Without this, you would need to manually parse requests and validate responses.
 
 

--- a/src/content/docs/agents/capabilities/mcp-server.mdx
+++ b/src/content/docs/agents/capabilities/mcp-server.mdx
@@ -1,32 +1,32 @@
 ---
 pcx_content_type: tutorial
-title: Build MCP Server on Cloudflare Workers
+title: Build an MCP Server
 sidebar:
   order: 1
   group:
     hideIndex: true
 description: Build and deploy an MCP server on Cloudflare Workers
 ---
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open standard that allows AI assistants & LLMs to interact with services directly. If you want users to access your service or product straight from their AI assistant, you can enable this by spinning up an MCP server for your application. 
 
-# Building an MCP Server on Cloudflare Workers
+## Building an MCP Server on Cloudflare Workers
 
-Model Context Protocol (MCP) is an open standard for interacting with AI services and applications. MCP is like a standardized interface that LLMs can use to connect to various data sources and tools. With Cloudflare Workers, you can easily build and deploy an MCP server that grants AI assistants access to your service’s functionality.
+Normally, setting up an MCP server requires handling infrastructure, API routing, and understanding the MCP protocol. But with [Cloudflare Workers](/workers/), all the heavy lifting is done for you, so all you need to do is define your service’s functionality.
+Once deployed, your Worker becomes an MCP server that AI assistants (as long as they support MCP) can connect to and use to interact with your service.
 
-## Why Build an MCP Server on Cloudflare Workers?
+## Benefits
 
-Using Cloudflare Workers to run your MCP server offers several key benefits:
-
-- **Minimal setup & built-in boilerplate:** Workers automatically handle API routing, server management, and protocol compliance. The [workers-mcp](https://www.npmjs.com/package/workers-mcp) package bootstraps your MCP server, so you can focus on your service logic.
+- **Minimal setup & built-in boilerplate:** The Worker automatically handles API routing, server management, and MCP protocol compliance. The [workers-mcp](https://www.npmjs.com/package/workers-mcp) package bootstraps your MCP server, allowing you to focus on your service logic.
 - **Automatic documentation:** Public methods annotated with JSDoc are automatically documented and exposed as MCP tools. This means AI assistants can quickly understand how to interact with your service, making tool discovery and integration much easier.
-- **Scalability & performance:** Deploy your MCP server on Cloudflare’s global edge network so that users can make fast, performant requests from their LLMs. Cloudflare automatically handles traffic spikes and high load, ensuring your service remains responsive regardless of demand.
-- **Expand MCP Server capabilities:** Easily connect to Workers AI, D1 databases, Durable Objects, and other Cloudflare services to add more functionality to your MCP Server. 
+- **Scalability & performance:** Deploy your MCP server on Cloudflare’s global edge network so that users can make fast, performant requests from their LLMs. Cloudflare will handle traffic spikes and high load, ensuring your service remains available and responsive. 
+- **Expand MCP server capabilities:** Easily connect to Workers AI, D1, Durable Objects, and other Cloudflare services to add more functionality to your MCP Server. 
 
 ## Get Started
 
 Follow these steps to create and deploy your own MCP server on Cloudflare Workers.
 
 
-### 1. Create a New Worker Project
+### 1. Create a new Worker 
 
 If you haven't already, install [Wrangler](https://developers.cloudflare.com/workers/wrangler/) and log in:
 
@@ -42,7 +42,7 @@ cd my-mcp-project
 ```
 
 ### 2. Install the MCP Tooling
-Inside your project directory, install the workers-mcp package:
+Inside your project directory, install the [workers-mcp](https://github.com/cloudflare/workers-mcp) package:
 
 ```bash
 npm install workers-mcp
@@ -51,19 +51,11 @@ npm install workers-mcp
 This package provides the tools needed to run your Worker as an MCP server.
 
 ### 3. Set up the MCP Server on Workers
-Replace the contents of your src/index.ts (or index.js) with the following boilerplate code:
+Replace the contents of your src/index.ts with the following boilerplate code:
 
-<TypeScriptExample filename="index.ts">
 ```ts
 import { WorkerEntrypoint } from 'cloudflare:workers';
 import { ProxyToSelf } from 'workers-mcp';
-
-/**
- * Extend the Env interface to declare KV, secrets, or other bindings from your wrangler.toml.
- */
-export interface Env {
-  // Example: MY_KV: KVNamespace
-}
 
 export default class MyWorker extends WorkerEntrypoint<Env> {
   /**
@@ -84,9 +76,15 @@ export default class MyWorker extends WorkerEntrypoint<Env> {
   }
 }
 ```
-</TypeScriptExample>
 
-**Note:** Every public method (like sayHello) that is annotated with JSDoc becomes an MCP tool that is discoverable by AI assistants.
+This converts your Cloudflare Worker into an MCP server, enabling interactions with AI assistants. The key components are:
+- **WorkerEntrypoint:** The WorkerEntrypoint class handles all incoming request management and routing. This provides the structure needed to expose MCP tools within the Worker.
+- **Tool Definition:** Methods (e.g. sayHello) are annotated with JSDoc, which automatically registers the method it as an MCP tool. AI assistants can call this method dynamically, passing a name and receiving a greeting in response. Additional tools can be defined using the same pattern.
+- **ProxyToSelf:** MCP servers must follow a specific request/response format. ProxyToSelf ensures that incoming requests are properly routed to the correct MCP tools. Without this, you would need to manually parse requests and validate responses.
+
+
+**Note:** Every public method that is annotated with JSDoc becomes an MCP tool that is discoverable by AI assistants. 
+
 
 ### 4. Deploy the MCP Server
 Update your wrangler.toml with the appropriate configuration then deploy your Worker:
@@ -97,7 +95,7 @@ wrangler deploy
 Your MCP server is now deployed globally and all your public class methods are exposed as MCP tools that AI assistants can now interact with. 
 
 ### Expanding the MCP Server capabilities
-Use existing Cloudflare products to expand the functionality of your MCP Server. You can: 
+Use existing Cloudflare products to expand the functionality of your MCP server. You can: 
 - Send emails using [Email Routing](/email-routing/)
 - Capture and share website previews using [Browser Rendering](/browser-rendering/)
 - Store and manage sessions, user data, or other persistent information with [Durable Objects](/durable-objects/)

--- a/src/content/docs/agents/capabilities/run-models.mdx
+++ b/src/content/docs/agents/capabilities/run-models.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Run models (Workers AI)
 external_link: /workers-ai/
 sidebar:
-  order: 2
+  order: 3
 head: []
 description: Run popular open-source AI models on Cloudflare's network. 
 ---

--- a/src/content/docs/agents/capabilities/send-email.mdx
+++ b/src/content/docs/agents/capabilities/send-email.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Send Email
 external_link: /email-routing/email-workers/send-email-workers/
 sidebar:
-  order: 2
+  order: 4
 head: []
 description: Send emails from your Worker for async updates to a user. 
 ---

--- a/src/content/docs/agents/capabilities/webrtc-realtime.mdx
+++ b/src/content/docs/agents/capabilities/webrtc-realtime.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Realtime voice (WebRTC)
 external_link: /calls/
 sidebar:
-  order: 4
+  order: 5
 head: []
 description: Build real-time serverless video, audio and data applications.
 ---


### PR DESCRIPTION
### Summary

Added a new page to the Agents documentation to show how customers how they can build an MCP server on Cloudflare Workers.

### Screenshots (optional)

<img width="775" alt="image" src="https://github.com/user-attachments/assets/32637392-cf31-4bdb-a4a4-daaac1b54b40" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [X ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
