### PR TITLE
Remove unimplemented command from Wrangler commands docs

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -921,19 +921,6 @@ wrangler workflows trigger <WORKFLOW_NAME> <PARAMS> [OPTIONS]
 wrangler workflows trigger my-workflow '{"hello":"world"}'
 ```
 
-### `delete`
-
-Delete (unregister) a Workflow.
-
-```sh
-wrangler workflows delete <WORKFLOW_NAME> [OPTIONS]
-```
-
-- `WORKFLOW_NAME` <Type text="string" /> <MetaInfo text="required" />
-  - The name of a registered Workflow.
-
-\*/}
-
 ## `tail`
 
 Start a session to livestream logs from a deployed Worker.


### PR DESCRIPTION
Remove unimplemented command from Wrangler commands docs.

`wrangler workflows delete` not currently implemented.