### PR TITLE
fix non-existing pages commands in the generated wrangler configuration section

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1284,8 +1284,8 @@ Wrangler uses this generated configuration only for the following deploy and dev
 - `wrangler versions upload`
 - `wrangler versions deploy`
 - `wrangler pages deploy`
-- `wrangler pages build`
-- `wrangler pages build-env`
+- `wrangler pages functions build`
+- `wrangler pages functions build-env`
 
 When running these commands, Wrangler looks up the directory tree from the current working directory for a file at the path `.wrangler/deploy/config.json`.
 This file must contain only a single JSON object of the form:


### PR DESCRIPTION
the `wrangler pages build` and `wrangler pages build-env` as missing the `functions` keyword

As you can see the `wrangler pages build-env` command is not recognized:
![Screenshot 2025-03-25 at 11 31 38](https://github.com/user-attachments/assets/4b2baf3e-bcc7-40be-a9fe-9691b5194a7c)

While `wrangler pages functions build-env` is:
![Screenshot 2025-03-25 at 11 31 52](https://github.com/user-attachments/assets/ab0e3773-ecb5-44f1-a03f-99f59ab3dafd)
