### PR TITLE
Add RedwoodSDK page to Worker's Framework section.

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
@@ -1,0 +1,51 @@
+---
+pcx_content_type: how-to
+title: RedwoodSDK
+head: []
+description: Create an RedwoodSDK application and deploy it to Cloudflare Workers with Workers Assets.
+---
+
+import {
+	Badge,
+	Description,
+	InlineBadge,
+	Render,
+	PackageManagers,
+} from "~/components";
+
+In this guide, you will create a new [RedwoodSDK](https://rwsdk.com/) application and deploy it to Cloudflare Workers.
+
+RedwoodSDK is a composable framework for building server-side web apps on Cloudflare. It starts as a Vite plugin that unlocks SSR, React Server Components, Server Functions, and realtime capabilities.
+
+## 1. Set up a new project
+
+Create a new project by running the following command, replacing `<project-name>` with your desired project name:
+
+<PackageManagers
+	type="exec"
+	pkg="degit"
+	args={"redwoodjs/sdk/starters/standard#main <project-name>"}
+/>
+
+Then, change the directory to your project and install dependencies:
+
+```sh
+cd <project-name>
+```
+
+<PackageManagers type="install" />
+
+## 2. Develop locally
+
+Once your project is set up, run the following command in the project directory to start a local development server.
+RedwoodSDK is just a plugin for Vite, so you can use the same dev workflow as any other Vite project:
+
+<PackageManagers type="run" args={"dev"} />
+
+## 3. Deploy your Project
+
+You can deploy your project to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), either from your local machine or from any CI/CD system, including [Cloudflare's own](/workers/ci-cd/builds/).
+
+The following command will build and deploy your project. If you're using CI, ensure you update your ["deploy command"](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
+
+<PackageManagers type="run" args={"release"} />


### PR DESCRIPTION
### Summary

This adds a RedwoodSDK page to the framework section, that allows the user to quickly install, develop, and deploy to Cloudflare.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
