### PR TITLE
Local development warning for S3 APIs

### DIFF
--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -10,7 +10,9 @@ import { Render } from "~/components";
 
 JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client.
 
-When using `wrangler dev` command, your locally running R2 emulator does not support the AWS S3 APIs, and therefore this method of connecting will not work.
+:::
+Currently, you cannot use AWS S3-compatible API while developing locally via `wrangler dev`.
+:::
 
 :::note[Compatibility]
 Client version `3.729.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.

--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -8,7 +8,9 @@ import { Render } from "~/components";
 <Render file="keys" />
 <br />
 
-JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client:
+JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client.
+
+When using `wrangler dev` command, your locally running R2 emulator does not support the AWS S3 APIs, and therefore this method of connecting will not work.
 
 :::note[Compatibility]
 Client version `3.729.0` introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.

--- a/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
+++ b/src/content/docs/r2/examples/aws/aws-sdk-js-v3.mdx
@@ -10,7 +10,7 @@ import { Render } from "~/components";
 
 JavaScript or TypeScript users may continue to use the [`@aws-sdk/client-s3`](https://www.npmjs.com/package/@aws-sdk/client-s3) npm package as per normal. You must pass in the R2 configuration credentials when instantiating your `S3` service client.
 
-:::
+:::note
 Currently, you cannot use AWS S3-compatible API while developing locally via `wrangler dev`.
 :::
 


### PR DESCRIPTION
### Summary
Add a note to the docs letting the reader know that connecting to an R2 bucket this way is not possible when it's running locally in emulation mode with Wrangler Dev.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
