### PR TITLE
Made json first in wrangler component

### DIFF
--- a/src/components/WranglerConfig.astro
+++ b/src/components/WranglerConfig.astro
@@ -45,10 +45,10 @@ if (language === "toml") {
 ---
 
 <Tabs syncKey="wranglerConfig">
-	<TabItem label="wrangler.toml" icon="setting">
-		<Code lang="toml" code={toml} />
-	</TabItem>
 	<TabItem label="wrangler.json" icon="seti:json">
 		<Code lang="jsonc" code={json} />
+	</TabItem>
+	<TabItem label="wrangler.toml" icon="setting">
+		<Code lang="toml" code={toml} />
 	</TabItem>
 </Tabs>


### PR DESCRIPTION
Request from @Oxyjun  (Thank you!)

The `<WranglerConfig>` component is a component which automatically creates a `json` equivalent for the `wrangler.toml` file. However, the component currently shows the `wrangler.toml` tab before `wrangler.json` (i.e. when a user lands on a page, they'll see `wrangler.toml` unless they explicitly choose to switch to `wrangler.json`.
It may be better to show `wrangler.json` first, if we're moving away from using `.toml` (for example, C3 now creates `wrangler.json` by default, so for new users, this will be the more natural option going forward.