### PR TITLE
[Docs Site] Remove API Deprecations from top-level release notes feed

### DIFF
--- a/src/content/docs/fundamentals/api/reference/deprecations.mdx
+++ b/src/content/docs/fundamentals/api/reference/deprecations.mdx
@@ -14,7 +14,7 @@ import { ProductChangelog } from "~/components";
 Cloudflare occasionally makes updates to our APIs that result in behavior changes or deprecations. When this happens, we will communicate when the API will no longer be available and whether there will be a replacement.
 
 :::note
-Subscribe to all API deprecation posts via [RSS](/release-notes/index.xml).
+Subscribe to all API deprecation posts via [RSS](/fundamentals/api/reference/deprecations/index.xml).
 :::
 
 <ProductChangelog />

--- a/src/pages/release-notes/index.xml.ts
+++ b/src/pages/release-notes/index.xml.ts
@@ -17,7 +17,9 @@ export const GET: APIRoute = async (context) => {
 
 	marked.use({ walkTokens });
 
-	const changelogs = await getCollection("changelogs");
+	const changelogs = await getCollection("changelogs", (e) => {
+		return e.id !== "api-deprecations";
+	});
 
 	changelogs.push(await getWranglerChangelog());
 


### PR DESCRIPTION
### Summary

These exist on their own page, https://developers.cloudflare.com/fundamentals/api/reference/deprecations/ and https://developers.cloudflare.com/fundamentals/api/reference/deprecations/index.xml respectively.