### PR TITLE
fix: instance.status() return type

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -397,7 +397,7 @@ Return the id of a Workflow.
 
 ### status
 
-Return the status of a running Workflow instance.
+Return the status of a running Workflow instance. 
 
 * <code>status(): Promise&lt;InstanceStatus&gt;</code>
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -397,7 +397,7 @@ Return the id of a Workflow.
 
 ### status
 
-Return the status of a running Workflow instance. 
+Return the status of a running Workflow instance.
 
 * <code>status(): Promise&lt;InstanceStatus&gt;</code>
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -399,7 +399,7 @@ Return the id of a Workflow.
 
 Return the status of a running Workflow instance.
 
-* <code>status(): Promise&lt;void&gt;</code>
+* <code>status(): Promise&lt;InstanceStatus&gt;</code>
 
 ### pause
 


### PR DESCRIPTION
### Summary

Fixes the return type for `WorkflowInstance` [status() method](https://developers.cloudflare.com/workflows/build/workers-api/#status)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

---

Closes #22199 