### PR TITLE
add note about environments in generated wrangler configuration section

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1504,15 +1504,13 @@ A common example of using a redirected configuration is where a custom build too
 
   This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
 
-- Then, the user runs a custom build, which might read the user's Wrangler configuration file to find the source code entry-point:
+- Then, the user runs a custom build for a given environment (for example `staging`). This will read the user's Wrangler configuration file to find the source code entry-point and environment specific settings:
 
   ```bash
-  > my-tool build
+  > my-tool build --env=staging
   ```
 
-  We'll assume that `my-tool` is specifically targeting the `staging` environment (for instance set by the user with some option of `my-tool`).
-
-- This `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
+- `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
   <FileTree>

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1493,9 +1493,6 @@ A common example of using a redirected configuration is where a custom build too
   name = "my-worker"
   main = "src/index.ts"
 
-  [[kv_namespaces]]
-  binding = "<BINDING_NAME1>"
-
   [vars]
   MY_VARIABLE = "production variable"
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1544,7 +1544,7 @@ A common example of using a redirected configuration is where a custom build too
   }
   ```
 
-  Note that, now, the `main` property points to the generated code entry-point, no environment is defined,
+  Now, the `main` property points to the generated code entry-point, no environment is defined,
   and the `MY_VARIABLE` variable is resolved to the staging environment value.
 
   And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1505,7 +1505,7 @@ A common example of using a redirected configuration is where a custom build too
 
   </WranglerConfig>
 
-  This configuration points `main` at the user's code entry-point and defined the `MY_VARIABLE` in two different environments.
+  This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
 
 - Then, the user runs a custom build, which might read the user's Wrangler configuration file to find the source code entry-point:
 
@@ -1513,7 +1513,7 @@ A common example of using a redirected configuration is where a custom build too
   > my-tool build
   ```
 
-  We'll assume that `my-tool` is specifically targeting the `staging` environment (for instance set by the user with some API of `my-tool`).
+  We'll assume that `my-tool` is specifically targeting the `staging` environment (for instance set by the user with some option of `my-tool`).
 
 - This `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file.
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1530,9 +1530,6 @@ A common example of using a redirected configuration is where a custom build too
   {
   	"name": "my-worker",
   	"main": "./index.js",
-  	"kv_namespaces": [
-  		{ "binding": "<BINDING_NAME1>", "id": "<NAMESPACE_ID1>" }
-  	],
   	"vars": {
   		"MY_VARIABLE": "staging variable"
   	}

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1478,8 +1478,8 @@ This file must contain only a single JSON object of the form:
 When this `config.json` file exists, Wrangler will follow the `configPath` (relative to the `.wrangler/deploy/config.json` file) to find the generated Wrangler configuration file to load and use in the current command.
 Wrangler will display messaging to the user to indicate that the configuration has been redirected to a different file than the user's configuration file.
 
-Note that the generated configuration file should not include any [environments](#environments).
-This is because such a file, when required, should be created based on a target environment's specific values, meaning that tools should generate distinct configuration files for different environments.
+The generated configuration file should not include any [environments](#environments).
+This is because such a file, when required, should be created based on a target environment's specific values and tools should generate distinct configuration files for different environments.
 
 ### Custom build tool example
 
@@ -1505,7 +1505,7 @@ A common example of using a redirected configuration is where a custom build too
 
   </WranglerConfig>
 
-  Note that this configuration points `main` at the user's code entry-point and that it also defined the `MY_VARIABLE` in two different environments.
+  This configuration points `main` at the user's code entry-point and defined the `MY_VARIABLE` in two different environments.
 
 - Then, the user runs a custom build, which might read the user's Wrangler configuration file to find the source code entry-point:
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1485,27 +1485,35 @@ This is because such a file, when required, should be created based on a target 
 
 A common example of using a redirected configuration is where a custom build tool, or framework, wants to modify the user's configuration to be used when deploying, by generating a new configuration in a `dist` directory.
 
-- First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file.
+- First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
 
-<WranglerConfig>
+  <WranglerConfig>
 
-```toml title="wrangler.toml"
-name = "my-worker"
-main = "src/index.ts"
-[[kv_namespaces]]
-binding = "<BINDING_NAME1>"
-id = "<NAMESPACE_ID1>"
-```
+  ```toml title="wrangler.toml"
+  name = "my-worker"
+  main = "src/index.ts"
 
