### PR TITLE
[GH Issues] Add Workers AI as an option for issue submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: Issue with Cloudflare 5XX errors
     url: https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/
     about: If you are encountering a Cloudflare 5XX error, please read our troubleshooting documentation for 5XX errors.
+  - name: Issue with Workers AI
+    url: https://discord.com/channels/595317990191398933/1105477009964027914
+    about: Issues relating to Workers AI models should be raised in our Developer Discord.
   - name: Issue with Cloudflare Workers
     url: https://github.com/cloudflare/workers-sdk/issues/new/choose
     about: Issues relating to Cloudflare Workers should be made in the workers-sdk repo.


### PR DESCRIPTION
### Summary

Adds a new, external link to the issue creation form for GitHub.

Directs folks to the Discord channel to report issues on specific models.