### PR TITLE
Update Logpush instructions for Zero Trust

### DIFF
--- a/src/content/docs/cloudflare-one/insights/logs/logpush.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/logpush.mdx
@@ -23,10 +23,11 @@ To enable Logpush for Zero Trust logs:
 2. Select **Add Logpush job**.
 3. Select **Create a Logpush job**.
 4. In **Select a destination**, select the service you want to export your logs to.
-5. Choose the **Zero Trust datasets** you would like to export.
-6. Enter a **Job name**, any **filters** you would like to add, and which **data fields** you want to include in each log.
-7. In **Advanced settings**, choose the timestamp format you prefer, and whether you want to enable log sampling.
-8. Select **Submit**.
+5. Follow the service-specific instructions to configure and validate your destination.
+6. Choose the [**Zero Trust datasets**](#zero-trust-datasets) you would like to export.
+7. Enter a **Job name**, any [filters](/logs/reference/filters/) you would like to add, and the data fields you want to include in the log.
+8. (Optional) In **Advanced settings**, choose the timestamp format you prefer and whether you want to enable log sampling.
+9. Select **Submit**.
 
 The setup of your Logpush integration is now complete. Logpush will send updated logs every five minutes to your selected destination.
 

--- a/src/content/docs/cloudflare-one/insights/logs/logpush.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/logpush.mdx
@@ -21,13 +21,12 @@ To enable Logpush for Zero Trust logs:
 
 1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Logs** > **Logpush**.
 2. Select **Add Logpush job**.
-3. Enter a **Job name**.
-4. From the drop-down menu, choose the [dataset](#zero-trust-datasets) to export.
-5. Next, select the data fields you want to include in the log.
-6. In **Advanced settings**, choose the timestamp format you prefer, and whether you want to enable logs sampling.
-7. Select **Next**.
-8. Select the service you want to export your logs to.
-9. Follow the service-specific instructions in Zero Trust to validate your destination.
+3. Select **Create a Logpush job**.
+4. In **Select a destination**, select the service you want to export your logs to.
+5. Choose the **Zero Trust datasets** you would like to export.
+6. Enter a **Job name**, any **filters** you would like to add, and which **data fields** you want to include in each log.
+7. In **Advanced settings**, choose the timestamp format you prefer, and whether you want to enable log sampling.
+8. Select **Submit**.
 
 The setup of your Logpush integration is now complete. Logpush will send updated logs every five minutes to your selected destination.
 


### PR DESCRIPTION
Logpush setup for Zero Trust now happens in the main Dashboard, so these instructions were outdated. This PR updates the instructions to reflect the user experience.
