### PR TITLE
[Docs site] update wrong text in c3 prompt

### DIFF
--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -100,7 +100,7 @@ This is the full format of a C3 invocation alongside the possible CLI arguments:
 
   - The possible values for this option are:
 
-    - `hello-world`: Hello World Starter
+    - `hello-world`: Hello World example
     - `web-framework`: Framework Starter
     - `demo`: Application Starter
     - `remote-template`: Template from a GitHub repo

--- a/src/content/partials/workers/c3-post-run-steps.mdx
+++ b/src/content/partials/workers/c3-post-run-steps.mdx
@@ -11,7 +11,7 @@ switch (props.category) {
 case 'hello-world':
 return (<ul>
 
-<li>For <em>What would you like to start with?</em>, choose <code>Hello World Starter</code>.</li>
+<li>For <em>What would you like to start with?</em>, choose <code>Hello World example</code>.</li>
 <li>For <em>Which template would you like to use?</em>, choose <code>{props.type}</code>.</li>
 <li>For <em>Which language do you want to use?</em>, choose <code>{props.lang}</code>.</li>
 <li>For <em>Do you want to use git for version control?</em>, choose <code>Yes</code>.</li>


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
- Updates `Hello World Starter` to `Hello World example`.
- I did this because the `workers-sdk` project has a history of updating `Starter` to `example`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
