### PR TITLE
docs: fix type of autorag `aiSearch()` params

### DIFF
--- a/src/content/partials/autorag/ai-search-api-params.mdx
+++ b/src/content/partials/autorag/ai-search-api-params.mdx
@@ -27,6 +27,6 @@ Configurations for customizing result ranking. Defaults to `{}`.
 - `score_threshold` <Type text="number" /> <MetaInfo text="optional" />
   - The minimum match score required for a result to be considered a match. Defaults to `0`. Must be between `0` and `1`.
 
-`streaming` <Type text="object" /> <MetaInfo text="optional" />
+`streaming` <Type text="boolean" /> <MetaInfo text="optional" />
 
 Returns a stream of results as they are available. Defaults to `false`.


### PR DESCRIPTION
### Summary

Changes type of `streaming` from object to boolean. Inferred type as `@cloudflare/worker-types` hasn't correctly typed `aiSearch()`, it uses `search()`'s params.. Inferred from the description saying default `false`, and Workers AI's streaming being a boolean too.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.


### Additional

I am not 100% sure whether it's `stream` or `streaming` either.

<img width="533" alt="image" src="https://github.com/user-attachments/assets/41c5266b-1758-4a79-a844-a3b05527070b" />
