### PR TITLE
[Gateway] TLS decryption does not happen with DNI

### DIFF
--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
@@ -17,7 +17,7 @@ import {
 
 Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) in order to inspect HTTPS traffic for malware and other security risks.
 
-When you enable TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/connections/connect-devices/user-side-certificates/). Gateway will decrypt and re-encrypt traffic regardless of HTTP policy action, including [Do Not Inspect](/cloudflare-one/policies/gateway/http-policies/#do-not-inspect).
+When you enable TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/connections/connect-devices/user-side-certificates/).
 
 Cloudflare prevents interference by decrypting, inspecting, and re-encrypting HTTPS requests in its data centers in memory only. Gateway only stores eligible cache content at rest. All cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/).
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/tls-decryption.mdx
@@ -17,7 +17,7 @@ import {
 
 Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) in order to inspect HTTPS traffic for malware and other security risks.
 
-When you enable TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/connections/connect-devices/user-side-certificates/).
+When you turn on TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/connections/connect-devices/user-side-certificates/).
 
 Cloudflare prevents interference by decrypting, inspecting, and re-encrypting HTTPS requests in its data centers in memory only. Gateway only stores eligible cache content at rest. All cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/).
 


### PR DESCRIPTION
Issue #13929 mentioned that TLS decryption still happens with DNI enabled, which led to #17266 to reflect that. This is incorrect: Do Not Inspect (DNI) _will not_ cause TLS decryption, otherwise we wouldn't be able to support Certificate Pinning applications.