### PR TITLE
remove beta tags for static assets

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/angular.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/angular.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Angular](https://angular.dev/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Angular](https://angular.dev/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Angular's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Angular project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Angular project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/astro.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/astro.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Astro](https://astro.build/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Astro](https://astro.build/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Astro's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Astro project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Astro project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/docusaurus.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/docusaurus.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Docusaurus](https://docusaurus.io/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Docusaurus](https://docusaurus.io/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Docusaurus' official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Docusaurus project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Docusaurus project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/gatsby.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/gatsby.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Gatsby](https://www.gatsbyjs.com/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Gatsby](https://www.gatsbyjs.com/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Gatsby's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Gatsby project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Gatsby project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -3,6 +3,8 @@ pcx_content_type: how-to
 title: Next.js
 head: []
 description: Create an Next.js application and deploy it to Cloudflare Workers with Workers Assets.
+sidebar:
+  badge: Beta
 ---
 
 import {
@@ -11,8 +13,12 @@ import {
 	Render,
 	PackageManagers,
 	Steps,
-	WranglerConfig
+	WranglerConfig,
 } from "~/components";
+
+:::note
+The OpenNext adapter is in currently in beta.
+:::
 
 **Start from CLI** - scaffold a Next.js project on Workers.
 
@@ -22,9 +28,7 @@ import {
 	args={"--framework=next --platform=workers"}
 />
 
-:::note
 This is a simple getting started guide. For detailed documentation on how the to use the Cloudflare OpenNext adapter, visit the [OpenNext website](https://opennext.js.org/cloudflare).
-:::
 
 ## What is Next.js?
 
@@ -40,38 +44,45 @@ You can deploy your Next.js app to Cloudflare Workers using the OpenNext adaptor
 
 1. **Create a new project with the create-cloudflare CLI (C3).**
 
-	<PackageManagers
-		type="create"
-		pkg="cloudflare@latest my-next-app"
-		args={"--framework=next --platform=workers"}
-	/>
+   <PackageManagers
+   	type="create"
+   	pkg="cloudflare@latest my-next-app"
+   	args={"--framework=next --platform=workers"}
+   />
 
-	<Details header="What's happening behind the scenes?">
-		When you run this command, C3 creates a new project directory, initiates [Next.js's official setup tool](https://nextjs.org/docs/app/api-reference/cli/create-next-app), and configures the project for Cloudflare. It then offers the option to instantly deploy your application to Cloudflare.
-	</Details>
+   <Details header="What's happening behind the scenes?">
+   	When you run this command, C3 creates a new project directory, initiates
+   	[Next.js's official setup
+   	tool](https://nextjs.org/docs/app/api-reference/cli/create-next-app), and
+   	configures the project for Cloudflare. It then offers the option to
+   	instantly deploy your application to Cloudflare.
+   </Details>
 
-2.  **Develop locally.**
+2. **Develop locally.**
 
-	After creating your project, run the following command in your project directory to start a local development server.
-	The command uses the Next.js development server. It offers the best developer experience by quickly reloading your app every time the source code is updated.
+   After creating your project, run the following command in your project directory to start a local development server.
+   The command uses the Next.js development server. It offers the best developer experience by quickly reloading your app every time the source code is updated.
 
-	<PackageManagers type="run" args="dev" />
+   <PackageManagers type="run" args="dev" />
 
-3.  **Test and preview your site with the Cloudflare adapter.**
+3. **Test and preview your site with the Cloudflare adapter.**
 
-	<PackageManagers type="run" args="preview" />
+   <PackageManagers type="run" args="preview" />
 
-	<Details header="What's the difference between dev and preview?">
-		The command used in the previous step uses the Next.js development server, which runs in Node.js.
-		However, your deployed application will run on Cloudflare Workers, which uses the `workerd` runtime. Therefore when running integration tests and previewing your application, you should use the preview command, which is more accurate to production, as it executes your application in the `workerd` runtime using `wrangler dev`.
-	</Details>
+   <Details header="What's the difference between dev and preview?">
+   	The command used in the previous step uses the Next.js development server,
+   	which runs in Node.js. However, your deployed application will run on
+   	Cloudflare Workers, which uses the `workerd` runtime. Therefore when
+   	running integration tests and previewing your application, you should use
+   	the preview command, which is more accurate to production, as it executes
+   	your application in the `workerd` runtime using `wrangler dev`.
+   </Details>
 
+4. **Deploy your project.**
 
-4.  **Deploy your project.**
+   You can deploy your project to a [`*.workers.dev` subdomain](/workers/configuration/routing/workers-dev/) or a [custom domain](/workers/configuration/routing/custom-domains/) from your local machine or any CI/CD system (including [Workers Builds](/workers/ci-cd/#workers-builds)). Use the following command to build and deploy. If you're using a CI service, be sure to update your "deploy command" accordingly.
 
-	You can deploy your project to a [`*.workers.dev` subdomain](/workers/configuration/routing/workers-dev/) or a [custom domain](/workers/configuration/routing/custom-domains/) from your local machine or any CI/CD system (including [Workers Builds](/workers/ci-cd/#workers-builds)). Use the following command to build and deploy. If you're using a CI service, be sure to update your "deploy command" accordingly.
-
-	<PackageManagers type="run" args="deploy" />
+   <PackageManagers type="run" args="deploy" />
 
 </Steps>
 
@@ -81,76 +92,80 @@ You can convert an existing Next.js application to run on Cloudflare
 
 <Steps>
 
-1. **Install [`@opennextjs/cloudflare`](https://www.npmjs.com/package/@opennextjs/cloudflare)**
+1.  **Install [`@opennextjs/cloudflare`](https://www.npmjs.com/package/@opennextjs/cloudflare)**
 
-	<PackageManagers type="install" pkg="@opennextjs/cloudflare@latest" />
+    <PackageManagers type="install" pkg="@opennextjs/cloudflare@latest" />
 
-2. **Add a Wrangler configuration file**
+2.  **Add a Wrangler configuration file**
 
-	In your project root, create a [Wrangler configuration file](/workers/wrangler/configuration/) with the following content:
+    In your project root, create a [Wrangler configuration file](/workers/wrangler/configuration/) with the following content:
 
-	<WranglerConfig>
-	```toml
-	main = ".open-next/worker.js"
-	name = "my-app"
-	compatibility_date = "2025-03-25"
-	compatibility_flags = ["nodejs_compat"]
-	assets = { directory = ".open-next/assets", binding = "ASSETS" }
-	```
-	</WranglerConfig>
+        		<WranglerConfig>
+        		```toml
+        			main = ".open-next/worker.js"
+        			name = "my-app"
+        			compatibility_date = "2025-03-25"
+        			compatibility_flags = ["nodejs_compat"]
+        			[assets]
+        			directory = "./dist"
+        			binding = "ASSETS"
+        		```
+        	</WranglerConfig>
 
-	:::note
-	As shown above, you must enable the [`nodejs_compat` compatibility flag](/workers/runtime-apis/nodejs/) _and_ set your [compatibility date](/workers/configuration/compatibility-dates/) to `2024-09-23` or later for your Next.js app to work with @opennextjs/cloudflare.
-	:::
+    :::note
+    As shown above, you must enable the [`nodejs_compat` compatibility flag](/workers/runtime-apis/nodejs/) _and_ set your [compatibility date](/workers/configuration/compatibility-dates/) to `2024-09-23` or later for your Next.js app to work with @opennextjs/cloudflare.
+    :::
 
-3. **Add a configuration file for OpenNext**
+3.  **Add a configuration file for OpenNext**
 
-	In your project root, create an OpenNext configuration file named `open-next.config.ts` with the following content:
+    In your project root, create an OpenNext configuration file named `open-next.config.ts` with the following content:
 
-	```ts
-	import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+    ```ts
+    import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
-	export default defineCloudflareConfig();
-	```
+    export default defineCloudflareConfig();
+    ```
 
-	:::note
-	`open-next.config.ts` is where you can configure the caching, see the [adapter documentation](https://opennext.js.org/cloudflare/caching) for more information
-	:::
+    :::note
+    `open-next.config.ts` is where you can configure the caching, see the [adapter documentation](https://opennext.js.org/cloudflare/caching) for more information
+    :::
 
-4. **Update `package.json`**
+4.  **Update `package.json`**
 
-	You can add the following scripts to your `package.json`:
+    You can add the following scripts to your `package.json`:
 
-	```json
-	"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-	"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-	"cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
-	```
+    ```json
+    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
+    ```
 
-	<Details header="Usage">
-		- `preview`: Builds your app and serves it locally, allowing you to quickly preview your app running locally in the Workers runtime, via a single command.
-		- `deploy`: Builds your app, and then deploys it to Cloudflare
-		- `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the root of your project containing the types for the env.
-	</Details>
+    <Details header="Usage">
+    	- `preview`: Builds your app and serves it locally, allowing you to
+    	quickly preview your app running locally in the Workers runtime, via a
+    	single command. - `deploy`: Builds your app, and then deploys it to
+    	Cloudflare - `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the
+    	root of your project containing the types for the env.
+    </Details>
 
 5.  **Develop locally.**
 
-	After creating your project, run the following command in your project directory to start a local development server.
-	The command uses the Next.js development server. It offers the best developer experience by quickly reloading your app after your source code is updated.
+    After creating your project, run the following command in your project directory to start a local development server.
+    The command uses the Next.js development server. It offers the best developer experience by quickly reloading your app after your source code is updated.
 
-	<PackageManagers type="run" args="dev" />
+    <PackageManagers type="run" args="dev" />
 
 6.  **Test your site with the Cloudflare adapter.**
 
-	The command used in the previous step uses the Next.js development server to offer a great developer experience.
-	However your application will run on Cloudflare Workers so you want to run your integration tests and verify that your application workers correctly in this environment.
+    The command used in the previous step uses the Next.js development server to offer a great developer experience.
+    However your application will run on Cloudflare Workers so you want to run your integration tests and verify that your application workers correctly in this environment.
 
-	<PackageManagers type="run" args="preview" />
+    <PackageManagers type="run" args="preview" />
 
 7.  **Deploy your project.**
 
-	You can deploy your project to a [`*.workers.dev` subdomain](/workers/configuration/routing/workers-dev/) or a [custom domain](/workers/configuration/routing/custom-domains/) from your local machine or any CI/CD system (including [Workers Builds](/workers/ci-cd/#workers-builds)). Use the following command to build and deploy. If you're using a CI service, be sure to update your "deploy command" accordingly.
+    You can deploy your project to a [`*.workers.dev` subdomain](/workers/configuration/routing/workers-dev/) or a [custom domain](/workers/configuration/routing/custom-domains/) from your local machine or any CI/CD system (including [Workers Builds](/workers/ci-cd/#workers-builds)). Use the following command to build and deploy. If you're using a CI service, be sure to update your "deploy command" accordingly.
 
-	<PackageManagers type="run" args="deploy" />
+    <PackageManagers type="run" args="deploy" />
 
 </Steps>

--- a/src/content/docs/workers/frameworks/framework-guides/nuxt.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nuxt.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Nuxt](https://nuxt.com/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Nuxt](https://nuxt.com/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Nuxt's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Nuxt project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Nuxt project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/qwik.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/qwik.mdx
@@ -3,6 +3,8 @@ pcx_content_type: how-to
 title: Qwik
 head: []
 description: Create a Qwik application and deploy it to Cloudflare Workers with Workers Assets.
+sidebar:
+  badge: Beta
 ---
 
 import {
@@ -13,13 +15,17 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Qwik](https://qwik.dev/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+:::note
+Support for Qwik projects on Cloudflare Workers is currently in beta.
+:::
+
+In this guide, you will create a new [Qwik](https://qwik.dev/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Qwik's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Qwik project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Qwik project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/qwik.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/qwik.mdx
@@ -3,8 +3,6 @@ pcx_content_type: how-to
 title: Qwik
 head: []
 description: Create a Qwik application and deploy it to Cloudflare Workers with Workers Assets.
-sidebar:
-  badge: Beta
 ---
 
 import {
@@ -14,10 +12,6 @@ import {
 	Render,
 	PackageManagers,
 } from "~/components";
-
-:::note
-Support for Qwik projects on Cloudflare Workers is currently in beta.
-:::
 
 In this guide, you will create a new [Qwik](https://qwik.dev/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 

--- a/src/content/docs/workers/frameworks/framework-guides/solid.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/solid.mdx
@@ -3,6 +3,8 @@ pcx_content_type: how-to
 title: Solid
 head: []
 description: Create a Solid application and deploy it to Cloudflare Workers with Workers Assets.
+sidebar:
+  badge: Beta
 ---
 
 import {
@@ -13,13 +15,17 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Solid](https://www.solidjs.com/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+:::note
+Support for SolidStart projects on Cloudflare Workers is currently in beta.
+:::
+
+In this guide, you will create a new [Solid](https://www.solidjs.com/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Solid's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Solid project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Solid project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/svelte.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/svelte.mdx
@@ -13,13 +13,13 @@ import {
 	PackageManagers,
 } from "~/components";
 
-In this guide, you will create a new [Svelte](https://svelte.dev/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Svelte](https://svelte.dev/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, initiate Svelte's official setup tool, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Svelte project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Svelte project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/framework-guides/vue.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/vue.mdx
@@ -16,13 +16,13 @@ import {
 	FileTree,
 } from "~/components";
 
-In this guide, you will create a new [Vue](https://vuejs.org/) application and deploy to Cloudflare Workers (with the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/)).
+In this guide, you will create a new [Vue](https://vuejs.org/) application and deploy to Cloudflare Workers (with the new [Workers Assets](/workers/static-assets/)).
 
 ## 1. Set up a new project
 
 Use the [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) CLI (C3) to set up a new project. C3 will create a new project directory, use code from the official Vue template, and provide the option to deploy instantly.
 
-To use `create-cloudflare` to create a new Vue project with <InlineBadge preset="beta" /> Workers Assets, run the following command:
+To use `create-cloudflare` to create a new Vue project with Workers Assets, run the following command:
 
 <PackageManagers
 	type="create"

--- a/src/content/docs/workers/frameworks/index.mdx
+++ b/src/content/docs/workers/frameworks/index.mdx
@@ -3,8 +3,6 @@ pcx_content_type: navigation
 title: Frameworks
 sidebar:
   order: 12
-  group:
-    badge: Beta
 head: []
 description: Create full-stack applications deployed to Cloudflare Workers.
 ---
@@ -26,7 +24,7 @@ import {
 	network.
 </Description>
 
-The following frameworks have support for Cloudflare Workers and the new [<InlineBadge preset="beta" /> Workers Assets](/workers/static-assets/). Refer to the individual guides below for instructions on how to get started.
+The following frameworks have support for Cloudflare Workers and the new [Workers Assets](/workers/static-assets/). Refer to the individual guides below for instructions on how to get started.
 
 <DirectoryListing folder="workers/frameworks/framework-guides" />
 

--- a/src/content/docs/workers/static-assets/index.mdx
+++ b/src/content/docs/workers/static-assets/index.mdx
@@ -3,8 +3,6 @@ pcx_content_type: navigation
 title: Static Assets
 sidebar:
   order: 11
-  group:
-    badge: Beta
 head: []
 description: Create full-stack applications deployed to Cloudflare Workers.
 ---


### PR DESCRIPTION
### Summary
couple of frameworks still need beta tags:
<img width="278" alt="Screenshot 2025-04-08 at 10 51 41" src="https://github.com/user-attachments/assets/70c88a56-f1f8-4a89-a03e-2f7cf717d6ef" />


<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
