### PR TITLE
Added Deploy to Cloudflare button to Cloudflare Workers examples

### DIFF
--- a/src/content/docs/workers/examples/103-early-hints.mdx
+++ b/src/content/docs/workers/examples/103-early-hints.mdx
@@ -15,7 +15,11 @@ sidebar:
 description: Allow a client to request static assets while waiting for the HTML response.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/103-early-hints)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/103-early-hints.mdx
+++ b/src/content/docs/workers/examples/103-early-hints.mdx
@@ -15,6 +15,8 @@ sidebar:
 description: Allow a client to request static assets while waiting for the HTML response.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/103-early-hints)
+
 import { TabItem, Tabs } from "~/components";
 
 `103` Early Hints is an HTTP status code designed to speed up content delivery. When enabled, Cloudflare can cache the `Link` headers marked with preload and/or preconnect from HTML pages and serve them in a `103` Early Hints response before reaching the origin server. Browsers can use these hints to fetch linked assets while waiting for the origin’s final response, dramatically improving page load speeds.

--- a/src/content/docs/workers/examples/accessing-the-cloudflare-object.mdx
+++ b/src/content/docs/workers/examples/accessing-the-cloudflare-object.mdx
@@ -16,7 +16,11 @@ description: Access custom Cloudflare properties and control how Cloudflare
   features are applied to every request.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/accessing-the-cloudflare-object)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/accessing-the-cloudflare-object.mdx
+++ b/src/content/docs/workers/examples/accessing-the-cloudflare-object.mdx
@@ -16,6 +16,8 @@ description: Access custom Cloudflare properties and control how Cloudflare
   features are applied to every request.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/accessing-the-cloudflare-object)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/aggregate-requests.mdx
+++ b/src/content/docs/workers/examples/aggregate-requests.mdx
@@ -14,6 +14,8 @@ description: Send two GET request to two urls and aggregates the responses into
   one response.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/aggregate-requests)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/aggregate-requests.mdx
+++ b/src/content/docs/workers/examples/aggregate-requests.mdx
@@ -14,7 +14,11 @@ description: Send two GET request to two urls and aggregates the responses into
   one response.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/aggregate-requests)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/alter-headers.mdx
+++ b/src/content/docs/workers/examples/alter-headers.mdx
@@ -19,7 +19,11 @@ description: Example of how to add, change, or delete headers sent in a request
   or returned in a response.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/alter-headers)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/alter-headers.mdx
+++ b/src/content/docs/workers/examples/alter-headers.mdx
@@ -19,6 +19,8 @@ description: Example of how to add, change, or delete headers sent in a request
   or returned in a response.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/alter-headers)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cache-api.mdx
+++ b/src/content/docs/workers/examples/cache-api.mdx
@@ -15,6 +15,8 @@ sidebar:
 description: Use the Cache API to store responses in Cloudflare's cache.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-api)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cache-api.mdx
+++ b/src/content/docs/workers/examples/cache-api.mdx
@@ -15,7 +15,11 @@ sidebar:
 description: Use the Cache API to store responses in Cloudflare's cache.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-api)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/cache-post-request.mdx
+++ b/src/content/docs/workers/examples/cache-post-request.mdx
@@ -15,6 +15,8 @@ sidebar:
 description: Cache POST requests using the Cache API.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-post-request)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cache-post-request.mdx
+++ b/src/content/docs/workers/examples/cache-post-request.mdx
@@ -15,7 +15,11 @@ sidebar:
 description: Cache POST requests using the Cache API.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-post-request)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/cache-tags.mdx
+++ b/src/content/docs/workers/examples/cache-tags.mdx
@@ -14,6 +14,8 @@ sidebar:
 description: Send Additional Cache Tags using Workers
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-tags)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cache-tags.mdx
+++ b/src/content/docs/workers/examples/cache-tags.mdx
@@ -14,7 +14,11 @@ sidebar:
 description: Send Additional Cache Tags using Workers
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-tags)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/cache-using-fetch.mdx
+++ b/src/content/docs/workers/examples/cache-using-fetch.mdx
@@ -18,6 +18,8 @@ description: Determine how to cache a resource by setting TTLs, custom cache
   keys, and cache headers in a fetch request.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-using-fetch)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cache-using-fetch.mdx
