### PR TITLE
Adding -- because the line after it get ignored currently

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/hono.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/hono.mdx
@@ -42,7 +42,7 @@ With Workers Assets, you can easily combine a Hono API running on Workers with a
     	<PackageManagers
     	type="create"
     	pkg="cloudflare@latest"
-    	args="my-hono-app --template=cloudflare/templates/vite-react-template"
+    	args="my-hono-app -- --template=cloudflare/templates/vite-react-template"
     	/>
     		 <Details header="How is this project set up?">
         			Below is a simplified file tree of the project.


### PR DESCRIPTION
 ```

npm create cloudflare@latest -- .  --template=cloudflare/templates/vite-react-template   

      
npm warn Unknown cli config "--template". This will stop working in the next major version of npm.

```
