### PR TITLE
[Docs Site] use unique IDs as example in rules-of-workflows.mdx

### DIFF
--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -461,7 +461,7 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
 		let instances = [{ id: "order-1001", params: { totalUsd: 29.99 }}, { id: "order-1002", params: { totalUsd: 9.49 }}];
 
-		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits.
+		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits. 
 		for (let instance of instances) {
 			await env.MY_WORKFLOW.create({
 				id: instance.id,

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -459,7 +459,7 @@ When creating multiple Workflow instances, use the [`createBatch`](/workflows/bu
 ```ts
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
-		let instances = [{ id: "order-1001", params: { totalUsd: 29.99 }}, { id: "order-1002", params: { totalUsd: 9.49 }}];
+		let instances = [{id: "user1", params: {name: "John"}}, {id: "user2", params: {name: "Jane"}}, {id: "user3", params: {name: "Alice"}}, {id: "user4", params: {name: "Bob"}}];
 
 		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits.
 		for (let instance of instances) {

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -461,7 +461,7 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
 		let instances = [{ id: "order-1001", params: { totalUsd: 29.99 }}, { id: "order-1002", params: { totalUsd: 9.49 }}];
 
-		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits. 
+		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits.
 		for (let instance of instances) {
 			await env.MY_WORKFLOW.create({
 				id: instance.id,

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -459,7 +459,7 @@ When creating multiple Workflow instances, use the [`createBatch`](/workflows/bu
 ```ts
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
-		let instances = [{"id": "user1", "params": {"name": "John"}}, {"id": "user2", "params": {"name": "Jane"}}, {"id": "user3", "params": {"name": "Alice"}}, {"id": "user4", "params": {"name": "Bob"}}];
+		let instances = [{ id: "order-1001", params: { totalUsd: 29.99 }}, { id: "order-1002", params: { totalUsd: 9.49 }}];
 
 		// 🔴 Bad: Create them one by one, which is more likely to hit creation rate limits.
 		for (let instance of instances) {


### PR DESCRIPTION
### Summary

One of the previous rules of Workflows suggests not using non-unique IDs such as user IDs, and here they are used (and not tagged as bad).

Suggestion: use order objects instead (order ids might be "more" unique).

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
