### PR TITLE
Fix a broken link in a note

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1113,7 +1113,7 @@ See https://developers.cloudflare.com/workers/wrangler/bundling/ for more detail
 ## Local development settings
 
 :::note
-If you're using the [Cloudflare Vite plugin](/workers/vite-plugin/), you should use Vite's [server options]](https://vite.dev/config/server-options.html) instead.
+If you're using the [Cloudflare Vite plugin](/workers/vite-plugin/), you should use Vite's [server options](https://vite.dev/config/server-options.html) instead.
 :::
 
 You can configure various aspects of local development, such as the local protocol or port.


### PR DESCRIPTION
### Summary

The link "server options" on the [Local Development Settings](https://developers.cloudflare.com/workers/wrangler/configuration/#local-development-settings) page is broken.

- Resolves #22196

### Screenshots (optional)

<img width="753" alt="Screenshot 2025-05-03 at 18 52 36" src="https://github.com/user-attachments/assets/8b33d995-cb9a-4b22-a100-e32d7a05be72" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
