### PR TITLE
[SSL/TLS] Remove previously required browser settings change in tls-13.mdx

### DIFF
--- a/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
@@ -13,7 +13,7 @@ TLS 1.3 enables the latest version of the TLS protocol (when supported) for impr
 
 TLS 1.3 is the newest, fastest, and most secure version of the TLS protocol. SSL/TLS is the protocol that encrypts communication between users and your website. When web traffic is encrypted with TLS, users will see the green padlock in their browser window.
 
-By turning on the TLS 1.3 feature, traffic to and from your website will be served over the TLS 1.3 protocol when supported by clients. TLS 1.3 protocol has improved latency over older versions, has several new features, and is currently supported in both Chrome (starting with release 66), Firefox (starting with release 60), and in development for Safari and Edge browsers.
+By turning on the TLS 1.3 feature, traffic to and from your website will be served over the TLS 1.3 protocol when supported by clients. TLS 1.3 protocol has improved latency over older versions, has several new features, and is currently supported in all updated major browsers.
 
 ## Availability
 
@@ -21,13 +21,13 @@ By turning on the TLS 1.3 feature, traffic to and from your website will be serv
 
 ## Enable TLS 1.3
 
-TLS 1.3 requires a two-step activation: in the Cloudflare dashboard and in the browser.
+TLS 1.3 can be activated in the Cloudflare dashboard or through the API:
 
 ### Enable TLS 1.3 in Cloudflare settings
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-To enable TLS 1.3 in the dashboard:
+To enable TLS 1.3 in the dashboard.
 
 1. Log in to your [Cloudflare account](https://dash.cloudflare.com) and go to a specific domain.
 2. Go to **SSL/TLS** > **Edge Certificates**.
@@ -38,37 +38,6 @@ To enable TLS 1.3 in the dashboard:
 To adjust your TLS 1.3 settings with the API, send a [`PATCH`](/api/resources/zones/subresources/settings/methods/edit/) request with `tls_1_3` as the setting name in the URI path, and set the `value` parameter to your desired setting (`"on"`, `"zrt"` or `"off"`). `zrt` refers to [Zero Round Trip Time Resumption (0-RTT)](https://blog.cloudflare.com/introducing-0-rtt/).
 
 </TabItem> </Tabs>
-
-### Enable TLS 1.3 in the browser
-
-<Details header="Chrome">
-
-1. In the address bar, enter `chrome://flags` and press **Enter**.
-2. Scroll to locate the **TLS 1.3 Early Data** entry, and set it to _Enabled_. A message saying that the change will take effect the next time you relaunch Chrome will appear.
-3. Select **RELAUNCH NOW** to restart Chrome.
-
-After enabling TLS 1.3, visit a site with TLS 1.3 enabled over HTTPS. Then:
-
-1. Open Chrome **Developer Tools**.
-2. Select the **Security** tab.
-3. Reload the page (Command-R in macOS, Ctrl-R in Windows).
-4. Select the site under **Main origin**.
-5. Under **Connection**, confirm that the protocol is **TLS 1.3**.
-
-</Details>
-
-<Details header="Firefox">
-
-1. In the address bar, enter `about:config` and select to accept the warranty warning.
-2. Search for `security.tls.version.max` and change the value from `3` (the default) to `4`.
-
-After enabling TLS 1.3, visit a site with TLS 1.3 enabled over HTTPS. Then:
-
-1. Select the lock icon in the address bar.
-2. Select **Connection secure** > **More information**.
-3. Under **Technical Details**, verify that the TLS version is TLS 1.3.
-
-</Details>
 
 ### Troubleshooting
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
@@ -11,7 +11,7 @@ TLS 1.3 enables the latest version of the TLS protocol (when supported) for impr
 
 ## What is TLS 1.3?
 
-TLS 1.3 is the newest, fastest, and most secure version of the TLS protocol. SSL/TLS is the protocol that encrypts communication between users and your website. When web traffic is encrypted with TLS, users will see the green padlock in their browser window.
+TLS 1.3 is the newest, fastest, and most secure version of the [TLS protocol](/ssl/reference/protocols/).
 
 By turning on the TLS 1.3 feature, traffic to and from your website will be served over the TLS 1.3 protocol when supported by clients. TLS 1.3 protocol has improved latency over older versions, has several new features, and is currently supported in all updated major browsers.
 
@@ -22,8 +22,6 @@ By turning on the TLS 1.3 feature, traffic to and from your website will be serv
 ## Enable TLS 1.3
 
 TLS 1.3 can be activated in the Cloudflare dashboard or through the API:
-
-### Enable TLS 1.3 in Cloudflare settings
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/tls-13.mdx
@@ -27,7 +27,7 @@ TLS 1.3 can be activated in the Cloudflare dashboard or through the API:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-To enable TLS 1.3 in the dashboard.
+To enable TLS 1.3 in the dashboard:
 
 1. Log in to your [Cloudflare account](https://dash.cloudflare.com) and go to a specific domain.
 2. Go to **SSL/TLS** > **Edge Certificates**.


### PR DESCRIPTION
### Summary

This is Tom Klein from the Cloudflare Customer Support team. In a customer interaction, we realised that the TLS 1.3 guide is a bit outdated and possibly confuses customers due to the "browser settings" requirement, that is no longer needed as of now, giving the impression that TLS 1.3 is not yet available by default in all updated major browsers.

Updating the TLS 1.3 page to remove the guide asking customers to change their browser settings to support TLS 1.3, as that TLS version is now widely available across all major browser (https://caniuse.com/tls1-3 + confirmed locally). Also modified the paragraphs around it to support the removal (e.g. removed mentions of changing it in the browser).

If this is considered a larger change, please let me know and I'll create an issue.

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/ae115b3c-4bcc-4958-b9c9-7ea377e93163)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] ~If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~
- [ ] ~Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~
