### PR TITLE
Fix setInnerContent not rendering correctly

### DIFF
--- a/src/content/docs/workers/runtime-apis/html-rewriter.mdx
+++ b/src/content/docs/workers/runtime-apis/html-rewriter.mdx
@@ -183,10 +183,8 @@ The `element` argument, used only in element handlers, is a representation of a 
 
   - Removes the element and inserts content in place of it.
 
-- <code>
-  	setInnerContent(contentContent, contentOptionsContentOptionsoptional)
-  </code>
-  : Element
+- <code>setInnerContent(contentContent, contentOptionsContentOptionsoptional)</code> :
+	Element
 
   - Replaces content of the element.
 
@@ -210,7 +208,7 @@ The `endTag` argument, used only in handlers registered with `element.onEndTag`,
 
 - `name` string
 
-  - The name of the tag, such as `"h1"` or `"div"`. This property can be assigned different values, to modify an element’s tag.
+  - The name of the tag, such as `"h1"` or `"div"`. This property can be assigned different values, to modify an element's tag.
 
 #### Methods
 


### PR DESCRIPTION
### Summary

Small change, `setInnerContent` is correctly not rendering correctly, this just fixes that.
before:
<img width="627" alt="image" src="https://github.com/user-attachments/assets/afcb90ea-b69b-4fa0-9adf-a928a912d7b6" />

After:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/54a5f724-09b4-4ed1-b6c5-ee29243f7d44" />

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
