### PR TITLE
docs(worker): format code snippet for Miniflare remote proxy session

### DIFF
--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -392,41 +392,40 @@ import { experimental_maybeStartOrUpdateRemoteProxySession } from "wrangler";
 let mf: Miniflare | null;
 
 let remoteProxySessionDetails: Awaited<
-ReturnType<typeof experimental_maybeStartOrUpdateRemoteProxySession>
-
+  ReturnType<typeof experimental_maybeStartOrUpdateRemoteProxySession>
 > | null = null;
 
 async function startOrUpdateDevSession() {
-remoteProxySessionDetails =
-await experimental_maybeStartOrUpdateRemoteProxySession(
-{
-bindings: {
-MY_KV: {
-type: 'kv_namespace',
-id: 'kv-id',
-experimental_remote: true,
-}
-}
-},
-remoteProxySessionDetails
-);
+  remoteProxySessionDetails =
+    await experimental_maybeStartOrUpdateRemoteProxySession(
+      {
+        bindings: {
+          MY_KV: {
+            type: "kv_namespace",
+            id: "kv-id",
+            experimental_remote: true,
+          },
+        },
+      },
+      remoteProxySessionDetails
+    );
 
-const miniflareOptions: MiniflareOptions = {
-scriptPath: "./worker.js",
-kvNamespaces: {
-MY_KV: {
-id: "kv-id",
-remoteProxyConnectionString:
-remoteProxySessionDetails?.session.remoteProxyConnectionString,
-},
-},
-};
+  const miniflareOptions: MiniflareOptions = {
+    scriptPath: "./worker.js",
+    kvNamespaces: {
+      MY_KV: {
+        id: "kv-id",
+        remoteProxyConnectionString:
+          remoteProxySessionDetails?.session.remoteProxyConnectionString,
+      },
+    },
+  };
 
-if (!mf) {
-mf = new Miniflare(miniflareOptions);
-} else {
-mf.setOptions(miniflareOptions);
-}
+  if (!mf) {
+    mf = new Miniflare(miniflareOptions);
+  } else {
+    mf.setOptions(miniflareOptions);
+  }
 }
 
 // ... tool logic that invokes `startOrUpdateDevSession()` ...


### PR DESCRIPTION
### Summary

- Formatted TypeScript snippet for Miniflare remote proxy session setup
- Improved readability for use in Workers documentation
