### PR TITLE
Remove duplicate workflow ID row

### DIFF
--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -21,7 +21,6 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum persisted state per step          | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum event [payload size](/workflows/build/events-and-parameters/) | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
 | Maximum state that can be persisted per Workflow instance | 100MB | 1GB |
-| Maximum length of a Workflow ID [^4]      | 64 characters | 64 characters |
 | Maximum `step.sleep` duration             | 365 days (1 year) | 365 days (1 year) |
 | Maximum steps per Workflow [^5]           | 1024 | 1024 |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |


### PR DESCRIPTION
### Summary

In the Workflow Limits page there was a duplicate row for the Workflow ID character limit 

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
