### PR TITLE
[Astro] Pcx_product should be name, not property

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -56,9 +56,9 @@ if (currentSection) {
 		}
 
 		if (product.data.product.title) {
-			["pcx_product", "algolia_product_filter"].map((property) => {
+			["pcx_product", "algolia_product_filter"].map((name) => {
 				metaTags.push({
-					property,
+					name,
 					content: product.data.product.title,
 				});
 			});


### PR DESCRIPTION
### Summary

Borked a piece of our search indexing in #20936. Should flip back to old logic b/c it mirrors what the other values are called too.

Before (`<meta property="pcx_product"...>`)
![image](https://github.com/user-attachments/assets/4fff99c5-1ca9-482c-bedd-aabcbffe7a2d)

After (`<meta name="pcx_product"...>`)
![image](https://github.com/user-attachments/assets/e195dfde-5922-480e-b090-48c4b14e5d82)

