### PR TITLE
[D1] D1 Prisma ORM tutorial update

### DIFF
--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -1,5 +1,5 @@
 ---
-updated: 2024-03-27
+updated: 2025-05-16
 difficulty: Beginner
 content_type: Tutorial
 pcx_content_type: tutorial
@@ -11,7 +11,7 @@ languages:
   - SQL
 ---
 
-import { WranglerConfig } from "~/components";
+import { WranglerConfig, FileTree } from "~/components";
 
 ## What is Prisma ORM?
 
@@ -86,6 +86,9 @@ generator client {
 +	previewFeatures = ["driverAdapters"]
 }
 ```
+:::note
+Do not specify an `output` destination in the `generator client` block. Instead, allow prisma to generate the files in the default output path.
+:::
 
 ### 3. Create your D1 database
 
@@ -108,7 +111,7 @@ Created your new D1 database.
     {
       "binding": "DB",
       "database_name": "prisma-demo-db",
-      "database_id": "<DATABASE_ID>"
+      "database_id": "<D1_DATABASE_ID>"
     }
   ]
 }
@@ -129,12 +132,12 @@ compatibility_flags = ["nodejs_compat"]
 [[d1_databases]]
 binding = "DB" # i.e. available in your Worker on env.DB
 database_name = "prisma-demo-db"
-database_id = "__YOUR_D1_DATABASE_ID__"
+database_id = "<D1_DATABASE_ID>"
 ```
 
 </WranglerConfig>
 
-`__YOUR_D1_DATABASE_ID__` should be replaced with the database ID of your D1 instance. If you were not able to fetch this ID from the terminal output, you can also find it in the [Cloudflare dashboard](https://dash.cloudflare.com/), or by running `npx wrangler d1 info prisma-demo-db` in your terminal.
+Replace `<D1_DATABASE_ID>` with the database ID of your D1 instance. If you were not able to fetch this ID from the terminal output, you can also find it in the [Cloudflare dashboard](https://dash.cloudflare.com/), or by running `npx wrangler d1 info prisma-demo-db` in your terminal.
 
 Next, you will create a database table in the database to send queries to D1 using Prisma ORM.
 
@@ -154,10 +157,11 @@ Answer `yes` to creating a new folder called `migrations`.
 
 The command has now created a new directory called `migrations` and an empty file called `0001_create_user_table.sql` inside of it:
 
-```
-migrations/
-└── 0001_create_user_table.sql
-```
+<FileTree>
+- prisma-d1-example
+  - migrations
+    - **0001_create_user_table.sql**
+</FileTree>
 
 Next, you need to add the SQL statement that will create a `User` table to that file.
 
@@ -198,7 +202,9 @@ You now need to use the `wrangler d1 migrations apply` command to send this SQL 
 - `--local`: Executes the statement against a _local_ version of D1. This local version of D1 is a SQLite database file that will be located in the `.wrangler/state` directory of your project. Use this approach when you want to develop and test your Worker on your local machine. Refer to [Local development](/d1/best-practices/local-development/) to learn more.
 - `--remote`: Executes the statement against your _remote_ version of D1. This version is used by your _deployed_ Cloudflare Workers. Refer to [Remote development](/d1/best-practices/remote-development/) to learn more.
 
-In this tutorial, you will do local and remote development. You will test the Worker locally and deploy your Worker afterwards. Open your terminal, and run both commands:
+In this tutorial, you will do both local and remote development. You will test the Worker locally, then deploy your Worker afterwards.
+
+Open your terminal, and run both commands:
 
 ```sh
 # For the local database
@@ -225,6 +231,10 @@ npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  \"User\" (\"email
 npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  \"User\" (\"email\", \"name\") VALUES
 ('jane@prisma.io', 'Jane Doe (Remote)');" --remote
 ```
+
+:::note
+If you receive an error to the effect of `Unknown arguments: (\email\,, \name\)...`, you may need to escape the double quotes with backticks (`) instead of backslashes (\\).
+:::
 
 ### 5. Query your database from the Worker
 

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -234,6 +234,14 @@ npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  \"User\" (\"email
 
 :::note
 If you receive an error to the effect of `Unknown arguments: (\email\,, \name\)...`, you may need to escape the double quotes with backticks (`) instead of backslashes (\\).
+
+Your Wrangler command will then look like:
+
+```sh
+# Escape with ` instead of \
+npx wrangler d1 execute prisma-demo-db --command "INSERT INTO  `"User`" (`"email`", `"name`") VALUES
+('jane@prisma.io', 'Jane Doe (Local)');" --<FLAG>
+```
 :::
 
 ### 5. Query your database from the Worker

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm/index.mdx
@@ -39,9 +39,7 @@ npm create cloudflare@latest prisma-d1-example -- --type hello-world
 In your terminal, you will be asked a series of questions related your project:
 
 1. Answer `yes` to using TypeScript.
-2. Answer `yes` to deploying your Worker.
-
-Once you deploy your Worker, you should be able to preview your Worker at `https://prisma-d1-example.USERNAME.workers.dev`, which displays "Hello World" in the browser.
+2. Answer `no` to deploying your Worker.
 
 ### 2. Initialize Prisma ORM
 
@@ -102,14 +100,18 @@ npx wrangler d1 create prisma-demo-db
 You should receive the following output on your terminal:
 
 ```
-✅ Successfully created DB 'prisma-demo-db' in region EEUR
-Created your database using D1's new storage backend. The new storage backend is not yet recommended for production workloads, but backs up your data via
-point-in-time restore.
+✅ Successfully created DB 'prisma-demo-db' in region WEUR
+Created your new D1 database.
 
-[[d1_databases]]
-binding = "DB" # i.e. available in your Worker on env.DB
-database_name = "prisma-demo-db"
-database_id = "__YOUR_D1_DATABASE_ID__"
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "prisma-demo-db",
+      "database_id": "<DATABASE_ID>"
+    }
+  ]
+}
 ```
 
 You now have a D1 database in your Cloudflare account with a binding to your Cloudflare Worker.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Lightly updated the D1 Prisma ORM tutorial page.

1. A note about escaping double quotes with backticks (`) instead of backslashes (\) has been added (an error which may be seen for Windows users, as pointed out in this PR https://github.com/cloudflare/cloudflare-docs/pull/22257.
2. Used "FileTree" component where appropriate.
3. Added a note to **not** specify the output path in the `prisma.schema`'s `generator client` block. When testing the steps, this was automatically populated, which caused errors when trying to deploy the Worker.
4. Ensured that the tutorial was still working.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
