### PR TITLE
[Workers] Update worker-size limits docs

### DIFF
--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -190,7 +190,7 @@ These errors occur when a Worker is uploaded or modified.
 | `10016`    | Invalid Worker name.                                                                                                            |
 | `10021`    | Validation Error. Refer to [Validation Errors](/workers/observability/errors/#validation-errors-10021) for details.             |
 | `10026`    | Could not parse request body.                                                                                                   |
-| `10027`    | Your Worker exceeded the size limit of XX MB (for more details see [Worker size limits](/workers/platform/limits/#worker-size)) |
+| `10027`    | The uploaded Worker exceeded the [Worker size limits](/workers/platform/limits/#worker-size). |
 | `10035`    | Multiple attempts to modify a resource at the same time                                                                         |
 | `10037`    | An account has exceeded the number of [Workers allowed](/workers/platform/limits/#number-of-workers).                           |
 | `10052`    | A [binding](/workers/runtime-apis/bindings/) is uploaded without a name.                                                        |
@@ -205,14 +205,6 @@ These errors occur when a Worker is uploaded or modified.
 The 10021 error code includes all errors that occur when you attempt to deploy a Worker, and Cloudflare then attempts to load and run the top-level scope (everything that happens before your Worker's [handler](/workers/runtime-apis/handlers/) is invoked). For example, if you attempt to deploy a broken Worker with invalid JavaScript that would throw a `SyntaxError` — Cloudflare will not deploy your Worker.
 
 Specific error cases include but are not limited to:
-
-#### Worker exceeded the upload size limit
-
-A Worker can be up to 10 MB in size after compression on the Workers Paid plan, and up to 3 MB on the Workers Free plan.
-
-To reduce the upload size of a Worker, you should consider removing unnecessary dependencies and/or using Workers KV, a D1 database or R2 to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code.
-
-Another method to reduce a Worker's file size is to split its functionality across multiple Workers and connect them using [Service bindings](/workers/runtime-apis/bindings/service-bindings/).
 
 #### Script startup exceeded CPU time limit
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -273,7 +273,7 @@ Each environment variable has a size limitation of 5 KB.
 
 ## Worker size
 
-A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan, and up to 3 MB on the Workers Free plan.
+A Worker can be up to 10 MB in size _after compression_ on the Workers Paid plan, and up to 3 MB on the Workers Free plan. On either plan, a Worker can be up to 64 MB _before compression_.
 
 You can assess the size of your Worker bundle after compression by performing a dry-run with `wrangler` and reviewing the final compressed (`gzip`) size output by `wrangler`:
 
@@ -286,7 +286,13 @@ wrangler deploy --outdir bundled/ --dry-run
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
 
-Note that larger Worker bundles can impact the start-up time of the Worker, as the Worker needs to be loaded into memory. You should consider removing unnecessary dependencies and/or using [Workers KV](/kv/), a [D1 database](/d1/) or [R2](/r2/) to store configuration files, static assets and binary data instead of attempting to bundle them within your Worker code.
+Note that larger Worker bundles can impact the start-up time of the Worker, as the Worker needs to be loaded into memory.
+
+To reduce the upload size of a Worker, consider some of the following strategies:
+
+- Removing unnecessary dependencies and packages
+- Storing configuration files, static assets, and binary data using [Workers KV](/kv/), [R2](/r2/), [D1](/d1/), or [Workers Static Assets](/workers/static-assets/) instead of bundling them within your Worker code.
+- Splitng functionality across multiple Workers and connecting them using [Service bindings](/workers/runtime-apis/bindings/service-bindings/).
 
 ---
 


### PR DESCRIPTION
### Summary

* simplify meaning text (avoid wrap, remove XXMB phrasing)
* consolidate remediation recommendations to limits doc (size-err doesn't belong in 10021 section anyhow)
* add 64M uncompressed limit (always existed; never documented)
* mention Assets for hosting static assets

## Screenshots
![image](https://github.com/user-attachments/assets/cafdab62-3923-44ce-a162-122725847da4)
![image](https://github.com/user-attachments/assets/f304eb23-da4c-42d6-a27a-9163fd612671)


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

