### PR TITLE
User Groups GA docs updates

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/scim-setup/entra.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/entra.mdx
@@ -88,6 +88,7 @@ curl -X POST 'https://graph.microsoft.com/v1.0/applicationTemplates/8adf8e6e-67b
     "appDisplayName": "Entra API create application test",
 	// ...snipped rest of JSON payload
 }
+}
 ```
 
 **3. Create a provisioning job**
@@ -113,6 +114,7 @@ curl -X POST 'https://graph.microsoft.com/v1.0/servicePrincipals/<SERVICE_PRINCI
     "interval": "PT40M",
     "state": "Disabled"
   },
+}
 // ... snipped rest of JSON payload
 ```
 

--- a/src/content/docs/fundamentals/manage-members/user-groups.mdx
+++ b/src/content/docs/fundamentals/manage-members/user-groups.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: User Groups
 sidebar:
   badge:
-    text: Beta
+    text: New
   order: 5
 ---
 
@@ -21,7 +21,6 @@ Additionally, when you manage User Groups with SCIM, you cannot change the name,
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account. 
 2. Go to **Manage Account** > **Members**.
-3. To opt-in to the User Groups Public Beta, select the **Try User Groups** button. After doing so, the UI will update and a **Groups** tab will appear. 
 4. Select the **Groups** tab.
 5. Select **Create a Group** and enter a name and description for your new group.
 6. Select **Create group** to confirm your changes. The **Group members** tab displays.

--- a/src/content/partials/fundamentals/idp-group-deprecation.mdx
+++ b/src/content/partials/fundamentals/idp-group-deprecation.mdx
@@ -4,5 +4,9 @@
 ---
 
 :::note
-**Important Update:** Cloudflare now supports native User Groups for enhanced access control. This new feature replaces the previous method of directly assigning Cloudflare roles based on IdP group mappings (identified by the pattern `CF-<accountID> - <Role Name>`), which is deprecated as of June 2nd, 2025. Update your SCIM configurations using the instructions below to utilize User Groups for seamless provisioning.
+**Important Update:** Cloudflare now supports native User Groups for enhanced access control. This new feature replaces the previous method of directly assigning Cloudflare roles based on IdP group mappings (identified by the pattern `CF-<accountID> - <Role Name>`), which is deprecated as of June 2nd, 2025. SCIM Virtual Groups will reach end-of-life on December 2, 2025. Update your SCIM configurations using the instructions below to utilize User Groups for seamless provisioning.
 :::
+
+
+
+


### PR DESCRIPTION
### Summary

Docs updates for User Groups & SCIM User Groups ahead of the GA on June 23rd. Includes updates to labels, removal of references to Beta/opting-in flows, and a few fixes for code snippets. 

Please hold off on merging until 11am PST 
