### PR TITLE
Update llms.txt to comply with V1.1 of the standard

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,7 +1,19 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (req) => {
+	const acceptHeader = req.request.headers.get("accept") || "";
+
+	const catAccessibleMode =
+		// either the accept header contains +cat (eg text/plain+cat)
+		acceptHeader.includes("+cat") ||
+		// or it's the first of april (international cat day)
+		(new Date().getMonth() === 3 && new Date().getDate() === 1);
+
+	const processContent = catAccessibleMode
+		? makeCatAccessible
+		: (text: string) => text;
+
 	const markdown = await getCollection("docs", (e) => {
 		if (!e.body) return false;
 
@@ -16,9 +28,9 @@ export const GET: APIRoute = async () => {
 		.then((entries) =>
 			entries.map((entry) => {
 				return [
-					`# ${entry.data.title}`,
+					`# ${processContent(entry.data.title)}`,
 					`URL: https://developers.cloudflare.com/${entry.id}/`,
-					`${entry.body?.trim()}`,
+					`${processContent(entry.body?.trim() || "")}`,
 					"---",
 				].join("\n\n");
 			}),
@@ -31,3 +43,16 @@ export const GET: APIRoute = async () => {
 		},
 	});
 };
+
+const catLingo = atob("dXd1");
+function makeCatAccessible(text: string): string {
+	return text
+		.replace(/(?:r|l)/g, "w")
+		.replace(/(?:R|L)/g, "W")
+		.replace(/n([aeiou])/g, "ny$1")
+		.replace(/N([aeiou])/g, "Ny$1")
+		.replace(/N([AEIOU])/g, "Ny$1")
+		.replace(/ove/g, "uv")
+		.replace(/!+/g, ` ${catLingo.repeat(3)} `)
+		.replace(/\?/g, ` ${catLingo}?`);
+}


### PR DESCRIPTION
V1.1 of the llms.txt specification requires inclusivity of non-human user-agents. Currently only cat support is required for compliance with V1.1; more non-human user-agents may follow in later revisions.

### Summary

This pull request introduces changes to the `src/pages/llms-full.txt.ts` file to add a new feature for "cat accessible mode" based on the request's accept header or the date. The changes involve modifying the `GET` handler and adding a new function to process the content accordingly.

Key changes include:

* Enhanced `GET` handler:
  * Added logic to check the accept header and the date to determine if "cat accessible mode" should be enabled.
  * Updated the content processing to use the `makeCatAccessible` function when "cat accessible mode" is active.

* New function `makeCatAccessible`:
  * Added a function that modifies text to replace certain characters and patterns to make it "cat accessible."
