### PR TITLE
Vectorize: clarify vector dimension storage precision

### DIFF
--- a/src/content/docs/vectorize/best-practices/insert-vectors.mdx
+++ b/src/content/docs/vectorize/best-practices/insert-vectors.mdx
@@ -21,13 +21,15 @@ Use the upsert operation if you want to overwrite the vector value for a vector 
 
 ## Supported vector formats
 
-Vectorize supports vectors in three formats:
+Vectorize supports the insert/upsert of vectors in three formats:
 
 - An array of floating point numbers (converted into a JavaScript `number[]` array).
 - A [Float32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array)
 - A [Float64Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array)
 
 In most cases, a `number[]` array is the easiest when dealing with other APIs, and is the return type of most machine-learning APIs.
+
+Vectorize stores and restitutes vector dimensions as Float32; vector dimensions provided as Float64 will be converted to Float32 before being stored.
 
 ## Metadata
 

--- a/src/content/docs/vectorize/platform/limits.mdx
+++ b/src/content/docs/vectorize/platform/limits.mdx
@@ -10,7 +10,8 @@ The following limits apply to accounts, indexes and vectors (as specified):
 | Feature                                                       | Current Limit                       |
 | ------------------------------------------------------------- | ----------------------------------- |
 | Indexes per account                                           | 50,000 (Workers Paid) / 100 (Free)  |
-| Maximum dimensions per vector                                 | 1536 dimensions                     |
+| Maximum dimensions per vector                                 | 1536 dimensions, 32 bits precision  |
+| Precision per vector dimension                                | 32 bits (float32)             |
 | Maximum vector ID length                                      | 64 bytes                            |
 | Metadata per vector                                           | 10KiB                               |
 | Maximum returned results (`topK`) with values or metadata     | 20                                  |


### PR DESCRIPTION
### Summary

Update the vectorize docs (limits and best practices) to mention that Vectorize stores vector dimensions as Float32.
