### PR TITLE
Add Workers for Platforms bindings documentation

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
@@ -140,4 +140,4 @@ Use Wrangler to deploy the User Worker with the bindings:
 npx wrangler deploy --name $SCRIPT_NAME --dispatch-namespace $NAMESPACE_NAME
 ```
 
-Once the Worker is deployed, the bindings will become accessable from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).
+Once the Worker is deployed, the bindings will become accessible from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
@@ -6,47 +6,33 @@ sidebar:
 ---
 import { Aside } from "@astrojs/starlight/components";
 
-[Bindings](/workers/runtime-apis/bindings/) are resources (KV store, database, etc.) that you can attach to User Workers to enable end customers to build more powerful applications. By utilizing bindings, you can extend Cloudflare's developer platform to your end customers without needing to build the infrastructure components yourself. 
+When you deploy User Workers through Workers for Platforms, you can attach [bindings](/workers/runtime-apis/bindings/) to give them access to resources like [KV namespaces](/kv/), [D1 databases](/d1/), [R2 buckets](/r2/), and more. This enables your end customers to build more powerful applications without you having to build the infrastructure components yourself.
 
-With bindings, your users can:
-- Use [KV](/kv/) for high-read, eventually consistent key-value storage
-- Use [D1](/d1/) for relational data and complex queries
-- Store large files and assets in [R2](/r2/)
-- Run AI inference using [Workers AI](/workers-ai/)
-- Gain observability via [Analytics Engine](/analytics/analytics-engine/)
-- Manage stateful coordination with [Durable Objects](/durable-objects/)
+With bindings, each of your users can have their own:
+- [KV namespace](/kv/) that they can use to store and retrieve data
+- [R2 bucket](/r2/) that they can use to store files and assets
+- [Analytics Engine](/analytics/analytics-engine/) dataset that they can use to collect observability data
+- [Durable Objects](/durable-objects/) class that they can use for stateful coordination
 
 #### Resource isolation
 
-Each Worker can only access the bindings that are explicitly attached to it. For full isolation, you can attach a unique resource (like a D1 database or KV namespace) to every User Worker. If multiple Workers need to access the same data, you can reuse a shared resource, but every Worker will still have its own binding to that shared resource.
+Each User Worker can only access the bindings that are explicitly attached to it. For complete isolation, you can create and attach a unique resource (like a D1 database or KV namespace) to every User Worker. 
 
 ![Resource Isolation Model](~/assets/images/reference-architecture/programmable-platforms/programmable-platforms-5.svg "Resource Isolation Model")
 
-## Adding Bindings to User Workers
-You can attach [bindings](/workers/runtime-apis/bindings/) to User Workers to give them access to resources like D1, KV, R2, or Workers Analytics Engine. This section explains how to create and attach those resources so they can be used from the User Worker.
-### 1. Create the resources
+## Adding a KV Namespace to a User Worker
+This example walks through how to create a [KV namespace](/kv/) and attach it to a User Worker. The same process can be used to attach to other [bindings](/workers/runtime-apis/bindings/). 
 
-For most bindings (e.g. KV, D1, R2, or Durable Objects), you'll first need to create the resource using the Wrangler CLI or Cloudflare API. This will generate a resource ID that you'll use when attaching the binding to the Worker in the next step. 
+### 1. Create a KV namespace
+Create a KV namespace using the [Cloudflare API](/api/resources/kv/subresources/namespaces/methods/bulk_update/). 
 
-Some bindings, like Workers AI or Workers Analytics Engine, don’t require you to create a resource in advance. If you're using one of those, you can skip this step and go directly to Step 2.
+### 2. Attach the KV namespace to the User Worker
+
+Use the [Upload User Worker API](/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/methods/update/) to attach the KV namespace binding to the Worker. You can do this when you're first uploading the Worker script or when updating an existing Worker. 
 
 :::note 
-For every product, be sure to check product specific limits. Some resources may require contacting Support to request limit increases.
+When using the API to upload scripts, bindings must be specified in the `metadata` object of your multipart upload request. You cannot upload the `wrangler.toml` file as a module to configure the bindings. For more details about multipart uploads, see [Multipart upload metadata](/workers/configuration/multipart-upload-metadata/).
 :::
-
-### 2. Attach the binding to the User Worker
-
-#### Using the API
-
-Use the [Upload User Worker API](/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/methods/update/) to attach bindings to a Worker. You can do this when you're first uploading the Worker script or when updating an existing Worker. 
-
-Once the API request is made, the Worker will be automatically redeployed with the updated configuration, making the binding available for use.
-
-You'll attach bindings using the `bindings` array within the `metadata` object of your API request. For each binding, you'll need to specify:
-
-- `type`: The binding type (e.g., kv_namespace, d1, r2_bucket, ai)
-- `name`: The variable name used to access the binding in the Worker code
-- (Optional) Resource-specific identifier: The namespace ID, database ID, bucket name, etc.
 
 ##### Example API request
 
@@ -62,21 +48,14 @@ curl -X PUT \
         "type": "kv_namespace",
         "name": "USER_KV",
         "namespace_id": "<your-namespace-id>"
-      },
-      {
-        "type": "d1", 
-        "name": "DB",
-        "id": "<your-database-id>"
-      },
-      {
-        "type": "ai",
-        "name": "AI"
       }
     ]
   }' \
   -F 'worker.js=@/path/to/worker.js'
 ```
