### PR TITLE
[Docs Site] Add fixed dimensions to Stream chapter thumbnails

### DIFF
--- a/src/components/Stream.astro
+++ b/src/components/Stream.astro
@@ -72,7 +72,9 @@ if (thumbnail) {
 									<img
 										src={thumbnail.toString()}
 										alt={chapter}
-										class="rounded-sm border border-accent"
+										width="120"
+										height="64"
+										class="border-accent bg-accent/10 rounded-sm border"
 									/>
 									<div class="flex h-full flex-col items-center justify-between">
 										<strong class="line-clamp-2 text-xs" title={chapter}>


### PR DESCRIPTION
### Summary

Add fixed dimensions to Stream chapter thumbnails

### Screenshots (optional)

Before:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/69a9c9e2-53af-4738-a950-84c377a84988" />

After:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/8297b589-dbed-4f74-923f-7700b2d09333" />
