### PR TITLE
Update to 'getting started' for Developer Platform products

### DIFF
--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: get-started
-title: Get started
+title: Getting started
 updated: 2024-06-19
 sidebar:
   order: 2

--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get started
+title: Getting started
 pcx_content_type: get-started
 updated: 2024-08-28
 sidebar:

--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get started
+title: Getting started
 pcx_content_type: get-started
 sidebar:
   order: 2

--- a/src/content/docs/images/get-started.mdx
+++ b/src/content/docs/images/get-started.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: get-started
-title: Get started
+title: Getting started
 sidebar:
   order: 2
 

--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get started
+title: Getting started
 pcx_content_type: get-started
 sidebar:
   order: 2

--- a/src/content/docs/pages/get-started/index.mdx
+++ b/src/content/docs/pages/get-started/index.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Get started
+title: Getting started
 sidebar:
   order: 2
 

--- a/src/content/docs/queues/get-started.mdx
+++ b/src/content/docs/queues/get-started.mdx
@@ -1,11 +1,11 @@
 ---
-title: Get started
+title: Getting started
 pcx_content_type: get-started
 sidebar:
   order: 2
 head:
   - tag: title
-    content: Get started
+    content: Getting started
 ---
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";

--- a/src/content/docs/r2/get-started.mdx
+++ b/src/content/docs/r2/get-started.mdx
@@ -1,11 +1,11 @@
 ---
-title: Get started
+title: Getting started
 pcx_content_type: get-started
 sidebar:
   order: 2
 head:
   - tag: title
-    content: Get started guide
+    content: Getting started guide
 
 ---
 

--- a/src/content/docs/workers-ai/get-started/index.mdx
+++ b/src/content/docs/workers-ai/get-started/index.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Get started
+title: Getting started
 sidebar:
   order: 2
 

--- a/src/content/docs/workers/get-started/index.mdx
+++ b/src/content/docs/workers/get-started/index.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Get started
+title: Getting started
 sidebar:
   order: 2
   group:


### PR DESCRIPTION
### Summary

Small heading changes to update from "Get Started" to "Getting Started" for Developer Platform docs

### Documentation checklist

- [ X ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

