### PR TITLE
Add note about how to preserve debug symbols in Rust

### DIFF
--- a/src/content/docs/workers/observability/dev-tools/cpu-usage.mdx
+++ b/src/content/docs/workers/observability/dev-tools/cpu-usage.mdx
@@ -32,6 +32,24 @@ To generate a CPU profile:
 
 You now have a CPU profile.
 
+:::note
+
+For Rust Workers, add the following to your `Cargo.toml` to preserve [DWARF](https://dwarfstd.org/) debug symbols (from [this comment](https://github.com/rustwasm/wasm-pack/issues/1351#issuecomment-2100231587)):
+
+```toml title="wrangler.toml"
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
+dwarf-debug-info = true
+```
+
+And update `wrangler.toml` to configure wasm-pack (via worker-build) to use the `dev` [profile](https://rustwasm.github.io/docs/wasm-pack/commands/build.html#profile) to preserve debug symbols:
+
+```toml title="Cargo.toml"
+[build]
+command = "cargo install -q worker-build && worker-build --dev"
+```
+
+:::
+
 ## An Example Profile
 
 Let's look at an example to learn how to read a CPU profile. Imagine you have the following Worker:

--- a/src/content/docs/workers/observability/dev-tools/cpu-usage.mdx
+++ b/src/content/docs/workers/observability/dev-tools/cpu-usage.mdx
@@ -41,7 +41,7 @@ For Rust Workers, add the following to your `Cargo.toml` to preserve [DWARF](htt
 dwarf-debug-info = true
 ```
 
-And update `wrangler.toml` to configure wasm-pack (via worker-build) to use the `dev` [profile](https://rustwasm.github.io/docs/wasm-pack/commands/build.html#profile) to preserve debug symbols:
+Then, update your `wrangler.toml` to configure wasm-pack (via worker-build) to use the `dev` [profile](https://rustwasm.github.io/docs/wasm-pack/commands/build.html#profile) to preserve debug symbols.
 
 ```toml title="Cargo.toml"
 [build]


### PR DESCRIPTION
### Summary

Add note about how to preserve debug symbols in Rust when profiling.

### Screenshots (optional)

Without debug symbols:
<img width="505" alt="Screenshot 2025-04-02 at 5 15 29 PM" src="https://github.com/user-attachments/assets/91e09edc-332c-4090-a6c0-5bd750baddc9" />

With debug symbols:
<img width="507" alt="Screenshot 2025-04-02 at 5 15 42 PM" src="https://github.com/user-attachments/assets/c1062fa4-1e1f-41a6-a875-56a6f5b8841f" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
