### PR TITLE
Update agents "routeAgentRequest" doc

### DIFF
--- a/src/content/docs/agents/api-reference/sdk.mdx
+++ b/src/content/docs/agents/api-reference/sdk.mdx
@@ -112,7 +112,7 @@ Your own methods can access the Agent's environment variables and bindings on `t
 
 You can create and run an instance of an Agent directly from a Worker in one of three ways:
 
-1. Using the `routeAgentRequest` helper: this will automatically map requests to an individual Agent based on the `/agents/:agent/:name` URL pattern. The value of `:agent` will be the name of your Agent class converted to `kebab-case`, and the value of `:name` will be the name of the Agent instance you want to create or retrieve.
+1. Using the `routeAgentRequest` helper: this will automatically map requests to an individual Agent based on the `/agents/:agent/:name` URL pattern. The value of `:agent` will be the binding name of your Agent converted to `kebab-case`, and the value of `:name` will be the name of the Agent instance you want to create or retrieve.
 2. Calling `getAgentByName`, which will create a new Agent instance if none exists by that name, or retrieve a handle to an existing instance.
 3. The [Durable Objects stub API](/durable-objects/api/id/), which provides a lower level API for creating and retrieving Agents.
 


### PR DESCRIPTION
### Summary

Update the `routeAgentRequest` description, as it's inaccurate. I tried to make it work for a while with the name of the JavaScript class but couldn't make it work. I had a look at the [routing helper code](
https://github.com/threepointone/partyserver/blob/main/packages/partyserver/src/index.ts#L112-L124) and it is using the `key` of the `env` object used by the agent (effectively the binding name given in the wrangler config).

Perhaps worth adding a note in the config docs too since users might be used to naming their bindings in uppercase?

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
