### PR TITLE
docs(vitest-pool-workers): update supported vitest versions

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -26,13 +26,13 @@ First, make sure that:
 - Vitest and `@cloudflare/vitest-pool-workers` are installed in your project as dev dependencies
 
   <PackageManagers
-  	pkg="vitest@~3.1.0 @cloudflare/vitest-pool-workers"
+  	pkg="vitest@~3.2.0 @cloudflare/vitest-pool-workers"
   	dev="true"
   />
 
   :::note
 
-  Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 3.1.x.
+  Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 3.2.x.
 
   :::
 


### PR DESCRIPTION
### Summary

We are adding Vitest 3.2 support to vitest-pool-workers in https://github.com/cloudflare/workers-sdk/pull/9439.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
