### PR TITLE
Add compatibility note for java php ruby boto aws sdks

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-java.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-java.mdx
@@ -10,6 +10,18 @@ import { Render } from "~/components";
 
 This example uses version 2 of the [aws-sdk-java](https://github.com/aws/aws-sdk-java-v2/#using-the-sdk) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
+:::note[Compatibility]
+Client version `2.30.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `2.29.52` or add the following to their S3Config:
+
+```java
+this.requestChecksumCalculation = "when_required",
+this.responseChecksumValidation = "when_required"
+```
+
+:::
+
 ```java
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;

--- a/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-php.mdx
@@ -12,6 +12,18 @@ import { Render } from "~/components";
 
 This example uses version 3 of the [aws-sdk-php](https://packagist.org/packages/aws/aws-sdk-php) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
+:::note[Compatibility]
+Client version `3.337.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `3.336.15` or add the following to their $options:
+
+```php
+'request_checksum_calculation' => 'when_required',
+'response_checksum_validation' => 'when_required'
+```
+
+:::
+
 ```php
 <?php
 require 'vendor/aws/aws-autoloader.php';

--- a/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-ruby.mdx
@@ -1,14 +1,26 @@
 ---
 title: aws-sdk-ruby
 pcx_content_type: example
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
-<Render file="keys" /><br/>
+<Render file="keys" />
+<br />
 
 Many Ruby projects also store these credentials in environment variables instead.
+
+:::note[Compatibility]
+Client version `1.178.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `1.177.0` or add the following to their s3 client instantiation:
+
+```ruby
+request_checksum_calculation: "when_required",
+response_checksum_validation: "when_required"
+```
+
+:::
 
 Add the following dependency to your `Gemfile`:
 

--- a/src/content/docs/r2/examples/aws/boto3.mdx
+++ b/src/content/docs/r2/examples/aws/boto3.mdx
@@ -10,6 +10,18 @@ import { Render } from "~/components";
 
 You must configure [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) to use a preconstructed `endpoint_url` value. This can be done through any `boto3` usage that accepts connection arguments; for example:
 
+:::note[Compatibility]
+Client version `1.36.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `1.35.99` or add the following to their s3 resource config:
+
+```python
+request_checksum_calculation = 'WHEN_REQUIRED',
+response_checksum_validation = 'WHEN_REQUIRED'
+```
+
+:::
+
 ```python
 import boto3
 


### PR DESCRIPTION
### Summary

Initially removed compatibility notes for all AWS SDK clients but reinstated them for clients with incompatible versions with R2, as not all clients are supported.

### Screenshots (optional)

Ruby
<img width="660" alt="Screenshot 2025-02-13 at 11 41 27 AM" src="https://github.com/user-attachments/assets/fa805304-2a74-4442-a4fa-509d5500de90" />

Php
<img width="664" alt="Screenshot 2025-02-13 at 11 41 38 AM" src="https://github.com/user-attachments/assets/51200302-31a3-4367-a30e-825f1651c090" />

Boto3
<img width="664" alt="Screenshot 2025-02-13 at 11 42 38 AM" src="https://github.com/user-attachments/assets/49f589e4-b0be-4232-9d24-3a319a1da12b" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
