### PR TITLE
[D1] Fix example date command in time-travel.mdx 

### DIFF
--- a/src/content/docs/d1/reference/time-travel.mdx
+++ b/src/content/docs/d1/reference/time-travel.mdx
@@ -128,6 +128,6 @@ Refer to the guide [Export and save D1 database](/workflows/examples/backup-d1/)
 
 ## Notes
 
-- You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date %+s`.
+- You can quickly get the Unix timestamp from the command-line in macOS and Windows via `date +%s`.
 - Time Travel does not yet allow you to clone or fork an existing database to a new copy. In the future, Time Travel will allow you to fork (clone) an existing database into a new database, or overwrite an existing database.
 - You can restore a database back to a point in time up to 30 days in the past (Workers Paid plan) or 7 days (Workers Free plan). Refer to [Limits](/d1/platform/limits/) for details on Time Travel's limits.


### PR DESCRIPTION

### Summary

* There was a mix up in the parameters for the example date command (`%` and `+` were swapped)
*  `date +%s` is correct, `date %+s` returns `date: illegal time format`
* Tested on Macos



<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

N/A

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
