### PR TITLE
[Email Routing] Updated steps to add a custom domain to the mta-sts worker in mta-sts.mdx

### DIFF
--- a/src/content/docs/email-routing/setup/mta-sts.mdx
+++ b/src/content/docs/email-routing/setup/mta-sts.mdx
@@ -31,11 +31,13 @@ Next you need an HTTPS endpoint at `mta-sts.example.com` to serve your policy fi
 
 To do this you need to deploy a Worker that allows email clients to pull Cloudflare’s Email Routing policy file using the “well-known” URI convention.
 
-4. Go to your **Account** > **Workers & Pages** and press **Create Application**. Pick the "MTA-STS" template from the list.
+4. Go to your **Account** > **Workers (Compute)** > **Workers & Pages** and press **Create**. Pick the "MTA-STS" template from the list.
 
 ![MTA-STS Worker](~/assets/images/email-routing/mta-sts-worker.png)
 
-5. This Worker proxies `https://mta-sts.mx.cloudflare.net/.well-known/mta-sts.txt` to your own domain. After deploying it, go to the Worker configuration, then **Triggers** > **Custom Domains** and **Add Custom Domain**. Type the subdomain `mta-sts.example.com`.
+This Worker proxies `https://mta-sts.mx.cloudflare.net/.well-known/mta-sts.txt` to your own domain.
+
+5. After deploying it, go to the Worker settings, then **Domains & Routes** and press **Add**. Choose **Custom Domain**, type the subdomain `mta-sts.example.com` then press **Add Domain**.
 
 ![MTA-STS Worker Custom Domain](~/assets/images/email-routing/mta-sts-domain.png)
 


### PR DESCRIPTION
### Summary

Email routing steps to setup mta-sts did not match the UI menus. Triggers > Custom Domains seems to be replaced by Domains & Routes in Worker settings.

Screenshot for add custom domain may need to be updated as the UI is different.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
