### PR TITLE
[KV] fix: use correct package name in assets tutorial

### DIFF
--- a/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
+++ b/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
@@ -49,7 +49,7 @@ cd example-kv-assets
 We'll also install the dependencies we will need for this project.
 
 ```sh
-npm install mimes accept-language-parser
+npm install mime accept-language-parser
 npm install --save-dev @types/accept-language-parser
 ```
 


### PR DESCRIPTION
### Summary

This PR resolves a minor issue with the "Store and retrieve static assets with Workers KV" tutorial instructing folks to install the `mimes` npm package instead of the package actually used, `mime`.

### Documentation checklist


- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
