### PR TITLE
[Logs] Add Description field in firewall_events dataset to the list of fields not supported for the filtering

### DIFF
--- a/src/content/partials/logs/filtering-limitations.mdx
+++ b/src/content/partials/logs/filtering-limitations.mdx
@@ -7,5 +7,5 @@
 
 Filtering is not supported on the following data types: `objects`, `array[object]`.
 
-For the Firewall events dataset, the following fields are not supported: `Action`, `Kind`, `MatchIndex`, `Metadata`, `OriginatorRayID`, `RuleID`, and `Source`.
+For the Firewall events dataset, the following fields are not supported: `Action`, `Description`, `Kind`, `MatchIndex`, `Metadata`, `OriginatorRayID`, `RuleID`, and `Source`.
 :::


### PR DESCRIPTION
### Summary

This adds `Description` field in `firewall_events` dataset to the list of fields not supported for the filtering.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
