### PR TITLE
[R2] Adding infrequent access storage example

### DIFF
--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -44,7 +44,7 @@ For example:
 
 ### Free tier
 
-You can use the following amount of storage and operations each month for free. The free tier only applies to Standard storage.
+You can use the following amount of storage and operations each month for free.
 
 |                                    | Free                        |
 | ---------------------------------- | --------------------------- |
@@ -52,6 +52,10 @@ You can use the following amount of storage and operations each month for free. 
 | Class A Operations                 | 1 million requests / month  |
 | Class B Operations                 | 10 million requests / month |
 | Egress (data transfer to Internet) | Free [^1]                   |
+
+:::caution
+The free tier only applies to Standard storage, and does not apply to Infrequent Access storage.
+:::
 
 ### Storage usage
 
@@ -116,33 +120,55 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 
 ## R2 billing examples
 
-### Standard storage example
+### Standard storage example 1
 
-If a user writes 1,000 objects in R2 standard storage for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price      |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ---------- |
-| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00      |
-| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00      |
-| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85     |
-| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00      |
-| **TOTAL**          |                                             |              |                   | **$14.85** |
-|                    |                                             |              |                   |            |
+|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00       |
+| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00       |
+| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
+| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00       |
+| **TOTAL**          |                                             |              |                   | **$14.85**  |
 
-### Infrequent access example
+### Standard storage example 2
 
-If a user writes 1,000 objects in R2 infrequent access storage for 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
+If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Standard storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price      |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ---------- |
-| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00      |
-| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00      |
-| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85     |
-| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | 1,000 GB          | $10.00     |
-| **TOTAL**          |                                             |              |                   | **$24.85** |
-|                    |                                             |              |                   |            |
+|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Class B Operations | 0                                           | 10 million   | 0                 | $0.00       |
+| Class A Operations | 0                                           | 1 million    | 0                 | $0.00       |
+| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
+| Data retrieval     | 0                                           | 0 GB         | None              | $0.00       |
+| **TOTAL**          |                                             |              |                   | **$14.85**  |
 
-Note that the minimal storage duration for infrequent access storage is 30 days, which means the billable quantity is 990 GB-months, rather than 157 GB-months.
+### Infrequent access example 1
+
+If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Infrequent Access storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
+
+|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Class B Operations | 0                                           | NA           | 0                 | $0.00       |
+| Class A Operations | 0                                           | NA           | 0                 | $0.00       |
+| Storage            | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
+| Data retrieval     | 0                                           | NA           | 0                 | $0.00       |
+| **TOTAL**          |                                             |              |                   | **$10.00**  |
+
+### Infrequent access example 2
+
+If a user writes 1,000 objects in R2 **Infrequent Access storage** for 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
+
+|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Class B Operations | (1,000 objects) \* (1,000 reads per object) | NA           | 1 million         | $0.90       |
+| Class A Operations | (1,000 objects) \* (1 write per object)     | NA           | 1,000             | $9.00       |
+| Storage            | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
+| Data retrieval     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB          | $10.00      |
+| **TOTAL**          |                                             |              |                   | **$29.90**  |
+
+Note that the minimal storage duration for infrequent access storage is 30 days, which means the billable quantity is 1,000 GB-months, rather than 167 GB-months.
 
 ### Asset hosting
 
@@ -154,7 +180,6 @@ If a user writes 100,000 files with an average size of 100 KB object and reads 1
 | Class A Operations | (100,000 writes)                        | 1 million    | 0                 | $0.00       |
 | Storage            | (100,000 objects) \* (100KB per object) | 10 GB-months | 0 GB-months       | $0.00       |
 | **TOTAL**          |                                         |              |                   | **$104.40** |
-|                    |                                         |              |                   |             |
 
 ## Cloudflare billing policy
 

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -108,7 +108,7 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 
 ### Data storage example 1
 
-If a user writes 1,000 objects in R2 for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 standard storage for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
 
 |                    | Usage                                       | Free Tier    | Billable Quantity | Price      |
 | ------------------ | ------------------------------------------- | ------------ | ----------------- | ---------- |
@@ -120,15 +120,16 @@ If a user writes 1,000 objects in R2 for 1 month with an average size of 1 GB an
 
 ### Data storage example 2
 
-If a user writes 10 objects in R2 for 1 month with an average size of 1 GB and requests 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 infrequent access storage for 1 month with an average size of 1 GB and requests 1,000 times per month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price     |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | --------- |
-| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00     |
-| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00     |
-| Storage            | (10 objects) \* (1 GB per object)           | 10 GB-months | 0                 | $0.00     |
-| **TOTAL**          |                                             |              |                   | **$0.00** |
-|                    |                                             |              |                   |           |
+|                    | Usage                                       | Free Tier    | Billable Quantity | Price      |
+| ------------------ | ------------------------------------------- | ------------ | ----------------- | ---------- |
+| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00      |
+| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00      |
+| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $9.90      |
+| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | 1,000 GB          | $10.00     |
+| **TOTAL**          |                                             |              |                   | **$19.00** |
+|                    |                                             |              |                   |            |
 
 ### Asset hosting
 

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -116,7 +116,7 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 
 ## R2 billing examples
 
