### PR TITLE
[Docs Site] Change pagination arrows to gray and reduce size

### DIFF
--- a/src/styles/pagination.css
+++ b/src/styles/pagination.css
@@ -32,7 +32,17 @@
 
 		& > svg {
 			align-self: self-end;
-			color: theme("colors.cl1.brand.orange");
+			color: var(--pagination-arrow-color);
+			font-size: 1.25rem;
+			margin-bottom: 1px;
 		}
 	}
+}
+
+:root[data-theme="light"] {
+	--pagination-arrow-color: theme("colors.cl1.gray.0");
+}
+
+:root[data-theme="dark"] {
+	--pagination-arrow-color: theme("colors.cl1.gray.9");
 }


### PR DESCRIPTION
### Summary

Change pagination arrows to gray and reduce size

### Screenshots (optional)

Before:

<img width="756" alt="image" src="https://github.com/user-attachments/assets/5af6fe7b-b361-4a5f-9946-eaef08f1e4e1" />

After:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/8b67b96e-1dbd-4c00-8682-0bf101d340d1" />
