### PR TITLE
Make edit and issue buttons less glaring

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -7,7 +7,7 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 ---
 
 <Default {...Astro.props} />
-</br>
+<br />
 <FeedbackPrompt client:idle />
 {
 	!Astro.url.pathname.startsWith("/support/") && (
@@ -17,7 +17,7 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 				{Astro.props.editUrl && (
 					<a
 						href={Astro.props.editUrl}
-						class="inline-flex h-8 items-center justify-center gap-2 rounded border border-gray-300 bg-white px-3 text-s font-small text-black hover:bg-gray-50"
+						class="inline-flex h-8 items-center justify-center gap-2 rounded border border-[--sl-color-hairline] px-3 text-black"
 					>
 						<Icon name="pencil" />
 						Edit
@@ -25,7 +25,7 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 				)}
 				<a
 					href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
-					class="inline-flex h-8 items-center justify-center gap-2 rounded border border-gray-300 bg-white px-3 text-s font-small text-black hover:bg-gray-50"
+					class="inline-flex h-8 items-center justify-center gap-2 rounded border border-[--sl-color-hairline] px-3 text-black"
 				>
 					<Icon name="github" />
 					Issue

--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -7,6 +7,8 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 ---
 
 <Default {...Astro.props} />
+</br>
+<FeedbackPrompt client:idle />
 {
 	!Astro.url.pathname.startsWith("/support/") && (
 		<>
@@ -15,7 +17,7 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 				{Astro.props.editUrl && (
 					<a
 						href={Astro.props.editUrl}
-						class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+						class="inline-flex h-8 items-center justify-center gap-2 rounded border border-gray-300 bg-white px-3 text-s font-small text-black hover:bg-gray-50"
 					>
 						<Icon name="pencil" />
 						Edit
@@ -23,7 +25,7 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 				)}
 				<a
 					href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
-					class="h-8 cursor-pointer content-center rounded bg-cl1-brand-orange px-4 text-sm font-medium text-cl1-black"
+					class="inline-flex h-8 items-center justify-center gap-2 rounded border border-gray-300 bg-white px-3 text-s font-small text-black hover:bg-gray-50"
 				>
 					<Icon name="github" />
 					Issue
@@ -32,5 +34,3 @@ import FeedbackPrompt from "../FeedbackPrompt.tsx";
 		</>
 	)
 }
-<br />
-<FeedbackPrompt client:idle />


### PR DESCRIPTION
### Summary
Making new edit / issue buttons a little less glaring since righ tnow they're the primary thing that jumps out on the page


### Screenshots (optional)
Current:
<img width="977" alt="Screenshot 2025-02-27 at 10 35 51 AM" src="https://github.com/user-attachments/assets/e0ab744f-ecd4-4f4f-ac1b-3533e6411b2c" />

Proposed: 
<img width="1054" alt="Screenshot 2025-02-27 at 10 35 47 AM" src="https://github.com/user-attachments/assets/f1cf790c-db04-490f-946e-30c1cae784c3" />


