### PR TITLE
[DO] Cross referencing limits for key and values to the limits page

### DIFF
--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -229,7 +229,7 @@ ctx.storage.onNextSessionRestoreBookmark(bookmark);
 
   - Stores the value and associates it with the given key. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types.
 
-    The size of keys and values have different limits depending on the flavor of Durable Object you are using. Refer to either:
+    The size of keys and values have different limits depending on the Durable Object storage backend you are using. Refer to either:
     - [SQLite-backed Durable Object limits](/durable-objects/platform/limits/#sqlite-backed-durable-objects-general-limits)
     - [KV-backed Durable Object limits](/durable-objects/platform/limits/#key-value-backed-durable-objects-general-limits).<br/><br/>
 

--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -227,13 +227,19 @@ ctx.storage.onNextSessionRestoreBookmark(bookmark);
 
 - <code>put(key <Type text="string" />, value <Type text="any" />, options{" "}<Type text="Object" /> <MetaInfo text="optional" />)</code>: <Type text="Promise" />
 
-  - Stores the value and associates it with the given key. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. Keys are limited to a max size of 2,048 bytes and values are limited to 128 KiB (131,072 bytes).<br/><br/>
+  - Stores the value and associates it with the given key. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types.
+
+    The size of keys and values have different limits depending on the flavor of Durable Object you are using. Refer to either:
+    - [SQLite-backed Durable Object limits](/durable-objects/platform/limits/#sqlite-backed-durable-objects-general-limits)
+    - [KV-backed Durable Object limits](/durable-objects/platform/limits/#key-value-backed-durable-objects-general-limits).<br/><br/>
 
 - <code>put(entries <Type text="Object" />, options <Type text="Object" />{" "}<MetaInfo text="optional" />)</code>: <Type text="Promise" />
 
   - Takes an Object and stores each of its keys and values to storage.
   - Each value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types.
-  - Supports up to 128 key-value pairs at a time. Each key is limited to a maximum size of 2,048 bytes and each value is limited to 128 KiB (131,072 bytes).
+  - Supports up to 128 key-value pairs at a time. The size of keys and values have different limits depending on the flavor of Durable Object you are using. Refer to either:
+     - [SQLite-backed Durable Object limits](/durable-objects/platform/limits/#sqlite-backed-durable-objects-general-limits)
+     - [KV-backed Durable Object limits](/durable-objects/platform/limits/#key-value-backed-durable-objects-general-limits)
 
 ### `delete`
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Previously, the KV API section mentioned a single set of limits for Key and Value size.
2. This was misleading, as the limits are different depending on the flavour of DO a user is using (SQLite-backed vs KV-backed).
3. This PR now removes mentioning specific values in the KV API section, but instead directs the attention to the Limits page, calling out that the Key / Value limits are different depending on the flavour of DO.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
