### PR TITLE
[Docs site] update wrong link in `workers-ai/guides/prompting` page

### DIFF
--- a/src/content/docs/workers-ai/guides/prompting.mdx
+++ b/src/content/docs/workers-ai/guides/prompting.mdx
@@ -57,7 +57,7 @@ Typically, the role can be one of three options:
 - <strong>assistant</strong> - Assistant messages hint to the AI about the
   desired output format. Not all models support this role.
 
-OpenAI has a [good explanation](/workers-ai/models/llama-2-13b-chat-awq) of how they use these roles with their GPT models. Even though chat templates are flexible, other text generation models tend to follow the same conventions.
+OpenAI has a [good explanation](https://platform.openai.com/docs/guides/text-generation#messages-and-roles) of how they use these roles with their GPT models. Even though chat templates are flexible, other text generation models tend to follow the same conventions.
 
 Here's an input example of a scoped prompt using system and user roles:
 


### PR DESCRIPTION
### Summary

Fixed links that were going to the wrong page that didn't match the link text.

The site I updated may not be the one users should be going to, so please let me know if this is the case.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
