### PR TITLE
Fix MCP imports/package name

### DIFF
--- a/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
@@ -12,6 +12,7 @@ When you build MCP Servers on Cloudflare, you extend the [`McpAgent` class](http
 <TypeScriptExample>
 
 ```ts title="src/index.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpAgent } from "agents/mcp";
 
 export class MyMCP extends McpAgent {

--- a/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
@@ -13,7 +13,6 @@ When you build MCP Servers on Cloudflare, you extend the [`McpAgent` class](http
 
 ```ts title="src/index.ts"
 import { McpAgent } from "agents/mcp";
-import { DurableMCP } from "@cloudflare/model-context-protocol";
 
 export class MyMCP extends McpAgent {
 	server = new McpServer({ name: "Demo", version: "1.0.0" });
@@ -46,6 +45,7 @@ But if you want your MCP server to:
 You can use the APIs below in order to do so.
 
 #### Hibernation Support
+
 `McpAgent` instances automatically support [WebSockets Hibernation](/durable-objects/best-practices/websockets/#websocket-hibernation-api), allowing stateful MCP servers to sleep during inactive periods while preserving their state. This means your agents only consume compute resources when actively processing requests, optimizing costs while maintaining the full context and conversation history.
 
 ### State synchronization APIs

--- a/src/content/docs/agents/model-context-protocol/tools.mdx
+++ b/src/content/docs/agents/model-context-protocol/tools.mdx
@@ -9,7 +9,7 @@ import { Render, TypeScriptExample } from "~/components";
 
 Model Context Protocol (MCP) tools are functions that a [MCP Server](/agents/model-context-protocol) provides and MCP clients can call.
 
-When you build MCP Servers with the `@cloudflare/model-context-protocol` package, you can define tools the [same way as shown in the `@modelcontextprotocol/typescript-sdk` package's examples](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#tools).
+When you build MCP Servers with the `agents` package, you can define tools the [same way as shown in the `@modelcontextprotocol/typescript-sdk` package's examples](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#tools).
 
 For example, the following code from [this example MCP server](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server) defines a simple MCP server that adds two numbers together:
 


### PR DESCRIPTION
We were referencing a package that didn't exist in the agents/mcp docs, this patch fixes that.



### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
