### PR TITLE
[R2] Improving visibility of common use-cases

### DIFF
--- a/src/content/docs/r2/buckets/create-buckets.mdx
+++ b/src/content/docs/r2/buckets/create-buckets.mdx
@@ -47,6 +47,6 @@ wrangler r2 bucket delete BUCKET_TO_DELETE
 
 ## Notes
 
-- Bucket names and buckets are not public by default. To allow public access to a bucket, [refer to the public bucket documentation](/r2/buckets/public-buckets/).
+- Bucket names and buckets are not public by default. To allow public access to a bucket, refer to [Public buckets](/r2/buckets/public-buckets/).
 - For information on controlling access to your R2 bucket with Cloudflare Access, refer to [Protect an R2 Bucket with Cloudflare Access](/r2/tutorials/cloudflare-access/).
 - Invalid (unauthorized) access attempts to private buckets do not incur R2 operations charges against that bucket. Refer to the [R2 pricing FAQ](/r2/pricing/#frequently-asked-questions) to understand what operations are billed vs. not billed.

--- a/src/content/docs/r2/buckets/create-buckets.mdx
+++ b/src/content/docs/r2/buckets/create-buckets.mdx
@@ -47,5 +47,6 @@ wrangler r2 bucket delete BUCKET_TO_DELETE
 
 ## Notes
 
-- Bucket names and buckets are not public by default. To allow public access to a bucket, [visit the public bucket documentation](/r2/buckets/public-buckets/).
+- Bucket names and buckets are not public by default. To allow public access to a bucket, [refer to the public bucket documentation](/r2/buckets/public-buckets/).
+- For information on controlling access to your R2 bucket with Cloudflare Access, refer to [Protect an R2 Bucket with Cloudflare Access](/r2/tutorials/cloudflare-access/).
 - Invalid (unauthorized) access attempts to private buckets do not incur R2 operations charges against that bucket. Refer to the [R2 pricing FAQ](/r2/pricing/#frequently-asked-questions) to understand what operations are billed vs. not billed.

--- a/src/content/docs/r2/buckets/public-buckets.mdx
+++ b/src/content/docs/r2/buckets/public-buckets.mdx
@@ -44,7 +44,7 @@ For more information on default Cache behavior and how to customize it, refer to
 
 To restrict access to your custom domain's bucket, use Cloudflare's existing security products.
 
-- [Cloudflare Zero Trust Access](/cloudflare-one/applications/configure-apps): Protects buckets that should only be accessible by your teammates. Refer to the tutorial: [Protect an R2 Bucket with Cloudflare Access](/r2/tutorials/cloudflare-access/) for more information.
+- [Cloudflare Zero Trust Access](/cloudflare-one/applications/configure-apps): Protects buckets that should only be accessible by your teammates. Refer to [Protect an R2 Bucket with Cloudflare Access](/r2/tutorials/cloudflare-access/) tutorial for more information.
 - [Cloudflare WAF Token Authentication](/waf/custom-rules/use-cases/configure-token-authentication/): Restricts access to documents, files, and media to selected users by providing them with an access token.
 
 :::caution

--- a/src/content/docs/r2/buckets/public-buckets.mdx
+++ b/src/content/docs/r2/buckets/public-buckets.mdx
@@ -44,7 +44,7 @@ For more information on default Cache behavior and how to customize it, refer to
 
 To restrict access to your custom domain's bucket, use Cloudflare's existing security products.
 
-- [Cloudflare Zero Trust Access](/cloudflare-one/applications/configure-apps): Protects buckets that should only be accessible by your teammates.
+- [Cloudflare Zero Trust Access](/cloudflare-one/applications/configure-apps): Protects buckets that should only be accessible by your teammates. Refer to the tutorial: [Protect an R2 Bucket with Cloudflare Access](/r2/tutorials/cloudflare-access/) for more information.
 - [Cloudflare WAF Token Authentication](/waf/custom-rules/use-cases/configure-token-authentication/): Restricts access to documents, files, and media to selected users by providing them with an access token.
 
 :::caution

--- a/src/content/docs/r2/buckets/storage-classes.mdx
+++ b/src/content/docs/r2/buckets/storage-classes.mdx
@@ -102,5 +102,5 @@ aws s3api --endpoint-url https://<ACCONUT_ID>.r2.cloudflarestorage.com \
   --storage-class STANDARD_IA
 ```
 
-- Refer to [object-level operations](/r2/api/s3/api/#object-level-operations) for the full list of object-level API operations with R2-compatible S3 API.
 - Refer to [aws CLI](/r2/examples/aws/aws-cli/) for more information on using `aws CLI`.
+- Refer to [object-level operations](/r2/api/s3/api/#object-level-operations) for the full list of object-level API operations with R2-compatible S3 API.

--- a/src/content/docs/r2/buckets/storage-classes.mdx
+++ b/src/content/docs/r2/buckets/storage-classes.mdx
@@ -4,7 +4,7 @@ pcx_content_type: how-to
 
 ---
 
-import { Badge } from "~/components"
+import { Badge, Tabs, TabItem } from "~/components"
 
 Storage classes allow you to trade off between the cost of storage and the cost of accessing data. Every object stored in R2 has an associated storage class.
 
@@ -16,50 +16,10 @@ All storage classes share the following characteristics:
 
 ## Available storage classes
 
-<table>
-  <tbody>
-    <th style="width:25%">
-      Storage class
-    </th>
-    <th style="width:25%">
-      Minimum storage duration
-    </th>
-    <th style="width:25%">
-      Data retrieval fees (processing)
-    </th>
-    <th style="width:25%">
-      Egress fees (data transfer to Internet)
-    </th>
-    <tr>
-      <td>
-        Standard
-      </td>
-      <td>
-        None
-      </td>
-      <td>
-        None
-      </td>
-      <td>
-        None
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Infrequent Access <inline-pill style="beta" />
-      </td>
-      <td>
-        30 days
-      </td>
-      <td>
-        Yes
-      </td>
-      <td>
-        None
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Storage class                  | Minimum storage duration  | Data retrieval fees (processing) | Egress fees (data transfer to Internet)  |
+|--------------------------------|---------------------------|----------------------------------|------------------------------------------|
+| Standard                       | None                      | None                             | None                                     |
+| Infrequent Access              | 30 days                   | Yes                              | None                                     |
 
 For more information on how storage classes impact pricing, refer to [Pricing](/r2/pricing/).
 
@@ -124,3 +84,23 @@ Once an object is stored in Infrequent Access, it cannot be transitioned to Stan
 :::
 
 To learn more about how to transition objects from Standard storage to Infrequent Access storage, refer to [Object lifecycles](/r2/buckets/object-lifecycles/).
+
+## Change storage class for objects
+
+You can change the storage class of an object which is already stored in R2 using the [`CopyObject` API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html).
+
+Use the `x-amz-storage-class` header to change between `STANDARD` and `STANDARD_IA`.
+
+An example of switching an object from `STANDARD` to `STANDARD_IA` using `aws cli` is shown below:
+
+```sh
+aws s3api --endpoint-url https://<ACCONUT_ID>.r2.cloudflarestorage.com \
+  --copy-object \
+  --bucket bucket-name \
+  --key path/to/object.txt \
+  --copy-source bucket-name/path/to/object.txt \
+  --storage-class STANDARD_IA
+```
+
+- Refer to [object-level operations](/r2/api/s3/api/#object-level-operations) for the full list of object-level API operations with R2-compatible S3 API.
+- Refer to [aws CLI](/r2/examples/aws/aws-cli/) for more information on using `aws CLI`.

--- a/src/content/docs/r2/buckets/storage-classes.mdx
+++ b/src/content/docs/r2/buckets/storage-classes.mdx
@@ -94,11 +94,11 @@ Use the `x-amz-storage-class` header to change between `STANDARD` and `STANDARD_
 An example of switching an object from `STANDARD` to `STANDARD_IA` using `aws cli` is shown below:
 
 ```sh
-aws s3api --endpoint-url https://<ACCONUT_ID>.r2.cloudflarestorage.com \
-  --copy-object \
+aws s3api copy-object \
+  --endpoint-url https://<ACCONUT_ID>.r2.cloudflarestorage.com \
   --bucket bucket-name \
   --key path/to/object.txt \
-  --copy-source bucket-name/path/to/object.txt \
+  --copy-source /bucket-name/path/to/object.txt \
   --storage-class STANDARD_IA
 ```
 

--- a/src/content/docs/r2/get-started.mdx
+++ b/src/content/docs/r2/get-started.mdx
@@ -57,6 +57,6 @@ You will receive a confirmation message after a successful upload.
 
 Cloudflare provides multiple ways for developers to access their R2 buckets:
 
-- [Workers Runtime API](/r2/api/workers/workers-api-usage/)
+- [R2 Workers Binding API](/r2/api/workers/workers-api-usage/)
 - [S3 API compatibility](/r2/api/s3/api/)
 - [Public buckets](/r2/buckets/public-buckets/)

--- a/src/content/docs/r2/objects/delete-objects.mdx
+++ b/src/content/docs/r2/objects/delete-objects.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 3
 ---
 
+import { Render } from "~/components";
+
 You can delete objects from your bucket from the Cloudflare dashboard or using the Wrangler.
 
 ## Delete objects via the Cloudflare dashboard
@@ -36,3 +38,5 @@ wrangler r2 object delete test-bucket/foo.png
 Deleting object "foo.png" from bucket "test-bucket".
 Delete complete.
 ```
+
+<Render file="link-to-workers-r2-api" product="r2"/>

--- a/src/content/docs/r2/objects/download-objects.mdx
+++ b/src/content/docs/r2/objects/download-objects.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 2
 ---
 
+import { Render } from "~/components";
+
 You can download objects from your bucket from the Cloudflare dashboard or using the Wrangler.
 
 ## Download objects via the Cloudflare dashboard
@@ -30,3 +32,5 @@ Download complete.
 ```
 
 The file will be downloaded into the current working directory. You can also use the `--file` flag to set a new name for the object as it is downloaded, and the `--pipe` flag to pipe the download to standard output (stdout).
+
+<Render file="link-to-workers-r2-api" product="r2"/>

--- a/src/content/docs/r2/objects/index.mdx
+++ b/src/content/docs/r2/objects/index.mdx
@@ -6,8 +6,10 @@ sidebar:
 
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing, Render } from "~/components"
 
 Objects are individual files or data that you store in an R2 bucket.
 
 <DirectoryListing />
+
+<Render file="link-to-workers-r2-api" product="r2"/>

--- a/src/content/docs/r2/objects/multipart-objects.mdx
+++ b/src/content/docs/r2/objects/multipart-objects.mdx
@@ -6,6 +6,8 @@ sidebar:
 
 ---
 
+import { Render } from "~/components";
+
 R2 supports [S3 API's Multipart Upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) with some limitations.
 
 ## Limitations
@@ -34,3 +36,5 @@ Note that the binary MD5 sums themselves are concatenated and then summed, not t
 echo -n $(echo -n bce6bf66aeb76c7040fdd5f4eccb78e6 | xxd -r -p -)\
 $(echo -n 8165449fc15bbf43d3b674595cbcc406 | xxd -r -p -) | md5sum
 ```
+
+<Render file="link-to-workers-r2-api" product="r2"/>

--- a/src/content/docs/r2/objects/upload-objects.mdx
+++ b/src/content/docs/r2/objects/upload-objects.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-import { Steps, Tabs, TabItem } from "~/components"
+import { Steps, Tabs, TabItem, Render } from "~/components"
 
 You can upload objects to your bucket from using API (both [Workers Binding API](/r2/api/workers/workers-api-reference/) or [compatible S3 API](/r2/api/s3/api/)), rclone, Cloudflare dashboard, or Wrangler.
 
@@ -72,3 +72,5 @@ Wrangler's `object put` command only allows you to upload one object at a time.
 
 Use rclone if you wish to upload multiple objects to R2.
 :::
+
+<Render file="link-to-workers-r2-api" product="r2"/>

--- a/src/content/partials/r2/link-to-workers-r2-api.mdx
+++ b/src/content/partials/r2/link-to-workers-r2-api.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+## Other resources
+
+For information on R2 Workers Binding API, refer to [R2 Workers API reference](/r2/api/workers/workers-api-reference/).


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Making it easier to go to R2 Workers Binding API by surfacing links in more places.
2. Adding a small section on changing the object type from STANDARD to STANDARD_IA using `aws cli`. This does not require users to configure lifecycle rules. I've explicitly tested the steps using `aws cli`, and have confirmed it to work.
3. Surfacing link to the tutorial 'Protect an R2 Bucket with Cloudflare Access` (https://developers.cloudflare.com/r2/tutorials/cloudflare-access/) in more / relevant places for better discoverability.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
