### PR TITLE
Release-Mar-17-2025 : Release 7 rules and announce 4 rules.

### DIFF
--- a/src/content/docs/waf/change-log/2025-03-17.mdx
+++ b/src/content/docs/waf/change-log/2025-03-17.mdx
@@ -1,0 +1,103 @@
+---
+title: "2025-03-17"
+type: table
+pcx_content_type: release-notes
+sidebar:
+  order: 797
+tableOfContents: false
+---
+
+import { RuleID } from "~/components";
+
+<table style="width: 100%">
+	<thead>
+		<tr>
+			<th>Ruleset</th>
+			<th>Rule ID</th>
+			<th>Legacy Rule ID</th>
+			<th>Description</th>
+			<th>Previous Action</th>
+			<th>New Action</th>
+			<th>Comments</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="28b2a12993a04e62a98abcd9e59ec18a" />
+			</td>
+			<td>100725</td>
+			<td>Fortinet FortiManager - Remote Code Execution - CVE:CVE-2023-42791, CVE:CVE-2024-23666</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="f253d755910e4998bd90365d1dbf58df" />
+			</td>
+			<td>100726</td>
+			<td>Ivanti - Remote Code Execution - CVE:CVE-2024-8190</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="19ae0094a8d845a1bb1997af0ad61fa7" />
+			</td>
+			<td>100727</td>
+			<td>Cisco IOS XE - Remote Code Execution - CVE:CVE-2023-20198</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="83a677f082264693ad64a2827ee56b66" />
+			</td>
+			<td>100728</td>
+			<td>Sitecore - Remote Code Execution - CVE:CVE-2024-46938</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="166b7ce85ce443538f021228a6752a38" />
+			</td>
+			<td>100729</td>
+			<td>Microsoft SharePoint - Remote Code Execution - CVE:CVE-2023-33160</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="35fe23e7bd324d00816c82d098d47b69" />
+			</td>
+			<td>100730</td>
+			<td>Pentaho - Template Injection - CVE:CVE-2022-43769, CVE:CVE-2022-43939</td>
+			<td>Log</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Cloudflare Managed Ruleset</td>
+			<td>
+				<RuleID id="2ce80fe815254f25b3c8f47569fe1e0d" />
+			</td>
+			<td>100700</td>
+			<td>Apache SSRF vulnerability CVE-2021-40438</td>
+			<td>N/A</td>
+			<td>Block</td>
+			<td></td>
+		</tr>
+	</tbody>
+</table>

--- a/src/content/docs/waf/change-log/scheduled-changes.mdx
+++ b/src/content/docs/waf/change-log/scheduled-changes.mdx
@@ -23,69 +23,47 @@ import { RuleID } from "~/components";
 	</thead>
 	<tbody>
 		<tr>
-			<td>2025-03-10</td>
 			<td>2025-03-17</td>
+			<td>2025-04-01</td>
 			<td>Log</td>
-			<td>100725</td>
+			<td>100732</td>
 			<td>
-				<RuleID id="28b2a12993a04e62a98abcd9e59ec18a" />
+				<RuleID id="8b8074e73b7d4aba92fc68f3622f0483" />
 			</td>
-			<td>Fortinet FortiManager - Remote Code Execution - CVE:CVE-2023-42791, CVE:CVE-2024-23666</td>
+			<td>Sitecore - Code Injection - CVE:CVE-2025-27218</td>
 			<td>This is a New Detection</td>
 		</tr>
 		<tr>
-			<td>2025-03-10</td>
 			<td>2025-03-17</td>
+			<td>2025-04-01</td>
 			<td>Log</td>
-			<td>100726</td>
+			<td>100733</td>
 			<td>
-				<RuleID id="f253d755910e4998bd90365d1dbf58df" />
+				<RuleID id="8350947451a1401c934f5e660f101cca" />
 			</td>
-			<td>Ivanti - Remote Code Execution - CVE:CVE-2024-8190</td>
+			<td>Angular-Base64-Upload - Remote Code Execution - CVE:CVE-2024-42640</td>
 			<td>This is a New Detection</td>
 		</tr>
 		<tr>
-			<td>2025-03-10</td>
 			<td>2025-03-17</td>
+			<td>2025-04-01</td>
 			<td>Log</td>
-			<td>100727</td>
+			<td>100734</td>
 			<td>
-				<RuleID id="19ae0094a8d845a1bb1997af0ad61fa7" />
+				<RuleID id="a9ec9cf625ff42769298671d1bbcd247" />
 			</td>
-			<td>Cisco IOS XE - Remote Code Execution - CVE:CVE-2023-20198</td>
+			<td>Apache Camel - Remote Code Execution - CVE:CVE-2025-29891</td>
 			<td>This is a New Detection</td>
 		</tr>
 		<tr>
-			<td>2025-03-10</td>
 			<td>2025-03-17</td>
+			<td>2025-04-01</td>
 			<td>Log</td>
-			<td>100728</td>
+			<td>100735</td>
 			<td>
-				<RuleID id="83a677f082264693ad64a2827ee56b66" />
+				<RuleID id="3d6bf99039b54312a1a2165590aea1ca" />
 			</td>
-			<td>Sitecore - Remote Code Execution - CVE:CVE-2024-46938</td>
-			<td>This is a New Detection</td>
-		</tr>
-		<tr>
-			<td>2025-03-10</td>
-			<td>2025-03-17</td>
-			<td>Log</td>
-			<td>100729</td>
-			<td>
-				<RuleID id="166b7ce85ce443538f021228a6752a38" />
-			</td>
-			<td>Microsoft SharePoint - Remote Code Execution - CVE:CVE-2023-33160</td>
-			<td>This is a New Detection</td>
-		</tr>
-		<tr>
-			<td>2025-03-10</td>
-			<td>2025-03-17</td>
-			<td>Log</td>
-			<td>100730</td>
-			<td>
-				<RuleID id="35fe23e7bd324d00816c82d098d47b69" />
-			</td>
-			<td>Pentaho - Template Injection - CVE:CVE-2022-43769, CVE:CVE-2022-43939</td>
+			<td>Progress Software WhatsUp Gold - Remote Code Execution - CVE:CVE-2024-4885</td>
 			<td>This is a New Detection</td>
 		</tr>
 	</tbody>

--- a/src/content/release-notes/waf.yaml
+++ b/src/content/release-notes/waf.yaml
@@ -5,11 +5,14 @@ productLink: "/waf/"
 productArea: Application security
 productAreaLink: /fundamentals/reference/changelog/security/
 entries:
-  - publish_date: "2025-03-10"
-    scheduled_date: "2025-03-17"
+  - publish_date: "2025-03-17"
+    scheduled_date: "2025-04-01"
     individual_page: true
     scheduled: true
     link: "/waf/change-log/scheduled-changes/"
+  - publish_date: "2025-03-17"
+    individual_page: true
+    link: "/waf/change-log/2025-03-17/"
   - publish_date: "2025-03-11"
     individual_page: true
     link: "/waf/change-log/2025-03-11-emergency/"


### PR DESCRIPTION
Released updates for March 17, 2025, including new detection rules for security vulnerabilities.

Added a new release note for March 17, 2025.
Introduced 4 new detections.
Updated action from 'N/A' to 'Block' for the new detection.
Added Files

src/content/docs/waf/change-log/2025-03-17.mdx