### PR TITLE
moved copy button to reduce excessive white space

### DIFF
--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -75,26 +75,34 @@ const hideTitle = Astro.locals.starlightRoute.hideTitle;
 const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
 ---
 
-{
-	!hideBreadcrumbs && (
-		<Breadcrumbs {...breadcrumbProps}>
-			<svg
-				slot="separator"
-				xmlns="http://www.w3.org/2000/svg"
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<polyline points="9 18 15 12 9 6" />
-			</svg>
-		</Breadcrumbs>
-	)
-}
+<div class="flex items-center justify-between">
+	{
+		!hideBreadcrumbs && (
+			<Breadcrumbs {...breadcrumbProps}>
+				<svg
+					slot="separator"
+					xmlns="http://www.w3.org/2000/svg"
+					width="24"
+					height="24"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<polyline points="9 18 15 12 9 6" />
+				</svg>
+			</Breadcrumbs>
+		)
+	}
+
+	{
+		frontmatter.template !== "splash" && (
+			<CopyPageButton client:idle />
+		)
+	}
+</div>
 
 {!hideTitle && <Default />}
 
@@ -121,14 +129,6 @@ const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
 			</a>
 			.
 		</Aside>
-	)
-}
-
-{
-	frontmatter.template !== "splash" && (
-		<div class="flex items-center justify-end">
-			<CopyPageButton client:idle />
-		</div>
 	)
 }
 


### PR DESCRIPTION
### Summary

This was a small quality of life fix, by moving the button to be in-line with the breadcrumbs we reduce the unnecessary whitespace.

![breadcrumbs + copy page button](https://github.com/user-attachments/assets/66ecec52-338d-4a39-851f-0596c68d594b)
_Copy Page button appears in-line with breadcrumbs using flex to push it to right side of screen_

![splash page w/o button](https://github.com/user-attachments/assets/29dfb91b-0673-441d-bef9-44f9615ac867)
_Still hidden on splash pages_


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
