### PR TITLE
Add aws sdk compatibility flags for go js net clients

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-go.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-go.mdx
@@ -1,14 +1,26 @@
 ---
 title: aws-sdk-go
 pcx_content_type: example
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
-<Render file="keys" /><br/>
+<Render file="keys" />
+<br />
 
 This example uses version 2 of the [aws-sdk-go](https://github.com/aws/aws-sdk-go-v2) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
+
+:::note[Compatibility]
+Client version `1.73.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `1.72.3` or add the following to their config:
+
+```go
+config.WithRequestChecksumCalculation(0)
+config.WithResponseChecksumValidation(0)
+```
+
+:::
 
 ```go
 package main

--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -10,6 +10,18 @@ import { Render } from "~/components";
 
 JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
+:::note[Compatibility]
+Client version `3.729.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `3.726.1` or add the following to their S3Client config:
+
+```ts
+requestChecksumCalculation: "WHEN_REQUIRED",
+responseChecksumValidation: "WHEN_REQUIRED",
+```
+
+:::
+
 ```ts
 import {
 	S3Client,

--- a/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
@@ -1,18 +1,30 @@
 ---
 title: aws-sdk-net
 pcx_content_type: example
-
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
-<Render file="keys" /><br/>
+<Render file="keys" />
+<br />
 
 This example uses version 3 of the [aws-sdk-net](https://www.nuget.org/packages/AWSSDK.S3) package. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
 
 ## Client setup
 
 In this example, you will pass credentials explicitly to the `IAmazonS3` initialization. If you wish, use a shared AWS credentials file or the SDK store in-line with other AWS SDKs. Refer to [Configure AWS credentials](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) for more details.
+
+:::note[Compatibility]
+Client version `3.7.963.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
+
+To mitigate, users can use `3.7.962.0` or add the following to their AmazonS3Config:
+
+```csharp
+RequestChecksumCalculation = "WHEN_REQUIRED",
+ResponseChecksumValidation = "WHEN_REQUIRED"
+```
+
+:::
 
 ```csharp
 private static IAmazonS3 s3Client;
@@ -72,9 +84,7 @@ The [PutObjectAsync](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/M
 
 :::caution
 
-
 `DisablePayloadSigning = true` must be passed as Cloudflare R2 does not currently support the Streaming SigV4 implementation used by AWSSDK.S3.
-
 
 :::
 


### PR DESCRIPTION
### Summary

We discovered a breaking change when requesting ranged reads with a CRC32 checksum. To address this, we're adding backward compatibility notes until we can confirm full compatibility for all clients with R2.
