### PR TITLE
Correct API token quota values

### DIFF
--- a/src/content/partials/fundamentals/api-rate-limits.mdx
+++ b/src/content/partials/fundamentals/api-rate-limits.mdx
@@ -10,9 +10,8 @@
 | Client API per user | 1200/5 minutes |
 | Client API per IP | 200/second|
 | GraphQL | Varies by query cost. Max 320/5 min|
-| API token quote[^1] | 500/Account |
-
-[^1]: The limit applies to both user and account owned API tokens.
+| User API token quota | 50 |
+| Account API token quota | 500 |
 
 :::note
 The global rate limit for the Cloudflare API is 1200 requests per five minute period per user, and applies cumulatively regardless of whether the request is made via the dashboard, API key, or API token.


### PR DESCRIPTION
### Summary

Update the API token quota values with the correct values of 50 for User API tokens and 500 for Account API tokens.

### Screenshots (optional)

N/A 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
