### PR TITLE
[Ruleset Engine] Fix field name

### DIFF
--- a/src/content/docs/ruleset-engine/rules-language/expressions/index.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/expressions/index.mdx
@@ -41,7 +41,7 @@ Where:
 For example, this expression uses the `and` operator to target requests to `www.example.com` that are not on ports 80 or 443:
 
 ```txt
-host eq www.example.com and not cf.edge.server_port in {80 443}
+http.host eq www.example.com and not cf.edge.server_port in {80 443}
 ```
 
 Compound expressions have the following general syntax:


### PR DESCRIPTION
### Summary

Fixes field name in example rule expression.
Closes #20863.
