### PR TITLE
[API Shield] Bearer prefix

### DIFF
--- a/src/content/docs/api-shield/security/jwt-validation/index.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/index.mdx
@@ -60,6 +60,10 @@ If you expect that two different JWTs should be present in a request and you wan
 
 If you expect to migrate between two different identity providers, you must create two different token configurations and two different validation rules, each corresponding to its own configuration. With this setup, you can change the action for different validation rules depending on the state of your migration.
 
+### JSON Web Tokens with the `Bearer` prefix
+
+API Shield will verify JSON Web Tokens regardless of whether or not they have the `Bearer` prefix.
+
 ## Availability
 
 JWT Validation is available for all API Shield customers. Enterprise customers who have not purchased API Shield can preview [API Shield as a non-contract service](https://dash.cloudflare.com/?to=/:account/:zone/security/api-shield) in the Cloudflare dashboard or by contacting your account team.


### PR DESCRIPTION
### Summary

Add info about API Shield's JWT Validation verification for JWTs that have or do not have the `Bearer` prefix.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
