### PR TITLE
update compatibility_date for @cloudflare/next-on-pages documentation

### DIFF
--- a/src/content/docs/pages/framework-guides/nextjs/ssr/get-started.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/get-started.mdx
@@ -51,7 +51,7 @@ Then, add a [Wrangler configuration file](/pages/functions/wrangler-configuratio
 
 ```toml
 name = "my-app"
-compatibility_date = "2024-07-29"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"
 ```


### PR DESCRIPTION
### Summary

As of the last version of Next.js, so pages failed on cloudflare pages

cf. issue https://github.com/cloudflare/next-on-pages/issues/908


### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [X] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [X] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
