### PR TITLE
[DO] Updating what methods can be applied to .exec().raw()

### DIFF
--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -125,7 +125,7 @@ A cursor (`SqlStorageCursor`) to iterate over query row results as objects. `Sql
   * Returns a row object if query result has exactly one row. If query result has zero rows or more than one row, `one()` throws an exception.
 * `raw()`: <Type text='Iterator' />
   * Returns an Iterator over the same query results, with each row as an array of column values (with no column names) rather than an object.
-  * Returned Iterator supports `next()`, `toArray()`, and `one()` methods above.
+  * Returned Iterator supports `next()` and `toArray()` methods above.
   * Returned cursor and `raw()` iterator iterate over the same query results and can be combined. For example:
 
 ```ts


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Previously, docs said you could apply all three (.toArray, .next, and .one) methods to the .raw().

However, .raw() does not support .one().

Updating docs to fix.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
