### PR TITLE
[Docs Site] fix: typo in "output-settings"

### DIFF
--- a/src/content/docs/pipelines/build-with-pipelines/output-settings.mdx
+++ b/src/content/docs/pipelines/build-with-pipelines/output-settings.mdx
@@ -34,7 +34,7 @@ By default, output files are compressed in the `gzip` format. Compression can be
 npx wrangler pipelines update [PIPELINE-NAME] --compression none
 ```
 
-Output files are named using a [UILD](https://github.com/ulid/spec) slug, followed by an extension.
+Output files are named using a [ULID](https://github.com/ulid/spec) slug, followed by an extension.
 
 ## Customize batch behavior
 When configuring your pipeline, you can define how records are batched before they are delivered to R2. Batches of records are written out to a single output file.


### PR DESCRIPTION
### Summary

Fix a simple typo in output settings documentation for pipelines.
