### PR TITLE
fix(.net): fix example for .NET

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
@@ -84,7 +84,7 @@ The [PutObjectAsync](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/M
 
 :::caution
 
-`DisablePayloadSigning = true` must be passed as Cloudflare R2 does not currently support the Streaming SigV4 implementation used by AWSSDK.S3.
+`DisablePayloadSigning = true` and `DisableDefaultChecksumValidation = true` must be passed as Cloudflare R2 does not currently support the Streaming SigV4 implementation used by AWSSDK.S3.
 
 :::
 
@@ -95,7 +95,8 @@ static async Task PutObject()
 	{
 		FilePath = @"/path/file.txt",
 		BucketName = "sdk-example",
-		DisablePayloadSigning = true
+		DisablePayloadSigning = true,
+    DisableDefaultChecksumValidation = true
 	};
 
 	var response = await s3Client.PutObjectAsync(request);

--- a/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-net.mdx
@@ -83,9 +83,7 @@ static async Task ListObjectsV2()
 The [PutObjectAsync](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/MIS3PutObjectAsyncPutObjectRequestCancellationToken.html) and [GetObjectAsync](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/MIS3GetObjectAsyncStringStringCancellationToken.html) methods can be used to upload objects and download objects from an R2 bucket respectively.
 
 :::caution
-
 `DisablePayloadSigning = true` and `DisableDefaultChecksumValidation = true` must be passed as Cloudflare R2 does not currently support the Streaming SigV4 implementation used by AWSSDK.S3.
-
 :::
 
 ```csharp


### PR DESCRIPTION

### Summary
When using latest version of AWS.S3 SDK the DisableDefaultChecksumValidation = true also needs to be provided else the SDK still tries to sign the payload.

### Screenshots (optional)



### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
