### PR TITLE
Remove extra backticks from development-testing

### DIFF
--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -463,4 +463,4 @@ When using remote development, all bindings automatically connect to their remot
 ### Limitations
 
 - When you run a remote development session using the `--remote` flag, a limit of 50 [routes](/workers/configuration/routing/routes/) per zone is enforced. Learn more in[ Workers platform limits](/workers/platform/limits/#number-of-routes-per-zone-when-using-wrangler-dev---remote).
-```
+


### PR DESCRIPTION
### Summary

At the bottom of the [development-testing page](https://developers.cloudflare.com/workers/development-testing/) there's an extra unwanted block:
![Screenshot 2025-06-18 at 21 13 04](https://github.com/user-attachments/assets/fe2a3f85-8174-40b1-bc29-717ff5ee87f8)

In this PR I am removing it



<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

