### PR TITLE
fix up assets c3 command

### DIFF
--- a/src/content/docs/workers/frameworks/index.mdx
+++ b/src/content/docs/workers/frameworks/index.mdx
@@ -26,13 +26,7 @@ import {
 	network.
 </Description>
 
-The following frameworks have experimental support for Cloudflare Workers and the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/). They can be initialized with the [`create-cloudflare` CLI](/workers/get-started/guide/) using the `--experimental` flag.
-
-<PackageManagers
-	type="create"
-	pkg="cloudflare@latest my-framework-app"
-	args={"--type=web-framework --experimental"}
-/>
+The following frameworks have support for Cloudflare Workers and the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/). See the individual guides below for how to get started.
 
 <DirectoryListing folder="workers/frameworks/framework-guides" />
 

--- a/src/content/docs/workers/frameworks/index.mdx
+++ b/src/content/docs/workers/frameworks/index.mdx
@@ -26,7 +26,7 @@ import {
 	network.
 </Description>
 
-The following frameworks have support for Cloudflare Workers and the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/). See the individual guides below for how to get started.
+The following frameworks have support for Cloudflare Workers and the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/). Refer to the individual guides below for instructions on how to get started.
 
 <DirectoryListing folder="workers/frameworks/framework-guides" />
 


### PR DESCRIPTION
### Summary

Now that some frameworks are being graduated from experimental status, we can't just tell users to add the `--experimental` flag for all frameworks or they wont find the relevant framework in experimental mode. To fix this we can just direct them to the individual framework guides which will display an up to date command

