### PR TITLE
Calls: Introduce simulcast API

### DIFF
--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -373,14 +373,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ChangeTracksRequest"
+              $ref: "#/components/schemas/UpdateTracksRequest"
             examples:
               reuse_transceiver:
                 description: Reuse an existing transceiver for a new track
                 value:
                   tracks:
-                    some-track-name:
-                      location: "remote"
+                    - location: "remote"
                       sessionId: "2a45361d5fd7cc14eface0587c276c94"
                       trackName: "other-track-name"
                       mid: "7"
@@ -388,8 +387,7 @@ paths:
                 description: Reuse an existing transceiver with simulcast preferences
                 value:
                   tracks:
-                    trackID2:
-                      location: "remote"
+                    - location: "remote"
                       sessionId: "2a45361d5fd7cc14eface0587c276c94"
                       trackName: "simulcast-track"
                       mid: "8"
@@ -428,8 +426,7 @@ paths:
                   value:
                     requiresImmediateRenegotiation: false
                     tracks:
-                      trackID1:
-                        mid: "7"
+                      - mid: "7"
                         sessionId: "2a45361d5fd7cc14eface0587c276c94"
                         trackName: "new-track-name"
 
@@ -673,6 +670,16 @@ components:
           description: Map of track IDs to track objects for changing tracks
         sessionDescription:
           $ref: "#/components/schemas/SessionDescription"
+    UpdateTracksRequest:
+      type: object
+      properties:
+        tracks:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrackObject"
+          description: Array of track objects for updating tracks
+        sessionDescription:
+          $ref: "#/components/schemas/SessionDescription"
     UpdateTracksResponse:
       type: object
       properties:
@@ -683,8 +690,8 @@ components:
         requiresImmediateRenegotiation:
           type: boolean
         tracks:
-          type: object
-          additionalProperties:
+          type: array
+          items:
             allOf:
               - $ref: "#/components/schemas/TrackObject"
               - properties:
@@ -692,4 +699,4 @@ components:
                     type: string
                   errorDescription:
                     type: string
-          description: Map of track IDs to track objects with results
+          description: Array of track objects with results

--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -386,7 +386,7 @@ paths:
                       trackName: "other-track-name"
                       mid: "7"
               reuse_with_simulcast:
-                description: Reuse an existing transceiver with simulcast preferences
+                description: Reuse an existing transceiver with new simulcast preferences
                 value:
                   tracks:
                     - location: "remote"
@@ -522,7 +522,7 @@ components:
           properties:
             preferredRid:
               type: string
-              description: Preferred RID (Resolution ID) for simulcast streams
+              description: Preferred RID for simulcast streams
             priorityOrdering:
               type: string
               enum:

--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -140,6 +140,33 @@ paths:
                       sessionId: 2a45361d5fd7cc14eface0587c276c94
                       trackName: generated-audio
                       kind: "audio"
+              simulcast_track:
+                description: Share a track with simulcast configuration
+                value:
+                  sessionDescription:
+                    sdp: |
+                      v=0
+                      o=- 0 0 IN IP4 127.0.0.1
+                      s=-
+                      c=IN IP4 127.0.0.1
+                      t=0 0
+                      m=audio 4000 RTP/AVP 111
+                      a=rtpmap:111 OPUS/48000/2
+                      m=video 4002 RTP/AVP 96
+                      a=rtpmap:96 VP8/90000
+                      a=simulcast:send f;h;q
+                      a=rid:f send
+                      a=rid:h send
+                      a=rid:q send
+                      ...
+                    type: offer
+                  tracks:
+                    - location: local
+                      trackName: simulcast-video-track
+                      mid: "1"
+                      simulcast:
+                        preferredRid: "h"
+                        preferredRidNotAvailable: "leastbandwidth"
       security:
         - secret: []
       parameters:
@@ -329,6 +356,75 @@ paths:
                 requiresImmediateRenegotiation: false
                 tracks:
                   - mid: "7"
