### PR TITLE
[ZT] WARP posture check commands to help customers troubleshoot 

### DIFF
--- a/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/corp-device.mdx
+++ b/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/corp-device.mdx
@@ -32,14 +32,16 @@ To create rules based on device serial numbers, you first need to create a [Gate
 
 You can now create an [Access policy](/cloudflare-one/policies/access/) or a Gateway [network policy](/cloudflare-one/policies/gateway/network-policies/common-policies/#enforce-device-posture) that checks if the device presents a serial number on your list. In Access, the serial number check will appear as a *Device Posture - Serial Number List* selector. In Gateway, your serial number list will appear in the **Value** dropdown when you choose the [Passed Device Posture Check](/cloudflare-one/policies/gateway/network-policies/#device-posture) selector.
 
-## Determine the serial number
+## Validate the serial number
+
+You can use the following commands to check the serial number of your device. The results can help you validate if the posture check is working as expected.
 
 ### macOS
 
 1. Open a terminal window.
 2. Use the `system_profiler` command to check for the value of `SPHardwareDataType` and retrieve the serial number.
 
-   ```txt
+   ```sh
    system_profiler SPHardwareDataType | grep 'Serial Number'
    ```
 
@@ -48,7 +50,7 @@ You can now create an [Access policy](/cloudflare-one/policies/access/) or a Gat
 1. Open a PowerShell window.
 2. Use the `Get-CimInstance` command to get the SerialNumber property of the `Win32_BIOS` class.
 
-   ```txt
+   ```powershell
    Get-CimInstance Win32_BIOS
    ```
 
@@ -57,7 +59,7 @@ You can now create an [Access policy](/cloudflare-one/policies/access/) or a Gat
 1. Open a Terminal Window
 2. Use the `dmidecode` command to get the version property `system-serial-number`.
 
-   ```txt
+   ```sh
    sudo dmidecode -s system-serial-number
    ```
 

--- a/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/disk-encryption.mdx
+++ b/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/disk-encryption.mdx
@@ -34,11 +34,11 @@ The Disk Encryption device posture attribute ensures that disks are encrypted on
 
 Next, go to **Logs** > **Posture** and verify that the disk encryption check is returning the expected results.
 
-## How WARP checks for encryption
+## Validate disk encryption status
 
-Operating systems determine disk encryption in various ways. The following information will allow you to understand how the client determines disk encryption status on various systems.
+The following commands will return the disk encryption status on various operating systems. The results can help you validate if the posture check is working as expected.
 
-### On macOS
+### macOS
 
 1. Open a terminal window.
 
@@ -68,13 +68,13 @@ Operating systems determine disk encryption in various ways. The following infor
     FileVault:                 Yes
    ```
 
-### On Windows
+### Windows
 
 1. Open a PowerShell window.
 2. Run the `Get-BitLockerVolume` command to list all volumes detected on the system.
 3. **Protection Status** must be set to **On** for the disk to be considered encrypted.
 
-### On Linux
+### Linux
 
 List all hard drives on the system:
 
@@ -95,6 +95,6 @@ nvme0n1                     259:0    0 476.9G  0 disk
 
 On Linux, encryption is reported per mounted partition, not physical drive. In the example above, the root and swap partitions are considered encrypted because they are located within a `crypt` container. The `/boot` and `/boot/efi` partitions remain unencrypted.
 
-### On iOS, Android and ChromeOS
+### iOS, Android and ChromeOS
 
 These platforms are always encrypted and so no disk encryption check is supported.

--- a/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/domain-joined.mdx
+++ b/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/domain-joined.mdx
@@ -37,11 +37,15 @@ The Domain Joined device posture attribute ensures that a user is a member of a 
 
 Next, go to **Logs** > **Posture** and verify that the Domain Joined check is returning the expected results.
 
-### Validate the domain value on your Windows device
+## Validate the domain value
+
+To check the domain value on your Windows device:
 
 1. Open a PowerShell window.
-2. Run the `(Get-WmiObject Win32_ComputerSystem).Domain` command to determine the value of your domain.
+2. Run the following command:
 
-   ```txt
+   ```powershell
    (Get-WmiObject Win32_ComputerSystem).Domain
    ```
+
+The command will return the Active Directory domain to which your device belongs.


### PR DESCRIPTION
PCX-17253
WARP Windows client now uses native Windows APIs to perform the checks. Customers can still use the PowerShell commands to read out values for troubleshooting.