### PR TITLE
Add timezone to cron triggers examples

### DIFF
--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -106,7 +106,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 - `0 17 * * sun` or `0 17 * * 1`
 
-  - 5PM (UTC) on Sunday
+  - 17:00 (UTC) on Sunday
 
 - `10 7 * * mon-fri` or `10 7 * * 2-6`
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -48,8 +48,8 @@ Refer to the example below for a Cron Triggers configuration:
 [triggers]
 # Schedule cron triggers:
 # - At every 3rd minute
-# - At 3PM on first day of the month
-# - At 11:59PM on the last weekday of the month
+# - At 3PM (UTC) on first day of the month
+# - At 11:59PM (UTC) on the last weekday of the month
 crons = [ "*/3 * * * *", "0 15 1 * *", "59 23 LW * *" ]
 ```
 
@@ -106,22 +106,22 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 - `0 17 * * sun` or `0 17 * * 1`
 
-  - 5PM on Sunday
+  - 5PM (UTC) on Sunday
 
 - `10 7 * * mon-fri` or `10 7 * * 2-6`
 
-  - 7:10AM on weekdays
+  - 7:10AM (UTC) on weekdays
 
 - `0 15 1 * *`
 
-  - 3PM on first day of the month
+  - 3PM (UTC) on first day of the month
 
 - `0 18 * * 6L` or `0 18 * * friL`
 
-  - 6PM on the last Friday of the month
+  - 6PM (UTC) on the last Friday of the month
 
 - `59 23 LW * *`
-  - 11:59PM on the last weekday of the month
+  - 11:59PM (UTC) on the last weekday of the month
 
 ## Test Cron Triggers
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -110,7 +110,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 - `10 7 * * mon-fri` or `10 7 * * 2-6`
 
-  - 7:10AM (UTC) on weekdays
+  - 07:10 (UTC) on weekdays
 
 - `0 15 1 * *`
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -121,7 +121,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
   - 6PM (UTC) on the last Friday of the month
 
 - `59 23 LW * *`
-  - 11:59PM (UTC) on the last weekday of the month
+  - 23:59 (UTC) on the last weekday of the month
 
 ## Test Cron Triggers
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -48,7 +48,7 @@ Refer to the example below for a Cron Triggers configuration:
 [triggers]
 # Schedule cron triggers:
 # - At every 3rd minute
-# - At 3PM (UTC) on first day of the month
+# - At 15:00 (UTC) on first day of the month
 # - At 11:59PM (UTC) on the last weekday of the month
 crons = [ "*/3 * * * *", "0 15 1 * *", "59 23 LW * *" ]
 ```

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -118,7 +118,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 - `0 18 * * 6L` or `0 18 * * friL`
 
-  - 6PM (UTC) on the last Friday of the month
+  - 18:00 (UTC) on the last Friday of the month
 
 - `59 23 LW * *`
   - 23:59 (UTC) on the last weekday of the month

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -49,7 +49,7 @@ Refer to the example below for a Cron Triggers configuration:
 # Schedule cron triggers:
 # - At every 3rd minute
 # - At 15:00 (UTC) on first day of the month
-# - At 11:59PM (UTC) on the last weekday of the month
+# - At 23:59 (UTC) on the last weekday of the month
 crons = [ "*/3 * * * *", "0 15 1 * *", "59 23 LW * *" ]
 ```
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -114,7 +114,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 - `0 15 1 * *`
 
-  - 3PM (UTC) on first day of the month
+  - 15:00 (UTC) on first day of the month
 
 - `0 18 * * 6L` or `0 18 * * friL`
 


### PR DESCRIPTION
https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20execute%20on%20UTC%20time. 

👆 too easy to skip in docs. Examples refer to times, but no timezone, therefore incomplete information in examples. Adding UTC for completeness (accepting repetitiveness)
