### PR TITLE
Rules: Add URL Rewrite Template for Normalizing Encoded Forward Slashes (%2F)

### DIFF
--- a/src/content/docs/rules/transform/examples/normalize-encoded-slash.mdx
+++ b/src/content/docs/rules/transform/examples/normalize-encoded-slash.mdx
@@ -1,0 +1,40 @@
+---
+pcx_content_type: example  
+summary: Create a rewrite URL rule (part of Transform Rules) to normalize encoded forward slashes (`%2F`) in the request path to standard slashes (`/`).  
+products:  
+  - Transform Rules  
+operation:  
+  - Rewrite URL  
+title: Normalize encoded slashes in URL path  
+description: Create a rewrite URL rule (part of Transform Rules) to normalize encoded forward slashes (`%2F`) in the request path to standard slashes (`/`).  
+---
+
+import { Example } from "~/components";
+
+## Why normalize `%2F`?
+
+Different web servers and applications handle encoded forward slashes (`%2F`) in URLs differently. Cloudflare follows [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), which specifies that `%2F` should **not** be automatically normalized to `/` because `/` is a reserved character in URLs, and decoding it might change the intended meaning of the path.
+
+However, many origin servers **do** automatically decode `%2F` into `/` when processing requests. If your origin server behaves this way, you may want to apply the same normalization at Cloudflare’s edge to ensure consistency in request handling, rule evaluation, and logging.
+
+## How to normalize `%2F`
+
+To normalize encoded forward slashes (`%2F`) to standard slashes (`/`) in the request path before [subsequent](/ruleset-engine/reference/phases-list/) rule evaluation, create a new rewrite URL rule and define a dynamic URL path rewrite using [`url_decode()`](/ruleset-engine/rules-language/functions/#url_decode) function:
+
+<Example>
+
+Text in **Expression Editor**:
+
+```txt
+(lower(raw.http.request.full_uri) wildcard "*%2f*")
+```
+
+Text after **Path** > **Rewrite to...** > _Dynamic_:
+
+```txt
+url_decode(http.request.uri.path)
+```
+
+</Example>
+
+This transformation ensures that `%2F` is always treated as `/` in the request path. This is particularly useful when setting up rules that depend on URL path matching, as it prevents discrepancies caused by differing normalization behaviors.

--- a/src/content/docs/rules/transform/examples/normalize-encoded-slash.mdx
+++ b/src/content/docs/rules/transform/examples/normalize-encoded-slash.mdx
@@ -11,9 +11,7 @@ description: Create a rewrite URL rule (part of Transform Rules) to normalize en
 
 import { Example } from "~/components";
 
-## Why normalize `%2F`?
-
-Different web servers and applications handle encoded forward slashes (`%2F`) in URLs differently. Cloudflare follows [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), which specifies that `%2F` should **not** be automatically normalized to `/` because `/` is a reserved character in URLs, and decoding it might change the intended meaning of the path.
+Different web servers and applications handle encoded forward slashes (`%2F`) in URLs differently. Cloudflare follows [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), which specifies that `%2F` **should not** be automatically normalized to `/` because `/` is a reserved character in URLs, and decoding it might change the intended meaning of the path.
 
 However, many origin servers **do** automatically decode `%2F` into `/` when processing requests. If your origin server behaves this way, you may want to apply the same normalization at Cloudflare’s edge to ensure consistency in request handling, rule evaluation, and logging.
 


### PR DESCRIPTION
### Summary

This PR introduces a new Transform Rules template that allows customers to normalize encoded forward slashes (%2F) in the request path to standard slashes (/). This helps align Cloudflare’s request handling with origin server behavior, as many web servers automatically decode %2F into /.

The template uses the url_decode(http.request.uri.path) function to ensure consistency in URL-based rule evaluation, logging, and request processing. This change does not alter Cloudflare’s default behavior, which follows [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) by preserving encoded reserved characters. Instead, it provides an optional one-click solution for users who need it.