### PR TITLE
[workers assets] remove experimental flag for framework guides for angular, gatsby and nuxt

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/angular.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/angular.mdx
@@ -24,7 +24,7 @@ To use `create-cloudflare` to create a new Angular project with <InlineBadge pre
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest my-angular-app"
-	args={"--framework=angular --experimental"}
+	args={"--framework=angular --platform=workers"}
 />
 
 <Render

--- a/src/content/docs/workers/frameworks/framework-guides/gatsby.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/gatsby.mdx
@@ -24,7 +24,7 @@ To use `create-cloudflare` to create a new Gatsby project with <InlineBadge pres
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest my-gatsby-app"
-	args={"--framework=gatsby --experimental"}
+	args={"--framework=gatsby --platform=workers"}
 />
 
 <Render

--- a/src/content/docs/workers/frameworks/framework-guides/nuxt.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nuxt.mdx
@@ -24,7 +24,7 @@ To use `create-cloudflare` to create a new Nuxt project with <InlineBadge preset
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest my-nuxt-app"
-	args={"--framework=nuxt --experimental"}
+	args={"--framework=nuxt --platform=workers"}
 />
 
 <Render


### PR DESCRIPTION
https://github.com/cloudflare/workers-sdk/pull/8372 graduates these templates from experimental.