### PR TITLE
Documents connect being shut off when outbound worker is used

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers.mdx
@@ -18,6 +18,13 @@ Outbound Workers can be used to:
 * Create, allow, or block lists for hostnames requested by user Workers.
 * Configure authentication to your APIs behind the scenes (without end developers needing to set credentials).
 
+:::note
+
+When an Outbound Worker is enabled, your customer's Worker will no longer be able to use the [`connect() API`](/workers/runtime-apis/tcp-sockets/#connect)
+to create outbound TCP Sockets. This is to ensure all outbound communication goes through the Outbound Worker's `fetch` method.
+
+:::
+
 ## Use Outbound Workers
 
 To use Outbound Workers:


### PR DESCRIPTION
### Summary

When an outbound workers is on, the connect() API no longer works. This adds a note to the documentation explaining this.

In the long-run, we may add an outboundConnect-like API to allow the platform user to handle outbound TCP or allow them to turn it on/off with a toggle. If we do that, then this should be reverted or changed.

### Screenshot

![Screenshot 2025-05-19 at 9 49 20 AM](https://github.com/user-attachments/assets/2710ca76-9dcd-42c1-a76e-08bcb32d35e0)


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
