### PR TITLE
[Docs Site] Add Copy Page dropdown for Markdown

### DIFF
--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -1,0 +1,102 @@
+import {
+  useFloating,
+  useInteractions,
+  useClick,
+  useDismiss,
+  shift,
+  offset,
+  autoUpdate,
+  FloatingPortal,
+} from "@floating-ui/react";
+import { useState } from "react";
+import { PiMarkdownLogo, PiClipboardTextLight, PiArrowSquareOutLight } from "react-icons/pi";
+
+export default function CopyPageButton() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    middleware: [shift(), offset(5)],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    click,
+    dismiss,
+  ]);
+
+  const handleViewMarkdown = () => {
+    const markdownUrl = new URL("index.md", window.location.href).toString();
+    window.open(markdownUrl, "_blank");
+  };
+
+  const handleCopyMarkdown = async () => {
+    const markdownUrl = new URL("index.md", window.location.href).toString();
+    try {
+      const response = await fetch(markdownUrl);
+      const markdown = await response.text();
+      await navigator.clipboard.writeText(markdown);
+    } catch (error) {
+      console.error("Failed to copy Markdown:", error);
+    }
+  };
+
+  const options = [
+    {
+      label: "Copy Page as Markdown",
+      description: "Copy the raw Markdown content to clipboard",
+      icon: PiClipboardTextLight,
+      onClick: handleCopyMarkdown,
+    },
+    {
+      label: "View Page as Markdown",
+      description: "Open the Markdown file in a new tab",
+      icon: PiArrowSquareOutLight,
+      onClick: handleViewMarkdown,
+    },
+  ];
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className="inline-flex bg-transparent items-center justify-center text-sm h-8 gap-2 rounded border border-[--sl-color-hairline] px-3 text-black"
+      >
+        Copy Page
+        <PiMarkdownLogo />
+      </button>
+      {isOpen && (
+        <FloatingPortal>
+          <ul
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="list-none rounded border border-[--sl-color-hairline] bg-[--sl-color-bg] pl-0 shadow-md min-w-[240px]"
+          >
+            {options.map(({ label, description, icon: Icon, onClick }) => (
+              <li key={label}>
+                <button
+                  onClick={onClick}
+                  className="block w-full px-3 bg-transparent py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
+                >
+                  <div className="flex items-center gap-2 text-sm">
+                    <Icon className="h-4 w-4" />
+                    {label}
+                  </div>
+                  <div className="text-xs text-[--sl-color-gray-3] mt-0.5 ml-6">
+                    {description}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </FloatingPortal>
+      )}
+    </>
+  );
+}

--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -13,10 +13,15 @@ import {
 	PiMarkdownLogo,
 	PiClipboardTextLight,
 	PiArrowSquareOutLight,
+	PiCheckCircleLight,
+	PiXCircleLight,
 } from "react-icons/pi";
+
+type CopyState = "idle" | "success" | "error";
 
 export default function CopyPageButton() {
 	const [isOpen, setIsOpen] = useState(false);
+	const [copyState, setCopyState] = useState<CopyState>("idle");
 
 	const { refs, floatingStyles, context } = useFloating({
 		open: isOpen,
@@ -42,10 +47,25 @@ export default function CopyPageButton() {
 		const markdownUrl = new URL("index.md", window.location.href).toString();
 		try {
 			const response = await fetch(markdownUrl);
+
+			if (!response.ok) {
+				throw new Error(`Received ${response.status} on ${response.url}`);
+			}
+
 			const markdown = await response.text();
 			await navigator.clipboard.writeText(markdown);
+
+			setCopyState("success");
+			setTimeout(() => {
+				setCopyState("idle");
+			}, 1500);
 		} catch (error) {
 			console.error("Failed to copy Markdown:", error);
+
+			setCopyState("error");
+			setTimeout(() => {
+				setCopyState("idle");
+			}, 1500);
 		}
 	};
 
@@ -64,15 +84,41 @@ export default function CopyPageButton() {
 		},
 	];
 
+	const getButtonContent = () => {
+		if (copyState === "success") {
+			return (
+				<>
+					<PiCheckCircleLight className="h-4 w-4 text-green-600" />
+					<span>Copied!</span>
+				</>
+			);
+		}
+
+		if (copyState === "error") {
+			return (
+				<>
+					<PiXCircleLight className="h-4 w-4 text-red-600" />
+					<span>Failed to copy</span>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<PiMarkdownLogo />
+				<span>Copy Page</span>
+			</>
+		);
+	};
+
 	return (
 		<>
 			<button
 				ref={refs.setReference}
 				{...getReferenceProps()}
-				className="inline-flex h-8 items-center justify-center gap-2 rounded border border-[--sl-color-hairline] bg-transparent px-3 text-sm text-black"
+				className="inline-flex h-8 cursor-pointer items-center justify-center gap-2 rounded border border-[--sl-color-hairline] bg-transparent px-3 text-sm text-black hover:bg-[--sl-color-bg-nav]"
 			>
-				Copy Page
-				<PiMarkdownLogo />
+				{getButtonContent()}
 			</button>
 			{isOpen && (
 				<FloatingPortal>
@@ -86,7 +132,7 @@ export default function CopyPageButton() {
 							<li key={label}>
 								<button
 									onClick={onClick}
-									className="block w-full bg-transparent px-3 py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
+									className="relative block w-full cursor-pointer bg-transparent px-3 py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
 								>
 									<div className="flex items-center gap-2 text-sm">
 										<Icon className="h-4 w-4" />

--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -88,8 +88,8 @@ export default function CopyPageButton() {
 		if (copyState === "success") {
 			return (
 				<>
-					<PiCheckCircleLight className="h-4 w-4 text-green-600" />
 					<span>Copied!</span>
+					<PiCheckCircleLight className="text-green-600" />
 				</>
 			);
 		}
@@ -97,16 +97,16 @@ export default function CopyPageButton() {
 		if (copyState === "error") {
 			return (
 				<>
-					<PiXCircleLight className="h-4 w-4 text-red-600" />
-					<span>Failed to copy</span>
+					<span>Failed</span>
+					<PiXCircleLight className="text-red-600" />
 				</>
 			);
 		}
 
 		return (
 			<>
-				<PiMarkdownLogo />
 				<span>Copy Page</span>
+				<PiMarkdownLogo />
 			</>
 		);
 	};
@@ -116,7 +116,7 @@ export default function CopyPageButton() {
 			<button
 				ref={refs.setReference}
 				{...getReferenceProps()}
-				className="inline-flex h-8 cursor-pointer items-center justify-center gap-2 rounded border border-[--sl-color-hairline] bg-transparent px-3 text-sm text-black hover:bg-[--sl-color-bg-nav]"
+				className="inline-flex h-8 min-w-32 cursor-pointer items-center justify-center gap-2 rounded border border-[--sl-color-hairline] bg-transparent px-3 text-sm text-black hover:bg-[--sl-color-bg-nav]"
 			>
 				{getButtonContent()}
 			</button>
@@ -126,7 +126,7 @@ export default function CopyPageButton() {
 						ref={refs.setFloating}
 						style={floatingStyles}
 						{...getFloatingProps()}
-						className="min-w-[240px] list-none rounded border border-[--sl-color-hairline] bg-[--sl-color-bg] pl-0 shadow-md"
+						className="list-none rounded border border-[--sl-color-hairline] bg-[--sl-color-bg] pl-0 shadow-md"
 					>
 						{options.map(({ label, description, icon: Icon, onClick }) => (
 							<li key={label}>
@@ -135,7 +135,7 @@ export default function CopyPageButton() {
 									className="relative block w-full cursor-pointer bg-transparent px-3 py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
 								>
 									<div className="flex items-center gap-2 text-sm">
-										<Icon className="h-4 w-4" />
+										<Icon />
 										{label}
 									</div>
 									<div className="ml-6 mt-0.5 text-xs text-[--sl-color-gray-3]">

--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -1,102 +1,106 @@
 import {
-  useFloating,
-  useInteractions,
-  useClick,
-  useDismiss,
-  shift,
-  offset,
-  autoUpdate,
-  FloatingPortal,
+	useFloating,
+	useInteractions,
+	useClick,
+	useDismiss,
+	shift,
+	offset,
+	autoUpdate,
+	FloatingPortal,
 } from "@floating-ui/react";
 import { useState } from "react";
-import { PiMarkdownLogo, PiClipboardTextLight, PiArrowSquareOutLight } from "react-icons/pi";
+import {
+	PiMarkdownLogo,
+	PiClipboardTextLight,
+	PiArrowSquareOutLight,
+} from "react-icons/pi";
 
 export default function CopyPageButton() {
-  const [isOpen, setIsOpen] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
 
-  const { refs, floatingStyles, context } = useFloating({
-    open: isOpen,
-    onOpenChange: setIsOpen,
-    middleware: [shift(), offset(5)],
-    whileElementsMounted: autoUpdate,
-  });
+	const { refs, floatingStyles, context } = useFloating({
+		open: isOpen,
+		onOpenChange: setIsOpen,
+		middleware: [shift(), offset(5)],
+		whileElementsMounted: autoUpdate,
+	});
 
-  const click = useClick(context);
-  const dismiss = useDismiss(context);
+	const click = useClick(context);
+	const dismiss = useDismiss(context);
 
-  const { getReferenceProps, getFloatingProps } = useInteractions([
-    click,
-    dismiss,
-  ]);
+	const { getReferenceProps, getFloatingProps } = useInteractions([
+		click,
+		dismiss,
+	]);
 
-  const handleViewMarkdown = () => {
-    const markdownUrl = new URL("index.md", window.location.href).toString();
-    window.open(markdownUrl, "_blank");
-  };
+	const handleViewMarkdown = () => {
+		const markdownUrl = new URL("index.md", window.location.href).toString();
+		window.open(markdownUrl, "_blank");
+	};
 
-  const handleCopyMarkdown = async () => {
-    const markdownUrl = new URL("index.md", window.location.href).toString();
-    try {
-      const response = await fetch(markdownUrl);
-      const markdown = await response.text();
-      await navigator.clipboard.writeText(markdown);
-    } catch (error) {
-      console.error("Failed to copy Markdown:", error);
-    }
-  };
+	const handleCopyMarkdown = async () => {
+		const markdownUrl = new URL("index.md", window.location.href).toString();
+		try {
+			const response = await fetch(markdownUrl);
+			const markdown = await response.text();
+			await navigator.clipboard.writeText(markdown);
+		} catch (error) {
+			console.error("Failed to copy Markdown:", error);
+		}
+	};
 
-  const options = [
-    {
-      label: "Copy Page as Markdown",
-      description: "Copy the raw Markdown content to clipboard",
-      icon: PiClipboardTextLight,
-      onClick: handleCopyMarkdown,
-    },
-    {
-      label: "View Page as Markdown",
-      description: "Open the Markdown file in a new tab",
-      icon: PiArrowSquareOutLight,
-      onClick: handleViewMarkdown,
-    },
-  ];
+	const options = [
+		{
+			label: "Copy Page as Markdown",
+			description: "Copy the raw Markdown content to clipboard",
+			icon: PiClipboardTextLight,
+			onClick: handleCopyMarkdown,
+		},
+		{
+			label: "View Page as Markdown",
+			description: "Open the Markdown file in a new tab",
+			icon: PiArrowSquareOutLight,
+			onClick: handleViewMarkdown,
+		},
+	];
 
-  return (
-    <>
-      <button
-        ref={refs.setReference}
-        {...getReferenceProps()}
-        className="inline-flex bg-transparent items-center justify-center text-sm h-8 gap-2 rounded border border-[--sl-color-hairline] px-3 text-black"
-      >
-        Copy Page
-        <PiMarkdownLogo />
-      </button>
-      {isOpen && (
-        <FloatingPortal>
-          <ul
-            ref={refs.setFloating}
-            style={floatingStyles}
-            {...getFloatingProps()}
-            className="list-none rounded border border-[--sl-color-hairline] bg-[--sl-color-bg] pl-0 shadow-md min-w-[240px]"
-          >
-            {options.map(({ label, description, icon: Icon, onClick }) => (
-              <li key={label}>
-                <button
-                  onClick={onClick}
-                  className="block w-full px-3 bg-transparent py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
-                >
-                  <div className="flex items-center gap-2 text-sm">
-                    <Icon className="h-4 w-4" />
-                    {label}
-                  </div>
-                  <div className="text-xs text-[--sl-color-gray-3] mt-0.5 ml-6">
-                    {description}
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
-        </FloatingPortal>
-      )}
-    </>
-  );
+	return (
+		<>
+			<button
+				ref={refs.setReference}
+				{...getReferenceProps()}
+				className="inline-flex h-8 items-center justify-center gap-2 rounded border border-[--sl-color-hairline] bg-transparent px-3 text-sm text-black"
+			>
+				Copy Page
+				<PiMarkdownLogo />
+			</button>
+			{isOpen && (
+				<FloatingPortal>
+					<ul
+						ref={refs.setFloating}
+						style={floatingStyles}
+						{...getFloatingProps()}
+						className="min-w-[240px] list-none rounded border border-[--sl-color-hairline] bg-[--sl-color-bg] pl-0 shadow-md"
+					>
+						{options.map(({ label, description, icon: Icon, onClick }) => (
+							<li key={label}>
+								<button
+									onClick={onClick}
+									className="block w-full bg-transparent px-3 py-2 text-left text-black no-underline hover:bg-[--sl-color-bg-nav]"
+								>
+									<div className="flex items-center gap-2 text-sm">
+										<Icon className="h-4 w-4" />
+										{label}
+									</div>
+									<div className="ml-6 mt-0.5 text-xs text-[--sl-color-gray-3]">
+										{description}
+									</div>
+								</button>
+							</li>
+						))}
+					</ul>
+				</FloatingPortal>
+			)}
+		</>
+	);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,7 +11,7 @@ export { default as AvailableNotifications } from "./AvailableNotifications.astr
 export { default as CompatibilityFlag } from "./CompatibilityFlag.astro";
 export { default as CompatibilityFlags } from "./CompatibilityFlags.astro";
 export { default as ComponentsUsage } from "./ComponentsUsage.astro";
-export { default as CopyPageButton } from "./CopyPageButton";
+export { default as CopyPageButton } from "./CopyPageButton.tsx";
 export { default as CURL } from "./CURL.astro";
 export { default as Description } from "./Description.astro";
 export { default as Details } from "./Details.astro";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as AvailableNotifications } from "./AvailableNotifications.astr
 export { default as CompatibilityFlag } from "./CompatibilityFlag.astro";
 export { default as CompatibilityFlags } from "./CompatibilityFlags.astro";
 export { default as ComponentsUsage } from "./ComponentsUsage.astro";
+export { default as CopyPageButton } from "./CopyPageButton";
 export { default as CURL } from "./CURL.astro";
 export { default as Description } from "./Description.astro";
 export { default as Details } from "./Details.astro";

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -114,9 +114,11 @@ const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
 
 {component && <Aside>To see a list of pages this component is used on, please visit the <a href={`/style-guide/components/usage/#${component.toLowerCase()}`}>usage page</a>.</Aside>}
 
-<div class="flex justify-end items-center">
-	<CopyPageButton client:idle />
-</div>
+{frontmatter.template !== "splash" && (
+	<div class="flex justify-end items-center">
+		<CopyPageButton client:idle />
+	</div>
+)}
 
 <style>
 	:root {

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -9,6 +9,7 @@ import { Aside } from "@astrojs/starlight/components";
 import Description from "~/components/Description.astro";
 import SpotlightAuthorDetails from "~/components/SpotlightAuthorDetails.astro";
 import LastReviewed from "~/components/LastReviewed.astro";
+import CopyPageButton from "~/components/CopyPageButton.tsx";
 
 import { getEntry } from "astro:content";
 
@@ -112,6 +113,10 @@ const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
 {summary && <Description set:html={marked.parse(summary)} />}
 
 {component && <Aside>To see a list of pages this component is used on, please visit the <a href={`/style-guide/components/usage/#${component.toLowerCase()}`}>usage page</a>.</Aside>}
+
+<div class="flex justify-end items-center">
+	<CopyPageButton client:idle />
+</div>
 
 <style>
 	:root {


### PR DESCRIPTION
### Summary

Add Copy Page dropdown for Markdown

### Screenshots (optional)

<img width="396" alt="image" src="https://github.com/user-attachments/assets/165c8983-a5c3-460a-895a-72f226961a7b" />
