### PR TITLE
Update DNS record instructions for browser-based RDP

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -36,9 +36,9 @@ Browser-based RDP can be used in conjunction with [routing over WARP](/cloudflar
 
 ## 3. Create a DNS record
 
-To connect you to your RDP targets (i.e., your Windows machines), configure a DNS record (including the subdomain) that users will connect to RDP targets with. This domain will be used to access any targets that are accessible to users through your Access application (see Step 4).
+To connect to your RDP targets (i.e., your Windows machines), configure a DNS record (including the subdomain) that users will use for RDP connections. This domain will be used to access any targets that are available to users through your Access application (see Step 4).
 
-For example, if your Access application is configured for `rdp.example.com`, you must have an "A" or "AAAA" DNS record for `rdp.example.com` created.
+For example, if your Access application is configured with `rdp.example.com`, you must have an "A" or "AAAA" DNS record for `rdp.example.com` created.
 
 To do this, go to the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your desired RDP domain.
 
@@ -49,7 +49,7 @@ If you do not already have a DNS record, [create a new DNS record](/dns/manage-d
 - **IPv6 address**: `100::`
 - **Proxy status**: On
 
-The domain does not need to point to a valid IP address. Cloudflare's RDP proxy will handle the routing to the correct target machine. The DNS record just has to exist.
+The IP address does not require active use; it just needs to be valid. Cloudflare's RDP proxy will handle the routing to the correct target.
 
 :::note
 		If you choose to create a _CNAME_ DNS record instead, *the Target field must be a fully qualified domain name.* It is *NOT* the target ID that you created in step (2). Using the example above, `rdp` would be the record Name and the Target field would be `www.rdp.example.com`. Proxy status would also need to be set to "On."

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -34,7 +34,26 @@ Browser-based RDP can be used in conjunction with [routing over WARP](/cloudflar
 
 <Render file="access/add-target" params={{ protocol: "rdp" }}/>
 
-## 3. Create an Access application
+
+Cloudflare must be aware of your publically routed domain to proxy browser-based RDP traffic to your private network; this includes any [subdomain](/dns/manage-dns-records/how-to/create-subdomain.mdx) you wish to utilize.
+
+To do this, please ensure there is a corresponding DNS record for your full domain. This enables Cloudflare to source browser-based RDP traffic to your private network. For example, if you would like browser-based RDP traffic to go through `rdp.example.com`, where `rdp` is the subdomain and `example.com` is the main domain, you need to ensure there is a Cloudflare DNS record for `rdp`.
+
+In the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, then go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your domain. Again, the subdomain *must* have a record as well. Any arbitrary DNS record will work.
+
+If you do not already have a DNS record, [create a new DNS record](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records). Using `rdp.example.com` for demonstration, create an `AAAA` record that points your Access application public subdomain (`rdp`) to the IPv6 [discard address range](https://www.rfc-editor.org/rfc/rfc6666.html):
+
+- **Type**: _AAAA_
+- **Name**: `rdp`
+- **IPv6 address**: `100::`
+- **Proxy status**: On
+
+:::note
+		If you choose to create a _CNAME_ DNS record instead, *the Target field must be a fully qualified domain name.* It is *NOT* the target ID that you created in step (2). Using the example above, `rdp` would be the record Name and the Target field would be `www.rdp.example.com`. Proxy status would also need to be set to "On."
+:::
+
+
+## 4. Create an Access application
 
 <Render file="access/self-hosted-app/create-app" />
 
@@ -81,17 +100,6 @@ Ensure that only **Allow** or **Block** policies are present. **Bypass** and **S
 18. <Render file="access/self-hosted-app/advanced-settings" product="cloudflare-one" />
 
 19. Select **Save**.
-
-## 4. Create a DNS record
-
-In the [Cloudflare dashboard](https://dash.cloudflare.com/login), go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your domain. The DNS record allows Cloudflare to proxy browser-based RDP traffic to your private network. Any arbitrary DNS record will work.
-
-If you do not already have a DNS record, [create a new DNS record](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records). For example, you could create an `AAAA` record that points your Access application public hostname (`app.example.com`) to the IPv6 [discard address range](https://www.rfc-editor.org/rfc/rfc6666.html):
-
-- **Type**: _AAAA_
-- **Name**: `app`
-- **IPv6 address**: `100::`
-- **Proxy status**: On
 
 ## 5. (Recommended) Modify order of precedence in Gateway
 <Render file="access/modify-gateway-policy-precedence" product="cloudflare-one" params={{ selector: "Access Infrastructure Target" }} />

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render, GlossaryTooltip  } from "~/components"
 
-With Cloudflare Zero Trust, users can connect to an RDP server without installing an RDP client or the [WARP client](/cloudflare-one/connections/connect-devices/warp/) on their device. Browser-based RDP leverages [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/), which creates a secure, outbound-only connection from your RDP server to Cloudflare's global network. Setup involves running the `cloudflared` daemon on the RDP server (or any other host machine within the private network) and routing RDP traffic over a public hostname.
+Users can connect to an RDP server without installing an RDP client or the [WARP client](/cloudflare-one/connections/connect-devices/warp/) on their device. Browser-based RDP leverages [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/), which creates a secure, outbound-only connection from your RDP server to Cloudflare's global network. Setup involves running the `cloudflared` daemon on the RDP server (or any other host machine within the private network) and routing RDP traffic over a public hostname.
 
 There are two ways for users to [reach the RDP server in their browser](#4-connect-as-a-user):
 - **App Launcher**: Users can log in to the [Access App Launcher](/cloudflare-one/applications/app-launcher/) with their Cloudflare Access credentials and then initiate an RDP connection within the browser to their Windows machine. Users will authenticate to the Windows machine using their pre-configured Windows username and password. Cloudflare does not manage any credentials on the Windows server.
@@ -36,11 +36,11 @@ Browser-based RDP can be used in conjunction with [routing over WARP](/cloudflar
 
 ## 3. Create a DNS record
 
-To enable Cloudflare to connect you to your targets (i.e., your Windows machines), you must configure a DNS record for the full public domain (including the subdomain) Cloudflare will be routing your browser-based RDP traffic through. This domain will be used to access any targets that are accessible to users through your Access application (see Step 4).
+To connect you to your RDP targets (i.e., your Windows machines), configure a DNS record (including the subdomain) that users will connect to RDP targets with. This domain will be used to access any targets that are accessible to users through your Access application (see Step 4).
 
-For example, if your Access application is configured for `rdp.example.com`, you must have a DNS record for `rdp` under the `example.com` domain.
+For example, if your Access application is configured for `rdp.example.com`, you must have an "A" or "AAAA" DNS record for `rdp.example.com` created.
 
-To do this, go to the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, then go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your domain. Again, the subdomain *must* have a record as well.
+To do this, go to the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your desired RDP domain.
 
 If you do not already have a DNS record, [create a new DNS record](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records). Using `rdp.example.com` for demonstration, create an `AAAA` record that points your public subdomain (`rdp`) to the IPv6 [discard address range](https://www.rfc-editor.org/rfc/rfc6666.html):
 
@@ -48,6 +48,8 @@ If you do not already have a DNS record, [create a new DNS record](/dns/manage-d
 - **Name**: `rdp`
 - **IPv6 address**: `100::`
 - **Proxy status**: On
+
+The domain does not need to point to a valid IP address. Cloudflare's RDP proxy will handle the routing to the correct target machine. The DNS record just has to exist.
 
 :::note
 		If you choose to create a _CNAME_ DNS record instead, *the Target field must be a fully qualified domain name.* It is *NOT* the target ID that you created in step (2). Using the example above, `rdp` would be the record Name and the Target field would be `www.rdp.example.com`. Proxy status would also need to be set to "On."

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -34,6 +34,7 @@ Browser-based RDP can be used in conjunction with [routing over WARP](/cloudflar
 
 <Render file="access/add-target" params={{ protocol: "rdp" }}/>
 
+## 3. Create a DNS record
 
 Cloudflare must be aware of your publically routed domain to proxy browser-based RDP traffic to your private network; this includes any [subdomain](/dns/manage-dns-records/how-to/create-subdomain.mdx) you wish to utilize.
 

--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -36,13 +36,13 @@ Browser-based RDP can be used in conjunction with [routing over WARP](/cloudflar
 
 ## 3. Create a DNS record
 
-Cloudflare must be aware of your publically routed domain to proxy browser-based RDP traffic to your private network; this includes any [subdomain](/dns/manage-dns-records/how-to/create-subdomain.mdx) you wish to utilize.
+To enable Cloudflare to connect you to your targets (i.e., your Windows machines), you must configure a DNS record for the full public domain (including the subdomain) Cloudflare will be routing your browser-based RDP traffic through. This domain will be used to access any targets that are accessible to users through your Access application (see Step 4).
 
-To do this, please ensure there is a corresponding DNS record for your full domain. This enables Cloudflare to source browser-based RDP traffic to your private network. For example, if you would like browser-based RDP traffic to go through `rdp.example.com`, where `rdp` is the subdomain and `example.com` is the main domain, you need to ensure there is a Cloudflare DNS record for `rdp`.
+For example, if your Access application is configured for `rdp.example.com`, you must have a DNS record for `rdp` under the `example.com` domain.
 
-In the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, then go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your domain. Again, the subdomain *must* have a record as well. Any arbitrary DNS record will work.
+To do this, go to the [Cloudflare dashboard](https://dash.cloudflare.com/login), select your domain, then go to **DNS** > **Records** and verify that a [DNS record](/dns/manage-dns-records/how-to/create-dns-records/) exists for your domain. Again, the subdomain *must* have a record as well.
 
-If you do not already have a DNS record, [create a new DNS record](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records). Using `rdp.example.com` for demonstration, create an `AAAA` record that points your Access application public subdomain (`rdp`) to the IPv6 [discard address range](https://www.rfc-editor.org/rfc/rfc6666.html):
+If you do not already have a DNS record, [create a new DNS record](/dns/manage-dns-records/how-to/create-dns-records/#create-dns-records). Using `rdp.example.com` for demonstration, create an `AAAA` record that points your public subdomain (`rdp`) to the IPv6 [discard address range](https://www.rfc-editor.org/rfc/rfc6666.html):
 
 - **Type**: _AAAA_
 - **Name**: `rdp`


### PR DESCRIPTION
Update DNS record instructions to be more descriptive on how to handle a AAAA record and a CNAME record. Reorder instructions to try to call better attention to DNS requirements (put application creation after DNS setup).
