### PR TITLE
release note entry for hyperdrive caching improvement

### DIFF
--- a/src/content/release-notes/hyperdrive.yaml
+++ b/src/content/release-notes/hyperdrive.yaml
@@ -5,6 +5,11 @@ productLink: "/hyperdrive/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
+  - publish_date: "2025-05-02"
+    title: Hyperdrive improves regional caching for prepared statements for faster cache hits
+    description: |-
+      Hyperdrive now better caches prepared statements closer to your Workers. This results in up to 5x faster cache hits by
+      reducing the roundtrips needed between your Worker and Hyperdrive's connection pool.
   - publish_date: "2025-03-07"
     title: Hyperdrive connects to your database using Cloudflare's IP address ranges
     description: |-

--- a/src/content/release-notes/hyperdrive.yaml
+++ b/src/content/release-notes/hyperdrive.yaml
@@ -5,7 +5,7 @@ productLink: "/hyperdrive/"
 productArea: Developer platform
 productAreaLink: /workers/platform/changelog/platform/
 entries:
-  - publish_date: "2025-05-02"
+  - publish_date: "2025-05-05"
     title: Hyperdrive improves regional caching for prepared statements for faster cache hits
     description: |-
       Hyperdrive now better caches prepared statements closer to your Workers. This results in up to 5x faster cache hits by


### PR DESCRIPTION
Unfortunately, we don't have impact on query latency since Hyperdrive does not have e2e latency instrumented (so this is a release not instead of changelog entry). This resulted in half of requests hitting cache near connection pooler being resolved in edge cache (100ms -> 20ms). 