### PR TITLE
Remove unnecessary condition and render llms-full.txt for all products

### DIFF
--- a/src/pages/[product]/llms-full.txt.ts
+++ b/src/pages/[product]/llms-full.txt.ts
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
 	const products = await getCollection("products", (p) => {
-		return p.data.product.group?.toLowerCase() === "developer platform";
+		return p.data.product.group;
 	});
 
 	return products.map((entry) => {


### PR DESCRIPTION
Remove the extra condition on product being part of Developer Platform to render the llms-full.txt page under the [product] slug