### PR TITLE
[Analytics] Avoid repeated word in sidebar

### DIFF
--- a/src/content/docs/analytics/network-analytics/reference/network-analytics-v1.mdx
+++ b/src/content/docs/analytics/network-analytics/reference/network-analytics-v1.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: reference
 source: https://support.cloudflare.com/hc/en-us/articles/360038696631-Understanding-Cloudflare-Network-Analytics-v1
-title: Network Analytics v1 (deprecated)
+title: Network Analytics v1
 sidebar:
   order: 3
   badge:


### PR DESCRIPTION
### Summary

The sidebar shows "Deprecated" twice:

![image](https://github.com/user-attachments/assets/c408b14f-59c5-47ee-9f98-e66f272a6d50)

This change will also remove "(deprecated)" from the H1, but there's a warning aside at the top of the page about the v1 deprecation.