### PR TITLE
[R2] Adding character length restriction for R2 buckets

### DIFF
--- a/src/content/docs/r2/buckets/create-buckets.mdx
+++ b/src/content/docs/r2/buckets/create-buckets.mdx
@@ -27,6 +27,7 @@ wrangler r2 bucket create your-bucket-name
 
 - Bucket names can only contain lowercase letters (a-z), numbers (0-9), and hyphens (-).
 - Bucket names cannot begin or end with a hyphen.
+- Bucket names can only be 3-63 characters long.
 
 The placeholder text is only for the example.
 

--- a/src/content/docs/r2/buckets/create-buckets.mdx
+++ b/src/content/docs/r2/buckets/create-buckets.mdx
@@ -27,7 +27,7 @@ wrangler r2 bucket create your-bucket-name
 
 - Bucket names can only contain lowercase letters (a-z), numbers (0-9), and hyphens (-).
 - Bucket names cannot begin or end with a hyphen.
-- Bucket names can only be 3-63 characters long.
+- Bucket names can only be between 3-63 characters in length.
 
 The placeholder text is only for the example.
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Stating that bucket names can only be between 3-63 characters in length.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
