### PR TITLE
fix(kv): Link to new nested API URLs for kv

### DIFF
--- a/src/content/docs/kv/api/delete-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/delete-key-value-pairs.mdx
@@ -68,7 +68,7 @@ Calling the `delete()` method will remove the key and value from your KV namespa
 
 ### Delete data in bulk
 
-Delete more than one key-value pair at a time with Wrangler or [via the REST API](/api/resources/kv/subresources/namespaces/methods/bulk_delete/).
+Delete more than one key-value pair at a time with Wrangler or [via the REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_delete/).
 
 The bulk REST API can accept up to 10,000 KV pairs at once. Bulk writes are not supported using the [KV binding](/kv/concepts/kv-bindings/).
 

--- a/src/content/docs/kv/api/write-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/write-key-value-pairs.mdx
@@ -84,7 +84,7 @@ Refer to [How KV works](/kv/concepts/how-kv-works/) for more information on this
 
 ### Write data in bulk
 
-Write more than one key-value pair at a time with Wrangler or [via the REST API](/api/resources/kv/subresources/namespaces/methods/bulk_update/).
+Write more than one key-value pair at a time with Wrangler or [via the REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_update/).
 
 The bulk API can accept up to 10,000 KV pairs at once.
 

--- a/src/content/docs/kv/index.mdx
+++ b/src/content/docs/kv/index.mdx
@@ -142,7 +142,7 @@ See the full [Workers KV binding API reference](/kv/api/read-key-value-pairs/).
     	</TabItem>
     </Tabs>
 
-See the full Workers KV [REST API and SDK reference](/api/resources/kv/subresources/namespaces/methods/list/) for details on using REST API from external applications, with pre-generated SDK's for external TypeScript, Python, or Go applications.
+See the full Workers KV [REST API and SDK reference](/api/resources/kv/) for details on using REST API from external applications, with pre-generated SDK's for external TypeScript, Python, or Go applications.
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/kv/platform/pricing.mdx
+++ b/src/content/docs/kv/platform/pricing.mdx
@@ -12,7 +12,7 @@ import { Render } from "~/components"
 
 ## Pricing FAQ
 
-### When writing via KV's [REST API](/api/resources/kv/subresources/namespaces/methods/bulk_update/), how are writes charged?
+### When writing via KV's [REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_update/), how are writes charged?
 
 Each key-value pair in the `PUT` request is counted as a single write, identical to how each call to `PUT` in the Workers API counts as a write. Writing 5,000 keys via the REST API incurs the same write costs as making 5,000 `PUT` calls in a Worker.
 

--- a/src/content/docs/kv/reference/faq.mdx
+++ b/src/content/docs/kv/reference/faq.mdx
@@ -30,7 +30,7 @@ Refer to [How KV works](/kv/concepts/how-kv-works/).
 
 ## Pricing
 
-### When writing via Workers KV's [REST API](/api/resources/kv/subresources/namespaces/methods/bulk_update/), how are writes charged?
+### When writing via Workers KV's [REST API](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_update/), how are writes charged?
 
 Each key-value pair in the `PUT` request is counted as a single write, identical to how each call to `PUT` in the Workers API counts as a write. Writing 5,000 keys via the REST API incurs the same write costs as making 5,000 `PUT` calls in a Worker.
 

--- a/src/content/docs/kv/workers-kv-api.mdx
+++ b/src/content/docs/kv/workers-kv-api.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: KV REST API
-external_link: /api/resources/kv/subresources/namespaces/methods/list/
+external_link: /api/resources/kv/
 sidebar:
   order: 8
 

--- a/src/content/release-notes/kv.yaml
+++ b/src/content/release-notes/kv.yaml
@@ -9,7 +9,7 @@ entries:
     title: Workers KV REST API bulk operations provide granular errors
     description: |-
 
-      The REST API endpoints for bulk operations ([write](/api/resources/kv/subresources/namespaces/methods/bulk_update/), [delete](/api/resources/kv/subresources/namespaces/methods/bulk_delete/)) now return the keys of operations that failed during the bulk operation. The updated response bodies are documented in the [REST API documentation](/api/resources/kv/subresources/namespaces/methods/list/) and contain the following information in the `result` field:
+      The REST API endpoints for bulk operations ([write](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_update/), [delete](/api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_delete/)) now return the keys of operations that failed during the bulk operation. The updated response bodies are documented in the [REST API documentation](/api/resources/kv/subresources/namespaces/methods/list/) and contain the following information in the `result` field:
 
       ```
       {
@@ -26,5 +26,5 @@ entries:
 
       Workers KV now has a new [metrics dashboard](/kv/observability/metrics-analytics/#view-metrics-in-the-dashboard) and [analytics API](/kv/observability/metrics-analytics/#query-via-the-graphql-api) that leverages the [GraphQL Analytics API](/analytics/graphql-api/) used by many other Cloudflare products. The new analytics API provides per-account and per-namespace metrics for both operations and storage, including latency metrics for read and write operations to Workers KV.
 
-      The legacy Workers KV [analytics REST API](/api/resources/kv/subresources/namespaces/subresources/analytics/methods/list/) will be turned off as of January 31st, 2025.
+      The legacy Workers KV analytics REST API will be turned off as of January 31st, 2025.
       Developers using this API will receive a series of email notifications prior to the shutdown of the legacy API.


### PR DESCRIPTION
### Summary

I was browsing the kv documentation and encountered some 404s when clicking through to the API documentation. The problem looks to be caused by the introduction of nesting in the kv API documentation, e.g:

```diff
- /api/resources/kv/subresources/namespaces/methods/bulk_delete/
+ /api/resources/kv/subresources/namespaces/subresources/keys/methods/bulk_delete/
```

While making this PR, I found broken links in the kv release notes, so I fixed them... but not sure if editing release notes after the fact is bad. I can remove that change if it's not good.