### PR TITLE
[Docs Site] Add nowrap to external link arrow

### DIFF
--- a/src/styles/links.css
+++ b/src/styles/links.css
@@ -1,0 +1,3 @@
+.external-link {
+	text-wrap-mode: nowrap;
+}


### PR DESCRIPTION
### Summary

Add nowrap to external link arrow

### Screenshots (optional)

Before:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/e6742ce9-e570-4875-aee7-0c908c1f6225" />

After:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/96a6fcf5-2c6f-466a-896a-11cd34673087" />
