### PR TITLE
[Agents] add a redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -108,6 +108,7 @@
 /agents/examples/sdk/ /agents/api-reference/agents-api/ 301
 /agents/examples/build-mcp-server/ /agents/api-reference/build-mcp-server/ 301
 /agents/api-reference/build-mcp-server/ /agents/guides/build-mcp-server/ 301
+/agents/api-reference/sdk/ /agents/api-reference/ 301
 
 
 # ai


### PR DESCRIPTION
searching for "cloudflare agents sdk" on google currently leads to /agents/api-reference/sdk/, which is a 404. This patch adds a redirect to /agents/api-reference/
