### PR TITLE
[Queues] Fix parameter name in pull consumer docs

### DIFF
--- a/src/content/docs/queues/configuration/pull-consumers.mdx
+++ b/src/content/docs/queues/configuration/pull-consumers.mdx
@@ -127,7 +127,7 @@ let resp = await fetch(
 			authorization: `Bearer ${QUEUES_API_TOKEN}`,
 		},
 		// Optional - you can provide an empty object '{}' and the defaults will apply.
-		body: JSON.stringify({ visibility_timeout: 6000, batch_size: 50 }),
+		body: JSON.stringify({ visibility_timeout_ms: 6000, batch_size: 50 }),
 	},
 );
 ```


### PR DESCRIPTION
### Summary

The name of the `visibility_timeout` param in the example is incorrect

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
