### PR TITLE
[Docs Site] Reorder Pricing for Vectorize

### DIFF
--- a/src/content/partials/vectorize/vectorize-pricing.mdx
+++ b/src/content/partials/vectorize/vectorize-pricing.mdx
@@ -2,10 +2,10 @@
 {}
 ---
 
-|                                     | [Workers Paid](/workers/platform/pricing/#workers)                              | [Workers Free](/workers/platform/pricing/#workers) |
-| ----------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- |
-| **Total queried vector dimensions** | First 50 million queried vector dimensions / month included + $0.01 per million | 30 million queried vector dimensions / month       |
-| **Total stored vector dimensions**  | First 10 million stored vector dimensions + $0.05 per 100 million               | 5 million stored vector dimensions                 |
+|                                     | [Workers Free](/workers/platform/pricing/#workers)       | [Workers Paid](/workers/platform/pricing/#workers)                              |
+| ----------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Total queried vector dimensions** | 30 million queried vector dimensions / month             | First 50 million queried vector dimensions / month included + $0.01 per million |
+| **Total stored vector dimensions**  | 5 million stored vector dimensions                       | First 10 million stored vector dimensions + $0.05 per 100 million               |
 
 ### Calculating vector dimensions
 


### PR DESCRIPTION


### Summary

Reordered the pricing page for Vectorize to be consistent with other pricing pages. 

#### Order
Before: Paid, Free
After: Free, Paid

### Screenshots (optional)
Before:
<img width="965" alt="Screenshot 2025-05-23 at 11 58 21 AM" src="https://github.com/user-attachments/assets/c3e86c4e-2edb-4663-9285-8a1f6b127233" />

After:
<img width="951" alt="Screenshot 2025-05-23 at 11 57 19 AM" src="https://github.com/user-attachments/assets/25420ef9-0885-474f-9daf-cc4e3ed28c33" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