+++ b/src/content/docs/workers/examples/cache-using-fetch.mdx
@@ -18,7 +18,11 @@ description: Determine how to cache a resource by setting TTLs, custom cache
   keys, and cache headers in a fetch request.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cache-using-fetch)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/conditional-response.mdx
+++ b/src/content/docs/workers/examples/conditional-response.mdx
@@ -16,6 +16,8 @@ description: Return a response based on the incoming request's URL, HTTP method,
   User Agent, IP address, ASN or device type.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/conditional-response)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/conditional-response.mdx
+++ b/src/content/docs/workers/examples/conditional-response.mdx
@@ -16,7 +16,11 @@ description: Return a response based on the incoming request's URL, HTTP method,
   User Agent, IP address, ASN or device type.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/conditional-response)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/cors-header-proxy.mdx
+++ b/src/content/docs/workers/examples/cors-header-proxy.mdx
@@ -16,6 +16,8 @@ sidebar:
 description: Add the necessary CORS headers to a third party API response.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cors-header-proxy)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/cors-header-proxy.mdx
+++ b/src/content/docs/workers/examples/cors-header-proxy.mdx
@@ -16,7 +16,11 @@ sidebar:
 description: Add the necessary CORS headers to a third party API response.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cors-header-proxy)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/country-code-redirect.mdx
+++ b/src/content/docs/workers/examples/country-code-redirect.mdx
@@ -17,6 +17,8 @@ sidebar:
 description: Redirect a response based on the country code in the header of a visitor.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/country-code-redirect)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/country-code-redirect.mdx
+++ b/src/content/docs/workers/examples/country-code-redirect.mdx
@@ -17,7 +17,11 @@ sidebar:
 description: Redirect a response based on the country code in the header of a visitor.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/country-code-redirect)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/cron-trigger.mdx
+++ b/src/content/docs/workers/examples/cron-trigger.mdx
@@ -13,7 +13,11 @@ sidebar:
 description: Set a Cron Trigger for your Worker.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cron-trigger)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs, WranglerConfig } from "~/components";
 

--- a/src/content/docs/workers/examples/cron-trigger.mdx
+++ b/src/content/docs/workers/examples/cron-trigger.mdx
@@ -13,6 +13,8 @@ sidebar:
 description: Set a Cron Trigger for your Worker.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/cron-trigger)
+
 import { Render, TabItem, Tabs, WranglerConfig } from "~/components";
 
 <Render file="cron-trigger-example" />

--- a/src/content/docs/workers/examples/data-loss-prevention.mdx
+++ b/src/content/docs/workers/examples/data-loss-prevention.mdx
@@ -16,7 +16,11 @@ description: Protect sensitive data to prevent data loss, and send alerts to a
   webhooks server in the event of a data breach.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/data-loss-prevention)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/data-loss-prevention.mdx
+++ b/src/content/docs/workers/examples/data-loss-prevention.mdx
@@ -16,6 +16,8 @@ description: Protect sensitive data to prevent data loss, and send alerts to a
   webhooks server in the event of a data breach.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/data-loss-prevention)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/debugging-logs.mdx
+++ b/src/content/docs/workers/examples/debugging-logs.mdx
@@ -14,7 +14,11 @@ sidebar:
 description: Send debugging information in an errored response to a logging service.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/debugging-logs)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/debugging-logs.mdx
+++ b/src/content/docs/workers/examples/debugging-logs.mdx
@@ -14,6 +14,8 @@ sidebar:
 description: Send debugging information in an errored response to a logging service.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/debugging-logs)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/extract-cookie-value.mdx
+++ b/src/content/docs/workers/examples/extract-cookie-value.mdx
@@ -16,7 +16,11 @@ description: Given the cookie name, get the value of a cookie. You can also use
   cookies for A/B testing.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/extract-cookie-value)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/extract-cookie-value.mdx
