### PR TITLE
Style guide reindex

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -8,8 +8,8 @@ import { getOgImage } from "~/util/og";
 import type { CollectionEntry } from "astro:content";
 
 const DEFAULT_TITLE_DELIMITER = "|";
-const NOINDEX_PRODUCTS = ["email-security", "style-guide", "security"];
-const CHATBOT_DEPRIORITIZE_PRODUCTS = ["firewall"];
+const NOINDEX_PRODUCTS = ["email-security", "security"];
+const CHATBOT_DEPRIORITIZE_PRODUCTS = ["firewall", "style-guide"];
 
 const currentSection = Astro.url.pathname.split("/")[1].replaceAll(".", "");
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/3rd-party-integration-guide.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/3rd-party-integration-guide.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: 3rd-party integration guide
+meta:
+  title: Content type - 3rd-party integration guide
 ---
 
 ## Purpose

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
@@ -1,11 +1,15 @@
 ---
 pcx_content_type: concept
 title: Changelog
+meta:
+  title: Content type - Changelog
 ---
+
+import { Type, MetaInfo } from "~/components";
 
 ## Purpose
 
-The purpose of a changelog is to log or record notable changes.
+The purpose of a changelog is to log or record notable changes, which then appear as part of the [Cloudflare changelog](/changelog/) and on product-specific changelog pages.
 
 ## Tone
 
