### PR TITLE
Fix tutorial instruction

### DIFF
--- a/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
+++ b/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
@@ -35,7 +35,7 @@ In your terminal, create a new React project called `blog-frontend` using the `c
 ```sh title="Create a new React application"
 npx create-vite -t react blog-frontend
 cd blog-frontend
-npm start
+npm run dev
 ```
 
 ### Set up your React project

--- a/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
+++ b/src/content/docs/pages/tutorials/build-an-api-with-pages-functions/index.mdx
@@ -35,6 +35,7 @@ In your terminal, create a new React project called `blog-frontend` using the `c
 ```sh title="Create a new React application"
 npx create-vite -t react blog-frontend
 cd blog-frontend
+npm install
 npm run dev
 ```
 


### PR DESCRIPTION
### Summary

Changed `npm start` -> `npm run dev`

`npm start` throws an error since it isn't a defined run script

I used the more verbose syntax to make it more obvious the user is calling a run script, not running an npm command named "dev"

### Screenshots (optional)

n/a

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.