### PR TITLE
docs: Add examples for scheduled handlers in Cron Triggers documentation

### DIFF
--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -5,7 +5,7 @@ head: []
 description: Enable your Worker to be executed on a schedule.
 ---
 
-import { WranglerConfig } from "~/components";
+import { Render, WranglerConfig } from "~/components";
 
 ## Background
 
@@ -27,22 +27,7 @@ Cron Triggers execute on UTC time.
 
 To respond to a Cron Trigger, you must add a [`"scheduled"` handler](/workers/runtime-apis/handlers/scheduled/) to your Worker.
 
-import { TypeScriptExample } from "~/components";
-
-<TypeScriptExample>
-```ts
-interface Env {}
-export default {
-	async scheduled(
-		controller: ScheduledController,
-		env: Env,
-		ctx: ExecutionContext,
-	) {
-		console.log("cron processed");
-	},
-};
-```
-</TypeScriptExample>
+<Render file="cron-trigger-example" />
 
 Refer to the following additional examples to write your code:
 
@@ -73,8 +58,6 @@ crons = [ "*/3 * * * *", "0 15 1 * *", "59 23 LW * *" ]
 </WranglerConfig>
 
 You also can set a different Cron Trigger for each [environment](/workers/wrangler/environments/) in your [Wrangler configuration file](/workers/wrangler/configuration/). You need to put the `[triggers]` table under your chosen environment. For example:
-
-
 
 <WranglerConfig>
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -27,20 +27,9 @@ Cron Triggers execute on UTC time.
 
 To respond to a Cron Trigger, you must add a [`"scheduled"` handler](/workers/runtime-apis/handlers/scheduled/) to your Worker.
 
-import { TabItem, Tabs } from "~/components";
+import { TypeScriptExample } from "~/components";
 
-<Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
-
-```js
-export default {
-	async scheduled(event, env, ctx) {
-		console.log("cron processed");
-	},
-};
-```
-
-</TabItem> <TabItem label="TypeScript" icon="seti:typescript">
-
+<TypeScriptExample>
 ```ts
 interface Env {}
 export default {
@@ -53,8 +42,7 @@ export default {
 	},
 };
 ```
-
-</TabItem> </Tabs>
+</TypeScriptExample>
 
 Refer to the following additional examples to write your code:
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -27,7 +27,36 @@ Cron Triggers execute on UTC time.
 
 To respond to a Cron Trigger, you must add a [`"scheduled"` handler](/workers/runtime-apis/handlers/scheduled/) to your Worker.
 
-Refer to the following examples to write your code:
+import { TabItem, Tabs } from "~/components";
+
+<Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+export default {
+	async scheduled(event, env, ctx) {
+		console.log("cron processed");
+	},
+};
+```
+
+</TabItem> <TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+interface Env {}
+export default {
+	async scheduled(
+		controller: ScheduledController,
+		env: Env,
+		ctx: ExecutionContext,
+	) {
+		console.log("cron processed");
+	},
+};
+```
+
+</TabItem> </Tabs>
+
+Refer to the following additional examples to write your code:
 
 - [Setting Cron Triggers](/workers/examples/cron-trigger/)
 - [Multiple Cron Triggers](/workers/examples/multiple-cron-triggers/)

--- a/src/content/docs/workers/examples/cron-trigger.mdx
+++ b/src/content/docs/workers/examples/cron-trigger.mdx
@@ -13,34 +13,9 @@ sidebar:
 description: Set a Cron Trigger for your Worker.
 ---
 
-import { TabItem, Tabs, WranglerConfig } from "~/components";
+import { Render, TabItem, Tabs, WranglerConfig } from "~/components";
 
-<Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
-
-```js
-export default {
-	async scheduled(event, env, ctx) {
-		console.log("cron processed");
-	},
-};
-```
-
-</TabItem> <TabItem label="TypeScript" icon="seti:typescript">
-
-```ts
-interface Env {}
-export default {
-	async scheduled(
-		controller: ScheduledController,
-		env: Env,
-		ctx: ExecutionContext,
-	) {
-		console.log("cron processed");
-	},
-};
-```
-
-</TabItem> </Tabs>
+<Render file="cron-trigger-example" />
 
 ## Set Cron Triggers in Wrangler
 
@@ -62,8 +37,6 @@ crons = ["0 * * * *"]
 </WranglerConfig>
 
 You also can set a different Cron Trigger for each [environment](/workers/wrangler/environments/) in your [Wrangler configuration file](/workers/wrangler/configuration/). You need to put the `[triggers]` table under your chosen environment. For example:
-
-
 
 <WranglerConfig>
 

--- a/src/content/partials/workers/cron-trigger-example.mdx
+++ b/src/content/partials/workers/cron-trigger-example.mdx
@@ -1,0 +1,20 @@
+---
+{}
+---
+
+import { TypeScriptExample } from "~/components";
+
+<TypeScriptExample>
+```ts
+interface Env {}
+export default {
+	async scheduled(
+		controller: ScheduledController,
+		env: Env,
+		ctx: ExecutionContext,
+	) {
+		console.log("cron processed");
+	},
+};
+```
+</TypeScriptExample>


### PR DESCRIPTION
### Summary

Add code sample for Worker cron triggers directly into the documentation

closes #20632

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/743ba0b3-7ef7-490a-95ae-3ff8f177fcbb)

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
