### PR TITLE
fix: use the right `type` when using `degit`

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/redwoodsdk.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/redwoodsdk.mdx
@@ -28,7 +28,7 @@ RedwoodSDK is a composable framework for building server-side web apps on Cloudf
 
 	Run the following command, replacing `<project-name>` with your desired project name:
 		<PackageManagers
-			type="exec"
+			type="dlx"
 			pkg="degit"
 			args={"redwoodjs/sdk/starters/standard#main <project-name>"}
 		/>


### PR DESCRIPTION
### Summary

`exec` executes a shell command within the scope of the project, but in this case we’re creating a brand new project using `degit`, so the right [`type`](https://starlight-package-managers.vercel.app/usage/#dlx) is `dlx`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

---

💖
