### PR TITLE
fix: Adds note on setting up hyperdrive locally

### DIFF
--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -129,18 +129,14 @@ If successful, the command will output your new Hyperdrive configuration:
 
 ```json
 {
-	"id": "<example id: 57b7076f58be42419276f058a8968187>",
-	"name": "YOUR_CONFIG_NAME",
-	"origin": {
-		"host": "YOUR_DATABASE_HOST",
-		"port": 5432,
-		"database": "DATABASE",
-		"user": "DATABASE_USER"
-	},
-	"caching": {
-		"disabled": false
-	}
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+			"id": "<example id: 57b7076f58be42419276f058a8968187>"
+    }
+  ]
 }
+
 ```
 
 Copy the `id` field: you will use this in the next step to make Hyperdrive accessible from your Worker script.
@@ -150,6 +146,7 @@ Copy the `id` field: you will use this in the next step to make Hyperdrive acces
 Hyperdrive will attempt to connect to your database with the provided credentials to verify they are correct before creating a configuration. If you encounter an error when attempting to connect, refer to Hyperdrive's [troubleshooting documentation](/hyperdrive/observability/troubleshooting/) to debug possible causes.
 
 :::
+
 
 ## 4. Bind your Worker to Hyperdrive
 

--- a/src/content/partials/hyperdrive/create-hyperdrive-binding.mdx
+++ b/src/content/partials/hyperdrive/create-hyperdrive-binding.mdx
@@ -26,9 +26,7 @@ Specifically:
 - Your binding is available in your Worker at `env.<BINDING_NAME>`.
 
 
-If you wish to use a local databse during development, you can add a
-`localConnectionString` to your  Hyperdrive configuration with the connection
-string of your database:
+If you wish to use a local database during development, you can add a `localConnectionString` to your  Hyperdrive configuration with the connection string of your database:
 
 
 <WranglerConfig>
@@ -44,7 +42,6 @@ localConnectionString = "<LOCAL_DATABASE_CONNECTION_URI>"
 
 :::note
 
-Learn more about setting up [Hyperdrive for local
-development](/hyperdrive/configuration/local-development/).
+Learn more about setting up [Hyperdrive for local development](/hyperdrive/configuration/local-development/).
 
 :::

--- a/src/content/partials/hyperdrive/create-hyperdrive-binding.mdx
+++ b/src/content/partials/hyperdrive/create-hyperdrive-binding.mdx
@@ -24,3 +24,27 @@ Specifically:
 - The value (string) you set for the `name` (binding name) will be used to reference this database in your Worker. In this tutorial, name your binding `HYPERDRIVE`.
 - The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "hyperdrive"` or `binding = "productionDB"` would both be valid names for the binding.
 - Your binding is available in your Worker at `env.<BINDING_NAME>`.
+
+
+If you wish to use a local databse during development, you can add a
+`localConnectionString` to your  Hyperdrive configuration with the connection
+string of your database:
+
+
+<WranglerConfig>
+
+```toml
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "<YOUR_DATABASE_ID>" # the ID associated with the Hyperdrive you just created
+localConnectionString = "<LOCAL_DATABASE_CONNECTION_URI>"
+```
+
+</WranglerConfig>
+
+:::note
+
+Learn more about setting up [Hyperdrive for local
+development](/hyperdrive/configuration/local-development/).
+
+:::


### PR DESCRIPTION
### Summary
Add note on using hyperdrive locally on the getting started page and also links  to the relevant full-docs page 
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
