### PR TITLE
Remove R2 compatibility notes on sdk clients

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-cli.mdx
+++ b/src/content/docs/r2/examples/aws/aws-cli.mdx
@@ -13,7 +13,11 @@ With the [`aws`](https://docs.aws.amazon.com/cli/latest/userguide/getting-starte
 :::note[Compatibility]
 Client versions `2.23.0` and `1.37.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
 
-To mitigate, users can use `2.22.35` or `1.36.40` as the documented overrides do not work consistently for all subcommands.
+To mitigate, users can use `2.22.35` or `1.36.40`, or alternatively, add the CRC32 checksum flag to the cli command:
+
+```sh
+aws s3api put-object --bucket sdk-example --key sdk.png --body file/path --checksum-algorithm CRC32
+```
 
 :::
 

--- a/src/content/docs/r2/examples/aws/aws-sdk-go.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-go.mdx
@@ -10,18 +10,6 @@ import { Render } from "~/components"
 
 This example uses version 2 of the [aws-sdk-go](https://github.com/aws/aws-sdk-go-v2) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
-:::note[Compatibility]
-Client version `1.73.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `1.72.3` or add the following to their config:
-
-```go
-config.WithRequestChecksumCalculation(0)
-config.WithResponseChecksumValidation(0)
-```
-
-:::
-
 ```go
 package main
 

--- a/src/content/docs/r2/examples/aws/aws-sdk-java.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-java.mdx
@@ -10,18 +10,6 @@ import { Render } from "~/components";
 
 This example uses version 2 of the [aws-sdk-java](https://github.com/aws/aws-sdk-java-v2/#using-the-sdk) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
-:::note[Compatibility]
-Client version `2.30.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `2.29.52` or add the following to their S3Config:
-
-```java
-this.requestChecksumCalculation = "when_required",
-this.responseChecksumValidation = "when_required"
-```
-
-:::
-
 ```java
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;

--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -10,18 +10,6 @@ import { Render } from "~/components";
 
 JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
-:::note[Compatibility]
-Client version `3.729.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `3.726.1` or add the following to their S3Client config:
-
-```ts
-requestChecksumCalculation: "WHEN_REQUIRED",
-responseChecksumValidation: "WHEN_REQUIRED",
-```
-
-:::
-
 ```ts
 import {
 	S3Client,

--- a/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
@@ -14,18 +14,6 @@ This example uses version 3 of the [aws-sdk-net](https://www.nuget.org/packages/
 
 In this example, you will pass credentials explicitly to the `IAmazonS3` initialization. If you wish, use a shared AWS credentials file or the SDK store in-line with other AWS SDKs. Refer to [Configure AWS credentials](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) for more details.
 
-:::note[Compatibility]
-Client version `3.7.963.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `3.7.962.0` or add the following to their AmazonS3Config:
-
-```csharp
-RequestChecksumCalculation = "WHEN_REQUIRED",
-ResponseChecksumValidation = "WHEN_REQUIRED"
-```
-
-:::
-
 ```csharp
 private static IAmazonS3 s3Client;
 

--- a/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
@@ -12,18 +12,6 @@ import { Render } from "~/components";
 
 This example uses version 3 of the [aws-sdk-php](https://packagist.org/packages/aws/aws-sdk-php) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
-:::note[Compatibility]
-Client version `3.337.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `3.336.15` or add the following to their $options:
-
-```php
-'request_checksum_calculation' => 'when_required',
-'response_checksum_validation' => 'when_required'
-```
-
-:::
-
 ```php
 <?php
 require 'vendor/aws/aws-autoloader.php';

--- a/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
@@ -10,18 +10,6 @@ import { Render } from "~/components"
 
 Many Ruby projects also store these credentials in environment variables instead.
 
-:::note[Compatibility]
-Client version `1.178.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `1.177.0` or add the following to their s3 client instantiation:
-
-```ruby
-request_checksum_calculation: "when_required",
-response_checksum_validation: "when_required"
-```
-
-:::
-
 Add the following dependency to your `Gemfile`:
 
 ```ruby

--- a/src/content/docs/r2/examples/aws/boto3.mdx
+++ b/src/content/docs/r2/examples/aws/boto3.mdx
@@ -10,18 +10,6 @@ import { Render } from "~/components";
 
 You must configure [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) to use a preconstructed `endpoint_url` value. This can be done through any `boto3` usage that accepts connection arguments; for example:
 
-:::note[Compatibility]
-Client version `1.36.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
-
-To mitigate, users can use `1.35.99` or add the following to their s3 resource config:
-
-```python
-request_checksum_calculation = 'WHEN_REQUIRED',
-response_checksum_validation = 'WHEN_REQUIRED'
-```
-
-:::
-
 ```python
 import boto3
 


### PR DESCRIPTION
### Summary
Removes outdated compatibility notes for SDK clients now that R2 is compatible for most clients. Updates the CLI documentation to specify the requirement for the CRC32 checksum flag. 

### Screenshots (optional)
<img width="684" alt="Screenshot 2025-02-10 at 5 22 55 PM" src="https://github.com/user-attachments/assets/89425075-47e6-4ad7-9b4f-028ba2fdadaa" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
