### PR TITLE
[Workers AI] Moves to use the field name but puts title in the on hover

### DIFF
--- a/src/components/models/SchemaRow.astro
+++ b/src/components/models/SchemaRow.astro
@@ -9,10 +9,11 @@ const { node, root } = Astro.props;
 	class={`py-2 !my-0 !list-none ${root ? "" : "border-l border-l-gray-200 dark:border-l-gray-500 pl-4"}`}
 >
 	{
-		node.title ? (
-			<span class="mr-2 font-bold">{node.title}</span>
-		) : (
-			<code class="mr-2 rounded-md bg-gray-100 !pr-0 font-mono">
+		(
+			<code
+				class="mr-2 rounded-md bg-gray-100 !pr-0 font-mono"
+				title={node.title}
+			>
 				{node.subpath[node.subpath.length - 1]}
 				{node.parent.fragment?.required?.includes(
 					node.subpath[node.subpath.length - 1],


### PR DESCRIPTION
### Summary

There was a problem where the title was being shown instead of the field name

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/51b4ee50-b9e9-472f-9336-3d5af7a45da7)

![image](https://github.com/user-attachments/assets/ab429670-1353-4f36-9065-cf8fb6d58905)

So now it looks like this (when hovered):
![image](https://github.com/user-attachments/assets/6de479f3-2094-4551-9b86-0c9bdcb117ae)
