### PR TITLE
fix: typo in environment-variables.mdx

### DIFF
--- a/src/content/docs/workers/local-development/environment-variables.mdx
+++ b/src/content/docs/workers/local-development/environment-variables.mdx
@@ -76,5 +76,5 @@ To simulate different local environments, you can:
 
 ## Learn more
 
-- To learn how to configure multiple environments in Wrangler configuration, [read the documenation](/workers/wrangler/environments/#_top).
+- To learn how to configure multiple environments in Wrangler configuration, [read the documentation](/workers/wrangler/environments/#_top).
 - To learn how to use Wrangler environments and Vite environments together, [read the Vite plugin documentation](/workers/vite-plugin/reference/cloudflare-environments/)


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Fix typo 'documenation' to be 'documentation'
### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
