### PR TITLE
[WARP] Release update

### DIFF
--- a/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
@@ -1,0 +1,26 @@
+releaseNotes: >-
+  This release contains support for a new WARP setting, Global WARP Override. As
+  well as significant improvements to our Captive Portal / public Wi-Fi
+  detection logic. We’d like anyone who has experienced issues with captive
+  portals in the past to re-test and give this version a try.
+
+
+  **Changes and improvements**
+
+  - Improved captive portal experience to make more public networks compatible
+  and have faster detection.
+
+  - WARP tunnel protocol details can now be viewed by `warp-cli tunnel stats`
+  command
+
+  - Fixed issue with device revocation and re-registration when switching
+  configurations
+
+  - Added a new Global WARP Override setting. This setting puts account admins
+  in control of disabling and enabling WARP across all devices registered to an
+  account from the dashboard. Global WARP Override is disabled by default.
+version: 2025.4.929.0
+releaseDate: 2025-05-12T23:21:47.865Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/noble-intel/version/2025.4.929.0
+packageSize: 45528916
+platformName: Linux

--- a/src/content/warp-releases/macos/ga/2025.4.929.0.yaml
+++ b/src/content/warp-releases/macos/ga/2025.4.929.0.yaml
@@ -1,0 +1,29 @@
+releaseNotes: |-
+  This release contains two significant changes all customers should be aware of:
+  1. All DNS traffic now flows inside the WARP tunnel. Customers are no longer required to configure their local Firewall rules to allow our [DoH IP Address or domains](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#doh-ip).
+  2. When using MASQUE, the connection will fall back to HTTP/2 (TCP) when we detect that HTTP/3 traffic is blocked. This allows for a much more reliable connection on some public WiFi networks.
+
+
+  **Changes and improvements**
+  - Fixed an issue where the managed network policies could incorrectly report network location beacons as missing.
+  - Improved DEX Test Error reporting.
+  - Fixed an issue causing client notifications to fail in IPv6 only environments which prevented the client from receiving configuration changes to settings like device profile.
+  - Improved captive portal detection.
+  - Added a TCP fallback for the MASQUE tunnel protocol to improve connectivity on networks that block UDP or http/3 specifically.
+  - Added new [IPs for Client Orchestration API](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#connectivity-check) for operations like tunnel connectivity checks. If your organization uses a firewall or other policies you will need to exempt these IPs.
+  - DNS over HTTPS traffic is now included in the WARP tunnel by default.
+  - Improved the error message displayed in the client GUI when the rate limit for entering an incorrect admin override code is met.
+  - Added a [Collect Captive Portal Diag](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/captive-portals/#get-captive-portal-logs) button in the client GUI to make it easier for users to collect captive portal debugging diagnostics.
+  - Improved handling of non-SLAAC IPv6 interface addresses for better connectivity in IPv6 only environments.
+  - Fixed an issue where frequent network changes could cause WARP to become unresponsive.
+  - Improvement for WARP to check if tunnel connectivity fails or times out at device wake before attempting to reconnect.
+  - Fixed an issue causing WARP connection disruptions after network changes.
+
+
+  **Known issues**
+  - macOS Sequoia: Due to changes Apple introduced in macOS 15.0.x, the WARP client may not behave as expected. Cloudflare recommends the use of macOS 15.4 or later.
+version: 2025.4.929.0
+releaseDate: 2025-05-12T23:20:27.810Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/macos/version/2025.4.929.0
+packageSize: 96424041
+platformName: macOS


### PR DESCRIPTION
To validate:

Go to the [Stable releases page](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/download-warp/) in the preview and check both `Linux` and `macOS` to make sure the latest releases match what we're adding here.