### PR TITLE
[Rules] Add example for subrequests from other zones

### DIFF
--- a/src/content/docs/rules/transform/examples/add-request-header-subrequest-other-zone.mdx
+++ b/src/content/docs/rules/transform/examples/add-request-header-subrequest-other-zone.mdx
@@ -1,0 +1,30 @@
+---
+pcx_content_type: example
+summary: Create a request header transform rule to add an HTTP header when the subrequest comes from a different zone.
+products:
+  - Transform Rules
+operation:
+  - Request modification
+title: Add a request header for subrequests from other zones
+description: Create a request header transform rule to add an HTTP header when the subrequest comes from a different zone.
+---
+
+import { Example } from "~/components";
+
+The following request header transform rule adds an HTTP header when the subrequest comes from a different zone, using the [`cf.worker.upstream_zone`](/ruleset-engine/rules-language/fields/reference/cf.worker.upstream_zone/) field:
+
+<Example>
+
+Text in **Expression Editor** (replace `myappexample.com` with your domain):
+
+```txt
+(cf.worker.upstream_zone != "" and cf.worker.upstream_zone != "myappexample.com")
+```
+
+Selected operation under **Modify request header**: _Set static_
+
+**Header name**: `X-External-Workers-Subrequest`
+
+**Value**: `1`
+
+</Example>

--- a/src/content/docs/rules/transform/examples/add-request-header-subrequest-other-zone.mdx
+++ b/src/content/docs/rules/transform/examples/add-request-header-subrequest-other-zone.mdx
@@ -1,17 +1,17 @@
 ---
 pcx_content_type: example
-summary: Create a request header transform rule to add an HTTP header when the subrequest comes from a different zone.
+summary: Create a request header transform rule to add an HTTP header when the Workers subrequest comes from a different zone.
 products:
   - Transform Rules
 operation:
   - Request modification
 title: Add a request header for subrequests from other zones
-description: Create a request header transform rule to add an HTTP header when the subrequest comes from a different zone.
+description: Create a request header transform rule to add an HTTP header when the Workers subrequest comes from a different zone.
 ---
 
 import { Example } from "~/components";
 
-The following request header transform rule adds an HTTP header when the subrequest comes from a different zone, using the [`cf.worker.upstream_zone`](/ruleset-engine/rules-language/fields/reference/cf.worker.upstream_zone/) field:
+The following request header transform rule adds an HTTP header to Workers subrequests coming from a different zone:
 
 <Example>
 
@@ -28,3 +28,5 @@ Selected operation under **Modify request header**: _Set static_
 **Value**: `1`
 
 </Example>
+
+The [`cf.worker.upstream_zone`](/ruleset-engine/rules-language/fields/reference/cf.worker.upstream_zone/) field used in the rule expression is set to empty if the current request is not a Workers subrequest.


### PR DESCRIPTION
### Summary

Add new Transform Rules example adding a header for subrequests from zones other than the current one.

Based on the example in the [related changelog entry](https://developers.cloudflare.com/changelog/2025-06-09-transform-rule-subrequest-matching/).
