### PR TITLE
docs: Fix typo in Update brower-rendering-autorag-tutorial.mdx

### DIFF
--- a/src/content/docs/autorag/tutorial/brower-rendering-autorag-tutorial.mdx
+++ b/src/content/docs/autorag/tutorial/brower-rendering-autorag-tutorial.mdx
@@ -25,7 +25,7 @@ npm create cloudflare@latest -- browser-r2-worker
 
 For setup, select the following options:
 
-- For _What would you like to start with_?, choose `Hello World Starter`.
+- For _What would you like to start with_?, choose `Hello World example`.
 - For _Which template would you like to use_?, choose `Worker only`.
 - For _Which language do you want to use_?, choose `TypeScript`.
 - For _Do you want to use git for version control_?, choose `Yes`.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

I was following the steps to create a worker to fetch webpages and upload in R2 and found the template/example name does not match the CLI. This PR fixes the issue and syncs the changes from the CLI to the document.

### Screenshots (optional)

In the screenshot below, you'll notice that the template is called `Hello World example`.

![CleanShot 2025-06-01 at 18 51 58](https://github.com/user-attachments/assets/ccd78f22-bdc4-428d-84e1-ea0657ec89d0)


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.