### PR TITLE
Extend D1 docs with clarifications for one-way type conversions

### DIFF
--- a/src/content/docs/d1/worker-api/index.mdx
+++ b/src/content/docs/d1/worker-api/index.mdx
@@ -40,25 +40,43 @@ const result = await env.MY_DB.prepare(
 
 ## Type conversion
 
-D1 automatically converts supported JavaScript (including TypeScript) types passed as parameters via the Workers Binding API to their associated D1 types. The type conversion is as follows:
+D1 automatically converts supported JavaScript (including TypeScript) types passed as parameters via the Workers Binding API to their associated D1 types <sup>1</sup>.
+This conversion is permanent and one-way only, meaning that when reading the written values back in your code you will get the converted values and not the originally inserted values.
 
-| JavaScript           | D1                                                                           |
-| -------------------- | ---------------------------------------------------------------------------- |
-| null                 | `NULL`                                                                       |
-| Number               | `REAL`                                                                       |
-| Number <sup>1</sup>  | `INTEGER`                                                                    |
-| String               | `TEXT`                                                                       |
-| Boolean <sup>2</sup> | `INTEGER`                                                                    |
-| ArrayBuffer          | `BLOB`                                                                       |
-| undefined            | Not supported. Queries with `undefined` values will return a `D1_TYPE_ERROR` |
+:::note
+We recommend using [STRICT tables](https://www.sqlite.org/stricttables.html) in your SQL schema to avoid issues with mismatched types actually stored in your database compared to what your schema defines.
+:::
 
-<sup>1</sup> D1 supports 64-bit signed `INTEGER` values internally, however
+The type conversion during writes is as follows:
+
+| JavaScript (write)   | D1                          | JavaScript (read)  |
+| -------------------- | --------------------------- | ------------------ |
+| null                 | `NULL`                      | null               |
+| Number               | `REAL`                      | Number             |
+| Number <sup>2</sup>  | `INTEGER`                   | Number             |
+| String               | `TEXT`                      | String             |
+| Boolean <sup>3</sup> | `INTEGER`                   | Number (`0`,`1`)   |
+| ArrayBuffer          | `BLOB`                      | Array <sup>4</sup> |
+| ArrayBuffer View     | `BLOB`                      | Array <sup>4</sup> |
+| undefined            | Not supported. <sup>5</sup> | -                  |
+
+<sup>1</sup> D1 types correspond to the underlying [SQLite
+types](https://www.sqlite.org/datatype3.html).
+
+<sup>2</sup> D1 supports 64-bit signed `INTEGER` values internally, however
 [BigInts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
 are not currently supported in the API yet. JavaScript integers are safe up to
 [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
 
-<sup>2</sup> Booleans will be cast to an `INTEGER` type where `1` is `TRUE` and
+<sup>3</sup> Booleans will be cast to an `INTEGER` type where `1` is `TRUE` and
 `0` is `FALSE`.
+
+<sup>4</sup> `ArrayBuffer` and [`ArrayBuffer`
+views](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView)
+are converted using
+[`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+
+<sup>5</sup> Queries with `undefined` values will return a `D1_TYPE_ERROR`.
 
 ## API playground
 

--- a/src/content/docs/d1/worker-api/index.mdx
+++ b/src/content/docs/d1/worker-api/index.mdx
@@ -41,10 +41,10 @@ const result = await env.MY_DB.prepare(
 ## Type conversion
 
 D1 automatically converts supported JavaScript (including TypeScript) types passed as parameters via the Workers Binding API to their associated D1 types <sup>1</sup>.
-This conversion is permanent and one-way only, meaning that when reading the written values back in your code you will get the converted values and not the originally inserted values.
+This conversion is permanent and one-way only. This means that when reading the written values back in your code, you will get the converted values rather than the originally inserted values.
 
 :::note
-We recommend using [STRICT tables](https://www.sqlite.org/stricttables.html) in your SQL schema to avoid issues with mismatched types actually stored in your database compared to what your schema defines.
+We recommend using [STRICT tables](https://www.sqlite.org/stricttables.html) in your SQL schema to avoid issues with mismatched types between values that are actually stored in your database compared to values defined by your schema.
 :::
 
 The type conversion during writes is as follows:


### PR DESCRIPTION
### Summary

fixes https://github.com/cloudflare/workers-sdk/issues/8642

Clarify the type conversion happening in D1 to avoid confusion by users. Example: https://github.com/cloudflare/workers-sdk/issues/8642

All the conversions are done in the D1 Worker binding inside the `bind()` method: https://github.com/cloudflare/workerd/blob/cf9071a1bda90dd3148bb49c38d06f39beb6bd52/src/cloudflare/internal/d1-api.ts#L380

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

### Test

I created the following worker to confirm the conversions.

```
export default {
	async fetch(request, env) {
		await env.DB.exec('CREATE TABLE IF NOT EXISTS test_blob ( id INTEGER PRIMARY KEY, data BLOB );');

		return new Response(
			JSON.stringify([
				await insert(env.DB, new Uint8Array([1, 2, 3])),
				await insert(env.DB, new Uint8Array([1, 2, 3]).buffer),
				await insert(env.DB, [1, 2, 3]),
				await insert(env.DB, ['hello', 'world'].join(',')),
				await insert(env.DB, 'boomer-string'),
				await insert(env.DB, 1111),
				await insert(env.DB, true),
				await insert(env.DB, false),
				await insert(env.DB, null),
			]),
			{
				headers: { 'Content-Type': 'application/json' },
			}
		);
	},
};

async function insert(db: D1Database, val: any) {
	await db.prepare('INSERT INTO test_blob (data) VALUES (?)').bind(val).run();
	const result = await db.prepare('SELECT data FROM test_blob ORDER BY id DESC LIMIT 1').first();
	const typeofName = typeof result?.data ?? '<unknown>';
	const constructorName = result?.data?.constructor?.name || 'undefined';

	return {
		constructor: constructorName,
		typeof: typeofName,
	};
}

```
Running that returns:
```
[
  {
    "constructor": "Array",
    "typeof": "object"
  },
  {
    "constructor": "Array",
    "typeof": "object"
  },
  {
    "constructor": "Array",
    "typeof": "object"
  },
  {
    "constructor": "String",
    "typeof": "string"
  },
  {
    "constructor": "String",
    "typeof": "string"
  },
  {
    "constructor": "Number",
    "typeof": "number"
  },
  {
    "constructor": "Number",
    "typeof": "number"
  },
  {
    "constructor": "Number",
    "typeof": "number"
  },
  {
    "constructor": "undefined",
    "typeof": "object"
  }
]
```