### PR TITLE
[docs] Fix typo in module alias example for node-fetch in Wrangler configuration docs

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1186,12 +1186,12 @@ You can alias all imports of `node-fetch` to instead point directly to the `fetc
 
 ```toml title="wrangler.toml"
 [alias]
-"node-fetch" = "./fetch-nolyfill"
+"node-fetch" = "./fetch-polyfill"
 ```
 
 </WranglerConfig>
 
-```js title="./fetch-nolyfill"
+```js title="./fetch-polyfill"
 export default fetch;
 ```
 


### PR DESCRIPTION
### Summary

This PR corrects a typo in the alias example in the Workers configuration documentation. The file name was mistakenly written as fetch-nolyfill.