### PR TITLE
[Workers] fix incorrect link in index.mdx

### DIFF
--- a/src/content/docs/workers/index.mdx
+++ b/src/content/docs/workers/index.mdx
@@ -17,7 +17,7 @@ A serverless platform for building, deploying, and scaling apps across [Cloudfla
 
 With Cloudflare Workers, you can expect to:
 - Deliver fast performance with high reliability anywhere in the world
-- Build full-stack apps with your framework of choice, including [React](/workers/frameworks/framework-guides/react-router/), [Vue](/workers/frameworks/framework-guides/vue/), [Svelte](/workers/frameworks/framework-guides/svelte/), [Next](/workers/frameworks/framework-guides/nextjs/), [Astro](/workers/frameworks/framework-guides/astro/), [React Router](/workers/frameworks/framework-guides/react-router/), [and more](/workers/frameworks/)
+- Build full-stack apps with your framework of choice, including [React](/workers/frameworks/framework-guides/react/), [Vue](/workers/frameworks/framework-guides/vue/), [Svelte](/workers/frameworks/framework-guides/svelte/), [Next](/workers/frameworks/framework-guides/nextjs/), [Astro](/workers/frameworks/framework-guides/astro/), [React Router](/workers/frameworks/framework-guides/react-router/), [and more](/workers/frameworks/)
 - Use your preferred language, including [JavaScript](/workers/languages/javascript/), [TypeScript](/workers/languages/typescript/), [Python](/workers/languages/python/), [Rust](/workers/languages/rust/), [and more](/workers/runtime-apis/webassembly/)
 - Gain deep visibility and insight with built-in [observability](/workers/observability/logs/)
 - Get started for free and grow with flexible [pricing](/workers/platform/pricing/), affordable at any scale


### PR DESCRIPTION
### Summary

This pull request fixes the link to point to the correct React framework guide page.
Fixes #22533

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
