### PR TITLE
[1.1.1.1] Add warning about lack of RFC for DoH JSON format

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
@@ -7,7 +7,7 @@ slug: 1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json
 :::caution
 The DNS over HTTPS JSON format does not have a formal RFC, which means behavior might be different between providers. Additionally, there might be small changes in behavior in the future.
 
-For critical use cases it's recommended to use the [DNS over HTTPS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/), which is defined in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
+For critical use cases, it is recommended to use the [DNS over HTTPS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/), which is defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html).
 :::
 
 Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. For lack of an agreed upon JSON schema for DNS over HTTPS in the Internet Engineering Task Force (IETF), Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
@@ -4,6 +4,12 @@ title: Using JSON
 slug: 1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json
 ---
 
+:::caution
+The DNS over HTTPS JSON format does not have a formal RFC, which means behavior might be different between providers. Additionally, there might be small changes in behavior in the future.
+
+For critical use cases it's recommended to use the [DNS over HTTPS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/), which is defined in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
+:::
+
 Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. For lack of an agreed upon JSON schema for DNS over HTTPS in the Internet Engineering Task Force (IETF), Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
 
 JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. The client should include an HTTP `Accept` request header field with a MIME type of `application/dns-json` to indicate that the client is able to accept a JSON response from the DNS over HTTPS resolver.

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat.mdx
@@ -7,7 +7,7 @@ head:
 slug: 1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat
 ---
 
-Cloudflare respects DNS wireformat as defined in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
+Cloudflare respects DNS wireformat as defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html).
 
 To send queries using DNS wireformat, set the header `accept: application/dns-message`, or `content-type: application/dns-message` if using `POST` to signalize the media type of the query.
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Adds a warning about the lack of RFC to the DoH JSON format documentation, and point users to the wireformat for critical use cases.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

<img width="760" alt="image" src="https://github.com/user-attachments/assets/b72489ad-fa8b-48f0-b9ac-b5b5c83c3188" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.