### PR TITLE
[Logs] Removes Logstream from examples

### DIFF
--- a/src/content/docs/logs/get-started/enable-destinations/ibm-cloud-logs.mdx
+++ b/src/content/docs/logs/get-started/enable-destinations/ibm-cloud-logs.mdx
@@ -90,7 +90,6 @@ Response:
       "record_suffix": "}}",
       "record_delimiter": ","
     },
-    "logstream": true,
     "max_upload_bytes": 2000000,
     "name": "<DOMAIN_NAME>"
   },
@@ -139,7 +138,6 @@ Response:
       "record_suffix": "}}",
       "record_delimiter": ","
     },
-    "logstream": true,
     "max_upload_bytes": 2000000,
     "name": "<DOMAIN_NAME>"
   },

--- a/src/content/docs/logs/get-started/enable-destinations/new-relic.mdx
+++ b/src/content/docs/logs/get-started/enable-destinations/new-relic.mdx
@@ -122,7 +122,6 @@ Response:
       "field_names": ["ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp","EdgeResponseBytes", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"],
       "timestamp_format": "unix"
     },
-    "logstream": true,
     "max_upload_bytes": 5000000,
     "name": "<DOMAIN_NAME>"
   },
@@ -166,7 +165,6 @@ Response:
        "field_names": ["ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp","EdgeResponseBytes", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"],
        "timestamp_format": "unix"
      },
-     "logstream": true,
      "max_upload_bytes": 5000000,
      "name": "<DOMAIN_NAME>"
   },

--- a/src/content/docs/logs/tutorials/examples/example-logpush-curl.mdx
+++ b/src/content/docs/logs/tutorials/examples/example-logpush-curl.mdx
@@ -364,7 +364,6 @@ curl https://api.cloudflare.com/client/v4/zones/{zone_id}/logpush/jobs/{job_id} 
   "result": {
     "id": <JOB_ID>,
     "dataset": "http_requests",
-    "logstream": true,
     "kind": "",
     "enabled": true,
     "name": "<DOMAIN_NAME>",
@@ -408,7 +407,6 @@ Note that at this time, the **CVE-2021-44228** option is not available through t
   "result": {
     "id": <JOB_ID>,
     "dataset": "http_requests",
-    "logstream": true,
     "kind": "",
     "enabled": true,
     "name": null,


### PR DESCRIPTION
### Summary

Removes Logstream field from examples.

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
