### PR TITLE
feat: basic skeleton for realtimekit (cancel)

### DIFF
--- a/src/content/docs/realtime/realtimekit/guides/index.mdx
+++ b/src/content/docs/realtime/realtimekit/guides/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Guides
+sidebar:
+  order: 1
+
+description: >-
+  "Explore a variety of guides to enhance your RealtimeKit experience. From AI
+  capabilities to customization
+---
+
+# Guides
+
+TBD

--- a/src/content/docs/realtime/realtimekit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/index.mdx
@@ -1,0 +1,34 @@
+---
+title: RealtimeKit
+sidebar:
+  order: 1
+---
+
+Integrate programmable, and easily customizable live video and voice into your web, mobile, and desktop applications with just a few lines of code.
+
+## SDK Documentation
+
+Build the way you want in the framework you want!
+
+### UI Kit
+
+- React
+- Angular
+- HTML
+- Flutter
+- React Native
+- iOS
+- Android
+
+### Core SDK
+
+- JS
+- React
+- Flutter
+- React Native
+- iOS
+- Android
+
+### REST API
+
+[Reference](/realtime/realtimekit/restapi)

--- a/src/content/docs/realtime/realtimekit/mobile/core/android/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/core/android/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Android
+sidebar:
+  order: 3
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/core/flutter/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/core/flutter/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Flutter
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/core/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/core/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Core SDK
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/core/ios/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/core/ios/index.mdx
@@ -1,0 +1,7 @@
+---
+title: iOS
+sidebar:
+  order: 4
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/core/react-native/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/core/react-native/index.mdx
@@ -1,0 +1,7 @@
+---
+title: React Native
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Mobile
+sidebar:
+  order: 3
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/ui-kit/android/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/ui-kit/android/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Android
+sidebar:
+  order: 3
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/ui-kit/flutter/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/ui-kit/flutter/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Flutter
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/ui-kit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/ui-kit/index.mdx
@@ -1,0 +1,7 @@
+---
+title: UI Kit
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/ui-kit/ios/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/ui-kit/ios/index.mdx
@@ -1,0 +1,7 @@
+---
+title: iOS
+sidebar:
+  order: 4
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/mobile/ui-kit/react-native/index.mdx
+++ b/src/content/docs/realtime/realtimekit/mobile/ui-kit/react-native/index.mdx
@@ -1,0 +1,7 @@
+---
+title: React Native
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/partials/_product-section.mdx
+++ b/src/content/docs/realtime/realtimekit/partials/_product-section.mdx
@@ -1,0 +1,37 @@
+import {
+	ChatMultipleRegular,
+	LiveRegular,
+	MicRegular,
+	VideoRegular,
+} from "@fluentui/react-icons";
+
+<CardSection
+	id="Quickstart"
+	title="Quickstart"
+	description="Learn how to integrate live video and voice, live stream, and chat experiences into your product."
+>
+	<Card
+		title="Live Video"
+		icon={<VideoRegular />}
+		to="/guides/live-video/intro-video-conf"
+		description="Add live video functionality to your web, mobile, and desktop applications."
+	/>
+	<Card
+		title="Voice Conferencing"
+		icon={<MicRegular />}
+		to="/guides/voice-conf/intro-voice-conf"
+		description="Integrate reliable voice calling experiences into your product."
+	/>
+	<Card
+		title="Interactive Livestreaming"
+		icon={<LiveRegular />}
+		to="/guides/livestream/livestream-overview"
+		description="Get started with interactive livestreaming and broadcast to a large audience"
+	/>
+	{/* <Card
+    title="Realtime Chat"
+    icon={<ChatMultipleRegular />}
+    to="/guides/realtime-chat/intro-chat"
+    description="Create interactive and collaborative in-app chat experiences."
+  /> */}
+</CardSection>

--- a/src/content/docs/realtime/realtimekit/restapi/index.mdx
+++ b/src/content/docs/realtime/realtimekit/restapi/index.mdx
@@ -1,0 +1,7 @@
+---
+title: REST API
+sidebar:
+  order: 4
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/core/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/core/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Core SDK
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/core/js/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/core/js/index.mdx
@@ -1,0 +1,7 @@
+---
+title: JS
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/core/react/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/core/react/index.mdx
@@ -1,0 +1,37 @@
+---
+title: React Core SDK
+sidebar:
+  order: 2
+---
+
+## Introduction
+
+The RealtimeKit Core SDK is designed to provide developers with an easy way to incorporate real-time communication (RTC) solutions into their apps and websites. With full customization and branding options, you can build your own user interface from the ground up without dealing with complicated media layers.
+
+The Core SDK acts as a data-only layer, offering high-level primitives and abstracting away complex media and networking optimizations. It only provides simple APIs that are user-friendly and easy to work with.
+
+### Hooks
+
+[React Hooks](https://beta.reactjs.org/reference/react) are functions that allow developers to manage state and other React features in functional components. Hooks were introduced in React version 16.8 as a way to simplify the code. RealtimeKit provides the following built-in hooks:
+
+- useRealtimeKitClient()
+- useRealtimeKitMeeting()
+- useRealtimeKitSelector()
+
+See [Hooks](/react-ui-kit/using-hooks) for more information.
+{/* refactor */}
+
+### Utility Modules
+
+The Core SDK includes various modules for in-call utilities like chat, polls, and recording that enable building a UI on top of it. The following are the core SDK modules:
+
+- **meeting.self**: This consists of properties and methods corresponding to the current (local) user, such as enabling or disabling their audio and video, getting a list of media devices or changing the device, or sharing your mobile screen.
+- **meeting.participants**: Use this module to get useful information about the other participants that are present in the meeting. A host can use this module for access control. For example, the host can mute or kick a participant.
+- **meeting.chat**: It provides the methods to integrate chat features such as sending/receiving, editing, and deleting text, images, and files.
+- **meeting.polls**: Meetings can have polls. This module lets you perform actions related to polls, that is create and manage a poll within a meeting.
+- **meeting.recording**: When a meeting needs to be recorded, this module can be used. It lets you start or stop a recording, and get the current status of an ongoing recording.
+- **meeting.meta**: This object consists of all the metadata related to the current meeting, such as the title, the timestamp of when it started, and more.
+
+<head>
+	<title>React Web Core Introduction</title>
+</head>

--- a/src/content/docs/realtime/realtimekit/web/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Web
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/ui-kit/angular/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/ui-kit/angular/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Angular
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/ui-kit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/ui-kit/index.mdx
@@ -1,0 +1,7 @@
+---
+title: UI Kit
+sidebar:
+  order: 2
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/ui-kit/react/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/ui-kit/react/index.mdx
@@ -1,0 +1,7 @@
+---
+title: React
+sidebar:
+  order: 1
+---
+
+TBD

--- a/src/content/docs/realtime/realtimekit/web/ui-kit/web-components/index.mdx
+++ b/src/content/docs/realtime/realtimekit/web/ui-kit/web-components/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Web Components
+sidebar:
+  order: 3
+---
+
+TBD


### PR DESCRIPTION
### Summary

This PR proposes the basic skeleton for RealtimeKit docs. There's a ton of "index.mdx" files, but this is just to show the skeleton in the sidebar. We can correct this as we go along. For the purpose of this PR, we should find alignment on the skeleton itself. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
