### PR TITLE
[Hyperdrive] Clarifying cache behaviour in Getting started.

### DIFF
--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -11,7 +11,7 @@ Hyperdrive accelerates access to your existing databases from Cloudflare Workers
 
 By maintaining a connection pool to your database within Cloudflare's network, Hyperdrive reduces seven round-trips to your database before you can even send a query: the TCP handshake (1x), TLS negotiation (3x), and database authentication (3x).
 
-Hyperdrive understands the difference between read and write queries to your database, and can cache the most common read queries, improving performance and reducing load on your origin database.
+Hyperdrive understands the difference between read and write queries to your database, and caches the most common read queries, improving performance and reducing load on your origin database.
 
 This guide will instruct you through:
 
@@ -124,6 +124,14 @@ To create a Hyperdrive connection, run the `wrangler` command, replacing the pla
 ```sh
 npx wrangler hyperdrive create <YOUR_CONFIG_NAME> --connection-string="postgres://user:password@HOSTNAME_OR_IP_ADDRESS:PORT/database_name"
 ```
+
+:::note[Manage caching]
+If you wish to disable caching, pass the flag `--caching-disabled`.
+
+Alternatively, you can use the `--max-age` flag to specify the maximum duration (in seconds) for which items should persist in the cache, before they are evicted. Default value is 60 seconds.
+
+Refer to [Hyperdrive Wrangler commands](/hyperdrive/reference/wrangler-commands/) for more information.
+:::
 
 If successful, the command will output your new Hyperdrive configuration:
 

--- a/src/content/docs/hyperdrive/reference/wrangler-commands.mdx
+++ b/src/content/docs/hyperdrive/reference/wrangler-commands.mdx
@@ -1,8 +1,11 @@
 ---
 pcx_content_type: navigation
 title: Wrangler commands
-external_link: /workers/wrangler/commands/#hyperdrive
 sidebar:
   order: 12
 
 ---
+
+import { Render } from "~/components";
+
+<Render file="hyperdrive" product="workers/wrangler-commands"/>


### PR DESCRIPTION
Updating Getting started for clarity.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Clarified that Hyperdrive caches by default.
2. Added a note in Getting started for guidance on managing cache.
3. Edited the `Wrangler commands` chapter to render the commands, rather than link out to `/Workers/`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
