### PR TITLE
[Docs Site] Add SubtractIPCalculator component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
 				"astro-breadcrumbs": "3.3.1",
 				"astro-icon": "1.1.5",
 				"astro-live-code": "0.0.5",
+				"cidr-tools": "11.0.3",
 				"codeowners-utils": "1.0.2",
 				"date-fns": "4.1.0",
 				"dedent": "1.5.3",
@@ -6711,6 +6712,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/cidr-tools": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/cidr-tools/-/cidr-tools-11.0.3.tgz",
+			"integrity": "sha512-7p0rp7B2P+nZfBkJlrQzUMDyUHeYK2h/XCJY80VUl1v5oxwLxQjZMy39BXVOXugwAX67l0oJ/QQ6OhANgUtUbw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"ip-bigint": "^8.2.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
@@ -10613,6 +10627,16 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ip-bigint": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/ip-bigint/-/ip-bigint-8.2.1.tgz",
+			"integrity": "sha512-ji9uf6Sfp+v2TgsDEWKRRRDEJHbWOF+2Oaqqd0keUtNRHymJQ/HaL1svJScL+aqMWlEhH34OaJC1Ai2e+3YUzA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/iron-webcrypto": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"astro-breadcrumbs": "3.3.1",
 		"astro-icon": "1.1.5",
 		"astro-live-code": "0.0.5",
+		"cidr-tools": "11.0.3",
 		"codeowners-utils": "1.0.2",
 		"date-fns": "4.1.0",
 		"dedent": "1.5.3",

--- a/src/components/SubtractIPCalculator.tsx
+++ b/src/components/SubtractIPCalculator.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { excludeCidr, parseCidr } from "cidr-tools";
+
+export default function SubtractIPCalculator({
+	defaults,
+}: {
+	defaults: {
+		base?: string;
+		exclude?: string[];
+	};
+}) {
+	const [base, setBase] = useState(defaults?.base ?? "");
+	const [exclude, setExclude] = useState<string[]>(defaults?.exclude ?? []);
+
+	const [result, setResult] = useState<string[]>([]);
+
+	function calculate() {
+		setResult(excludeCidr(base, exclude));
+	}
+
+	function disableButton() {
+		try {
+			parseCidr(base);
+			exclude.map((cidr) => parseCidr(cidr));
+
+			return false;
+		} catch {
+			return true;
+		}
+	}
+
+	useEffect(() => {
+		if (defaults) {
+			calculate();
+		}
+	}, []);
+
+	return (
+		<div className="rounded-md border border-solid border-gray-200 p-6 no-underline dark:border-gray-700">
+			<div>
+				<label className="mr-4">
+					<strong>Base CIDR: </strong>
+					<input
+						type="text"
+						value={base}
+						onChange={(e) => setBase(e.target.value)}
+					/>
+				</label>
+				<label>
+					<strong>Excluded CIDRs: </strong>
+					<input
+						type="text"
+						value={exclude}
+						onChange={(e) => setExclude(e.target.value.split(","))}
+					/>
+				</label>
+			</div>
+			<div>
+				<button
+					className="h-8 cursor-pointer rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black disabled:cursor-not-allowed disabled:bg-cl1-gray-4 disabled:text-cl1-gray-1"
+					disabled={disableButton()}
+					onClick={() => calculate()}
+				>
+					Calculate
+				</button>
+			</div>
+			<div>
+				{result.length > 0 && (
+					<>
+						<strong>Results: </strong>
+						{result.map((cidr, idx) => (
+							<>
+								<code key={cidr}>{cidr}</code>
+								{idx < result.length - 1 && <span>, </span>}
+							</>
+						))}
+					</>
+				)}
+			</div>
+		</div>
+		// <ul>
+		// 	{excludeCidr("10.0.0.0/8", ["10.0.0.0/24"]).map((cidr) => (
+		// 		<li key={cidr}>{cidr}</li>
+		// 	))}
+		// </ul>
+	);
+}

--- a/src/content/docs/style-guide/components/subtract-ip-calculator.mdx
+++ b/src/content/docs/style-guide/components/subtract-ip-calculator.mdx
@@ -1,0 +1,52 @@
+---
+title: Subtract IP calculator
+---
+
+import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+
+## Import
+
+```mdx
+import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+```
+
+## Usage
+
+<br />
+<SubtractIPCalculator client:load />
+
+```mdx
+import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+
+<SubtractIPCalculator client:load />
+```
+
+## `<SubtractIPCalculator>` Props
+
+### `defaults`
+
+**type:** `object`
+
+An optional object containing `base` (`string`) and `exclude` (`string[]`) properties, to set default inputs.
+
+**example:**
+
+<SubtractIPCalculator
+	client:load
+	defaults={{
+		base: "10.0.0.0/8",
+		exclude: ["10.0.0.0/24", "10.32.0.0/11"]
+	}}
+/>
+
+```mdx
+import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
+
+<SubtractIPCalculator
+	client:load
+	defaults={{
+		base: "10.0.0.0/8",
+		exclude: ["10.0.0.0/24", "10.32.0.0/11"]
+	}}
+/>
+```


### PR DESCRIPTION
### Summary

Adds a SubtractIPCalculator component to be used on pages like https://developers.cloudflare.com/learning-paths/replace-vpn/configure-device-agent/split-tunnel-settings/#configure-split-tunnels-for-private-network-access

### Screenshots (optional)

<img width="791" alt="image" src="https://github.com/user-attachments/assets/bd308c6e-b127-43e4-9a13-1a14fea48468" />
