### PR TITLE
Add Descope as MCP auth provider

### DIFF
--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -160,7 +160,7 @@ Get started with a remote MCP server that uses WorkOS's AuthKit to authenticate 
 
 #### Descope
 
-Get started with a remote MCP server that uses [Descope](https://www.descope.com/) Inbound Apps to authenticate and authorize users (e.g. email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
+Get started with a remote MCP server that uses [Descope](https://www.descope.com/) Inbound Apps to authenticate and authorize users (for example, email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server-descope-auth)
 

--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -124,7 +124,7 @@ Read the docs for the [Workers oAuth Provider Library](https://github.com/cloudf
 
 ### (3) Bring your own OAuth Provider
 
-If your application already implements an Oauth Provider itself, or you use [Stytch](https://stytch.com/), [Auth0](https://auth0.com/), [WorkOS](https://workos.com/), or authorization-as-a-service provider, you can use this in the same way that you would use a third-party OAuth provider, described above in (2).
+If your application already implements an Oauth Provider itself, or you use [Stytch](https://stytch.com/), [Auth0](https://auth0.com/), [WorkOS](https://workos.com/), [Descope](https://www.descope.com/) or another authorization-as-a-service provider, you can use this in the same way that you would use a third-party OAuth provider, described above in (2).
 
 You can use the auth provider to: 
 - Allow users to authenticate to your MCP server through email, social logins, SSO (single sign-on), and MFA (multi-factor authentication).
@@ -160,7 +160,7 @@ Get started with a remote MCP server that uses WorkOS's AuthKit to authenticate 
 
 #### Descope
 
-Get started with a remote MCP server that uses Descope's Inbound Apps to authenticate and authorize users (e.g. email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
+Get started with a remote MCP server that uses [Descope](https://www.descope.com/) Inbound Apps to authenticate and authorize users (e.g. email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server-descope-auth)
 

--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -158,6 +158,12 @@ Get started with a remote MCP server that uses WorkOS's AuthKit to authenticate 
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authkit)
 
+#### Descope
+
+Get started with a remote MCP server that uses Descope's Inbound Apps to authenticate and authorize users (e.g. email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server-descope-auth)
+
 ## Using Authentication Context in Your MCP Server
 
 When a user authenticates to your MCP server through Cloudflare's OAuth Provider, their identity information and tokens are made available through the `props` parameter.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
This PR adds [Descope](https://www.descope.com/) as an MCP OAuth provider.

It is a companion PR to the demo being added in `cloudflare/ai` [here](https://github.com/cloudflare/ai/pull/104).

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->
<img width="1373" alt="Screenshot 2025-04-14 at 10 49 21 AM" src="https://github.com/user-attachments/assets/2e0bcf7f-09e8-4d19-83cd-9f54df4125a7" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.