### PR TITLE
[API Shield] Change API Gateway naming to API Shield

### DIFF
--- a/src/content/docs/api-shield/plans.mdx
+++ b/src/content/docs/api-shield/plans.mdx
@@ -7,9 +7,9 @@ sidebar:
 
 ---
 
-Free, Pro, Business, and Enterprise customers without an API Gateway subscription can access [Endpoint Management](/api-shield/management-and-monitoring/) and [Schema validation](/api-shield/security/schema-validation/), but no other [API Gateway](/api-shield/api-gateway/) features.
+Free, Pro, Business, and Enterprise customers without an API Shield subscription can access [Endpoint Management](/api-shield/management-and-monitoring/) and [Schema validation](/api-shield/security/schema-validation/), but no other [API Shield](/api-shield/) features.
 
-To subscribe to API Gateway, upgrade to an Enterprise plan and contact your account team.
+To subscribe to API Shield, upgrade to an Enterprise plan and contact your account team.
 
 Limits to endpoints apply to Endpoint Management and Schema validation. Refer to the table below for limits based on your zone plan. 
 
@@ -18,5 +18,5 @@ Limits to endpoints apply to Endpoint Management and Schema validation. Refer to
 | **Free** | 100 | 5 | 200 kB | `Block` only |
 | **Pro** | 250 | 5 | 500 kB | `Block` only |
 | **Business** | 500 | 10 | 2 MB | `Block` only |
-| **Enterprise without API Gateway** | 500 | 5 | 5 MB | `Log` or `Block` |
-| **Enterprise with API Gateway** | 10,000 | 10+ | 10+ MB | `Log` or `Block` |
+| **Enterprise without API Shield** | 500 | 5 | 5 MB | `Log` or `Block` |
+| **Enterprise with API Shield** | 10,000 | 10+ | 10+ MB | `Log` or `Block` |

--- a/src/content/docs/ruleset-engine/reference/phases-list.mdx
+++ b/src/content/docs/ruleset-engine/reference/phases-list.mdx
@@ -37,7 +37,7 @@ The phases execute in the order they appear in the table.
 | `http_config_settings`          | [Configuration Rules](/rules/configuration-rules/)                                      |
 | `http_request_origin`           | [Origin Rules](/rules/origin-rules/)                                                    |
 | `ddos_l7`\*                     | [HTTP DDoS Attack Protection](/ddos-protection/managed-rulesets/http/)                  |
-| `http_request_api_gateway`      | [API Gateway](/api-shield/api-gateway/)                                                 |
+| `http_request_api_shield`      | [API Shield](/api-shield/)                                                 |
 | `http_request_firewall_custom`  | [Custom rules (Web Application Firewall)](/waf/custom-rules/)                           |
 | `http_ratelimit`                | [Rate limiting rules (WAF)](/waf/rate-limiting-rules/)                                  |
 | _N/A_ (internal phase)          | [API Shield](/api-shield/)                                                              |


### PR DESCRIPTION
### Summary

PCX-16958

Updates API Shield Plans and Rate Limiting docs to say API Shield instead of API Gateway. Additional changes to existing docs that still have API Gateway is TBD

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
