### PR TITLE
Don't add arrow to external image links

### DIFF
--- a/src/plugins/rehype/external-links.ts
+++ b/src/plugins/rehype/external-links.ts
@@ -1,9 +1,19 @@
 import rehypeExternalLinks, { type Options } from "rehype-external-links";
 
 export const rehypeExternalLinksOptions = {
-	content: {
-		type: "text",
-		value: " ↗",
+	content: (element) => {
+		if (
+			element.children.length === 1 &&
+			element.children[0].type === "element" &&
+			element.children[0].tagName === "img"
+		) {
+			return;
+		}
+
+		return {
+			type: "text",
+			value: " ↗",
+		};
 	},
 	contentProperties: {
 		class: "external-link",


### PR DESCRIPTION
### Summary

`rel` attribute is preserved. `↗` text is dropped.

### Screenshots (optional)

<img width="283" alt="image" src="https://github.com/user-attachments/assets/44223d83-7630-4e35-ba1e-989cd9376d87" />
