### PR TITLE
[DO] Repositioning Videos sidebar

### DIFF
--- a/src/content/docs/durable-objects/platform/index.mdx
+++ b/src/content/docs/durable-objects/platform/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Platform
 sidebar:
-  order: 11
+  order: 12
   group:
     hideIndex: true
 ---

--- a/src/content/docs/durable-objects/reference/index.mdx
+++ b/src/content/docs/durable-objects/reference/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Reference
 sidebar:
-  order: 12
+  order: 13
   group:
     hideIndex: true
 ---

--- a/src/content/docs/durable-objects/release-notes.mdx
+++ b/src/content/docs/durable-objects/release-notes.mdx
@@ -4,7 +4,7 @@ title: Release notes
 release_notes_file_name:
   - durable-objects
 sidebar:
-  order: 15
+  order: 20
 ---
 
 import { ProductReleaseNotes } from "~/components";


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Repositioning Video item in the sidebar. There is an ongoing initiative to create more videos, and to place them somewhere visible in the docs.

We may need to rethink our structure to cleanup / minimise load between:

- `Examples`
- `Tutorials`
- `Demos and architectures`
- `Videos`

-> maybe they should all sit inside another top-level folder?

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
