### PR TITLE
add dynamic base URL config for Zola preview deployments

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -107,7 +107,7 @@ Every time you commit new code to your Zola site, Cloudflare Pages will automati
 
 ### Handling Preview Deployments
 
-When working with Cloudflare Pages, you'll often use preview deployments for testing changes before merging to your main branch. However, these preview deployments use different URLs (like `https://your-branch-name.my-zola-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded.
+When working with Cloudflare Pages, you might use preview deployments for testing changes before merging to your main branch. However, these preview deployments use different URLs (like `https://your-branch-name.my-zola-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded.
 
 To fix this, modify your build command in the Cloudflare Pages configuration to dynamically set the base URL depending on the environment:
 

--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -105,4 +105,17 @@ base_url = "https://my-zola-project.pages.dev"
 
 Every time you commit new code to your Zola site, Cloudflare Pages will automatically rebuild your project and deploy it. You will also get access to [preview deployments](/pages/configuration/preview-deployments/) on new pull requests, so you can preview how changes look to your site before deploying them to production.
 
+### Handling Preview Deployments
+
+When working with Cloudflare Pages, you'll often use preview deployments for testing changes before merging to your main branch. However, these preview deployments use different URLs (like `https://your-branch-name.my-zola-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded.
+
+To fix this, modify your build command in the Cloudflare Pages configuration to dynamically set the base URL depending on the environment:
+```sh
+if [ "$CF_PAGES_BRANCH" = "main" ]; then zola build --base-url 'https://my-zola-project.pages.dev/'; else zola build --base-url $CF_PAGES_URL; fi
+```
+
+This command uses:
+- Your production URL when building from the main branch
+- The preview deployment URL (automatically provided by Cloudflare Pages as `$CF_PAGES_URL`) for all other branches
+
 <Render file="framework-guides/learn-more" params={{ one: "Zola" }} />

--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -110,12 +110,13 @@ Every time you commit new code to your Zola site, Cloudflare Pages will automati
 When working with Cloudflare Pages, you'll often use preview deployments for testing changes before merging to your main branch. However, these preview deployments use different URLs (like `https://your-branch-name.my-zola-project.pages.dev`), which can cause issues with asset loading if your `base_url` is hardcoded.
 
 To fix this, modify your build command in the Cloudflare Pages configuration to dynamically set the base URL depending on the environment:
+
 ```sh
-if [ "$CF_PAGES_BRANCH" = "main" ]; then zola build --base-url 'https://my-zola-project.pages.dev/'; else zola build --base-url $CF_PAGES_URL; fi
+if [ "$CF_PAGES_BRANCH" = "main" ]; then zola build; else zola build --base-url $CF_PAGES_URL; fi
 ```
 
 This command uses:
-- Your production URL when building from the main branch
+- The `base_url` set in `config.toml` when building from the `main` branch
 - The preview deployment URL (automatically provided by Cloudflare Pages as `$CF_PAGES_URL`) for all other branches
 
 <Render file="framework-guides/learn-more" params={{ one: "Zola" }} />


### PR DESCRIPTION
### Summary

Adds documentation to help users solve a common issue with Zola deployments on Cloudflare Pages where preview deployments don't properly load stylesheets due to base URL configuration. Example: https://github.com/welpo/tabi/discussions/521

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.