### PR TITLE
Fix a couple of broken links to Hyperdrive dashboard pages

### DIFF
--- a/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-postgres.mdx
@@ -17,7 +17,7 @@ New to Hyperdrive? Refer to the [Get started guide](/hyperdrive/get-started/) to
 
 :::
 
-To create a Hyperdrive that connects to an existing PostgreSQL database, use the [wrangler](/workers/wrangler/install-and-update/) CLI or the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers-and-pages/hyperdrive).
+To create a Hyperdrive that connects to an existing PostgreSQL database, use the [wrangler](/workers/wrangler/install-and-update/) CLI or the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/hyperdrive).
 
 When using wrangler, replace the placeholder value provided to `--connection-string` with the connection string for your database:
 

--- a/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
+++ b/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
@@ -16,7 +16,7 @@ You can change the connection information and credentials of your Hyperdrive con
 
 Creating a new Hyperdrive configuration to update your database credentials allows you to keep your existing Hyperdrive configuration unchanged, gradually migrate your Worker to the new Hyperdrive configuration, and easily roll back to the previous configuration if needed.
 
-To create a Hyperdrive configuration that connects to an existing PostgreSQL database, use the [Wrangler](/workers/wrangler/install-and-update/) CLI or the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers-and-pages/hyperdrive).
+To create a Hyperdrive configuration that connects to an existing PostgreSQL database, use the [Wrangler](/workers/wrangler/install-and-update/) CLI or the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/hyperdrive).
 
 ```sh
 # wrangler v3.11 and above required


### PR DESCRIPTION
I'm not sure if these used to work or not, but it's certainly the case now that the `/:account/workers/hyperdrive` path works and the `/:account/workers-and-pages/hyperdrive` path doesn't.