### PR TITLE
Update MCP dev docs to include example of authless remote mcp server

### DIFF
--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -9,16 +9,22 @@ import { Details, Render, PackageManagers } from "~/components";
 
 ## Deploy your first MCP server
 
-This guide walks you through deploying an [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) to your Cloudflare account. 
-Once deployed, you can customize the MCP server to add your own [tools](/agents/model-context-protocol/tools/). This example does not require users to authenticate, meaning any client can connect to the server to use the tools. To add authentication & authorization to your MCP server, follow the example [below](/agents/guides/remote-mcp-server/#add-authentication). 
+This guide will show you how to deploy your own remote MCP server on Cloudflare, with two options:
+
+- **Without authentication** — anyone can connect and use the server (no login required).
+- **With [authentication and authorization](/agents/guides/remote-mcp-server/#add-authentication)** — users sign in before accessing tools, and you can control which tools an agent can call based on the user's permissions.
+
+You can start by deploying a [public MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) without authentication, then add user authentication and scoped authorization later. If you already know your server will require authentication, you can skip ahead to the next section.
 
 The button below will guide you through everything you need to do to deploy this [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) to your Cloudflare account:
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
 
+Once the MCP server is set up, you can customize the server to add your own [tools](/agents/model-context-protocol/tools/). This example does not require users to authenticate, meaning any client can connect to the server to use the tools. To add authentication & authorization to your MCP server, follow the example in the [next section](/agents/guides/remote-mcp-server/#add-authentication). 
+
 Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.your-account.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). 
 
-Once you deploy the MCP server, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
+If you're using the "Deploy to Cloudflare" button, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy to Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
 
 ## Set up and deploy your MCP server via CLI
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -24,7 +24,7 @@ Once deployed, this server will be live at your workers.dev subdomain (e.g. remo
 
 If you're using the "Deploy to Cloudflare" button, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy to Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
 
-## Set up and deploy your MCP server via CLI
+### Set up and deploy your MCP server via CLI
 
 Alternatively, you can use the command line as shown below to create a new MCP Server on your local machine.
 
@@ -40,7 +40,7 @@ Now, you have the MCP server setup, with dependencies installed. Move into that 
 cd my-mcp-server
 ```
 
-### Local development
+#### Local development
 
 In the directory of your new project, run the following command to start the development server:
 
@@ -66,7 +66,7 @@ In the inspector, enter the URL of your MCP server, `http://localhost:8787/sse`,
 
 ![MCP inspector — authenticated](~/assets/images/agents/mcp-inspector-authenticated.png)
 
-### Deploy your MCP server
+#### Deploy your MCP server
 
 You can deploy your MCP server to Cloudflare using the following [Wrangler CLI command](/workers/wrangler) within the example project:
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -14,7 +14,7 @@ This guide will show you how to deploy your own remote MCP server on Cloudflare,
 - **Without authentication** — anyone can connect and use the server (no login required).
 - **With [authentication and authorization](/agents/guides/remote-mcp-server/#add-authentication)** — users sign in before accessing tools, and you can control which tools an agent can call based on the user's permissions.
 
-You can start by deploying a [public MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) without authentication, then add user authentication and scoped authorization later. If you already know your server will require authentication, you can skip ahead to the next section.
+You can start by deploying a [public MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) without authentication, then add user authentication and scoped authorization later. If you already know your server will require authentication, you can skip ahead to the [next section](/agents/guides/remote-mcp-server/#add-authentication).
 
 The button below will guide you through everything you need to do to deploy this [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) to your Cloudflare account:
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -9,20 +9,25 @@ import { Details, Render, PackageManagers } from "~/components";
 
 ## Deploy your first MCP server
 
-This guide will walk you through how to deploy an [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server) to your Cloudflare account. You will then customize this example to suit your needs.
+This guide walks you through deploying an [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) to your Cloudflare account. 
+Once deployed, you can customize the MCP server to add your own [tools](/agents/model-context-protocol/tools/). This example does not require users to authenticate, meaning any client can connect to the server to use the tools. To add authentication & authorization to your MCP server, follow the example [below](/agents/guides/remote-mcp-server/#add-authentication). 
 
-The link below will guide you through everything you need to do to deploy this [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server) to your Cloudflare account:
+The button below will guide you through everything you need to do to deploy this [example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless) to your Cloudflare account:
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
 
-At the end of this process, you will have a new git repository on your GitHub or GitLab account for your MCP server, configured to automatically deploy Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
+Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.<your-account>.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). 
+
+Once you deploy the MCP server, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
+
+## Set up and deploy your MCP server via CLI
 
 Alternatively, you can use the command line as shown below to create a new MCP Server on your local machine.
 
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest"
-	args={"my-mcp-server --template=cloudflare/ai/demos/remote-mcp-server"}
+	args={"my-mcp-server --template=cloudflare/ai/demos/remote-mcp-authless"}
 />
 
 Now, you have the MCP server setup, with dependencies installed. Move into that project folder:
@@ -53,17 +58,7 @@ Open the MCP inspector in your web browser:
 open http://localhost:5173
 ```
 
-In the inspector, enter the URL of your MCP server, `http://localhost:8787/sse`, and click **Connect**:
-
-![MCP inspector — where to enter the URL of your MCP server](~/assets/images/agents/mcp-inspector-enter-url.png)
-
-You will be redirected to an example OAuth login page. Enter any username and password and click "Log in and approve" to continue. 
-
-Note: You can add your own authentication and/or authorization provider to replace this. Refer to the [authorization](/agents/model-context-protocol/authorization/) section for details on how to do this.
-
-![MCP OAuth Login Page](~/assets/images/agents/mcp-demo-oauth-flow.png)
-
-Once you have logged in, you will be redirected back to the inspector. You should see the "List Tools" button, which will list the tools that your MCP server exposes.
+In the inspector, enter the URL of your MCP server, `http://localhost:8787/sse`, and click **Connect**. You should see the "List Tools" button, which will list the tools that your MCP server exposes.
 
 ![MCP inspector — authenticated](~/assets/images/agents/mcp-inspector-authenticated.png)
 
@@ -81,7 +76,7 @@ After deploying, take the URL of your deployed MCP server, and enter it in the M
 
 ### Connect your Remote MCP server to Claude and other MCP Clients via a local proxy
 
-Now that your MCP server is running with OAuth authentication, you can use the [`mcp-remote` local proxy](https://www.npmjs.com/package/mcp-remote) to connect Claude Desktop or other MCP clients to it — even though these tools aren't yet _remote_ MCP clients, and don't support remote transport or authorization on the client side. This lets you to test what an interaction with your OAuth-enabled MCP server will be like with a real MCP client.
+Now that your MCP server is running, you can use the [`mcp-remote` local proxy](https://www.npmjs.com/package/mcp-remote) to connect Claude Desktop or other MCP clients to it — even though these tools aren't yet _remote_ MCP clients, and don't support remote transport or authorization on the client side. This lets you test what an interaction with your MCP server will be like with a real MCP client.
 
 Update your Claude Desktop configuration to point to the URL of your MCP server. You can use either the `localhost:8787/sse` URL, or the URL of your deployed MCP server:
 
@@ -99,15 +94,19 @@ Update your Claude Desktop configuration to point to the URL of your MCP server.
 }
 ```
 
-Restart Claude Desktop and complete the authentication flow again. Once this is done, Claude will be able to make calls to your remote MCP server. you can test this by asking Claude to use one of your tools. For example: "Could you use the math tool to add 23 and 19?". Claude should invoke the tool and show the result generated by the MCP server.
+Restart Claude Desktop after updating your config file to load the MCP Server. Once this is done, Claude will be able to make calls to your remote MCP server. You can test this by asking Claude to use one of your tools. For example: "Could you use the math tool to add 23 and 19?". Claude should invoke the tool and show the result generated by the MCP server.
 
 Learn more about other ways of using remote MCP servers with MCP clients here in [this section](/agents/guides/test-remote-mcp-server).
 
 ## Add Authentication
 
-The example MCP server you just deployed above acts as an OAuth provider to MCP clients, handling authorization, but has a placeholder authentication flow. It lets you enter any username and password to log in, and doesn't actually authenticate you against any user database.
+Now that you’ve deployed a public MCP server, let’s walk through how to enable user authentication using OAuth.
 
-In the next section, you will add a real authentication provider to your MCP server. Following these steps will show you more clearly how to integrate it with your MCP server. We'll use GitHub in this example, but you can use any OAuth provider that supports the OAuth 2.0 specification, including Google, Slack, Stytch, Auth0, and more.
+The public server example you deployed earlier allows any client to connect and invoke tools without logging in. To add authentication, you’ll update your MCP server to act as an OAuth provider, handling secure login flows and issuing access tokens that MCP clients can use to make authenticated tool calls.
+
+This is especially useful if users already need to log in to use your service. Once authentication is enabled, users can sign in with their existing account and grant their AI agent permission to interact with the tools exposed by your MCP server, using scoped permissions.
+
+In this example, we use GitHub as an OAuth provider, but you can connect your MCP server with any [OAuth provider](/agents/model-context-protocol/authorization/#2-third-party-oauth-provider) that supports the OAuth 2.0 specification, including Google, Slack, [Stytch](/agents/model-context-protocol/authorization/#stytch), [Auth0](/agents/model-context-protocol/authorization/#stytch), [WorkOS](/agents/model-context-protocol/authorization/#stytch), and more.
 
 ### Step 1 — Create and deploy a new MCP server
 
@@ -219,7 +218,7 @@ wrangler secret put GITHUB_CLIENT_SECRET
 
 #### Finally, connect to your MCP server
 
-Now that you've added the ID and secret of your production OAuth app, you should now be able to connect to your MCP server running at `worker-name.account-name.workers.dev/sse` using the MCP inspector or ([other MCP clients](/agents/guides/remote-mcp-server/#connect-your-mcp-server-to-claude-and-other-mcp-clients)), and authenticate with GitHub.
+Now that you've added the ID and secret of your production OAuth app, you should now be able to connect to your MCP server running at `worker-name.account-name.workers.dev/sse` using the [AI Playground](https://playground.ai.cloudflare.com/), MCP inspector or ([other MCP clients](/agents/guides/remote-mcp-server/#connect-your-mcp-server-to-claude-and-other-mcp-clients)), and authenticate with GitHub.
 
 ## Next steps
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -16,7 +16,7 @@ The button below will guide you through everything you need to do to deploy this
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
 
-Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.<your-account>.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). 
+Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.your-account.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). 
 
 Once you deploy the MCP server, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -20,9 +20,7 @@ The button below will guide you through everything you need to do to deploy this
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
 
-Once the MCP server is set up, you can customize the server to add your own [tools](/agents/model-context-protocol/tools/). This example does not require users to authenticate, meaning any client can connect to the server to use the tools. To add authentication & authorization to your MCP server, follow the example in the [next section](/agents/guides/remote-mcp-server/#add-authentication). 
-
-Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.your-account.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). 
+Once deployed, this server will be live at your workers.dev subdomain (e.g. remote-mcp-server-authless.your-account.workers.dev/sse). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy). Then, once you're ready, you can customize the MCP server and add your own [tools](/agents/model-context-protocol/tools/). 
 
 If you're using the "Deploy to Cloudflare" button, a new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy to Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can then clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start writing code and building.
 


### PR DESCRIPTION
Updated MCP docs to include example of authless remote mcp server that can be deployed to get started immediately
