### PR TITLE
[GH] Move anchor link audit to dispatch only

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -5,8 +5,6 @@ name: Anchor link audit
 # **Who does it impact**: PCX team
 
 on:
-  schedule:
-    - cron: "0 0 * * 0" # Run at 00:00 UTC every Sunday
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Summary

Since we've moved to Hyperlint, we no longer need just the issue reporting.

Keeping in case folks want to run on their own branches though.

cc: @bllchmbrs, if you wanted this for marketing 😄 