### PR TITLE
[Workers] Add "internal error id" entry to Workers and DO changelogs

### DIFF
--- a/src/content/changelogs/durable-objects.yaml
+++ b/src/content/changelogs/durable-objects.yaml
@@ -7,7 +7,7 @@ productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2025-02-11"
     description: |-
-      - When Durable Objects generate an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
+      - When Durable Objects generate an "internal error" exception in response to certain failures, the exception message may provide a reference ID that customers can include in support communication for easier error identification. For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2024-10-07"
     title: Alarms re-enabled in (beta) SQLite-backed Durable Object classes
     description: |-

--- a/src/content/changelogs/durable-objects.yaml
+++ b/src/content/changelogs/durable-objects.yaml
@@ -7,7 +7,7 @@ productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2025-02-11"
     description: |-
-      - When the runtime generates an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
+      - When Durable Objects generate an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2024-10-07"
     title: Alarms re-enabled in (beta) SQLite-backed Durable Object classes
     description: |-

--- a/src/content/changelogs/durable-objects.yaml
+++ b/src/content/changelogs/durable-objects.yaml
@@ -5,6 +5,9 @@ productLink: "/durable-objects/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2025-02-11"
+    description: |-
+      - When the runtime generates an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2024-10-07"
     title: Alarms re-enabled in (beta) SQLite-backed Durable Object classes
     description: |-

--- a/src/content/changelogs/workers.yaml
+++ b/src/content/changelogs/workers.yaml
@@ -5,6 +5,9 @@ productLink: "/workers/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2025-02-11"
+    description: |-
+      - When the runtime generates an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2025-01-31"
     description: |-
       - Updated v8 to version 13.3.

--- a/src/content/changelogs/workers.yaml
+++ b/src/content/changelogs/workers.yaml
@@ -7,7 +7,7 @@ productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2025-02-11"
     description: |-
-      - When the runtime generates an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
+      - When Workers generate an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2025-01-31"
     description: |-
       - Updated v8 to version 13.3.

--- a/src/content/changelogs/workers.yaml
+++ b/src/content/changelogs/workers.yaml
@@ -7,7 +7,7 @@ productAreaLink: /workers/platform/changelog/platform/
 entries:
   - publish_date: "2025-02-11"
     description: |-
-      - When Workers generate an "internal error" exception in response to certain failures, the exception message may include a reference ID that customers can include in support communication, to help make the error easier to diagnose.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
+      - When Workers generate an "internal error" exception in response to certain failures, the exception message may provide a reference ID that customers can include in support communication for easier error identification.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
   - publish_date: "2025-01-31"
     description: |-
       - Updated v8 to version 13.3.


### PR DESCRIPTION
### Summary

Adds entries to the Workers and DO changelogs describing a change to "internal error" exception messages to include "reference" ids.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
