### PR TITLE
[Several docs] Product name in main page title

### DIFF
--- a/src/content/docs/ai-gateway/index.mdx
+++ b/src/content/docs/ai-gateway/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare AI Gateway
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: AI Gateway
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/api-shield/index.mdx
+++ b/src/content/docs/api-shield/index.mdx
@@ -1,13 +1,12 @@
 ---
-title: Overview
+title: Cloudflare API Shield
 pcx_content_type: overview
 type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare API Shield
-
+    content: Overview
 ---
 
 import { Description, Feature, Plan, RelatedProduct, Render } from "~/components"

--- a/src/content/docs/automatic-platform-optimization/index.mdx
+++ b/src/content/docs/automatic-platform-optimization/index.mdx
@@ -1,9 +1,11 @@
 ---
-title: Welcome
+title: Automatic Platform Optimization
 pcx_content_type: overview
 sidebar:
   order: 1
-
+head:
+  - tag: title
+    content: Overview
 ---
 
 Take your WordPress site’s performance to the next level with Automatic Platform Optimizations (APO). APO allows Cloudflare to serve your entire WordPress site from its edge network ensuring consistent, fast performance for visitors no matter where they are.

--- a/src/content/docs/bots/index.mdx
+++ b/src/content/docs/bots/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare bot solutions
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare bot solutions
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct, Render } from "~/components"

--- a/src/content/docs/calls/index.mdx
+++ b/src/content/docs/calls/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Calls
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Calls
+    content: Overview
 ---
 
 import { Description, LinkButton } from "~/components";

--- a/src/content/docs/cloudflare-one/index.mdx
+++ b/src/content/docs/cloudflare-one/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Overview
+title: Cloudflare Zero Trust
 type: overview
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Zero Trust
+    content: Overview
 ---
 
 import { GlossaryTooltip, Render } from "~/components";

--- a/src/content/docs/d1/index.mdx
+++ b/src/content/docs/d1/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare D1
 order: 0
 type: overview
 pcx_content_type: overview
