### PR TITLE
remove Account Custom Nameservers from Foundation DNS features

### DIFF
--- a/src/content/docs/dns/foundation-dns/index.mdx
+++ b/src/content/docs/dns/foundation-dns/index.mdx
@@ -17,7 +17,6 @@ With Foundation DNS, you get access to increased reliability, security, and insi
 * DNSSEC keys unique to your zone
 * Additional DNS settings, including:
   * [Zone defaults](/dns/additional-options/dns-zone-defaults/)
-  * [Account custom nameservers](/dns/nameservers/custom-nameservers/account-custom-nameservers/)
   * Custom [SOA record](/dns/manage-dns-records/reference/dns-record-types/#soa) and [Nameserver TTL](/dns/nameservers/nameserver-options/#nameserver-ttl)
 
 ## Availability


### PR DESCRIPTION
### Summary

remove Account Custom Nameservers since it's not actually supported.

Ref: https://developers.cloudflare.com/dns/foundation-dns/advanced-nameservers/


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.