### PR TITLE
docs(tutorial): fix link to cloudflare_dns_record

### DIFF
--- a/src/content/docs/terraform/tutorial/index.mdx
+++ b/src/content/docs/terraform/tutorial/index.mdx
@@ -12,7 +12,7 @@ Before you begin, [install Terraform](/terraform/installing/). Each tutorial bui
 
 * Brief introduction.
 * Introduction of `terraform init`, `plan`, `apply`, and `show`.
-* Resource covered: [`cloudflare_dns_record`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) (DNS record).
+* Resource covered: [`cloudflare_record`](https://registry.terraform.io/providers/cloudflare/cloudflare/4.52.0/docs/resources/record) (DNS record).
 
 ## [2 – Track your history](/terraform/tutorial/track-history/)
 

--- a/src/content/docs/terraform/tutorial/index.mdx
+++ b/src/content/docs/terraform/tutorial/index.mdx
@@ -6,13 +6,13 @@ sidebar:
 
 ---
 
-Before you begin, make sure you [install Terraform](/terraform/installing/). Each tutorial builds on the previous, so you should complete the tutorials in the order shown below.
+Before you begin, [install Terraform](/terraform/installing/). Each tutorial builds on the previous, so you should complete the tutorials in the order shown below.
 
 ## [1 – Initialize Terraform](/terraform/tutorial/initialize-terraform/)
 
 * Brief introduction.
 * Introduction of `terraform init`, `plan`, `apply`, and `show`.
-* Resource covered: [`cloudflare_record`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) (DNS record).
+* Resource covered: [`cloudflare_dns_record`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) (DNS record).
 
 ## [2 – Track your history](/terraform/tutorial/track-history/)
 


### PR DESCRIPTION
### Summary

Update the link to the current cloudflare_dns_record resource in place of the depcrated cloudflare_record resource

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
