### PR TITLE
[WAF] Fix link

### DIFF
--- a/src/content/docs/terraform/additional-configurations/rate-limiting-rules.mdx
+++ b/src/content/docs/terraform/additional-configurations/rate-limiting-rules.mdx
@@ -77,7 +77,7 @@ This example defines a [custom ruleset](/ruleset-engine/custom-rulesets/) with a
 
 ```tf
 resource "cloudflare_ruleset" "account_rl" {
-  account_id  = <ACCOUNT_ID>
+  account_id  = "<ACCOUNT_ID>"
   name        = "Rate limiting rules for APIs"
   description = ""
   kind        = "custom"

--- a/src/content/docs/waf/account/rate-limiting-rulesets/link-create-terraform.mdx
+++ b/src/content/docs/waf/account/rate-limiting-rulesets/link-create-terraform.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: Create using Terraform
-external_link: /terraform/additional-configurations/rate-limiting-rules/#create-a-rate-limiting-rule
+external_link: /terraform/additional-configurations/rate-limiting-rules/#create-a-rate-limiting-rule-at-the-account-level
 sidebar:
   order: 17
 ---


### PR DESCRIPTION
### Summary

Fixing the broken anchor in an external link.
It's causing 159 warnings in the link checker, since it's in the sidebar.