### PR TITLE
[Workers KV] IA cleanup + consistency matching

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1645,6 +1645,7 @@
 /workers-ai/tutorials/image-generator-flux/ /workers-ai/tutorials/image-generation-playground/ 301
 
 # workers KV
+/kv/glossary/ /kv/reference/glossary/ 301
 /kv/platform/environments/ /kv/reference/environments/ 301
 /kv/platform/kv-commands/ /kv/reference/kv-commands/ 301
 /kv/learning/ /kv/reference/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1651,12 +1651,13 @@
 # workers KV
 /kv/glossary/ /kv/reference/glossary/ 301
 /kv/platform/environments/ /kv/reference/environments/ 301
-/kv/platform/kv-commands/ /kv/reference/kv-commands/ 301
+/kv/platform/kv-commands/ /kv/kv-commands/ 301
 /kv/learning/ /kv/reference/ 301
 /kv/learning/how-kv-works/ /kv/concepts/how-kv-works/ 301
 /kv/learning/kv-bindings/ /kv/concepts/kv-bindings/ 301
 /kv/learning/kv-namespaces/ /kv/concepts/kv-namespaces/ 301
 /kv/reference/how-kv-works/ /kv/concepts/how-kv-works/ 301
+/kv/reference/kv-commands/ /kv/kv-commands/ 301
 /kv/reference/kv-bindings/ /kv/concepts/kv-bindings/ 301
 /kv/reference/kv-namespaces/ /kv/concepts/kv-namespaces/ 301
 /kv/tutorials/workers-kv-from-rust/ /workers/tutorials/workers-kv-from-rust/ 301

