### PR TITLE
[Email Security | RBI] Open links in Browser Isolation

### DIFF
--- a/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
+++ b/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
@@ -241,41 +241,46 @@ Email Security displays the following details:
 
 #### Open links
 
-You can open links in [Security Center](/security-center/) or [Browser Isolation](/cloudflare-one/policies/browser-isolation/), or copy and paste the link so you can investigate links in external tools.
+You can open links in [Security Center](/security-center/) or [Browser Isolation](/cloudflare-one/policies/browser-isolation/), or copy and paste the link so you can investigate content in external tools.
 
 To open links in Security Center:
 
-1. Go to the link you want to open.
-2. Select **Open in Security Center**.
-3. You will be redirected to Security Center's Investigate.
-4. Select **Scan now**.
-5. The dashboard will generate a report for your link.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Email Security** > **Investigation**.
+2. Locate the message you want to open links for, select the three dots, then select **View details**.
+2. Under **Details**, go to **Links identified**. 
+3. Locate the link you want to open, and select **Open in Security Center**.
+4. You will be redirected to **Investigate** under **Security Center**.
+5. Select **Scan now**.
+6. The dashboard will generate a report for your link.
 
 To open links in Browser Isolation:
 
-1. Go to the link you want to open.
-2. Select **Open in Browser Isolation**.
-3. The link will open in a separate window where you will be able to browse the content securely.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Email Security** > **Investigation**.
+2. Locate the message you want to open links for, select the three dots, then select **View details**.
+2. Under **Details**, go to **Links identified**. 
+3. Locate the link you want to open, and select **Open in Browser Isolation**.
+4. The link will open in a separate window where you will be able to browse the content securely.
 
-You may receive a HTTP 400 Bad Request Error when opening a link in Browser Isolation. Follow these steps if you encounter this problem:
-
-1. In [Zero Trust](https://one.dash.cloudflare.com/), select **Settings**.
-2. Select **Browser Isolation**, then enable **Clientless Web Isolation**.
-
-If you still receive a 400 Bad Request error after enabling Clientless Web Isolation:
-
-1. Go to **Settings** > **Resources**.
-2. Select **Generate certificate**.
-3. Choose the **Expiration** (5 years is recommended), then select **Generate certificate**. Your certificate is now generated, and the dashboard will display its **Deployment Status** as **INACTIVE**.
-4. Select the three dots, and then select **Activate** to activate your certificate.
-5. Select the three dots, and then select **Mark as in-use**.
-6. Your certificate deployment status should display **AVAILABLE IN-USE**.
+Alternatively, you can directly [open links in Browser Isolation](/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation/#open-links-in-browser-isolation).
 
 To open and investigate a link in an external tool:
 
 1. Go to the link you want to open.
 2. Select **Copy URL**.
 3. Paste the link in your external tool.
+
+:::caution
+You may encounter a 400 Bad Request error after turning **Clientless Web Isolation** on. 
+
+If you encounter this error:
+
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Settings** > **Resources**.
+2. Select **Generate certificate**.
+3. Choose the **Expiration** (5 years is recommended), then select **Generate certificate**. Your certificate is now generated, and the dashboard will display its **Deployment Status** as **INACTIVE**.
+4. Select the three dots, and then select **Activate** to activate your certificate.
+5. Select the three dots, and then select **Mark as in-use**.
+6. Your certificate deployment status should display **AVAILABLE IN-USE**.
+:::
 
 ### Action log
 

--- a/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
+++ b/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
@@ -265,8 +265,10 @@ Alternatively, you can directly [open links in Browser Isolation](/cloudflare-on
 
 To open and investigate a link in an external tool:
 
-1. Go to the link you want to open.
-2. Select **Copy URL**.
+1. In [Zero Trust](https://one.dash.cloudflare.com/), go to **Email Security** > **Investigation**.
+2. Locate the message you want to open links for, select the three dots, then select **View details**.
+2. Under **Details**, go to **Links identified**. 
+3. Locate the link you want to open, and select **Copy URL**.
 3. Paste the link in your external tool.
 
 :::caution

--- a/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
+++ b/src/content/docs/cloudflare-one/email-security/email-monitoring/search-email.mdx
@@ -272,7 +272,7 @@ To open and investigate a link in an external tool:
 3. Paste the link in your external tool.
 
 :::caution
-You may encounter a 400 Bad Request error after turning **Clientless Web Isolation** on. 
+You may encounter a `400 Bad Request` error after turning **Clientless Web Isolation** on. 
 
 If you encounter this error:
 

--- a/src/content/docs/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation.mdx
+++ b/src/content/docs/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation.mdx
@@ -27,6 +27,14 @@ Clientless Web Isolation allows users to securely browse high risk or sensitive 
 
 Your application will now be served in an isolated browser for users matching your policies.
 
+### Open links using Browser Isolation
+
+To open links using Browser Isolation:
+
+1. In [Zero Trust](https://one.dash.cloudflare.com), go to **Browser Isolation**.
+2. Select **Launch isolated browser**. Turn **Clientless web isolation** on.
+3. In **Launch browser**, enter the URL link, and then select **Launch**. Your URL will open in a secure isolated browser.
+
 ## Filter DNS queries
 
 Gateway filters and resolves DNS queries for isolated sessions via [DNS policies](/cloudflare-one/policies/gateway/dns-policies/). Enterprise users can resolve domains available only through private resolvers by creating [resolver policies](/cloudflare-one/policies/gateway/resolver-policies/).

--- a/src/content/docs/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation.mdx
+++ b/src/content/docs/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation.mdx
@@ -27,7 +27,7 @@ Clientless Web Isolation allows users to securely browse high risk or sensitive 
 
 Your application will now be served in an isolated browser for users matching your policies.
 
-### Open links using Browser Isolation
+### Open links in Browser Isolation
 
 To open links using Browser Isolation:
 


### PR DESCRIPTION
This PR aims at:

- Adding content in the Browser Isolation docs to inform users on how to open links in Browser Isolation without having to set up a policy. This content will be referenced in Email Security.
- Reorganizing the open links section (added more steps so users don't get lost).
- Making tiny changes to be in line with the Style Guide (for example, changed **enable `name_of_toggle`** to **turn `name_of_toggle` on**).