### PR TITLE
[C3] fix cli docs typo in c3.mdx

### DIFF
--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -171,7 +171,7 @@ This is the full format of a C3 invocation alongside the possible CLI arguments:
 
 - `--ts` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
 
-  - Use TypeScript in your application. Deprecated. Uuse `--lang=ts` instead.
+  - Use TypeScript in your application. Deprecated. Use `--lang=ts` instead.
 
 - `--git` <Type text="boolean" /> <MetaInfo text="(default: true) optional" />
 


### PR DESCRIPTION
Fixed typo in deprecated usage of `--ts`

### Summary

- C3 CLI docs typo fix

### Screenshots (optional)

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
