### PR TITLE
[Hyperlint] Add first plaintext check

### DIFF
--- a/.github/styles/plain-text-style-checks/spelling.md
+++ b/.github/styles/plain-text-style-checks/spelling.md
@@ -1,0 +1,1 @@
+Fix spelling errors.

--- a/.hyperlint/config.yaml
+++ b/.hyperlint/config.yaml
@@ -12,5 +12,9 @@ reviewer:
   vale_style_guide:
     check_status_upon_review_failure: neutral
     enabled: true
+  custom_style_guide:
+    enabled: true
+    path_to_style_guide_dir: ".github/styles/plain-text-style-checks/"
+    check_status_upon_review_failure: neutral
   limit_num_reviews: 2
   limit_num_comments: 5


### PR DESCRIPTION
Think I'm doing this correctly, @bllchmbrs. 

Wanted to get a first plaintext check up there. Also, I'm still not _exactly_ sure on the mechanism for denoting which checks are run on the PR level vs the background automation. Sounds like that's a backend thing that you'll be helping with?

For now, I'd want this to run in the background. If we can do this for spelling, I'd imagine a series of checks that we could roll out:
- Some that only run in the background
- Others that we start in the background and then "graduate" to the on PR checks based on false positive rate