### PR TITLE
[R2] Adding Sip n Slurp migration strategy

### DIFF
--- a/src/content/docs/r2/data-migration/index.mdx
+++ b/src/content/docs/r2/data-migration/index.mdx
@@ -57,7 +57,20 @@ Quickly and easily migrate data from other cloud providers to R2. Explore each o
 
 ## Migration strategies
 
-You can use a combination of Super Slurper and Sippy to effectively migrate all objects without any downtime.
+You can use a combination of Super Slurper and Sippy to effectively migrate all objects with minimal downtime.
 
-1. Activate Sippy to gradually copy objects from the previous bucket to an R2 bucket when they are requested (on-demand).
+### When the source bucket is actively being read from / written to
+
+1. Enable Sippy and start using the R2 bucket in your application.
+   - This copies objects from your previous bucket into the R2 bucket on demand when they are requested by the application.
+   - New uploads will go to the R2 bucket.
 2. Use Super Slurper to trigger a one-off migration to copy the remaining objects into the R2 bucket.
+   - In the **Destination R2 bucket** > **Overwrite files?**, select "Skip existing".
+
+### When the source bucket is not being read often
+
+1. Use Super Slurper to copy all objects to the R2 bucket.
+   - Note that Super Slurper may skip some objects if they are uploaded after it lists the objects to be copied.
+2. Enable Sippy on your R2 bucket, then start using the R2 bucket in your application.
+   - New uploads will go to the R2 bucket.
+   - Objects which were uploaded while Super Slurper was copying the objects will be copied on-demand (by Sippy) when they are requested by the application.

--- a/src/content/docs/r2/data-migration/index.mdx
+++ b/src/content/docs/r2/data-migration/index.mdx
@@ -55,22 +55,4 @@ Quickly and easily migrate data from other cloud providers to R2. Explore each o
 	</tbody>
 </table>
 
-## Migration strategies
-
-You can use a combination of Super Slurper and Sippy to effectively migrate all objects with minimal downtime.
-
-### When the source bucket is actively being read from / written to
-
-1. Enable Sippy and start using the R2 bucket in your application.
-   - This copies objects from your previous bucket into the R2 bucket on demand when they are requested by the application.
-   - New uploads will go to the R2 bucket.
-2. Use Super Slurper to trigger a one-off migration to copy the remaining objects into the R2 bucket.
-   - In the **Destination R2 bucket** > **Overwrite files?**, select "Skip existing".
-
-### When the source bucket is not being read often
-
-1. Use Super Slurper to copy all objects to the R2 bucket.
-   - Note that Super Slurper may skip some objects if they are uploaded after it lists the objects to be copied.
-2. Enable Sippy on your R2 bucket, then start using the R2 bucket in your application.
-   - New uploads will go to the R2 bucket.
-   - Objects which were uploaded while Super Slurper was copying the objects will be copied on-demand (by Sippy) when they are requested by the application.
+For information on how to leverage these tools effectively, refer to [Migration Strategies](/r2/data-migration/migration-strategies/)

--- a/src/content/docs/r2/data-migration/index.mdx
+++ b/src/content/docs/r2/data-migration/index.mdx
@@ -54,3 +54,10 @@ Quickly and easily migrate data from other cloud providers to R2. Explore each o
 		</tr>
 	</tbody>
 </table>
+
+## Migration strategies
+
+You can use a combination of Super Slurper and Sippy to effectively migrate all objects without any downtime.
+
+1. Activate Sippy to gradually copy objects from the previous bucket to an R2 bucket when they are requested (on-demand).
+2. Use Super Slurper to trigger a one-off migration to copy the remaining objects into the R2 bucket.

--- a/src/content/docs/r2/data-migration/migration-strategies.mdx
+++ b/src/content/docs/r2/data-migration/migration-strategies.mdx
@@ -1,0 +1,28 @@
+---
+title: Migration Strategies
+pcx_content_type: how-to
+learning_center:
+  title: Migration strategies
+sidebar:
+  order: 5
+---
+
+import { Render } from "~/components";
+
+You can use a combination of Super Slurper and Sippy to effectively migrate all objects with minimal downtime.
+
+### When the source bucket is actively being read from / written to
+
+1. Enable Sippy and start using the R2 bucket in your application.
+   - This copies objects from your previous bucket into the R2 bucket on demand when they are requested by the application.
+   - New uploads will go to the R2 bucket.
+2. Use Super Slurper to trigger a one-off migration to copy the remaining objects into the R2 bucket.
+   - In the **Destination R2 bucket** > **Overwrite files?**, select "Skip existing".
+
+### When the source bucket is not being read often
+
+1. Use Super Slurper to copy all objects to the R2 bucket.
+   - Note that Super Slurper may skip some objects if they are uploaded after it lists the objects to be copied.
+2. Enable Sippy on your R2 bucket, then start using the R2 bucket in your application.
+   - New uploads will go to the R2 bucket.
+   - Objects which were uploaded while Super Slurper was copying the objects will be copied on-demand (by Sippy) when they are requested by the application.

--- a/src/content/docs/r2/data-migration/super-slurper.mdx
+++ b/src/content/docs/r2/data-migration/super-slurper.mdx
@@ -45,7 +45,10 @@ This setting specifies the prefix within the source bucket where objects will be
 
 #### Overwrite files?
 
-This setting determines what happens when an object being copied from the source storage bucket matches the path of an existing object in the destination R2 bucket. There are two options: overwrite (default) and skip.
+This setting determines what happens when an object being copied from the source storage bucket matches the path of an existing object in the destination R2 bucket. There are two options:
+
+- Overwrite (default)
+- Skip
 
 ## Supported cloud storage providers
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->


Adding a migration strategy using Sippy first, then Super Slurper, to effectively migrate all objects into an R2 bucket without any downtime.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
