### PR TITLE
Add troubleshooting section with exposing-ports sub-section to containers local-dev docs

### DIFF
--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -65,3 +65,6 @@ And if you call `getTCPPort()` on a port that you have not exposed in your `Dock
 ```text
 connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.
 ```
+
+You may also see this while the container is starting up and no ports are available yet. You should retry until the ports become available.
+This retry logic should be handled for you if you are using the [containers package](https://github.com/cloudflare/containers/tree/main/src).

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -44,3 +44,24 @@ You may prefer to set up your own code watchers and reloading mechanisms, or mou
 into the local container images to sync code changes. This can be done, but there is no built-in
 mechanism for doing so in Wrangler, and best-practices will depend on the languages and frameworks
 you are using in your container code.
+
+## Troubleshooting
+
+### Exposing Ports
+
+In production, all of your container's ports will be accessible by your Worker,
+so you do not need to specifically expose ports using the [`EXPOSE` instruction](https://docs.docker.com/reference/dockerfile/#expose) in your Dockerfile.
+
+But for local development on non-Linux systems, you most likely need to expose a port to access your container properly; for example: `EXPOSE 4000`.
+
+If you have not exposed any ports, you will see the following type of error when building or pulling your container image:
+
+```text
+The container "MyContainer" does not expose any ports, please expose any port that you want to use with `getTCPPort()`.
+```
+
+And if you call `getTCPPort()` on an unexposed port you will see the following error:
+
+```text
+connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.
+```

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -52,15 +52,15 @@ you are using in your container code.
 In production, all of your container's ports will be accessible by your Worker,
 so you do not need to specifically expose ports using the [`EXPOSE` instruction](https://docs.docker.com/reference/dockerfile/#expose) in your Dockerfile.
 
-But for local development on non-Linux systems, you will need to declare any ports you need to access in your Dockerfile with the EXPOSE instruction; for example: `EXPOSE 4000`, if you will be accessing port 4000.
+But for local development you will need to declare any ports you need to access in your Dockerfile with the EXPOSE instruction; for example: `EXPOSE 4000`, if you will be accessing port 4000.
 
 If you have not exposed any ports, you will see the following error in local development:
 
 ```text
-The container "MyContainer" does not expose any ports, please expose any port that you want to use with `getTCPPort()`.
+The container "MyContainer" does not expose any ports. In your Dockerfile, please expose any ports you intend to connect to.
 ```
 
-And if you call `getTCPPort()` on a port that you have not exposed in your `Dockerfile` you will see the following error:
+And if you try to connect to any port that you have not exposed in your `Dockerfile` you will see the following error:
 
 ```text
 connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -56,13 +56,13 @@ But for local development you will need to declare any ports you need to access 
 
 If you have not exposed any ports, you will see the following error in local development:
 
-```text
+```txt
 The container "MyContainer" does not expose any ports. In your Dockerfile, please expose any ports you intend to connect to.
 ```
 
 And if you try to connect to any port that you have not exposed in your `Dockerfile` you will see the following error:
 
-```text
+```txt
 connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.
 ```
 

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -52,15 +52,15 @@ you are using in your container code.
 In production, all of your container's ports will be accessible by your Worker,
 so you do not need to specifically expose ports using the [`EXPOSE` instruction](https://docs.docker.com/reference/dockerfile/#expose) in your Dockerfile.
 
-But for local development on non-Linux systems, you most likely need to expose a port to access your container properly; for example: `EXPOSE 4000`.
+But for local development on non-Linux systems, you will need to declare any ports you need to access in your Dockerfile with the EXPOSE instruction; for example: `EXPOSE 4000`, if you will be accessing port 4000.
 
-If you have not exposed any ports, you will see the following type of error when building or pulling your container image:
+If you have not exposed any ports, you will see the following error in local development:
 
 ```text
 The container "MyContainer" does not expose any ports, please expose any port that you want to use with `getTCPPort()`.
 ```
 
-And if you call `getTCPPort()` on an unexposed port you will see the following error:
+And if you call `getTCPPort()` on a port that you have not exposed in your `Dockerfile` you will see the following error:
 
 ```text
 connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.


### PR DESCRIPTION
Internal ref: DEVX-2024