--- a/src/content/docs/kv/api/delete-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/delete-key-value-pairs.mdx
@@ -73,4 +73,4 @@ Delete more than one key-value pair at a time with Wrangler or [via the REST API
 The bulk REST API can accept up to 10,000 KV pairs at once. Bulk writes are not supported using the [KV binding](/kv/concepts/kv-bindings/).
 
 ## Other methods to access KV
-You can also [delete key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#kv-namespace-delete) or [with the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/delete/).
+You can also [delete key-value pairs from the command line with Wrangler](/kv/kv-commands/#kv-namespace-delete) or [with the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/delete/).

--- a/src/content/docs/kv/api/list-keys.mdx
+++ b/src/content/docs/kv/api/list-keys.mdx
@@ -159,4 +159,4 @@ await NAMESPACE.put(key, "", {
 ```
 
 ## Other methods to access KV
-You can also [list keys on the command line with Wrangler](/kv/reference/kv-commands/#kv-namespace-list) or [with the REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/list/).
+You can also [list keys on the command line with Wrangler](/kv/kv-commands/#kv-namespace-list) or [with the REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/list/).

--- a/src/content/docs/kv/api/read-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/read-key-value-pairs.mdx
@@ -166,5 +166,5 @@ The effective `cacheTtl` of an already cached item can be reduced by getting it 
 
 ## Other methods to access KV
 
-You can [read key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#kv-key-get) and [from the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/get/).
+You can [read key-value pairs from the command line with Wrangler](/kv/kv-commands/#kv-key-get) and [from the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/get/).
 

--- a/src/content/docs/kv/api/write-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/write-key-value-pairs.mdx
@@ -270,4 +270,4 @@ async function retryWithBackoff(
 
 ## Other methods to access KV
 
-You can also [write key-value pairs from the command line with Wrangler](/kv/reference/kv-commands/#kv-namespace-create) and [write data via the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/update/).
+You can also [write key-value pairs from the command line with Wrangler](/kv/kv-commands/#kv-namespace-create) and [write data via the REST API](/api/resources/kv/subresources/namespaces/subresources/values/methods/update/).

--- a/src/content/docs/kv/demos.mdx
+++ b/src/content/docs/kv/demos.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Demos and architectures
 sidebar:
-  order: 5
+  order: 6
 
 ---
 

--- a/src/content/docs/kv/demos.mdx
+++ b/src/content/docs/kv/demos.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Demos and architectures
 sidebar:
-  order: 6
+  order: 7
 
 ---
 

--- a/src/content/docs/kv/examples/index.mdx
+++ b/src/content/docs/kv/examples/index.mdx
@@ -4,7 +4,7 @@ hideChildren: false
 pcx_content_type: navigation
 title: Examples
 sidebar:
-  order: 5
+  order: 6
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/examples/index.mdx
+++ b/src/content/docs/kv/examples/index.mdx
@@ -4,7 +4,7 @@ hideChildren: false
 pcx_content_type: navigation
 title: Examples
 sidebar:
-  order: 4
+  order: 5
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -295,7 +295,7 @@ Exactly **one** of `--binding` or `--namespace-id` is required.
 To view the value directly within the terminal, add `--text`
 :::
 
-Refer to the [`kv bulk` documentation](/kv/reference/kv-commands/#kv-bulk) to write a file of multiple key-value pairs to a given KV namespace.
+Refer to the [`kv bulk` documentation](/kv/kv-commands/#kv-bulk) to write a file of multiple key-value pairs to a given KV namespace.
 
 </TabItem><TabItem label='Dashboard'>
 
@@ -470,4 +470,4 @@ If you have any feature requests or notice any bugs, share your feedback directl
 
 - Learn more about the [KV API](/kv/api/).
 - Understand how to use [Environments](/kv/reference/environments/) with Workers KV.
-- Read the Wrangler [`kv` command documentation](/kv/reference/kv-commands/).
+- Read the Wrangler [`kv` command documentation](/kv/kv-commands/).

--- a/src/content/docs/kv/kv-commands.mdx
+++ b/src/content/docs/kv/kv-commands.mdx
@@ -1,8 +1,8 @@
 ---
 pcx_content_type: reference
-title: Wrangler KV commands
+title: KV Wrangler commands
 sidebar:
-  order: 2
+  order: 5
 ---
 
 import {Render} from "~/components"

--- a/src/content/docs/kv/observability/index.mdx
+++ b/src/content/docs/kv/observability/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Observability
 sidebar:
-  order: 5
+  order: 6
   group:
     hideIndex: true
 

--- a/src/content/docs/kv/observability/index.mdx
+++ b/src/content/docs/kv/observability/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Observability
 sidebar:
-  order: 6
+  order: 7
   group:
     hideIndex: true
 

--- a/src/content/docs/kv/platform/index.mdx
+++ b/src/content/docs/kv/platform/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Platform
 sidebar:
-  order: 5
+  order: 6
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/platform/index.mdx
+++ b/src/content/docs/kv/platform/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Platform
 sidebar:
-  order: 6
+  order: 7
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/platform/index.mdx
+++ b/src/content/docs/kv/platform/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Platform
 sidebar:
-  order: 7
+  order: 8
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/reference/environments.mdx
+++ b/src/content/docs/kv/reference/environments.mdx
@@ -45,7 +45,7 @@ wrangler kv key put --namespace-id=<YOUR_ID> "<KEY>" "<VALUE>"
 
 :::caution
 
-Since version 3.60.0, Wrangler KV commands support the `kv ...` syntax. If you are using versions of Wrangler below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/reference/kv-commands/) for KV page.
+Since version 3.60.0, Wrangler KV commands support the `kv ...` syntax. If you are using versions of Wrangler below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/kv-commands/) for KV page.
 :::
 
 Most `kv` subcommands also allow you to specify an environment with the optional `--env` flag.

--- a/src/content/docs/kv/reference/glossary.mdx
+++ b/src/content/docs/kv/reference/glossary.mdx
@@ -2,7 +2,7 @@
 title: Glossary
 pcx_content_type: glossary
 sidebar:
-  order: 7
+  order: 10
 
 ---
 

--- a/src/content/docs/kv/reference/index.mdx
+++ b/src/content/docs/kv/reference/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Reference
 sidebar:
-  order: 7
+  order: 8
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/reference/index.mdx
+++ b/src/content/docs/kv/reference/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Reference
 sidebar:
-  order: 6
+  order: 7
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/reference/index.mdx
+++ b/src/content/docs/kv/reference/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Reference
 sidebar:
-  order: 8
+  order: 9
   group:
     hideIndex: true
 ---

--- a/src/content/docs/kv/tutorials/index.mdx
+++ b/src/content/docs/kv/tutorials/index.mdx
@@ -3,7 +3,7 @@ title: Tutorials
 pcx_content_type: navigation
 hideChildren: true
 sidebar:
-  order: 4
+  order: 5
 
 ---
 

--- a/src/content/docs/kv/tutorials/index.mdx
+++ b/src/content/docs/kv/tutorials/index.mdx
@@ -3,7 +3,7 @@ title: Tutorials
 pcx_content_type: navigation
 hideChildren: true
 sidebar:
-  order: 5
+  order: 6
 
 ---
 

--- a/src/content/docs/kv/workers-kv-api.mdx
+++ b/src/content/docs/kv/workers-kv-api.mdx
@@ -3,6 +3,6 @@ pcx_content_type: navigation
 title: KV REST API
 external_link: /api/resources/kv/subresources/namespaces/methods/list/
 sidebar:
-  order: 8
+  order: 4
 
 ---

--- a/src/content/partials/workers/wrangler-commands/kv.mdx
+++ b/src/content/partials/workers/wrangler-commands/kv.mdx
@@ -15,7 +15,7 @@ The `kv ...` commands allow you to manage your Workers KV resources in the Cloud
 
 :::caution
 
-Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/reference/kv-commands/#deprecations) for KV page.
+Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/kv-commands/#deprecations) for KV page.
 :::
 
 <AnchorHeading title="`create`" slug="kv-namespace-create" depth={3} />
@@ -155,7 +155,7 @@ The `kv ...` commands allow you to manage your Workers KV resources in the Cloud
 
 :::caution
 
-Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/reference/kv-commands/) for KV page.
+Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/kv-commands/) for KV page.
 :::
 
 <AnchorHeading title="`put`" slug="kv-key-put" depth={3} />
@@ -380,7 +380,7 @@ The `kv ...` commands allow you to manage your Workers KV resources in the Cloud
 
 :::caution
 
-Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/reference/kv-commands/) for KV page.
+Since version 3.60.0, Wrangler supports the `kv ...` syntax. If you are using versions below 3.60.0, the command follows the `kv:...` syntax. Learn more about the deprecation of the `kv:...` syntax in the [Wrangler commands](/kv/kv-commands/) for KV page.
 :::
 
 <AnchorHeading title="`put`" slug="kv-bulk-put" depth={3} />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Matching the Sidebar structure to align with D1 and DO.

1. `KV REST API` has been brought up to sit under `Workers Binding API` section.
2. `KV Wrangler command` has been brought up sit under `KV REST API` link.
3. `Glossary` has been moved into `Reference`.
4. `Demo and Architecture` has been relocated to sit under `Tutorials`.

All internal links and public redirects have been setup.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
