### PR TITLE
[Docs Site] Fix typo in `images/get-started.mdx`

### DIFF
--- a/src/content/docs/images/get-started.mdx
+++ b/src/content/docs/images/get-started.mdx
@@ -35,7 +35,7 @@ To enable transformations on your zone:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account.
 2. Go to **Images** > **Transformations**.
 3. Go to the specific zone where you want to enable transformations.
-4. Select **Enabl for zonee**. This will allow you to optimize and deliver remote images.
+4. Select **Enable for zone**. This will allow you to optimize and deliver remote images.
 
 :::note
 


### PR DESCRIPTION
### Summary

There was a typo in the Images docs where it reads "Enabl for zonee" instead of "Enable for zone".