### PR TITLE
[SSL] Update pqc-support.mdx

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -21,7 +21,7 @@ The list below is for reference only. Responsibility for third-party software li
 - Default for recent [Opera](https://opera.com) and [Brave](https://brave.com)
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
-- [OpenSSL 3.5.0+](https://www.openssl.org/) (Alpha)
+- [OpenSSL 3.5.0+](https://www.openssl.org/)
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 - [GnuTLS](https://www.gnutls.org)
     - 3.8.9+ compiled with leancrypto 1.2.0+
@@ -53,8 +53,8 @@ The list below is for reference only. Responsibility for third-party software li
 - Cloudflare's [fork of QUIC-go](https://github.com/cloudflare/qtls-pq)
 - Goutam Tamvada's [fork of Firefox](https://github.com/xvzcf/firefox-pq-demos)
 - [Open Quantum Safe](https://openquantumsafe.org/)
-    - C library: `liboqs` 0.5.0-0.12.0
-    - OpenSSL provider: `oqs-provider` 0.5.0-0.8.0
+    - C library: liboqs 0.5.0-0.12.0
+    - OpenSSL provider: oqs-provider 0.5.0-0.8.0
 - [Zig 0.11.0-0.13.0](https://ziglang.org/)
 - [nginx](https://www.nginx.org/) when [compiled with BoringSSL](https://mailman.nginx.org/pipermail/nginx/2023-August/NOISOYU3QTB2DGIYUBGF7CAMQHDI2QLT.html) ([guide](https://blog.centminmod.com/2023/10/03/2860/how-to-enable-cloudflare-post-quantum-x25519kyber768-key-exchange-support-in-centmin-mod-nginx/))
 - [Botan C++ library 3.2.0+](https://botan.randombit.net/) ([instructions](https://github.com/randombit/botan/discussions/3747))


### PR DESCRIPTION
* remove alpha note now that [openssl-3.5.0] is released

* fix some inconsistent formatting

[openssl-3.5.0]: https://github.com/openssl/openssl/releases/tag/openssl-3.5.0