### PR TITLE
[Vitest Integration] explains how to import modules on the global setup file

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
@@ -64,7 +64,8 @@ You can find an example in the [Recipes](/workers/testing/vitest-integration/rec
 
 ### Importing modules from global setup file
 
-While Vitest is instructed to resolve packages for the `workerd` runtime, it runs your global setup file in the NodeJS environment. This is why you might encounter issue importing pacakges like [Postgres.js](https://github.com/cloudflare/workers-sdk/issues/6465) that export non-node version for `workerd`. To get around this issue, you can create a wrapper that uses Vite's SSR module loader to import your global setup file under the correct conditions. Then, adjust your Vitest configuration to point to this wrapper. For example:
+Although Vitest is set up to resolve packages for the `workerd` runtime, it runs your global setup file in the Node.js environment. This can cause issues when importing packages like [Postgres.js](https://github.com/cloudflare/workers-sdk/issues/6465), which exports a non-Node version for `workerd`.
+To work around this, you can create a wrapper that uses Vite's SSR module loader to import the global setup file under the correct conditions. Then, adjust your Vitest configuration to point to this wrapper. For example:
 
 ```ts
 // File: global-setup-wrapper.ts

--- a/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
@@ -61,3 +61,48 @@ export default defineWorkersConfig({
 ```
 
 You can find an example in the [Recipes](/workers/testing/vitest-integration/recipes) page.
+
+### Importing modules from global setup file
+
+While Vitest is instructed to resolve packages for the `workerd` runtime, it runs your global setup file in the NodeJS environment. This is why you might encounter issue importing pacakges like [Postgres.js](https://github.com/cloudflare/workers-sdk/issues/6465) that export non-node version for `workerd`. To get around this issue, you can create a wrapper that uses Vite's SSR module loader to import your global setup file under the correct conditions. Then, adjust your Vitest configuration to point to this wrapper. For example:
+
+```ts
+// File: global-setup-wrapper.ts
+import { createServer } from "vite"
+
+// Import the actual global setup file with the correct setup
+const mod = await viteImport("./global-setup.ts")
+
+export default mod.default;
+
+// Helper to import the file with default node setup
+async function viteImport(file: string) {
+  const server = await createServer({
+    root: import.meta.dirname,
+    configFile: false,
+    server: { middlewareMode: true, hmr: false, watch: null, ws: false },
+    optimizeDeps: { noDiscovery: true },
+    clearScreen: false,
+  });
+  const mod = await server.ssrLoadModule(file);
+  await server.close();
+  return mod;
+}
+```
+
+```ts
+// File: vitest.config.ts
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+	test: {
+		// Replace the globalSetup with the wrapper file
+		globalSetup: ["./global-setup-wrapper.ts"],
+		poolOptions: {
+			workers: {
+				// ...
+			},
+		},
+	},
+});
+```


### PR DESCRIPTION
### Summary

This PR documents the limitation we had when importing modules on the global setup file, including the workaround shared on https://github.com/cloudflare/workers-sdk/issues/6465#issuecomment-2558941565.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
