### PR TITLE
[Docs Site] Remove trailing whitespace from Type component

### DIFF
--- a/src/components/Type.astro
+++ b/src/components/Type.astro
@@ -1,6 +1,7 @@
 ---
 import { z } from "astro:schema";
 import { Badge } from "@astrojs/starlight/components";
+import { componentToString } from "~/util/container";
 
 type Props = z.infer<typeof props>;
 
@@ -11,15 +12,17 @@ const props = z
 	.strict();
 
 const { text } = props.parse(Astro.props);
----
 
-<Badge
-	text={text}
-	style={{
+const html = await componentToString(Badge, {
+	text,
+	style: {
 		color: "var(--sl-text-white)",
 		backgroundColor: "var(--sl-color-gray-6)",
 		borderColor: "var(--sl-color-gray-3)",
 		fontSize: "0.7rem",
 		fontWeight: "bold",
-	}}
-/>
+	},
+});
+---
+
+<Fragment set:html={html.trim()} />

--- a/src/util/container.ts
+++ b/src/util/container.ts
@@ -3,7 +3,6 @@ import { getContainerRenderer } from "@astrojs/mdx";
 import { loadRenderers } from "astro:container";
 import { render, type CollectionEntry } from "astro:content";
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
-import type { AstroGlobal } from "astro";
 
 export async function entryToString(
 	entry: CollectionEntry<"docs" | "changelog">,

--- a/src/util/container.ts
+++ b/src/util/container.ts
@@ -2,6 +2,8 @@ import { experimental_AstroContainer } from "astro/container";
 import { getContainerRenderer } from "@astrojs/mdx";
 import { loadRenderers } from "astro:container";
 import { render, type CollectionEntry } from "astro:content";
+import type { AstroComponentFactory } from "astro/runtime/server/index.js";
+import type { AstroGlobal } from "astro";
 
 export async function entryToString(
 	entry: CollectionEntry<"docs" | "changelog">,
@@ -21,6 +23,22 @@ export async function entryToString(
 	const html = await container.renderToString(Content, {
 		params: { slug: entry.id },
 		locals,
+	});
+
+	return html;
+}
+
+export async function componentToString(
+	component: AstroComponentFactory,
+	props: any,
+) {
+	const renderers = await loadRenderers([getContainerRenderer()]);
+	const container = await experimental_AstroContainer.create({
+		renderers,
+	});
+
+	const html = await container.renderToString(component, {
+		props,
 	});
 
 	return html;


### PR DESCRIPTION
### Summary

Components with whitespace between the markup and style tags result in trailing whitespace.

A possible proposal, albeit a breaking change, is tracked at https://github.com/withastro/roadmap/discussions/868

This fixes the issue in the interim - there are workarounds, like wrapping the markup in a fragment, but they do not apply to components we don't control (i.e the Starlight `Badge`) so we just render it to HTML and trim the whitespace.