### PR TITLE
[Turnstile] Waiting Room Analytics link

### DIFF
--- a/src/content/docs/turnstile/extensions/pages-plugin.mdx
+++ b/src/content/docs/turnstile/extensions/pages-plugin.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-title: Pages plugin
+title: Pages Plugin
 external_link: /pages/functions/plugins/turnstile/
 sidebar:
   order: 1

--- a/src/content/docs/turnstile/extensions/waiting-room.mdx
+++ b/src/content/docs/turnstile/extensions/waiting-room.mdx
@@ -1,0 +1,8 @@
+---
+pcx_content_type: concept
+title: Waiting Room Analytics
+external_link: /waiting-room/waiting-room-analytics/#turnstile-widget-traffic
+sidebar:
+  order: 3
+
+---


### PR DESCRIPTION
### Summary

Add link to Waiting Room Analytics's Turnstile traffic section under Extensions.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
