### PR TITLE
[Browser Rendering] Removed API term

### DIFF
--- a/src/content/docs/browser-rendering/get-started.mdx
+++ b/src/content/docs/browser-rendering/get-started.mdx
@@ -7,5 +7,5 @@ sidebar:
 
 Browser rendering can be used in two ways:
 
-- [Workers Binding API](/browser-rendering/workers-binding-api) for complex scripts.
+- [Workers Bindings](/browser-rendering/workers-binding-api) for complex scripts.
 - [REST API](/browser-rendering/rest-api/) for simple actions.

--- a/src/content/docs/browser-rendering/index.mdx
+++ b/src/content/docs/browser-rendering/index.mdx
@@ -34,7 +34,7 @@ You can integrate Browser Rendering into your applications using one of the foll
 - **[REST API](/browser-rendering/rest-api/)**: Ideal for simple, stateless tasks like capturing screenshots, generating PDFs, extracting HTML content, and more.
 - **[Workers Bindings](/browser-rendering/workers-binding-api/)**: Suitable for advanced browser automation within [Cloudflare Workers](/workers/). This method provides greater control, enabling more complex workflows and persistent sessions.
 
-Choose the method that best fits your use case. For example, use the [REST API endpoints](/browser-rendering/rest-api/) for straightforward tasks from external applications and the [Workers Bindings](/browser-rendering/workers-binding-api/) for complex automation within the Cloudflare ecosystem.
+Choose the method that best fits your use case. For example, use the [REST API endpoints](/browser-rendering/rest-api/) for straightforward tasks from external applications and use [Workers Bindings](/browser-rendering/workers-binding-api/) for complex automation within the Cloudflare ecosystem.
 
 ## Use Cases
 

--- a/src/content/docs/browser-rendering/index.mdx
+++ b/src/content/docs/browser-rendering/index.mdx
@@ -32,9 +32,9 @@ Browser Rendering enables developers to programmatically control and interact wi
 You can integrate Browser Rendering into your applications using one of the following methods:
 
 - **[REST API](/browser-rendering/rest-api/)**: Ideal for simple, stateless tasks like capturing screenshots, generating PDFs, extracting HTML content, and more.
-- **[Workers Binding API](/browser-rendering/workers-binding-api/)**: Suitable for advanced browser automation within [Cloudflare Workers](/workers/). This method provides greater control, enabling more complex workflows and persistent sessions.
+- **[Workers Bindings](/browser-rendering/workers-binding-api/)**: Suitable for advanced browser automation within [Cloudflare Workers](/workers/). This method provides greater control, enabling more complex workflows and persistent sessions.
 
-Choose the method that best fits your use case. For example, use the [REST API endpoints](/browser-rendering/rest-api/) for straightforward tasks from external applications and the [Workers Binding API](/browser-rendering/workers-binding-api/) for complex automation within the Cloudflare ecosystem.
+Choose the method that best fits your use case. For example, use the [REST API endpoints](/browser-rendering/rest-api/) for straightforward tasks from external applications and the [Workers Bindings](/browser-rendering/workers-binding-api/) for complex automation within the Cloudflare ecosystem.
 
 ## Use Cases
 