-### Data storage example 1
+### Standard storage example
 
 If a user writes 1,000 objects in R2 standard storage for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
 
@@ -129,18 +129,20 @@ If a user writes 1,000 objects in R2 standard storage for 1 month with an averag
 | **TOTAL**          |                                             |              |                   | **$14.85** |
 |                    |                                             |              |                   |            |
 
-### Data storage example 2
+### Infrequent access example
 
-If a user writes 1,000 objects in R2 infrequent access storage for 1 month with an average size of 1 GB and requests 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 infrequent access storage for 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
 
 |                    | Usage                                       | Free Tier    | Billable Quantity | Price      |
 | ------------------ | ------------------------------------------- | ------------ | ----------------- | ---------- |
 | Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00      |
 | Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00      |
-| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $9.90      |
+| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85     |
 | Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | 1,000 GB          | $10.00     |
-| **TOTAL**          |                                             |              |                   | **$19.00** |
+| **TOTAL**          |                                             |              |                   | **$24.85** |
 |                    |                                             |              |                   |            |
+
+Note that the minimal storage duration for infrequent access storage is 30 days, which means the billable quantity is 990 GB-months, rather than 157 GB-months.
 
 ### Asset hosting
 

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -120,53 +120,29 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 
 ## R2 billing examples
 
-### Standard storage example 1
+### Standard storage example
 
-If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an average size of 1 GB and reads each object 1,000 times during the month, the estimated cost for the month would be:
 
-|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Storage                     | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
-| Class A Operations          | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00       |
-| Class B Operations          | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00       |
-| Data retrieval (processing) | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00       |
-| **TOTAL**                   |                                             |              |                   | **$14.85**  |
+|                             | Usage                                                         | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object) = 1,000 GB-months        | 10 GB-months | 990 GB-months     | $14.85      |
+| Class A Operations          | (1,000 objects) \* (1 write per object) = 1,000 writes        | 1 million    | 0                 | $0.00       |
+| Class B Operations          | (1,000 objects) \* (1,000 reads per object) = 1 million reads | 10 million   | 0                 | $0.00       |
+| Data retrieval (processing) | (1,000 objects) \* (1 GB per object) = 1,000 GB               | 0 GB         | None              | $0.00       |
+| **TOTAL**                   |                                                               |              |                   | **$14.85**  |
 
-### Standard storage example 2
-
-If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Standard storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
-
-|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Storage                     | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
-| Class A Operations          | 0                                           | 1 million    | 0                 | $0.00       |
-| Class B Operations          | 0                                           | 10 million   | 0                 | $0.00       |
-| Data retrieval (processing) | 0                                           | 0 GB         | None              | $0.00       |
-| **TOTAL**                   |                                             |              |                   | **$14.85**  |
-
-### Infrequent access example 1
-
-If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Infrequent Access storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
-
-|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Storage                     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
-| Class A Operations          | 0                                           | NA           | 0                 | $0.00       |
-| Class B Operations          | 0                                           | NA           | 0                 | $0.00       |
-| Data retrieval (processing) | 0                                           | NA           | 0                 | $0.00       |
-| **TOTAL**                   |                                             |              |                   | **$10.00**  |
-
-### Infrequent access example 2
+### Infrequent access example
 
 If a user writes 1,000 objects in R2 **Infrequent Access storage** across 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
 
-|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Storage                     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
-| Class A Operations          | (1,000 objects) \* (1 write per object)     | NA           | 1,000             | $9.00       |
-| Class B Operations          | (1,000 objects) \* (1,000 reads per object) | NA           | 1 million         | $0.90       |
-| Data retrieval (processing) | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB          | $10.00      |
-| **TOTAL**                   |                                             |              |                   | **$29.90**  |
+|                             | Usage                                                         | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object) = 1,000 GB-months        | NA           | 1,000 GB-months   | $10.00      |
+| Class A Operations          | (1,000 objects) \* (1 write per object) = 1,000 writes        | NA           | 1,000             | $9.00       |
+| Class B Operations          | (1,000 objects) \* (1,000 reads per object) = 1 million reads | NA           | 1 million         | $0.90       |
+| Data retrieval (processing) | (1,000 objects) \* (1 GB per object) = 1,000 GB               | NA           | 1,000 GB          | $10.00      |
+| **TOTAL**                   |                                                               |              |                   | **$29.90**  |
 
 Note that the minimal storage duration for infrequent access storage is 30 days, which means the billable quantity is 1,000 GB-months, rather than 167 GB-months.
 

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -134,7 +134,7 @@ If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an av
 
 ### Infrequent access example
 
