### PR TITLE
CACHE-11939: add request cf overriding cache rules compat flags

### DIFF
--- a/src/content/compatibility-flags/fetch-api-request-cf-overrides-cache-rules.md
+++ b/src/content/compatibility-flags/fetch-api-request-cf-overrides-cache-rules.md
@@ -1,0 +1,14 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Override cache rules cache settings in `request.cf` object for Fetch API"
+sort_date: "2023-08-01"
+enable_date: "2025-04-02"
+enable_flag: "request_cf_overrides_cache_rules"
+disable_flag: "no_request_cf_overrides_cache_rules"
+---
+
+This flag changes the behavior of cache when requesting assets via the [Fetch API](/workers/runtime-apis/fetch). Cache settings specified in the `request.cf` object, such as `cacheEverything` and `cacheTtl`, are now given precedence over any [Cache Rules](/cache/how-to/cache-rules/) set.


### PR DESCRIPTION
### Summary

Adding a new compatibility flags: `request_cf_overrides_cache_rules`. The Cache team has fixed a behavior in cache recently for workers scripts that make subrequests either via the Fetch where by the cache settings in the `request.cf` object specified given the precedence vs Cache Rules. Up until now, for example, if `cacheTtl` was specified in both the worker script and a cache rule was configured to modify `cacheTtl` for the requested resource, cache rules would override the `cacheTtl` specified in the `request.cf` object. However, with the upcoming change, we have updated Cache such if the above flags are enabled then settings specified in the `request.cf` object take precedence. 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
