### PR TITLE
Update TURN credential generation docs to use /generate-ice-servers

### DIFF
--- a/src/content/docs/calls/turn/generate-credentials.mdx
+++ b/src/content/docs/calls/turn/generate-credentials.mdx
@@ -24,7 +24,7 @@ With a TURN key you can:
 You should generate short-lived credentials for each TURN user. In order to create credentials, you should have a back-end service that uses your TURN Token ID and API token to generate credentials. It will make an API call like this:
 
 ```bash
-curl https://rtc.live.cloudflare.com/v1/turn/keys/$TURN_KEY_ID/credentials/generate \
+curl https://rtc.live.cloudflare.com/v1/turn/keys/$TURN_KEY_ID/credentials/generate-ice-servers \
 --header "Authorization: Bearer $TURN_KEY_API_TOKEN" \
 --header "Content-Type: application/json" \
 --data '{"ttl": 86400}'
@@ -34,33 +34,43 @@ The JSON response below can then be passed on to your front-end application:
 
 ```json
 {
-  "iceServers": {
-    "urls": [
-      "stun:stun.cloudflare.com:3478",
-      "turn:turn.cloudflare.com:3478?transport=udp",
-      "turn:turn.cloudflare.com:3478?transport=tcp",
-      "turns:turn.cloudflare.com:5349?transport=tcp"
-    ],
-    "username": "bc91b63e2b5d759f8eb9f3b58062439e0a0e15893d76317d833265ad08d6631099ce7c7087caabb31ad3e1c386424e3e",
-    "credential": "ebd71f1d3edbc2b0edae3cd5a6d82284aeb5c3b8fdaa9b8e3bf9cec683e0d45fe9f5b44e5145db3300f06c250a15b4a0"
-  }
+  "iceServers": [
+		{
+			"urls": [
+				"stun:stun.cloudflare.com:3478",
+				"stun:stun.cloudflare.com:53",
+				"turn:turn.cloudflare.com:3478?transport=udp",
+				"turn:turn.cloudflare.com:53?transport=udp",
+				"turn:turn.cloudflare.com:3478?transport=tcp",
+				"turn:turn.cloudflare.com:80?transport=tcp",
+				"turns:turn.cloudflare.com:5349?transport=tcp",
+				"turns:turn.cloudflare.com:443?transport=tcp"
+			],
+			"username": "bc91b63e2b5d759f8eb9f3b58062439e0a0e15893d76317d833265ad08d6631099ce7c7087caabb31ad3e1c386424e3e",
+			"credential": "ebd71f1d3edbc2b0edae3cd5a6d82284aeb5c3b8fdaa9b8e3bf9cec683e0d45fe9f5b44e5145db3300f06c250a15b4a0"
+		}
+	]
 }
 ```
 
-Use `username` and `credential` as follows when instantiating the `RTCPeerConnection` (note, `iceServers` is now an array):
+Use `iceServers` as follows when instantiating the `RTCPeerConnection`:
 
 ```js
 const myPeerConnection = new RTCPeerConnection({
   iceServers: [
     {
       urls: [
-        "stun:stun.cloudflare.com:3478",
-        "turn:turn.cloudflare.com:3478?transport=udp",
-        "turn:turn.cloudflare.com:3478?transport=tcp",
-        "turns:turn.cloudflare.com:5349?transport=tcp"
+				"stun:stun.cloudflare.com:3478",
+				"stun:stun.cloudflare.com:53",
+				"turn:turn.cloudflare.com:3478?transport=udp",
+				"turn:turn.cloudflare.com:53?transport=udp",
+				"turn:turn.cloudflare.com:3478?transport=tcp",
+				"turn:turn.cloudflare.com:80?transport=tcp",
+				"turns:turn.cloudflare.com:5349?transport=tcp",
+				"turns:turn.cloudflare.com:443?transport=tcp"
       ],
-      username: "REPLACE_WITH_USERNAME",
-      credential: "REPLACE_WITH_CREDENTIAL",
+			"username": "bc91b63e2b5d759f8eb9f3b58062439e0a0e15893d76317d833265ad08d6631099ce7c7087caabb31ad3e1c386424e3e",
+			"credential": "ebd71f1d3edbc2b0edae3cd5a6d82284aeb5c3b8fdaa9b8e3bf9cec683e0d45fe9f5b44e5145db3300f06c250a15b4a0"
     },
   ],
 });


### PR DESCRIPTION
### Summary

Updates the TURN credential generation to reference the new preferred endpoint, which has `iceServers` as an array, so that it's ready to pass into RTCPeerConnection constructor as-is.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
