### PR TITLE
[Release notes] Stop pulling Wrangler release notes from GitHub API

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1461,6 +1461,7 @@
 /workers/learning/fetch-event-lifecycle/ /workers/runtime-apis/fetch-event/ 301
 /workers/learning/getting-started/ /workers/get-started/quickstarts/ 301
 /workers/learning/profiling-workers/ /workers/reference/how-workers-works/ 301
+/workers/platform/changelog/wrangler/ https://github.com/cloudflare/workers-sdk/releases 301
 /workers/platform/scripts/ /api/resources/workers/subresources/scripts/methods/list/ 301
 /workers/platform/services/ /workers/runtime-apis/bindings/service-bindings/ 301
 /workers/platform/web-assembly/ /workers/platform/webassembly/ 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -1462,6 +1462,7 @@
 /workers/learning/getting-started/ /workers/get-started/quickstarts/ 301
 /workers/learning/profiling-workers/ /workers/reference/how-workers-works/ 301
 /workers/platform/changelog/wrangler/ https://github.com/cloudflare/workers-sdk/releases 301
+/workers/platform/changelog/wrangler/index.xml https://github.com/cloudflare/workers-sdk/releases.atom 301
 /workers/platform/scripts/ /api/resources/workers/subresources/scripts/methods/list/ 301
 /workers/platform/services/ /workers/runtime-apis/bindings/service-bindings/ 301
 /workers/platform/web-assembly/ /workers/platform/webassembly/ 301

--- a/src/content/docs/workers/platform/changelog/wrangler.mdx
+++ b/src/content/docs/workers/platform/changelog/wrangler.mdx
@@ -1,16 +1,5 @@
 ---
-pcx_content_type: changelog
+pcx_content_type: navigation
 title: Wrangler
-release_notes_file_name:
-  - wrangler
-head:
-  - tag: title
-    content: Wrangler Changelog
-description: Review recent changes to Cloudflare Wrangler.
+external_link: https://github.com/cloudflare/workers-sdk/releases
 ---
-
-import { ProductReleaseNotes } from "~/components";
-
-{/* <!-- All changelog entries are pulled directly from https://api.github.com/repos/cloudflare/workers-sdk/releases and manipulated in the src/util/release-notes.ts file (getWranglerChangelog() function). This is unique compared to other changelog entries. --> */}
-
-<ProductReleaseNotes />

--- a/src/pages/[...changelog].xml.ts
+++ b/src/pages/[...changelog].xml.ts
@@ -2,7 +2,6 @@ import rss from "@astrojs/rss";
 import { getCollection, getEntry } from "astro:content";
 import type { APIRoute } from "astro";
 import { marked, type Token } from "marked";
-import { getWranglerReleases } from "~/util/release-notes";
 import { slug } from "github-slugger";
 import { entryToString } from "~/util/container";
 
@@ -56,10 +55,6 @@ export const GET: APIRoute = async (context) => {
 				entry.data.release_notes_product_area_name
 		);
 	});
-
-	if (entry.data.release_notes_file_name?.includes("wrangler")) {
-		releaseNotes.push(await getWranglerReleases());
-	}
 
 	const mapped = await Promise.all(
 		releaseNotes.flatMap((product) => {

--- a/src/pages/release-notes/index.xml.ts
+++ b/src/pages/release-notes/index.xml.ts
@@ -2,7 +2,6 @@ import rss from "@astrojs/rss";
 import { getCollection, getEntry } from "astro:content";
 import type { APIRoute } from "astro";
 import { marked, type Token } from "marked";
-import { getWranglerReleases } from "~/util/release-notes";
 import { slug } from "github-slugger";
 import { entryToString } from "~/util/container";
 
@@ -20,8 +19,6 @@ export const GET: APIRoute = async (context) => {
 	const releaseNotes = await getCollection("release-notes", (e) => {
 		return e.id !== "api-deprecations";
 	});
-
-	releaseNotes.push(await getWranglerReleases());
 
 	const mapped = await Promise.all(
 		releaseNotes.flatMap((product) => {

--- a/src/util/release-notes.ts
+++ b/src/util/release-notes.ts
@@ -1,6 +1,4 @@
-import { z } from "astro:schema";
 import { getCollection } from "astro:content";
-import { type CollectionEntry } from "astro:content";
 
 export async function getReleaseNotes(opts?: {
 	filter?: Parameters<typeof getCollection<"release-notes">>[1];

--- a/src/util/release-notes.ts
+++ b/src/util/release-notes.ts
@@ -9,9 +9,7 @@ export async function getReleaseNotes(opts?: {
 }) {
 	let releaseNotes;
 
-	if (opts?.wranglerOnly) {
-		releaseNotes = [await getWranglerReleases()];
-	} else if (opts?.filter) {
+	if (opts?.filter) {
 		releaseNotes = await getCollection("release-notes", opts.filter);
 	} else {
 		releaseNotes = await getCollection("release-notes");
@@ -57,51 +55,4 @@ export async function getReleaseNotes(opts?: {
 	const entries = grouped.sort().reverse();
 
 	return { products, productAreas, releaseNotes: entries };
-}
-
-export async function getWranglerReleases(): Promise<
-	CollectionEntry<"release-notes">
-> {
-	const response = await fetch(
-		"https://api.github.com/repos/cloudflare/workers-sdk/releases?per_page=100",
-	);
-
-	if (!response.ok) {
-		throw new Error(
-			`[GetWranglerReleases] Received ${response.status} response from GitHub API.`,
-		);
-	}
-
-	const json = await response.json();
-
-	let releases = z
-		.object({
-			published_at: z.coerce.date(),
-			name: z.string(),
-			body: z.string(),
-		})
-		.array()
-		.parse(json);
-
-	releases = releases.filter((x) => x.name.startsWith("wrangler@"));
-
-	return {
-		id: "wrangler",
-		collection: "release-notes",
-		data: {
-			link: "/workers/platform/changelog/wrangler/",
-			productName: "wrangler",
-			productLink: "/workers/wrangler/",
-			productArea: "Developer platform",
-			productAreaLink: "/workers/platform/changelog/platform/",
-			entries: releases.map((release) => {
-				return {
-					publish_date: release.published_at.toISOString().substring(0, 10),
-					title: release.name.split("@")[1],
-					link: `https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%40${release.name.split("@")[1]}`,
-					description: release.body,
-				};
-			}),
-		},
-	};
 }


### PR DESCRIPTION
### Summary

With the Wrangler team more consistently writing up [summarized changelog entries](https://developers.cloudflare.com/changelog/2025-03-13-wrangler-v4/), think it's time to re-think having the [Wrangler release notes](https://developers.cloudflare.com/workers/platform/changelog/wrangler/) ported into docs.

The reason why is b/c the GitHub API usually ends up failing about `8 builds` a day as a result of [rate limiting](https://github.com/cloudflare/cloudflare-docs/actions/runs/13993938229/job/39184210591#step:6:1007). Given that the information is also already clearly available in GitHub (with an RSS feed there too), there doesn't appear to be much added value in also surfacing them in docs.

Theoretically, I suppose we could rewrite the component.... but there's a lot of other investment that needs to go into other things changelog so I'd rather spend the time there.

cc: @GregBrimble / @mikenomitch, fyi that this is an option we're considering. Open to having a convo if I'm missing pieces related to ☝️ .

### Additional context on timing

This has been more painful recently and -- with Dev Week coming up -- we don't want to be blocking any docs previews or publishes from going live.
