### PR TITLE
Remove unused "Example"

### DIFF
--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from "~/components";
 Affects interpretation of `width` and `height`. All resizing modes preserve aspect ratio. Used as a string in Workers integration. Available modes are:
 
 - `scale-down`\
-  Similar to `contain`, but the image is never enlarged. If the image is larger than given `width` or `height`, it will be resized. Otherwise its original size will be kept. Example:
+  Similar to `contain`, but the image is never enlarged. If the image is larger than given `width` or `height`, it will be resized. Otherwise its original size will be kept.
 - `contain`\
   Image will be resized (shrunk or enlarged) to be as large as possible within the given `width` or `height` while preserving the aspect ratio. If you only provide a single dimension (for example, only `width`), the image will be shrunk or enlarged to exactly match that dimension.
 - `cover`\


### PR DESCRIPTION
"Example:" string did not contain an example for the scale down fit. None of the other fits contained an example either.

### Summary

Options under https://developers.cloudflare.com/images/transform-images/transform-via-url/#fit do not contain any examples. The extra string causes confusion making it seem as though the other fit options are an example for scale-down

### Screenshots (optional)

<img width="572" alt="image" src="https://github.com/user-attachments/assets/0392e1bb-0691-4914-8be9-0bf6e3c6bf51" />


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
