### PR TITLE
Fix Codeblocks in Images documentation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ dist
 public/__redirects
 public/analytics/static/downloads/main.css
 src/content/workers-ai-models/*.json
+src/content/partials/images/*.mdx

--- a/src/content/partials/images/onerror.mdx
+++ b/src/content/partials/images/onerror.mdx
@@ -11,5 +11,9 @@ This setting only works directly with [image transformations](/images/transform-
 In case of a [fatal error](/images/reference/troubleshooting/#error-responses-from-resizing) that prevents the image from being resized, redirects to the unresized source image URL. This may be useful in case some images require user authentication and cannot be fetched anonymously via Worker. This option should not be used if there is a chance the source image is very large. This option is ignored if the image is from another domain, but you can use it with subdomains.
 
 <Tabs>
-	<TabItem label="URL format">```js onerror=redirect ```</TabItem>
+	<TabItem label="URL format">
+		```js
+		onerror=redirect
+		```
+	</TabItem>
 </Tabs>

--- a/src/content/partials/images/slow-connection-quality.mdx
+++ b/src/content/partials/images/slow-connection-quality.mdx
@@ -9,8 +9,16 @@ Allows overriding `quality` value whenever a slow connection is detected.
 Available options are same as [quality](/images/transform-images/transform-via-url/#quality).
 
 <Tabs>
-	<TabItem label="URL format">```js slow-connection-quality=50 ```</TabItem>
-	<TabItem label="URL format alias">```js scq=50 ```</TabItem>
+	<TabItem label="URL format">
+		```js
+		slow-connection-quality=50
+		```
+	</TabItem>
+	<TabItem label="URL format alias">
+		```js
+		scq=50
+		```
+	</TabItem>
 </Tabs>
 
 Detecting slow connections is currently only supported on Chromium-based browsers such as Chrome, Edge, and Opera.


### PR DESCRIPTION
### Summary

Codeblocks in the codebase work like this:
```js
console.log("my code here");
```

In certain circumstances, prettier tries to push this into one line:
```js console.log("my code here");```

This isn't supported and leads to incorrect looking output:
![image](https://github.com/user-attachments/assets/196a744b-7307-40d0-acc1-545501db5f7c)

This PR fixes a couple of files that were inadvertently broken and adds them to the .prettierignore list so that it doesn't automatically break again.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.