### PR TITLE
Clarify 15MB limit for WAF Content Scanning

### DIFF
--- a/src/content/docs/waf/detections/malicious-uploads/index.mdx
+++ b/src/content/docs/waf/detections/malicious-uploads/index.mdx
@@ -58,7 +58,7 @@ All content objects in an incoming request will be checked, namely for requests 
 The content scanner will fully check content objects with a size up to 15 MB. For larger content objects, the scanner will analyze the first 15 MB and provide scan results based on that portion of the object.
 
 :::caution
-The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations.
+The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations. Please also note that the size limit of 15MB still applies for all plans.
 :::
 
 ## Custom scan expressions

--- a/src/content/docs/waf/detections/malicious-uploads/index.mdx
+++ b/src/content/docs/waf/detections/malicious-uploads/index.mdx
@@ -58,7 +58,7 @@ All content objects in an incoming request will be checked, namely for requests 
 The content scanner will fully check content objects with a size up to 15 MB. For larger content objects, the scanner will analyze the first 15 MB and provide scan results based on that portion of the object.
 
 :::caution
-The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations. Please also note that the size limit of 15MB still applies for all plans.
+The AV scanner will not scan some particular types of files, namely encrypted or password-protected files. Refer to [Non-scannable files](/cloudflare-one/policies/gateway/http-policies/antivirus-scanning/#non-scannable-files) for a list of AV scanning limitations. For WAF content scanning, the size limit of 15 MB applies to all plans.
 :::
 
 ## Custom scan expressions


### PR DESCRIPTION
The linked page goes to a Cloudflare Gateway page, which has different limits per plan. Adding this comment to clarify that WAF Content Scanning is subject to the 15MB limit on all plans.


