### PR TITLE
[WAF] Fix output syntax highlighting in migration guide

### DIFF
--- a/src/content/docs/waf/reference/migration-guides/waf-managed-rules-migration.mdx
+++ b/src/content/docs/waf/reference/migration-guides/waf-managed-rules-migration.mdx
@@ -428,7 +428,9 @@ The recommended steps for replacing your old WAF managed rules configuration in 
 
    ```sh null {3,6}
    cf-terraforming generate --zone <ZONE_ID> --resource-type "cloudflare_ruleset"
+   ```
 
+   ```txt output
    resource "cloudflare_ruleset" "terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31" {
      kind    = "zone"
      name    = "default"
@@ -450,7 +452,7 @@ The recommended steps for replacing your old WAF managed rules configuration in 
 terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31 zone/<ZONE_ID>/3c0b456bc2aa443089c5f40f45f51b31
 ```
 
-```sh output
+```txt output
  cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Importing from ID "zone/<ZONE_ID>/3c0b456bc2aa443089c5f40f45f51b31"...
  cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Import prepared!
    Prepared cloudflare_ruleset for import
@@ -468,7 +470,7 @@ terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa44308
    terraform plan
    ```
 
-   ```sh output
+   ```txt output
 
    cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Refreshing state... [id=3c0b456bc2aa443089c5f40f45f51b31]
    [...]
@@ -489,7 +491,7 @@ terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa44308
       terraform state list | grep -E '^cloudflare_waf_(package|group|rule)\.'
       ```
 
-      ```sh output
+      ```txt output
       cloudflare_waf_package.my_package
       cloudflare_waf_group.my_group
       ```
@@ -500,7 +502,7 @@ terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa44308
       terraform state rm -dry-run cloudflare_waf_package.my_package cloudflare_waf_group.my_group
       ```
 
-      ```sh output
+      ```txt output
       Would remove cloudflare_waf_package.my_package
       Would remove cloudflare_waf_group.my_group
       ```
@@ -511,7 +513,7 @@ terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa44308
       terraform state rm cloudflare_waf_package.my_package cloudflare_waf_group.my_group
       ```
 
-      ```sh output
+      ```txt output
       Removed cloudflare_waf_package.my_package
       Removed cloudflare_waf_group.my_group
       Successfully removed 2 resource instance(s).
@@ -525,7 +527,7 @@ terraform import cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa44308
    terraform plan
    ```
 
-   ```sh output
+   ```txt output
    cloudflare_ruleset.terraform_managed_resource_3c0b456bc2aa443089c5f40f45f51b31: Refreshing state... [id=3c0b456bc2aa443089c5f40f45f51b31]
    [...]
 


### PR DESCRIPTION
### Summary

Terraform output blocks should not have syntax highlighting.
