### PR TITLE
Update messaging for Workers Static Assets bucketing strategy

### DIFF
--- a/src/content/docs/workers/static-assets/direct-upload.mdx
+++ b/src/content/docs/workers/static-assets/direct-upload.mdx
@@ -114,7 +114,7 @@ curl -X POST https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/
 
 The resulting response will contain a JWT, which provides authentication during file upload. The JWT is valid for one hour.
 
-In addition to the JWT, the response instructs users how to optimally batch upload their files. These instructions are encoded in the `buckets` field. Each array in `buckets` contains a list of file hashes which should be uploaded together. Hashes of files that have been recently uploaded may not be returned in the API response; they do not need to be re-uploaded.
+In addition to the JWT, the response instructs users how to optimally batch upload their files. These instructions are encoded in the `buckets` field. Each array in `buckets` contains a list of file hashes which should be uploaded together. Unmodified files will not be returned in the `buckets` field (as they do not need to be re-uploaded) if they have recently been uploaded in previous versions of your Worker.
 
 ```json
 {


### PR DESCRIPTION
### Summary

It's currently not clear for what circumstance a file "may" not be included in the bucket response. This change updates the docs in order to clearly identify that the last 100k previously uploaded files will not be presented in the returned bucket field, and thus do not need to be re-uploaded.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
