### PR TITLE
Fixes small typo in CVE-2025-29927 changelog

### DIFF
--- a/src/content/changelog/workers/2025-03-22-next-js-vulnerability-waf.mdx
+++ b/src/content/changelog/workers/2025-03-22-next-js-vulnerability-waf.mdx
@@ -60,7 +60,7 @@ We've made a WAF (Web Application Firewall) rule available to all sites on Cloud
 **Note**: This rule is not enabled by default as it blocked requests across sites for specific authentication middleware.
 
 * This managed rule protects sites using Next.js on Workers and Pages, as well as sites using Cloudflare to protect Next.js applications hosted elsewhere.
-* This rule has been made avaiable (but not enabled by default) to all sites as part of our [WAF Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) and blocks requests that attempt to bypass authentication in Next.js applications.
+* This rule has been made available (but not enabled by default) to all sites as part of our [WAF Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) and blocks requests that attempt to bypass authentication in Next.js applications.
 * The vulnerability affects almost all Next.js versions, and is patched in Next.js `14.2.25` and `15..2.3`. **Users on older versions of Next.js (`11.1.4` to `13.5.6`) do not have a patch available**.
 
 The managed WAF rule mitigates this by blocking _external_ user requests with the `x-middleware-subrequest` header regardless of Next.js version, but we recommend users using Next.js 14 and 15 upgrade to the patched versions of Next.js as an additional mitigation.


### PR DESCRIPTION
Fixes small typo in `CVE-2025-29927` changelog