### PR TITLE
Update public-buckets.mdx with `partial` zone restriction

### DIFF
--- a/src/content/docs/r2/buckets/public-buckets.mdx
+++ b/src/content/docs/r2/buckets/public-buckets.mdx
@@ -69,6 +69,7 @@ If the zone is on an Enterprise plan, make sure that you [release the zone hold]
 ### Restrictions
 
 There is a restriction when using custom domains to access R2 buckets. The domain being used must belong to the same account as the R2 bucket.
+The zone containing an R2 Custom Domain must not use a `partial` DNS setup.
 
 ## Disable domain access
 


### PR DESCRIPTION
### Summary

It seems that R2 custom domain doesn't work when the record is created within a zone that uses partial DNS setup.

Tested using the web console and using the [r2_bucket_custom_domain](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_custom_domain) Terraform resource. The error in both cases is non-descriptive - Terraform fails with saying that `zone_id` is `incorrect`, and webconsole configures the domain, shows it as green in the R2 bucket settings, but it doesn't work. 

On a non-partial domain both TF resource and webconsole works. I used a subdomain delegation setup