### PR TITLE
Update firewall.mdx

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/firewall.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/firewall.mdx
@@ -21,7 +21,7 @@ The WARP client connects to Cloudflare via a standard HTTPS connection outside t
 Only required for [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode.
 :::
 
-In [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode, the WARP client sends DNS requests to Gateway over an HTTPS connection outside the tunnel. For DNS to work correctly, you must allow `<ACCOUNT_ID>.cloudflare-gateway.com` which will lookup the following IPs:
+In [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode, the WARP client sends DNS requests to Gateway over an HTTPS connection inside the tunnel. For DNS to work correctly, you must allow `<ACCOUNT_ID>.cloudflare-gateway.com` which will lookup the following IPs:
 
 - IPv4 DoH Addresses: `162.159.36.1` and `162.159.46.1`
 - IPv6 DoH Addresses: `2606:4700:4700::1111` and `2606:4700:4700::1001`

--- a/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/firewall.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/warp/deployment/firewall.mdx
@@ -21,7 +21,7 @@ The WARP client connects to Cloudflare via a standard HTTPS connection outside t
 Only required for [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode.
 :::
 
-In [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode, the WARP client sends DNS requests to Gateway over an HTTPS connection inside the tunnel. For DNS to work correctly, you must allow `<ACCOUNT_ID>.cloudflare-gateway.com` which will lookup the following IPs:
+In [Gateway with DoH](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#gateway-with-doh) mode, the WARP client sends DNS requests to Gateway over an HTTPS connection. For DNS to work correctly, you must allow `<ACCOUNT_ID>.cloudflare-gateway.com` which will lookup the following IPs:
 
 - IPv4 DoH Addresses: `162.159.36.1` and `162.159.46.1`
 - IPv6 DoH Addresses: `2606:4700:4700::1111` and `2606:4700:4700::1001`


### PR DESCRIPTION

### Summary

In WARP version 2025.4.929.0 there was a change where DoH traffic is now inside the tunnel.  See: 

https://developers.cloudflare.com/cloudflare-one/changelog/#2025-05-14

 >All DNS traffic now flows inside the WARP tunnel. Customers are no longer required to configure their local firewall rules to allow our DoH IP addresses and domains.


### Documentation checklist

- The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

