### PR TITLE
remove all `the the` and `and and` repetitions

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
@@ -9,7 +9,7 @@ The `/scrape` endpoint extracts structured data from specific elements on a webp
 
 ## Basic usage
 
-Go to `https://example.com` and and extract metadata from all `h1` and `a` elements in the DOM.
+Go to `https://example.com` and extract metadata from all `h1` and `a` elements in the DOM.
 
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/scrape' \

--- a/src/content/docs/cloudflare-one/email-security/phish-submissions.mdx
+++ b/src/content/docs/cloudflare-one/email-security/phish-submissions.mdx
@@ -32,7 +32,7 @@ To set up PhishNet O365:
 
 1. Log in to the [Microsoft admin panel](https://admin.microsoft.com/). Go to **Microsoft 365 admin center** > **Settings** > **Integrated Apps**.
 2. Select **Upload custom apps**.
-3. Choose **Provide link to manifest file** and paste the the following URL:
+3. Choose **Provide link to manifest file** and paste the following URL:
     ```txt
     https://phishnet-o365.area1cloudflare-webapps.workers.dev?clientId=ODcxNDA0MjMyNDM3NTA4NjQwNDk1Mzc3MDIxNzE0OTcxNTg0Njk5NDEyOTE2NDU5ODQyNjU5NzYzNjYyNDQ3NjEwMzIxODEyMDk1NQ
     ```

--- a/src/content/docs/d1/best-practices/query-d1.mdx
+++ b/src/content/docs/d1/best-practices/query-d1.mdx
@@ -19,7 +19,7 @@ D1 understands SQLite semantics, which allows you to query a database using SQL 
 
 ### Use foreign key relationships
 
-When using SQL with D1, you may wish to define and and enforce foreign key constraints across tables in a database. Foreign key constraints allow you to enforce relationships across tables, or prevent you from deleting rows that reference rows in other tables. An example of a foreign key relationship is shown below.
+When using SQL with D1, you may wish to define and enforce foreign key constraints across tables in a database. Foreign key constraints allow you to enforce relationships across tables, or prevent you from deleting rows that reference rows in other tables. An example of a foreign key relationship is shown below.
 
 ```sql
 CREATE TABLE users (

--- a/src/content/docs/learning-paths/secure-o365-email/configure-email-security/report-phish.mdx
+++ b/src/content/docs/learning-paths/secure-o365-email/configure-email-security/report-phish.mdx
@@ -13,7 +13,7 @@ To set up PhishNet O365:
 
 1. Log in to the Microsoft admin panel. Go to **Microsoft 365 admin center** > **Settings** > **Integrated Apps**.
 2. Select **Upload custom apps**.
-3. Choose **Provide link to manifest file** and paste the the following URL:
+3. Choose **Provide link to manifest file** and paste the following URL:
 
 ```txt
 https://phishnet-o365.area1cloudflare-webapps.workers.dev?clientId=ODcxNDA0MjMyNDM3NTA4NjQwNDk1Mzc3MDIxNzE0OTcxNTg0Njk5NDEyOTE2NDU5ODQyNjU5NzYzNjYyNDQ3NjEwMzIxODEyMDk1NQ

--- a/src/content/docs/zaraz/consent-management/iab-tcf-compliance.mdx
+++ b/src/content/docs/zaraz/consent-management/iab-tcf-compliance.mdx
@@ -11,7 +11,7 @@ head:
 
 The Zaraz Consent Management Platform is compliant with the IAB Transparency & Consent Framework. Enabling this feature [could be required](https://blog.google/products/adsense/new-consent-management-platform-requirements-for-serving-ads-in-the-eea-and-uk/) in order to serve Google Ads in the EEA and the UK.
 
-The CMP ID of the approval is 433 and be can seen in the the [IAB Europe](https://iabeurope.eu/cmp-list/) website.
+The CMP ID of the approval is 433 and be can seen in the [IAB Europe](https://iabeurope.eu/cmp-list/) website.
 
 Using the Zaraz Consent Management Platform in IAB TCF Compliance Mode is is opt-in.
 

--- a/src/content/docs/zaraz/reference/context.mdx
+++ b/src/content/docs/zaraz/reference/context.mdx
@@ -31,7 +31,7 @@ System properties, which are automatically collected by Zaraz, provide insights 
 | ---------------- | ------ | ------------------------------------------------ |
 | `system.cookies` | Object | Key-Value object containing all present cookies. |
 
-The the keys inside the `system.cookies` are the cookies name. The property `system.cookies.foo` will return the value of the a cookie named `foo`.
+The keys inside the `system.cookies` are the cookies name. The property `system.cookies.foo` will return the value of the a cookie named `foo`.
 
 ### Device information
 

--- a/src/content/release-notes/images.yaml
+++ b/src/content/release-notes/images.yaml
@@ -8,7 +8,7 @@ entries:
   - publish_date: "2024-04-04"
     title: Images upload widget
     description: |-
-      Use the upload widget to integrate Cloudflare Images into your application by embedding the script into a static HTML page or installing a package that works with your preferred framework. To try out the upload widget, [sign up for the the closed beta](https://forms.gle/vBu47y3638k8fkGF8).
+      Use the upload widget to integrate Cloudflare Images into your application by embedding the script into a static HTML page or installing a package that works with your preferred framework. To try out the upload widget, [sign up for the closed beta](https://forms.gle/vBu47y3638k8fkGF8).
   - publish_date: "2024-04-04"
     title: Face cropping
     description: |-

--- a/src/content/workers-ai-models/whisper-large-v3-turbo.json
+++ b/src/content/workers-ai-models/whisper-large-v3-turbo.json
@@ -44,7 +44,7 @@
                 },
                 "prefix": {
                     "type": "string",
-                    "description": "The prefix it appended the the beginning of the output of the transcription and can guide the transcription result."
+                    "description": "The prefix it appended the beginning of the output of the transcription and can guide the transcription result."
                 }
             },
             "required": [


### PR DESCRIPTION
### Summary

This PR simply removes occurrences of `the the` and `and and` repetitions

I imagine that these are just old ones and newer ones are being taken care of by this: https://github.com/cloudflare/cloudflare-docs/blob/8ecb8cf5dbf05fbfefb37a9f4b6680bf393f5101/.github/styles/cloudflare/Repetition.yml
?

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
