### PR TITLE
Remove incorrect backticks present in vite3 page

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
@@ -76,4 +76,4 @@ Cloudflare Pages will automatically rebuild your project and deploy it on every 
 Additionally, you will have access to [preview deployments](/pages/configuration/preview-deployments/), which repeat the build-and-deploy process for pull requests. With these, you can preview changes to your project with a real URL before deploying them to production.
 
 <Render file="framework-guides/learn-more" params={{ one: "Vite 3" }} />
-```
+


### PR DESCRIPTION
Pretty minor, I'm just removing backticks that I assume have been added to the page by mistake:
![Screenshot 2025-04-01 at 12 48 56](https://github.com/user-attachments/assets/2bb7082d-3d6f-4f75-aabf-43255fcc9143)
