### PR TITLE
Fix Docs to use Global API Key when disabling SSO

### DIFF
--- a/src/content/docs/cloudflare-one/applications/configure-apps/dash-sso-apps.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/dash-sso-apps.mdx
@@ -150,7 +150,8 @@ curl https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/sso/v2/connectors
 ```bash title="cURL command"
 curl --request PATCH \
 'https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/sso/v2/connectors/2828' \
---header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+--header "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+--header "X-Auth-Key: $CLOUDFLARE_API_KEY" \
 --header "Content-Type: application/json" \
 --data '{
   "sso_connector_status": "DIS"


### PR DESCRIPTION
This API only accepts Global API authentication; example using token is inaccurate.

### Summary

Changing the authentication method on the example to use Global API Key instead of token.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
