### PR TITLE
Clarify pattern matching for run_worker_first

### DIFF
--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -85,7 +85,7 @@ The array supports glob patterns with `*` for deep matching and negative pattern
 
 Negative patterns have precedence over non-negative patterns. The Worker will run first when a non-negative pattern matches and none of the negative pattern matches.
 
-Note that the order in which the patterns are listed is not significant.
+The order in which the patterns are listed is not significant.
 
 This is often paired with the [`not_found_handling = "single-page-application"` setting](/workers/static-assets/routing/single-page-application/#advanced-routing-control):
 

--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -79,7 +79,15 @@ run_worker_first = true
 
 </WranglerConfig>
 
-You can also specify `run_worker_first` as an array of route patterns to selectively run the Worker script first only for specific routes. This is often paired with the [`not_found_handling = "single-page-application"` setting](/workers/static-assets/routing/single-page-application/#advanced-routing-control):
+You can also specify `run_worker_first` as an array of route patterns to selectively run the Worker script first only for specific routes.
+
+The array supports glob patterns with `*` for deep matching and negative patterns with `!` prefix.
+
+Negative patterns have precedence over non-negative patterns. The Worker will run first when a non-negative pattern matches and none of the negative pattern matches.
+
+Note that the order in which the patterns are listed is not significant.
+
+This is often paired with the [`not_found_handling = "single-page-application"` setting](/workers/static-assets/routing/single-page-application/#advanced-routing-control):
 
 <WranglerConfig>
 
@@ -98,7 +106,8 @@ You can also specify `run_worker_first` as an array of route patterns to selecti
 ```
 
 </WranglerConfig>
-The array supports glob patterns with `*` for deep matching and exception patterns with `!` prefix. In this configuration, requests to `/api/*` routes will invoke the Worker script first, except for `/api/docs/*` which will follow the default asset-first routing behavior.
+
+In this configuration, requests to `/api/*` routes will invoke the Worker script first, except for `/api/docs/*` which will follow the default asset-first routing behavior.
 
 ## `binding`
 

--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -87,7 +87,7 @@ Negative patterns have precedence over non-negative patterns. The Worker will ru
 
 The order in which the patterns are listed is not significant.
 
-This is often paired with the [`not_found_handling = "single-page-application"` setting](/workers/static-assets/routing/single-page-application/#advanced-routing-control):
+`run_worker_first` is often paired with the [`not_found_handling = "single-page-application"` setting](/workers/static-assets/routing/single-page-application/#advanced-routing-control):
 
 <WranglerConfig>
 


### PR DESCRIPTION
### Summary

Clarify pattern matching for run_worker_first: 

- negative patterns have precedence over non-negative patterns
- the order of the patterns is not significant

Also changed from "exception patterns" to "negative patterns" to align with the [API docs](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/update/):

```text
Contains a list path rules to control routing to either the Worker or assets. Glob (*) and negative (!) rules are supported. Rules must start with either '/' or '!/'. At least one non-negative rule must be provided, and negative rules have higher precedence than non-negative rules.
```

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

