### PR TITLE
Vectorize: Make index naming requirement explicit

### DIFF
--- a/src/content/docs/vectorize/best-practices/create-indexes.mdx
+++ b/src/content/docs/vectorize/best-practices/create-indexes.mdx
@@ -11,7 +11,7 @@ Indexes are the "atom" of Vectorize. Vectors are inserted into an index and enab
 
 Creating an index requires three inputs:
 
-- A kebab-cased name, for example `prod-search-index` or `recommendations-idx-dev`.
+- A kebab-cased name, such as `prod-search-index` or `recommendations-idx-dev`.
 - The (fixed) [dimension size](#dimensions) of each vector, for example 384 or 1536.
 - The (fixed) [distance metric](#distance-metrics) to use for calculating vector similarity.
 

--- a/src/content/docs/vectorize/best-practices/create-indexes.mdx
+++ b/src/content/docs/vectorize/best-practices/create-indexes.mdx
@@ -11,7 +11,7 @@ Indexes are the "atom" of Vectorize. Vectors are inserted into an index and enab
 
 Creating an index requires three inputs:
 
-- A name, for example `prod-search-index` or `recommendations-idx-dev`.
+- A kebab-cased name, for example `prod-search-index` or `recommendations-idx-dev`.
 - The (fixed) [dimension size](#dimensions) of each vector, for example 384 or 1536.
 - The (fixed) [distance metric](#distance-metrics) to use for calculating vector similarity.
 


### PR DESCRIPTION
### Summary

Names can be arbitrary strings more often than not (I'm not referring to cloudflare here but programming in general), so it doesn't follow from examples that other casing can't be used.