--- a/src/content/docs/browser-rendering/platform/limits.mdx
+++ b/src/content/docs/browser-rendering/platform/limits.mdx
@@ -18,8 +18,8 @@ To increase this limit, you’ll need to [upgrade to a Workers Paid plan](/worke
 
 | Feature                                | Limit           |
 | -------------------------------------- | --------------- |
-| Concurrent browsers per account (Workers Binding API only)        | 3 per account   |
-| New browser instances per minute (Workers Binding API only)      | 3 per minute    |
+| Concurrent browsers per account (Workers Bindings only)        | 3 per account   |
+| New browser instances per minute (Workers Bindings only)      | 3 per minute    |
 | Browser timeout                        | 60 seconds [^2] |
 | Total requests per min (REST API only) | 6 per minute    |
 
@@ -29,8 +29,8 @@ To increase this limit, you’ll need to [upgrade to a Workers Paid plan](/worke
 
 | Feature                                | Limit               |
 | -------------------------------------- | ------------------- |
-| Concurrent browsers per account (Workers Binding API only)        | 10 per account [^1] |
-| New browser instances per minute (Workers Binding API only)       | 10 per minute [^1]  |
+| Concurrent browsers per account (Workers Bindings only)        | 10 per account [^1] |
+| New browser instances per minute (Workers Bindings only)       | 10 per minute [^1]  |
 | Browser timeout                        | 60 seconds [^2][^1] |
 | Total requests per min (REST API only) | 60 per minute       |
 

--- a/src/content/docs/browser-rendering/rest-api/index.mdx
+++ b/src/content/docs/browser-rendering/rest-api/index.mdx
@@ -12,7 +12,7 @@ import { DirectoryListing } from "~/components";
 
 <DirectoryListing />
 
-Use the REST API when you need a fast, simple way to perform common browser tasks such as capturing screenshots, extracting HTML, or generating PDFs without writing complex scripts. If you require more advanced automation, custom workflows, or persistent browser sessions, the [Workers Binding API](/browser-rendering/workers-binding-api/) is the better choice.
+Use the REST API when you need a fast, simple way to perform common browser tasks such as capturing screenshots, extracting HTML, or generating PDFs without writing complex scripts. If you require more advanced automation, custom workflows, or persistent browser sessions, [Workers Bindings](/browser-rendering/workers-binding-api/) are the better choice.
 
 ## Before you begin
 
@@ -22,6 +22,6 @@ Before you begin, make sure you [create a custom API Token](/fundamentals/api/ge
 
 :::note[Note]
 
-Currently, the Cloudflare dashboard displays usage metrics exclusively for the [Workers Binding API method](/browser-rendering/workers-binding-api/). Usage data for the REST API is not yet available in the dashboard. We are actively working on adding REST API usage metrics to the dashboard.
+Currently, the Cloudflare dashboard displays usage metrics exclusively for the [Workers Bindings method](/browser-rendering/workers-binding-api/). Usage data for the REST API is not yet available in the dashboard. We are actively working on adding REST API usage metrics to the dashboard.
 
 :::

--- a/src/content/docs/browser-rendering/workers-binding-api/index.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/index.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: navigation
-title: Workers Binding
+title: Workers Bindings
 sidebar:
   order: 2
 ---

--- a/src/content/docs/browser-rendering/workers-binding-api/index.mdx
+++ b/src/content/docs/browser-rendering/workers-binding-api/index.mdx
@@ -1,14 +1,14 @@
 ---
 pcx_content_type: navigation
-title: Workers Binding API
+title: Workers Binding
 sidebar:
   order: 2
 ---
 
 import { DirectoryListing } from "~/components";
 
-The Workers Binding API allows you to execute advanced browser rendering scripts within Cloudflare Workers. It provides developers the flexibility to automate and control complex workflows and browser interactions. The following options are available for browser rendering tasks:
+Workers Bindings allow you to execute advanced browser rendering scripts within Cloudflare Workers. They provide developers the flexibility to automate and control complex workflows and browser interactions. The following options are available for browser rendering tasks:
 
 <DirectoryListing />
 
-Use the Workers Binding API when you need advanced browser automation, custom workflows, or complex interactions beyond basic rendering. For quick, one-off tasks like capturing screenshots or extracting HTML, the [REST API](/browser-rendering/rest-api/) is the simpler choice.
+Use Workers Bindings when you need advanced browser automation, custom workflows, or complex interactions beyond basic rendering. For quick, one-off tasks like capturing screenshots or extracting HTML, the [REST API](/browser-rendering/rest-api/) is the simpler choice.


### PR DESCRIPTION
Request from @kathayl to remove "API" from these pages