### PR TITLE
Expand on error 512 resolutions: HTTPS compatibility

### DIFF
--- a/src/content/docs/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.mdx
+++ b/src/content/docs/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors.mdx
@@ -195,7 +195,7 @@ The two most common causes of 521 errors are:
 - Review origin web server error logs to identify web server application crashes or outages.
 - Confirm [Cloudflare IP addresses](https://www.cloudflare.com/ips) are not blocked or rate limited
 - Allow all [Cloudflare IP ranges](https://www.cloudflare.com/ips) in your origin web server's firewall or other security software
-- Confirm that — if you have your **SSL/TLS mode** set to **Full** or **Full (Strict**) — you have installed a [Cloudflare Origin Certificate](/ssl/origin-configuration/origin-ca)
+- Confirm that — if you have your **SSL/TLS mode** set to **Full** or **Full (Strict**) — your origin supports HTTPS and/or you have installed a [Cloudflare Origin Certificate](/ssl/origin-configuration/origin-ca)
 - Find additional troubleshooting information on the [Cloudflare Community](https://community.cloudflare.com/t/community-tip-fixing-error-521-web-server-is-down/42461).
 
 ---


### PR DESCRIPTION
### Summary

In full mode the proxy connects to port 443 only. This means the webserver must support this. Currently this is not clear from the possible resolutions for error 521.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
