### PR TITLE
Add "Build a Remote MCP client" to Guides section

### DIFF
--- a/src/content/docs/agents/guides/build-mcp-client.mdx
+++ b/src/content/docs/agents/guides/build-mcp-client.mdx
@@ -1,0 +1,9 @@
+---
+pcx_content_type: navigation
+title: Build a Remote MCP Client
+external_link: https://github.com/cloudflare/ai/tree/main/demos/mcp-client
+sidebar:
+  order: 7
+head: []
+description: Build an AI Agent that acts as a remote MCP client. 
+---


### PR DESCRIPTION
### Summary

In the Guides section of the Agents docs, adding a page for building a remote MCP client which redirects to https://github.com/cloudflare/ai/tree/main/demos/mcp-client. 
