### PR TITLE
[Rules] Custom Errors: Asset description is a required field

### DIFF
--- a/src/content/docs/rules/custom-errors/create-api.mdx
+++ b/src/content/docs/rules/custom-errors/create-api.mdx
@@ -104,6 +104,7 @@ curl --request PUT \
 --header "Authorization: Bearer <API_TOKEN>" \
 --header "Content-Type: application/json" \
 --data '{
+  "description": "Standard 5xx error template page",
   "url": "https://example.com/errors/500_new_template.html"
 }'
 ```

--- a/src/content/docs/rules/custom-errors/parameters.mdx
+++ b/src/content/docs/rules/custom-errors/parameters.mdx
@@ -58,7 +58,7 @@ Custom error assets have the following parameters:
     - Numbers (`0-9`)
     - The underscore (`_`) character
   - The maximum length is 200 characters.
-- **`description`** <Type text="String"/> <MetaInfo text="Optional"/>
+- **`description`** <Type text="String"/> <MetaInfo text="Required"/>
   - A string describing the custom error asset.
   - Example value: `"Standard 5xx error template page"`.
 - **`url`** <Type text="String"/> <MetaInfo text="Required"/>


### PR DESCRIPTION
### Summary

Updated the documentation to reflect that the 'description' field for Custom Error Assets is required for both creation and update operations.