### PR TITLE
[D1] Fix "Starter code for D1 Sessions API demo" link in read-replication.mdx

### DIFF
--- a/src/content/docs/d1/best-practices/read-replication.mdx
+++ b/src/content/docs/d1/best-practices/read-replication.mdx
@@ -464,5 +464,5 @@ You may wish to refer to the following resources:
 - Blog: [Sequential consistency without borders: How D1 implements global read replication](https://blog.cloudflare.com/d1-read-replication-beta/)
 - Blog: [Building D1: a Global Database](https://blog.cloudflare.com/building-d1-a-global-database/)
 - [D1 Sessions API documentation](/d1/worker-api/d1-database#withsession)
-- [Starter code for D1 Sessions API demo](https://github.com/cloudflare/templates/tree/staging/d1-starter-sessions-api)
+- [Starter code for D1 Sessions API demo](https://github.com/cloudflare/templates/tree/main/d1-starter-sessions-api-template)
 - [E-commerce store read replication tutorial](/d1/tutorials/using-read-replication-for-e-com)


### PR DESCRIPTION
### Summary

Added "template" suffix and changed branch to main in d1 sessions demo link.

Related to [cloudflare/templates/pull/387](https://github.com/cloudflare/templates/pull/387).

### Documentation checklist

I believe none of them apply to this.