### PR TITLE
Clarify additional option

### DIFF
--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
@@ -120,7 +120,7 @@ It should also have updated [Access Control Lists (ACLs)](/dns/zone-setups/zone-
 
 Using the information from your secondary DNS provider, [create NS records](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) on your zone apex listing your secondary nameservers.
 
-By default, Cloudflare ignores NS records added to the zone apex. To modify this behavior, enable [multi-provider DNS](/dns/nameservers/nameserver-options/#multi-provider-dns). 
+By default, Cloudflare ignores NS records added to the zone apex. To modify this behavior, enable [multi-provider DNS](/dns/nameservers/nameserver-options/#multi-provider-dns).
 
 :::note
 If your account [zone defaults](/dns/additional-options/dns-zone-defaults/) are already defined to have **Multi-provider DNS** enabled, this step may not be necessary.
@@ -147,7 +147,9 @@ Send the following `PATCH` request replacing the placeholders with your zone ID 
 
 </TabItem> </Tabs>
 
-In case you want to keep Cloudflare as the only public Primary, do not enable multi-provider DNS. In this way, your secondary DNS is kept hidden and up-to-date with the Cloudflare primary, as a backup option for disaster recovery scenarios.
+:::note
+In case you want to keep Cloudflare as the only authoritative DNS provider, do not enable multi-provider DNS. In this way, your secondary DNS is kept hidden and up-to-date with the Cloudflare primary, as a backup option for disaster recovery scenarios.
+:::
 
 ## 6. Enable outgoing zone transfers
 

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-primary/setup.mdx
@@ -120,7 +120,7 @@ It should also have updated [Access Control Lists (ACLs)](/dns/zone-setups/zone-
 
 Using the information from your secondary DNS provider, [create NS records](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records) on your zone apex listing your secondary nameservers.
 
-By default, Cloudflare ignores NS records added to the zone apex. To modify this behavior, enable [multi-provider DNS](/dns/nameservers/nameserver-options/#multi-provider-dns):
+By default, Cloudflare ignores NS records added to the zone apex. To modify this behavior, enable [multi-provider DNS](/dns/nameservers/nameserver-options/#multi-provider-dns). 
 
 :::note
 If your account [zone defaults](/dns/additional-options/dns-zone-defaults/) are already defined to have **Multi-provider DNS** enabled, this step may not be necessary.
@@ -146,6 +146,8 @@ Send the following `PATCH` request replacing the placeholders with your zone ID 
 />
 
 </TabItem> </Tabs>
+
+In case you want to keep Cloudflare as the only public Primary, do not enable multi-provider DNS. In this way, your secondary DNS is kept hidden and up-to-date with the Cloudflare primary, as a backup option for disaster recovery scenarios.
 
 ## 6. Enable outgoing zone transfers
 


### PR DESCRIPTION
Some users might want to use Cloudflare as public primary and their DNS infrastructure as hidden secondary for DR purposes.  Clarify that this is also possible.
