### PR TITLE
[Workers] fixed misspelling in build_branches.mdx

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/build-branches.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-branches.mdx
@@ -24,4 +24,4 @@ To enable or disable non-production branch builds:
 1. In **Overview**, select your Workers project.
 2. Go to **Settings** > **Build** > **Branch control**. The checkbox allows you to enable or disable builds for non-production branches.
 
-When enabled, every push event made to a non-production branch will trigger a build and execute the [build command](/workers/ci-cd/builds/configuration/#build-command), follwed by the [non-production branch deploy command](/workers/ci-cd/builds/configuration/#non-production-branch-deploy-command).
+When enabled, every push event made to a non-production branch will trigger a build and execute the [build command](/workers/ci-cd/builds/configuration/#build-command), followed by the [non-production branch deploy command](/workers/ci-cd/builds/configuration/#non-production-branch-deploy-command).


### PR DESCRIPTION
### Summary

Fixed spelling "follwed" to "followed" on the final sentence of the workers build branches page, build_branches.mdx.