### PR TITLE
Include user role requirements for Zone Versioning

### DIFF
--- a/src/content/docs/version-management/index.mdx
+++ b/src/content/docs/version-management/index.mdx
@@ -43,6 +43,7 @@ To use Version Management, the following must all be true:
 * Your zone uses [WAF managed rules](/waf/managed-rules/).
 * Your zone has migrated to use [Custom Rules](/waf/reference/migration-guides/firewall-rules-to-custom-rules/) instead of Firewall Rules (deprecated).
 * Your account uses the [new WAF](https://blog.cloudflare.com/new-cloudflare-waf/) (if not, contact your account team).
+* Your user account must have a Super Administrator or Administrator [role](/fundamentals/setup/manage-members/roles/).
 * Your user account must have an API Key provisioned (if not, [view your API Key](/fundamentals/api/get-started/keys/#view-your-global-api-key)).
 * Your user account must have API Access enabled. Refer to [control API Access](/fundamentals/api/how-to/control-api-access/) for more information.
 * You must use the dashboard to manage versioning.


### PR DESCRIPTION
During a recent troubleshooting it was uncovered that Zone version clones should be done by either the admin or super admin to avoid version clone failures due to lack of permissions on certain features (E.g. IP access Rules).

At this time, the feature requirements do not (yet) state that any specific role is needed.