-If a user writes 1,000 objects in R2 **Infrequent Access storage** across 5 days with an average size of 1 GB and reads each object 1,000 times in 5 days, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 **Infrequent Access storage** across five days with an average size of 1 GB and reads each object 1,000 times in five days, the estimated cost for the month would be:
 
 |                             | Usage                                                         | Free Tier    | Billable Quantity | Price       |
 | --------------------------- | ------------------------------------------------------------- | ------------ | ----------------- | ----------- |

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -32,6 +32,16 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 | Data Retrieval (processing)        | None                     | $0.01 / GB                                              |
 | Egress (data transfer to Internet) | Free [^1]                | Free [^1]                                               |
 
+:::caution[Billable unit rounding]
+Cloudflare rounds up your usage to the next billing unit.
+
+For example:
+
+- If you have performed one million and one operations, you will be billed for two million operations.
+- If you have used 1.1 GB-month, you will be billed for 2 GB-month.
+- If you have retrieved data (for infrequent access storage) for 1.1 GB, you will be billed for 2 GB.
+:::
+
 ### Free tier
 
 You can use the following amount of storage and operations each month for free. The free tier only applies to Standard storage.

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -115,6 +115,7 @@ If a user writes 1,000 objects in R2 standard storage for 1 month with an averag
 | Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00      |
 | Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00      |
 | Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85     |
+| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00      |
 | **TOTAL**          |                                             |              |                   | **$14.85** |
 |                    |                                             |              |                   |            |
 

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -124,49 +124,49 @@ To learn about potential cost savings from using R2, refer to the [R2 pricing ca
 
 If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an average size of 1 GB and requests each 1,000 times per month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Class B Operations | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00       |
-| Class A Operations | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00       |
-| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
-| Data retrieval     | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00       |
-| **TOTAL**          |                                             |              |                   | **$14.85**  |
+|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
+| Class A Operations          | (1,000 objects) \* (1 write per object)     | 1 million    | 0                 | $0.00       |
+| Class B Operations          | (1,000 objects) \* (1,000 reads per object) | 10 million   | 0                 | $0.00       |
+| Data retrieval (processing) | (1,000 objects) \* (1 GB per object)        | 0 GB         | None              | $0.00       |
+| **TOTAL**                   |                                             |              |                   | **$14.85**  |
 
 ### Standard storage example 2
 
 If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Standard storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Class B Operations | 0                                           | 10 million   | 0                 | $0.00       |
-| Class A Operations | 0                                           | 1 million    | 0                 | $0.00       |
-| Storage            | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
-| Data retrieval     | 0                                           | 0 GB         | None              | $0.00       |
-| **TOTAL**          |                                             |              |                   | **$14.85**  |
+|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object)        | 10 GB-months | 990 GB-months     | $14.85      |
+| Class A Operations          | 0                                           | 1 million    | 0                 | $0.00       |
+| Class B Operations          | 0                                           | 10 million   | 0                 | $0.00       |
+| Data retrieval (processing) | 0                                           | 0 GB         | None              | $0.00       |
+| **TOTAL**                   |                                             |              |                   | **$14.85**  |
 
 ### Infrequent access example 1
 
 If a user has already stored 1,000 objects with an average size of 1 GB in R2 **Infrequent Access storage** in a previous month, and did not read any of the objects during the month, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Class B Operations | 0                                           | NA           | 0                 | $0.00       |
-| Class A Operations | 0                                           | NA           | 0                 | $0.00       |
-| Storage            | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
-| Data retrieval     | 0                                           | NA           | 0                 | $0.00       |
-| **TOTAL**          |                                             |              |                   | **$10.00**  |
+|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
+| Class A Operations          | 0                                           | NA           | 0                 | $0.00       |
+| Class B Operations          | 0                                           | NA           | 0                 | $0.00       |
+| Data retrieval (processing) | 0                                           | NA           | 0                 | $0.00       |
+| **TOTAL**                   |                                             |              |                   | **$10.00**  |
 
 ### Infrequent access example 2
 
-If a user writes 1,000 objects in R2 **Infrequent Access storage** for 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 **Infrequent Access storage** across 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
 
