### PR TITLE
Document that previews don't have logs

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -105,3 +105,4 @@ If you disable Preview URLs in the Cloudflare dashboard but do not update your W
 - Preview URLs are not generated for Workers that implement a [Durable Object](/durable-objects/).
 - Preview URLs are not currently generated for [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) [user Workers](/cloudflare-for-platforms/workers-for-platforms/reference/how-workers-for-platforms-works/#user-workers). This is a temporary limitation, we are working to remove it.
 - You cannot currently configure Preview URLs to run on a subdomain other than [`workers.dev`](/workers/configuration/routing/workers-dev/).
+- You cannot view logs for Preview URLs today, this includes Workers Logs, Wrangler tail and Logpush.


### PR DESCRIPTION
### Summary

Question around preview url logs comes up quite a bit but we don't document the limitation today.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
