### PR TITLE
[Docs Site] Add edit / issue buttons to sidebar

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -7,26 +7,30 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 ---
 
 <Default {...Astro.props} />
-<br />
-<div class="flex gap-2">
-	{
-		Astro.props.editUrl && (
-			<a
-				href={Astro.props.editUrl}
-				class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
-			>
-				<Icon name="pencil" />
-				Edit
-			</a>
-		)
-	}
-	<a
-		href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
-		class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
-	>
-		<Icon name="github" />
-		Issue
-	</a>
-</div>
+{
+	!Astro.url.pathname.startsWith("/support/") && (
+		<>
+			<br />
+			<div class="flex gap-2">
+				{Astro.props.editUrl && (
+					<a
+						href={Astro.props.editUrl}
+						class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+					>
+						<Icon name="pencil" />
+						Edit
+					</a>
+				)}
+				<a
+					href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
+					class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+				>
+					<Icon name="github" />
+					Issue
+				</a>
+			</div>
+		</>
+	)
+}
 <br />
 <FeedbackPrompt client:idle />

--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -2,9 +2,31 @@
 import type { Props } from "@astrojs/starlight/props";
 import Default from "@astrojs/starlight/components/TableOfContents.astro";
 
+import { Icon } from "@astrojs/starlight/components";
 import FeedbackPrompt from "../FeedbackPrompt.tsx";
 ---
 
 <Default {...Astro.props} />
+<br />
+<div class="flex gap-2">
+	{
+		Astro.props.editUrl && (
+			<a
+				href={Astro.props.editUrl}
+				class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+			>
+				<Icon name="pencil" />
+				Edit
+			</a>
+		)
+	}
+	<a
+		href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
+		class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+	>
+		<Icon name="github" />
+		Issue
+	</a>
+</div>
 <br />
 <FeedbackPrompt client:idle />


### PR DESCRIPTION
### Summary

Add edit / issue buttons to sidebar

### Screenshots (optional)

<img width="255" alt="image" src="https://github.com/user-attachments/assets/441e1401-ca98-4ed7-a061-30e4ffb5011b" />
