### PR TITLE
hyperlint - adjust

### DIFF
--- a/.hyperlint/automations/styles/cloudflare/HeadingPunctuation.yml
+++ b/.hyperlint/automations/styles/cloudflare/HeadingPunctuation.yml
@@ -8,6 +8,6 @@ action:
   name: edit
   params:
     - trim_right
-    - ".?!"
+    - ".!"
 tokens:
-  - "[a-z][.?!]$"
+  - "[a-z][.!]$"


### PR DESCRIPTION
For now, `?` linting in FAQ heading titles is too noisy. Removing.

No validation needed, only affects automated checks.