### PR TITLE
[Docs Site] Fix regression for anchors in search results

### DIFF
--- a/src/plugins/docsearch/index.ts
+++ b/src/plugins/docsearch/index.ts
@@ -9,8 +9,8 @@ export default {
 	// can be used in local development and previews.
 	transformItems(items) {
 		return items.map((item) => {
-			const path = new URL(item.url).pathname;
-			const url = new URL(path, window.origin);
+			const { pathname, hash } = new URL(item.url);
+			const url = new URL(pathname + hash, window.location.origin);
 
 			return {
 				...item,


### PR DESCRIPTION
### Summary

Fix regression for anchors in search results as we only used the `pathname` from the original hit URL, missing the `hash`.