### PR TITLE
fixed typo in src -> content -> docs -> containers -> image-management

### DIFF
--- a/src/content/docs/containers/image-management.mdx
+++ b/src/content/docs/containers/image-management.mdx
@@ -106,5 +106,5 @@ Images are limited to 2 GB in size and you are limited to 50 total GB in your ac
 These limits will likely increase in the future.
 :::
 
-Delete images with `wrangler containers images delete` to free up space, but note that reverting a
+Delete images with `wrangler containers images delete` to free up space, but reverting a
 Worker to a previous version that uses a deleted image will then error.

--- a/src/content/docs/containers/image-management.mdx
+++ b/src/content/docs/containers/image-management.mdx
@@ -106,5 +106,5 @@ Images are limited to 2 GB in size and you are limited to 50 total GB in your ac
 These limits will likely increase in the future.
 :::
 
-Delete images with `wrangler containers delete` to free up space, but note that reverting a
+Delete images with `wrangler containers images delete` to free up space, but note that reverting a
 Worker to a previous version that uses a deleted image will then error.


### PR DESCRIPTION
### Summary

fixed typo in : src -> content -> docs -> containers -> image-management
 FROM : "wrangler containers delete"
 TO: "wrangler containers images delete"
 
REASON: this is a image-management page not a container management.


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->