@@ -7,8 +7,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare D1
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/ddos-protection/index.mdx
+++ b/src/content/docs/ddos-protection/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare DDoS Protection
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare DDoS Protection
-
+    content: Overview
 ---
 
 import { Description, Feature, FeatureTable, GlossaryTooltip, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/dmarc-management/index.mdx
+++ b/src/content/docs/dmarc-management/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare DMARC Management
 pcx_content_type: overview
 sidebar:
   order: 1
@@ -7,9 +7,8 @@ sidebar:
     text: Beta
 head:
   - tag: title
-    content: Cloudflare DMARC Management
+    content: Overview
 description: Stop brand impersonation.
-
 ---
 
 import { Description, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/durable-objects/index.mdx
+++ b/src/content/docs/durable-objects/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare Durable Objects
 order: 0
 type: overview
 pcx_content_type: overview
@@ -7,8 +7,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Durable Objects
-
+    content: Overview
 ---
 
 import { Render, CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct, LinkButton } from "~/components"

--- a/src/content/docs/email-routing/index.mdx
+++ b/src/content/docs/email-routing/index.mdx
@@ -1,19 +1,18 @@
 ---
-title: Overview
+title: Cloudflare Email Routing
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Email Routing
-
+    content: Overview
 ---
 
 import { Description, Feature, Plan, RelatedProduct, Render } from "~/components"
 
 <Description>
 
-Create custom email addresses for your domain and route incoming emails to your preferred mailbox. 
+Create custom email addresses for your domain and route incoming emails to your preferred mailbox.
 </Description>
 
 <Plan id="email.email_routing.properties.availability.summary" />
@@ -27,15 +26,15 @@ It is available to all Cloudflare customers [using Cloudflare as an authoritativ
 ## Features
 
 <Feature header="Email Workers" href="/email-routing/email-workers/">
-Leverage the power of Cloudflare Workers to implement any logic you need to process your emails. Create rules as complex or simple as you need. 
+Leverage the power of Cloudflare Workers to implement any logic you need to process your emails. Create rules as complex or simple as you need.
 </Feature>
 
 <Feature header="Custom addresses" href="/email-routing/get-started/enable-email-routing/">
-With Email Routing you can have many custom email addresses to use for specific situations. 
+With Email Routing you can have many custom email addresses to use for specific situations.
 </Feature>
 
 <Feature header="Analytics" href="/email-routing/get-started/email-routing-analytics/">
-Email Routing includes metrics to help you check on your email traffic history. 
+Email Routing includes metrics to help you check on your email traffic history.
 </Feature>
 
 ***
@@ -43,9 +42,9 @@ Email Routing includes metrics to help you check on your email traffic history.
 ## Related products
 
 <RelatedProduct header="Area 1 Email Security" href="/email-security/" product="email-security">
-Cloudflare Area 1 Email Security is a cloud-native service that stops phishing attacks, the biggest cybersecurity threat, across all threat vectors - email, web, and network - either at the edge or in the cloud. 
+Cloudflare Area 1 Email Security is a cloud-native service that stops phishing attacks, the biggest cybersecurity threat, across all threat vectors - email, web, and network - either at the edge or in the cloud.
 </RelatedProduct>
 
 <RelatedProduct header="DNS" href="/dns/" product="dns">
-Email Routing is available to customers using Cloudflare as an authoritative nameserver. 
+Email Routing is available to customers using Cloudflare as an authoritative nameserver.
 </RelatedProduct>

--- a/src/content/docs/fundamentals/index.mdx
+++ b/src/content/docs/fundamentals/index.mdx
@@ -1,12 +1,14 @@
 ---
-title: Overview
+title: Cloudflare Fundamentals
 pcx_content_type: overview
 sidebar:
   order: 1
-
+head:
+  - tag: title
+    content: Overview
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 <Render file="what-is-cloudflare" product="fundamentals" />
 

--- a/src/content/docs/hyperdrive/index.mdx
+++ b/src/content/docs/hyperdrive/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Hyperdrive
 order: 0
 type: overview
 pcx_content_type: overview
@@ -7,7 +7,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Hyperdrive
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/images/index.mdx
+++ b/src/content/docs/images/index.mdx
@@ -1,20 +1,19 @@
 ---
-title: Overview
+title: Cloudflare Images
 pcx_content_type: overview
 description: Streamline your image infrastructure with Cloudflare Images. Store, transform, and deliver images efficiently using Cloudflare's global network.
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Images
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan } from "~/components"
 
 <Description>
 
-Store, transform, optimize, and deliver images at scale 
+Store, transform, optimize, and deliver images at scale
 </Description>
 
 <Plan type="all" />
@@ -30,7 +29,7 @@ Cloudflare Images is available on both [Free and Paid plans](/images/pricing/). 
 
 :::note[Image Resizing is now available as transformations]
 
-All Image Resizing features are available as transformations with Images. Each unique transformation is billed only once per 30 days. 
+All Image Resizing features are available as transformations with Images. Each unique transformation is billed only once per 30 days.
 
 If you are using a legacy plan with Image Resizing, visit the [dashboard](https://dash.cloudflare.com/) to switch to an Imagesplan.
 
@@ -48,15 +47,15 @@ Use Cloudflare’s edge network to store your images.
 </Feature>
 
 <Feature header="Direct creator upload" href="/images/upload-images/direct-creator-upload/">
-Accept uploads directly and securely from your users by generating a one-time token. 
+Accept uploads directly and securely from your users by generating a one-time token.
 </Feature>
 
 <Feature header="Variants" href="/images/transform-images" cta="Create variants by transforming images">
-Add up to 100 variants to specify how images should be resized for various use cases. 
+Add up to 100 variants to specify how images should be resized for various use cases.
 </Feature>
 
 <Feature header="Signed URLs" href="/images/manage-images/serve-images/serve-private-images" cta="Serve private images">
-Control access to your images by using signed URL tokens. 
+Control access to your images by using signed URL tokens.
 </Feature>
 
 ***
@@ -67,7 +66,7 @@ Control access to your images by using signed URL tokens.
 
 <LinkTitleCard title="Community Forum" href="https://community.cloudflare.com/c/developers/images/63" icon="open-book">
 
-Engage with other users and the Images team on Cloudflare support forum. 
+Engage with other users and the Images team on Cloudflare support forum.
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/key-transparency/index.mdx
+++ b/src/content/docs/key-transparency/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Key Transparency Auditor
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Key Transparency Auditor 
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, RelatedProduct } from "~/components"

--- a/src/content/docs/magic-firewall/index.mdx
+++ b/src/content/docs/magic-firewall/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Magic Firewall
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Magic Firewall
-
+    content: Overview
 ---
 
 import { Description, Feature, GlossaryTooltip, Plan, RelatedProduct } from "~/components"
@@ -28,7 +27,7 @@ Magic Firewall is available with the purchase of [Magic Transit](/magic-transit/
 ## Features
 
 <Feature header="Intrusion Detection System (IDS)" href="/magic-firewall/how-to/enable-ids/">
-Actively monitor for a wide range of known threat signatures in your traffic. 
+Actively monitor for a wide range of known threat signatures in your traffic.
 </Feature>
 
 ***
@@ -36,9 +35,9 @@ Actively monitor for a wide range of known threat signatures in your traffic.
 ## Related products
 
 <RelatedProduct header="Cloudflare Magic Transit" href="/magic-transit/" product="cloudflare-one">
-Secure your network from incoming Internet traffic, and improve performance at Cloudflare scale. 
+Secure your network from incoming Internet traffic, and improve performance at Cloudflare scale.
 </RelatedProduct>
 
 <RelatedProduct header="Cloudflare Magic WAN" href="/magic-wan/" product="magic-wan">
-Improve security and performance for your entire corporate networking, reducing cost and operation complexity. 
+Improve security and performance for your entire corporate networking, reducing cost and operation complexity.
 </RelatedProduct>

--- a/src/content/docs/magic-network-monitoring/index.mdx
+++ b/src/content/docs/magic-network-monitoring/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Magic Network Monitoring
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Magic Network Monitoring
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/magic-transit/index.mdx
+++ b/src/content/docs/magic-transit/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Magic Transit
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Magic Transit
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/magic-wan/index.mdx
+++ b/src/content/docs/magic-wan/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Magic WAN
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Magic WAN
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/network-error-logging/index.mdx
+++ b/src/content/docs/network-error-logging/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Network Error Logging
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Network Error Logging
-
+    content: Overview
 ---
 
 Network Error Logging (NEL) is a browser-based reporting system that allows users to report their own failures to an external endpoint. You can use Network Error Logging to gain insight into connectivity issues on the Internet to learn when and where an incident is happening, who is impacted, and how they are being impacted.

--- a/src/content/docs/network-interconnect/index.mdx
+++ b/src/content/docs/network-interconnect/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Network Interconnect
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Network Interconnect
-
+    content: Overview
 ---
 
 import { Description, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/network/index.mdx
+++ b/src/content/docs/network/index.mdx
@@ -1,9 +1,11 @@
 ---
-title: Overview
+title: Network settings
 pcx_content_type: overview
 sidebar:
   order: 1
-
+head:
+  - tag: title
+    content: Overview
 ---
 
 import { Description, Feature, Plan, RelatedProduct } from "~/components"
@@ -19,15 +21,15 @@ Manage network settings for your website.
 ## Features
 
 <Feature header="IP Geolocation" href="/network/ip-geolocation/">
-Include the country code of the visitor location with all requests to your website. 
+Include the country code of the visitor location with all requests to your website.
 </Feature>
 
 <Feature header="IPv6 Compatibility" href="/network/ipv6-compatibility/">
-Enable IPv6 support and gateway. 
+Enable IPv6 support and gateway.
 </Feature>
 
 <Feature header="WebSockets" href="/network/websockets/">
-Allow WebSockets connections to your origin server. 
+Allow WebSockets connections to your origin server.
 </Feature>
 
 ***
@@ -35,9 +37,9 @@ Allow WebSockets connections to your origin server.
 ## Related products
 
 <RelatedProduct header="China Network" href="/china-network/" product="china-network">
-The Cloudflare China Network is a package of selected Cloudflare’s performance and security products running on data centers located in mainland China and operated by Cloudflare’s partner JD Cloud. 
+The Cloudflare China Network is a package of selected Cloudflare’s performance and security products running on data centers located in mainland China and operated by Cloudflare’s partner JD Cloud.
 </RelatedProduct>
 
 <RelatedProduct header="Managed Transforms" href="/rules/transform/managed-transforms/" product="rules">
-Managed Transforms allow you to perform common adjustments to HTTP request and response headers with the click of a button. 
+Managed Transforms allow you to perform common adjustments to HTTP request and response headers with the click of a button.
 </RelatedProduct>

--- a/src/content/docs/pages/index.mdx
+++ b/src/content/docs/pages/index.mdx
@@ -1,13 +1,12 @@
 ---
-title: Overview
+title: Cloudflare Pages
 type: overview
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Pages documentation
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct, Render } from "~/components"

--- a/src/content/docs/privacy-gateway/index.mdx
+++ b/src/content/docs/privacy-gateway/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare Privacy Gateway
 pcx_content_type: overview
 sidebar:
   order: 1
@@ -7,8 +7,7 @@ sidebar:
     text: Beta
 head:
   - tag: title
-    content: Cloudflare Privacy Gateway
-
+    content: Overview
 ---
 
 import { Description, Feature, Plan } from "~/components"

--- a/src/content/docs/pub-sub/index.mdx
+++ b/src/content/docs/pub-sub/index.mdx
@@ -1,9 +1,12 @@
 ---
-title: Overview
+title: Pub/Sub
 pcx_content_type: overview
 sidebar:
   badge:
     text: Beta
+head:
+  - tag: title
+    content: Overview
 ---
 
 :::note

--- a/src/content/docs/pulumi/index.mdx
+++ b/src/content/docs/pulumi/index.mdx
@@ -1,9 +1,11 @@
 ---
-title: Overview
+title: Pulumi
 pcx_content_type: overview
 sidebar:
   order: 1
-
+head:
+  - tag: title
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, RelatedProduct } from "~/components"
@@ -23,11 +25,11 @@ Provision and manage Cloudflare using infrastructure as code through [Pulumi](ht
 ## Features
 
 <Feature header="Open Source" href="https://www.pulumi.com/blog/pulumi-hearts-opensource/" cta="View open source commitment">
-[Pulumi](https://github.com/pulumi/pulumi) is open source and uses the Apache 2.0 license. 
+[Pulumi](https://github.com/pulumi/pulumi) is open source and uses the Apache 2.0 license.
 </Feature>
 
 <Feature header="Multiple languages and SDKs" href="https://www.pulumi.com/docs/languages-sdks/">
-Use TypeScript, JavaScript, Python, Go, .Net, Java, or YAML to write Pulumi programs. Each language is as capable as the other and supports the entire [Pulumi Registry](https://www.pulumi.com/registry/). 
+Use TypeScript, JavaScript, Python, Go, .Net, Java, or YAML to write Pulumi programs. Each language is as capable as the other and supports the entire [Pulumi Registry](https://www.pulumi.com/registry/).
 </Feature>
 
 ***
@@ -35,15 +37,15 @@ Use TypeScript, JavaScript, Python, Go, .Net, Java, or YAML to write Pulumi prog
 ## Related products
 
 <RelatedProduct header="Pulumi Cloud" href="https://www.pulumi.com/product/pulumi-cloud/" product="pulumi">
-Pulumi Cloud fully manages infrastructure state and secrets, provides rich search capabilities, and more. 
+Pulumi Cloud fully manages infrastructure state and secrets, provides rich search capabilities, and more.
 </RelatedProduct>
 
 <RelatedProduct header="Pulumi AI" href="https://www.pulumi.com/ai" product="pulumi">
-Pulumi AI is an experimental feature that lets you use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language. 
+Pulumi AI is an experimental feature that lets you use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language.
 </RelatedProduct>
 
-<RelatedProduct header="Pulumi ESC" href="https://www.pulumi.com/product/esc/" product="pulumi"> 
-Pulumi ESC provides centralized management of environments, secrets, and configurations. 
+<RelatedProduct header="Pulumi ESC" href="https://www.pulumi.com/product/esc/" product="pulumi">
+Pulumi ESC provides centralized management of environments, secrets, and configurations.
 </RelatedProduct>
 
 ***
@@ -54,12 +56,12 @@ Pulumi ESC provides centralized management of environments, secrets, and configu
 
 <LinkTitleCard title="Visit the Pulumi docs" href="https://www.pulumi.com/docs" icon="open-book">
 
-To learn more about Pulumi. 
+To learn more about Pulumi.
 </LinkTitleCard>
 
 <LinkTitleCard title="Report issues" href="https://github.com/pulumi/pulumi" icon="heart">
 
-Report Pulumi configuration issues via GitHub. 
+Report Pulumi configuration issues via GitHub.
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/queues/index.mdx
+++ b/src/content/docs/queues/index.mdx
@@ -1,13 +1,12 @@
 ---
-title: Overview
+title: Cloudflare Queues
 type: overview
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Queues
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/r2/index.mdx
+++ b/src/content/docs/r2/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare R2
 type: overview
 pcx_content_type: overview
 sidebar:
@@ -7,8 +7,7 @@ sidebar:
 description: Cloudflare R2 is a cost-effective, scalable object storage solution for cloud-native apps, web content, and data lakes without egress fees.
 head:
   - tag: title
-    content: Cloudflare R2
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkButton, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/radar/index.mdx
+++ b/src/content/docs/radar/index.mdx
@@ -1,19 +1,18 @@
 ---
-title: Overview
+title: Cloudflare Radar
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Radar
-
+    content: Overview
 ---
 
 import { Description, Feature, Plan } from "~/components"
 
 <Description>
 
-Get access to Cloudflare's data on global Internet traffic. 
+Get access to Cloudflare's data on global Internet traffic.
 </Description>
 
 <Plan type="all" />
@@ -31,9 +30,9 @@ Data available via Radar API endpoints is made available under the [CC BY-NC 4.0
 ## Features
 
 <Feature header="Make your first API request" href="/radar/get-started/first-request/" cta="Make your first API request">
-Start learning how to use Radar's API by making your first request. 
+Start learning how to use Radar's API by making your first request.
 </Feature>
 
 <Feature header="Compare data" href="/radar/get-started/making-comparisons/" cta="Compare data">
-What to know before making comparisons between locations, [autonomous systems](https://www.cloudflare.com/en-gb/learning/network-layer/what-is-an-autonomous-system/) and more. 
+What to know before making comparisons between locations, [autonomous systems](https://www.cloudflare.com/en-gb/learning/network-layer/what-is-an-autonomous-system/) and more.
 </Feature>

--- a/src/content/docs/randomness-beacon/index.mdx
+++ b/src/content/docs/randomness-beacon/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Randomness Beacon
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Randomness Beacon
-
+    content: Overview
 ---
 
 drand (pronounced "dee-rand") is a distributed randomness beacon daemon written in Golang. Servers running drand can be linked to each other to produce collective, publicly verifiable, unbiased, unpredictable random values at fixed intervals using bilinear pairings and threshold cryptography.

--- a/src/content/docs/registrar/index.mdx
+++ b/src/content/docs/registrar/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Registrar
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Registrar
-
+    content: Overview
 ---
 
 import { Description, Feature, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/security-center/index.mdx
+++ b/src/content/docs/security-center/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Security Center
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Security Center
-
+    content: Overview
 ---
 
 import { LinkButton, Render } from "~/components"

--- a/src/content/docs/stream/index.mdx
+++ b/src/content/docs/stream/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Stream
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Stream
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkButton, LinkTitleCard, Render } from "~/components"
@@ -67,7 +66,7 @@ Understand and analyze which videos and live streams are viewed most and break d
 <CardGrid>
 
 <LinkTitleCard title="Discord" href="https://discord.cloudflare.com" icon="discord">
-&#x20;Join the Stream developer community 
+&#x20;Join the Stream developer community
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/tenant/index.mdx
+++ b/src/content/docs/tenant/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Tenant
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
     content: Overview
-
 ---
 
 The Cloudflare Tenant API is a provisioning mechanism to help Channel and Alliance partners set up and manage Cloudflare accounts and services for their customers.

--- a/src/content/docs/terraform/index.mdx
+++ b/src/content/docs/terraform/index.mdx
@@ -1,12 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Terraform provider
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Terraform
-
+    content: Overview
 ---
 
 Configure Cloudflare using HashiCorp's “Infrastructure as Code” tool, Terraform. With [Cloudflare’s Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs), you can manage the Cloudflare global network using the same familiar tools you use to automate the rest of your infrastructure. Define and store configuration in source code repositories like GitHub, track and version changes over time, and roll back when needed — all without needing to use the Cloudflare APIs.

--- a/src/content/docs/time-services/index.mdx
+++ b/src/content/docs/time-services/index.mdx
@@ -1,13 +1,12 @@
 ---
-title: Overview
+title: Cloudflare Time Services
 pcx_content_type: overview
 type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Time Services docs
-
+    content: Overview
 ---
 
 import { DirectoryListing } from "~/components"

--- a/src/content/docs/turnstile/index.mdx
+++ b/src/content/docs/turnstile/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Turnstile
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Turnstile
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/vectorize/index.mdx
+++ b/src/content/docs/vectorize/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare Vectorize
 order: 0
 type: overview
 pcx_content_type: overview
@@ -7,8 +7,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Vectorize
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct, Render } from "~/components"

--- a/src/content/docs/version-management/index.mdx
+++ b/src/content/docs/version-management/index.mdx
@@ -1,17 +1,19 @@
 ---
-title: Overview
+title: Cloudflare Version Management
 type: overview
 pcx_content_type: overview
 sidebar:
   order: 1
-
+head:
+  - tag: title
+    content: Overview
 ---
 
 import { Description, FeatureTable, Plan, Render } from "~/components"
 
 <Description>
 
-Safely test, deploy, and roll back changes to your zone configurations using Version Management. 
+Safely test, deploy, and roll back changes to your zone configurations using Version Management.
 </Description>
 
 <Plan type="enterprise" />

--- a/src/content/docs/warp-client/index.mdx
+++ b/src/content/docs/warp-client/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare WARP client
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare WARP client
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/web-analytics/index.mdx
+++ b/src/content/docs/web-analytics/index.mdx
@@ -1,19 +1,18 @@
 ---
-title: Overview
+title: Cloudflare Web Analytics
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Web Analytics
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"
 
 <Description>
 
-Get vital web analytics for your website without compromising user privacy. 
+Get vital web analytics for your website without compromising user privacy.
 </Description>
 
 <Plan type="all" />
@@ -50,7 +49,7 @@ Use dimensions to categorize and organize various metrics or data types effectiv
 ## Related products
 
 <RelatedProduct header="Analytics" href="/analytics/" product="analytics">
-Cloudflare visualizes the metadata collected by our products in the Cloudflare dashboard. 
+Cloudflare visualizes the metadata collected by our products in the Cloudflare dashboard.
 </RelatedProduct>
 
 <RelatedProduct header="Speed" href="/speed/" product="speed">
@@ -70,7 +69,7 @@ Refer to our latest resources to learn more about security, performance and reli
 </LinkTitleCard>
 
 <LinkTitleCard title="Cloudflare blog" href="https://blog.cloudflare.com/privacy-first-web-analytics/" icon="open-book">
-Read articles about the latest updates about Web Analytics. 
+Read articles about the latest updates about Web Analytics.
 </LinkTitleCard>
 
 </CardGrid>

--- a/src/content/docs/web3/index.mdx
+++ b/src/content/docs/web3/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Web3
 pcx_content_type: overview
 sidebar:
   order: 1
@@ -7,7 +7,9 @@ head: []
 description: Cloudflare offers gateways to various networks to help Web3
   developers do what they do best, develop applications without having to worry
   about running infrastructure.
-
+head:
+  - tag: title
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, Render } from "~/components"

--- a/src/content/docs/web3/index.mdx
+++ b/src/content/docs/web3/index.mdx
@@ -3,7 +3,6 @@ title: Web3
 pcx_content_type: overview
 sidebar:
   order: 1
-head: []
 description: Cloudflare offers gateways to various networks to help Web3
   developers do what they do best, develop applications without having to worry
   about running infrastructure.

--- a/src/content/docs/workers-ai/index.mdx
+++ b/src/content/docs/workers-ai/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare Workers AI
 order: 0
 type: overview
 pcx_content_type: overview
@@ -7,8 +7,7 @@ sidebar:
   order: 1
 head:
   - tag: title
-    content: Workers AI
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct, Render, LinkButton, Flex } from "~/components"

--- a/src/content/docs/workers/index.mdx
+++ b/src/content/docs/workers/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Overview
+title: Cloudflare Workers
 type: overview
 pcx_content_type: overview
 sidebar:
   order: 1
 head:
   - tag: title
-    content: Cloudflare Workers
+    content: Overview
 ---
 
 import {

--- a/src/content/docs/workflows/index.mdx
+++ b/src/content/docs/workflows/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Cloudflare Workflows
 order: 0
 type: overview
 pcx_content_type: overview
@@ -9,8 +9,7 @@ sidebar:
     text: Beta
 head:
   - tag: title
-    content: Cloudflare Workflows
-
+    content: Overview
 ---
 
 import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"

--- a/src/content/docs/zaraz/index.mdx
+++ b/src/content/docs/zaraz/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Cloudflare Zaraz
 pcx_content_type: overview
 sidebar:
   order: 0
 head:
   - tag: title
-    content: Cloudflare Zaraz
+    content: Overview
 ---
 
 import {

--- a/src/content/products/access.yaml
+++ b/src/content/products/access.yaml
@@ -6,6 +6,6 @@ product:
   url: /cloudflare-one/policies/access/
 
 meta:
-  title: Cloudflare Access
+  title: Cloudflare Access docs
   description: Determine who can reach your application using policies.
   author: "@cloudflare"

--- a/src/content/products/agents.yaml
+++ b/src/content/products/agents.yaml
@@ -8,7 +8,7 @@ product:
   tags: [AI]
 
 meta:
-  title: Cloudflare Agents
+  title: Cloudflare Agents docs
   description: Build AI-powered agents that can autonomously perform tasks, persist state, browse the web, and communicate back to users in real-time over any channel.
   author: "@cloudflare"
 

--- a/src/content/products/hyperdrive.yaml
+++ b/src/content/products/hyperdrive.yaml
@@ -7,7 +7,7 @@ product:
   additional_groups: [Storage]
 
 meta:
-  title: Hyperdrive
+  title: Hyperdrive docs
   description: Service which accelerates queries you make to existing databases.
   author: "@cloudflare"
 

--- a/src/content/products/key-transparency.yaml
+++ b/src/content/products/key-transparency.yaml
@@ -7,6 +7,6 @@ product:
   additional_groups: [Privacy]
 
 meta:
-  title: Key Transparency Auditor
-  description: Key Transparency Auditor docs
+  title: Key Transparency Auditor docs
+  description: Secure the distribution of public keys in your end-to-end encrypted messaging systems.
   author: "@cloudflare"

--- a/src/content/products/kv.yaml
+++ b/src/content/products/kv.yaml
@@ -7,7 +7,7 @@ product:
   additional_groups: [Storage]
 
 meta:
-  title: Cloudflare Workers KV
+  title: Cloudflare Workers KV docs
   description: Global, low-latency, key-value data store.
   author: "@cloudflare"
 

--- a/src/content/products/leaked-credentials.yaml
+++ b/src/content/products/leaked-credentials.yaml
@@ -1,7 +1,7 @@
-name: Leaked credentials checks
+name: Leaked credentials detection
 
 product:
-  title: Leaked credentials checks
+  title: Leaked credentials detection
   group: Application security
   url: /waf/detections/leaked-credentials/
   wrap: true

--- a/src/content/products/privacy-gateway.yml
+++ b/src/content/products/privacy-gateway.yml
@@ -8,7 +8,7 @@ product:
   additional_groups: [Privacy]
 
 meta:
-  title: Cloudflare Privacy Gateway
+  title: Cloudflare Privacy Gateway docs
   description:
     A managed gateway service that implements the Oblivious HTTP IETF standard
     and improves client privacy.

--- a/src/content/products/pub-sub.yml
+++ b/src/content/products/pub-sub.yml
@@ -8,7 +8,7 @@ product:
   group: Developer platform
 
 meta:
-  title: Cloudflare Pub/Sub
+  title: Cloudflare Pub/Sub docs
   description: Cloudflare Pub/Sub allows developers to connect any MQTT-capable device – an ecosystem of tens of millions of devices — directly to Cloudflare's edge using the industry-standard MQTT protocol.
   author: "@cloudflare"
 

--- a/src/content/products/pulumi.yaml
+++ b/src/content/products/pulumi.yaml
@@ -8,6 +8,6 @@ product:
   additional_groups: [Developer platform]
 
 meta:
-  title: Pulumi
+  title: Pulumi docs
   description: Create, deploy, and manage Cloudflare resources in various programming languages.
   author: "@cloudflare"

--- a/src/content/products/queues.yaml
+++ b/src/content/products/queues.yaml
@@ -7,7 +7,7 @@ product:
   additional_groups: [Storage]
 
 meta:
-  title: Cloudflare Queues
+  title: Cloudflare Queues docs
   description: Reliably send and receive messages without the egress fees.
   author: "@cloudflare"
 

--- a/src/content/products/vectorize.yaml
+++ b/src/content/products/vectorize.yaml
@@ -8,7 +8,7 @@ product:
   tags: [AI]
 
 meta:
-  title: Vectorize
+  title: Cloudflare Vectorize docs
   description: Documentation for Vectorize, Cloudflare's vector database
   author: "@cloudflare"
 


### PR DESCRIPTION
### Summary

Updates the page title in product landing pages, according to team decision (T.Crit. 2024-09-19).

* Sidebar entry is "Overview" _(unchanged)_
* Page title (H1) is "\<Product name>" _(changed from "Overview")_
* Page title (meta) is "Overview | \<Product name> docs" _(made small adjustments, like adding "docs")_