### PR TITLE
Add cross-references to API reference docs

### DIFF
--- a/src/content/docs/fundamentals/api/reference/deprecations.mdx
+++ b/src/content/docs/fundamentals/api/reference/deprecations.mdx
@@ -4,7 +4,7 @@ title: API deprecations
 release_notes_file_name:
   - api-deprecations
 sidebar:
-  order: 5
+  order: 6
 ---
 
 import { ProductReleaseNotes } from "~/components";

--- a/src/content/docs/fundamentals/api/reference/graphql-api.mdx
+++ b/src/content/docs/fundamentals/api/reference/graphql-api.mdx
@@ -1,0 +1,7 @@
+---
+pcx_content_type: navigation
+title: GraphQL API
+external_link: /analytics/graphql-api/
+sidebar:
+  order: 2
+---

--- a/src/content/docs/fundamentals/api/reference/limits.mdx
+++ b/src/content/docs/fundamentals/api/reference/limits.mdx
@@ -2,10 +2,9 @@
 pcx_content_type: reference
 title: Limits
 sidebar:
-  order: 2
-
+  order: 6
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 <Render file="api-rate-limits" product="fundamentals" />

--- a/src/content/docs/fundamentals/api/reference/limits.mdx
+++ b/src/content/docs/fundamentals/api/reference/limits.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: reference
-title: Limits
+title: Rate limits
 sidebar:
   order: 6
 ---

--- a/src/content/docs/fundamentals/api/reference/permissions.mdx
+++ b/src/content/docs/fundamentals/api/reference/permissions.mdx
@@ -2,7 +2,7 @@
 title: API token permissions
 pcx_content_type: reference
 sidebar:
-  order: 3
+  order: 5
 ---
 
 import { Render, TabItem, Tabs } from "~/components";

--- a/src/content/docs/fundamentals/api/reference/rest-api.mdx
+++ b/src/content/docs/fundamentals/api/reference/rest-api.mdx
@@ -1,0 +1,7 @@
+---
+pcx_content_type: navigation
+title: REST API
+external_link: /api/
+sidebar:
+  order: 1
+---

--- a/src/content/docs/fundamentals/api/reference/sdks.mdx
+++ b/src/content/docs/fundamentals/api/reference/sdks.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: reference
 title: SDKs
 sidebar:
-  order: 5
+  order: 7
 ---
 
 Cloudflare offers language software development kits (SDKs) as well as `curl` examples to demonstrate how to use the Cloudflare API. The SDK libraries allow you to interact with the Cloudflare API in language-specific syntax and more easily integrate with your existing applications.

--- a/src/content/docs/fundamentals/api/reference/template.mdx
+++ b/src/content/docs/fundamentals/api/reference/template.mdx
@@ -3,136 +3,135 @@ title: API token templates
 pcx_content_type: reference
 description: Explore Cloudflare's API token templates to efficiently manage permissions. Start with a template and customize token permissions and resources as needed.
 sidebar:
-  order: 4
-
+  order: 6
 ---
 
 Below is a table of the currently available API token templates and the default [token permissions](/fundamentals/api/reference/permissions/) they grant. You can start creating a token with one of these templates and modify the permissions and resources from there.
 
 <table>
-  <tbody>
-    <tr>
-      <th>Template Name</th>
-      <th>Permission</th>
-      <th>Resource</th>
-    </tr>
-    <tr>
-      <td>Edit Zone DNS</td>
-      <td>DNS Write</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td rowspan="2">Read billing info</td>
-      <td>Billing Read</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Account resources: Include all accounts</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td rowspan="2">Read analytics and logs</td>
-      <td>Analytics Read</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Logs Read</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td rowspan="8">Edit Cloudflare Workers</td>
-      <td>Workers Routes Write</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Workers Scripts Write</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Workers KV Storage Write</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Workers Tail Read</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Workers R2 Storage Write</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Account Settings Read</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>User Details Read</td>
-      <td>User</td>
-    </tr>
-    <tr>
-      <td>User Memberships Read</td>
-      <td>User</td>
-    </tr>
-    <tr>
-      <td rowspan="2">Edit load balancing configuration</td>
-      <td>Load Balancing: Monitors and Pools Write</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>Load Balancers Write</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td rowspan="8">WordPress</td>
-      <td>Analytics Read</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Zone Read</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Zone Settings Write</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Account Settings Read</td>
-      <td>Account</td>
-    </tr>
-    <tr>
-      <td>DNS Read</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Cache Purge</td>
-      <td>Zone</td>
-    </tr>
-    <tr>
-      <td>Account resources: Include all accounts</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Zone resources: Include all zones</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Create Additional Tokens</td>
-      <td>API Tokens Write</td>
-      <td>User</td>
-    </tr>
-    <tr>
-      <td rowspan="3">Read All Resources</td>
-      <td>
-        <em>(All read permissions)</em>
-      </td>
-      <td>Account, Zone, User</td>
-    </tr>
-    <tr>
-      <td>Account resources: Include all accounts</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Zone resources: Include all zones</td>
-      <td></td>
-    </tr>
-  </tbody>
+	<tbody>
+		<tr>
+			<th>Template Name</th>
+			<th>Permission</th>
+			<th>Resource</th>
+		</tr>
+		<tr>
+			<td>Edit Zone DNS</td>
+			<td>DNS Write</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td rowspan="2">Read billing info</td>
+			<td>Billing Read</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Account resources: Include all accounts</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td rowspan="2">Read analytics and logs</td>
+			<td>Analytics Read</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Logs Read</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td rowspan="8">Edit Cloudflare Workers</td>
+			<td>Workers Routes Write</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Workers Scripts Write</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Workers KV Storage Write</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Workers Tail Read</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Workers R2 Storage Write</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Account Settings Read</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>User Details Read</td>
+			<td>User</td>
+		</tr>
+		<tr>
+			<td>User Memberships Read</td>
+			<td>User</td>
+		</tr>
+		<tr>
+			<td rowspan="2">Edit load balancing configuration</td>
+			<td>Load Balancing: Monitors and Pools Write</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>Load Balancers Write</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td rowspan="8">WordPress</td>
+			<td>Analytics Read</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Zone Read</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Zone Settings Write</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Account Settings Read</td>
+			<td>Account</td>
+		</tr>
+		<tr>
+			<td>DNS Read</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Cache Purge</td>
+			<td>Zone</td>
+		</tr>
+		<tr>
+			<td>Account resources: Include all accounts</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Zone resources: Include all zones</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Create Additional Tokens</td>
+			<td>API Tokens Write</td>
+			<td>User</td>
+		</tr>
+		<tr>
+			<td rowspan="3">Read All Resources</td>
+			<td>
+				<em>(All read permissions)</em>
+			</td>
+			<td>Account, Zone, User</td>
+		</tr>
+		<tr>
+			<td>Account resources: Include all accounts</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>Zone resources: Include all zones</td>
+			<td></td>
+		</tr>
+	</tbody>
 </table>

--- a/src/content/docs/fundamentals/api/reference/wrangler-api.mdx
+++ b/src/content/docs/fundamentals/api/reference/wrangler-api.mdx
@@ -1,0 +1,7 @@
+---
+pcx_content_type: navigation
+title: Wrangler API
+external_link: /workers/wrangler/api/
+sidebar:
+  order: 3
+---


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
I noticed that we don't have cross-references to the various API docs in the fundamentals section right now. I've added these to improve discoverability and navigation. I also changed the order to alphabetize the rest of the reference content in this folder. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