@@ -21,199 +25,110 @@ For more details, refer to [`pcx_content_type`](/style-guide/frontmatter/custom-
 
 ## Ownership
 
-Developers and engineers maintain changelogs manually or via an automated process that their team owns. PCX provides a review but should not own creating or writing changelogs.
+Product managers and engineers maintain changelogs manually or via an automated process that their team owns. PCX provides a review but should not own creating or writing changelogs.
 
-The structure of the page can differ depending on the frequency or type of page.
+## Structure
 
-:::note
-
-Do not use the following terms: change log (two words), release notes, what's new, or README.
-
-"What's New" is a specific [content type](https://www.cloudflare.com/whats-new/) for marketing communication.
-:::
-
-## Structure (single-page)
-
-When creating a changelog, you need an MDX page file and a corresponding YAML file in the [`src/content/changelogs` folder](https://github.com/cloudflare/cloudflare-docs/tree/production/src/content/changelogs).
+When creating a changelog, you need an MDX page file and a corresponding folder of changelog entries.
 
 The combination of these files allows us to:
 
-- Render traditional changelog content on an [HTML page](/stream/changelog/).
-- Programmatically create an [RSS feed](/stream/changelog/index.xml) with the changelog content.
+- Render traditional changelog content on an [HTML page](/dns/changelog/).
+- Programmatically create an [RSS feed](/changelog/rss/dns.xml) with the changelog content.
 - Pull all our changelog content into a [Cloudflare-wide changelog](/changelog/).
 
 ### Markdown file
 
 Your Markdown file needs to have several special values to pull in the changelog information. These values are highlighted in the sample page.
 
-```mdx title="/src/content/docs/queues/platform/changelog.mdx"
+```mdx title="/src/content/docs/dns/changelog.mdx"
 ---
 pcx_content_type: changelog
 title: Changelog
-release_notes_file_name:
-  - queues
-sidebar:
-  order: 4
 ---
 
-import { ProductReleaseNotes } from "~/components";
+import { ProductChangelog } from "~/components";
 
-{/* <!-- Actual content lives in /src/content/release-notes/queues.yaml. Update the file there for new entries to appear here. For more details, refer to https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/#yaml-file --> */}
+{/* <!-- Actual content lives in /src/content/changelog/dns/. --> */}
 
-<ProductReleaseNotes />
+<ProductChangelog product="dns" />
 ```
 
-### YAML file
+### Changelog entries
 
-The `<ProductReleaseNotes>` component renders data that lives in a file within the [`/src/content/changelogs` folder](https://github.com/cloudflare/cloudflare-docs/tree/production/src/content/changelogs).
+Changelog entries live in a different location of our docs, [`/src/content/changelog/`](https://github.com/cloudflare/cloudflare-docs/tree/production/src/content/changelog).
 
-- `link` string required
+Each entry will be it's own MDX file, similar to the following.
 
-  - Relative path to the changelog page, such as `"/queues/changelog/"`.
-
-- `productName` string required
-
-  - Product name to display on the [changelog](/changelog/) product filter list, as well as other areas of the template.
-
-- `productLink` string required
-
-  - Link to top-level docs for your product (helpful for context if someone is landing on the top-level changelog page)
-
-- `productArea` string required
-
-  - Rollup grouping to surface related products together in context.
-
-- `productAreaLink` string required
-
-  - Rollup grouping to surface related products together in context. Helps pull together related RSS feeds.
-
-- `entries` object required
-
-  - `publish_date` date required
-
-    - Date of published change, formatted as `YYYY-MM-DD`.
-
-  - `title` string optional
-
-    - Name of published change. Optional, but highly encouraged.
-
-  - `description` string required
-
-    - Markdown string that also follows YAML conventions. For multi-line strings, start the entry with `|-` and then type on an indented new line.
-
-```yml title="/src/content/changelogs/queues.yaml"
+````mdx title="src/content/changelog/dns/"
 ---
-link: "/queues/changelog/"
-productName: Queues
-productLink: "/queues/"
-productArea: Developer platform
-productAreaLink: /workers/platform/changelog/platform/
-entries:
-  - publish_date: "2023-03-28"
-    title: Consumer concurrency (enabled)
-    description:
-      Queue consumers will now [automatically scale up](/queues/learning/consumer-concurrency/)
-      based on the number of messages being written to the queue. To control or limit
-      concurrency, you can explicitly define a [`max_concurrency`](/queues/platform/configuration/#consumer)
-      for your consumer.
-  - publish_date: "2023-03-15"
-    title: Consumer concurrency (upcoming)
-    description: |-
-      Queue consumers will soon automatically scale up concurrently as a queues' backlog grows in order to keep overall message processing latency down. Concurrency will be enabled on all existing queues by 2023-03-28.
+title: Account-level DNS analytics now available via GraphQL Analytics API
+description: Authoritative DNS analytics can now be accessed on the account level via the GraphQL Analytics API.
+date: 2025-06-19T12:00:00Z
+---
 
-      **To opt-out, or to configure a fixed maximum concurrency**, set `max_concurrency = 1` in your Wrangler file or via [the queues dashboard](https://dash.cloudflare.com/?to=/:account/queues).
+Authoritative DNS analytics are now available on the **account level** via the [Cloudflare GraphQL Analytics API](/analytics/graphql-api/).
 
-      **To opt-in, you do not need to take any action**: your consumer will begin to scale out as needed to keep up with your message backlog. It will scale back down as the backlog shrinks, and/or if a consumer starts to generate a higher rate of errors. To learn more about how consumers scale, refer to the [consumer concurrency](/queues/learning/consumer-concurrency/) documentation.
-  - publish_date: "2023-03-02"
-    title: Explicit acknowledgement (new feature)
-    description: |-
-      You can now [acknowledge individual messages with a batch](/queues/learning/batching-retries/#explicit-acknowledgement) by calling `.ack()` on a message.
+This allows users to query DNS analytics across multiple zones in their account, by using the `accounts` filter.
 
-      This allows you to mark a message as delivered as you process it within a batch, and avoids the entire batch from being redelivered if your consumer throws an error during batch processing. This can be particularly useful when you are calling external APIs, writing messages to a database, or otherwise performing non-idempotent actions on individual messages within a batch.
-  - publish_date: "2023-03-01"
-    title: Higher per-queue throughput
-    description:
-      The per-queue throughput limit has now been [raised to 400 messages
-      per second](/queues/platform/limits/).
-  - publish_date: "2022-12-12"
-    title: Increased per-account limits
-    description:
-      Queues now allows developers to create up to 100 queues per account,
-      up from the initial beta limit of 10 per account. This limit will continue to
-      increase over time.
-  - publish_date: "2022-12-13"
-    title: sendBatch support
-    description:
-      The JavaScript API for Queue producers now includes a `sendBatch` method
-      which supports sending up to 100 messages at a time.
+Here is an example to retrieve all DNS queries across all zones in an account that resulted in an `NXDOMAIN` response over a given time frame. Please replace `a30f822fcd7c401984bf85d8f2a5111c` with your actual account ID.
+
+```graphql graphql-api-explorer title="GraphQL example for account-level DNS analytics"
+query Viewer {
+	viewer {
+		accounts(filter: { accountTag: "a30f822fcd7c401984bf85d8f2a5111c" }) {
+			dnsAnalyticsAdaptive(
+				limit: 10
+				filter: {
+					date_geq: "2025-06-16"
+					responseCode: "NXDOMAIN"
+					date_leq: "2025-06-18"
+				}
+				orderBy: [datetime_DESC]
+			) {
+				zoneTag
+				queryName
+				responseCode
+				queryType
+				datetime
+			}
+		}
+	}
+}
 ```
 
----
+To learn more and get started, refer to the [DNS Analytics documentation](/dns/additional-options/analytics/#analytics).
+````
 
-## Structure (multi-page)
+#### Properties
 
-In some cases, your changelog may have a separate page for each entry. The general structure is the same as the [single-page changelog](#structure-single-page), but with a few small differences.
+Each changelog entries has the following properties:
 
-### Markdown files
+- `title` <Type text="string" /> <MetaInfo text="required" />
+  - Shown in the title heading and on social media embeds.
+- `description` <Type text="string" /> <MetaInfo text="required" />
+  - Shown in social media embeds.
+- `date` <Type text="date" /> <MetaInfo text="required" />
+  - This should be a date in `YYYY-MM-DD` format. For example, `2025-02-04`.
+- `preview_image` <Type text="string" /> <MetaInfo text="optional" />
+  - Path to an image file
+- `products` <Type text="Array<String>" /> <MetaInfo text="(default: current location) optional" />
 
-#### Top-level pages
+  - The products list is case-sensitive. Only use lowercase.
+  - This should be an array of strings, each referring to the name of a file in the products collection without the file extension.
+  - The folder that your entry is in, such as `src/content/changelog/workers/2025-02-13-new-product-feature.mdx`, is inferred as part of this property. If you do not want to associate the entry with additional products, you can omit it from the frontmatter entirely.
+  - If you wish to reference a product that does not exist in this collection, such as one that resides in the subpath of an existing product, you can create a "metadata only" entry:
 
-For the top-level pages, you need the same frontmatter as the [single-page example](#markdown-file), but do not include any shortcodes in the body of the page.
+    ```yaml title="src/content/proucts/workers-observability.yaml"
+    name: Workers Observability
 
-#### Individual entries
+    product:
+    	title: Workers Observability
+    	url: /workers/observability/
+    	group: Developer platform
+    	show: false
+    ```
 
-For each entry page, create a regular markdown page. These do not require a separate style of page or any adjustments.
-
-### YAML file
-
-Each individual entry needs an abbreviated entry in the changelog `.yaml` file.
-
-```yml title="/src/content/changelogs/waf.yaml"
----
-link: "/waf/change-log/"
-productName: WAF
-productLink: "/waf/"
-productArea: Application security
-productAreaLink: /fundamentals/reference/changelog/security/
-entries:
-  - publish_date: "2023-09-18"
-    scheduled_date: "2023-09-25"
-    individual_page: true
-    scheduled: true
-    link: "/waf/change-log/scheduled-changes/"
-  - publish_date: "2023-09-18"
-    individual_page: true
-    link: "/waf/change-log/2023-09-18/"
-```
-
-- `publish_date` date required
-
-  - Date when the page was published, formatted as `YYYY-MM-DD`. For pages with scheduled changes, you should update this field when adding/updating entries, so that the changelog item gets placed at the top of the changelog list (and feed). You should _not_ update this date when clearing all scheduled changes due to a release, since this change is not as relevant.
-
-- `individual_page` boolean required
-
-  - Used to pull in the content from the page itself, as opposed to structured data in YAML.
-
-- `link` string required
-
-  - Link to the individual page.
-
-- `scheduled` boolean optional
-
-  - Should be included for scheduled pages. Because this component renders content on the underlying page, you should only have a) one scheduled entry per scheduled entry page and b) only a scheduled entry when the scheduled entry page has content.
-
-- `scheduled_date` date required
-
-  - Should be included for pages with scheduled changes. Helps render the date of the upcoming change in the title, which provides more actionable information to folks scanning titles or the associated RSS feeds.
-
-:::note
-
-If the scheduled date gets pushed for a change, update the `publish_date` and `scheduled_date` fields of the changelog entry. This process makes sure customers will receive notifications via their RSS feeds.
-
-:::
-
-## Examples
-
-- [Stream Changelog](/stream/changelog/)
-- [Pages Changelog](/pages/platform/changelog/)
-- [WAF Changelog](/waf/change-log/)
+- `hidden` <Type text="Boolean" /> <MetaInfo text="(default: false) optional" />
+  - If `true`, this page will be accessible from the direct link, but hidden from the main [changelog](/changelog/) page and all RSS feeds.
+  - If `true`, will also add a `noindex` property so the page is not indexed by search crawlers.

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
@@ -11,6 +11,12 @@ import { Type, MetaInfo } from "~/components";
 
 The purpose of a changelog is to log or record notable changes, which then appear as part of the [Cloudflare changelog](/changelog/) and on product-specific changelog pages.
 
+:::note[Disambiguation]
+
+This page describes the content strategy for changelogs. For updates on Cloudflare products, refer to [Changelog](/changelog/).
+
+:::
+
 ## Tone
 
 instructional, straightforward

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
@@ -64,7 +64,7 @@ import { ProductChangelog } from "~/components";
 
 Changelog entries live in a different location of our docs, [`/src/content/changelog/`](https://github.com/cloudflare/cloudflare-docs/tree/production/src/content/changelog).
 
-Each entry will be it's own MDX file, similar to the following.
+Each entry will be its own MDX file, similar to the following.
 
 ````mdx title="src/content/changelog/dns/"
 ---

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/changelog.mdx
@@ -31,7 +31,7 @@ For more details, refer to [`pcx_content_type`](/style-guide/frontmatter/custom-
 
 ## Ownership
 
-Product managers and engineers maintain changelogs manually or via an automated process that their team owns. PCX provides a review but should not own creating or writing changelogs.
+Product managers and engineers maintain changelogs manually or via an automated process that their team owns. PCX provides a review but does not own creating or writing changelogs.
 
 ## Structure
 
@@ -106,7 +106,7 @@ query Viewer {
 To learn more and get started, refer to the [DNS Analytics documentation](/dns/additional-options/analytics/#analytics).
 ````
 
-#### Properties
+### Properties
 
 Each changelog entries has the following properties:
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/concept.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/concept.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Concept
+meta:
+  title: Content type - Concept
 ---
 
 ## Purpose

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/configuration.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/configuration.mdx
@@ -1,7 +1,8 @@
 ---
 pcx_content_type: concept
 title: Configuration
-
+meta:
+  title: Content type - Configuration
 ---
 
 ## Purpose
@@ -12,7 +13,7 @@ The purpose of a configuration is to show examples of specific settings, values,
 
 plain, descriptive, straightforward
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: configuration

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/design-guide.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/design-guide.mdx
@@ -1,7 +1,8 @@
 ---
 pcx_content_type: concept
 title: Design guide
-
+meta:
+  title: Content type - Design guide
 ---
 
 ## Purpose
@@ -12,7 +13,7 @@ Help users understand how to plan and design a solution using Cloudflare. Typica
 
 instructional, straightforward
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: design-guide

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/design-guide.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/design-guide.mdx
@@ -7,7 +7,13 @@ meta:
 
 ## Purpose
 
-Help users understand how to plan and design a solution using Cloudflare. Typically design guides are a subset of a reference architecture.
+Help users understand how to plan and design a solution using Cloudflare. Typically [design guides](/reference-architecture/design-guides/) are a subset of a [reference architecture](/reference-architecture/).
+
+:::note[Disambiguation]
+
+This page describes the content strategy for a design guide. For help with Cloudflare products, refer to [Design guides](/reference-architecture/design-guides/).
+
+:::
 
 ## Tone
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/faq.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/faq.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: FAQ
+meta:
+  title: Content type - FAQ
 ---
 
 ## Purpose

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/get-started.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/get-started.mdx
@@ -1,14 +1,15 @@
 ---
 pcx_content_type: concept
 title: Get started
-
+meta:
+  title: Content type - Get started
 ---
 
 ## Purpose
 
 The purpose of Get started content is to help users go from not using a product to successfully configuring and setting up.
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: get-started
@@ -24,16 +25,16 @@ For more details, refer to [`pcx_content_type`](/style-guide/frontmatter/custom-
 
 [**Prerequisites**](/style-guide/documentation-content-strategy/component-attributes/prerequisites/): Which may include:
 
-* An active zone
-* Certain subscription / enabled product / plan
-* Other tasks you might need to do to set up other things (your origin) outside of CF
-* Do you need to make certain decisions before you start?
+- An active zone
+- Certain subscription / enabled product / plan
+- Other tasks you might need to do to set up other things (your origin) outside of CF
+- Do you need to make certain decisions before you start?
 
 [**Steps**](/style-guide/documentation-content-strategy/component-attributes/steps-tasks-procedures/): Steps that lead someone to whatever would be considered Product Adoption.
 
-* Often, these can be partialized files from your How-to pages.
-* This is usually the bare minimum (a single Bot Management FW rule) + the most general use case for a product.
-* This may at times contradict the flow in the Cloudflare dashboard at times. If it does, consider raising it up to the Product team.
+- Often, these can be partialized files from your How-to pages.
+- This is usually the bare minimum (a single Bot Management FW rule) + the most general use case for a product.
+- This may at times contradict the flow in the Cloudflare dashboard at times. If it does, consider raising it up to the Product team.
 
 ### Optional components
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/how-to.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/how-to.mdx
@@ -1,10 +1,11 @@
 ---
 pcx_content_type: concept
-title: How to template
-
+title: How to
+meta:
+  title: Content type - How to
 ---
 
-import { Render } from "~/components"
+import { Render } from "~/components";
 
 ## Purpose
 
@@ -16,7 +17,7 @@ The purpose of a how to is to explain how to complete a task within the product.
 
 instructional, straightforward
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: how-to

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/implementation-guide.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/implementation-guide.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
-title: Implementation guide template
+title: Implementation guide
+meta:
+  title: Content type - Implementation guide
 ---
 
 ## Purpose
@@ -11,7 +13,7 @@ Walk the reader through best practices for the implementation of a solution usin
 
 instructional, straightforward
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: implementation-guide

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/implementation-guide.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/implementation-guide.mdx
@@ -7,7 +7,13 @@ meta:
 
 ## Purpose
 
-Walk the reader through best practices for the implementation of a solution using Cloudflare.
+Walk the reader through best practices for the [implementation](/reference-architecture/implementation-guides/) of a solution using Cloudflare.
+
+:::note[Disambiguation]
+
+This page describes the content strategy for an implementation guide. For help with Cloudflare products, refer to [Implementation guides](/reference-architecture/implementation-guides/).
+
+:::
 
 ## Tone
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture-diagram.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture-diagram.mdx
@@ -11,6 +11,12 @@ import { Render } from "~/components";
 
 To provide a visual reference and explanation of using Cloudflare for a specific solution.
 
+:::note[Disambiguation]
+
+This page describes the content strategy for a reference architecture diagram. For help with Cloudflare products, refer to [Reference archiectures diagrams](/reference-architecture/diagrams/).
+
+:::
+
 ## Tone
 
 instructional, straightforward

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture-diagram.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture-diagram.mdx
@@ -1,7 +1,8 @@
 ---
 pcx_content_type: concept
 title: Reference architecture diagram
-
+meta:
+  title: Content type - Reference architecture diagram
 ---
 
 import { Render } from "~/components";
@@ -14,7 +15,7 @@ To provide a visual reference and explanation of using Cloudflare for a specific
 
 instructional, straightforward
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: reference-architecture-diagram

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture.mdx
@@ -9,9 +9,15 @@ import { Render } from "~/components";
 
 ## Purpose
 
-The purpose of a reference architecture is to provide a high-level view of how all or part of the Cloudflare platform is built and how Cloudflare products would fit into a customer's existing infrastructure. Reference architectures are designed to show where our platform fits in with a customer's current environment and describe key aspects of a Cloudflare feature/service. Reference architectures should also map customer use cases to Cloudflare solutions.
+The purpose of a [reference architecture](/reference-architecture/) is to provide a high-level view of how all or part of the Cloudflare platform is built and how Cloudflare products would fit into a customer's existing infrastructure. Reference architectures are designed to show where our platform fits in with a customer's current environment and describe key aspects of a Cloudflare feature/service. Reference architectures should also map customer use cases to Cloudflare solutions.
 
 Reference architectures are typically very detailed. To describe a single architecture without much written content, use a [Reference architecture diagram](/style-guide/documentation-content-strategy/content-types/reference-architecture-diagram/).
+
+:::note[Disambiguation]
+
+This page describes the content strategy for a reference architecture. For help with Cloudflare products, refer to [Reference archiectures](/reference-architecture/).
+
+:::
 
 ## Tone
 

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/reference-architecture.mdx
@@ -1,7 +1,8 @@
 ---
 pcx_content_type: concept
 title: Reference architecture
-
+meta:
+  title: Content type - Reference architecture
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/reference.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/reference.mdx
@@ -1,7 +1,8 @@
 ---
 title: Reference
+meta:
+  title: Content type - Reference
 pcx_content_type: concept
-
 ---
 
 ## Purpose

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/troubleshooting.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/troubleshooting.mdx
@@ -1,7 +1,8 @@
 ---
 title: Troubleshooting
+meta:
+  title: Content type - Troubleshooting
 pcx_content_type: concept
-
 ---
 
 This troubleshooting strategy outlines our approach to troubleshooting content that is specific to a product or platform.
@@ -14,7 +15,7 @@ The purpose of Troubleshooting content is to provide guidance for solving common
 
 Guiding, straightforward, solution-oriented
 
-## content\_type
+## content_type
 
 ```yaml
 pcx_content_type: troubleshooting

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/tutorial.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/tutorial.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-title: Tutorial
+title: Content type - Tutorial
 ---
 
 import { GlossaryDefinition, Render } from "~/components";

--- a/src/content/docs/style-guide/documentation-content-strategy/content-types/tutorial.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/content-types/tutorial.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
-title: Content type - Tutorial
+title: Tutorial
+meta:
+  title: Content type - Tutorial
 ---
 
 import { GlossaryDefinition, Render } from "~/components";

--- a/src/content/docs/style-guide/index.mdx
+++ b/src/content/docs/style-guide/index.mdx
@@ -6,13 +6,19 @@ sidebar:
   order: 1
 ---
 
+import { DirectoryListing } from "~/components";
+
 Use this guide when writing any content for product, including the dashboard and documentation.
 
 Understanding Cloudflare style is the first step in being able to write, review, and edit documentation. Adhering to Cloudflare style ensures consistency across the company's documentation and promotes the following benefits:
 
-* A professional and reliable product image
-* A seamless customer experience across Cloudflare products
-* Minimized customer confusion
-* Simplified translation process
+- A professional and reliable product image
+- A seamless customer experience across Cloudflare products
+- Minimized customer confusion
+- Simplified translation process
 
 Visit the [Cloudflare Docs](https://github.com/cloudflare/cloudflare-docs) repository to contribute to developer documentation.
+
+## Available resources
+
+<DirectoryListing folder="style-guide" maxDepth={4} />


### PR DESCRIPTION
### Summary

- Removes the `noindex` blanket statement for `/style-guide/` (though adds the `chatbot_deprioritize` across since not relevant for chat).
- Updates the `Content strategy > Content types` titles to be less SEO capturing
- Adds disambiguation links where possible
- Fixes the guidelines for the Cloudflare Changelog to be more reflective of best practices today
- Adds `DirectoryListing` to the top-level style-guide landing page to experiment with that as a navigation pattern
