### PR TITLE
[DO] Clarifying getAlarm behaviour if called while alarm is running

### DIFF
--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -35,7 +35,7 @@ Alarms can be used to build distributed primitives, like queues or batching of w
 
   - If there is an alarm set, then return the currently set alarm time as the number of milliseconds elapsed since the UNIX epoch. Otherwise, return `null`.
 
-  - If `getAlarm` is called while an [`alarm`](/durable-objects/api/alarms/#alarm) is already running, it returns `null` unless `setAlarm` has been called since the alarm handler started running.
+  - If `getAlarm` is called while an [`alarm`](/durable-objects/api/alarms/#alarm) is already running, it returns `null` unless `setAlarm` has also been called since the alarm handler started running.
 
 ### `setAlarm`
 

--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -35,6 +35,8 @@ Alarms can be used to build distributed primitives, like queues or batching of w
 
   - If there is an alarm set, then return the currently set alarm time as the number of milliseconds elapsed since the UNIX epoch. Otherwise, return `null`.
 
+  - If `getAlarm` is called while an [`alarm`](/durable-objects/api/alarms/#alarm) is already running, it returns `null` unless `setAlarm` has been called since the alarm handler started running.
+
 ### `setAlarm`
 
 - <code>{" "}setAlarm(scheduledTimeMs <Type text="number" />)</code>
@@ -61,6 +63,7 @@ Alarms can be used to build distributed primitives, like queues or batching of w
   - The optional parameter `alarmInfo` object has two properties:
     - `retryCount` <Type text="number"/>: The number of times this alarm event has been retried.
     - `isRetry` <Type text="boolean"/>: A boolean value to indicate if the alarm has been retried. This value is `true` if this alarm event is a retry.
+
 
   - The `alarm()` handler has guaranteed at-least-once execution and will be retried upon failure using exponential backoff, starting at 2 second delays for up to 6 retries. Retries will be performed if the method fails with an uncaught exception.
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Previously, the Alarms API (Workers Binding API) did not comment on the behaviour of `getAlarm` if an alarm was already running.

This PR adds in that missing detail, specifically, that:

- If `getAlarm` is called while an `alarm` is running, it will return `null`, unless `setAlarm` has been called since the `alarm` started running.
- This also implies (though not stated in the doc as it's redundant) that if you call `getAlarm` within an `alarm`, it will return `null` unless `setAlarm` has been called first inside the `alarm`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