-|                    | Usage                                       | Free Tier    | Billable Quantity | Price       |
-| ------------------ | ------------------------------------------- | ------------ | ----------------- | ----------- |
-| Class B Operations | (1,000 objects) \* (1,000 reads per object) | NA           | 1 million         | $0.90       |
-| Class A Operations | (1,000 objects) \* (1 write per object)     | NA           | 1,000             | $9.00       |
-| Storage            | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
-| Data retrieval     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB          | $10.00      |
-| **TOTAL**          |                                             |              |                   | **$29.90**  |
+|                             | Usage                                       | Free Tier    | Billable Quantity | Price       |
+| --------------------------- | ------------------------------------------- | ------------ | ----------------- | ----------- |
+| Storage                     | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB-months   | $10.00      |
+| Class A Operations          | (1,000 objects) \* (1 write per object)     | NA           | 1,000             | $9.00       |
+| Class B Operations          | (1,000 objects) \* (1,000 reads per object) | NA           | 1 million         | $0.90       |
+| Data retrieval (processing) | (1,000 objects) \* (1 GB per object)        | NA           | 1,000 GB          | $10.00      |
+| **TOTAL**                   |                                             |              |                   | **$29.90**  |
 
 Note that the minimal storage duration for infrequent access storage is 30 days, which means the billable quantity is 1,000 GB-months, rather than 167 GB-months.
 
@@ -176,9 +176,9 @@ If a user writes 100,000 files with an average size of 100 KB object and reads 1
 
 |                    | Usage                                   | Free Tier    | Billable Quantity | Price       |
 | ------------------ | --------------------------------------- | ------------ | ----------------- | ----------- |
-| Class B Operations | (10,000,000 reads per day) \* (30 days) | 10 million   | 290,000,000       | $104.40     |
-| Class A Operations | (100,000 writes)                        | 1 million    | 0                 | $0.00       |
 | Storage            | (100,000 objects) \* (100KB per object) | 10 GB-months | 0 GB-months       | $0.00       |
+| Class A Operations | (100,000 writes)                        | 1 million    | 0                 | $0.00       |
+| Class B Operations | (10,000,000 reads per day) \* (30 days) | 10 million   | 290,000,000       | $104.40     |
 | **TOTAL**          |                                         |              |                   | **$104.40** |
 
 ## Cloudflare billing policy

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -134,7 +134,7 @@ If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an av
 
 ### Infrequent access example
 
-If a user writes 1,000 objects in R2 **Infrequent Access storage** across 5 days with an average size of 1 GB and requests 1,000 times in 5 days, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 **Infrequent Access storage** across 5 days with an average size of 1 GB and reads each object 1,000 times in 5 days, the estimated cost for the month would be:
 
 |                             | Usage                                                         | Free Tier    | Billable Quantity | Price       |
 | --------------------------- | ------------------------------------------------------------- | ------------ | ----------------- | ----------- |

--- a/src/content/docs/r2/pricing.mdx
+++ b/src/content/docs/r2/pricing.mdx
@@ -129,12 +129,12 @@ If a user writes 1,000 objects in R2 **Standard storage** for 1 month with an av
 | Storage                     | (1,000 objects) \* (1 GB per object) = 1,000 GB-months        | 10 GB-months | 990 GB-months     | $14.85      |
 | Class A Operations          | (1,000 objects) \* (1 write per object) = 1,000 writes        | 1 million    | 0                 | $0.00       |
 | Class B Operations          | (1,000 objects) \* (1,000 reads per object) = 1 million reads | 10 million   | 0                 | $0.00       |
-| Data retrieval (processing) | (1,000 objects) \* (1 GB per object) = 1,000 GB               | 0 GB         | None              | $0.00       |
+| Data retrieval (processing) | (1,000 objects) \* (1 GB per object) = 1,000 GB               | NA         | None              | $0.00       |
 | **TOTAL**                   |                                                               |              |                   | **$14.85**  |
 
 ### Infrequent access example
 
-If a user writes 1,000 objects in R2 **Infrequent Access storage** across five days with an average size of 1 GB and reads each object 1,000 times in five days, the estimated cost for the month would be:
+If a user writes 1,000 objects in R2 Infrequent Access storage with an average size of 1 GB, stores them for 5 days, and then deletes them (delete operations are free), and during those 5 days each object is read 1,000 times, the estimated cost for the month would be:
 
 |                             | Usage                                                         | Free Tier    | Billable Quantity | Price       |
 | --------------------------- | ------------------------------------------------------------- | ------------ | ----------------- | ----------- |


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Currently, there's a redundant example. We're repurposing that example to deal with Infrequent Access storage example to diversify the examples we show.

The four examples are:

1. Standard storage: highlights regular R2 usage, but within free-tier limits.
2. Standard storage: highlights using R2 to simply store (and not read/write) objects for a month.
3. IA storage: highlights using R2 to simply store objects, thereby showcasing the cost-efficiency for using IA.
4. IA storage: highlights active R2 usage, which will incur higher cost than Standard storage.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
