### PR TITLE
Realtime: added warning about port 53 URLs

### DIFF
--- a/src/content/docs/realtime/turn/generate-credentials.mdx
+++ b/src/content/docs/realtime/turn/generate-credentials.mdx
@@ -53,7 +53,7 @@ The JSON response below can then be passed on to your front-end application:
 }
 ```
 
-Note: the list of URLs returned contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers. So this TURN URL will time out if used in browsers. If you are using trickle ICE this not going to cause problems. But if you wait for ICE gathering to finish before passing on the ICE candidates you might want to filter out the alternate URL with port 53 to avoid waiting for it to time out.
+Note: the list of URLs returned contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers. So this TURN URL will time out if used in browsers. If you are using trickle ICE this is not going to cause problems. But if you wait for ICE gathering to finish before passing on the ICE candidates you might want to filter out the alternate URL with port 53 to avoid waiting for it to time out.
 
 Use `iceServers` as follows when instantiating the `RTCPeerConnection`:
 

--- a/src/content/docs/realtime/turn/generate-credentials.mdx
+++ b/src/content/docs/realtime/turn/generate-credentials.mdx
@@ -53,6 +53,8 @@ The JSON response below can then be passed on to your front-end application:
 }
 ```
 
+Note: the list of URLs returned contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers. So this TURN URL will time out if used in browsers. If you are using trickle ICE this not going to cause problems. But if you wait for ICE gathering to finish before passing on the ICE candidates you might want to filter out the alternate URL with port 53 to avoid waiting for it to time out.
+
 Use `iceServers` as follows when instantiating the `RTCPeerConnection`:
 
 ```js

--- a/src/content/docs/realtime/turn/generate-credentials.mdx
+++ b/src/content/docs/realtime/turn/generate-credentials.mdx
@@ -53,7 +53,9 @@ The JSON response below can then be passed on to your front-end application:
 }
 ```
 
-Note: the list of URLs returned contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers. So this TURN URL will time out if used in browsers. If you are using trickle ICE this is not going to cause problems. But if you wait for ICE gathering to finish before passing on the ICE candidates you might want to filter out the alternate URL with port 53 to avoid waiting for it to time out.
+:::note
+The list of returned URLs contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers, and the TURN URL will time out if used in browsers. If you are using trickle ICE, this will not cause issues, but you should let ICE gathering finish before passing.
+:::
 
 Use `iceServers` as follows when instantiating the `RTCPeerConnection`:
 

--- a/src/content/docs/realtime/turn/generate-credentials.mdx
+++ b/src/content/docs/realtime/turn/generate-credentials.mdx
@@ -54,7 +54,7 @@ The JSON response below can then be passed on to your front-end application:
 ```
 
 :::note
-The list of returned URLs contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers, and the TURN URL will time out if used in browsers. If you are using trickle ICE, this will not cause issues, but you should let ICE gathering finish before passing.
+The list of returned URLs contains URLs with the primary and alternate ports. The alternate port 53 is known to be blocked by web browsers, and the TURN URL will time out if used in browsers. If you are using trickle ICE, this will not cause issues. Without trickle ICE you might want to filter out the URL with port 53 to avoid waiting for a timeout.
 :::
 
 Use `iceServers` as follows when instantiating the `RTCPeerConnection`:


### PR DESCRIPTION
### Summary

If users take directly the output from the TURN credentials endpoint call and don't utilize trickle ICE they have to wait for a 40 second timeout.
This PR adds a warning regarding this know problem and how to prevent it.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
