### PR TITLE
Use one.one.one.one in example

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
@@ -38,7 +38,7 @@ You can learn more about how DoH works in RFC 8484, more specifically [the HTTP 
 Example request:
 
 ```sh
-curl --http2 --header "accept: application/dns-json" "https://1.1.1.1/dns-query?name=cloudflare.com" --next --http2 --header "accept: application/dns-json" "https://1.1.1.1/dns-query?name=example.com"
+curl --http2 --header "accept: application/dns-json" "https://one.one.one.one/dns-query?name=cloudflare.com" --next --http2 --header "accept: application/dns-json" "https://one.one.one.one/dns-query?name=example.com"
 ```
 
 ## Authentication


### PR DESCRIPTION
### Summary

Current given IPv4 example, does not work in IPv6 only servers.
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