+  /apps/{appId}/sessions/{sessionId}/tracks/change:
+    post:
+      tags:
+        - Change tracks
+      summary: Change tracks by reusing existing transceivers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeTracksRequest"
+            examples:
+              reuse_transceiver:
+                description: Reuse an existing transceiver for a new track
+                value:
+                  tracks:
+                    some-track-name:
+                      location: "remote"
+                      sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                      trackName: "other-track-name"
+                      mid: "7"
+              reuse_with_simulcast:
+                description: Reuse an existing transceiver with simulcast preferences
+                value:
+                  tracks:
+                    trackID2:
+                      location: "remote"
+                      sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                      trackName: "simulcast-track"
+                      mid: "8"
+                      simulcast:
+                        preferredRid: "h"
+                        preferredRidNotAvailable: "leastbandwidth"
+      security:
+        - secret: []
+      parameters:
+        - in: path
+          name: appId
+          schema:
+            type: string
+          required: true
+          description: WebRTC application ID
+        - in: path
+          name: sessionId
+          schema:
+            type: string
+          required: true
+          description: Current PeerConnection session ID
+      responses:
+        "200":
+          description: OK
+          headers:
+            vary:
+              schema:
+                type: string
+                example: Origin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeTracksResponse"
+              examples:
+                success:
+                  value:
+                    requiresImmediateRenegotiation: false
+                    tracks:
+                      trackID1:
+                        mid: "7"
+                        sessionId: "2a45361d5fd7cc14eface0587c276c94"
+                        trackName: "new-track-name"
+
   /apps/{appId}/sessions/{sessionId}:
     get:
       tags:
@@ -412,6 +508,21 @@ components:
         kind:
           type: string
           description: Give a hint to the SFU about the transceiver kind. This is required when the SFU generates the offer
+        simulcast:
+          type: object
+          description: Simulcast configuration for the track
+          properties:
+            preferredRid:
+              type: string
+              description: Preferred RID (Resolution ID) for simulcast streams
+            preferredRidNotAvailable:
+              type: string
+              enum:
+                - leastbandwidth
+                - none
+                - error
+              default: leastbandwidth
+              description: Fallback strategy when preferred RID is not available anymore from the remote peer
     CloseTrackObject:
       type: object
       properties:
@@ -543,3 +654,34 @@ components:
           type: string
         sessionDescription:
           $ref: "#/components/schemas/SessionDescription"
+    ChangeTracksRequest:
+      type: object
+      properties:
+        tracks:
+          type: object
+          additionalProperties:
+            allOf:
+              - $ref: "#/components/schemas/TrackObject"
+          description: Map of track IDs to track objects for changing tracks
+        sessionDescription:
+          $ref: "#/components/schemas/SessionDescription"
+    ChangeTracksResponse:
+      type: object
+      properties:
+        errorCode:
+          type: string
+        errorDescription:
+          type: string
+        requiresImmediateRenegotiation:
+          type: boolean
+        tracks:
+          type: object
+          additionalProperties:
+            allOf:
+              - $ref: "#/components/schemas/TrackObject"
+              - properties:
+                  errorCode:
+                    type: string
+                  errorDescription:
+                    type: string
+          description: Map of track IDs to track objects with results

--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -140,33 +140,16 @@ paths:
                       sessionId: 2a45361d5fd7cc14eface0587c276c94
                       trackName: generated-audio
                       kind: "audio"
-              simulcast_track:
-                description: Share a track with simulcast configuration
+              remote_track_with_simulcast:
+                description: Pull a remote track with simulcast preferences
                 value:
