### PR TITLE
[Chore] Update token perms to fix broken workflows

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   label_products:
     name: Label products
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +26,9 @@ jobs:
 
   label_size:
     name: Label size
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,9 @@ jobs:
   compile:
     name: Update assignees
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/assign-pr


### PR DESCRIPTION
Some checks are now broken b/c of updates to the broader CF org.

Originally blessed security-wise in `REVIEW-8695`
