### PR TITLE
remove the beta badge for Next.js

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -3,8 +3,6 @@ pcx_content_type: how-to
 title: Next.js
 tags: ["full-stack"]
 description: Create an Next.js application and deploy it to Cloudflare Workers with Workers Assets.
-sidebar:
-  badge: Beta
 ---
 
 import {

--- a/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/nextjs.mdx
@@ -14,10 +14,6 @@ import {
 	WranglerConfig,
 } from "~/components";
 
-:::note
-The OpenNext adapter is in currently in beta.
-:::
-
 **Start from CLI** - scaffold a Next.js project on Workers.
 
 <PackageManagers


### PR DESCRIPTION
We released [v1.0.0](https://www.npmjs.com/package/@opennextjs/cloudflare) of the adapter yesterday 🚀 