### PR TITLE
fix: Update API docs links to prevent 404s

### DIFF
--- a/src/content/docs/magic-wan/configuration/connector/network-options/application-based-policies/breakout-traffic.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/network-options/application-based-policies/breakout-traffic.mdx
@@ -82,7 +82,7 @@ The traffic for that application will now go directly to the Internet and bypass
 
     Take note of the `"managed_app_id"` value for any application you want to configure.
 
-2.  Send a [`POST` request](/api/resources/magic_transit/subresources/sites/subresources/app_configuration/methods/create/) to add new apps the breakout traffic policy.
+2.  Send a [`POST` request](/api/resources/magic_transit/subresources/apps/methods/create/) to add new apps the breakout traffic policy.
 
     Example:
 

--- a/src/content/docs/magic-wan/configuration/connector/network-options/application-based-policies/prioritized-traffic.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/network-options/application-based-policies/prioritized-traffic.mdx
@@ -64,7 +64,7 @@ The traffic for the applications you chose are now processed first by Connector.
 
    Take note of the `"managed_app_id"` value for any application you want to configure.
 
-2. Send a [`POST` request](/api/resources/magic_transit/subresources/sites/subresources/app_configuration/methods/create/) to add new apps the priority traffic policy.
+2. Send a [`POST` request](/api/resources/magic_transit/subresources/apps/methods/create/) to add new apps the priority traffic policy.
 
    Example:
 


### PR DESCRIPTION
### Summary

The links were 404ing due to incorrect paths for the POST request links. This PR updates the paths.
