### PR TITLE
Update limits.mdx

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/limits.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/limits.mdx
@@ -22,7 +22,7 @@ Workers for Platforms do not have a limit for the number of Durable Object names
 
 ## Cache API
 
-For isolation, `caches.default()` is disabled for namespaced scripts. To learn more about the cache, refer to [How the cache Works](/workers/reference/how-the-cache-works/).
+For isolation, `caches.default` is disabled for namespaced scripts. To learn more about the cache, refer to [How the cache Works](/workers/reference/how-the-cache-works/).
 
 ## ​Tags
 

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works.mdx
@@ -71,6 +71,6 @@ Service bindings and Workers for Platforms can be used simultaneously when build
 
 ## [Cache API](/workers/runtime-apis/cache/)
 
-Workers for Platforms user Workers have access to namespaced cache through the [cache API](/workers/runtime-apis/cache/). Namespaced cache is isolated across user Workers. For isolation, `caches.default()` is disabled for namespaced scripts.
+Workers for Platforms user Workers have access to namespaced cache through the [cache API](/workers/runtime-apis/cache/). Namespaced cache is isolated across user Workers. For isolation, `caches.default` is disabled for namespaced scripts.
 
 To learn more about the cache, refer to [How the cache Works](/workers/reference/how-the-cache-works/).


### PR DESCRIPTION
### Summary

The WfP Limits page incorrectly refers to `caches.default` as a method call rather than a property.
