### PR TITLE
[Docs Site] Add video page onto Learning Path cards

### DIFF
--- a/src/components/LearningPathCatalog.tsx
+++ b/src/components/LearningPathCatalog.tsx
@@ -42,6 +42,7 @@ const LearningPathCatalog = ({
 			description: lp.description,
 			products: lp.products,
 			groups,
+			video: lp.video,
 		};
 	});
 
@@ -152,19 +153,22 @@ const LearningPathCatalog = ({
 							href={path.link}
 							className="rounded-md border border-solid border-gray-200 p-6 !text-inherit no-underline hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
 						>
-							{path.icon && (
-								<div className="w-fit rounded-full bg-orange-50 p-1 text-orange-500 dark:bg-orange-950">
-									<svg
-										{...path.icon.attributes}
-										width={24}
-										height={24}
-										dangerouslySetInnerHTML={{ __html: path.icon.body }}
-									/>
-								</div>
-							)}
+							<div className="flex gap-2">
+								{path.icon && (
+									<div className="w-fit rounded-full bg-orange-50 p-1 text-orange-500 dark:bg-orange-950">
+										<svg
+											{...path.icon.attributes}
+											width={24}
+											height={24}
+											dangerouslySetInnerHTML={{ __html: path.icon.body }}
+										/>
+									</div>
+								)}
+								{path.video && <span className="sl-badge tip">Video</span>}
+							</div>
 							<p className="!mt-3 font-semibold">{path.title}</p>
 							<Markdown
-								className="!mt-1 text-sm leading-6"
+								className="leading-2 !mt-1 text-sm"
 								disallowedElements={["a"]}
 								unwrapDisallowed={true}
 							>

--- a/src/content/learning-paths/sase-overview-course.json
+++ b/src/content/learning-paths/sase-overview-course.json
@@ -3,10 +3,8 @@
 	"path": "/learning-paths/sase-overview-course/series/evolution-corporate-networks-1/",
 	"priority": 1,
 	"description": "Watch this series and learn all about Cloudflare's Secure Access Service Edge (SASE) platform to learn how it can revolutionize your corporate network.",
-	"products": [
-		"Cloudflare One"
-	],
+	"products": ["Cloudflare One"],
 	"product_group": "Cloudflare One",
-	"additional_groups": ["Cloudflare One"]
+	"additional_groups": ["Cloudflare One"],
+	"video": true
 }
-

--- a/src/schemas/learning-paths.ts
+++ b/src/schemas/learning-paths.ts
@@ -10,5 +10,6 @@ export const learningPathsSchema = z
 		products: z.string().array(),
 		product_group: z.string(),
 		additional_groups: z.string().array().optional(),
+		video: z.boolean().default(false),
 	})
 	.strict();


### PR DESCRIPTION
### Summary

Add video page onto Learning Path cards when `video` is set to `true`.

### Screenshots (optional)

<img width="824" alt="image" src="https://github.com/user-attachments/assets/7a0dd2a3-2421-41de-b6f2-14ad9986901c" />