### PR TITLE
[Docs] Fix build warnings (code block languages)

### DIFF
--- a/src/content/docs/agents/concepts/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/human-in-the-loop.mdx
@@ -3,10 +3,7 @@ title: Human in the Loop
 pcx_content_type: concept
 sidebar:
   order: 5
-
 ---
-
-import { Render, Note, Aside } from "~/components";
 
 ### What is Human-in-the-Loop?
 

--- a/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx
@@ -113,7 +113,7 @@ JSONata transformations are not compatible with [SAML attribute statements](#sam
 
 For example, the following JSONata script merges group names into a list and adds an `eduPersonPrincipalName` field which maps to the user email.
 
-```jsonata title = "JSONata expression"
+```txt title = "JSONata expression"
 $merge([$, {"groups": groups.name, 'eduPersonPrincipalName': email}])
 ```
 
@@ -217,7 +217,7 @@ For more JSONata transform use cases, refer to the following examples.
 
 The following JSONata script removes the `groups` SAML attribute. This can be useful if your SaaS application does not need to receive user group information.
 
-```jsonata title="JSONata expression"
+```txt title="JSONata expression"
 $ ~> |$|{}, ['groups']|
 ```
 
@@ -262,7 +262,7 @@ Result after applying the JSONata transform:
 
 The following JSONata script changes the `groups.name` field from `name` to `group_name` and removes the `groups.id` field:
 
-```jsonata title="JSONata expression"
+```txt title="JSONata expression"
 {
   "account_id": account_id,
   "amr": amr,
@@ -336,7 +336,7 @@ Result after applying the JSONata transform:
 
 The following JSONata script filters groups to those that match a regular expression.
 
-```jsonata title="JSONata expression"
+```txt title="JSONata expression"
 $merge([$, { "groups": $filter(groups, function($v) { $contains($v.name, /Administrator/) }) }])
 ```
 

--- a/src/content/docs/d1/best-practices/read-replication.mdx
+++ b/src/content/docs/d1/best-practices/read-replication.mdx
@@ -288,7 +288,7 @@ For this REST endpoint, you need to have an API token with `D1:Edit` permission.
 
 <Tabs>
 <TabItem label="cURL">
-```curl
+```sh
 curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/d1/database/{database_id}" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -325,7 +325,7 @@ Disabling read replication takes up to 24 hours for replicas to stop processing 
 
 <Tabs>
 <TabItem label="cURL">
-```curl
+```sh
 curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/d1/database/{database_id}" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -359,7 +359,7 @@ For this REST endpoint, you need to have an API token with `D1:Read` permission.
 
 <Tabs>
 <TabItem label="cURL">
-```curl
+```sh
 curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/d1/database/{database_id}" \
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/src/content/docs/pipelines/tutorials/query-data-with-motherduck/index.mdx
+++ b/src/content/docs/pipelines/tutorials/query-data-with-motherduck/index.mdx
@@ -321,7 +321,7 @@ With these flags, your pipeline will deliver an uncompressed file of data to you
 These flags are useful for testing, but we recommend keeping the default settings in a production environment.
 :::
 
-```output
+```txt output
 ✅ Successfully created Pipeline "clickstream-pipeline" with ID <PIPELINE_ID>
 
 Id:    <PIPELINE_ID>
@@ -423,7 +423,7 @@ npm run deploy
 
 This will deploy the application to the Cloudflare Workers platform.
 
-```output
+```txt output
 🌀 Building list of assets...
 🌀 Starting asset upload...
 🌀 Found 1 new or modified static asset to upload. Proceeding with upload...

--- a/src/content/docs/pipelines/tutorials/send-data-from-client/index.mdx
+++ b/src/content/docs/pipelines/tutorials/send-data-from-client/index.mdx
@@ -212,7 +212,7 @@ With these flags, your pipeline will deliver an uncompressed file of data to you
 These flags are useful for testing, but we recommend keeping the default settings in a production environment.
 :::
 
-```output
+```txt output
 ✅ Successfully created Pipeline "clickstream-pipeline-client" with ID <PIPELINE_ID>
 
 Id:    <PIPELINE_ID>
@@ -381,7 +381,7 @@ npm run deploy
 
 This will deploy the application to the Cloudflare Workers platform.
 
-```output
+```txt output
 🌀 Building list of assets...
 🌀 Starting asset upload...
 🌀 Found 1 new or modified static asset to upload. Proceeding with upload...

--- a/src/content/docs/realtime/simulcast.mdx
+++ b/src/content/docs/realtime/simulcast.mdx
@@ -15,7 +15,6 @@ graph LR
 B -->|Low quality| C@{ shape: procs, label: "Subscribers"}
 B -->|Medium quality| D@{ shape: procs, label: "Subscribers"}
 B -->|High quality| E@{ shape: procs, label: "Subscribers"}
-
 ```
 
 ### How it works
@@ -56,7 +55,7 @@ When a layer switch is requested (through updating `preferredRid`) with the `/tr
 
 For publishers (local tracks), you only need to include the simulcast attributes in your SDP. The SFU will automatically handle the simulcast configuration based on the SDP. For example, the SDP should contain a section like this:
 
-```sdp
+```txt
 a=simulcast:send f;h;q
 a=rid:f send
 a=rid:h send
@@ -75,6 +74,7 @@ const transceiver = peerConnection.addTransceiver(track, {
   ]
 });
 ```
+
 ## Example
 
 Here's an example of how to use simulcast with Cloudflare Realtime:

--- a/src/content/docs/workers/frameworks/framework-guides/astro.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/astro.mdx
@@ -129,7 +129,7 @@ If your Astro project uses [on demand rendering (also known as SSR)](https://doc
 2.  **Add a `.assetsignore` file**
     Create a `.assetsignore` file in your `public/` folder, and add the following lines to it:
 
-    ```title=".assetsignore"
+    ```txt title=".assetsignore"
     _worker.js
     _routes.json
     ```


### PR DESCRIPTION
### Summary

Fixes the following build warnings:

```
09:16:55 [WARN] [astro-expressive-code] Error while highlighting code block using language "sdp" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/realtime/simulcast.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "curl" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/d1/best-practices/read-replication.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "curl" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/d1/best-practices/read-replication.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "curl" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/d1/best-practices/read-replication.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:51 [WARN] [astro-expressive-code] Error while highlighting code block using language "output" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/pipelines/tutorials/query-data-with-motherduck/index.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:51 [WARN] [astro-expressive-code] Error while highlighting code block using language "output" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/pipelines/tutorials/query-data-with-motherduck/index.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:51 [WARN] [astro-expressive-code] Error while highlighting code block using language "output" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/pipelines/tutorials/send-data-from-client/index.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:51 [WARN] [astro-expressive-code] Error while highlighting code block using language "output" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/pipelines/tutorials/send-data-from-client/index.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:17:58 [WARN] [astro-expressive-code] Error while highlighting code block using language "title=".assetsignore"" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/workers/frameworks/framework-guides/astro.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:18:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "jsonata" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:18:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "jsonata" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:18:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "jsonata" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:18:05 [WARN] [astro-expressive-code] Error while highlighting code block using language "jsonata" in document "/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/cloudflare-one/applications/configure-apps/saas-apps/generic-saml-saas.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
09:18:21 [WARN] [vite] src/content/docs/agents/concepts/human-in-the-loop.mdx (38:16): "Note" is not exported by "src/components/index.ts", imported by "src/content/docs/agents/concepts/human-in-the-loop.mdx".
```
