### PR TITLE
[Chore] Remove 'content_type' property b/c we can infer it

### DIFF
--- a/src/components/ListTutorials.astro
+++ b/src/components/ListTutorials.astro
@@ -20,6 +20,8 @@ if (!currentProduct) {
 }
 
 const productTitle = currentProduct.data.product.title;
+const videoText = "🎥 Video"
+const tutorialText = "📝 Tutorial"
 
 const docs = await getCollection("docs", (entry) => {
 	return (
@@ -82,7 +84,7 @@ const timeAgo = (date?: Date) => {
 							<Fragment set:html={anchor} />
 						</td>
 						<td>{timeAgo(tutorial.data.updated)}</td>
-						<td>{tutorial.data.content_type}</td>
+						<td>{tutorial.collection === "docs" ? tutorialText : videoText}</td>
 						<td>{tutorial.data.difficulty}</td>
 					</tr>
 				);

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -1,6 +1,5 @@
 ---
 pcx_content_type: tutorial
-
 difficulty: Beginner
 updated: 2024-08-01
 title: Create your first AI Gateway using Workers AI

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 difficulty: Beginner
 updated: 2024-08-01
 title: Create your first AI Gateway using Workers AI

--- a/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
+++ b/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-09-27
 difficulty: Beginner
-
 pcx_content_type: tutorial
 tags:
   - AI

--- a/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
+++ b/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-09-27
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 tags:
   - AI

--- a/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
@@ -6,7 +6,6 @@ products:
   - Durable Objects
   - R2
 difficulty: Beginner
-
 updated: 2023-09-28
 languages:
   - JavaScript

--- a/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
@@ -6,7 +6,7 @@ products:
   - Durable Objects
   - R2
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 updated: 2023-09-28
 languages:
   - JavaScript

--- a/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
@@ -2,7 +2,7 @@
 updated: 2023-11-27
 category: 🔐 Access
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Create custom headers for Cloudflare Access-protected origins with Workers
 products:

--- a/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
@@ -2,7 +2,6 @@
 updated: 2023-11-27
 category: 🔐 Access
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Create custom headers for Cloudflare Access-protected origins with Workers
 products:

--- a/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
@@ -6,7 +6,7 @@ pcx_content_type: tutorial
 title: Use Cloudflare R2 as a Zero Trust log destination
 products:
   - R2
-content_type: 📝 Tutorial
+
 
 ---
 

--- a/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
@@ -7,7 +7,6 @@ title: Use Cloudflare R2 as a Zero Trust log destination
 products:
   - R2
 
-
 ---
 
 :::note

--- a/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-01
 difficulty: Intermediate
-content_type: 🎥 Video
+
 pcx_content_type: tutorial
 title: Build a Comments API
 products:

--- a/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-01
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build a Comments API
 products:

--- a/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-03-21
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build a Staff Directory Application
 products:

--- a/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-03-21
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a Staff Directory Application
 products:

--- a/src/content/docs/d1/tutorials/build-an-api-to-access-d1/index.mdx
+++ b/src/content/docs/d1/tutorials/build-an-api-to-access-d1/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-09-20
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build an API to access D1 using a proxy Worker
 products:

--- a/src/content/docs/d1/tutorials/build-an-api-to-access-d1/index.mdx
+++ b/src/content/docs/d1/tutorials/build-an-api-to-access-d1/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-09-20
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build an API to access D1 using a proxy Worker
 products:

--- a/src/content/docs/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.mdx
@@ -2,7 +2,7 @@
 updated: 2024-04-21
 pcx_content_type: tutorial
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 title: Create a sitemap from Sanity CMS with Workers
 products:
   - Workers

--- a/src/content/docs/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/create-sitemap-from-sanity-cms.mdx
@@ -2,7 +2,6 @@
 updated: 2024-04-21
 pcx_content_type: tutorial
 difficulty: Beginner
-
 title: Create a sitemap from Sanity CMS with Workers
 products:
   - Workers

--- a/src/content/docs/developer-spotlight/tutorials/creating-a-recommendation-api.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/creating-a-recommendation-api.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-06-24
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Recommend products on e-commerce sites using Workers AI and Stripe
 products:

--- a/src/content/docs/developer-spotlight/tutorials/creating-a-recommendation-api.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/creating-a-recommendation-api.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-06-24
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Recommend products on e-commerce sites using Workers AI and Stripe
 products:

--- a/src/content/docs/developer-spotlight/tutorials/custom-access-control-for-files.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/custom-access-control-for-files.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-06-17
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Custom access control for files in R2 using D1 and Workers
 products:

--- a/src/content/docs/developer-spotlight/tutorials/custom-access-control-for-files.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/custom-access-control-for-files.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-06-17
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Custom access control for files in R2 using D1 and Workers
 products:

--- a/src/content/docs/developer-spotlight/tutorials/fullstack-authentication-with-next-js-and-cloudflare-d1.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/fullstack-authentication-with-next-js-and-cloudflare-d1.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2025-01-13
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Setup Fullstack Authentication with Next.js, Auth.js, and Cloudflare D1
 products:

--- a/src/content/docs/developer-spotlight/tutorials/fullstack-authentication-with-next-js-and-cloudflare-d1.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/fullstack-authentication-with-next-js-and-cloudflare-d1.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2025-01-13
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Setup Fullstack Authentication with Next.js, Auth.js, and Cloudflare D1
 products:

--- a/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-06-17
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Send form submissions using Astro and Resend
 products:

--- a/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
+++ b/src/content/docs/developer-spotlight/tutorials/handle-form-submission-with-astro-resend.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-06-17
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Send form submissions using Astro and Resend
 products:

--- a/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
+++ b/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-09-24
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a seat booking app with SQLite in Durable Objects
 products:

--- a/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
+++ b/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-09-24
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build a seat booking app with SQLite in Durable Objects
 products:

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-10-30
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed time-series API with Timescale
 products:

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-10-30
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed time-series API with Timescale
 products:

--- a/src/content/docs/load-balancing/pools/cloudflare-pages-origin.mdx
+++ b/src/content/docs/load-balancing/pools/cloudflare-pages-origin.mdx
@@ -3,7 +3,6 @@ pcx_content_type: tutorial
 title: Use Pages as an origin for Load Balancing
 updated: 2024-07-03
 difficulty: Beginner
-
 products:
   - Pages
 sidebar:

--- a/src/content/docs/load-balancing/pools/cloudflare-pages-origin.mdx
+++ b/src/content/docs/load-balancing/pools/cloudflare-pages-origin.mdx
@@ -3,7 +3,7 @@ pcx_content_type: tutorial
 title: Use Pages as an origin for Load Balancing
 updated: 2024-07-03
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 products:
   - Pages
 sidebar:

--- a/src/content/docs/magic-firewall/tutorials/graphql-analytics.mdx
+++ b/src/content/docs/magic-firewall/tutorials/graphql-analytics.mdx
@@ -1,7 +1,6 @@
 ---
 title: GraphQL Analytics
 pcx_content_type: tutorial
-
 languages:
   - GraphQL
 sidebar:

--- a/src/content/docs/magic-firewall/tutorials/graphql-analytics.mdx
+++ b/src/content/docs/magic-firewall/tutorials/graphql-analytics.mdx
@@ -1,7 +1,7 @@
 ---
 title: GraphQL Analytics
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 languages:
   - GraphQL
 sidebar:

--- a/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
+++ b/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-04-01
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Deploy a static WordPress site
 tags:

--- a/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
+++ b/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-04-01
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Deploy a static WordPress site
 tags:

--- a/src/content/docs/pages/tutorials/add-a-react-form-with-formspree/index.mdx
+++ b/src/content/docs/pages/tutorials/add-a-react-form-with-formspree/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2021-11-30
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Add a React form with Formspree
 tags:

--- a/src/content/docs/pages/tutorials/add-a-react-form-with-formspree/index.mdx
+++ b/src/content/docs/pages/tutorials/add-a-react-form-with-formspree/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2021-11-30
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Add a React form with Formspree
 tags:

--- a/src/content/docs/pages/tutorials/add-an-html-form-with-formspree/index.mdx
+++ b/src/content/docs/pages/tutorials/add-an-html-form-with-formspree/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2021-11-30
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Add an HTML form with Formspree
 tags:

--- a/src/content/docs/pages/tutorials/add-an-html-form-with-formspree/index.mdx
+++ b/src/content/docs/pages/tutorials/add-an-html-form-with-formspree/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2021-11-30
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Add an HTML form with Formspree
 tags:

--- a/src/content/docs/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.mdx
+++ b/src/content/docs/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2022-08-03
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 difficulty: Intermediate
 title: Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages
 tags:

--- a/src/content/docs/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.mdx
+++ b/src/content/docs/pages/tutorials/build-a-blog-using-nuxt-and-sanity/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2022-08-03
 pcx_content_type: tutorial
-
 difficulty: Intermediate
 title: Build a blog using Nuxt.js and Sanity.io on Cloudflare Pages
 tags:

--- a/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
+++ b/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-01
 pcx_content_type: tutorial
-
 difficulty: Intermediate
 title: Build an API for your front end using Pages Functions
 languages:

--- a/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
+++ b/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-01
 pcx_content_type: tutorial
-content_type: 🎥 Video
+
 difficulty: Intermediate
 title: Build an API for your front end using Pages Functions
 languages:

--- a/src/content/docs/pages/tutorials/forms/index.mdx
+++ b/src/content/docs/pages/tutorials/forms/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2022-07-28
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Create a HTML form
 tags:

--- a/src/content/docs/pages/tutorials/forms/index.mdx
+++ b/src/content/docs/pages/tutorials/forms/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2022-07-28
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Create a HTML form
 tags:

--- a/src/content/docs/pages/tutorials/localize-a-website/index.mdx
+++ b/src/content/docs/pages/tutorials/localize-a-website/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-05-06
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Localize a website with HTMLRewriter
 languages:

--- a/src/content/docs/pages/tutorials/localize-a-website/index.mdx
+++ b/src/content/docs/pages/tutorials/localize-a-website/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-05-06
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Localize a website with HTMLRewriter
 languages:

--- a/src/content/docs/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.mdx
+++ b/src/content/docs/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-07-22
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Use R2 as static asset storage with Cloudflare Pages
 products:

--- a/src/content/docs/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.mdx
+++ b/src/content/docs/pages/tutorials/use-r2-as-static-asset-storage-for-pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-07-22
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Use R2 as static asset storage with Cloudflare Pages
 products:

--- a/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
+++ b/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
@@ -3,7 +3,7 @@ updated: 2024-09-25
 difficulty: Beginner
 title: Handle rate limits of external APIs
 summary: Example of how to use Queues to handle rate limits of external APIs.
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 products:
   - Workers

--- a/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
+++ b/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
@@ -3,7 +3,6 @@ updated: 2024-09-25
 difficulty: Beginner
 title: Handle rate limits of external APIs
 summary: Example of how to use Queues to handle rate limits of external APIs.
-
 pcx_content_type: tutorial
 products:
   - Workers

--- a/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
+++ b/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
@@ -3,7 +3,7 @@ updated: 2024-08-06
 difficulty: Intermediate
 title: Build a web crawler with Queues and Browser Rendering
 summary: Example of how to use Queues and Browser Rendering to power a web crawler.
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 products:
   - Workers

--- a/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
+++ b/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
@@ -3,7 +3,6 @@ updated: 2024-08-06
 difficulty: Intermediate
 title: Build a web crawler with Queues and Browser Rendering
 summary: Example of how to use Queues and Browser Rendering to power a web crawler.
-
 pcx_content_type: tutorial
 products:
   - Workers

--- a/src/content/docs/r2/examples/ssec.mdx
+++ b/src/content/docs/r2/examples/ssec.mdx
@@ -2,7 +2,7 @@
 title: Use SSE-C
 pcx_content_type: tutorial
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 updated: 2024-09-27
 ---
 

--- a/src/content/docs/r2/examples/ssec.mdx
+++ b/src/content/docs/r2/examples/ssec.mdx
@@ -2,7 +2,6 @@
 title: Use SSE-C
 pcx_content_type: tutorial
 difficulty: Intermediate
-
 updated: 2024-09-27
 ---
 

--- a/src/content/docs/r2/tutorials/cloudflare-access.mdx
+++ b/src/content/docs/r2/tutorials/cloudflare-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: Protect an R2 Bucket with Cloudflare Access
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 updated: 2024-04-16
 
 ---

--- a/src/content/docs/r2/tutorials/cloudflare-access.mdx
+++ b/src/content/docs/r2/tutorials/cloudflare-access.mdx
@@ -1,7 +1,6 @@
 ---
 title: Protect an R2 Bucket with Cloudflare Access
 pcx_content_type: tutorial
-
 updated: 2024-04-16
 
 ---

--- a/src/content/docs/r2/tutorials/mastodon.mdx
+++ b/src/content/docs/r2/tutorials/mastodon.mdx
@@ -2,7 +2,7 @@
 title: Mastodon
 pcx_content_type: tutorial
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 updated: 2023-01-31
 
 ---

--- a/src/content/docs/r2/tutorials/mastodon.mdx
+++ b/src/content/docs/r2/tutorials/mastodon.mdx
@@ -2,7 +2,6 @@
 title: Mastodon
 pcx_content_type: tutorial
 difficulty: Beginner
-
 updated: 2023-01-31
 
 ---

--- a/src/content/docs/r2/tutorials/postman.mdx
+++ b/src/content/docs/r2/tutorials/postman.mdx
@@ -1,7 +1,7 @@
 ---
 title: Postman
 summary: Learn how to configure Postman to interact with R2.
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 description: Learn how to configure Postman to interact with R2.
 updated: 2022-07-15

--- a/src/content/docs/r2/tutorials/postman.mdx
+++ b/src/content/docs/r2/tutorials/postman.mdx
@@ -1,7 +1,6 @@
 ---
 title: Postman
 summary: Learn how to configure Postman to interact with R2.
-
 pcx_content_type: tutorial
 description: Learn how to configure Postman to interact with R2.
 updated: 2022-07-15

--- a/src/content/docs/r2/tutorials/summarize-pdf.mdx
+++ b/src/content/docs/r2/tutorials/summarize-pdf.mdx
@@ -1,7 +1,6 @@
 ---
 title: Use event notification to summarize PDF files on upload
 pcx_content_type: tutorial
-
 products:
   - Queues
   - Workers

--- a/src/content/docs/r2/tutorials/summarize-pdf.mdx
+++ b/src/content/docs/r2/tutorials/summarize-pdf.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use event notification to summarize PDF files on upload
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 products:
   - Queues
   - Workers

--- a/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
+++ b/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
@@ -1,7 +1,7 @@
 ---
 title: Log and store upload events in R2 with event notifications
 pcx_content_type: tutorial
-content_type: 📝 Tutorial
+
 products:
   - Queues
   - Workers

--- a/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
+++ b/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
@@ -1,7 +1,6 @@
 ---
 title: Log and store upload events in R2 with event notifications
 pcx_content_type: tutorial
-
 products:
   - Queues
   - Workers

--- a/src/content/docs/turnstile/tutorials/excluding-turnstile-from-e2e-tests.mdx
+++ b/src/content/docs/turnstile/tutorials/excluding-turnstile-from-e2e-tests.mdx
@@ -3,7 +3,7 @@ title: Exclude Turnstile from E2E tests
 pcx_content_type: tutorial
 updated: 2025-01-24
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 languages:
   - TypeScript
 tags:

--- a/src/content/docs/turnstile/tutorials/excluding-turnstile-from-e2e-tests.mdx
+++ b/src/content/docs/turnstile/tutorials/excluding-turnstile-from-e2e-tests.mdx
@@ -3,7 +3,6 @@ title: Exclude Turnstile from E2E tests
 pcx_content_type: tutorial
 updated: 2025-01-24
 difficulty: Intermediate
-
 languages:
   - TypeScript
 tags:

--- a/src/content/docs/turnstile/tutorials/implicit-vs-explicit-rendering.mdx
+++ b/src/content/docs/turnstile/tutorials/implicit-vs-explicit-rendering.mdx
@@ -3,7 +3,7 @@ title: Implement Turnstile using implicit and explicit rendering
 pcx_content_type: tutorial
 updated: 2024-09-16
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/turnstile/tutorials/implicit-vs-explicit-rendering.mdx
+++ b/src/content/docs/turnstile/tutorials/implicit-vs-explicit-rendering.mdx
@@ -3,7 +3,6 @@ title: Implement Turnstile using implicit and explicit rendering
 pcx_content_type: tutorial
 updated: 2024-09-16
 difficulty: Beginner
-
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
+++ b/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
@@ -3,7 +3,6 @@ title: Integrate Turnstile, WAF, & Bot Management
 pcx_content_type: tutorial
 updated: 2024-09-17
 difficulty: Beginner
-
 products:
   - Web Application Firewall
   - Bot Management

--- a/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
+++ b/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
@@ -3,7 +3,7 @@ title: Integrate Turnstile, WAF, & Bot Management
 pcx_content_type: tutorial
 updated: 2024-09-17
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 products:
   - Web Application Firewall
   - Bot Management

--- a/src/content/docs/turnstile/tutorials/login-pages.mdx
+++ b/src/content/docs/turnstile/tutorials/login-pages.mdx
@@ -3,7 +3,6 @@ title: Protect your login pages
 pcx_content_type: tutorial
 updated: 2024-07-09
 difficulty: Beginner
-
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/turnstile/tutorials/login-pages.mdx
+++ b/src/content/docs/turnstile/tutorials/login-pages.mdx
@@ -3,7 +3,7 @@ title: Protect your login pages
 pcx_content_type: tutorial
 updated: 2024-07-09
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/turnstile/tutorials/protecting-your-payment-form-from-attackers-bots-using-turnstile.mdx
+++ b/src/content/docs/turnstile/tutorials/protecting-your-payment-form-from-attackers-bots-using-turnstile.mdx
@@ -3,7 +3,7 @@ title: Protect payment forms from malicious bots using Turnstile
 pcx_content_type: tutorial
 updated: 2024-12-17
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/turnstile/tutorials/protecting-your-payment-form-from-attackers-bots-using-turnstile.mdx
+++ b/src/content/docs/turnstile/tutorials/protecting-your-payment-form-from-attackers-bots-using-turnstile.mdx
@@ -3,7 +3,6 @@ title: Protect payment forms from malicious bots using Turnstile
 pcx_content_type: tutorial
 updated: 2024-12-17
 difficulty: Beginner
-
 languages:
   - JavaScript
 tags:

--- a/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-11-21
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Build a Retrieval Augmented Generation (RAG) AI
 products:

--- a/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-11-21
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a Retrieval Augmented Generation (RAG) AI
 products:

--- a/src/content/docs/workers-ai/tutorials/build-a-voice-notes-app-with-auto-transcription.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-voice-notes-app-with-auto-transcription.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-12-18
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build a Voice Notes App with auto transcriptions using Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/build-a-voice-notes-app-with-auto-transcription.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-a-voice-notes-app-with-auto-transcription.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-12-18
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a Voice Notes App with auto transcriptions using Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-11-06
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build an interview practice tool with Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
+++ b/src/content/docs/workers-ai/tutorials/build-ai-interview-practice-tool.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-11-06
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build an interview practice tool with Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-02-08
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Explore Code Generation Using DeepSeek Coder Models
 tags:

--- a/src/content/docs/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-02-08
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Explore Code Generation Using DeepSeek Coder Models
 tags:

--- a/src/content/docs/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.mdx
+++ b/src/content/docs/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-07-29
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Explore Workers AI Models Using a Jupyter Notebook
 tags:

--- a/src/content/docs/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.mdx
+++ b/src/content/docs/workers-ai/tutorials/explore-workers-ai-models-using-a-jupyter-notebook.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-07-29
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Explore Workers AI Models Using a Jupyter Notebook
 tags:

--- a/src/content/docs/workers-ai/tutorials/fine-tune-models-with-autotrain.mdx
+++ b/src/content/docs/workers-ai/tutorials/fine-tune-models-with-autotrain.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-04-01
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Fine Tune Models With AutoTrain from HuggingFace
 tags:

--- a/src/content/docs/workers-ai/tutorials/fine-tune-models-with-autotrain.mdx
+++ b/src/content/docs/workers-ai/tutorials/fine-tune-models-with-autotrain.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-04-01
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Fine Tune Models With AutoTrain from HuggingFace
 tags:

--- a/src/content/docs/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.mdx
+++ b/src/content/docs/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-02-06
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Choose the Right Text Generation Model
 tags:

--- a/src/content/docs/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.mdx
+++ b/src/content/docs/workers-ai/tutorials/how-to-choose-the-right-text-generation-model.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-02-06
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Choose the Right Text Generation Model
 tags:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-content_type: 🎥 Video
+
 pcx_content_type: video
 title: Add New AI Models to your Playground (Part 2)
 sidebar:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux-newmodels.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-
 pcx_content_type: video
 title: Add New AI Models to your Playground (Part 2)
 sidebar:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-
 pcx_content_type: video
 title: Build an AI Image Generator Playground (Part 1)
 tableOfContents: false

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-flux.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-content_type: 🎥 Video
+
 pcx_content_type: video
 title: Build an AI Image Generator Playground (Part 1)
 tableOfContents: false

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2025-01-29
 difficulty: Beginner
-content_type: 🎥 Video
+
 pcx_content_type: video
 title: Store and Catalog AI Generated Images with R2 (Part 3)
 sidebar:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/image-generator-store-and-catalog.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2025-01-29
 difficulty: Beginner
-
 pcx_content_type: video
 title: Store and Catalog AI Generated Images with R2 (Part 3)
 sidebar:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/index.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-content_type: 🎥 Video
+
 pcx_content_type: tutorial
 title: How to Build an Image Generator using Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/image-generation-playground/index.mdx
+++ b/src/content/docs/workers-ai/tutorials/image-generation-playground/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-17
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: How to Build an Image Generator using Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/llama-vision-tutorial.mdx
+++ b/src/content/docs/workers-ai/tutorials/llama-vision-tutorial.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2025-02-05
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Llama 3.2 11B Vision Instruct model on Cloudflare Workers AI
 tags:

--- a/src/content/docs/workers-ai/tutorials/llama-vision-tutorial.mdx
+++ b/src/content/docs/workers-ai/tutorials/llama-vision-tutorial.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2025-02-05
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Llama 3.2 11B Vision Instruct model on Cloudflare Workers AI
 tags:

--- a/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-10-21
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Using BigQuery with Workers AI
 products:

--- a/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
+++ b/src/content/docs/workers-ai/tutorials/using-bigquery-with-workers-ai.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-10-21
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Using BigQuery with Workers AI
 products:

--- a/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
+++ b/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-11-20
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Automate analytics reporting with Cloudflare Workers and email routing
 products:

--- a/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
+++ b/src/content/docs/workers/tutorials/automated-analytics-reporting/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-11-20
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Automate analytics reporting with Cloudflare Workers and email routing
 products:

--- a/src/content/docs/workers/tutorials/build-a-jamstack-app/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-jamstack-app/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-05-14
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Build a todo list Jamstack application
 products:

--- a/src/content/docs/workers/tutorials/build-a-jamstack-app/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-jamstack-app/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-05-14
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a todo list Jamstack application
 products:

--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-06-29
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Build a QR code generator
 languages:

--- a/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-06-29
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a QR code generator
 languages:

--- a/src/content/docs/workers/tutorials/build-a-slackbot/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-slackbot/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-06-05
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build a Slackbot
 tags:

--- a/src/content/docs/workers/tutorials/build-a-slackbot/index.mdx
+++ b/src/content/docs/workers/tutorials/build-a-slackbot/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-06-05
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Build a Slackbot
 tags:

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-04-01
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Connect to and query your Turso database using Workers
 languages:

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-04-01
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Connect to and query your Turso database using Workers
 languages:

--- a/src/content/docs/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.mdx
+++ b/src/content/docs/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.mdx
@@ -1,5 +1,5 @@
 ---
-content_type: 📝 Tutorial
+
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Create a fine-tuned OpenAI model with R2

--- a/src/content/docs/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.mdx
+++ b/src/content/docs/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.mdx
@@ -1,5 +1,4 @@
 ---
-
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Create a fine-tuned OpenAI model with R2

--- a/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
+++ b/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-09-13
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Deploy a real-time chat application
 products:

--- a/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
+++ b/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-09-13
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Deploy a real-time chat application
 products:

--- a/src/content/docs/workers/tutorials/deploy-button/index.mdx
+++ b/src/content/docs/workers/tutorials/deploy-button/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-08-01
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Create a deploy button with GitHub Actions
 

--- a/src/content/docs/workers/tutorials/deploy-button/index.mdx
+++ b/src/content/docs/workers/tutorials/deploy-button/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-08-01
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Create a deploy button with GitHub Actions
 

--- a/src/content/docs/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.mdx
+++ b/src/content/docs/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-03-27
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Generate YouTube thumbnails with Workers and Cloudflare Image Resizing
 products:

--- a/src/content/docs/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.mdx
+++ b/src/content/docs/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-03-27
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Generate YouTube thumbnails with Workers and Cloudflare Image Resizing
 products:

--- a/src/content/docs/workers/tutorials/github-sms-notifications-using-twilio/index.mdx
+++ b/src/content/docs/workers/tutorials/github-sms-notifications-using-twilio/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-09-28
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: GitHub SMS notifications using Twilio
 languages:

--- a/src/content/docs/workers/tutorials/github-sms-notifications-using-twilio/index.mdx
+++ b/src/content/docs/workers/tutorials/github-sms-notifications-using-twilio/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-09-28
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: GitHub SMS notifications using Twilio
 languages:

--- a/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable/index.mdx
+++ b/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-06-13
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Handle form submissions with Airtable
 tags:

--- a/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable/index.mdx
+++ b/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-06-13
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Handle form submissions with Airtable
 tags:

--- a/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
+++ b/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-11-07
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Build Live Cursors with Next.js, RPC and Durable Objects
 products:

--- a/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
+++ b/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-11-07
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Build Live Cursors with Next.js, RPC and Durable Objects
 products:

--- a/src/content/docs/workers/tutorials/openai-function-calls-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/openai-function-calls-workers/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-06-14
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: OpenAI GPT function calling with JavaScript and Cloudflare Workers
 languages:

--- a/src/content/docs/workers/tutorials/openai-function-calls-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/openai-function-calls-workers/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-06-14
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: OpenAI GPT function calling with JavaScript and Cloudflare Workers
 languages:

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-08-23
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Connect to a PostgreSQL database with Cloudflare Workers
 products:

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-08-23
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Connect to a PostgreSQL database with Cloudflare Workers
 products:

--- a/src/content/docs/workers/tutorials/send-emails-with-postmark/index.mdx
+++ b/src/content/docs/workers/tutorials/send-emails-with-postmark/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-05-02
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Send Emails With Postmark
 tags:

--- a/src/content/docs/workers/tutorials/send-emails-with-postmark/index.mdx
+++ b/src/content/docs/workers/tutorials/send-emails-with-postmark/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-05-02
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Send Emails With Postmark
 tags:

--- a/src/content/docs/workers/tutorials/send-emails-with-resend/index.mdx
+++ b/src/content/docs/workers/tutorials/send-emails-with-resend/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-04-26
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Send Emails With Resend
 tags:

--- a/src/content/docs/workers/tutorials/send-emails-with-resend/index.mdx
+++ b/src/content/docs/workers/tutorials/send-emails-with-resend/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-04-26
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Send Emails With Resend
 tags:

--- a/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
+++ b/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-09-05
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed REST API with Fauna
 tags:

--- a/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
+++ b/src/content/docs/workers/tutorials/store-data-with-fauna/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-09-05
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed REST API with Fauna
 tags:

--- a/src/content/docs/workers/tutorials/upload-assets-with-r2/index.mdx
+++ b/src/content/docs/workers/tutorials/upload-assets-with-r2/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2023-06-15
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Securely access and upload assets with Cloudflare R2
 products:

--- a/src/content/docs/workers/tutorials/upload-assets-with-r2/index.mdx
+++ b/src/content/docs/workers/tutorials/upload-assets-with-r2/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2023-06-15
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Securely access and upload assets with Cloudflare R2
 products:

--- a/src/content/docs/workers/tutorials/using-prisma-postgres-with-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/using-prisma-postgres-with-workers/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2025-02-12
 difficulty: Beginner
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Set up and use a Prisma Postgres database
 languages:

--- a/src/content/docs/workers/tutorials/using-prisma-postgres-with-workers/index.mdx
+++ b/src/content/docs/workers/tutorials/using-prisma-postgres-with-workers/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2025-02-12
 difficulty: Beginner
-
 pcx_content_type: tutorial
 title: Set up and use a Prisma Postgres database
 languages:

--- a/src/content/docs/workers/tutorials/workers-kv-from-rust/index.mdx
+++ b/src/content/docs/workers/tutorials/workers-kv-from-rust/index.mdx
@@ -1,7 +1,7 @@
 ---
 updated: 2024-05-15
 difficulty: Intermediate
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Use Workers KV directly from Rust
 products:

--- a/src/content/docs/workers/tutorials/workers-kv-from-rust/index.mdx
+++ b/src/content/docs/workers/tutorials/workers-kv-from-rust/index.mdx
@@ -1,7 +1,6 @@
 ---
 updated: 2024-05-15
 difficulty: Intermediate
-
 pcx_content_type: tutorial
 title: Use Workers KV directly from Rust
 products:

--- a/src/content/videos/index.yaml
+++ b/src/content/videos/index.yaml
@@ -9,7 +9,7 @@
   author: craig
   updated: 2024-06-20
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MlV9Kvkh9hw
   id: Build a URL Shortener with an AI-based admin section
   description: We are building a URL Shortener, shrty.dev, on Cloudflare. The apps uses Workers KV and Workers Analytics engine. Craig decided to build with Workers AI runWithTools to provide a chat interface for admins.
@@ -20,7 +20,7 @@
   author: craig
   updated: 2024-07-01
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=dttu4QtKkO0
   id: Build Rust Powered Apps
   description: In this video, we will show you how to build a global database using workers-rs to keep track of every country and city you’ve visited.
@@ -31,7 +31,7 @@
   author: confidence
   updated: 2024-06-25
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=GRpwVMkVmKo
   id: API Roll (Father's Day)
   description: This walks through how to use Workers AI with Hono and Zod to create a streaming pun generating API.
@@ -42,7 +42,7 @@
   author: craig
   updated: 2024-06-15
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MLbo7MGY_lU
   id: AI can see clearly now - Build Vision Apps on Cloudflare Workers AI
   description: The LlaVa model is hosted on Cloudflare Workers AI. Which means you are an API call away from brand new powerful vision use cases in all of your applications.
@@ -53,7 +53,7 @@
   author: craig
   updated: 2024-06-11
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=QTsaAhFvX9o
   id: Stateful Apps with Cloudflare Workers
   description: Learn how to access external APIs, cache and retrieve data using Workers KV, and create SQL-driven applications with Cloudflare D1.
@@ -64,7 +64,7 @@
   author: kristian
   updated: 2024-05-22
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=5UTExUQ8Fwo
   id: Workers AI - Getting Started - Vanilla Chat App
   description: Get started building AI apps on Cloudflare using Pages and the GitHub starter template for a Vanilla JavaScript Chat App.
@@ -75,7 +75,7 @@
   author: craig
   updated: 2024-04-17
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=H7Qe96fqg1M
   id: Learn Cloudflare Workers - Full Course for Beginners
   description: Learn how to build your first Cloudflare Workers application and deploy it to Cloudflare's global network.
@@ -86,7 +86,7 @@
   author: kristian
   updated: 2024-03-12
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=8SnrvAYAJ4Q
   id: Image Generation, Inpainting, and Vision Models
   description: Is that person you are about to swipe right on, actually real? Are they AI Generated?
@@ -97,7 +97,7 @@
   author: craig
   updated: 2024-03-08
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=9JM5Z0KzQsQ
   id: Learn AI Development (models, embeddings, vectors)
   description: In this workshop, Kristian Freeman, Cloudflare Developer Advocate, teaches the basics of AI Development - models, embeddings, and vectors (including vector databases).
@@ -107,7 +107,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=idKdjA8t0jw
   id: Optimize your AI App & fine-tune models (AI Gateway, R2)
   description: In this workshop, Kristian Freeman, Cloudflare Developer Advocate, shows how to optimize your existing AI applications with Cloudflare AI Gateway, and how to finetune OpenAI models using R2.
@@ -118,7 +118,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=CHfKeFakGAI
   id: How to use Cloudflare AI models and inference in Python with Jupyter Notebooks
   description: Cloudflare Workers AI provides a ton of AI models and inference capabilities. In this video, we will explore how to make use of Cloudflare’s AI model catalog using a Python Jupyter Notebook.
@@ -129,7 +129,7 @@
   author: craig
   updated: 2023-12-14
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/cK_leoJsBWY
   id: Cloudflare Workers AI, Building a "Hello, World" AI App!
   description: Cloudflare's Workers AI helps you add AI functionality to the apps you are building. In this video we show you how simple and straightforward it is to build the Hello World of AI apps in under 5 minutes.
@@ -141,7 +141,7 @@
   author: craig
   updated: 2024-09-11
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/9IjfyBJsJRQ
   id: Use Vectorize to add additional context to your AI Applications through RAG
   description: A RAG based AI Chat app that uses Vectorize to access video game data for employees of Gamertown.
@@ -153,7 +153,7 @@
   author: craig
   updated: 2024-09-12
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/doKt9wWQF9A
   id: AI meets Maps | Using Cloudflare AI, Langchain, Mapbox, Folium and Streamlit
   description: Welcome to RouteMe, a smart tool that helps you plan the most efficient route between landmarks in any city. Powered by Cloudflare Workers AI, Langchain and Mapbox. This Streamlit webapp uses LLMs and Mapbox off my scripts API to solve the classic traveling salesman problem, turning your sightseeing into an optimized adventure!
@@ -165,7 +165,7 @@
   author: lizzie
   updated: 2024-09-16
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/bwJkwD-F0kQ
   id: Welcome to the Cloudflare Developer Channel
   description: Welcome to the Cloudflare Developers YouTube channel. We've got tutorials and working demos and everything you need to level up your projects. Whether you're working on your next big thing or just dorking around with some side projects, we've got you covered! So why don't you come hang out, subscribe to our developer channel and together we'll build something awesome. You're gonna love it.
@@ -177,7 +177,7 @@
   author: craig
   updated: 2024-09-18
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/10-kiyJNr8s
   id: Build a private AI chatbot using Meta's Llama 3.1
   description: In this video, you will learn how to set up a private AI chat powered by Llama 3.1 for secure, fast interactions, deploy the model on Cloudflare Workers for serverless, scalable performance and use Cloudflare's Workers AI for seamless integration and edge computing benefits.
@@ -189,7 +189,7 @@
   author: confidence
   updated: 2024-10-07
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-hono-site/#creator-interview
   id: DevTalk | Episode 01 - Yusuke Wada, creator of Hono Framework
   description: In this interview, Yusuke Wada reflects on his journey in developing Hono.
@@ -200,7 +200,7 @@
   author: yusuke
   updated: 2024-10-08
   difficulty: Beginner
-  pcx_content_type: interview
+    pcx_content_type: interview
 - link: https://youtu.be/W45MIi_t_go
   id: Building Front-End Applications | Now Supported by Cloudflare Workers
   description: You can now build front-end applications, just like you do on Cloudflare Pages, but with the added benefit of Workers.
@@ -212,7 +212,7 @@
   author: confidence
   updated: 2024-10-23
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/HXOpxNaKUzw
   id: How to Build Event-Driven Applications with Cloudflare Queues
   description: In this video, we demonstrate how to build an event-driven application using Cloudflare Queues. Event-driven system lets you decouple services, allowing them to process and scale independently.
@@ -224,7 +224,7 @@
   author: harshil
   updated: 2024-09-26
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/slS4RBV0SBk
   id: Cloudflare Workflows | Introduction (Part 1 of 3)
   description: In this video, we introduce Cloudflare Workflows, the Newest Developer Platform Primitive at Cloudflare.
@@ -236,7 +236,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/y4PPsvHrQGA
   id: Cloudflare Workflows | Batching and Monitoring Your Durable Execution (Part 2 of 3)
   description: Workflows exposes metrics such as execution, error rates, steps, and total duration!
@@ -248,7 +248,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/L6gR4Yr3UW8
   id: Cloudflare Workflows | Schedule and Sleep For Your Apps (Part 3 of 3)
   description: Cloudflare Workflows allows you to initiate sleep as an explicit step, which can be useful when you want a Workflow to wait, schedule work ahead, or pause until an input or other external state is ready.
@@ -260,7 +260,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/frameworks/framework-guides/nextjs/#video-tutorial
   id: Deploy Your NextJS Application To Workers
   description: Watch to learn how to easily deploy your NextJS application to the Cloudflare global network.
@@ -272,7 +272,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/observability/logs/#video-tutorial
   id: Workers Observability
   description: With Workers Logs, you can collect, store, filter, and analyze all logging data from your Workers directly in the Cloudflare dashboard.
@@ -284,7 +284,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/RmF05GpLE20
   id: DevTalk Episode 02 | Post-Quantum Cryptography
   description: Bas Westerbaan is Cloudflare’s Research Lead on Post-Quantum efforts. His work ranges from cryptographic implementation and standardization, to driving large-scale experiment and subsequent deployment.
@@ -295,7 +295,7 @@
   author: bas
   updated: 2024-11-14
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/xu4Wb-IppmM
   id: OpenAI Relay Server on Cloudflare Workers
   description: In this video, Craig Dennis walks you through the deployment of OpenAI's relay server to use with their realtime API.
@@ -306,7 +306,7 @@
   author: craig
   updated: 2024-11-14
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/runtime-apis/rpc/#video-tutorial
   id: Workers RPC Tutorial
   description: Learn how to implement RPC in your JavaScript applications and build serverless solutions.
@@ -317,7 +317,7 @@
   author: confidence
   updated: 2024-11-10
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://youtu.be/B2bLUc3iOsI
   id: Deploy your React App to Cloudflare Workers
   description: Learn how to deploy an existing React application to Cloudflare Workers.
@@ -328,7 +328,7 @@
   author: confidence
   updated: 2024-11-05
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-an-astro-site/#video-tutorial
   id: Build a Full-Stack Application using Astro and Cloudflare Workers
   description: Learn how to deploy an Astro application to Cloudflare Workers.
@@ -339,7 +339,7 @@
   author: kristian
   updated: 2024-11-19
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workflows/examples/twilio/
   id: Schedule Twilio Messaging and Phone Calls with Workflows
   description: Integrate Workflows with Twilio. Learn how to receive and send text messages and phone calls via APIs and Webhooks.
@@ -350,7 +350,7 @@
   author: craig
   updated: 2024-11-30
   difficulty: Intermediate
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nuxt-site/#video-tutorial
   id: Deploy Your Nuxt Application To Workers
   description: Watch to learn how to easily deploy your Nuxt application to the Cloudflare global network.
@@ -361,7 +361,7 @@
   author: kristian
   updated: 2025-01-08
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers-ai/tutorials/image-generation-playground/
   id: How to Build an Image Generator using Workers AI
   description: In this series of videos, learn how to build an AI Image Playground, add new AI Models and store your generated images using R2.
@@ -372,7 +372,7 @@
   author: kristian
   updated: 2025-01-29
   difficulty: Beginner
-  pcx_content_type: tutorial
+    pcx_content_type: tutorial
 # - link:
 #   id:
 #   description:
@@ -383,4 +383,4 @@
 #   author:
 #   updated:
 #   difficulty: Intermediate
-#   pcx_content_type: tutorial
+#   #   pcx_content_type: tutorial

--- a/src/content/videos/index.yaml
+++ b/src/content/videos/index.yaml
@@ -9,7 +9,7 @@
   author: craig
   updated: 2024-06-20
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MlV9Kvkh9hw
   id: Build a URL Shortener with an AI-based admin section
@@ -21,7 +21,7 @@
   author: craig
   updated: 2024-07-01
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=dttu4QtKkO0
   id: Build Rust Powered Apps
@@ -33,7 +33,7 @@
   author: confidence
   updated: 2024-06-25
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=GRpwVMkVmKo
   id: API Roll (Father's Day)
@@ -45,7 +45,7 @@
   author: craig
   updated: 2024-06-15
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MLbo7MGY_lU
   id: AI can see clearly now - Build Vision Apps on Cloudflare Workers AI
@@ -57,7 +57,7 @@
   author: craig
   updated: 2024-06-11
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=QTsaAhFvX9o
   id: Stateful Apps with Cloudflare Workers
@@ -69,7 +69,7 @@
   author: kristian
   updated: 2024-05-22
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=5UTExUQ8Fwo
   id: Workers AI - Getting Started - Vanilla Chat App
@@ -81,7 +81,7 @@
   author: craig
   updated: 2024-04-17
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=H7Qe96fqg1M
   id: Learn Cloudflare Workers - Full Course for Beginners
@@ -93,7 +93,7 @@
   author: kristian
   updated: 2024-03-12
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=8SnrvAYAJ4Q
   id: Image Generation, Inpainting, and Vision Models
@@ -105,7 +105,7 @@
   author: craig
   updated: 2024-03-08
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=9JM5Z0KzQsQ
   id: Learn AI Development (models, embeddings, vectors)
@@ -116,7 +116,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=idKdjA8t0jw
   id: Optimize your AI App & fine-tune models (AI Gateway, R2)
@@ -128,7 +128,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=CHfKeFakGAI
   id: How to use Cloudflare AI models and inference in Python with Jupyter Notebooks
@@ -140,7 +140,7 @@
   author: craig
   updated: 2023-12-14
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/cK_leoJsBWY
   id: Cloudflare Workers AI, Building a "Hello, World" AI App!
@@ -153,7 +153,7 @@
   author: craig
   updated: 2024-09-11
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/9IjfyBJsJRQ
   id: Use Vectorize to add additional context to your AI Applications through RAG
@@ -166,7 +166,7 @@
   author: craig
   updated: 2024-09-12
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/doKt9wWQF9A
   id: AI meets Maps | Using Cloudflare AI, Langchain, Mapbox, Folium and Streamlit
@@ -179,7 +179,7 @@
   author: lizzie
   updated: 2024-09-16
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/bwJkwD-F0kQ
   id: Welcome to the Cloudflare Developer Channel
@@ -192,7 +192,7 @@
   author: craig
   updated: 2024-09-18
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/10-kiyJNr8s
   id: Build a private AI chatbot using Meta's Llama 3.1
@@ -205,7 +205,7 @@
   author: confidence
   updated: 2024-10-07
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-hono-site/#creator-interview
   id: DevTalk | Episode 01 - Yusuke Wada, creator of Hono Framework
@@ -217,7 +217,7 @@
   author: yusuke
   updated: 2024-10-08
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: interview
 - link: https://youtu.be/W45MIi_t_go
   id: Building Front-End Applications | Now Supported by Cloudflare Workers
@@ -230,7 +230,7 @@
   author: confidence
   updated: 2024-10-23
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/HXOpxNaKUzw
   id: How to Build Event-Driven Applications with Cloudflare Queues
@@ -243,7 +243,7 @@
   author: harshil
   updated: 2024-09-26
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/slS4RBV0SBk
   id: Cloudflare Workflows | Introduction (Part 1 of 3)
@@ -256,7 +256,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/y4PPsvHrQGA
   id: Cloudflare Workflows | Batching and Monitoring Your Durable Execution (Part 2 of 3)
@@ -269,7 +269,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/L6gR4Yr3UW8
   id: Cloudflare Workflows | Schedule and Sleep For Your Apps (Part 3 of 3)
@@ -282,7 +282,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/frameworks/framework-guides/nextjs/#video-tutorial
   id: Deploy Your NextJS Application To Workers
@@ -295,7 +295,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/observability/logs/#video-tutorial
   id: Workers Observability
@@ -308,7 +308,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/RmF05GpLE20
   id: DevTalk Episode 02 | Post-Quantum Cryptography
@@ -320,7 +320,7 @@
   author: bas
   updated: 2024-11-14
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/xu4Wb-IppmM
   id: OpenAI Relay Server on Cloudflare Workers
@@ -332,7 +332,7 @@
   author: craig
   updated: 2024-11-14
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/runtime-apis/rpc/#video-tutorial
   id: Workers RPC Tutorial
@@ -344,7 +344,7 @@
   author: confidence
   updated: 2024-11-10
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://youtu.be/B2bLUc3iOsI
   id: Deploy your React App to Cloudflare Workers
@@ -356,7 +356,7 @@
   author: confidence
   updated: 2024-11-05
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-an-astro-site/#video-tutorial
   id: Build a Full-Stack Application using Astro and Cloudflare Workers
@@ -368,7 +368,7 @@
   author: kristian
   updated: 2024-11-19
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workflows/examples/twilio/
   id: Schedule Twilio Messaging and Phone Calls with Workflows
@@ -380,7 +380,7 @@
   author: craig
   updated: 2024-11-30
   difficulty: Intermediate
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nuxt-site/#video-tutorial
   id: Deploy Your Nuxt Application To Workers
@@ -392,7 +392,7 @@
   author: kristian
   updated: 2025-01-08
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers-ai/tutorials/image-generation-playground/
   id: How to Build an Image Generator using Workers AI
@@ -404,7 +404,7 @@
   author: kristian
   updated: 2025-01-29
   difficulty: Beginner
-  content_type: 🎥 Video
+
   pcx_content_type: tutorial
 # - link:
 #   id:
@@ -416,5 +416,5 @@
 #   author:
 #   updated:
 #   difficulty: Intermediate
-#   content_type: 🎥 Video
+#
 #   pcx_content_type: tutorial

--- a/src/content/videos/index.yaml
+++ b/src/content/videos/index.yaml
@@ -9,7 +9,7 @@
   author: craig
   updated: 2024-06-20
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MlV9Kvkh9hw
   id: Build a URL Shortener with an AI-based admin section
   description: We are building a URL Shortener, shrty.dev, on Cloudflare. The apps uses Workers KV and Workers Analytics engine. Craig decided to build with Workers AI runWithTools to provide a chat interface for admins.
@@ -20,7 +20,7 @@
   author: craig
   updated: 2024-07-01
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=dttu4QtKkO0
   id: Build Rust Powered Apps
   description: In this video, we will show you how to build a global database using workers-rs to keep track of every country and city you’ve visited.
@@ -31,7 +31,7 @@
   author: confidence
   updated: 2024-06-25
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=GRpwVMkVmKo
   id: API Roll (Father's Day)
   description: This walks through how to use Workers AI with Hono and Zod to create a streaming pun generating API.
@@ -42,7 +42,7 @@
   author: craig
   updated: 2024-06-15
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MLbo7MGY_lU
   id: AI can see clearly now - Build Vision Apps on Cloudflare Workers AI
   description: The LlaVa model is hosted on Cloudflare Workers AI. Which means you are an API call away from brand new powerful vision use cases in all of your applications.
@@ -53,7 +53,7 @@
   author: craig
   updated: 2024-06-11
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=QTsaAhFvX9o
   id: Stateful Apps with Cloudflare Workers
   description: Learn how to access external APIs, cache and retrieve data using Workers KV, and create SQL-driven applications with Cloudflare D1.
@@ -64,7 +64,7 @@
   author: kristian
   updated: 2024-05-22
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=5UTExUQ8Fwo
   id: Workers AI - Getting Started - Vanilla Chat App
   description: Get started building AI apps on Cloudflare using Pages and the GitHub starter template for a Vanilla JavaScript Chat App.
@@ -75,7 +75,7 @@
   author: craig
   updated: 2024-04-17
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=H7Qe96fqg1M
   id: Learn Cloudflare Workers - Full Course for Beginners
   description: Learn how to build your first Cloudflare Workers application and deploy it to Cloudflare's global network.
@@ -86,7 +86,7 @@
   author: kristian
   updated: 2024-03-12
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=8SnrvAYAJ4Q
   id: Image Generation, Inpainting, and Vision Models
   description: Is that person you are about to swipe right on, actually real? Are they AI Generated?
@@ -97,7 +97,7 @@
   author: craig
   updated: 2024-03-08
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=9JM5Z0KzQsQ
   id: Learn AI Development (models, embeddings, vectors)
   description: In this workshop, Kristian Freeman, Cloudflare Developer Advocate, teaches the basics of AI Development - models, embeddings, and vectors (including vector databases).
@@ -107,7 +107,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=idKdjA8t0jw
   id: Optimize your AI App & fine-tune models (AI Gateway, R2)
   description: In this workshop, Kristian Freeman, Cloudflare Developer Advocate, shows how to optimize your existing AI applications with Cloudflare AI Gateway, and how to finetune OpenAI models using R2.
@@ -118,7 +118,7 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=CHfKeFakGAI
   id: How to use Cloudflare AI models and inference in Python with Jupyter Notebooks
   description: Cloudflare Workers AI provides a ton of AI models and inference capabilities. In this video, we will explore how to make use of Cloudflare’s AI model catalog using a Python Jupyter Notebook.
@@ -129,7 +129,7 @@
   author: craig
   updated: 2023-12-14
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/cK_leoJsBWY
   id: Cloudflare Workers AI, Building a "Hello, World" AI App!
   description: Cloudflare's Workers AI helps you add AI functionality to the apps you are building. In this video we show you how simple and straightforward it is to build the Hello World of AI apps in under 5 minutes.
@@ -141,7 +141,7 @@
   author: craig
   updated: 2024-09-11
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/9IjfyBJsJRQ
   id: Use Vectorize to add additional context to your AI Applications through RAG
   description: A RAG based AI Chat app that uses Vectorize to access video game data for employees of Gamertown.
@@ -153,7 +153,7 @@
   author: craig
   updated: 2024-09-12
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/doKt9wWQF9A
   id: AI meets Maps | Using Cloudflare AI, Langchain, Mapbox, Folium and Streamlit
   description: Welcome to RouteMe, a smart tool that helps you plan the most efficient route between landmarks in any city. Powered by Cloudflare Workers AI, Langchain and Mapbox. This Streamlit webapp uses LLMs and Mapbox off my scripts API to solve the classic traveling salesman problem, turning your sightseeing into an optimized adventure!
@@ -165,7 +165,7 @@
   author: lizzie
   updated: 2024-09-16
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/bwJkwD-F0kQ
   id: Welcome to the Cloudflare Developer Channel
   description: Welcome to the Cloudflare Developers YouTube channel. We've got tutorials and working demos and everything you need to level up your projects. Whether you're working on your next big thing or just dorking around with some side projects, we've got you covered! So why don't you come hang out, subscribe to our developer channel and together we'll build something awesome. You're gonna love it.
@@ -177,7 +177,7 @@
   author: craig
   updated: 2024-09-18
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/10-kiyJNr8s
   id: Build a private AI chatbot using Meta's Llama 3.1
   description: In this video, you will learn how to set up a private AI chat powered by Llama 3.1 for secure, fast interactions, deploy the model on Cloudflare Workers for serverless, scalable performance and use Cloudflare's Workers AI for seamless integration and edge computing benefits.
@@ -189,7 +189,7 @@
   author: confidence
   updated: 2024-10-07
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-hono-site/#creator-interview
   id: DevTalk | Episode 01 - Yusuke Wada, creator of Hono Framework
   description: In this interview, Yusuke Wada reflects on his journey in developing Hono.
@@ -200,7 +200,7 @@
   author: yusuke
   updated: 2024-10-08
   difficulty: Beginner
-    pcx_content_type: interview
+  pcx_content_type: interview
 - link: https://youtu.be/W45MIi_t_go
   id: Building Front-End Applications | Now Supported by Cloudflare Workers
   description: You can now build front-end applications, just like you do on Cloudflare Pages, but with the added benefit of Workers.
@@ -212,7 +212,7 @@
   author: confidence
   updated: 2024-10-23
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/HXOpxNaKUzw
   id: How to Build Event-Driven Applications with Cloudflare Queues
   description: In this video, we demonstrate how to build an event-driven application using Cloudflare Queues. Event-driven system lets you decouple services, allowing them to process and scale independently.
@@ -224,7 +224,7 @@
   author: harshil
   updated: 2024-09-26
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/slS4RBV0SBk
   id: Cloudflare Workflows | Introduction (Part 1 of 3)
   description: In this video, we introduce Cloudflare Workflows, the Newest Developer Platform Primitive at Cloudflare.
@@ -236,7 +236,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/y4PPsvHrQGA
   id: Cloudflare Workflows | Batching and Monitoring Your Durable Execution (Part 2 of 3)
   description: Workflows exposes metrics such as execution, error rates, steps, and total duration!
@@ -248,7 +248,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/L6gR4Yr3UW8
   id: Cloudflare Workflows | Schedule and Sleep For Your Apps (Part 3 of 3)
   description: Cloudflare Workflows allows you to initiate sleep as an explicit step, which can be useful when you want a Workflow to wait, schedule work ahead, or pause until an input or other external state is ready.
@@ -260,7 +260,7 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/frameworks/framework-guides/nextjs/#video-tutorial
   id: Deploy Your NextJS Application To Workers
   description: Watch to learn how to easily deploy your NextJS application to the Cloudflare global network.
@@ -272,7 +272,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/observability/logs/#video-tutorial
   id: Workers Observability
   description: With Workers Logs, you can collect, store, filter, and analyze all logging data from your Workers directly in the Cloudflare dashboard.
@@ -284,7 +284,7 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/RmF05GpLE20
   id: DevTalk Episode 02 | Post-Quantum Cryptography
   description: Bas Westerbaan is Cloudflare’s Research Lead on Post-Quantum efforts. His work ranges from cryptographic implementation and standardization, to driving large-scale experiment and subsequent deployment.
@@ -295,7 +295,7 @@
   author: bas
   updated: 2024-11-14
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/xu4Wb-IppmM
   id: OpenAI Relay Server on Cloudflare Workers
   description: In this video, Craig Dennis walks you through the deployment of OpenAI's relay server to use with their realtime API.
@@ -306,7 +306,7 @@
   author: craig
   updated: 2024-11-14
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/runtime-apis/rpc/#video-tutorial
   id: Workers RPC Tutorial
   description: Learn how to implement RPC in your JavaScript applications and build serverless solutions.
@@ -317,7 +317,7 @@
   author: confidence
   updated: 2024-11-10
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://youtu.be/B2bLUc3iOsI
   id: Deploy your React App to Cloudflare Workers
   description: Learn how to deploy an existing React application to Cloudflare Workers.
@@ -328,7 +328,7 @@
   author: confidence
   updated: 2024-11-05
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-an-astro-site/#video-tutorial
   id: Build a Full-Stack Application using Astro and Cloudflare Workers
   description: Learn how to deploy an Astro application to Cloudflare Workers.
@@ -339,7 +339,7 @@
   author: kristian
   updated: 2024-11-19
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workflows/examples/twilio/
   id: Schedule Twilio Messaging and Phone Calls with Workflows
   description: Integrate Workflows with Twilio. Learn how to receive and send text messages and phone calls via APIs and Webhooks.
@@ -350,7 +350,7 @@
   author: craig
   updated: 2024-11-30
   difficulty: Intermediate
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nuxt-site/#video-tutorial
   id: Deploy Your Nuxt Application To Workers
   description: Watch to learn how to easily deploy your Nuxt application to the Cloudflare global network.
@@ -361,7 +361,7 @@
   author: kristian
   updated: 2025-01-08
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers-ai/tutorials/image-generation-playground/
   id: How to Build an Image Generator using Workers AI
   description: In this series of videos, learn how to build an AI Image Playground, add new AI Models and store your generated images using R2.
@@ -372,7 +372,7 @@
   author: kristian
   updated: 2025-01-29
   difficulty: Beginner
-    pcx_content_type: tutorial
+  pcx_content_type: tutorial
 # - link:
 #   id:
 #   description:
@@ -383,4 +383,4 @@
 #   author:
 #   updated:
 #   difficulty: Intermediate
-#   #   pcx_content_type: tutorial
+#   pcx_content_type: tutorial

--- a/src/content/videos/index.yaml
+++ b/src/content/videos/index.yaml
@@ -9,7 +9,6 @@
   author: craig
   updated: 2024-06-20
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MlV9Kvkh9hw
   id: Build a URL Shortener with an AI-based admin section
@@ -21,7 +20,6 @@
   author: craig
   updated: 2024-07-01
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=dttu4QtKkO0
   id: Build Rust Powered Apps
@@ -33,7 +31,6 @@
   author: confidence
   updated: 2024-06-25
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=GRpwVMkVmKo
   id: API Roll (Father's Day)
@@ -45,7 +42,6 @@
   author: craig
   updated: 2024-06-15
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=MLbo7MGY_lU
   id: AI can see clearly now - Build Vision Apps on Cloudflare Workers AI
@@ -57,7 +53,6 @@
   author: craig
   updated: 2024-06-11
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=QTsaAhFvX9o
   id: Stateful Apps with Cloudflare Workers
@@ -69,7 +64,6 @@
   author: kristian
   updated: 2024-05-22
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=5UTExUQ8Fwo
   id: Workers AI - Getting Started - Vanilla Chat App
@@ -81,7 +75,6 @@
   author: craig
   updated: 2024-04-17
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=H7Qe96fqg1M
   id: Learn Cloudflare Workers - Full Course for Beginners
@@ -93,7 +86,6 @@
   author: kristian
   updated: 2024-03-12
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=8SnrvAYAJ4Q
   id: Image Generation, Inpainting, and Vision Models
@@ -105,7 +97,6 @@
   author: craig
   updated: 2024-03-08
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=9JM5Z0KzQsQ
   id: Learn AI Development (models, embeddings, vectors)
@@ -116,7 +107,6 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=idKdjA8t0jw
   id: Optimize your AI App & fine-tune models (AI Gateway, R2)
@@ -128,7 +118,6 @@
   author: kristian
   updated: 2023-12-14
   difficulty: Advanced
-
   pcx_content_type: tutorial
 - link: https://www.youtube.com/watch?v=CHfKeFakGAI
   id: How to use Cloudflare AI models and inference in Python with Jupyter Notebooks
@@ -140,7 +129,6 @@
   author: craig
   updated: 2023-12-14
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/cK_leoJsBWY
   id: Cloudflare Workers AI, Building a "Hello, World" AI App!
@@ -153,7 +141,6 @@
   author: craig
   updated: 2024-09-11
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://youtu.be/9IjfyBJsJRQ
   id: Use Vectorize to add additional context to your AI Applications through RAG
@@ -166,7 +153,6 @@
   author: craig
   updated: 2024-09-12
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/doKt9wWQF9A
   id: AI meets Maps | Using Cloudflare AI, Langchain, Mapbox, Folium and Streamlit
@@ -179,7 +165,6 @@
   author: lizzie
   updated: 2024-09-16
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/bwJkwD-F0kQ
   id: Welcome to the Cloudflare Developer Channel
@@ -192,7 +177,6 @@
   author: craig
   updated: 2024-09-18
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://youtu.be/10-kiyJNr8s
   id: Build a private AI chatbot using Meta's Llama 3.1
@@ -205,7 +189,6 @@
   author: confidence
   updated: 2024-10-07
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-hono-site/#creator-interview
   id: DevTalk | Episode 01 - Yusuke Wada, creator of Hono Framework
@@ -217,7 +200,6 @@
   author: yusuke
   updated: 2024-10-08
   difficulty: Beginner
-
   pcx_content_type: interview
 - link: https://youtu.be/W45MIi_t_go
   id: Building Front-End Applications | Now Supported by Cloudflare Workers
@@ -230,7 +212,6 @@
   author: confidence
   updated: 2024-10-23
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://youtu.be/HXOpxNaKUzw
   id: How to Build Event-Driven Applications with Cloudflare Queues
@@ -243,7 +224,6 @@
   author: harshil
   updated: 2024-09-26
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/slS4RBV0SBk
   id: Cloudflare Workflows | Introduction (Part 1 of 3)
@@ -256,7 +236,6 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/y4PPsvHrQGA
   id: Cloudflare Workflows | Batching and Monitoring Your Durable Execution (Part 2 of 3)
@@ -269,7 +248,6 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/L6gR4Yr3UW8
   id: Cloudflare Workflows | Schedule and Sleep For Your Apps (Part 3 of 3)
@@ -282,7 +260,6 @@
   author: craig
   updated: 2024-10-30
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/frameworks/framework-guides/nextjs/#video-tutorial
   id: Deploy Your NextJS Application To Workers
@@ -295,7 +272,6 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/observability/logs/#video-tutorial
   id: Workers Observability
@@ -308,7 +284,6 @@
   author: confidence
   updated: 2024-10-31
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://youtu.be/RmF05GpLE20
   id: DevTalk Episode 02 | Post-Quantum Cryptography
@@ -320,7 +295,6 @@
   author: bas
   updated: 2024-11-14
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://youtu.be/xu4Wb-IppmM
   id: OpenAI Relay Server on Cloudflare Workers
@@ -332,7 +306,6 @@
   author: craig
   updated: 2024-11-14
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers/runtime-apis/rpc/#video-tutorial
   id: Workers RPC Tutorial
@@ -344,7 +317,6 @@
   author: confidence
   updated: 2024-11-10
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://youtu.be/B2bLUc3iOsI
   id: Deploy your React App to Cloudflare Workers
@@ -356,7 +328,6 @@
   author: confidence
   updated: 2024-11-05
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-an-astro-site/#video-tutorial
   id: Build a Full-Stack Application using Astro and Cloudflare Workers
@@ -368,7 +339,6 @@
   author: kristian
   updated: 2024-11-19
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workflows/examples/twilio/
   id: Schedule Twilio Messaging and Phone Calls with Workflows
@@ -380,7 +350,6 @@
   author: craig
   updated: 2024-11-30
   difficulty: Intermediate
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nuxt-site/#video-tutorial
   id: Deploy Your Nuxt Application To Workers
@@ -392,7 +361,6 @@
   author: kristian
   updated: 2025-01-08
   difficulty: Beginner
-
   pcx_content_type: tutorial
 - link: https://developers.cloudflare.com/workers-ai/tutorials/image-generation-playground/
   id: How to Build an Image Generator using Workers AI
@@ -404,7 +372,6 @@
   author: kristian
   updated: 2025-01-29
   difficulty: Beginner
-
   pcx_content_type: tutorial
 # - link:
 #   id:
@@ -416,5 +383,4 @@
 #   author:
 #   updated:
 #   difficulty: Intermediate
-#
 #   pcx_content_type: tutorial

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -47,7 +47,6 @@ export const baseSchema = ({ image }: SchemaContext) =>
 			.describe(
 				"The purpose of the page, and defined through specific pages in [Content strategy](/style-guide/documentation-content-strategy/content-types/).",
 			),
-		content_type: z.string().optional(),
 		tags: z
 			.string()
 			.array()

--- a/src/schemas/videos.ts
+++ b/src/schemas/videos.ts
@@ -12,7 +12,6 @@ export const videosSchema = z
 		author: z.string(),
 		updated: z.coerce.date(),
 		difficulty: z.string(),
-		content_type: z.string(),
 		pcx_content_type: z.string(),
 		languages: z.string().array().optional(),
 	})

--- a/templates/tutorial-template.mdx
+++ b/templates/tutorial-template.mdx
@@ -1,7 +1,6 @@
 ---
 updated: YYYY-MM-DD
 difficulty: Beginner | Intermediate | Expert
-
 pcx_content_type: tutorial
 title: Tutorial title. Second-person imperative verb phrase that reflects user goal or job-to-be-done. For example, 'Create a Worker' or 'Build a Pages application'.
 products:

--- a/templates/tutorial-template.mdx
+++ b/templates/tutorial-template.mdx
@@ -1,7 +1,7 @@
 ---
 updated: YYYY-MM-DD
 difficulty: Beginner | Intermediate | Expert
-content_type: 📝 Tutorial
+
 pcx_content_type: tutorial
 title: Tutorial title. Second-person imperative verb phrase that reflects user goal or job-to-be-done. For example, 'Create a Worker' or 'Build a Pages application'.
 products:


### PR DESCRIPTION
### Summary

Should result in no changes to the customer-facing experience. Removes `content_type` as a frontmatter property, inferring this from the collection it comes from.

This only affects the `ListTutorials` component.
