### PR TITLE
[Docs Site] Remove duplicate markup link fragment

### DIFF
--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -73,7 +73,7 @@ Create a new Worker as the means to query your database.
     Your new `d1-tutorial` directory includes:
 
     - A `"Hello World"` [Worker](/workers/get-started/guide/#3-write-code) in `index.ts`.
-    - A [[Wrangler configuration file](/workers/wrangler/configuration/)](/workers/wrangler/configuration/). This file is how your `d1-tutorial` Worker accesses your D1 database.
+    - A [[Wrangler configuration file](/workers/wrangler/configuration/)]. This file is how your `d1-tutorial` Worker accesses your D1 database.
 
 </Steps>
 

--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -73,7 +73,7 @@ Create a new Worker as the means to query your database.
     Your new `d1-tutorial` directory includes:
 
     - A `"Hello World"` [Worker](/workers/get-started/guide/#3-write-code) in `index.ts`.
-    - A [[Wrangler configuration file](/workers/wrangler/configuration/)]. This file is how your `d1-tutorial` Worker accesses your D1 database.
+    - A [Wrangler configuration file](/workers/wrangler/configuration/). This file is how your `d1-tutorial` Worker accesses your D1 database.
 
 </Steps>
 


### PR DESCRIPTION
### Summary

Simply remove an extra markup link in the Cloudflare D1 "Get Started" documentation

### Screenshots (optional)

![Screenshot 2025-02-28 at 15 59 47](https://github.com/user-attachments/assets/8fee0bf8-4d72-4a69-a2cc-56fde1eda6b2)


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
