### PR TITLE
[Workers] RedwoodSDK framework - reformat

### DIFF
--- a/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
@@ -1,0 +1,51 @@
+---
+pcx_content_type: how-to
+title: RedwoodSDK
+head: []
+description: Create an RedwoodSDK application and deploy it to Cloudflare Workers with Workers Assets.
+---
+
+import {
+	Badge,
+	Description,
+	InlineBadge,
+	Render,
+	PackageManagers,
+} from "~/components";
+
+In this guide, you will create a new [RedwoodSDK](https://rwsdk.com/) application and deploy it to Cloudflare Workers.
+
+RedwoodSDK is a composable framework for building server-side web apps on Cloudflare. It starts as a Vite plugin that unlocks SSR, React Server Components, Server Functions, and realtime capabilities.
+
+## 1. Set up a new project
+
+Create a new project by running the following command, replacing `<project-name>` with your desired project name:
+
+<PackageManagers
+	type="exec"
+	pkg="degit"
+	args={"redwoodjs/sdk/starters/standard#main <project-name>"}
+/>
+
+Then, change the directory to your project and install dependencies:
+
+```sh
+cd <project-name>
+```
+
+<PackageManagers type="install" />
+
+## 2. Develop locally
+
+Once your project is set up, run the following command in the project directory to start a local development server.
+RedwoodSDK is just a plugin for Vite, so you can use the same dev workflow as any other Vite project:
+
+<PackageManagers type="run" args={"dev"} />
+
+## 3. Deploy your Project
+
+You can deploy your project to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), either from your local machine or from any CI/CD system, including [Cloudflare's own](/workers/ci-cd/builds/).
+
+The following command will build and deploy your project. If you're using CI, ensure you update your ["deploy command"](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
+
+<PackageManagers type="run" args={"release"} />

--- a/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
@@ -11,41 +11,43 @@ import {
 	InlineBadge,
 	Render,
 	PackageManagers,
+	Steps,
 } from "~/components";
 
 In this guide, you will create a new [RedwoodSDK](https://rwsdk.com/) application and deploy it to Cloudflare Workers.
 
 RedwoodSDK is a composable framework for building server-side web apps on Cloudflare. It starts as a Vite plugin that unlocks SSR, React Server Components, Server Functions, and realtime capabilities.
 
-## 1. Set up a new project
+## Deploy a new RedwoodSDK application on Workers
 
-Create a new project by running the following command, replacing `<project-name>` with your desired project name:
+<Steps>
+1. **Create a new project.**
 
-<PackageManagers
-	type="exec"
-	pkg="degit"
-	args={"redwoodjs/sdk/starters/standard#main <project-name>"}
-/>
+	Run the following command, replacing `<project-name>` with your desired project name:
+		<PackageManagers
+			type="exec"
+			pkg="degit"
+			args={"redwoodjs/sdk/starters/standard#main <project-name>"}
+		/>
 
-Then, change the directory to your project and install dependencies:
+2. **Change the directory.**
+	```sh
+	cd <project-name>
+	```
 
-```sh
-cd <project-name>
-```
+3. **Install dependencies.**
+	<PackageManagers type="install" />
 
-<PackageManagers type="install" />
+4. **Develop locally.**
 
-## 2. Develop locally
+	Run the following command in the project directory to start a local development server. RedwoodSDK is just a plugin for Vite, so you can use the same dev workflow as any other Vite project:
+		<PackageManagers type="run" args={"dev"} />
 
-Once your project is set up, run the following command in the project directory to start a local development server.
-RedwoodSDK is just a plugin for Vite, so you can use the same dev workflow as any other Vite project:
+5. **Deploy your project.**
 
-<PackageManagers type="run" args={"dev"} />
+	You can deploy your project to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), either from your local machine or from any CI/CD system, including [Cloudflare Workers CI/CD](/workers/ci-cd/builds/).
 
-## 3. Deploy your Project
+	Use the following command to build and deploy. If you're using CI, make sure to update your [deploy command](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
+		<PackageManagers type="run" args={"release"} />
 
-You can deploy your project to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), either from your local machine or from any CI/CD system, including [Cloudflare's own](/workers/ci-cd/builds/).
-
-The following command will build and deploy your project. If you're using CI, ensure you update your ["deploy command"](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
-
-<PackageManagers type="run" args={"release"} />
+</Steps>

--- a/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/redwoodsdk.mdx
@@ -47,7 +47,7 @@ RedwoodSDK is a composable framework for building server-side web apps on Cloudf
 
 	You can deploy your project to a `*.workers.dev` subdomain or a [Custom Domain](/workers/configuration/routing/custom-domains/), either from your local machine or from any CI/CD system, including [Cloudflare Workers CI/CD](/workers/ci-cd/builds/).
 
-	Use the following command to build and deploy. If you're using CI, make sure to update your [deploy command](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
+	Use the following command to build and deploy. If you are using CI, make sure to update your [deploy command](/workers/ci-cd/builds/configuration/#build-settings) configuration accordingly.
 		<PackageManagers type="run" args={"release"} />
 
 </Steps>


### PR DESCRIPTION
Reformatting of #21495

This adds a RedwoodSDK page to the framework section, that allows the user to quickly install, develop, and deploy to Cloudflare.