### PR TITLE
MY_DURABLE_OBJECT => MY_DURABLE_OBJECT_NAMESPACE

### DIFF
--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -128,9 +128,9 @@ To communicate with a Durable Object, the Worker's fetch handler should look lik
 ```ts
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const id:DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+		const id:DurableObjectId = env.MY_DURABLE_OBJECT_NAMESPACE.idFromName(new URL(request.url).pathname);
 
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT_NAMESPACE.get(id);
 
 		const greeting = await stub.sayHello();
 
@@ -144,7 +144,7 @@ In the code above, you have:
 
 1. Exported your Worker's main event handlers, such as the `fetch()` handler for receiving HTTP requests.
 2. Passed `env` into the `fetch()` handler. Bindings are delivered as a property of the environment object passed as the second parameter when an event handler or class constructor is invoked. By calling the `idFromName()` function on the binding, you use a string-derived object ID. You can also ask the system to [generate random unique IDs](/durable-objects/api/namespace/#newuniqueid). System-generated unique IDs have better performance characteristics, but require you to store the ID somewhere to access the Object again later.
-3. Derived an object ID from the URL path. `MY_DURABLE_OBJECT.idFromName()` always returns the same ID when given the same string as input (and called on the same class), but never the same ID for two different strings (or for different classes). In this case, you are creating a new object for each unique path.
+3. Derived an object ID from the URL path. `MY_DURABLE_OBJECT_NAMESPACE.idFromName()` always returns the same ID when given the same string as input (and called on the same class), but never the same ID for two different strings (or for different classes). In this case, you are creating a new object for each unique path.
 4. Constructed the stub for the Durable Object using the ID. A stub is a client object used to send messages to the Durable Object.
 5. Called a Durable Object by invoking a RPC method, `sayHello()`, on the Durable Object, which returns a `Hello, World!` string greeting.
 6. Received an HTTP response back to the client by constructing a HTTP Response with `return new Response()`.
@@ -153,13 +153,13 @@ Refer to [Access a Durable Object from a Worker](/durable-objects/best-practices
 
 ## 4. Configure Durable Object bindings
 
-[Bindings](/workers/runtime-apis/bindings/) allow your Workers to interact with resources on the Cloudflare developer platform. The Durable Object bindings in your Worker project's [Wrangler configuration file](/workers/wrangler/configuration/) will include a binding name (for this guide, use `MY_DURABLE_OBJECT`) and the class name (`MyDurableObject`).
+[Bindings](/workers/runtime-apis/bindings/) allow your Workers to interact with resources on the Cloudflare developer platform. The Durable Object bindings in your Worker project's [Wrangler configuration file](/workers/wrangler/configuration/) will include a binding name (for this guide, use `MY_DURABLE_OBJECT_NAMESPACE`) and the class name (`MyDurableObject`).
 
 <WranglerConfig>
 
 ```toml
 [[durable_objects.bindings]]
-name = "MY_DURABLE_OBJECT"
+name = "MY_DURABLE_OBJECT_NAMESPACE"
 class_name = "MyDurableObject"
 ```
 
@@ -235,9 +235,9 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 export default {
 	async fetch(request, env, ctx):Promise<Response> {
-		const id:DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+		const id:DurableObjectId = env.MY_DURABLE_OBJECT_NAMESPACE.idFromName(new URL(request.url).pathname);
 
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT_NAMESPACE.get(id);
 
 		const greeting = await stub.sayHello();
 


### PR DESCRIPTION
It is confusing to say that the binding name is `MY_DURABLE_OBJECT` — singular — and then call methods on it in order to....get a single Durable Objects instance.

I don't think this creates the correct mental model, makes it seem like `MY_DURABLE_OBJECT` is a single durable object, instead of what it is — a namepaces of Durable Objects — plural.

Something I am missing as to why we don't use this language today?