### PR TITLE
[DO] Note on nominal metadata when writing to SQLite DO

### DIFF
--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -44,7 +44,9 @@ For Durable Object classes with [SQLite storage backend](/durable-objects/best-p
 
 <Render file="limits_increase" product="workers" />
 
-## How much work can a single Durable Object do?
+## Frequently Asked Questions
+
+### How much work can a single Durable Object do?
 
 Durable Objects can scale horizontally across many Durable Objects. Each individual Object is inherently single-threaded.
 
@@ -54,7 +56,7 @@ Durable Objects can scale horizontally across many Durable Objects. Each individ
 
 A Durable Object that receives too many requests will, after attempting to queue them, return an [overloaded](/durable-objects/observability/troubleshooting/#durable-object-is-overloaded) error to the caller.
 
-## How many Durable Objects can I create?
+### How many Durable Objects can I create?
 
 Durable Objects are designed such that the number of individual objects in the system do not need to be limited, and can scale horizontally.
 

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -119,8 +119,14 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 <Render file="storage_api_pricing" product="workers" />
 
-:::caution[Metadata when writing to a SQLite-backed Durable Objects]
-All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in the Durable Object, which counts towards your billable [storage](/durable-objects/best-practices/access-durable-objects-storage/).
+## Frequently Asked Questions
+
+### Does metadata stored in Durable Objects count towards my storage?
+
+Yes, although minimal.
+
+All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in internal tables in the Durable Object, which counts towards your billable storage.
+
+These tables can consume at least a few kilobytes, based on the number of columns (table width) in the table. Your metadata table may consume approximately 12 KB of storage.
 
 The metadata remains in the Durable Object until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall).
-:::

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -120,7 +120,7 @@ In this scenario, the estimated monthly cost would be calculated as:
 <Render file="storage_api_pricing" product="workers" />
 
 :::caution[Metadata when writing to SQLite-backed Durable Object]
-All writes to a SQLite-backed Durable Object records nominal amounts of metadata, which counts towards your billable storage.
+All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in the Durable Object, which counts towards your billable storage.
 
-The metadata remains until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall) on the Durable Object.
+The metadata remains in the Durable Object until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall).
 :::

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -119,8 +119,8 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 <Render file="storage_api_pricing" product="workers" />
 
-:::caution[Metadata when writing to SQLite-backed Durable Object]
-All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in the Durable Object, which counts towards your billable storage.
+:::caution[Metadata when writing to a SQLite-backed Durable Objects]
+All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in the Durable Object, which counts towards your billable [storage](/durable-objects/best-practices/access-durable-objects-storage/).
 
 The metadata remains in the Durable Object until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall).
 :::

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -127,6 +127,6 @@ Yes, although minimal.
 
 All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in internal tables in the Durable Object, which counts towards your billable storage.
 
-These tables can consume at least a few kilobytes, based on the number of columns (table width) in the table. Your metadata table may consume approximately 12 KB of storage.
+These tables can consume at least a few kilobytes, based on the number of columns (table width) in the table. An empty SQLite database consumes approximately 12 KB of storage, and additional nominal amounts metadata may be written into these internal tables.
 
 The metadata remains in the Durable Object until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall).

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -121,12 +121,12 @@ In this scenario, the estimated monthly cost would be calculated as:
 
 ## Frequently Asked Questions
 
+### Does an empty table / SQLite database contribute to my storage?
+
+Yes, although minimal. Empty tables can consume at least a few kilobytes, based on the number of columns (table width) in the table. An empty SQLite database consumes approximately 12 KB of storage.
+
 ### Does metadata stored in Durable Objects count towards my storage?
 
-Yes, although minimal.
-
 All writes to a SQLite-backed Durable Object stores nominal amounts of metadata in internal tables in the Durable Object, which counts towards your billable storage.
-
-These tables can consume at least a few kilobytes, based on the number of columns (table width) in the table. An empty SQLite database consumes approximately 12 KB of storage, and additional nominal amounts metadata may be written into these internal tables.
 
 The metadata remains in the Durable Object until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall).

--- a/src/content/docs/durable-objects/platform/pricing.mdx
+++ b/src/content/docs/durable-objects/platform/pricing.mdx
@@ -118,3 +118,9 @@ In this scenario, the estimated monthly cost would be calculated as:
 ## Storage API billing
 
 <Render file="storage_api_pricing" product="workers" />
+
+:::caution[Metadata when writing to SQLite-backed Durable Object]
+All writes to a SQLite-backed Durable Object records nominal amounts of metadata, which counts towards your billable storage.
+
+The metadata remains until you call [`deleteAll()`](/durable-objects/api/storage-api/#deleteall) on the Durable Object.
+:::


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

When you write to a SQLite-backed DO, you generate a nominal amount of metadata which counts towards billable storage. 

This PR clarifies this point in the pricing page for DO.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
