### PR TITLE
Lucas/20984 browser rendering screenshot fails

### DIFF
--- a/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
@@ -15,7 +15,7 @@ sidebar:
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";
 
-By following this guide, you will create a Worker that uses the Browser Rendering API along with [Durable Objects](/durable-objects/) to scrape titles from web pages and store them in [R2](/r2/).
+By following this guide, you will create a Worker that uses the Browser Rendering API along with [Durable Objects](/durable-objects/) to take screenshots from web pages and store them in [R2](/r2/).
 
 Using Durable Objects to persist browser sessions improves performance by eliminating the time that it takes to spin up a new browser session. Since Durable Objects re-uses sessions, it reduces the number of concurrent sessions needed.
 

--- a/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/browser-rendering-with-DO.mdx
@@ -15,7 +15,7 @@ sidebar:
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";
 
-By following this guide, you will create a Worker that uses the Browser Rendering API along with [Durable Objects](/durable-objects/) to take screenshots from web pages and store them in [R2](/r2/).
+By following this guide, you will create a Worker that uses the Browser Rendering API along with [Durable Objects](/durable-objects/) to scrape titles from web pages and store them in [R2](/r2/).
 
 Using Durable Objects to persist browser sessions improves performance by eliminating the time that it takes to spin up a new browser session. Since Durable Objects re-uses sessions, it reduces the number of concurrent sessions needed.
 
@@ -172,7 +172,7 @@ export class Browser {
 			await page.setViewport({ width: width[i], height: height[i] });
 			await page.goto("https://workers.cloudflare.com/");
 			const fileName = "screenshot_" + width[i] + "x" + height[i];
-			const sc = await page.screenshot({ path: fileName + ".jpg" });
+			const sc = await page.screenshot();
 
 			await this.env.BUCKET.put(folder + "/" + fileName + ".jpg", sc);
 		}


### PR DESCRIPTION
…ppeteer does not try to call fs to store images

### Summary

<!-- Add context such as the type of documentation being updated or added -->

closes #20984 for Browser Rendering documentation example. 

The example shows how to take a screenshot with puppeteer from a worker and save the image in R2. In this example, the call to page.screenshot failed due to fs not being available in Cloudflare Workers. 

Removing the "path" parameter from the call to page.screenshot fixed the issue, because puppeteer just passes the bytes array instead of trying to save the file locally.    

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
