### PR TITLE
Bump redirects-in-workers@0.0.7 and raise limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
 				"react-icons": "5.5.0",
 				"react-instantsearch": "7.15.4",
 				"react-markdown": "10.1.0",
-				"redirects-in-workers": "0.0.5",
+				"redirects-in-workers": "0.0.7",
 				"rehype": "13.0.2",
 				"rehype-autolink-headings": "7.1.0",
 				"rehype-external-links": "3.0.0",
@@ -15219,9 +15219,9 @@
 			}
 		},
 		"node_modules/redirects-in-workers": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/redirects-in-workers/-/redirects-in-workers-0.0.5.tgz",
-			"integrity": "sha512-FZZjw7c7iiSHlVQXAwv+KFovPGM1KIrCzgOcKVOk4vvGFToWJg3J75eoNjYufxAFWGJOXsUihMsEIpdbY5RfpQ==",
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/redirects-in-workers/-/redirects-in-workers-0.0.7.tgz",
+			"integrity": "sha512-RAN76DEgp3/W1IU1c+BXyccfSN38zUR/C2YCnsP2L+3uPbmFPFLXWC+vwLyvVSF1n4SgV6MNtWHaF+eZkmF3uw==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"react-icons": "5.5.0",
 		"react-instantsearch": "7.15.4",
 		"react-markdown": "10.1.0",
-		"redirects-in-workers": "0.0.5",
+		"redirects-in-workers": "0.0.7",
 		"rehype": "13.0.2",
 		"rehype-autolink-headings": "7.1.0",
 		"rehype-external-links": "3.0.0",

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2,13 +2,16 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateRedirectsEvaluator } from "redirects-in-workers";
 import redirectsFileContents from "../dist/__redirects";
 
-const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents);
+const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
+	maxLineLength: 10_000, // Usually 2_000
+	maxStaticRules: 10_000, // Usually 2_000
+	maxDynamicRules: 2_000, // Usually 100
+});
 
 export default class extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request) {
 		try {
 			try {
-				// @ts-expect-error Ignore Fetcher type mismatch
 				const redirect = await redirectsEvaluator(request, this.env.ASSETS);
 				if (redirect) {
 					return redirect;
@@ -24,7 +27,6 @@ export default class extends WorkerEntrypoint<Env> {
 				);
 				const redirect = await redirectsEvaluator(
 					new Request(forceTrailingSlashURL, request),
-					// @ts-expect-error Ignore Fetcher type mismatch
 					this.env.ASSETS,
 				);
 				if (redirect) {


### PR DESCRIPTION
Increased limits to save @kodster28's sanity. This does come at a cost, especially for the dynamic rules.

Expect cold start requests to take longer, the larger the `__redirects` file you have. Expect **every request** to take longer, the more dynamic rules you have.