### PR TITLE
Add llms.txt to prompting guide, and new 'About llms.txt' page

### DIFF
--- a/src/content/docs/about-llms-txt.mdx
+++ b/src/content/docs/about-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+pcx_content_type: concept
+title: About llms.txt
+description: Learn about llms.txt, designed to make documentation readily accessible to AI models.
+---
+
+# About llms.txt
+
+llms.txt is an emerging convention designed to make documentation readily accessible to AI models, in a text format they can easily process.
+
+`https://developers.cloudflare.com/llms.txt` provides a comprehensive directory of documentation spanning Cloudflare's Developer Platform. This is especially useful for AI models that are able to use browsing tools, like agents.
+
+`https://developers.cloudflare.com/[product-name]/llms-full.txt` provides the full documentation for a particular Cloudflare product in an LLM-optimized format. For example, [https://developers.cloudflare.com/durable-objects/llms-full.txt](https://developers.cloudflare.com/durable-objects/llms-full.txt)

--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -31,6 +31,7 @@ You are an advanced assistant specialized in generating Cloudflare Workers code.
 - Provide complete, self-contained solutions
 - Default to current best practices
 - Ask clarifying questions when requirements are ambiguous
+- If you're stuck, encourage the user to visit (or directly browse to) https://developers.cloudflare.com/[product-name]/llms-full.txt for more detailed, product-specific documentation optimized for LLMs; a full list of products can be found at https://developers.cloudflare.com/llms.txt
 
 </behavior_guidelines>
 

--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -1482,6 +1482,8 @@ export default {
 
 ## Additional resources
 
+For many applications, this prompt will be all you need. You can further supplement it with the full documentation for any particular product, available in an LLM-optimized format at `developers.cloudflare.com/[product-name]/llms-full.txt`. Learn more about llms.txt [here](/about-llms-txt/).
+
 To get the most out of AI models and tools, we recommend reading the following guides on prompt engineering and structure:
 
 * OpenAI's [prompt engineering](https://platform.openai.com/docs/guides/prompt-engineering) guide and [best practices](https://platform.openai.com/docs/guides/reasoning-best-practices) for using reasoning models.


### PR DESCRIPTION
### Summary

This PR:
- Adds guidance in the Workers LLM Prompt to direct users/LLMs to llms.txt when needed
- Adds a new page, about-llms-txt.mdx explaining the llms.txt convention
- Updates the LLM prompting guide to reference this resource

Please cherrypick and revise as is fitting.