-</WranglerConfig>
+  [[kv_namespaces]]
+  binding = "<BINDING_NAME1>"
 
-Note that this configuration points `main` at the user's code entry-point.
+  [vars]
+  MY_VARIABLE = "production variable"
+
+  [env.staging.vars]
+  MY_VARIABLE = "staging variable"
+  ```
+
+  </WranglerConfig>
+
+  Note that this configuration points `main` at the user's code entry-point and that it also defined the `MY_VARIABLE` in two different environments.
 
 - Then, the user runs a custom build, which might read the user's Wrangler configuration file to find the source code entry-point:
 
   ```bash
   > my-tool build
   ```
+
+  We'll assume that `my-tool` is specifically targeting the `staging` environment (for instance set by the user with some API of `my-tool`).
 
 - This `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file.
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
@@ -1527,11 +1535,17 @@ Note that this configuration points `main` at the user's code entry-point.
   {
   	"name": "my-worker",
   	"main": "./index.js",
-  	"kv_namespaces": [{ "binding": "<BINDING_NAME1>", "id": "<NAMESPACE_ID1>" }]
+  	"kv_namespaces": [
+  		{ "binding": "<BINDING_NAME1>", "id": "<NAMESPACE_ID1>" }
+  	],
+  	"vars": {
+  		"MY_VARIABLE": "staging variable"
+  	}
   }
   ```
 
-  Note that, now, the `main` property points to the generated code entry-point.
+  Note that, now, the `main` property points to the generated code entry-point, no environment is defined,
+  and the `MY_VARIABLE` variable is resolved to the staging environment value.
 
   And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1479,7 +1479,7 @@ When this `config.json` file exists, Wrangler will follow the `configPath` (rela
 Wrangler will display messaging to the user to indicate that the configuration has been redirected to a different file than the user's configuration file.
 
 The generated configuration file should not include any [environments](#environments).
-This is because such a file, when required, should be created based on a target environment's specific values and tools should generate distinct configuration files for different environments.
+This is because such a file, when required, should be created as part of a build step, which should already target a specific environment. These build tools should generate distinct deployment configuration files for different environments.
 
 ### Custom build tool example
 
@@ -1515,7 +1515,7 @@ A common example of using a redirected configuration is where a custom build too
 
   We'll assume that `my-tool` is specifically targeting the `staging` environment (for instance set by the user with some option of `my-tool`).
 
-- This `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file.
+- This `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
   <FileTree>

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1478,6 +1478,9 @@ This file must contain only a single JSON object of the form:
 When this `config.json` file exists, Wrangler will follow the `configPath` (relative to the `.wrangler/deploy/config.json` file) to find the generated Wrangler configuration file to load and use in the current command.
 Wrangler will display messaging to the user to indicate that the configuration has been redirected to a different file than the user's configuration file.
 
+Note that the generated configuration file should not include any [environments](#environments).
+This is because such a file, when required, should be created based on a target environment's specific values, meaning that tools should generate distinct configuration files for different environments.
+
 ### Custom build tool example
 
 A common example of using a redirected configuration is where a custom build tool, or framework, wants to modify the user's configuration to be used when deploying, by generating a new configuration in a `dist` directory.


### PR DESCRIPTION
This PR adds a note to the generated wrangler configuration section clarifying that the generated config file should not include any environments.

Note: this is being enforced by the changes in https://github.com/cloudflare/workers-sdk/pull/8596