### PR TITLE
Update dns-resolution.mdx

### DIFF
--- a/src/content/docs/dns/zone-setups/partial-setup/dns-resolution.mdx
+++ b/src/content/docs/dns/zone-setups/partial-setup/dns-resolution.mdx
@@ -70,15 +70,15 @@ In this case, Cloudflare will always resolve the CNAME target based on the value
 ```mermaid
     flowchart TD
       accTitle: DNS resolution flow with CNAME target in a zone within the same account
-      A[Request to <code>www.alice.com</code>] --> B[<code>CNAME</code> record for <code>www.alice.com</code> to <code>www.partialzone.com</code>]
-      B --> C[<code>A</code> record for <code>www.partialzone.com</code> to <code>192.0.2.4</code>]
+      A[Request to <code>www\.alice.com</code>] --> B[<code>CNAME</code> record for <code>www\.alice.com</code> to <code>www\.partialzone.com</code>]
+      B --> C[<code>A</code> record for <code>www\.partialzone.com</code> to <code>192.0.2.4</code>]
       C --> D[<code>192.0.2.4</code>]
       subgraph Cloudflare account
         subgraph Cloudflare zone 1
           B
         end
         subgraph Cloudflare zone 2
-        E[<code>A</code> record for <code>www.partialzone.com</code> to <code>203.0.113.1</code>]
+        E[<code>A</code> record for <code>www\.partialzone.com</code> to <code>203.0.113.1</code>]
         end
       end
       subgraph Authoritative DNS


### PR DESCRIPTION
fixed broken domain names in flowchart, due to mermaid trying to resolve them as links. escaped . following www. Before change "www.alice.com" and "www.partialzone.com" were rendering as "Unsupported markdown: link" 

