### PR TITLE
[AI Gateway] OpenAI SDK example fix

### DIFF
--- a/src/content/docs/ai-gateway/chat-completion.mdx
+++ b/src/content/docs/ai-gateway/chat-completion.mdx
@@ -33,7 +33,7 @@ Specify the model using `{provider}/{model}` format. For example:
 import OpenAI from "openai";
 const client = new OpenAI({
 	apiKey: "YOUR_PROVIDER_API_KEY", // Provider API key
-  // NOTE: the OpenAI client automatically adds /chat/completion to the end of the URL, you should not add it yourself.
+  // NOTE: the OpenAI client automatically adds /chat/completions to the end of the URL, you should not add it yourself.
 	baseURL: "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
 });
 

--- a/src/content/docs/ai-gateway/chat-completion.mdx
+++ b/src/content/docs/ai-gateway/chat-completion.mdx
@@ -33,8 +33,8 @@ Specify the model using `{provider}/{model}` format. For example:
 import OpenAI from "openai";
 const client = new OpenAI({
 	apiKey: "YOUR_PROVIDER_API_KEY", // Provider API key
-	baseURL:
-		"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions",
+  // NOTE: the OpenAI client automatically adds /chat/completion to the end of the URL, you should not add it yourself.
+	baseURL: "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
 });
 
 const response = await client.chat.completions.create({


### PR DESCRIPTION
### Summary

Originally reported by a user on the Discord (https://discord.com/channels/595317990191398933/1154819662161395742/1379844865202065631).

The OpenAI SDK automatically adds `/chat/completions` to the end of the URL, and adding it yourself (so it's duplicated) causes the SDK to throw an internal error.

This PR just removes `/chat/completions` from the SDK example in the docs (it's kept for cURL because it's still required) and adds a comment explaining why the user shouldn't add it themselves.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.