### PR TITLE
Replace wrangler.toml with cargo.toml for Rust

### DIFF
--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -214,16 +214,12 @@ To run the resulting Wasm binary on Workers, `workers-rs` includes a build tool 
 
 Unoptimized Rust Wasm binaries can be large and may exceed Worker bundle size limits or experience long startup times. The template project pre-configures several useful size optimizations in your `Cargo.toml` file:
 
-<WranglerConfig>
-
 ```toml
 [profile.release]
 lto = true
 strip = true
 codegen-units = 1
 ```
-
-</WranglerConfig>
 
 Finally, `worker-bundle` automatically invokes [`wasm-opt`](https://github.com/brson/wasm-opt-rs) to further optimize binary size before upload.
 


### PR DESCRIPTION
Fixes #19150

Replaced
<img width="801" alt="Screenshot 2025-03-13 at 4 31 48 PM" src="https://github.com/user-attachments/assets/3a0a513d-1a33-489f-801b-77c61e2c2d40" />
with
<img width="793" alt="Screenshot 2025-03-13 at 4 31 30 PM" src="https://github.com/user-attachments/assets/bfdab4f9-08d3-4a1a-8d38-cad2a84428cd" />