### PR TITLE
[Docs Site] Turn off table alignment in index.md, fix glossary button

### DIFF
--- a/src/components/Glossary.astro
+++ b/src/components/Glossary.astro
@@ -1,7 +1,6 @@
 ---
 import { marked } from "marked";
 import { getGlossaryEntries } from "~/util/glossary";
-import { LinkButton } from "@astrojs/starlight/components";
 
 interface Props {
 	product?: string;

--- a/src/components/Glossary.astro
+++ b/src/components/Glossary.astro
@@ -44,9 +44,14 @@ const INITIAL_VISIBLE_ROWS = 20;
 
 {
 	terms.length > INITIAL_VISIBLE_ROWS && (
-		<LinkButton id="glossary-button" href="" class="justify-center">
-			View more terms
-		</LinkButton>
+		<div class="flex items-center justify-center">
+			<button
+				id="glossary-button"
+				class="h-12 cursor-pointer rounded bg-cl1-brand-orange px-6 font-medium text-cl1-black"
+			>
+				View more terms
+			</button>
+		</div>
 	)
 }
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -46,7 +46,7 @@ export default class extends WorkerEntrypoint<Env> {
 					rehypeParse,
 					rehypeBaseUrl,
 					rehypeFilterElements,
-					remarkGfm,
+					[remarkGfm, { tablePipeAlign: false }],
 					rehypeRemark,
 					remarkStringify,
 				]);


### PR DESCRIPTION
### Summary

Turn off table alignment in index.md, fix glossary button (shouldn't be `<a>`)