+++ b/src/content/docs/workers/examples/extract-cookie-value.mdx
@@ -16,6 +16,8 @@ description: Given the cookie name, get the value of a cookie. You can also use
   cookies for A/B testing.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/extract-cookie-value)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/fetch-html.mdx
+++ b/src/content/docs/workers/examples/fetch-html.mdx
@@ -17,7 +17,11 @@ description: Send a request to a remote server, read HTML from the response, and
   serve that HTML.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/fetch-html)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/fetch-html.mdx
+++ b/src/content/docs/workers/examples/fetch-html.mdx
@@ -17,6 +17,8 @@ description: Send a request to a remote server, read HTML from the response, and
   serve that HTML.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/fetch-html)
+
 import { Render, TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/fetch-json.mdx
+++ b/src/content/docs/workers/examples/fetch-json.mdx
@@ -16,7 +16,11 @@ description: Send a GET request and read in JSON from the response. Use to fetch
   external data.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/fetch-json)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/fetch-json.mdx
+++ b/src/content/docs/workers/examples/fetch-json.mdx
@@ -16,6 +16,8 @@ description: Send a GET request and read in JSON from the response. Use to fetch
   external data.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/fetch-json)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/geolocation-app-weather.mdx
+++ b/src/content/docs/workers/examples/geolocation-app-weather.mdx
@@ -14,6 +14,8 @@ sidebar:
 description: Fetch weather data from an API using the user's geolocation data.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-app-weather)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/geolocation-app-weather.mdx
+++ b/src/content/docs/workers/examples/geolocation-app-weather.mdx
@@ -14,7 +14,11 @@ sidebar:
 description: Fetch weather data from an API using the user's geolocation data.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-app-weather)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/geolocation-custom-styling.mdx
+++ b/src/content/docs/workers/examples/geolocation-custom-styling.mdx
@@ -13,7 +13,11 @@ sidebar:
 description: Personalize website styling based on localized user time.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-custom-styling)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/geolocation-custom-styling.mdx
+++ b/src/content/docs/workers/examples/geolocation-custom-styling.mdx
@@ -13,6 +13,8 @@ sidebar:
 description: Personalize website styling based on localized user time.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-custom-styling)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/geolocation-hello-world.mdx
+++ b/src/content/docs/workers/examples/geolocation-hello-world.mdx
@@ -16,7 +16,11 @@ sidebar:
 description: Get all geolocation data fields and display them in HTML.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-hello-world)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/geolocation-hello-world.mdx
+++ b/src/content/docs/workers/examples/geolocation-hello-world.mdx
@@ -16,6 +16,8 @@ sidebar:
 description: Get all geolocation data fields and display them in HTML.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/geolocation-hello-world)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/hot-link-protection.mdx
+++ b/src/content/docs/workers/examples/hot-link-protection.mdx
@@ -17,7 +17,11 @@ description: Block other websites from linking to your content. This is useful
   for protecting images.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/hot-link-protection)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/hot-link-protection.mdx
+++ b/src/content/docs/workers/examples/hot-link-protection.mdx
@@ -17,6 +17,8 @@ description: Block other websites from linking to your content. This is useful
   for protecting images.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/hot-link-protection)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/images-workers.mdx
+++ b/src/content/docs/workers/examples/images-workers.mdx
@@ -14,6 +14,8 @@ description: Set up custom domain for Images using a Worker or serve images
   using a prefix path and Cloudflare registered domain.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/images-workers)
+
 import { TabItem, Tabs } from "~/components";
 
 To serve images from a custom domain:

--- a/src/content/docs/workers/examples/images-workers.mdx
+++ b/src/content/docs/workers/examples/images-workers.mdx
@@ -14,7 +14,11 @@ description: Set up custom domain for Images using a Worker or serve images
   using a prefix path and Cloudflare registered domain.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/images-workers)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/logging-headers.mdx
+++ b/src/content/docs/workers/examples/logging-headers.mdx
@@ -18,7 +18,11 @@ sidebar:
 description: Examine the contents of a Headers object by logging to console with a Map.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/logging-headers)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/logging-headers.mdx
