### PR TITLE
Remove namespace requirement from Containers image

### DIFF
--- a/src/content/docs/containers/image-management.mdx
+++ b/src/content/docs/containers/image-management.mdx
@@ -67,7 +67,7 @@ Then you can specify the URL in the image attribute:
 ```json
 {
 	"containers": {
-		"image": "registry.cloudflare.com/your-namespace/your-image:tag"
+		"image": "registry.cloudflare.com/your-image:tag"
 		// ...rest of config...
 	}
 }
@@ -86,7 +86,7 @@ wrangler containers push <image>:<tag>
 ```
 
 :::note
-We plan to allow configuring public images directly in wrangler config. Cloudflare will
+We plan to allow configuring public images directly in Wrangler config. Cloudflare will
 download your image, optionally using auth credentials, then cache it globally in the Cloudflare Registry.
 
 This is not yet available.


### PR DESCRIPTION
### Summary

Once https://github.com/cloudflare/workers-sdk/pull/9813 is merged, users will not need to add their account ID namespace to the image name.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
