### PR TITLE
Changing @cloudflare/textsplitters to @langchain/textsplitters correct package name

### DIFF
--- a/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -487,7 +487,7 @@ For large pieces of text, it is recommended to split the text into smaller chunk
 To implement this, we'll add a new NPM package to our project, `@langchain/textsplitters':
 
 ```sh
-npm install @cloudflare/textsplitters
+npm install @langchain/textsplitters
 ```
 
 The `RecursiveCharacterTextSplitter` class provided by this package will split the text into smaller chunks. It can be customized to your liking, but the default config works in most cases:


### PR DESCRIPTION
I think the package we meant to reference here is the @langchain/textsplitters. @cloudflare/textsplitters doesn't seem to exist: https://www.npmjs.com/search?q=@cloudflare/textsplitters

FYI I love this tutorial, so easy to follow and well written! <3 