### PR TITLE
Add WCI WRANGLER_CI_OVERRIDE_NAME documentation

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
+++ b/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
@@ -26,6 +26,8 @@ The build system uses the `name` argument in the wrangler.toml to determine whic
 This does not apply to [Wrangler Environments](/workers/wrangler/environments/) if the Worker name before the `-<env_name>` suffix matches the name in wrangler.toml.
 
 For example, a Worker named `my-worker-staging` on the dashboard can be deployed from a repository that contains a wrangler.toml with the arguments `name = my-worker` and `[env.staging]` using the deploy command `npx wrangler deploy --env staging`.
+
+Additionally, on Wrangler versions greater than 3.xx, Workers Builds will automatically override the name to match the worker it is connected to using the `WRANGLER_CI_OVERRIDE_NAME` environment variable.
 :::
 
 ### Missing wrangler.toml
@@ -42,7 +44,7 @@ If you see this error, the wrangler.toml likely has an `account_id` for a differ
 
 ### Stale API token
 
-`	Failed: The build token selected for this build has been deleted or rolled and cannot be used for this build. Please update your build token in the Worker Builds settings and retry the build.`
+` Failed: The build token selected for this build has been deleted or rolled and cannot be used for this build. Please update your build token in the Worker Builds settings and retry the build.`
 
 The API Token dropdown in Build Configuration settings may show stale tokens that were edited, deleted, or rolled. If you encounter an error due to a stale token, create a new API Token and select it for the build.
 

--- a/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
+++ b/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
@@ -27,7 +27,7 @@ This does not apply to [Wrangler Environments](/workers/wrangler/environments/) 
 
 For example, a Worker named `my-worker-staging` on the dashboard can be deployed from a repository that contains a wrangler.toml with the arguments `name = my-worker` and `[env.staging]` using the deploy command `npx wrangler deploy --env staging`.
 
-Additionally, on Wrangler versions greater than 3.xx, Workers Builds will automatically override the name to match the worker it is connected to using the `WRANGLER_CI_OVERRIDE_NAME` environment variable.
+Additionally, on Wrangler versions greater than 3.xx, Workers Builds will automatically override the name to match the Worker it is connected to using the `WRANGLER_CI_OVERRIDE_NAME` environment variable.
 :::
 
 ### Missing wrangler.toml

--- a/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
+++ b/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
@@ -27,7 +27,7 @@ This does not apply to [Wrangler Environments](/workers/wrangler/environments/) 
 
 For example, a Worker named `my-worker-staging` on the dashboard can be deployed from a repository that contains a wrangler.toml with the arguments `name = my-worker` and `[env.staging]` using the deploy command `npx wrangler deploy --env staging`.
 
-Additionally, on Wrangler versions greater than 3.xx, Workers Builds will automatically override the name to match the Worker it is connected to using the `WRANGLER_CI_OVERRIDE_NAME` environment variable.
+On Wrangler v3 and up, Workers Builds automatically matches the name of the connected Worker by overriding it with the `WRANGLER_CI_OVERRIDE_NAME` environment variable.
 :::
 
 ### Missing wrangler.toml


### PR DESCRIPTION
### Summary

Document worker name override behavior in Workers Builds. These wrangler changes are included here: 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
