### PR TITLE
docs: correct spelling of repository in guide.mdx

### DIFF
--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -199,7 +199,7 @@ If you see [`523` errors](/support/troubleshooting/http-status-codes/cloudflare-
 
 To do more:
 
-- Push your project to a GitHub or GitLab respoitory then [connect to builds](/workers/ci-cd/builds/#get-started) to enable automatic builds and deployments.
+- Push your project to a GitHub or GitLab repository then [connect to builds](/workers/ci-cd/builds/#get-started) to enable automatic builds and deployments.
 - Visit the [Cloudflare dashboard](https://dash.cloudflare.com/) for simpler editing.
 - Review our [Examples](/workers/examples/) and [Tutorials](/workers/tutorials/) for inspiration.
 - Set up [bindings](/workers/runtime-apis/bindings/) to allow your Worker to interact with other resources and unlock new functionality.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
change `respoitory` to `repository`

