### PR TITLE
Update Node.js Compat docs to mirror compatibility report

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -31,52 +31,41 @@ compatibility_date = "2024-09-23"
 
 The runtime APIs from Node.js listed below as "🟢 supported" are currently natively supported in the Workers Runtime.
 
-[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index) are not included as part of the list below:
+[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index), and APIs that do not fit in a serverless context, are not included as part of the list below:
 
 | API Name                                                                             | Natively supported by the Workers Runtime |
 |--------------------------------------------------------------------------------------|-------------------------------------------|
 | [Assertion testing](/workers/runtime-apis/nodejs/assert/)                            | 🟢 supported                              |
 | [Asynchronous context tracking](/workers/runtime-apis/nodejs/asynclocalstorage/)     | 🟢 supported                              |
 | [Buffer](/workers/runtime-apis/nodejs/buffer/)                                       | 🟢 supported                              |
-| C++ addons                                                                           | ⚪ not supported                          |
-| C/C++ addons with Node-API                                                           | ⚪ not supported                          |
-| C++ embedder API                                                                     | ⚪ not supported                          |
-| Child processes                                                                      | ⚪ not supported                          |
-| Cluster                                                                              | ⚪ not supported                          |
 | Console                                                                              | 🟢 supported                              |
-| [Crypto](/workers/runtime-apis/nodejs/crypto/)                                       | 🟡 partially supported                    |
+| [Crypto](/workers/runtime-apis/nodejs/crypto/)                                       | 🟢 supported                              |
 | [Debugger](/workers/observability/dev-tools/)                                        | 🟢 supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/) |
 | [Diagnostics Channel](/workers/runtime-apis/nodejs/diagnostics-channel/)             | 🟢 supported                              |
 | [DNS](/workers/runtime-apis/nodejs/dns/)                                             | 🟢 supported                              |
 | Errors                                                                               | 🟢 supported                              |
 | Events                                                                               | 🟢 supported                              |
-| File system                                                                          | ⚪ not supported                          |
+| File system                                                                          | ⚪ coming soon                            |
 | Globals                                                                              | 🟢 supported                              |
-| HTTP                                                                                 | ⚪ not supported                          |
-| HTTP/2                                                                               | ⚪ not supported                          |
-| HTTPS                                                                                | ⚪ not supported                          |
+| HTTP                                                                                 | ⚪ not yet supported                      |
+| HTTP/2                                                                               | ⚪ not yet supported                      |
+| HTTPS                                                                                | ⚪ not yet supported                      |
 | Inspector                                                                            | 🟢 supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/) |
 | [Net](/workers/runtime-apis/nodejs/net/)                                             | 🟢 supported                              |
-| OS                                                                                   | ⚪ not supported                          |
+| OS                                                                                   | ⚪ not yet supported                      |
 | [Path](/workers/runtime-apis/nodejs/path/)                                           | 🟢 supported                              |
 | Performance hooks                                                                    | 🟡 partially supported                    |
 | Process                                                                              | 🟢 supported                              |
 | Query strings                                                                        | 🟢 supported                              |
-| Readline                                                                             | ⚪ not supported                          |
 | Stream                                                                               | 🟢 supported                              |
 | [String decoder](/workers/runtime-apis/nodejs/string-decoder/)                       | 🟢 supported                              |
-| Test runner                                                                          | ⚪ not supported                          |
 | [Timers](/workers/runtime-apis/nodejs/timers/)                                       | 🟢 supported                              |
-| TLS/SSL                                                                              | 🟡 partially supported                         |
-| TTY                                                                                  | ⚪ not supported                          |
-| UDP/datagram                                                                         | ⚪ not supported                          |
+| TLS/SSL                                                                              | 🟡 partially supported                    |
+| UDP/datagram                                                                         | ⚪ not yet supported                      |
 | [URL](/workers/runtime-apis/nodejs/url/)                                             | 🟢 supported                              |
 | [Utilities](/workers/runtime-apis/nodejs/util/)                                      | 🟢 supported                              |
-| V8                                                                                   | ⚪ not supported                          |
-| VM                                                                                   | ⚪ not supported                          |
 | Web Crypto API                                                                       | 🟢 supported                              |
 | Web Streams API                                                                      | 🟢 supported                              |
-| Worker threads                                                                       | ⚪ not supported                          |
 | [Zlib](/workers/runtime-apis/nodejs/zlib/)                                           | 🟢 supported                              |
 
 Unless otherwise specified, native implementations of Node.js APIs in Workers are intended to match the implementation in the [Current release of Node.js](https://github.com/nodejs/release#release-schedule).


### PR DESCRIPTION
https://workers-nodejs-compat-matrix.pages.dev/ reports only APIs that are actually relevant to applications at runtime:

> The following modules do not fit in a serverless context, are deprecated, or are experimental, and removed from the report: _stream_wrap, child_process, constants, cluster, domain, inspector, inspector/promises, punycode, readline, readline/promises, repl, tty, v8, vm, wasi, worker_threads

This change mirrors that here, to make the list most representative.