### PR TITLE
Clarify permissions for notifications and webhooks

### DIFF
--- a/src/content/docs/notifications/get-started/index.mdx
+++ b/src/content/docs/notifications/get-started/index.mdx
@@ -17,9 +17,11 @@ You can check the [Notification History](/notifications/notification-history/) u
 
 To create a notification via the Cloudflare dashboard, you will need to have the Super Administrator or Administrator role.
 
-You can also create a notification if you have an edit role for the feature that you want to create an alert for. For example, if you want to create a Load Balancing Pool Enablement notification, you will need to have the Load Balancer role.
+You can also create a notification if you have the account edit role, which allows you create any type of notification.
 
 An API token needs to have the [Notifications Read/Write permission](https://developers.cloudflare.com/fundamentals/api/reference/permissions/) to create a notification,
+
+Some notifications can only be created if you have a Professional, Business or Enterprise account or are using a particular Cloudflare product.
 
 ## Configure notifications
 
@@ -38,7 +40,7 @@ You can create a notification via the Cloudflare dashboard.
 
 :::note
 
-Professional and Business plans will have access to other options such as configuring PagerDuty or accessing webhooks. 
+Professional and Business plans will have access to more notifications and PagerDuty. Accounts with a paid service will additionally have access to webhooks. 
 :::
 
 6. (Optional) Specify any additional options for the notification, if required. For example, some notifications require that you select one or more domains or services.

--- a/src/content/docs/notifications/get-started/index.mdx
+++ b/src/content/docs/notifications/get-started/index.mdx
@@ -21,7 +21,7 @@ You can also create a notification if you have the account edit role, which allo
 
 An API token needs to have the [Notifications Read/Write permission](https://developers.cloudflare.com/fundamentals/api/reference/permissions/) to create a notification,
 
-Some notifications can only be created if you have a Professional, Business or Enterprise account or are using a particular Cloudflare product.
+Some notifications can only be created if you have a Professional, Business or Enterprise account or if you are using a particular Cloudflare product.
 
 ## Configure notifications
 


### PR DESCRIPTION
Please feel free to re-word / clarify the edits, I wanted to provide a bit more detail with the permissions.

### Summary

It was implied that customers could scope down notification creation access to particular products. This isn't true at the current time.

A customer with account edit permissions can create any account level notification policy, similarly a token with "Account Settings: Edit" can create any kind of notification policy.

The restrictions on creation of policies depends on the products that an account is entitled to (e.g enterprise, business, professional or free).

I also clarified that webhooks are available to everyone with a paid service, for example if you pay for Cloudflare Workers you get webhooks.

### Screenshots (optional)

n/a

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
