### PR TITLE
Removed extraneous wrangler parameter

### DIFF
--- a/src/content/docs/workers/local-development/local-data.mdx
+++ b/src/content/docs/workers/local-development/local-data.mdx
@@ -77,7 +77,7 @@ You may also include [other metadata](/workers/wrangler/commands/#r2-object-put)
 <PackageManagers
 	type="exec"
 	pkg="wrangler"
-	args="wrangler d1 execute <DATABASE_NAME> --file=./schema.sql --local"
+	args="d1 execute <DATABASE_NAME> --file=./schema.sql --local"
 />
 
 ### Durable Objects


### PR DESCRIPTION
### Summary

The code example for executing a SQL file with wrangler had an additional `wrangler` parameter.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.