### PR TITLE
docs(write-your-first-test): change toml extension to jsonc

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -49,7 +49,7 @@ export default defineWorkersConfig({
 	test: {
 		poolOptions: {
 			workers: {
-				wrangler: { configPath: "./wrangler.toml" },
+				wrangler: { configPath: "./wrangler.jsonc" },
 			},
 		},
 	},
@@ -65,7 +65,7 @@ For example, this configuration would add a KV namespace `TEST_NAMESPACE` that w
         	test: {
         		poolOptions: {
         			workers: {
-        				wrangler: { configPath: "./wrangler.toml" },
+        				wrangler: { configPath: "./wrangler.jsonc" },
         				miniflare: {
         					kvNamespaces: ["TEST_NAMESPACE"],
         				},


### PR DESCRIPTION
### Summary

The `write-your-first-test` page currently references TOML Wrangler configuration. This pull request addresses that issue by updating the content to reflect the growing preference for the JSONC format.