-Once you've added bindings to a Worker, if you want to add additional ones, use the `keep_bindings` parameter to ensure existing bindings are preserved while adding new ones:
+Now, the User Worker has can access the `USER_KV` binding through the `env` argument using `env.USER_DATA.get()`, `env.USER_DATA.put()`, and other KV methods.
+
+Note: If you plan to add new bindings to the Worker, use the `keep_bindings` parameter to ensure existing bindings are preserved while adding new ones. 
 
 ```bash
 curl -X PUT \
@@ -91,53 +70,6 @@ curl -X PUT \
         "bucket_name": "<your-bucket-name>"
       }
     ],
-    "keep_bindings": ["kv_namespace", "d1", "ai"]
+    "keep_bindings": ["kv_namespace"]
   }'
 ```
-Once the API request is made, the Worker will be redeployed with the new bindings. The bindings will then become accessible from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).
-
-#### Using Wrangler
-
-If your platform supports a CLI-based deployment process, you can use Wrangler to add bindings to your User Workers. 
-
-The bindings will be managed in the [Wrangler configuration file](/workers/wrangler/configuration/): 
-
-import { WranglerConfig } from "~/components";
-
-<WranglerConfig>
-
-```toml
-name = "user-worker"
-main = "src/index.js"
-compatibility_date = "2025-06-10"
-
-# KV binding
-kv_namespaces = [
-  { binding = "USER_KV", id = "<your-namespace-id>" }
-]
-
-# D1 binding
-[[d1_databases]]
-binding = "DB"
-database_id = "<your-database-id>"
-
-# R2 binding  
-[[r2_buckets]]
-binding = "STORAGE"
-bucket_name = "<your-bucket-name>"
-
-# Workers AI binding
-[ai]
-binding = "AI"
-```
-
-</WranglerConfig>
-
-**Deploy the Worker**
-
-Use Wrangler to deploy the User Worker with the bindings: 
-```bash
-npx wrangler deploy --name $SCRIPT_NAME --dispatch-namespace $NAMESPACE_NAME
-```
-
-Once the Worker is deployed, the bindings will become accessible from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
@@ -1,0 +1,143 @@
+---
+pcx_content_type: how-to
+title: Bindings
+sidebar:
+  order: 5
+---
+import { Aside } from "@astrojs/starlight/components";
+
+[Bindings](/workers/runtime-apis/bindings/) are resources (KV store, database, etc.) that you can attach to User Workers to enable end customers to build more powerful applications. By utilizing bindings, you can extend Cloudflare's developer platform to your end customers without needing to build the infrastructure components yourself. 
+
+With bindings, your users can:
+- Use [KV](/kv/) for high-read, eventually consistent key-value storage
+- Use [D1](/d1/) for relational data and complex queries
+- Store large files and assets in [R2](/r2/)
+- Run AI inference using [Workers AI](/workers-ai/)
+- Gain observability via [Analytics Engine](/analytics/analytics-engine/)
+- Manage stateful coordination with [Durable Objects](/durable-objects/)
+
+#### Resource isolation
+
+Each Worker can only access the bindings that are explicitly attached to it. For full isolation, you can attach a unique resource (like a D1 database or KV namespace) to every User Worker. If multiple Workers need to access the same data, you can reuse a shared resource, but every Worker will still have its own binding to that shared resource.
+
+![Resource Isolation Model](~/assets/images/reference-architecture/programmable-platforms/programmable-platforms-5.svg "Resource Isolation Model")
+
+## Adding Bindings to User Workers
+You can attach [bindings](/workers/runtime-apis/bindings/) to User Workers to give them access to resources like D1, KV, R2, or Workers Analytics Engine. This section explains how to create and attach those resources so they can be used from the User Worker.
+### 1. Create the resources
+
+For most bindings (e.g. KV, D1, R2, or Durable Objects), you'll first need to create the resource using the Wrangler CLI or Cloudflare API. This will generate a resource ID that you'll use when attaching the binding to the Worker in the next step. 
+
+Some bindings, like Workers AI or Workers Analytics Engine, don’t require you to create a resource in advance. If you're using one of those, you can skip this step and go directly to Step 2.
+
+:::note 
+For every product, be sure to check product specific limits. Some resources may require contacting Support to request limit increases.
+:::
+
+### 2. Attach the binding to the User Worker
+
+#### Using the API
+
+Use the [Upload User Worker API](http://localhost:1111/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/methods/update/) to attach bindings to a Worker. You can do this when you're first uploading the Worker script or when updating an existing Worker. 
+
+Once the API request is made, the Worker will be automatically redeployed with the updated configuration, making the binding available for use.
+
+You'll attach bindings using the `bindings` array within the `metadata` object of your API request. For each binding, you'll need to specify:
+
+- `type`: The binding type (e.g., kv_namespace, d1, r2_bucket, ai)
+- `name`: The variable name used to access the binding in the Worker code
+- (Optional) Resource-specific identifier: The namespace ID, database ID, bucket name, etc.
+
+##### Example API request
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/<account-id>/workers/dispatch/namespaces/<your-namespace>/scripts/<script-name>" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Authorization: Bearer <api-token>" \
+  -F 'metadata={
+    "main_module": "worker.js",
+    "bindings": [
+      {
+        "type": "kv_namespace",
+        "name": "USER_KV",
+        "namespace_id": "<your-namespace-id>"
+      },
+      {
+        "type": "d1", 
+        "name": "DB",
+        "id": "<your-database-id>"
+      },
+      {
+        "type": "ai",
+        "name": "AI"
+      }
+    ]
+  }' \
+  -F 'worker.js=@/path/to/worker.js'
+```
+Once you've added bindings to a Worker, if you want to add additional ones, use the `keep_bindings` parameter to ensure existing bindings are preserved while adding new ones:
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/<account-id>/workers/dispatch/namespaces/<your-namespace>/scripts/<script-name>" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Authorization: Bearer <api-token>" \
+  -F 'metadata={
+    "bindings": [
+      {
+        "type": "r2_bucket",
+        "name": "STORAGE", 
+        "bucket_name": "<your-bucket-name>"
+      }
+    ],
+    "keep_bindings": ["kv_namespace", "d1", "ai"]
+  }'
+```
+Once the API request is made, the Worker will be redeployed with the new bindings. The bindings will then become accessable from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).
+
+#### Using Wrangler
+
+If your platform supports a CLI-based deployment process, you can use Wrangler to add bindings to your User Workers. 
+
+The bindings will be managed in the [Wrangler configuration file](/workers/wrangler/configuration/): 
+
+import { WranglerConfig } from "~/components";
+
+<WranglerConfig>
+
+```toml
+name = "user-worker"
+main = "src/index.js"
+compatibility_date = "2025-06-10"
+
+# KV binding
+kv_namespaces = [
+  { binding = "USER_KV", id = "<your-namespace-id>" }
+]
+
+# D1 binding
+[[d1_databases]]
+binding = "DB"
+database_id = "<your-database-id>"
+
+# R2 binding  
+[[r2_buckets]]
+binding = "STORAGE"
+bucket_name = "<your-bucket-name>"
+
+# Workers AI binding
+[ai]
+binding = "AI"
+```
+
+</WranglerConfig>
+
+**Deploy the Worker**
+
+Use Wrangler to deploy the User Worker with the bindings: 
+```bash
+npx wrangler deploy --name $SCRIPT_NAME --dispatch-namespace $NAMESPACE_NAME
+```
+
+Once the Worker is deployed, the bindings will become accessable from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
@@ -38,7 +38,7 @@ For every product, be sure to check product specific limits. Some resources may 
 
 #### Using the API
 
