### PR TITLE
[Docs Site] Use ClipboardItem for async fetch in CopyPageButton

### DIFF
--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -53,6 +53,7 @@ export default function CopyPageButton() {
 			const clipboardItem = new ClipboardItem({
 				["text/plain"]: fetch(markdownUrl)
 					.then((r) => r.text())
+					.then((t) => new Blob([t], { type: "text/plain" }))
 					.catch((e) => {
 						throw new Error(`Received ${e.message} for ${markdownUrl}`);
 					}),

--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -50,14 +50,15 @@ export default function CopyPageButton() {
 	const handleCopyMarkdown = async () => {
 		const markdownUrl = new URL("index.md", window.location.href).toString();
 		try {
-			const response = await fetch(markdownUrl);
+			const clipboardItem = new ClipboardItem({
+				["text/plain"]: fetch(markdownUrl)
+					.then((r) => r.text())
+					.catch((e) => {
+						throw new Error(`Received ${e.message} for ${markdownUrl}`);
+					}),
+			});
 
-			if (!response.ok) {
-				throw new Error(`Received ${response.status} on ${response.url}`);
-			}
-
-			const markdown = await response.text();
-			await navigator.clipboard.writeText(markdown);
+			await navigator.clipboard.write([clipboardItem]);
 			track("clicked copy page button", {
 				value: "copy markdown",
 			});


### PR DESCRIPTION
### Summary

Use ClipboardItem for async fetch in CopyPageButton

Fixes an issue with Safari where the transient activation required to allow clipboard access did not allow for the time taken in async calls.