### PR TITLE
[ai-gateway] clarify authentication behavior for Worker bindings

### DIFF
--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -61,6 +61,11 @@ const openai = createOpenAI({
 
 ## Expected behavior
 
+:::note
+When an AI Gateway is accessed from a Cloudflare Worker using a **binding**, the `cf-aig-authorization` header does not need to be manually included.  
+Requests made through bindings are **pre-authenticated** within the associated Cloudflare account. 
+:::
+
 The following table outlines gateway behavior based on the authentication settings and header status:
 
 | Authentication Setting | Header Info    | Gateway State           | Response                                   |


### PR DESCRIPTION
clarify that cf-aig-authorization header is not required for Worker bindings

### Summary

Requests made via Cloudflare Worker bindings are pre-authenticated and do not require
manual inclusion of the cf-aig-authorization header. This note helps clarify internal
vs external request behavior when using Authenticated Gateway.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