+++ b/src/content/docs/workers/examples/logging-headers.mdx
@@ -18,6 +18,8 @@ sidebar:
 description: Examine the contents of a Headers object by logging to console with a Map.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/logging-headers)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/modify-request-property.mdx
+++ b/src/content/docs/workers/examples/modify-request-property.mdx
@@ -17,6 +17,8 @@ description: Create a modified request with edited properties based off of an
   incoming request.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/modify-request-property)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/modify-request-property.mdx
+++ b/src/content/docs/workers/examples/modify-request-property.mdx
@@ -17,7 +17,11 @@ description: Create a modified request with edited properties based off of an
   incoming request.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/modify-request-property)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/modify-response.mdx
+++ b/src/content/docs/workers/examples/modify-response.mdx
@@ -17,7 +17,11 @@ description: Fetch and modify response properties which are immutable by
   creating a copy first.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/modify-response)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/modify-response.mdx
+++ b/src/content/docs/workers/examples/modify-response.mdx
@@ -17,6 +17,8 @@ description: Fetch and modify response properties which are immutable by
   creating a copy first.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/modify-response)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/multiple-cron-triggers.mdx
+++ b/src/content/docs/workers/examples/multiple-cron-triggers.mdx
@@ -13,6 +13,8 @@ sidebar:
 description: Set multiple Cron Triggers on three different schedules.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/multiple-cron-triggers)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/multiple-cron-triggers.mdx
+++ b/src/content/docs/workers/examples/multiple-cron-triggers.mdx
@@ -13,7 +13,11 @@ sidebar:
 description: Set multiple Cron Triggers on three different schedules.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/multiple-cron-triggers)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/openai-sdk-streaming.mdx
+++ b/src/content/docs/workers/examples/openai-sdk-streaming.mdx
@@ -14,7 +14,11 @@ head: []
 description: Use the OpenAI v4 SDK to stream responses from OpenAI.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/openai-sdk-streaming)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/openai-sdk-streaming.mdx
+++ b/src/content/docs/workers/examples/openai-sdk-streaming.mdx
@@ -14,6 +14,8 @@ head: []
 description: Use the OpenAI v4 SDK to stream responses from OpenAI.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/openai-sdk-streaming)
+
 import { TabItem, Tabs } from "~/components";
 
 In order to run this code, you must install the OpenAI SDK by running `npm i openai`.

--- a/src/content/docs/workers/examples/post-json.mdx
+++ b/src/content/docs/workers/examples/post-json.mdx
@@ -14,7 +14,11 @@ sidebar:
 description: Send a POST request with JSON data. Use to share data with external servers.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/post-json)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/post-json.mdx
+++ b/src/content/docs/workers/examples/post-json.mdx
@@ -14,6 +14,8 @@ sidebar:
 description: Send a POST request with JSON data. Use to share data with external servers.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/post-json)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
+++ b/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
@@ -16,7 +16,11 @@ description: Protect against timing attacks by safely comparing values using
   `timingSafeEqual`.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/protect-against-timing-attacks)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
+++ b/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
@@ -16,6 +16,8 @@ description: Protect against timing attacks by safely comparing values using
   `timingSafeEqual`.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/protect-against-timing-attacks)
+
 import { TabItem, Tabs } from "~/components";
 
 The [`crypto.subtle.timingSafeEqual`](/workers/runtime-apis/web-crypto/#timingsafeequal) function compares two values using a constant-time algorithm. The time taken is independent of the contents of the values.

--- a/src/content/docs/workers/examples/read-post.mdx
+++ b/src/content/docs/workers/examples/read-post.mdx
@@ -17,6 +17,8 @@ description: Serve an HTML form, then read POST requests. Use also to read JSON
   or POST data from an incoming request.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/read-post)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/read-post.mdx
+++ b/src/content/docs/workers/examples/read-post.mdx
@@ -17,7 +17,11 @@ description: Serve an HTML form, then read POST requests. Use also to read JSON
   or POST data from an incoming request.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/read-post)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/redirect.mdx
