### PR TITLE
fix(docs): correct data center number in Argo Smart Routing section

### DIFF
--- a/src/content/docs/reference-architecture/architectures/cdn.mdx
+++ b/src/content/docs/reference-architecture/architectures/cdn.mdx
@@ -202,7 +202,7 @@ Figure 6 details the traffic flow when Tiered Cache and Argo Smart Routing are n
 
 ![Figure 6: Diagram with bidirectional arrows indicating a request between an end user and origin server without Argo Smart Routing enabled.](~/assets/images/reference-architecture/cdn-reference-architecture-images/ref-arch-cdn-figure6.svg "Figure 6: Cloudflare CDN without Tiered Cache or Argo Smart Routing")
 
-Figure 7 articulates the traffic flow with both Tiered Cache and Argo Smart Routing enabled. When a request is received by Data Center 1 and there is a cache miss, the cache of the upper tier data center, Data Center 4, is checked. If the cached content is not found at the upper tier data center, with Argo Smart Routing enabled, the request is sent on the fastest path from the upper tier data center to the origin.
+Figure 7 articulates the traffic flow with both Tiered Cache and Argo Smart Routing enabled. When a request is received by Data Center 1 and there is a cache miss, the cache of the upper tier data center, Data Center 6, is checked. If the cached content is not found at the upper tier data center, with Argo Smart Routing enabled, the request is sent on the fastest path from the upper tier data center to the origin.
 
 The fastest path is determined by the Argo network intelligence capabilities, which take into account real-time network data such as congestion, latency, and RTT.
 


### PR DESCRIPTION
### Summary

This PR addresses a discrepancy in the Cloudflare CDN Reference Architecture documentation, specifically in the [Argo Smart Routing section](https://developers.cloudflare.com/reference-architecture/architectures/cdn/#argo-smart-routing). In Figure 7, the diagram illustrates a request being routed from Data Center 1 to Data Center 6. However, the accompanying text incorrectly states that the request is sent to Data Center 4. This update corrects the textual reference to align with the diagram, ensuring consistency and accuracy in the documentation.

### Screenshots (optional)

<img width="1127" alt="Screenshot 2025-04-27 at 6 10 32 PM" src="https://github.com/user-attachments/assets/035c0040-81ee-48ea-afa0-73d7e2a0d3d7" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.