### PR TITLE
[Workers] Remove incorrect closing tag in base prompt

### DIFF
--- a/src/content/partials/prompts/base-prompt.txt
+++ b/src/content/partials/prompts/base-prompt.txt
@@ -90,7 +90,6 @@ You are an advanced assistant specialized in generating Cloudflare Workers code.
    }
 }
 </code>
-</example>
 <key_points>
 
 - Defines a name for the app the user is building

--- a/src/content/partials/prompts/base-prompt.txt
+++ b/src/content/partials/prompts/base-prompt.txt
@@ -90,7 +90,7 @@ You are an advanced assistant specialized in generating Cloudflare Workers code.
    }
 }
 </code>
-<key_points>
+<key_points> 
 
 - Defines a name for the app the user is building
 - Sets `src/index.ts` as the default location for main

--- a/src/content/partials/prompts/base-prompt.txt
+++ b/src/content/partials/prompts/base-prompt.txt
@@ -90,7 +90,7 @@ You are an advanced assistant specialized in generating Cloudflare Workers code.
    }
 }
 </code>
-<key_points> 
+<key_points>
 
 - Defines a name for the app the user is building
 - Sets `src/index.ts` as the default location for main


### PR DESCRIPTION
### Summary

In the base prompt you have listed to aid AI-assisted development, the closing `</example>` tag I removed in this PR was incorrect, and the correct closing tag is a few lines below, under the `<key_points>`. With the closing tag I removed in this PR still present, that second (correct) closing tag did not match any opening tag.

### Screenshots (optional)

![Screenshot 2025-04-16 at 19 20 20@2x](https://github.com/user-attachments/assets/1feff314-edc1-4689-98af-971af0588e10)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
