### PR TITLE
[ZT] GDrive cert own section

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1735,6 +1735,7 @@
 /cloudflare-one/policies/browser-isolation/clientless-browser-isolation/ /cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation/ 301
 /cloudflare-one/connections/connect-devices/agentless/dns-over-https/ /cloudflare-one/connections/connect-devices/agentless/dns/dns-over-https/ 301
 /cloudflare-one/connections/connect-devices/agentless/dns-over-tls/ /cloudflare-one/connections/connect-devices/agentless/dns/dns-over-tls/ 301
+/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment/#google-drive-for-desktop /cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment/#google-drive 301
 /cloudflare-one/connections/connect-devices/warp/install-cloudflare-cert/ /cloudflare-one/connections/connect-devices/warp/user-side-certificates/ 301
 /cloudflare-one/connections/connect-devices/warp/control-proxy/ /cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/ 301
 /cloudflare-one/connections/connect-devices/warp/deployment/macOS-Teams/ /cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/ 301

--- a/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment.mdx
@@ -710,7 +710,11 @@ The file at `~/ca.pem` needs to remain in place in order for the `gcloud` utilit
 
 If you use Kaniko with Google Cloud SDK, you must install a Cloudflare certificate in the [Kaniko CA store](https://docs.gitlab.com/ee/ci/docker/using_kaniko.html#using-a-registry-with-a-custom-certificate). For more information, refer to the [`gcloud` documentation](https://cloud.google.com/sdk/gcloud/reference/builds/submit).
 
-#### Google Drive for desktop
+#### Google Apps Manager (GAM)
+
+Google Apps Manager (GAM) uses its own certificate store. To add a Cloudflare certificate to GAM, refer to the [GAM documentation](https://github.com/GAM-team/GAM/wiki/#using-gam-with-ssl--tls-mitm-inspection).
+
+### Google Drive
 
 To trust a Cloudflare root certificate in the Google Drive desktop application, follow the procedure for your operating system. These steps require you to [download a `.pem` certificate](#download-the-cloudflare-root-certificate).
 
@@ -773,10 +777,6 @@ Get-ItemProperty -Path "HKLM:\SOFTWARE\Google\DriveFS" | Select-Object TrustedRo
 </Tabs>
 
 For more information, refer to the [Google documentation](https://support.google.com/a/answer/7644837) for the `TrustedRootCertsFile` setting.
-
-#### Google Apps Manager (GAM)
-
-Google Apps Manager (GAM) uses its own certificate store. To add a Cloudflare certificate to GAM, refer to the [GAM documentation](https://github.com/GAM-team/GAM/wiki/#using-gam-with-ssl--tls-mitm-inspection).
 
 ### AWS CLI
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/common-policies.mdx
@@ -310,7 +310,7 @@ For more information on supported file types, refer to [Download and Upload File
 
 ## Block Google services
 
-To enable Gateway inspection for Google Drive traffic, you must [add a Cloudflare certificate to Google Drive](/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment/#google-drive-for-desktop).
+To enable Gateway inspection for Google Drive traffic, you must [add a Cloudflare certificate to Google Drive](/cloudflare-one/connections/connect-devices/user-side-certificates/manual-deployment/#google-drive).
 
 ### Block Google Drive downloads
 


### PR DESCRIPTION
Moves the Google Drive cert installation instructions into their own section for better visibility.