### PR TITLE
[wrangler] remove stray wrangler init deprecation message

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -134,12 +134,6 @@ wrangler docs [<COMMAND>]
 
 ## `init`
 
-:::note
-
-The `init` command will be removed in a future version. Please use `npm create cloudflare@latest` instead.
-
-:::
-
 Create a new project via the [create-cloudflare-cli (C3) tool](/workers/get-started/guide/#1-create-a-new-worker-project). A variety of web frameworks are available to choose from as well as templates. Dependencies are installed by default, with the option to deploy your project immediately.
 
 ```txt


### PR DESCRIPTION
### Summary

Wrangler init is *not* being deprecated. Most warnings were removed in a PR a few months ago but this one seems to have snuck back in.