-                  sessionDescription:
-                    sdp: |
-                      v=0
-                      o=- 0 0 IN IP4 127.0.0.1
-                      s=-
-                      c=IN IP4 127.0.0.1
-                      t=0 0
-                      m=audio 4000 RTP/AVP 111
-                      a=rtpmap:111 OPUS/48000/2
-                      m=video 4002 RTP/AVP 96
-                      a=rtpmap:96 VP8/90000
-                      a=simulcast:send f;h;q
-                      a=rid:f send
-                      a=rid:h send
-                      a=rid:q send
-                      ...
-                    type: offer
                   tracks:
-                    - location: local
+                    - location: remote
+                      sessionId: 2a45361d5fd7cc14eface0587c276c94
                       trackName: simulcast-video-track
-                      mid: "1"
                       simulcast:
                         preferredRid: "h"
-                        preferredRidNotAvailable: "leastbandwidth"
+                        fallbackStrategy: "leastBandwidth"
       security:
         - secret: []
       parameters:
@@ -232,6 +215,31 @@ paths:
                         a=rtpmap:111 OPUS/48000/2
                         m=video 4002 RTP/AVP 96
                         a=rtpmap:96 VP8/90000
+                        ...
+                      type: offer
+                remote_tracks_with_simulcast:
+                  value:
+                    requiresImmediateRenegotiation: true
+                    tracks:
+                      - sessionId: 2a45361d5fd7cc14eface0587c276c94
+                        trackName: simulcast-video-track
+                        mid: "5"
+                        simulcast:
+                          preferredRid: "h"
+                          fallbackStrategy: "leastBandwidth"
+                    sessionDescription:
+                      sdp: |
+                        v=0
+                        o=- 0 0 IN IP4 127.0.0.1
+                        s=-
+                        c=IN IP4 127.0.0.1
+                        t=0 0
+                        m=video 4002 RTP/AVP 96
+                        a=rtpmap:96 VP8/90000
+                        a=simulcast:recv f;h;q
+                        a=rid:f recv
+                        a=rid:h recv
+                        a=rid:q recv
                         ...
                       type: offer
   /apps/{appId}/sessions/{sessionId}/renegotiate:
@@ -356,8 +364,8 @@ paths:
                 requiresImmediateRenegotiation: false
                 tracks:
                   - mid: "7"
-  /apps/{appId}/sessions/{sessionId}/tracks/change:
-    post:
+  /apps/{appId}/sessions/{sessionId}/tracks/update:
+    put:
       tags:
         - Change tracks
       summary: Change tracks by reusing existing transceivers
@@ -387,7 +395,7 @@ paths:
                       mid: "8"
                       simulcast:
                         preferredRid: "h"
-                        preferredRidNotAvailable: "leastbandwidth"
+                        fallbackStrategy: "leastBandwidth"
       security:
         - secret: []
       parameters:
@@ -414,7 +422,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ChangeTracksResponse"
+                $ref: "#/components/schemas/UpdateTracksResponse"
               examples:
                 success:
                   value:
@@ -515,14 +523,14 @@ components:
             preferredRid:
               type: string
               description: Preferred RID (Resolution ID) for simulcast streams
-            preferredRidNotAvailable:
+            fallbackStrategy:
               type: string
               enum:
-                - leastbandwidth
+                - auto
+                - leastBandwidth
                 - none
-                - error
-              default: leastbandwidth
-              description: Fallback strategy when preferred RID is not available anymore from the remote peer
+              default: auto
+              description: General fallback strategy when any constraint (like preferredRid, minWidth, maxBandwidth, etc.) cannot be met. 'auto' will select the best quality possible within constraints.
     CloseTrackObject:
       type: object
       properties:
@@ -665,7 +673,7 @@ components:
           description: Map of track IDs to track objects for changing tracks
         sessionDescription:
           $ref: "#/components/schemas/SessionDescription"
-    ChangeTracksResponse:
+    UpdateTracksResponse:
       type: object
       properties:
         errorCode:

--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -149,7 +149,8 @@ paths:
                       trackName: simulcast-video-track
                       simulcast:
                         preferredRid: "h"
