### PR TITLE
[WAF] Add custom rules availability table

### DIFF
--- a/src/content/docs/waf/custom-rules/index.mdx
+++ b/src/content/docs/waf/custom-rules/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-import { Render } from "~/components";
+import { Render, FeatureTable } from "~/components";
 
 <Render file="custom-rules-intro" product="waf" />
 
@@ -17,6 +17,10 @@ Refer to the [migration guide](/waf/reference/migration-guides/firewall-rules-to
 :::
 
 To define sets of custom rules that apply to more than one zone, use [custom rulesets](/waf/account/custom-rulesets/), which require an Enterprise plan with a paid add-on.
+
+## Availability
+
+<FeatureTable id="security.waf_c_custom_rules" />
 
 ---
 


### PR DESCRIPTION
### Summary

Adds availability table to custom rules, previously only visible in the Plans page.
