### PR TITLE
[MT/MWAN] Summarized routes + IP ranges

### DIFF
--- a/src/content/docs/magic-transit/how-to/configure-static-routes.mdx
+++ b/src/content/docs/magic-transit/how-to/configure-static-routes.mdx
@@ -22,7 +22,6 @@ import { Render } from "~/components"
 		trafficSteering: "/magic-transit/reference/traffic-steering/",
 		magicWANecmp: " ",
 		createPath: "Magic Transit > Configuration",
-		tunnelEndpoints: "/magic-transit/how-to/configure-tunnels/",
-		ipRanges: " "
+		tunnelEndpoints: "/magic-transit/how-to/configure-tunnels/"
 	}}
 />

--- a/src/content/docs/magic-wan/configuration/manually/how-to/configure-static-routes.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/how-to/configure-static-routes.mdx
@@ -15,14 +15,14 @@ import { Render } from "~/components"
 	file="static-routes"
 	product="magic-transit"
 	params={{
+		magicProduct: "Magic WAN",
 		productName: "Magic WAN",
 		BGPpath: "/magic-wan/configuration/manually/how-to/bgp-peering/",
 		anycastURL: "/magic-wan/reference/tunnels/",
 		trafficSteering: "/magic-wan/reference/traffic-steering/",
 		magicWANecmp: "The maximum number of routes you can have with the same priority is 64.",
 		createPath: "Magic WAN > Configuration",
-		tunnelEndpoints: "/magic-wan/configuration/manually/how-to/configure-tunnels/",
-		ipRanges: "<br /> When using Magic WAN and Cloudflare Tunnel together, remember to consider the IP ranges utilized in the static routes of Cloudflare Tunnel when selecting static routes for Magic WAN. For more information, refer to [Cloudflare Tunnel](/magic-wan/zero-trust/cloudflare-tunnel/). <p></p>"
+		tunnelEndpoints: "/magic-wan/configuration/manually/how-to/configure-tunnels/"
 	}}
 />
 

--- a/src/content/partials/magic-transit/static-routes.mdx
+++ b/src/content/partials/magic-transit/static-routes.mdx
@@ -8,7 +8,6 @@ params:
   - magicWANecmp?
   - createPath
   - tunnelEndpoints
-  - ipRanges?
 ---
 
 import { Aside, GlossaryTooltip, Markdown, AnchorHeading, Render, TabItem, Tabs } from "~/components";
@@ -130,17 +129,42 @@ Cloudflare has nine geographic regions across the world which are listed below.
 
 Configure scoping for your traffic in the **Region code** section when adding or editing a static route. Refer to [Create a static route](#create-a-static-route) and [Edit a static route](#edit-a-static-route) more information.
 
-## Allowed IP ranges
+{ props.magicProduct === "Magic Transit" && (
+  <>
+    <AnchorHeading title="Allowed IP ranges" depth={2} />
+		<Markdown
+    text={`
+Allowed IP ranges for static routes are:
 
-By default, you can only add static routes with [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) IP prefixes like:
+- Cloudflare leased IPs assigned to your account
+- BYOIP prefixes. For BYOIP, you have the option to use them as-is, or to create a summary route to cover all your onboarded prefixes.
+			`}
+				inline={false}
+  />
+  </>
+  )
+}
 
-- `10.0.0.0/8`
-- `172.16.0.0/12`
-- `192.168.0.0/16`
+{ props.magicProduct === "Magic WAN" && (
+  <>
+    <AnchorHeading title="Allowed IP ranges" depth={2} />
+		<Markdown
+    text={`
+By default, you can only add static routes with RFC 1918 IP prefixes like:
+- \`10.0.0.0/8\`
+- \`172.16.0.0/12\`
+- \`192.168.0.0/16\`
 
-<Markdown text={props.ipRanges} />
-If your use case requires IP prefixes outside RFC 1918, contact your Cloudflare
-customer service manager.
+When using Magic WAN and Cloudflare Tunnel together, remember to consider the IP ranges utilized in the static routes of Cloudflare Tunnel when selecting static routes for Magic WAN. For more information, refer to [Cloudflare Tunnel](/magic-wan/zero-trust/cloudflare-tunnel/).
+
+For prefixes outside RFC 1918 contact your Cloudflare customer service manager.
+			`}
+				inline={false}
+  />
+  </>
+  )
+}
+
 
 ## Create a static route
 

--- a/src/content/partials/magic-transit/static-routes.mdx
+++ b/src/content/partials/magic-transit/static-routes.mdx
@@ -11,7 +11,7 @@ params:
   - ipRanges?
 ---
 
-import { GlossaryTooltip, Markdown, AnchorHeading, Render, TabItem, Tabs } from "~/components";
+import { Aside, GlossaryTooltip, Markdown, AnchorHeading, Render, TabItem, Tabs } from "~/components";
 
 :::note
 If you are connecting to Cloudflare via a [Direct CNI connection](/network-interconnect/express-cni/), refer to <a href={props.BGPpath}>BGP peering</a> to learn how to take advantage of this [routing](https://www.cloudflare.com/learning/network-layer/what-is-routing/) protocol. If not, continue reading.
@@ -64,6 +64,29 @@ In the example below, `TUNNEL_2_IAD` is likely to receive twice as much traffic 
     inline={false}
   />
 		<p>The minimum advertising prefix is <code>/24</code>, but because Cloudflare uses anycast tunnels as an outer wrapper for your traffic, we can route prefixes within that <code>/24</code> to different tunnel endpoints. For example, you can send <code>x.x.x.0/29</code> to Data Center 1 and <code>x.x.x.8/29</code> to Data Center 2. This is helpful when you operate in an environment with constrained IP resources.</p>
+  </>
+  )
+}
+
+{ props.magicProduct === "Magic Transit" && (
+  <>
+    <AnchorHeading title="Map routes prefixes bigger than onboarded prefixes" depth={2} />
+		<Markdown
+    text={`
+		If you have multiple onboarded \`/24\` subnets that belong to a larger contiguous block, you can configure a summary static route for the corresponding supernet (like a \`/23\` or a \`/22\`) instead of adding each \`/24\` individually. This eliminates the need to configure each \`/24\` route individually, as all traffic will be routed through the same GRE tunnels.
+
+		For example, if you have two tunnels:
+
+		- \`192.0.2.0/24\`
+		- \`192.0.3.0/24\`
+
+		You can summarize these into a single \`192.0.2.0/23\`.
+
+		Refer to [Add tunnels](/magic-transit/how-to/configure-tunnels/#add-tunnels) to learn more about configuring GRE tunnels.
+			`}
+				inline={false}
+  />
+	<Aside type="note">These address blocks are a part of <a href="https://datatracker.ietf.org/doc/rfc5737/" target="_blank" rel="noopener noreferrer">RFC 5737</a> and are reserved for use as examples in documentation.</Aside>
   </>
   )
 }


### PR DESCRIPTION
### Summary

- Closes PCX-15908
- Adds info on how to summarize routes to Magic Transit
- Corrects info for allowed ip ranges for MT

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
