### PR TITLE
Removed empty notes

### DIFF
--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -147,10 +147,6 @@ To create a KV namespace via Wrangler:
 4. Select **Add**.
 </Steps>
 
-:::note
-
-:::
-
 </TabItem></Tabs>
 
 ## 3. Bind your Worker to your KV namespace


### PR DESCRIPTION
Saw there was an empty notes section in the Getting Started guide. Want to flag to see if it's needed.