### PR TITLE
Add headers and redirects section to Vite plugin docs

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -63,11 +63,15 @@ It accepts an optional `PluginConfig` parameter.
   All requests are routed through your entry Worker.
   During the build, each Worker is output to a separate subdirectory of `dist`.
 
-:::note
-When running `wrangler deploy`, only your main (entry) Worker will be deployed.
-If using multiple Workers, each auxiliary Worker must be deployed individually.
-You can inspect the `dist` directory and then run `wrangler deploy -c dist/<auxiliary-worker>/wrangler.json` for each.
-:::
+  :::note
+  Auxiliary Workers are not currently supported when using [React Router](https://reactrouter.com/) as a framework.
+  :::
+
+  :::note
+  When running `wrangler deploy`, only your main (entry) Worker will be deployed.
+  If using multiple Workers, each auxiliary Worker must be deployed individually.
+  You can inspect the `dist` directory and then run `wrangler deploy -c dist/<auxiliary-worker>/wrangler.json` for each.
+  :::
 
 ## `interface AuxiliaryWorkerConfig`
 

--- a/src/content/docs/workers/vite-plugin/reference/static-assets.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/static-assets.mdx
@@ -32,7 +32,13 @@ assets = { not_found_handling = "single-page-application" }
 
 </WranglerConfig>
 
-{/* Add docs for _headers and _redirects */}
+## Headers and redirects
+
+Custom [headers](/workers/static-assets/headers/) and [redirects](/workers/static-assets/redirects/) are supported at build, preview and deploy time by adding `_headers` and `_redirects` files to your [`public` directory](https://vite.dev/guide/assets#the-public-directory).
+The paths in these files should reflect the structure of your client build output.
+For example, generated assets are typically located in an [assets subdirectory](https://vite.dev/config/build-options#build-assetsdir).
+
+<br />
 
 :::note
 The Cloudflare Vite plugin does not support [run_worker_first](/workers/static-assets/binding/#run_worker_first).


### PR DESCRIPTION
### Summary

Adds headers and redirects section to the Static Assets page in the Vite plugin docs.
Also adds a note that auxiliary Workers are not currently compatible with React Router.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
