### PR TITLE
[workers-observability] changelog: increase workers trace events limit to 256 KB

### DIFF
--- a/src/content/changelog/workers/2025-04-07-increase-trace-events-limit.mdx
+++ b/src/content/changelog/workers/2025-04-07-increase-trace-events-limit.mdx
@@ -1,0 +1,14 @@
+---
+title: Workers increases maximum log events per invocation to 256 KB
+description: Workers increases maximum log events per invocation to 256 KB
+products:
+  - workers
+date: 2025-04-07T00:00:00Z
+---
+
+You can now capture a maximum of 256 KB of log events per Workers invocation, helping you gain better visiblity into application behavior.
+
+256 KB encompasses console.log() statements, exceptions, request metadata, and headers to the console per invocation. This is a 2x increase
+from the previous 128 KB limit. After you exceed this limit, further context associated with the request will not be recorded in your logs.
+
+This limit is automatically applied to all Workers.

--- a/src/content/changelog/workers/2025-04-07-increase-trace-events-limit.mdx
+++ b/src/content/changelog/workers/2025-04-07-increase-trace-events-limit.mdx
@@ -1,6 +1,6 @@
 ---
-title: Workers increases maximum log events per invocation to 256 KB
-description: Workers increases maximum log events per invocation to 256 KB
+title: Capture up to 256 KB of log events in each Workers Invocation
+description: You can now capture up to 256 KB of log events per Workers Invocation helping you gain better visibility into application behavior.
 products:
   - workers
 date: 2025-04-07T00:00:00Z
@@ -8,7 +8,12 @@ date: 2025-04-07T00:00:00Z
 
 You can now capture a maximum of 256 KB of log events per Workers invocation, helping you gain better visiblity into application behavior.
 
-256 KB encompasses console.log() statements, exceptions, request metadata, and headers to the console per invocation. This is a 2x increase
-from the previous 128 KB limit. After you exceed this limit, further context associated with the request will not be recorded in your logs.
+All console.log() statements, exceptions, request metadata, and headers are automatically captured during the Worker invocation and emitted
+as [JSON object](/logs/reference/log-fields/account/workers_trace_events). [Workers Logs](/workers/observability/logs/workers-logs) deserializes 
+this object before indexing the fields and storing them. You can also capture, transform, and export the JSON object in a
+[Tail Worker](/workers/observability/logs/tail-workers).
+
+256 KB is a 2x increase from the previous 128 KB limit. After you exceed this limit, further context associated with the request will not be
+ recorded in your logs.
 
 This limit is automatically applied to all Workers.

--- a/src/content/docs/workers/observability/logs/workers-logs.mdx
+++ b/src/content/docs/workers/observability/logs/workers-logs.mdx
@@ -191,11 +191,11 @@ head_sampling_rate = 0.01 # 1% sampling rate
 | ------------------------------------------------------------------ | ---------- |
 | Maximum log retention period                                       | 7 Days     |
 | Maximum logs per account per day<sup>1</sup>                       | 5 Billion  |
-| Maximum log size<sup>2</sup>                                       | 128 KB     |
+| Maximum log size<sup>2</sup>                                       | 256 KB     |
 
 <sup>1</sup> While Workers Logs is in open beta, there is a daily limit of 5 billion logs per account per day. After the limit is exceed, a 1% head-based sample will be applied for the remainder of the day.
 
-<sup>2</sup> A single log has a maximum size limit of [128 KB](/workers/platform/limits/#log-size). Logs exceeding that size will be truncated and the log's `$cloudflare.truncated` field will be set to true.
+<sup>2</sup> A single log has a maximum size limit of [256 KB](/workers/platform/limits/#log-size). Logs exceeding that size will be truncated and the log's `$cloudflare.truncated` field will be set to true.
 
 ## Pricing
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -312,7 +312,7 @@ When using Image Resizing with Workers, refer to [Image Resizing documentation](
 
 ## Log size
 
-You can emit a maximum of 128 KB of data (across `console.log()` statements, exceptions, request metadata and headers) to the console for a single request. After you exceed this limit, further context associated with the request will not be recorded in logs, appear when tailing logs of your Worker, or within a [Tail Worker](/workers/observability/logs/tail-workers/).
+You can emit a maximum of 256 KB of data (across `console.log()` statements, exceptions, request metadata and headers) to the console for a single request. After you exceed this limit, further context associated with the request will not be recorded in logs, appear when tailing logs of your Worker, or within a [Tail Worker](/workers/observability/logs/tail-workers/).
 
 Refer to the [Workers Trace Event Logpush documentation](/workers/observability/logs/logpush/#limits) for information on the maximum size of fields sent to logpush destinations.
 


### PR DESCRIPTION

<img width="449" alt="Screenshot 2025-04-07 at 11 22 59 AM" src="https://github.com/user-attachments/assets/b892a5ce-3264-4861-92cd-222e9f8ea931" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
