### PR TITLE
[Images] Add missing blur transformation in `bindings.mdx` example

### DIFF
--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -60,6 +60,7 @@ const response = (
 await env.IMAGES.input(stream)
         .transform({ rotate: 90 })
         .transform({ width: 128 })
+        .transform({ blur: 20 })
         .output({ format: "image/avif" })
       ).response();
  


### PR DESCRIPTION
### Summary

Updating the example code in the `bindings.mdx` file to include the missing `blur` transformation.

The text preceding the example mentions `rotate`, `resize`, and `blur` an image, but the example code did not include the blur transformation.

> For example, to rotate, resize, and blur an image, then output the image as AVIF:

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.