### PR TITLE
Fix broken links in Deploy to Cloudflare buttons

### DIFF
--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -20,7 +20,7 @@ If you wish to learn more about Durable Objects, refer to [What are Durable Obje
 
 If you want to skip the steps and get started quickly, click on the button below.
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/staging/hello-world-do-template)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/hello-world-do-template)
 
 This creates a repository in your GitHub account and deploys the application to Cloudflare Workers. Use this option if you are familiar with Cloudflare Workers, and wish to skip the step-by-step guidance.
 

--- a/src/content/docs/workers/frameworks/framework-guides/astro.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/astro.mdx
@@ -30,7 +30,7 @@ import {
 
 **Or just deploy**: Create a static blog with Astro and deploy it on Cloudflare Workers, with CI/CD and previews all set up for you.
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/staging/astro-blog-starter-template)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/astro-blog-starter-template)
 
 ## What is Astro?
 

--- a/src/content/docs/workers/frameworks/framework-guides/hono.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/hono.mdx
@@ -27,7 +27,7 @@ import {
 
 **Or just deploy** - create a full-stack app using Hono, React and Vite, with CI/CD and previews all set up for you.
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/staging/vite-react-template)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/vite-react-template)
 
 ## What is Hono?
 

--- a/src/content/docs/workers/frameworks/framework-guides/react.mdx
+++ b/src/content/docs/workers/frameworks/framework-guides/react.mdx
@@ -27,7 +27,7 @@ import {
 
 **Or just deploy** - create a full-stack app using React, Hono API and Vite, with CI/CD and previews all set up for you.
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/staging/vite-react-template)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create/deploy-to-workers&repository=https://github.com/cloudflare/templates/tree/main/vite-react-template)
 
 ## What is React?
 

--- a/src/content/docs/workers/platform/deploy-buttons.mdx
+++ b/src/content/docs/workers/platform/deploy-buttons.mdx
@@ -11,7 +11,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 If you're building a Workers application and would like to share it with other developers, you can embed a Deploy to Cloudflare button in your README, blog post, or documentation to enable others to quickly deploy your application on their own Cloudflare account. Deploy to Cloudflare buttons eliminate the need for complex setup, allowing developers to get started with your public GitHub or GitLab repository in just a few clicks.
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/staging/saas-admin-template)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/saas-admin-template)
 
 ## What are Deploy to Cloudflare buttons?
 Deploy to Cloudflare buttons simplify the deployment of a Workers application by enabling Cloudflare to:


### PR DESCRIPTION
### Summary

Swaps "staging" to "main" branch for links in Deploy to Cloudflare buttons. The staging branch no longer exists in the [templates](https://github.com/cloudflare/templates) repo, so the staging-based links are broken.

