### PR TITLE
[Docs Site] Track Linux releases with WARP script

### DIFF
--- a/bin/fetch-warp-releases.js
+++ b/bin/fetch-warp-releases.js
@@ -2,7 +2,14 @@ import fs from "fs";
 import YAML from "yaml";
 import { marked } from "marked";
 
-const tracks = ["windows/ga", "windows/beta", "macos/ga", "macos/beta"];
+const tracks = [
+	"windows/ga",
+	"windows/beta",
+	"macos/ga",
+	"macos/beta",
+	"noble-intel/ga",
+	"noble-intel/beta",
+];
 
 const linesToRemove = [
 	"For related Cloudflare for Teams documentation please see: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp",
@@ -11,11 +18,23 @@ const linesToRemove = [
 	"For Consumer documentation please see: https://developers.cloudflare.com/warp-client/",
 ];
 
-for (const track of tracks) {
+for (let track of tracks) {
 	fetch(`https://downloads.cloudflareclient.com/v1/update/json/${track}`)
 		.then((res) => res.json())
 		.then((data) => {
+			if (!data.items) {
+				console.warn(
+					`${track} has no releases: ${JSON.stringify(data, null, 2)}`,
+				);
+
+				return;
+			}
+
 			data.items.forEach((item) => {
+				if (track.startsWith("noble-intel")) {
+					track = track.replace("noble-intel", "linux");
+				}
+
 				const path = `./src/content/warp-releases/${track}/${item.version}.yaml`;
 
 				if (fs.existsSync(path)) {


### PR DESCRIPTION
### Summary

Track Linux releases with WARP script.

Adds "no items" logic for tracks that don't yet have any releases, but will in the future.