### PR TITLE
[CAT] Fix links

### DIFF
--- a/src/content/docs/cloudflare-challenges/concepts/how-challenges-work.mdx
+++ b/src/content/docs/cloudflare-challenges/concepts/how-challenges-work.mdx
@@ -48,7 +48,7 @@ If a visitor was unable to run JavaScript detection, the `cf.bot_management.js_d
 
 Cloudflare challenges cannot support the following:
 
-- [Browser extensions](#browser-extensions) that modify the browser's `User-Agent` value or Web APIs such as `Canvas` and `WebGL`.
+- [Browser extensions](/cloudflare-challenges/reference/supported-browsers/#browser-extensions) that modify the browser's `User-Agent` value or Web APIs such as `Canvas` and `WebGL`.
 - Implementations where a domain serves a challenge page originally requested for another domain.
 - Challenge pages cannot be embedded in cross-origin iframes.
 - Client software where the solve request of a Managed Challenge comes from a different IP than the original IP a challenge request was issued to. For example, if you receive the challenge from one IP and solve it using another IP, the solve is not valid and you may encounter a challenge loop.

--- a/src/content/docs/turnstile/troubleshooting/troubleshooting-faqs.mdx
+++ b/src/content/docs/turnstile/troubleshooting/troubleshooting-faqs.mdx
@@ -23,7 +23,7 @@ Turnstile is hosted under `challenges.cloudflare.com`.
 
 ## I am seeing a 401 error in your console during a Turnstile security check, is this a problem?
 
-You can safely ignore the error. It is requesting a [Private Access Token (PAT)](https://blog.cloudflare.com/eliminating-captchas-on-iphones-and-macs-using-new-standard/) that your device or browser does not support yet.
+You can safely ignore the error. It is requesting a [Private Access Token (PAT)](/cloudflare-challenges/reference/private-access-tokens/) that your device or browser does not support yet.
 
 
 ## How can I obtain the Ray ID or QR code for troubleshooting?


### PR DESCRIPTION
### Summary

Replaces a link on Turnstile's troubleshooting FAQs to go from a blog post to challenges dev docs + fixes a broken link on browser extensions

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
