### PR TITLE
[Release notes] Add notice to reach RSS subscribers

### DIFF
--- a/src/content/release-notes/feed-deprecation.yaml
+++ b/src/content/release-notes/feed-deprecation.yaml
@@ -1,0 +1,13 @@
+---
+link: "/fundamentals/new-features/available-rss-feeds/"
+productName: Fundamentals
+productLink: "/fundamentals/"
+productArea: Core platform
+productAreaLink: /fundamentals/reference/changelog/platform/
+entries:
+- publish_date: "2025-04-25"
+  title: "Move to Changelog RSS feed"
+  description: |-
+    Release notes are being deprecated in favor of the [Cloudflare changelog](/changelog/).
+
+    To keep up with product updates, subscribe to [the Changelog RSS feed](/changelog/rss/index.xml) instead. Or, review your options at [Available RSS feeds](/fundamentals/new-features/available-rss-feeds/).


### PR DESCRIPTION
### Summary

We need a new entry announcing the `/release-notes/` deprecation within the release-notes experience itself. This provides more viz + has a better chance of reaching RSS-only subscribers (and directing them to the right location for future subscribing).
