### PR TITLE
Remove redundant redirect in Workflows code example

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -88,8 +88,6 @@ export default {
 			id: instance.id,
 			details: await instance.status(),
 		});
-
-		return Response.json({ result });
 	},
 };
 ```

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -88,7 +88,7 @@ export default {
 			id: instance.id,
 			details: await instance.status(),
 		});
-	},
+	}, 
 };
 ```
 

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -88,7 +88,7 @@ export default {
 			id: instance.id,
 			details: await instance.status(),
 		});
-	}, 
+	},
 };
 ```
 


### PR DESCRIPTION
Remove redundant/wrong return in workflows example

### Summary

This Workflows example has two consecutive `return` statements. This PR removes the second one, as it looks wrong to me.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
