### PR TITLE
[Support] Add page on status page and subscribing

### DIFF
--- a/src/content/docs/fundamentals/api/reference/deprecations.mdx
+++ b/src/content/docs/fundamentals/api/reference/deprecations.mdx
@@ -18,3 +18,9 @@ Subscribe to all API deprecation posts via [RSS](/fundamentals/api/reference/dep
 :::
 
 <ProductReleaseNotes />
+
+## Related resources
+
+- [Available RSS feeds](/fundamentals/new-features/available-rss-feeds/) (for the [Cloudflare changelog](/changelog/))
+- [Subscribe to Cloudflare Status](/support/about-cloudflare/cloudflare-status/)
+- [Planned maintenance windows](/support/troubleshooting/disruptive-maintenance/)

--- a/src/content/docs/fundamentals/new-features/available-rss-feeds.mdx
+++ b/src/content/docs/fundamentals/new-features/available-rss-feeds.mdx
@@ -11,3 +11,8 @@ Cloudflare offers various RSS feeds as part of our [changelog](/changelog/), whi
 For more details on how these feeds are structured, refer to [Consuming RSS Feeds](/fundamentals/new-features/consuming-rss-feeds/).
 
 <AvailableChangelogFeeds />
+
+## Related resources
+
+- [Planned maintenance windows](/support/troubleshooting/disruptive-maintenance/)
+- [Subscribe to Cloudflare Status](/support/about-cloudflare/cloudflare-status/)

--- a/src/content/docs/support/about-cloudflare/cloudflare-status.mdx
+++ b/src/content/docs/support/about-cloudflare/cloudflare-status.mdx
@@ -1,0 +1,26 @@
+---
+pcx_content_type: concept
+title: Cloudflare Status
+---
+
+Cloudflare provides updates on the status of our services and network at https://www.cloudflarestatus.com/, which you should check if you notice unexpected behavior with Cloudflare.
+
+Beyond looking at the page itself, there are programmatic ways to consume this information.
+
+## Configure notifications
+
+Cloudflare offers a dedicated notification called **Incident Alert**, which lets you know when Cloudflare is experiencing an incident.
+
+You can configure this notification to send via [email](/notifications/get-started/), [Webhooks](/notifications/get-started/configure-webhooks/), or [PagerDuty](/notifications/get-started/configure-pagerduty/).
+
+## Use the API
+
+Cloudflare also provides status information through the [Cloudflare Status API](https://www.cloudflarestatus.com/api).
+
+Endpoints are displayed with examples using cURL and our embeded JavaScript widget (if available).
+
+## Related resources
+
+- [Available RSS feeds](/fundamentals/new-features/available-rss-feeds/) (for the [Cloudflare changelog](/changelog/))
+- [API deprecations](/fundamentals/api/reference/deprecations/)
+- [Planned maintenance windows](/support/troubleshooting/disruptive-maintenance/)

--- a/src/content/docs/support/troubleshooting/disruptive-maintenance/index.mdx
+++ b/src/content/docs/support/troubleshooting/disruptive-maintenance/index.mdx
@@ -2,20 +2,19 @@
 pcx_content_type: troubleshooting
 source: https://support.cloudflare.com/hc/en-us/articles/360060050511-Disruptive-Maintenance-Windows
 title: Disruptive Maintenance
-
 ---
 
-import { AvailableNotifications, Render } from "~/components"
+import { AvailableNotifications, Render } from "~/components";
 
 ## Scheduled Maintenance Windows
 
-Planned maintenances will be published on the status page using a *calendar* that is updated on a daily basis.
+Planned maintenances will be published on the status page using a _calendar_ that is updated on a daily basis.
 
 During these maintenance windows, customers may experience a slight increase in latency to the edge location which is under maintenance.
 
 :::note
 
-All dates in the calendar are in UTC Timezone. 
+All dates in the calendar are in UTC Timezone.
 :::
 
 ### Maintenance Calendar links
@@ -27,7 +26,10 @@ All dates in the calendar are in UTC Timezone.
 
 Scheduled maintenances can also be sent out via [Cloudflare Notifications](/notifications/).
 
-<AvailableNotifications product="Cloudflare Status" notificationFilter="Maintenance Notification" />
+<AvailableNotifications
+	product="Cloudflare Status"
+	notificationFilter="Maintenance Notification"
+/>
 
 <Render file="get-started" product="notifications" />
 
@@ -42,3 +44,9 @@ To check for unplanned maintenance, you can confirm at all times if a location w
 If you have a [CNI connection](/network-interconnect/) with Cloudflare at a re-routed location, it may become temporarily unavailable during planned or unplanned maintenance, and regular internet routing may be used instead to reach your network.
 
 In the Magic family of products, the routing is defined explicitly using [static routes](/magic-wan/configuration/manually/how-to/configure-static-routes/) to send traffic to the specified tunnels, with customer-configured priorities. If you have a CNI tunnel, we strongly recommend that you also add routes to an alternative tunnel, such as a fallback Internet tunnel, to make sure your traffic can be routed at all times.
+
+## Related resources
+
+- [Available RSS feeds](/fundamentals/new-features/available-rss-feeds/) (for the [Cloudflare changelog](/changelog/))
+- [Subscribe to Cloudflare Status](/support/about-cloudflare/cloudflare-status/)
+- [API deprecations](/fundamentals/api/reference/deprecations/)


### PR DESCRIPTION
### Summary

Gap in documentation that we're trying to improve on `programmatic ways to follow updates related to Cloudflare`, done in #21001 and #21007

Also added crosslinks