### PR TITLE
clarify which bindings require module-worker syntax

### DIFF
--- a/src/content/docs/workers/reference/migrate-to-module-workers.mdx
+++ b/src/content/docs/workers/reference/migrate-to-module-workers.mdx
@@ -14,10 +14,11 @@ This guide will show you how to migrate your Workers from the [Service Worker](h
 
 There are several reasons to migrate your Workers to the ES modules format:
 
-1. [Durable Objects](/durable-objects/), [D1](/d1/), [Workers AI](/workers-ai/), [Vectorize](/vectorize/) and other bindings can only be used from Workers that use ES modules.
-2. Your Worker will run faster. With service workers, bindings are exposed as globals. This means that for every request, the Workers runtime must create a new JavaScript execution context, which adds overhead and time. Workers written using ES modules can reuse the same execution context across multiple requests.
-3. You can [gradually deploy changes to your Worker](/workers/configuration/versions-and-deployments/gradual-deployments/) when you use the ES modules format.
-4. You can easily publish Workers using ES modules to `npm`, allowing you to import and reuse Workers within your codebase.
+1. Your Worker will run faster. With service workers, bindings are exposed as globals. This means that for every request, the Workers runtime must create a new JavaScript execution context, which adds overhead and time. Workers written using ES modules can reuse the same execution context across multiple requests.
+2. Implementing [Durable Objects](/durable-objects/) requires Workers that use ES modules.
+3. Bindings for [D1](/d1/), [Workers AI](/workers-ai/), [Vectorize](/vectorize/), [Workflows](/workflows/), and [Images](/images/) can only be used from Workers that use ES modules.
+4. You can [gradually deploy changes to your Worker](/workers/configuration/versions-and-deployments/gradual-deployments/) when you use the ES modules format.
+5. You can easily publish Workers using ES modules to `npm`, allowing you to import and reuse Workers within your codebase.
 
 ## Migrate a Worker
 

--- a/src/content/docs/workers/reference/migrate-to-module-workers.mdx
+++ b/src/content/docs/workers/reference/migrate-to-module-workers.mdx
@@ -16,7 +16,7 @@ There are several reasons to migrate your Workers to the ES modules format:
 
 1. Your Worker will run faster. With service workers, bindings are exposed as globals. This means that for every request, the Workers runtime must create a new JavaScript execution context, which adds overhead and time. Workers written using ES modules can reuse the same execution context across multiple requests.
 2. Implementing [Durable Objects](/durable-objects/) requires Workers that use ES modules.
-3. Bindings for [D1](/d1/), [Workers AI](/workers-ai/), [Vectorize](/vectorize/), [Workflows](/workflows/), and [Images](/images/) can only be used from Workers that use ES modules.
+3. Bindings for [D1](/d1/), [Workers AI](/workers-ai/), [Vectorize](/vectorize/), [Workflows](/workflows/), and [Images](/images/transform-images/bindings/) can only be used from Workers that use ES modules.
 4. You can [gradually deploy changes to your Worker](/workers/configuration/versions-and-deployments/gradual-deployments/) when you use the ES modules format.
 5. You can easily publish Workers using ES modules to `npm`, allowing you to import and reuse Workers within your codebase.
 

--- a/src/content/docs/workers/runtime-apis/bindings/images.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/images.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: Images
-external_link: /images
+external_link: /images/transform-images/bindings/
 head: []
 description: Store, transform, optimize, and deliver images at scale.
 


### PR DESCRIPTION
### Summary

* Clarify which bindings are incompatible with ServiceWorker syntax - "other bindings" is not helpful.
* Clarify SW interaction with DO - bindings are fine, implementing a DO requires MW
* Put speed first - don't want people not using restricted bindings to miss benefit to them by skimming.
* deeplink to images bindings
    Images bindings are hard to find from the main "images" landing page.
    Linking directly to them saves some confusion.
    
 ### Screenshot
 
![image](https://github.com/user-attachments/assets/fadb20e0-e70b-483e-97c6-dc8623b0ba94)
   

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