+++ b/src/content/docs/workers/examples/redirect.mdx
@@ -20,7 +20,11 @@ description: Redirect requests from one URL to another or from one set of URLs
   to another set.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/redirect)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/redirect.mdx
+++ b/src/content/docs/workers/examples/redirect.mdx
@@ -20,6 +20,8 @@ description: Redirect requests from one URL to another or from one set of URLs
   to another set.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/redirect)
+
 import { Render, TabItem, Tabs } from "~/components";
 
 ## Redirect all requests to one URL

--- a/src/content/docs/workers/examples/respond-with-another-site.mdx
+++ b/src/content/docs/workers/examples/respond-with-another-site.mdx
@@ -19,7 +19,11 @@ description: Respond to the Worker request with the response from another
   website (example.com in this example).
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/respond-with-another-site)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/respond-with-another-site.mdx
+++ b/src/content/docs/workers/examples/respond-with-another-site.mdx
@@ -19,6 +19,8 @@ description: Respond to the Worker request with the response from another
   website (example.com in this example).
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/respond-with-another-site)
+
 import { Render, TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/return-html.mdx
+++ b/src/content/docs/workers/examples/return-html.mdx
@@ -18,7 +18,11 @@ sidebar:
 description: Deliver an HTML page from an HTML string directly inside the Worker script.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/return-html)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/return-html.mdx
+++ b/src/content/docs/workers/examples/return-html.mdx
@@ -18,6 +18,8 @@ sidebar:
 description: Deliver an HTML page from an HTML string directly inside the Worker script.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/return-html)
+
 import { Render, TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/return-json.mdx
+++ b/src/content/docs/workers/examples/return-json.mdx
@@ -21,7 +21,11 @@ description: Return JSON directly from a Worker script, useful for building APIs
   and middleware.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/return-json)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { Render, TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/return-json.mdx
+++ b/src/content/docs/workers/examples/return-json.mdx
@@ -21,6 +21,8 @@ description: Return JSON directly from a Worker script, useful for building APIs
   and middleware.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/return-json)
+
 import { Render, TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/rewrite-links.mdx
+++ b/src/content/docs/workers/examples/rewrite-links.mdx
@@ -14,6 +14,8 @@ description: Rewrite URL links in HTML using the HTMLRewriter. This is useful
   for JAMstack websites.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/rewrite-links)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/rewrite-links.mdx
+++ b/src/content/docs/workers/examples/rewrite-links.mdx
@@ -14,7 +14,11 @@ description: Rewrite URL links in HTML using the HTMLRewriter. This is useful
   for JAMstack websites.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/rewrite-links)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/security-headers.mdx
+++ b/src/content/docs/workers/examples/security-headers.mdx
@@ -20,6 +20,8 @@ description: Set common security headers (X-XSS-Protection, X-Frame-Options,
   Strict-Transport-Security, Content-Security-Policy).
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/security-headers)
+
 import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">

--- a/src/content/docs/workers/examples/security-headers.mdx
+++ b/src/content/docs/workers/examples/security-headers.mdx
@@ -20,7 +20,11 @@ description: Set common security headers (X-XSS-Protection, X-Frame-Options,
   Strict-Transport-Security, Content-Security-Policy).
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/security-headers)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/signing-requests.mdx
+++ b/src/content/docs/workers/examples/signing-requests.mdx
@@ -18,7 +18,11 @@ sidebar:
 description: Verify a signed request using the HMAC and SHA-256 algorithms or return a 403.
 ---
 
+If you want to get started quickly, click on the button below.
+
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/signing-requests)
+
+This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
 import { TabItem, Tabs } from "~/components";
 

--- a/src/content/docs/workers/examples/signing-requests.mdx
+++ b/src/content/docs/workers/examples/signing-requests.mdx
@@ -18,6 +18,8 @@ sidebar:
 description: Verify a signed request using the HMAC and SHA-256 algorithms or return a 403.
 ---
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/signing-requests)
+
 import { TabItem, Tabs } from "~/components";
 
 :::note


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Updated workers examples to display a "Deploy to Cloudflare" button that is linked to https://github.com/cloudflare/docs-examples

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
