### PR TITLE
Adds changelog and flag information for process.env population

### DIFF
--- a/src/content/changelog/workers/2025-03-07-process-env-support.mdx
+++ b/src/content/changelog/workers/2025-03-07-process-env-support.mdx
@@ -3,7 +3,7 @@ title: Access environment variables on process.env in you Worker
 description: With Node.js compatability on, process.env is automatically populated with environment variables and secrets
 products:
   - workers
-date: 2025-03-07T11:00:00Z
+date: 2025-03-07T15:00:00Z
 ---
 
 You can now access [environment variables](/workers/configuration/environment-variables/) and

--- a/src/content/changelog/workers/2025-03-07-process-env-support.mdx
+++ b/src/content/changelog/workers/2025-03-07-process-env-support.mdx
@@ -1,0 +1,33 @@
+---
+title: Access environment variables on process.env in you Worker
+description: With Node.js compatability on, process.env is automatically populated with environment variables and secrets
+products:
+  - workers
+date: 2025-03-07T11:00:00Z
+---
+
+You can now access [environment variables](/workers/configuration/environment-variables/) and
+[secrets](/workers/configuration/secrets/) on [`process.env`](/workers/runtime-apis/nodejs/process/#processenv)
+when using the [`nodejs_compat` compatability flag](/workers/configuration/compatibility-flags/#nodejs-compatibility-flag).
+
+```js
+const apiClient = ApiClient.new({ apiKey: process.env.API_KEY });
+const LOG_LEVEL = process.env.LOG_LEVEL || "info";
+```
+
+In Node.js, environment variable are exposed via the global `process.env` object. Some libraries
+assume that this object will be populated, and many developers may be used to accessing variables
+in this way.
+
+Previously, the `process.env` object was added when Node.js compatability was turned on, but it was empty.
+This could cause unexpected errors or friction when developing Workers with code previously written for
+Node.js.
+
+Now, [environment variables](/workers/configuration/environment-variables/),
+[secrets](/workers/configuration/secrets/), and [version metadata](/workers/runtime-apis/bindings/version-metadata/)
+can all be accessed on `process.env`.
+
+After April 1, 2025, populating `process.env` will become the default behavior when `nodejs_compat` is enabled, and
+your Worker's compatability date is after "2025-04-01". Until then, users can opt-in to this behavior by adding the
+[`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#nodejs-compat-populate-process-env)
+compatability flag.

--- a/src/content/changelog/workers/2025-03-07-process-env-support.mdx
+++ b/src/content/changelog/workers/2025-03-07-process-env-support.mdx
@@ -1,5 +1,5 @@
 ---
-title: Access environment variables on process.env in you Worker
+title: Access your Worker's environment variables from process.env
 description: With Node.js compatability on, process.env is automatically populated with environment variables and secrets
 products:
   - workers
@@ -15,13 +15,12 @@ const apiClient = ApiClient.new({ apiKey: process.env.API_KEY });
 const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 ```
 
-In Node.js, environment variable are exposed via the global `process.env` object. Some libraries
+In Node.js, environment variables are exposed via the global `process.env` object. Some libraries
 assume that this object will be populated, and many developers may be used to accessing variables
 in this way.
 
-Previously, the `process.env` object was added when Node.js compatability was turned on, but it was empty.
-This could cause unexpected errors or friction when developing Workers with code previously written for
-Node.js.
+Previously, the `process.env` object was always empty unless written to in Worker code. This could
+cause unexpected errors or friction when developing Workers using code previously written for Node.js.
 
 Now, [environment variables](/workers/configuration/environment-variables/),
 [secrets](/workers/configuration/secrets/), and [version metadata](/workers/runtime-apis/bindings/version-metadata/)
@@ -29,5 +28,5 @@ can all be accessed on `process.env`.
 
 After April 1, 2025, populating `process.env` will become the default behavior when `nodejs_compat` is enabled, and
 your Worker's compatability date is after "2025-04-01". Until then, users can opt-in to this behavior by adding the
-[`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#nodejs-compat-populate-process-env)
+[`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv)
 compatability flag.

--- a/src/content/changelog/workers/2025-03-11-process-env-support.mdx
+++ b/src/content/changelog/workers/2025-03-11-process-env-support.mdx
@@ -3,7 +3,7 @@ title: Access your Worker's environment variables from process.env
 description: With Node.js compatability on, process.env is automatically populated with environment variables and secrets
 products:
   - workers
-date: 2025-03-07T15:00:00Z
+date: 2025-03-11T17:00:00Z
 ---
 
 You can now access [environment variables](/workers/configuration/environment-variables/) and

--- a/src/content/changelog/workers/2025-03-11-process-env-support.mdx
+++ b/src/content/changelog/workers/2025-03-11-process-env-support.mdx
@@ -3,7 +3,7 @@ title: Access your Worker's environment variables from process.env
 description: With Node.js compatability on, process.env is automatically populated with environment variables and secrets
 products:
   - workers
-date: 2025-03-11T17:00:00Z
+date: 2025-03-11T15:00:00Z
 ---
 
 You can now access [environment variables](/workers/configuration/environment-variables/) and

--- a/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
+++ b/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
@@ -1,0 +1,27 @@
+---
+name: "Enable `cache: no-store` HTTP standard API"
+sort_date: "2025-02-27"
+enable_date: "2025-04-01"
+enable_flag: "nodejs_compat_populate_process_env"
+disable_flag: "nodejs_compat_do_not_populate_process_env"
+---
+
+When you enable the `nodejs_compat_populate_process_env` compatibility flag and the [`nodejs_compat`](/workers/runtime-apis/nodejs/)
+flag is also enabled, `process.env` will be populated with values from any bindings with text or JSON values.
+This means that if you have added environment variables [environment variables](/workers/configuration/environment-variables/),
+[secrets](/workers/configuration/secrets/), or [version metadata](/workers/runtime-apis/bindings/version-metadata/)
+bindings, these values can be accessed on `proecess.env`.
+
+```js
+const apiClient = ApiClient.new({ apiKey: process.env.API_KEY });
+const LOG_LEVEL = process.env.LOG_LEVEL || "info";
+```
+
+This makes accessing these values easier and conforms to common Node.js patterns, which can
+reduce toil and help with compatability for existing Node.js libraries.
+
+If users do not wish for these values to be accessible via `process.env`, they can use the
+`nodejs_compat_do_not_populate_process_env`. In this case, `process.env` will still be available,
+but will not have values automatically added.
+
+This flag will default to on for any compatability dates after `2025-04-01`.

--- a/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
+++ b/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
@@ -1,5 +1,5 @@
 ---
-name: "Enable `cache: no-store` HTTP standard API"
+name: "Enable auto-populating `process.env`"
 sort_date: "2025-02-27"
 enable_date: "2025-04-01"
 enable_flag: "nodejs_compat_populate_process_env"

--- a/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
+++ b/src/content/compatibility-flags/nodejs-compat-populate-process-env.md
@@ -8,9 +8,9 @@ disable_flag: "nodejs_compat_do_not_populate_process_env"
 
 When you enable the `nodejs_compat_populate_process_env` compatibility flag and the [`nodejs_compat`](/workers/runtime-apis/nodejs/)
 flag is also enabled, `process.env` will be populated with values from any bindings with text or JSON values.
-This means that if you have added environment variables [environment variables](/workers/configuration/environment-variables/),
+This means that if you have added [environment variables](/workers/configuration/environment-variables/),
 [secrets](/workers/configuration/secrets/), or [version metadata](/workers/runtime-apis/bindings/version-metadata/)
-bindings, these values can be accessed on `proecess.env`.
+bindings, these values can be accessed on `process.env`.
 
 ```js
 const apiClient = ApiClient.new({ apiKey: process.env.API_KEY });
@@ -21,7 +21,5 @@ This makes accessing these values easier and conforms to common Node.js patterns
 reduce toil and help with compatability for existing Node.js libraries.
 
 If users do not wish for these values to be accessible via `process.env`, they can use the
-`nodejs_compat_do_not_populate_process_env`. In this case, `process.env` will still be available,
-but will not have values automatically added.
-
-This flag will default to on for any compatability dates after `2025-04-01`.
+`nodejs_compat_do_not_populate_process_env` flag. In this case, `process.env` will still be
+available, but will not have values automatically added.

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -26,7 +26,10 @@ nextTick(() => {
 
 ## `process.env`
 
-In the Node.js implementation of `process.env`, the `env` object is a copy of the environment variables at the time the process was started. In the Workers implementation, there is no process-level environment, so `env` is an empty object. You can still set and get values from `env`, and those will be globally persistent for all Workers running in the same isolate and context (for example, the same Workers entry point).
+In the Node.js implementation of `process.env`, the `env` object is a copy of the environment variables at the time the process was started. In the Workers implementation, there is no process-level environment, so by default `env` is an empty object. You can still set and get values from `env`, and those will be globally persistent for all Workers running in the same isolate and context (for example, the same Workers entry point).
+
+When [Node.js compatability](/workers/runtime-apis/nodejs/) is turned on and the [`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#nodejs-compat-populate-process-env) compatability flag is set, `process.env` will contain any [environment variables](/workers/configuration/environment-variables/),
+[secrets](/workers/configuration/secrets/), or [version metadata](/workers/runtime-apis/bindings/version-metadata/) metadata that has been configured on your Worker.
 
 ### Relationship to per-request `env` argument in `fetch()` handlers
 

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -28,7 +28,7 @@ nextTick(() => {
 
 In the Node.js implementation of `process.env`, the `env` object is a copy of the environment variables at the time the process was started. In the Workers implementation, there is no process-level environment, so by default `env` is an empty object. You can still set and get values from `env`, and those will be globally persistent for all Workers running in the same isolate and context (for example, the same Workers entry point).
 
-When [Node.js compatability](/workers/runtime-apis/nodejs/) is turned on and the [`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#nodejs-compat-populate-process-env) compatability flag is set, `process.env` will contain any [environment variables](/workers/configuration/environment-variables/),
+When [Node.js compatability](/workers/runtime-apis/nodejs/) is turned on and the [`nodejs_compat_populate_process_env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv) compatability flag is set, `process.env` will contain any [environment variables](/workers/configuration/environment-variables/),
 [secrets](/workers/configuration/secrets/), or [version metadata](/workers/runtime-apis/bindings/version-metadata/) metadata that has been configured on your Worker.
 
 ### Relationship to per-request `env` argument in `fetch()` handlers


### PR DESCRIPTION
### Summary

Adds process.env population changelog and flag info

Also, we should update this page: https://developers.cloudflare.com/workers/configuration/environment-variables/

But going to way until the importable `env` change is rolled out to update it in one swoop with both new methods.