### PR TITLE
[Email Routing] fix: code blocks in email routing changelog

### DIFF
--- a/src/content/changelog/email-routing/2025-04-08-local-development.mdx
+++ b/src/content/changelog/email-routing/2025-04-08-local-development.mdx
@@ -19,6 +19,7 @@ export default {
 		console.log(email);
 	},
 };
+```
 
 Now when you run `npx wrangler dev`, wrangler will expose a local `/cdn-cgi/handler/email` endpoint that you can `POST` email messages to and trigger your Worker's `email()` handler:
 


### PR DESCRIPTION
### Summary

Fixes the code blocks so this renders correctly now:
![](https://i.james.pub/file/2025/04/fae7ee9d-af08-4610-8b63-8c4e5a7af2d8.png)

(Note the `Now when you run `npx wrangler dev...` text being swallowed by the unclosed code block

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
