### PR TITLE
[Magic Firewall] Update the bucket name in the packet capture doc

### DIFF
--- a/src/content/docs/magic-firewall/packet-captures/collect-pcaps.mdx
+++ b/src/content/docs/magic-firewall/packet-captures/collect-pcaps.mdx
@@ -93,7 +93,7 @@ While the collection is in progress, the response returns the `status` field as 
 		"packet_limit": 10000,
 		"byte_limit": 100000000,
 		"colo": "ORD",
-		"destination_conf": "gs://test-magic-pcaps"
+		"destination_conf": "gs://<bucket-name>" // Ensure you use a bucket that you created and registered in the Cloudflare dashboard
 	},
 	"success": true,
 	"errors": [],

--- a/src/content/docs/magic-firewall/packet-captures/pcaps-bucket-setup.mdx
+++ b/src/content/docs/magic-firewall/packet-captures/pcaps-bucket-setup.mdx
@@ -72,7 +72,7 @@ The response has a `"filename"` parameter which contains the content of the `own
 		"status": "pending",
 		"submitted": "2022-04-22T18:54:13.397413Z",
 		"validated": "",
-		"destination_conf": "gs://bucket-test",
+		"destination_conf": "gs://bucket-test", // Ensure you use a bucket that you created and registered in the Cloudflare dashboard.
 		"filename": "ownership-challenge-1234.txt"
 	},
 	"success": true,
@@ -101,7 +101,7 @@ curl https://api.cloudflare.com/client/v4/accounts/{account_id}/pcaps/ownership/
 		"status": "success",
 		"submitted": "2022-04-22T18:54:13.397413Z",
 		"validated": "2022-04-27T14:54:46.440548Z",
-		"destination_conf": "gs://bucket-test",
+		"destination_conf": "gs://<bucket-name>", // Ensure you use a bucket that you created and registered in the Cloudflare dashboard
 		"filename": "ownership-challenge-1234.txt"
 	},
 	"success": true,


### PR DESCRIPTION
### Summary

Magic PCAPs - This PR is to clarify the customer that the specified bucket names in the devdocs are placeholder names and they need to create (and use) their own.

### Screenshots (optional)

![vuln-pcaps-result](https://github.com/user-attachments/assets/59becec2-0a37-45f3-995e-3ea6ae077512)


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
