### PR TITLE
[Docs] Fix quotes in strings with variables

### DIFF
--- a/src/content/docs/ai-gateway/configuration/caching.mdx
+++ b/src/content/docs/ai-gateway/configuration/caching.mdx
@@ -13,7 +13,7 @@ Enable and customize your gateway cache to serve requests directly from Cloudfla
 
 :::note
 
-Currently caching is supported only for text and image responses, and it applies only to identical requests. 
+Currently caching is supported only for text and image responses, and it applies only to identical requests.
 
 This is helpful for use cases when there are limited prompt options - for example, a support bot that asks "How can I help you?" and lets the user select an answer from a limited set of options works well with the current caching configuration.
 We plan on adding semantic search for caching in the future to improve cache hit rates.
@@ -73,7 +73,7 @@ As an example, when submitting a request to OpenAI, include the header in the fo
 
 ```bash title="Request skipping the cache"
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
-  --header 'Authorization: Bearer $TOKEN' \
+  --header "Authorization: Bearer $TOKEN" \
   --header 'Content-Type: application/json' \
   --header 'cf-aig-skip-cache: true' \
   --data ' {
@@ -98,7 +98,7 @@ As an example, when submitting a request to OpenAI, include the header in the fo
 
 ```bash title="Request to be cached for an hour"
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
-  --header 'Authorization: Bearer $TOKEN' \
+  --header "Authorization: Bearer $TOKEN" \
   --header 'Content-Type: application/json' \
   --header 'cf-aig-cache-ttl: 3600' \
   --data ' {

--- a/src/content/docs/ai-gateway/configuration/custom-costs.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-costs.mdx
@@ -32,7 +32,7 @@ In this example, if you have a negotiated price of $1 per million input tokens a
 
 ```bash title="Request with custom cost"
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
-  --header 'Authorization: Bearer $TOKEN' \
+  --header "Authorization: Bearer $TOKEN" \
   --header 'Content-Type: application/json' \
   --header 'cf-aig-custom-cost: {"per_token_in":0.000001,"per_token_out":0.000002}' \
   --data ' {

--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -36,7 +36,7 @@ In the example below, we use `cf-aig-collect-log` to bypass the default setting 
 
 ```bash
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
-  --header 'Authorization: Bearer $TOKEN' \
+  --header "Authorization: Bearer $TOKEN" \
   --header 'Content-Type: application/json' \
   --header 'cf-aig-collect-log: false \
   --data ' {

--- a/src/content/docs/analytics/graphql-api/migration-guides/zone-analytics-colos.mdx
+++ b/src/content/docs/analytics/graphql-api/migration-guides/zone-analytics-colos.mdx
@@ -3,10 +3,9 @@ pcx_content_type: reference
 title: Zone Analytics Colos Endpoint to GraphQL Analytics
 sidebar:
   order: 13
-
 ---
 
-import { Details } from "~/components"
+import { Details } from "~/components";
 
 This guide shows how you might migrate from the deprecated (and soon to be sunset) zone analytics API to the GraphQL API. It provides an example for a plausible use-case of the colos endpoint, then shows how that use-case is translated to the GraphQL API. It also explores features of the GraphQL API that make it more powerful than the API it replaces.
 
@@ -18,8 +17,8 @@ curl -H "Authorization: Bearer $API_TOKEN" "https://api.cloudflare.com/client/v4
 
 This query says:
 
-* Given an `API_TOKEN` which has Analytics Read access to `ZONE_ID`.
-* Fetch colos analytics for `ZONE_ID` with a time range that starts on
+- Given an `API_TOKEN` which has Analytics Read access to `ZONE_ID`.
+- Fetch colos analytics for `ZONE_ID` with a time range that starts on
   `2020-12-10T00:00:00Z` (`since` parameter) to now.
 
 The question that we want to answer is: "What is the number of requests for ZHR per hour?" Using the colos endpoint response data and some wrangling by jq we can answer that question with this command:
@@ -57,7 +56,6 @@ This selects only lines that contain more than 0 requests and the `colo_id` is Z
 
 The final data we get looks like the following response:
 
-
 <Details header="Response">
 
 ```json
@@ -74,7 +72,6 @@ The final data we get looks like the following response:
 {"colo_id":"ZRH","timeslot":"2020-12-10T10:00:00Z","requests":2203,"bandwidth":2504615}
 ...
 ```
-
 
 </Details>
 
@@ -112,7 +109,7 @@ The following is a GraphQL API query to retrieve the data we need to answer the 
 Then we can run it with curl:
 
 ```bash
-curl -X POST -H 'Authorization: Bearer $API_TOKEN'  https://api.cloudflare.com/client/v4/graphql -d "@./coloGroups.json" > graphqlColoGroupsResponse.json
+curl -X POST -H "Authorization: Bearer $API_TOKEN"  https://api.cloudflare.com/client/v4/graphql -d "@./coloGroups.json" > graphqlColoGroupsResponse.json
 ```
 
 We can answer our question in the same way as before using jq:

--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/index.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/index.mdx
@@ -112,7 +112,7 @@ Send a `PUT` request to the [Update Zero Trust account configuration](/api/resou
 
 ```sh
 curl --request PUT \
-'https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/gateway/configuration' \
+"https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/gateway/configuration" \
 --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
 --header "Content-Type: application/json" \
 --data '{


### PR DESCRIPTION
### Summary

Variable replacement (like for `$TOKEN`) does not occur in strings enclosed in single quotes. We must use double quotes or no quotes.
This PR fixes the few occurrences we have of single-quoted strings with variables.
