### PR TITLE
[Docs Site] Fix index.html.md routing

### DIFF
--- a/src/pages/[...entry]/index.html.md.ts
+++ b/src/pages/[...entry]/index.html.md.ts
@@ -10,7 +10,7 @@ export const getStaticPaths = (async () => {
 		return {
 			params: {
 				// https://llmstxt.org/: (URLs without file names should append index.html.md instead.)
-				entry: entry.id + "/index",
+				entry: entry.id,
 			},
 			props: {
 				entry,


### PR DESCRIPTION
### Summary

Fix index.html.md routing

With Astro 5 adding `/index` is no-longer necessary.