### PR TITLE
Remove typo in tutorial's index.js code

### DIFF
--- a/src/content/docs/cloudflare-one/tutorials/extend-sso-with-workers.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/extend-sso-with-workers.mdx
@@ -72,7 +72,7 @@ This approach allows you to:
       async fetch(request, env, ctx) {
         // The name of the cookie
         const COOKIE_NAME = "CF_Authorization";
-      const CF_GET_IDENTITY = "https://<your-team-name>.cloudflareaccess.com>/cdn-cgi/access/get-identity";
+      const CF_GET_IDENTITY = "https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/get-identity";
         const cookie = parse(request.headers.get("Cookie") || "");
         if (cookie[COOKIE_NAME] != null) {
         try {


### PR DESCRIPTION
The example index.js code contains a URL that the user needs to edit. However, it has an additional erroneous '>' character.

### Summary

This URL:
`"https://<your-team-name>.cloudflareaccess.com>/cdn-cgi/access/get-identity"`

Should be:
`"https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/get-identity"`