-Use the [Upload User Worker API](http://localhost:1111/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/methods/update/) to attach bindings to a Worker. You can do this when you're first uploading the Worker script or when updating an existing Worker. 
+Use the [Upload User Worker API](/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/methods/update/) to attach bindings to a Worker. You can do this when you're first uploading the Worker script or when updating an existing Worker. 
 
 Once the API request is made, the Worker will be automatically redeployed with the updated configuration, making the binding available for use.
 

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/bindings.mdx
@@ -94,7 +94,7 @@ curl -X PUT \
     "keep_bindings": ["kv_namespace", "d1", "ai"]
   }'
 ```
-Once the API request is made, the Worker will be redeployed with the new bindings. The bindings will then become accessable from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).
+Once the API request is made, the Worker will be redeployed with the new bindings. The bindings will then become accessible from the Worker code using `env.BINDING_NAME` (e.g., `env.USER_KV.get()`).
 
 #### Using Wrangler
 

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/user-workers.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/user-workers.mdx
@@ -30,6 +30,6 @@ Since you will be deploying Workers on behalf of your users, you will likely wan
 
 ## Bindings
 
-You can use any Workers [bindings](/workers/runtime-apis/bindings/) with the dynamic dispatch Worker or any user Workers.
+You can use any Workers [bindings](/workers/runtime-apis/bindings/) with the dynamic dispatch Worker or any [user Workers](/cloudflare-for-platforms/workers-for-platforms/get-started/bindings/).
 
-Bindings for your user Workers can be defined on [multipart script uploads](/api/resources/workers_for_platforms/subresources/dispatch/subresources/namespaces/subresources/scripts/subresources/content/methods/update/) in the [metadata](/workers/configuration/multipart-upload-metadata/) part.
+To learn how to extend KV, D1, R2, and other resources to your User Workers through bindings, see [Bindings](/cloudflare-for-platforms/workers-for-platforms/get-started/bindings/).


### PR DESCRIPTION
### Summary

Adding a new page to the Workers for Platforms docs to document how platform customers can add bindings to user workers. 

### Screenshots (optional)
<img width="871" alt="Screenshot 2025-06-09 at 5 45 05 PM" src="https://github.com/user-attachments/assets/cf4bbd61-6fbc-4756-95fd-2eaf9b73ed09" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [X ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.