### PR TITLE
Add fix for an error widows users may encounter

### DIFF
--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -224,14 +224,15 @@ npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  \"User\" (\"email
 ('jane@prisma.io', 'Jane Doe (Remote)');" --remote
 ```
 
-If you're getting an error like `Unknown arguments: (\email\,, \name\)...`, you may need to escape the double quotes with `\``.
+:::note
+If you receive an error to the effect of `Unknown arguments: (\email\,, \name\)...`, you may need to escape the double quotes with `\``.
 
 ```sh
 # Escape with ` instead of \
 npx wrangler d1 execute prisma-demo-db --command "INSERT INTO `"User`" (`"email`", `"name`") VALUES
 ('jane@prisma.io', 'Jane Doe (Local)');" --local
 ```
-
+:::
 ### 5. Query your database from the Worker
 
 To query your database from the Worker using Prisma ORM, you need to:

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -224,6 +224,14 @@ npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  \"User\" (\"email
 ('jane@prisma.io', 'Jane Doe (Remote)');" --remote
 ```
 
+If you're getting an error like `Unknown arguments: (\email\,, \name\)...`, you may need to escape the double quotes with `\``.
+
+```sh
+# Escape with ` instead of \
+npx wrangler d1 execute prisma-demo-db --command "INSERT INTO `"User`" (`"email`", `"name`") VALUES
+('jane@prisma.io', 'Jane Doe (Local)');" --local
+```
+
 ### 5. Query your database from the Worker
 
 To query your database from the Worker using Prisma ORM, you need to:


### PR DESCRIPTION
### Summary

With the commands right above [step 5 in these docs](https://developers.cloudflare.com/d1/tutorials/d1-and-prisma-orm/#5-query-your-database-from-the-worker), I encountered an error where the `\"` wasn't properly interpreted when using PowerShell (specifically in vscode in this case, though I'm unsure if that makes a difference)

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->
Previously, the command would error like this:
![image](https://github.com/user-attachments/assets/6ad80d43-7eba-44e0-9547-03f6f0eb80d1)

Now, it doesn't.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
