### PR TITLE
Add additional info for worker service binding rpc example

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -56,7 +56,7 @@ Worker A that declares a Service binding to Worker B can call Worker B in two di
 
 ## Example — build your first Service binding using RPC
 
-This example [extends the `WorkerEntrypoint` class](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
+This example [extends the `WorkerEntrypoint` class](/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
 First, create the Worker that you want to communicate with. Let's call this "Worker B". Worker B exposes the public method, `add(a, b)`:
 
 

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -56,8 +56,8 @@ Worker A that declares a Service binding to Worker B can call Worker B in two di
 
 ## Example — build your first Service binding using RPC
 
+This example [extends the `WorkerEntrypoint class`](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
 First, create the Worker that you want to communicate with. Let's call this "Worker B". Worker B exposes the public method, `add(a, b)`:
-
 
 
 <WranglerConfig>

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -56,7 +56,7 @@ Worker A that declares a Service binding to Worker B can call Worker B in two di
 
 ## Example — build your first Service binding using RPC
 
-This example [extends the `WorkerEntrypoint class`](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
+This example [extends the `WorkerEntrypoint` class](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
 First, create the Worker that you want to communicate with. Let's call this "Worker B". Worker B exposes the public method, `add(a, b)`:
 
 


### PR DESCRIPTION
Fixes #17421
The main issue raised in #17421 was the lack of `default` which was fixed by #18163 . So, I think the only thing left to do is to add some additional context for the example.