### PR TITLE
Adds changelog entry for cpu_ms limit bump

### DIFF
--- a/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
+++ b/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
@@ -1,0 +1,48 @@
+---
+title: Run Workers for up to 5 minutes of CPU-time
+description: Workers now support up to 5 minutes of CPU time per request. Allowing more CPU-intensive workloads.
+products:
+  - workers
+date: 2025-03-25T17:00:00Z
+---
+
+import { Render, TypeScriptExample, WranglerConfig } from "~/components";
+
+You can now run a Worker for up to 5 minutes of CPU time for each request.
+
+Previously, each Workers request ran for a maximum of 30 seconds of CPU time. This
+meant that some compute-intensive tasks were impossible to do with a Worker. For instance,
+a user might want to take the cryptographic hash of a large file from R2. If
+this computation ran for over 30 seconds, the Worker request would have timed out.
+
+By default, Workers are still limited to 30 seconds of CPU time. This protects developers
+from incurring accidental cost due to buggy code.
+
+By changing the `cpu_ms` value in your Wrangler configuration, you can opt in to
+any value up to 300,000 (5 minutes).
+
+<WranglerConfig>
+
+```jsonc
+{
+	// ...rest of your configuration...
+	"limits": {
+		"cpu_ms": 300000,
+	},
+	// ...rest of your configuration...
+}
+```
+
+</WranglerConfig>
+
+:::note
+CPU time is the amount of time the CPU actually spends doing work during a given request.
+If a Worker's request makes a sub-request and waits for that request to come back before
+doing additional work, this time spent waiting **is not** counted towards CPU time.
+
+Worker requests could run for more than 30 seconds of total time prior to this change — only
+CPU time was limited.
+:::
+
+For more information, see the documentation on [Wrangler configuration for `cpu_ms`](/workers/wrangler/configuration/#limits)
+and on [Workers CPU time limits](/workers/platform/limits/#cpu-time).

--- a/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
+++ b/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
@@ -12,7 +12,7 @@ You can now run a Worker for up to 5 minutes of CPU time for each request.
 
 Previously, each Workers request ran for a maximum of 30 seconds of CPU time. This
 meant that some compute-intensive tasks were impossible to do with a Worker. For instance,
-a user might want to take the cryptographic hash of a large file from R2. If
+you might want to take the cryptographic hash of a large file from R2. If
 this computation ran for over 30 seconds, the Worker request would have timed out.
 
 By default, Workers are still limited to 30 seconds of CPU time. This protects developers

--- a/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
+++ b/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
@@ -44,5 +44,7 @@ Worker requests could run for more than 30 seconds of total time prior to this c
 CPU time was limited.
 :::
 
-For more information, see the documentation on [Wrangler configuration for `cpu_ms`](/workers/wrangler/configuration/#limits)
+For more information on the updates limits, see the documentation on [Wrangler configuration for `cpu_ms`](/workers/wrangler/configuration/#limits)
 and on [Workers CPU time limits](/workers/platform/limits/#cpu-time).
+
+For building long-running tasks on Cloudflare, we also recommend checking out [Workflows](/workflows/) and [Queues](/queues/). 

--- a/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
+++ b/src/content/changelog/workers/2025-03-25-higher-cpu-limits.mdx
@@ -3,14 +3,14 @@ title: Run Workers for up to 5 minutes of CPU-time
 description: Workers now support up to 5 minutes of CPU time per request. Allowing more CPU-intensive workloads.
 products:
   - workers
-date: 2025-03-25T17:00:00Z
+date: 2025-03-26T17:00:00Z
 ---
 
 import { Render, TypeScriptExample, WranglerConfig } from "~/components";
 
 You can now run a Worker for up to 5 minutes of CPU time for each request.
 
-Previously, each Workers request ran for a maximum of 30 seconds of CPU time. This
+Previously, each Workers request ran for a maximum of 30 seconds of CPU time — that is the time that a Worker is actually performing a task (we still allowed unlimited wall-clock time, in case you were waiting on slow resources). This
 meant that some compute-intensive tasks were impossible to do with a Worker. For instance,
 you might want to take the cryptographic hash of a large file from R2. If
 this computation ran for over 30 seconds, the Worker request would have timed out.

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -62,7 +62,7 @@ Cloudflare does not enforce response limits on response body sizes, but cache li
 | ------------------------ | ------------------------------------------ | ---------------- |
 | [Request](#request)      | 100,000 requests/day<br/>1000 requests/min | No limit         |
 | [Worker memory](#memory) | 128 MB                                     | 128 MB           |
-| [CPU time](#cpu-time)    | 10 ms                                      | 30 s HTTP request <br/> 15 min [Cron Trigger](/workers/configuration/cron-triggers/)    	|
+| [CPU time](#cpu-time)    | 10 ms                                      | 5 min HTTP request <br/> 15 min [Cron Trigger](/workers/configuration/cron-triggers/)    	|
 | [Duration](#duration)    | No limit                                   | No limit for Workers. <br/>15 min duration limit for [Cron Triggers](/workers/configuration/cron-triggers/), [Durable Object Alarms](/durable-objects/api/alarms/) and [Queue Consumers](/queues/configuration/javascript-apis/#consumer) |
 
 ### Duration
@@ -82,7 +82,7 @@ CPU time is the amount of time the CPU actually spends doing work, during a give
 
 Using DevTools locally can help identify CPU intensive portions of your code. See the [CPU profiling with DevTools documentation](/workers/observability/dev-tools/cpu-usage/) to learn more.
 
-You can also set a custom limit on the amount of CPU time that can be used during each invocation of your Worker. To do so, navigate to the Workers section in the Cloudflare dashboard. Select the specific Worker you wish to modify, then click on the "Settings" tab where you can adjust the CPU time limit.
+You can also set a [custom limit](/workers/wrangler/configuration/#limits) on the amount of CPU time that can be used during each invocation of your Worker. To do so, navigate to the Workers section in the Cloudflare dashboard. Select the specific Worker you wish to modify, then click on the "Settings" tab where you can adjust the CPU time limit.
 
 :::note
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -398,7 +398,9 @@ watch_dir = "build_watch_dir"
 
 ## Limits
 
-You can impose limits on your Worker's behavior at runtime. Limits are only supported for the [Standard Usage Model](/workers/platform/pricing/#example-pricing-standard-usage-model). Limits are only enforced when deployed to Cloudflare's network, not in local development. The CPU limit can be set to a maximum of 30,000 milliseconds (30 seconds).
+You can impose limits on your Worker's behavior at runtime. Limits are only supported for the [Standard Usage Model](/workers/platform/pricing/#example-pricing-standard-usage-model).
+Limits are only enforced when deployed to Cloudflare's network, not in local development. The CPU limit
+can be set to a maximum of 300,000 milliseconds (5 minutes).
 
 <Render file="isolate-cpu-flexibility" /> <br />
 


### PR DESCRIPTION
### Summary

Adds changelog entry and tweaks docs for allowing cpu_ms to go up to 5 minutes.