### PR TITLE
[Pages] Update GitHub Action for Cloudflare Pages CI in use-direct-upload-with-continuous-integration.mdx

### DIFF
--- a/src/content/docs/pages/how-to/use-direct-upload-with-continuous-integration.mdx
+++ b/src/content/docs/pages/how-to/use-direct-upload-with-continuous-integration.mdx
@@ -72,17 +72,16 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Run your project's build step
       # - name: Build
       #   run: npm install && npm run build
-      - name: Publish
-        uses: cloudflare/pages-action@v1
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: YOUR_PROJECT_NAME # e.g. 'my-project'
-          directory: YOUR_DIRECTORY_OF_STATIC_ASSETS # e.g. 'dist'
+          command: pages deploy YOUR_DIRECTORY_OF_STATIC_ASSETS --project-name=YOUR_PROJECT_NAME
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 ```
 


### PR DESCRIPTION
### Summary

Switched the GitHub Actions workflow in `use-direct-upload-with-continuous-integration.mdx` from [cloudflare/pages-action](https://github.com/cloudflare/pages-action) to [cloudflare/wrangler-action](https://github.com/cloudflare/wrangler-action) as per the deprecation notice on the pages-action repo. Also updated actions/checkout to v4 to match the documentation from wrangler-action.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

Thanks,
Elliott