### PR TITLE
[wrangler] add docs link to .env file for wrangler bulk secrets command

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -741,7 +741,7 @@ wrangler secret bulk [<FILENAME>] [OPTIONS]
 - `FILENAME` <Type text="string" /> <MetaInfo text="optional" />
   - A file containing either [JSON](https://www.json.org/json-en.html) or the [.env](https://www.dotenv.org/docs/security/env) format
   - The JSON file containing key-value pairs to upload as secrets, in the form `{"SECRET_NAME": "secret value", ...}`.
-  - The `.env` file containing key-value pairs to upload as secrets, in the form `SECRET_NAME=secret value`.
+  - The `.env` file containing [key-value pairs to upload as secrets](/workers/configuration/secrets/#local-development-with-secrets), in the form `SECRET_NAME=secret value`.
   - If omitted, Wrangler expects to receive input from `stdin` rather than a file.
 - `--name` <Type text="string" /> <MetaInfo text="optional" />
   - Perform on a specific Worker rather than inheriting from the [Wrangler configuration file](/workers/wrangler/configuration/).
@@ -1229,7 +1229,7 @@ wrangler pages secret bulk [<FILENAME>] [OPTIONS]
 - `FILENAME` <Type text="string" /> <MetaInfo text="optional" />
   - A file containing either [JSON](https://www.json.org/json-en.html) or the [.env](https://www.dotenv.org/docs/security/env) format
   - The JSON file containing key-value pairs to upload as secrets, in the form `{"SECRET_NAME": "secret value", ...}`.
-  - The `.env` file containing key-value pairs to upload as secrets, in the form `SECRET_NAME=secret value`.
+  - The `.env` file containing [key-value pairs to upload as secrets](/workers/configuration/secrets/#local-development-with-secrets), in the form `SECRET_NAME=secret value`.
   - If omitted, Wrangler expects to receive input from `stdin` rather than a file.
 - `--project-name` <Type text="string" /> <MetaInfo text="optional" />
   - The name of your Pages project.


### PR DESCRIPTION
### Summary

Deep link .env files as an example.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
