### PR TITLE
fix typo

### DIFF
--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -171,7 +171,7 @@ This is the full format of a C3 invocation alongside the possible CLI arguments:
 
 - `--ts` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
 
-  - Use TypeScript in your application. Deprecated. Uuse `--lang=ts` instead.
+  - Use TypeScript in your application. Deprecated. Use `--lang=ts` instead.
 
 - `--git` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
 


### PR DESCRIPTION
### Summary

Use was spelt "Uuse"

### Screenshots (optional)
![image](https://github.com/user-attachments/assets/eb4782db-1809-4fcd-9a17-2c6d2034d517)

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
