### PR TITLE
[Docs Site] fix: changelog scrollbar overflow

### DIFF
--- a/src/components/changelog-next/Header.astro
+++ b/src/components/changelog-next/Header.astro
@@ -75,5 +75,6 @@ const products = await uniqueProducts(notes);
 
 	.content-panel {
 		padding-top: 0 !important;
+		overflow-x: hidden;
 	}
 </style>


### PR DESCRIPTION
### Summary

Resolves a minor issue where the changelog page is overflowing on the X axis . On MacOS, this is less noticeable, but Windows scrollabars are much more ugly and obvious.

URL: https://developers.cloudflare.com/changelog/2025-02-07-new-ways-to-get-started-on-workers/

Before: ![](https://i.james.pub/file/2025/02/d1a866b1-7330-4647-a9c1-4da10e116885.png)
After: ![](https://i.james.pub/file/2025/02/21b879f5-5fec-4189-8898-7ba53c9baa6a.png)

cc @KianNH 