### PR TITLE
Fix OpenAI tutorial link

### DIFF
--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -42,7 +42,7 @@ Below is a list of our supported model providers:
 
 If you do not have a provider preference, start with one of our dedicated tutorials:
 
-- [OpenAI](/ai-gateway/integrations/aig-workers-ai-binding/)
+- [OpenAI](/ai-gateway/tutorials/deploy-aig-worker/)
 - [Workers AI](/ai-gateway/tutorials/create-first-aig-workers/)
 
 ## View analytics


### PR DESCRIPTION
### Summary

Update link for OpenAI tutorial from https://developers.cloudflare.com/ai-gateway/integrations/aig-workers-ai-binding/ to https://developers.cloudflare.com/ai-gateway/tutorials/deploy-aig-worker/

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.