### PR TITLE
Tell the reader to remove unwanted `binding` property in "Pages to Workers" migration docs

### DIFF
--- a/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
@@ -79,6 +79,12 @@ Now, with **Cloudflare Workers**:
 
 </WranglerConfig>
 
+:::note
+
+If your Worker will only contain assets and no Worker script, then you should remove the `"binding": "ASSETS"` field from your Pages configuration file, since this is only valid if you have a Worker script indicated by a `"main"` property. See the [Assets binding](#assets-binding) section below.
+
+:::
+
 #### Serving behavior
 
 Pages would automatically attempt to determine the type of project you deployed. It would look for `404.html` and `index.html` files as signals for whether the project was likely a [Single Page Application (SPA)](/pages/configuration/serving-pages/#single-page-application-spa-rendering) or if it should [serve custom 404 pages](/pages/configuration/serving-pages/#not-found-behavior).

--- a/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
@@ -81,7 +81,7 @@ Now, with **Cloudflare Workers**:
 
 :::note
 
-If your Worker will only contain assets and no Worker script, then you should remove the `"binding": "ASSETS"` field from your Pages configuration file, since this is only valid if you have a Worker script indicated by a `"main"` property. See the [Assets binding](#assets-binding) section below.
+If your Worker will only contain assets and no Worker script, then you should remove the `"binding": "ASSETS"` field from your configuration file, since this is only valid if you have a Worker script indicated by a `"main"` property. See the [Assets binding](#assets-binding) section below.
 
 :::
 


### PR DESCRIPTION

This was brought up in the Wrangler Discord office hours

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
