### PR TITLE
update Docusaurus on Workers with Assets guide now that it no longer experimental

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/docusaurus.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/docusaurus.mdx
@@ -24,7 +24,7 @@ To use `create-cloudflare` to create a new Docusaurus project with <InlineBadge 
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest my-docusaurus-app"
-	args={"--framework=docusaurus --experimental"}
+	args={"--framework=docusaurus --platform=workers"}
 />
 
 <Render


### PR DESCRIPTION
### Summary

Updating Docusaurus Workers (with Assets) getting started guide.

Blocked on landing https://github.com/cloudflare/workers-sdk/pull/7752.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
