### PR TITLE
Duplicate "Figure 3:" on figure caption

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/sase/zero-trust-and-virtual-desktop-infrastructure.mdx
+++ b/src/content/docs/reference-architecture/diagrams/sase/zero-trust-and-virtual-desktop-infrastructure.mdx
@@ -57,7 +57,7 @@ The diagram above shows the general flow of how user traffic goes from their loc
 
 When replacing your VDI is not an option and a fully virtualized desktop is required for legacy applications, Cloudflare's [SASE platform](https://www.cloudflare.com/zero-trust/) can still help secure these environments by authorizing the access to them using identity based Zero Trust policies, as well as securing the Internet bound traffic from the devices themselves.
 
-![Figure 3: Using Cloudflare Access ZTNA to secure VDI.](~/assets/images/reference-architecture/zero-trust-and-virtual-desktop-infrastructure/figure3.svg "Figure 3: Figure 3: Using Cloudflare Access ZTNA to secure VDI.")
+![Figure 3: Using Cloudflare Access ZTNA to secure VDI.](~/assets/images/reference-architecture/zero-trust-and-virtual-desktop-infrastructure/figure3.svg "Figure 3: Using Cloudflare Access ZTNA to secure VDI.")
 
 The diagram above displays a general Zero Trust deployment using best practices for authenticating your remote users to the VDI infrastructure
 


### PR DESCRIPTION
### Summary

On the page for [Zero Trust and Virtual Desktop Infrastructure](https://developers.cloudflare.com/reference-architecture/diagrams/sase/zero-trust-and-virtual-desktop-infrastructure/#securing-access-to-your-vdi-using-zero-trust-policies), the third figure has the caption "Figure 3: Figure 3:" which certainly isn't what's intended.

This PR is simply to remove the duplication.

### Screenshots (optional)

![Twice Figure 3](https://github.com/user-attachments/assets/ac87b681-d469-40e2-be89-39936b2a7295)

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
