### PR TITLE
[Workers for Platforms] Fix pricing formula for scripts in pricing.mdx

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
@@ -27,7 +27,7 @@ A Workers for Platforms project that serves 100 million requests per month, uses
 | **Subscription** | $25.00        |                                                                                                             |
 | **Requests**     | $24.00        | (100,000,000 requests - 20,000,000 included requests) / 1,000,000 \* $0.30                                  |
 | **CPU time**     | $18.80        | ((10 ms of CPU time per request \* 100,000,000 requests) - 60,000,000 included CPU ms) / 1,000,000 \* $0.02 |
-| **Scripts**      | $4.00         | 1200 scripts - 1000 included scripts \* $0.02                                                               |
+| **Scripts**      | $4.00         | (1200 scripts - 1000 included scripts) \* $0.02                                                             |
 | **Total**        | $71.80        |                                                                                                             |
 
 :::note[Custom limits]

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
@@ -27,7 +27,7 @@ A Workers for Platforms project that serves 100 million requests per month, uses
 | **Subscription** | $25.00        |                                                                                                             |
 | **Requests**     | $24.00        | (100,000,000 requests - 20,000,000 included requests) / 1,000,000 \* $0.30                                  |
 | **CPU time**     | $18.80        | ((10 ms of CPU time per request \* 100,000,000 requests) - 60,000,000 included CPU ms) / 1,000,000 \* $0.02 |
-| **Scripts**      | $4.00         | (1200 scripts - 1000 included scripts) \* $0.02                                                             | 
+| **Scripts**      | $4.00         | (1200 scripts - 1000 included scripts) \* $0.02                                                             |
 | **Total**        | $71.80        |                                                                                                             |
 
 :::note[Custom limits]

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/platform/pricing.mdx
@@ -27,7 +27,7 @@ A Workers for Platforms project that serves 100 million requests per month, uses
 | **Subscription** | $25.00        |                                                                                                             |
 | **Requests**     | $24.00        | (100,000,000 requests - 20,000,000 included requests) / 1,000,000 \* $0.30                                  |
 | **CPU time**     | $18.80        | ((10 ms of CPU time per request \* 100,000,000 requests) - 60,000,000 included CPU ms) / 1,000,000 \* $0.02 |
-| **Scripts**      | $4.00         | (1200 scripts - 1000 included scripts) \* $0.02                                                             |
+| **Scripts**      | $4.00         | (1200 scripts - 1000 included scripts) \* $0.02                                                             | 
 | **Total**        | $71.80        |                                                                                                             |
 
 :::note[Custom limits]


### PR DESCRIPTION
### Summary

* Fixes order of operations. Without parentheses surrounding the subtraction, the result is `1,200 − 1,000 * 0.02 = 1,180` instead of  `(1,200 − 1,000) * 0.02 = 4`

