### PR TITLE
Don't limit input image pixels

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -69,6 +69,14 @@ export default defineConfig({
 			rehypeTitleFigure,
 		],
 	},
+	image: {
+		service: {
+			entrypoint: "astro/assets/services/sharp",
+			config: {
+				limitInputPixels: false,
+			},
+		},
+	},
 	experimental: {
 		contentIntellisense: true,
 	},


### PR DESCRIPTION
### Summary

Large gifs are failing the build: https://github.com/cloudflare/cloudflare-docs/actions/runs/14011261801/job/39231343261?pr=21062

https://docs.astro.build/en/reference/configuration-reference/#imageservice

Maybe we could look into adding an adhoc optimization pass like we do for SVG minification, but this'll do for now.
