### PR TITLE
[Rules] Update page headings

### DIFF
--- a/src/content/docs/rules/compression-rules/create-api.mdx
+++ b/src/content/docs/rules/compression-rules/create-api.mdx
@@ -1,11 +1,9 @@
 ---
-title: Create a rule via API
+title: Create a compression rule via API
 pcx_content_type: how-to
 sidebar:
   order: 2
-head:
-  - tag: title
-    content: Create a compression rule via API
+  label: Create a rule via API
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/compression-rules/create-dashboard.mdx
+++ b/src/content/docs/rules/compression-rules/create-dashboard.mdx
@@ -1,11 +1,9 @@
 ---
-title: Create a rule in the dashboard
+title: Create a compression rule in the dashboard
 pcx_content_type: how-to
 sidebar:
   order: 1
-head:
-  - tag: title
-    content: Create a compression rule in the dashboard
+  label: Create a rule in the dashboard
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/configuration-rules/create-api.mdx
+++ b/src/content/docs/rules/configuration-rules/create-api.mdx
@@ -1,12 +1,10 @@
 ---
-title: Create a rule via API
+title: Create a configuration rule via API
 pcx_content_type: how-to
 type: overview
 sidebar:
-  order: 4
-head:
-  - tag: title
-    content: Create a configuration rule via API
+  order: 3
+  label: Create a rule via API
 ---
 
 import { Details, Render, APIRequest } from "~/components";

--- a/src/content/docs/rules/configuration-rules/create-dashboard.mdx
+++ b/src/content/docs/rules/configuration-rules/create-dashboard.mdx
@@ -1,11 +1,9 @@
 ---
+title: Create a configuration rule in the dashboard
 pcx_content_type: how-to
-title: Create a rule in the dashboard
 sidebar:
-  order: 3
-head:
-  - tag: title
-    content: Create a configuration rule in the dashboard
+  order: 2
+  label: Create a rule in the dashboard
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/origin-rules/create-api.mdx
+++ b/src/content/docs/rules/origin-rules/create-api.mdx
@@ -1,11 +1,9 @@
 ---
-title: Create a rule via API
+title: Create an origin rule via API
 pcx_content_type: how-to
 sidebar:
   order: 3
-head:
-  - tag: title
-    content: Create an origin rule via API
+  label: Create a rule via API
 ---
 
 import { Details, Render, APIRequest } from "~/components";

--- a/src/content/docs/rules/origin-rules/create-dashboard.mdx
+++ b/src/content/docs/rules/origin-rules/create-dashboard.mdx
@@ -1,11 +1,9 @@
 ---
 pcx_content_type: how-to
-title: Create a rule in the dashboard
+title: Create an origin rule in the dashboard
 sidebar:
   order: 2
-head:
-  - tag: title
-    content: Create an origin rule in the dashboard
+  label: Create a rule in the dashboard
 ---
 
 import { Render } from "~/components";


### PR DESCRIPTION
### Summary

Updates page headings in Rules to improve internal results.

External search engines seem to correctly use page titles (in meta tags), but internal results have a few results all named "Create a rule in the dashboard".
