### PR TITLE
Update reference.mdx

### DIFF
--- a/src/content/docs/rules/transform/managed-transforms/reference.mdx
+++ b/src/content/docs/rules/transform/managed-transforms/reference.mdx
@@ -159,6 +159,6 @@ Adds several security-related HTTP response headers. The added response headers 
 - `x-xss-protection: 1; mode=block`
 - `x-frame-options: SAMEORIGIN`
 - `referrer-policy: same-origin`
-- `expect-ct: max-age=86400, enforce`
+
 
 To increase protection, [enable HTTP Strict Transport Security (HSTS)](/ssl/edge-certificates/additional-options/http-strict-transport-security/) for your website.


### PR DESCRIPTION
The Expect-CT header is deprecated. This header was used to enforce Certificate Transparency (CT) requirements, but it is no longer recommended for use. Chromium-based browsers, such as Google Chrome, deprecated the Expect-CT header starting from version 107, as they now enforce CT by default

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