-                        fallbackStrategy: "leastBandwidth"
+                        priorityOrdering: "asciibetical"
+                        ridUnavailableStrategy: "nextPriority"
       security:
         - secret: []
       parameters:
@@ -226,7 +227,8 @@ paths:
                         mid: "5"
                         simulcast:
                           preferredRid: "h"
-                          fallbackStrategy: "leastBandwidth"
+                          priorityOrdering: "asciibetical"
+                          ridUnavailableStrategy: "nextPriority"
                     sessionDescription:
                       sdp: |
                         v=0
@@ -393,7 +395,8 @@ paths:
                       mid: "8"
                       simulcast:
                         preferredRid: "h"
-                        fallbackStrategy: "leastBandwidth"
+                        priorityOrdering: "asciibetical"
+                        ridUnavailableStrategy: "nextPriority"
       security:
         - secret: []
       parameters:
@@ -520,14 +523,20 @@ components:
             preferredRid:
               type: string
               description: Preferred RID (Resolution ID) for simulcast streams
-            fallbackStrategy:
+            priorityOrdering:
               type: string
               enum:
-                - auto
-                - leastBandwidth
                 - none
-              default: auto
-              description: General fallback strategy when any constraint (like preferredRid, minWidth, maxBandwidth, etc.) cannot be met. 'auto' will select the best quality possible within constraints.
+                - asciibetical
+              default: none
+              description: Controls what happens if there is not enough network resources available to send the preferredRid. 'none' means keep sending even if not enough bandwidth, 'asciibetical' uses a-z order to determine priority where a is most desirable and z is least desirable.
+            ridUnavailableStrategy:
+              type: string
+              enum:
+                - none
+                - nextPriority
+              default: none
+              description: Controls what happens when the rid currently being used or preferredRid is no longer being sent by the publisher. 'none' means do nothing, 'nextPriority' uses the next on the priorityOrdering.
     CloseTrackObject:
       type: object
       properties:

