### PR TITLE
Remove workers.dev Access limitation

### DIFF
--- a/src/content/docs/workers/configuration/routing/workers-dev.mdx
+++ b/src/content/docs/workers/configuration/routing/workers-dev.mdx
@@ -52,10 +52,6 @@ If you do not specify `workers_dev = false` but add a [`routes` component](/work
 If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's Wrangler file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you deploy your Worker with Wrangler.
 :::
 
-## Limitations
-
-- You cannot currently secure `workers.dev` URLs behind [Cloudflare Access](/cloudflare-one/policies/access/). This is a temporary limitation, we are working to remove it.
-
 ## Related resources
 
 - [Announcing `workers.dev`](https://blog.cloudflare.com/announcing-workers-dev)


### PR DESCRIPTION
### Summary

You can indeed now configure Access in front of `workers.dev` zones. [Here's an example](https://developers.cloudflare.com/workers/configuration/previews/#manage-access-to-preview-urls) of doing it for one app's Preview URLs, though it can be done for an entire Worker or even the entire account subdomain. I just removed this limitation from this page, because it didn't really feel like a natural place to talk about Access, but we could add in more detail or links here about how to configure it if PCX wants to.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
