### PR TITLE
Document WRANGLER_LOG_PATH system environment variable

### DIFF
--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -61,7 +61,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_LOG_PATH` <Type text="string" /> <MetaInfo text="optional" />
 
-  * A file or directory path where Wrangler will write its logs. When specifying a path to a file, the filename must end with `.log`. When specifying a directory or using the default location, a filename with a timestamp is used.
+  * A file or directory path where Wrangler will write debug logs. When specifying a path to a file, the filename must end with `.log`. When specifying a directory or using the default location, a filename with a timestamp is used.
 
 * `FORCE_COLOR` <Type text="string" /> <MetaInfo text="optional" />
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -59,6 +59,10 @@ Wrangler supports the following environment variables:
 
   * Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`. Levels are case-insensitive and default to `"log"`. If an invalid level is specified, Wrangler will fallback to the default. Logs can include requests to Cloudflare's API, any usage data being collected, and more verbose error logs.
 
+* `WRANGLER_LOG_PATH` <Type text="string" /> <MetaInfo text="optional" />
+
+  * A file or directory path where Wrangler will write its logs. When specifying a path to a file, the filename must end with `.log`. When specifying a directory or using the default location, a filename with a timestamp is used.
+
 * `FORCE_COLOR` <Type text="string" /> <MetaInfo text="optional" />
 
   * By setting this to `0`, you can disable Wrangler's colorised output, which makes it easier to read with some terminal setups. For example, `FORCE_COLOR=0`.
@@ -78,6 +82,7 @@ CLOUDFLARE_EMAIL=<YOUR_EMAIL>
 WRANGLER_SEND_METRICS=true
 CLOUDFLARE_API_BASE_URL=https://api.cloudflare.com/client/v4
 WRANGLER_LOG=debug
+WRANGLER_LOG_PATH=../Desktop/my-logs/my-log-file.log
 ```
 
 ## Deprecated global variables

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -61,7 +61,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_LOG_PATH` <Type text="string" /> <MetaInfo text="optional" />
 
-  * A file or directory path where Wrangler will write debug logs. When specifying a path to a file, the filename must end with `.log`. When specifying a directory or using the default location, a filename with a timestamp is used.
+  * A file or directory path where Wrangler will write debug logs. If the path ends in `.log`, Wrangler will consider this the path to a file where all logs will be written. Otherwise, Wrangler will treat the path as a directory where it will write one or more log files using a timestamp for the filenames.
 
 * `FORCE_COLOR` <Type text="string" /> <MetaInfo text="optional" />
 


### PR DESCRIPTION
I see this option in the Changelog and in the source, but not in the docs.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

I took some of the same language from the [Changelog entry](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/CHANGELOG.md#minor-changes-112).