### PR TITLE
Fix wrangler installation step in Next.js workers guide

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -98,7 +98,7 @@ You can convert an existing Next.js application to run on Cloudflare
 
 2.  **Install [`wrangler CLI`](https://developers.cloudflare.com/workers/wrangler) as a devDependency**
 
-    <PackageManagers type="install" pkg="wrangler@latest" dev />
+    <PackageManagers pkg="wrangler@latest" dev />
 
 3.  **Add a Wrangler configuration file**
 


### PR DESCRIPTION
### Summary

wrangler now installs as a devDependency (removed type="install")

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

