### PR TITLE
Rename to cf-requirements and add pywrangler section.

### DIFF
--- a/src/content/docs/workers/languages/python/how-python-workers-work.mdx
+++ b/src/content/docs/workers/languages/python/how-python-workers-work.mdx
@@ -50,9 +50,9 @@ Refer to the [Python examples](/workers/languages/python/examples/) to learn how
 
 To reduce cold start times, when you deploy a Python Worker, Cloudflare performs as much of the expensive work as possible upfront, at deploy time. When you run npx `wrangler@latest deploy`, the following happens:
 
-1. Wrangler uploads your Python code and your `requirements.txt` file to the Workers API.
-2. Cloudflare sends your Python code, and your `requirements.txt` file to the Workers runtime to be validated.
-3. Cloudflare creates a new v8 isolate for your Worker, and automatically injects Pyodide plus any packages you’ve specified in your `requirements.txt` file.
+1. Wrangler uploads your Python code and any vendored packages to the Workers API.
+2. Cloudflare sends your Python code, and any vendored packages to the Workers runtime to be validated.
+3. Cloudflare creates a new v8 isolate for your Worker, and automatically injects Pyodide plus any built-in packages requested by your bundle.
 4. Cloudflare scans the Worker’s code for import statements, execute them, and then take a snapshot of the Worker’s WebAssembly linear memory. Effectively, we perform the expensive work of importing packages at deploy time, rather than at runtime.
 5. Cloudflare deploys this snapshot alongside your Worker’s Python code to the Cloudflare network.
 

--- a/src/content/docs/workers/languages/python/packages/index.mdx
+++ b/src/content/docs/workers/languages/python/packages/index.mdx
@@ -8,77 +8,43 @@ head:
 
 import { Render } from "~/components";
 
-<Render file="python-workers-beta-packages" product="workers" />
+[Pywrangler](https://github.com/cloudflare/workers-py?tab=readme-ov-file#pywrangler) is a CLI tool for managing packages and Python Workers.
+It is meant as a wrapper for wrangler that sets up a full environment for you, including bundling your packages into
+your worker bundle on deployment.
 
-To import a Python package, add the package name to the `requirements.txt` file within the same directory as your [Wrangler configuration file](/workers/wrangler/configuration/).
+To get started, create a pyproject.toml file with the following contents:
 
-For example, if your Worker depends on [FastAPI](https://fastapi.tiangolo.com/), you would add the following:
+```toml
+[project]
+name = "YourProjectName"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi"
+]
+
+[dependency-groups]
+dev = ["workers-py"]
+```
+
+The above will allow your worker to depend on the [FastAPI](https://fastapi.tiangolo.com/) package.
+
+To run the worker locally:
 
 ```
-fastapi
+uv run pywrangler dev
 ```
 
-## Package versioning
+To deploy your worker:
 
-In the example above, you likely noticed that there is no explicit version of the Python package declared in `requirements.txt`.
+```
+uv run pywrangler deploy
+```
 
-In Workers, Python package versions are set via [Compatibility Dates](/workers/configuration/compatibility-dates/) and [Compatibility Flags](/workers/configuration/compatibility-flags/). Given a particular compatibility date, a specific version of the [Pyodide Python runtime](https://pyodide.org/en/stable/project/changelog.html) is provided to your Worker, providing a specific set of Python packages pinned to specific versions.
+Your dependencies will get bundled with your worker automatically on deployment.
 
-As new versions of Pyodide and additional Python packages become available in Workers, we will publish compatibility flags and their associated compatibility dates here on this page.
-
-## Supported Packages
-
-A subset of the [Python packages that Pyodide supports](https://pyodide.org/en/latest/usage/packages-in-pyodide.html) are provided directly by the Workers runtime:
-
-- aiohttp: 3.9.3
-- aiohttp-tests: 3.9.3
-- aiosignal: 1.3.1
-- annotated-types: 0.6.0
-- annotated-types-tests: 0.6.0
-- anyio: 4.2.0
-- async-timeout: 4.0.3
-- attrs: 23.2.0
-- certifi: 2024.2.2
-- charset-normalizer: 3.3.2
-- distro: 1.9.0
-- [fastapi](/workers/languages/python/packages/fastapi): 0.110.0
-- frozenlist: 1.4.1
-- h11: 0.14.0
-- h11-tests: 0.14.0
-- hashlib: 1.0.0
-- httpcore: 1.0.4
-- httpx: 0.27.0
-- idna: 3.6
-- jsonpatch: 1.33
-- jsonpointer: 2.4
-- langchain: 0.1.8
-- langchain-core: 0.1.25
-- langchain-openai: 0.0.6
-- langsmith: 0.1.5
-- lzma: 1.0.0
-- micropip: 0.6.0
-- multidict: 6.0.5
-- numpy: 1.26.4
-- numpy-tests: 1.26.4
-- openai: 1.12.0
-- openssl: 1.1.1n
-- packaging: 23.2
-- pydantic: 2.6.1
-- pydantic-core: 2.16.2
-- pydecimal: 1.0.0
-- pydoc-data: 1.0.0
-- pyyaml: 6.0.1
-- regex: 2023.12.25
-- regex-tests: 2023.12.25
-- requests: 2.31.0
-- six: 1.16.0
-- sniffio: 1.3.0
-- sniffio-tests: 1.3.0
-- sqlite3: 1.0.0
-- ssl: 1.0.0
-- starlette: 0.36.3
-
-Looking for a package not listed here? Tell us what you'd like us to support by [opening a discussion on Github](https://github.com/cloudflare/workerd/discussions/new?category=python-packages).
+The `pywrangler` CLI also supports all commands supported by the `wrangler` tool, for the full list of commands run `uv run pywrangler --help`.
 
 ## HTTP Client Libraries
 


### PR DESCRIPTION
### Summary

Updated the Python docs to refer to cf-requirements.txt instead of requirements.txt and added a new section about pywrangler to point people to it instead of the old Built-in package pathway.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
