### PR TITLE
Clarify dashboard account/domain roles needed for Google Tag Gateway

### DIFF
--- a/src/content/docs/google-tag-gateway/index.mdx
+++ b/src/content/docs/google-tag-gateway/index.mdx
@@ -12,6 +12,10 @@ Google tag gateway for advertisers allows website owners using Cloudflare as a C
 
 ### Configure Google tag gateway for advertisers in the dashboard
 
+:::note
+Your Cloudflare dashboard user must have one of the following [Account Roles](/fundamentals/setup/manage-members/roles/#account-scoped-roles): Super Administrator, Administrator or Zaraz Admin. If you are using Domain Scoped Roles, your [Domain Role](/fundamentals/setup/manage-members/roles/#domain-scoped-roles) must be Domain Administrator.
+:::
+
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account.
 2. Go to **Tag Management** > **Google tag gateway**.
 3. Select your domain.


### PR DESCRIPTION
Clarify dashboard account/domain roles needed for Google Tag Gateway