### PR TITLE
Hibernation support for McpAgent

### DIFF
--- a/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
@@ -43,7 +43,10 @@ But if you want your MCP server to:
 - cache the state of a previous external API call, so that subsequent tool calls can reuse it
 - do anything that an Agent can do, but allow MCP clients to communicate with it
 
-You can use the following APIs in order to do so.
+You can use the APIs below in order to do so.
+
+#### Hibernation Support
+`McpAgent` instances automatically support [WebSockets Hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/#websocket-hibernation-api), allowing stateful MCP servers to sleep during inactive periods while preserving their state. This means your agents only consume compute resources when actively processing requests, optimizing costs while maintaining the full context and conversation history.
 
 ### State synchronization APIs
 


### PR DESCRIPTION
Add information about hibernation support for McpAgent

### Summary

Added: 

`McpAgent` instances automatically support [WebSockets Hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/#websocket-hibernation-api), allowing stateful MCP servers to sleep during inactive periods while preserving their state. This means your agents only consume compute resources when actively processing requests, optimizing costs while maintaining the full context and conversation history.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
