### PR TITLE
[Docs Site] Restore larger content width when ToC is disabled

### DIFF
--- a/src/components/overrides/Page.astro
+++ b/src/components/overrides/Page.astro
@@ -62,3 +62,9 @@ if (data.updated) {
 ---
 
 <Default {...Astro.props} set:html={html} />
+
+<style>
+	html:not([data-has-toc]) {
+		--sl-content-width: 67.5rem;
+	}
+</style>


### PR DESCRIPTION
### Summary

Restore larger content width when ToC is disabled

### Screenshots (optional)

Before:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/a9068920-e1a0-4c52-aa4c-e8b6d8972242" />

After:

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/49240ca4-3643-49fd-9922-1a3d43c6a8d0" />
