### PR TITLE
[Pages] Include documentation for Node Version in nextjs/deploy-a-static-nextjs-site.mdx

### DIFF
--- a/src/content/docs/pages/framework-guides/nextjs/deploy-a-static-nextjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/deploy-a-static-nextjs-site.mdx
@@ -70,3 +70,19 @@ After deploying your site, you will receive a unique subdomain for your project 
 Every time you commit new code to your Next.js site, Cloudflare Pages will automatically rebuild your project and deploy it. You will also get access to [preview deployments](/pages/configuration/preview-deployments/) on new pull requests, so you can preview how changes look to your site before deploying them to production.
 
 For the complete guide to deploying your first site to Cloudflare Pages, refer to the [Get started guide](/pages/get-started/).
+
+## Using a specific Node.js version
+
+Some Next.js projects have additional requirements for different Node.js versions. 
+
+```sh
+You are using Node.js 18.17.1. For Next.js, Node.js version "^18.18.0 || ^19.8.0 || >= 20.0.0" is required.
+```
+To use a specific Node.js version for Next.js:
+
+1. In Root directory of your project, create a `.nvmrc` file
+1. Specify the version of Node.js required like below:
+
+```
+v18.18.0
+```


### PR DESCRIPTION
Included additional documentation for updating node version for a next.js static site using .nvmrc

### Summary

<!-- Add context such as the type of documentation being updated or added -->

Additional documentation to update Node.js version used is Cloudflare builds by default.

Recent Next.js versions require a minimum Node.js version to be used in builds. Most other documentation on specifying Node.js version applies to a full Next.js site. For a static website, the simplest approach is to update the `.nvmrc` file as Cloudflare builds use nvm for detection of node version

Fixes https://github.com/cloudflare/cloudflare-docs/issues/22529

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

