### PR TITLE
[Docs Site] New schema value for Support AI

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -83,6 +83,16 @@ if (shouldNoIndex) {
 	});
 }
 
+if (frontmatter.chatbot_deprioritize) {
+	head.push({
+		tag: "meta",
+		attrs: {
+			name: "pcx_chatbot_deprioritize",
+			content: frontmatter.chatbot_deprioritize,
+		},
+	});
+}
+
 if (
 	frontmatter.description &&
 	head.findIndex(

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -9,6 +9,7 @@ import type { CollectionEntry } from "astro:content";
 
 const DEFAULT_TITLE_DELIMITER = "|";
 const NOINDEX_PRODUCTS = ["email-security", "style-guide", "security"];
+const CHATBOT_DEPRIORITIZE_PRODUCTS = ["firewall"];
 
 const currentSection = Astro.url.pathname.split("/")[1].replaceAll(".", "");
 
@@ -21,6 +22,10 @@ const shouldNoIndex =
 	NOINDEX_PRODUCTS.includes(currentSection) ||
 	frontmatter.noindex ||
 	frontmatter.external_link;
+
+const shouldChatbotDeprioritize =
+	CHATBOT_DEPRIORITIZE_PRODUCTS.includes(currentSection) ||
+	frontmatter.chatbot_deprioritize;
 
 if (currentSection) {
 	const product = await getEntry("products", currentSection);
@@ -83,12 +88,12 @@ if (shouldNoIndex) {
 	});
 }
 
-if (frontmatter.chatbot_deprioritize) {
+if (shouldChatbotDeprioritize) {
 	head.push({
 		tag: "meta",
 		attrs: {
 			name: "pcx_chatbot_deprioritize",
-			content: frontmatter.chatbot_deprioritize,
+			content: true,
 		},
 	});
 }

--- a/src/content/docs/firewall/index.mdx
+++ b/src/content/docs/firewall/index.mdx
@@ -8,6 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Cloudflare Firewall Rules (deprecated)
+chatbot_relevant: false
 ---
 
 import { FeatureTable, Render } from "~/components";

--- a/src/content/docs/firewall/index.mdx
+++ b/src/content/docs/firewall/index.mdx
@@ -8,7 +8,7 @@ sidebar:
 head:
   - tag: title
     content: Cloudflare Firewall Rules (deprecated)
-chatbot_relevant: false
+chatbot_deprioritize: true
 ---
 
 import { FeatureTable, Render } from "~/components";

--- a/src/content/docs/firewall/index.mdx
+++ b/src/content/docs/firewall/index.mdx
@@ -8,7 +8,6 @@ sidebar:
 head:
   - tag: title
     content: Cloudflare Firewall Rules (deprecated)
-chatbot_deprioritize: true
 ---
 
 import { FeatureTable, Render } from "~/components";

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -97,13 +97,13 @@ export const baseSchema = ({ image }: SchemaContext) =>
 			.boolean()
 			.optional()
 			.describe(
-				"If true, this property adds a `noindex` declaration to the page, which will tell internal / external search crawlers to ignore this page. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `chatbot_relevant` property.",
+				"If true, this property adds a `noindex` declaration to the page, which will tell internal / external search crawlers to ignore this page. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `chatbot_deprioritize` property.",
 			),
-		chatbot_relevant: z
+		chatbot_deprioritize: z
 			.boolean()
 			.optional()
 			.describe(
-				"If false, this property will de-prioritize this page in the responses surfaced by Support AI. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `noindex` property.",
+				"If true, this property will de-prioritize this page in the responses surfaced by Support AI. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `noindex` property.",
 			),
 		sidebar,
 		hideChildren: z

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -97,7 +97,13 @@ export const baseSchema = ({ image }: SchemaContext) =>
 			.boolean()
 			.optional()
 			.describe(
-				"If true, this property adds a `noindex` declaration to the page, which will tell internal / external search crawlers to ignore this page. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/).",
+				"If true, this property adds a `noindex` declaration to the page, which will tell internal / external search crawlers to ignore this page. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `chatbot_relevant` property.",
+			),
+		chatbot_relevant: z
+			.boolean()
+			.optional()
+			.describe(
+				"If false, this property will de-prioritize this page in the responses surfaced by Support AI. Helpful for pages that are historically accurate, but no longer recommended, such as [Workers Sites](/workers/configuration/sites/). Companion to the `noindex` property.",
 			),
 		sidebar,
 		hideChildren: z

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -32,12 +32,16 @@ export async function htmlToMarkdown(
 	const description = dom.querySelector("meta[name='description']")?.attributes
 		.content;
 	const lastUpdated = dom.querySelector(".meta time")?.attributes.datetime;
+	const chatbotDeprioritize = dom.querySelector(
+		"meta[name='pcx_chatbot_deprioritize']",
+	)?.attributes.content;
 
 	const withFrontmatter = [
 		"---",
 		`title: ${title}`,
 		description ? `description: ${description}` : [],
 		lastUpdated ? `lastUpdated: ${lastUpdated}` : [],
+		chatbotDeprioritize ? `chatbotDeprioritize: ${chatbotDeprioritize}` : [],
 		`source_url:`,
 		`  html: ${url.replace("index.md", "")}`,
 		`  md: ${url}`,

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -35,6 +35,7 @@ export async function htmlToMarkdown(
 	const chatbotDeprioritize = dom.querySelector(
 		"meta[name='pcx_chatbot_deprioritize']",
 	)?.attributes.content;
+	const tags = dom.querySelector("meta[name='pcx_tags']")?.attributes.content;
 
 	const withFrontmatter = [
 		"---",
@@ -42,6 +43,7 @@ export async function htmlToMarkdown(
 		description ? `description: ${description}` : [],
 		lastUpdated ? `lastUpdated: ${lastUpdated}` : [],
 		chatbotDeprioritize ? `chatbotDeprioritize: ${chatbotDeprioritize}` : [],
+		tags ? `tags: ${tags}` : [],
 		`source_url:`,
 		`  html: ${url.replace("index.md", "")}`,
 		`  md: ${url}`,


### PR DESCRIPTION
### Summary

In addition to `noindex` behavior used in places like #22758, we need a bit more nuance / flexibility for de-emphasizing certain pages.

This should still be applied cautiously, b/c the deprioritization needs to be assumed in **whatever context** someone might be asking questions to the chatbot.

A good, current example of this would be `/firewall/`, where the feature is deprecated but we don't want it fully hidden from Google / our search. A bad example would be something like `/pages/`, where we're trying to recommend folks use Workers Assets but Pages is still a valid way of accomplishing your actions.

Part of the rollout (and testing) related to #22754.

PCX-17631