### PR TITLE
[WAF / DDoS] Add feed buttons

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -48,6 +48,7 @@ export { default as PublicStats } from "./PublicStats.astro";
 export { default as RelatedProduct } from "./RelatedProduct.astro";
 export { default as Render } from "./Render.astro";
 export { default as ResourcesBySelector } from "./ResourcesBySelector.astro";
+export { default as RSSButton } from "./RSSButton.astro";
 export { default as RuleID } from "./RuleID.astro";
 export { default as SpotlightAuthorDetails } from "./SpotlightAuthorDetails.astro";
 export { default as Stream } from "./Stream.astro";

--- a/src/content/docs/ddos-protection/change-log/general-updates.mdx
+++ b/src/content/docs/ddos-protection/change-log/general-updates.mdx
@@ -1,6 +1,6 @@
 ---
 title: "General updates"
-pcx_content_type: concept
+pcx_content_type: changelog
 release_notes_file_name:
   - ddos
 release_notes_name: DDoS protection

--- a/src/content/docs/ddos-protection/change-log/http/index.mdx
+++ b/src/content/docs/ddos-protection/change-log/http/index.mdx
@@ -11,7 +11,7 @@ head:
     content: Changelog for the HTTP DDoS managed ruleset
 ---
 
-import { LinkButton } from "~/components";
+import { LinkButton, RSSButton } from "~/components";
 
 This section contains past and upcoming changes to the [HTTP DDoS Attack Protection managed ruleset](/ddos-protection/managed-rulesets/http/).
 
@@ -21,3 +21,5 @@ This section contains past and upcoming changes to the [HTTP DDoS Attack Protect
 >
 	View scheduled changes
 </LinkButton>
+
+<RSSButton href="/ddos-protection/change-log/http/index.xml" />

--- a/src/content/docs/ddos-protection/change-log/index.mdx
+++ b/src/content/docs/ddos-protection/change-log/index.mdx
@@ -14,6 +14,8 @@ head:
     content: Changelog for global changes to DDoS protection
 ---
 
+import { RSSButton } from "~/components";
+
 Cloudflare has a regular cadence of releasing updates and new rules to the DDoS managed rulesets. The updates either improve a rule's accuracy, lower false positives rates, or increase the protection due to a change in the threat landscape.
 
 The release cycle for a new rule within the regular cadence follows this process:
@@ -25,3 +27,9 @@ The release cycle for a new rule within the regular cadence follows this process
 Changes to existing rules follow the same process, except that Cloudflare will create a temporary updated rule (denoted as `BETA` in rule description) before updating the original rule on the next release cycle.
 
 Cloudflare is very proactive in responding to new attack vectors, which may need to be released outside of the 7-day cycle, defined as an Emergency Release. This emergency release is only used to respond to new high priority threats with a low false positive probability.
+
+## RSS feeds
+
+- [General updates](/ddos-protection/change-log/general-updates/) - <RSSButton href="/ddos-protection/change-log/general-updates/index.xml" />
+- [Network-layer DDoS managed ruleset](/ddos-protection/change-log/network/) - <RSSButton href="/ddos-protection/change-log/network/index.xml" />
+- [HTTP DDoS managed ruleset](/ddos-protection/change-log/http/) - <RSSButton href="/ddos-protection/change-log/http/index.xml" />

--- a/src/content/docs/ddos-protection/change-log/network/index.mdx
+++ b/src/content/docs/ddos-protection/change-log/network/index.mdx
@@ -11,7 +11,7 @@ head:
     content: Changelog for the Network-layer DDoS managed ruleset
 ---
 
-import { LinkButton } from "~/components";
+import { LinkButton, RSSButton } from "~/components";
 
 This section contains past and upcoming changes to the [Network-layer DDoS Attack Protection managed ruleset](/ddos-protection/managed-rulesets/network/).
 
@@ -26,3 +26,5 @@ The Network-layer DDoS Attack Protection managed ruleset protects Cloudflare cus
 >
 	View scheduled changes
 </LinkButton>
+
+<RSSButton href="/ddos-protection/change-log/network/index.xml" />

--- a/src/content/docs/waf/change-log/index.mdx
+++ b/src/content/docs/waf/change-log/index.mdx
@@ -16,9 +16,6 @@ import { LinkButton, RSSButton } from "~/components";
 
 The WAF changelog provides information about changes to managed rulesets and general updates to WAF protection.
 
-<br />
-<RSSButton href="/waf/change-log/index.xml" />
-
 ## Changelog for managed rulesets
 
 Cloudflare has a regular cadence of releasing updates and new rules to WAF managed rulesets. The updates either improve a rule's accuracy, lower false positives rates, or increase the protection due to a change in the threat landscape.
@@ -36,3 +33,8 @@ If you do notice a new or updated rule generating an increased volume of securit
 <LinkButton type="primary" href="/waf/change-log/scheduled-changes/">
 	View scheduled changes
 </LinkButton>
+<RSSButton href="/waf/change-log/index.xml" />
+
+## General updates
+
+For more general updates to the WAF, refer to [general updates](/waf/change-log/general-updates/).

--- a/src/content/docs/waf/change-log/index.mdx
+++ b/src/content/docs/waf/change-log/index.mdx
@@ -12,9 +12,12 @@ head:
     content: Changelog for managed rulesets
 ---
 
-import { LinkButton } from "~/components";
+import { LinkButton, RSSButton } from "~/components";
 
 The WAF changelog provides information about changes to managed rulesets and general updates to WAF protection.
+
+<br />
+<RSSButton href="/waf/change-log/index.xml" />
 
 ## Changelog for managed rulesets
 

--- a/src/content/docs/waf/change-log/scheduled-changes.mdx
+++ b/src/content/docs/waf/change-log/scheduled-changes.mdx
@@ -7,7 +7,9 @@ sidebar:
 tableOfContents: false
 ---
 
-import { RuleID } from "~/components";
+import { RSSButton, RuleID } from "~/components";
+
+<RSSButton href="/waf/change-log/index.xml" />
 
 <table style="width: 100%">
 	<thead>
@@ -41,7 +43,9 @@ import { RuleID } from "~/components";
 			<td>
 				<RuleID id="8350947451a1401c934f5e660f101cca" />
 			</td>
-			<td>Angular-Base64-Upload - Remote Code Execution - CVE:CVE-2024-42640</td>
+			<td>
+				Angular-Base64-Upload - Remote Code Execution - CVE:CVE-2024-42640
+			</td>
 			<td>This is a New Detection</td>
 		</tr>
 		<tr>
@@ -63,7 +67,10 @@ import { RuleID } from "~/components";
 			<td>
 				<RuleID id="3d6bf99039b54312a1a2165590aea1ca" />
 			</td>
-			<td>Progress Software WhatsUp Gold - Remote Code Execution - CVE:CVE-2024-4885</td>
+			<td>
+				Progress Software WhatsUp Gold - Remote Code Execution -
+				CVE:CVE-2024-4885
+			</td>
 			<td>This is a New Detection</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
### Summary

Adding several `RSSButton` elements to the WAF / DDoS pages b/c those feeds aren't nearly as visible as the others in our docs.