--- a/src/content/docs/realtime/simulcast.mdx
+++ b/src/content/docs/realtime/simulcast.mdx
@@ -1,0 +1,76 @@
+---
+pcx_content_type: get-started
+title: Simulcast
+sidebar:
+  order: 8
+---
+
+Simulcast is a feature of WebRTC that allows a publisher to send multiple streams of the same media at different qualities. For example, this is useful for scenarios where you want to send a high quality stream for desktop users and a lower quality stream for mobile users.
+
+```mermaid
+graph LR
+    A[Publisher] -->|Low quality| B[Cloudflare Calls SFU]
+    A -->|Medium quality| B
+    A -->|High quality| B
+B -->|Low quality| C@{ shape: procs, label: "Subscribers"}
+B -->|Medium quality| D@{ shape: procs, label: "Subscribers"}
+B -->|High quality| E@{ shape: procs, label: "Subscribers"}
+
+```
+
+### How it works
+
+Simulcast in WebRTC allows a single media source, like a camera or screen share, to be encoded at multiple quality levels and sent simultaneously, which is beneficial for subscribers with varying network conditions and device capabilities. The media source is encoded into multiple streams, each identified by RIDs (RTP Stream Identifiers) for different quality levels, such as low, medium, and high. These simulcast streams are described in the SDP you send to Cloudflare Calls SFU. It's the responsibility of the Cloudflare Calls SFU to ensure that the appropriate quality stream is delivered to each subscriber based on their network conditions and device capabilities.
+
+Cloudflare Calls SFU will automatically handle the simulcast configuration based on the SDP you send to it from the publisher. The SFU will then automatically switch between the different quality levels based on the subscriber's network conditions. You can control the quality switching behavior using the `simulcast` configuration object when you send an API call to start pulling a remote track.
+
+### Quality Control
+
+The `simulcast` configuration object in the API call when you start pulling a remote track allows you to specify:
+
+- `preferredRid`: The preferred stream (RID for the simulcast stream. [RIDs can be specified by the publisher.](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#encodings))
+- `priorityOrdering`: Controls how the SFU handles bandwidth constraints
+  - `none`: Keep sending the preferred layer even if there's not enough bandwidth
+  - `asciibetical`: Use alphabetical ordering (a-z) to determine priority, where 'a' is most desirable and 'z' is least desirable
+- `ridUnavailableStrategy`: Controls what happens when the preferred RID is no longer available, for example when the publisher stops sending it
+
+  - `none`: Do nothing
+  - `nextPriority`: Switch to the next available RID based on the priority ordering
+
+  You will likely want to order the asciibetical RIDs based on your desired metric, such as higest resoltion to lowest or highest bandwidth to lowest.
+
+### Bandwidth Management across media tracks
+
+Cloudflare Calls treats all media tracks equally at the transport level. For example, if you have multiple video tracks (cameras, screen shares, etc.), they all have equal priority for bandwidth allocation. This means:
+
+1. Each track's simulcast configuration is handled independently
+1. The SFU performs automatic bandwidth estimation and layer switching based on network conditions independently for each track
+
+### Layer Switching Behavior
+
+When a layer switch is requested (through updating `preferredRid`) with the `/tracks/update` API:
+
+1. The SFU will automatically generate a Picture Loss Indication (PLI)
+2. Layer switching only occurs when a keyframe arrives on the target layer
+3. PLI generation is debounced to prevent excessive requests
+
+### Publisher Configuration
+
+For publishers (local tracks), you only need to include the simulcast attributes in your SDP. The SFU will automatically handle the simulcast configuration based on the SDP. For example, the SDP should contain a section like this:
+
+```sdp
+a=simulcast:send f;h;q
+a=rid:f send
+a=rid:h send
+a=rid:q send
+```
+
+## Example
+
+Here's an example of how to use simulcast with Cloudflare Calls:
+
+1. Create a new local track with simulcast configuration. There should be a section in the SDP with `a=simulcast:send`.
+2. Use the [Cloudflare Calls API](/calls/https-api) to push this local track, by calling the /tracks/new endpoint.
+3. Use the [Cloudflare Calls API](/calls/https-api) to start pulling a remote track (from another browser or device), by calling the /tracks/new endpoint and specifying the `simulcast` configuration object along with the remote track ID you get from step 2.
+
+For more examples, check out the [Calls Examples GitHub repository](https://github.com/cloudflare/calls-examples/tree/main/simulcast).

--- a/src/content/docs/realtime/simulcast.mdx
+++ b/src/content/docs/realtime/simulcast.mdx
@@ -65,6 +65,17 @@ a=rid:h send
 a=rid:q send
 ```
 
+You can include these by specifying `sendEncodings` when creating the transceiver:
+
+```js
+const transceiver = peerConnection.addTransceiver(track, {
+  direction: "sendonly",
+  sendEncodings: [
+    { scaleResolutionDownBy: 1, rid: "a" },
+    { scaleResolutionDownBy: 2, rid: "b" },
+    { scaleResolutionDownBy: 4, rid: "c" }
+  ]
+});
 ## Example
 
 Here's an example of how to use simulcast with Cloudflare Calls:


### PR DESCRIPTION
This is a first stab at introducing simulcast into the Cloudflare Calls SFU API.

# Examples
### Example 1: Using the /tracks/change endpoint to reuse a transceiver

This example shows how to reuse an existing transceiver (with mid "2") to receive a different track from a remote session.

```
curl -X POST "https://rtc.live.cloudflare.com/v1/apps/YOUR_APP_ID/sessions/e017a2629c754fedc1f7d8587e06d126/tracks/change" \
  -H "Authorization: Bearer YOUR_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "tracks": {
      "video-track-1": {
        "location": "remote",
        "sessionId": "2a45361d5fd7cc14eface0587c276c94",
        "trackName": "new-video-track",
        "mid": "2"
      }
    }
  }'
  ```
  
  
### Example 2: Using the /tracks/change endpoint with simulcast preferences

This example demonstrates how to reuse a transceiver while specifying simulcast preferences, requesting the high-quality stream ("h") and falling back to the least bandwidth option if that's not available.

```
curl -X POST "https://rtc.live.cloudflare.com/v1/apps/YOUR_APP_ID/sessions/e017a2629c754fedc1f7d8587e06d126/tracks/change" \
  -H "Authorization: Bearer YOUR_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "tracks": {
      "simulcast-video": {
        "location": "remote",
        "sessionId": "2a45361d5fd7cc14eface0587c276c94",
        "trackName": "simulcast-camera",
        "mid": "3",
        "simulcast": {
          "preferredRid": "h",
          "preferredRidNotAvailable": "leastbandwidth"
        }
      }
    }
  }'
  ```
  
 ### Example 3: Changing multiple tracks simultaneously
  
 This example shows how to change multiple tracks in a single request, reusing different transceivers for different remote tracks.
 
 ```
 curl -X POST "https://rtc.live.cloudflare.com/v1/apps/YOUR_APP_ID/sessions/e017a2629c754fedc1f7d8587e06d126/tracks/change" \
  -H "Authorization: Bearer YOUR_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "tracks": {
      "video-track": {
        "location": "remote",
        "sessionId": "2a45361d5fd7cc14eface0587c276c94",
        "trackName": "camera-feed",
        "mid": "2"
      },
      "audio-track": {
        "location": "remote",
        "sessionId": "2a45361d5fd7cc14eface0587c276c94",
        "trackName": "microphone",
        "mid": "0"
      }
    }
  }'
  ```
  
 ### Example 4: Using the /tracks/new endpoint with simulcast
  
 This example demonstrates adding a new local track with simulcast capabilities, specifying the SDP with simulcast attributes and indicating a preference for the high-quality stream.
  
  ```
 curl -X POST "https://rtc.live.cloudflare.com/v1/apps/YOUR_APP_ID/sessions/e017a2629c754fedc1f7d8587e06d126/tracks/new" \
  -H "Authorization: Bearer YOUR_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "sessionDescription": {
      "sdp": "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=video 4002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=simulcast:send f;h;q\r\na=rid:f send\r\na=rid:h send\r\na=rid:q send\r\n",
      "type": "offer"
    },
    "tracks": [
      {
        "location": "local",
        "trackName": "simulcast-camera-feed",
        "mid": "0",
        "simulcast": {
          "preferredRid": "h",
          "preferredRidNotAvailable": "leastbandwidth"
        }
      }
    ]
  }'
  ```
  
 ### Example 5: Using the /tracks/change endpoint with a different fallback strategy
 
 This example shows how to request a specific quality level (in this case, the lowest quality "q") with a fallback strategy of "none", which means no fallback will be attempted if the preferred RID is not available.
 
 ```
 curl -X POST "https://rtc.live.cloudflare.com/v1/apps/YOUR_APP_ID/sessions/e017a2629c754fedc1f7d8587e06d126/tracks/change" \
  -H "Authorization: Bearer YOUR_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "tracks": {
      "simulcast-video": {
        "location": "remote",
        "sessionId": "2a45361d5fd7cc14eface0587c276c94",
        "trackName": "simulcast-camera",
        "mid": "3",
        "simulcast": {
          "preferredRid": "q",
          "preferredRidNotAvailable": "none"
        }
      }
    }
  }'
  ```
  
  
  # Open Questions
  
 The following case is not handled: "I REALLY want the RID I just told you, but if the RID is no longer being published, then downgrade. However I'm okay with packet loss with a higher rid I can't handle", because we are using `preferredRidNotAvailable` for both "RID stopped published" and also "you don't have enough bandwidth for this RID"
  