### PR TITLE
[Workers] Update vitest-pool-workers docs to newer vitest version

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -26,13 +26,13 @@ First, make sure that:
 - Vitest and `@cloudflare/vitest-pool-workers` are installed in your project as dev dependencies
 
   <PackageManagers
-  	pkg="vitest@~3.0.0 @cloudflare/vitest-pool-workers"
+  	pkg="vitest@~3.1.0 @cloudflare/vitest-pool-workers"
   	dev="true"
   />
 
   :::note
 
-  Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 3.0.x.
+  Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 3.1.x.
 
   :::
 


### PR DESCRIPTION
### Summary

Update docs to install 3.1.x of vitest, and update compatibility note.

Relevant compatibility change: https://github.com/cloudflare/workers-sdk/pull/8804

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
