### PR TITLE
[Astro] Update link linting for changelog

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -122,7 +122,7 @@ export default defineConfig({
 								exclude: [
 									"/api/",
 									"/api/**",
-									"/changelog/",
+									"/changelog/**",
 									"/http/resources/**",
 									"{props.*}",
 									"/",


### PR DESCRIPTION
Broadened exemption for `changelog` links b/c our link checker doesn't like custom pages