### PR TITLE
fix: syntax - missing parentheses

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -35,7 +35,7 @@ Run the following command to create and deploy a new Worker with a container, fr
 npm create cloudflare@latest -- --template=cloudflare/templates/containers-template
 ```
 
-When you want to deploy a code change to either the Worker or Container code, you can run the following command using [Wrangler CLI](/workers/wrangler/:
+When you want to deploy a code change to either the Worker or Container code, you can run the following command using [Wrangler CLI](/workers/wrangler/):
 
 <PackageManagers type="exec" pkg="wrangler" args="deploy" />
 


### PR DESCRIPTION
### Summary

Containers docs "Get started" page was missing a closing parentheses, so the enclosed link did not work.

