### PR TITLE
Update ownership for changelog content + include image path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,8 @@
 
 # Changelogs
 
-/src/content/changelogs-next/ @elithrar @irvinebroque @jonesphillip @rita3ko @zaidf
+/src/content/changelogs/ @cloudflare/pm-changelogs
+/src/assets/images/changelogs/ @cloudflare/pm-changelogs
 
 # Cloudflare One
 


### PR DESCRIPTION
### Summary

Created new group (additional members needed to be added to CF org) that has approval perms over changelog content + recommended image paths.