### PR TITLE
[Email Security] Add example file

### DIFF
--- a/src/content/docs/cloudflare-one/email-security/detection-settings/allow-policies.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/allow-policies.mdx
@@ -27,8 +27,19 @@ To configure allow policies:
            - **Regular expressions**: Must be valid Java expressions. Regular expressions are matched with fields related to the sender email address (envelope from, header from, reply-to), the originating IP address, and the server name for the email.
      - **(Recommended) Sender verification**: This option enforces DMARC, SPF, or DKIM authentication. If you choose to enable this option, Email Security will only honor policies that pass authentication.
        - **Notes**: Provide additional information about your allow policy.
-   - **Uploading an allow policy**: Upload a file no larger than 150 KB. The file can only contain `Pattern`, `Notes`, `Verify Email`, `Trusted Sender`, `Exempt Recipient` and `Acceptable Sender` fields. The first row must be a header row.
+   - **Uploading an allow policy**: Upload a file no larger than 150 KB. The file can only contain `Pattern`, `Pattern Type`, `Verify Email`, `Trusted Sender`, `Exempt Recipient`, `Acceptable Sender`, `Notes` fields. The first row must be a header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/allow-policies/#csv-uploads) for an example file.
 6. Select **Save**.
+
+### CSV uploads
+
+You can upload a file no larger than 150 KB. The file can only contain `Pattern`, `Pattern Type`, `Verify Email`, `Trusted Sender`, `Exempt Recipient`, `Acceptable Sender`, `Notes`. The first row must be a header row.
+
+An example file would look like this:
+
+```txt
+Pattern, Pattern Type, Verify Email, Trusted Sender, Exempt Recipient, Acceptable Sender, Notes
+whale@notaphish.com, EMAIL, true, true, false, true, not a phish
+```
 
 ## Export allow policies
 

--- a/src/content/docs/cloudflare-one/email-security/detection-settings/blocked-senders.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/blocked-senders.mdx
@@ -21,8 +21,20 @@ To configure blocked senders:
              - **Domains**: Must be a valid domain.
              - **Regular expressions**: Must be valid Java expressions. Regular expressions are matched with fields related to the sender email address (envelope from, header from, reply-to), the originating IP address, and the server name for the email.
          - **Notes**: Provide additional information about the blocked sender policy.
-   - **Upload blocked sender list**: Upload a file no larger than 150 KB. The file cannot can only contain `Blocked_Sender` and `Notes` fields. The first row must be a header row.
+   - **Upload blocked sender list**: Upload a file no larger than 150 KB. The file cannot can only contain `Blocked_Sender`, `Pattern Type,` and `Notes` fields. The first row must be a header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/allow-policies/#csv-uploads) for an example file.
 6. Select **Save**.
+
+### CSV uploads
+
+You can upload a file no larger than 150 KB. The file cannot can only contain `Blocked_Sender`, `Pattern Type,` and `Notes` fields. The first row must be a header row. 
+
+An example file would look like this:
+
+```txt
+Blocked Sender, Pattern Type, Notes
+john.smith@gmail.com, EMAIL, John Smith
+example.com, DOMAIN, Melanie Turner
+```
 
 ## Export blocked senders
 

--- a/src/content/docs/cloudflare-one/email-security/detection-settings/blocked-senders.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/blocked-senders.mdx
@@ -21,7 +21,7 @@ To configure blocked senders:
              - **Domains**: Must be a valid domain.
              - **Regular expressions**: Must be valid Java expressions. Regular expressions are matched with fields related to the sender email address (envelope from, header from, reply-to), the originating IP address, and the server name for the email.
          - **Notes**: Provide additional information about the blocked sender policy.
-   - **Upload blocked sender list**: Upload a file no larger than 150 KB. The file cannot can only contain `Blocked_Sender`, `Pattern Type,` and `Notes` fields. The first row must be a header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/allow-policies/#csv-uploads) for an example file.
+   - **Upload blocked sender list**: Upload a file no larger than 150 KB. The file cannot can only contain `Blocked_Sender`, `Pattern Type,` and `Notes` fields. The first row must be a header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/blocked-senders/#csv-uploads) for an example file.
 6. Select **Save**.
 
 ### CSV uploads

--- a/src/content/docs/cloudflare-one/email-security/detection-settings/impersonation-registry.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/impersonation-registry.mdx
@@ -44,7 +44,6 @@ Star Phish, star@nophish.com
 Phish Ee, phishee@nophish.com
 ```
 
-
 ## Edit users
 
 :::note

--- a/src/content/docs/cloudflare-one/email-security/detection-settings/impersonation-registry.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/impersonation-registry.mdx
@@ -26,11 +26,24 @@ To add a user to the impersonation registry:
        - **User email**: Enter one of the following:
          - **Email address**: Enter all known email addresses, separated by a comma.
          - **Regular expressions**: Must be valid Java expressions.
-   - **Upload manual list**: You can upload a file no larger than 150 KB containing all variables of potential emails. The file must contain `Display_Name` and `Email`, and the first row must be the header row.
+   - **Upload manual list**: You can upload a file no larger than 150 KB containing all variables of potential emails. The file must contain `Display_Name` and `Email`, and the first row must be the header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/impersonation-registry/#csv-uploads) for an example file.
    - **Select from existing directories**:
        - **Select directory**: Select your directory.
        - **Add users or groups**: Choose the users or groups you want to register.
 6. Select **Save**.
+
+### CSV uploads
+
+You can upload a file no larger than 150 KB containing all variables of potential emails. The file must contain `Display_Name` and `Email`, and the first row must be the header row.
+
+An example file would look like this:
+
+```txt
+Display Name, Email
+Star Phish, star@nophish.com
+Phish Ee, phishee@nophish.com
+```
+
 
 ## Edit users
 

--- a/src/content/docs/cloudflare-one/email-security/detection-settings/trusted-domains.mdx
+++ b/src/content/docs/cloudflare-one/email-security/detection-settings/trusted-domains.mdx
@@ -20,8 +20,20 @@ To configure a trusted domain:
        * **Proximity domain**: Domains with similar spelling to your existing domain.
        * **Recent domain**: Domains created recently.
      * **Notes**: Provide additional information about the trusted domain list.
-   - **Upload trusted domain list**: You can upload a file no larger than 150 KB of multiple trusted domains. The file can only contain `Domain`, `Notes`, `Proximity` and `Recent` fields. The first row must be a header row.
+   - **Upload trusted domain list**: You can upload a file no larger than 150 KB of multiple trusted domains. The file can only contain `Domain`, `Proximity`, `New` and `Notes` fields. The first row must be a header row. Refer to [CSV uploads](/cloudflare-one/email-security/detection-settings/trusted-domains/#csv-uploads) for an example file.
 6. Select **Save**.
+
+### CSV uploads
+
+You can upload a file no larger than 150 KB of multiple trusted domains. The file can only contain `Domain`, `Proximity`, `New` and `Notes` fields. The first row must be a header row.
+
+An example file would look like this:
+
+```txt
+Domain, Proximity, New, Notes
+mydomain.com, true, true, First Person
+testdomain.com, false, true, New Hire
+```
 
 ## Export trusted domains
 


### PR DESCRIPTION
This PR aims at adding example CSV files for the following policies:

- Allow policies
- Blocked senders
- Trusted domains
- Impersonation registry

It also updates the fields list as it was outdated.