### PR TITLE
Remove unreachable return statement in trigger-workflows.mdx

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -88,8 +88,6 @@ export default {
 			id: instance.id,
 			details: await instance.status(),
 		});
-
-		return Response.json({ result });
 	},
 };
 ```


### PR DESCRIPTION
Remove unreachable return statement

### Summary

Adjust code example on https://developers.cloudflare.com/workflows/build/trigger-workflows/

The `return` statement would never be reached as there was a `return` statement above it on line 87.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
