### PR TITLE
[Workers] Fix URL Matching Usage in `custom_headers.mdx` Example

### DIFF
--- a/src/content/partials/workers/custom_headers.mdx
+++ b/src/content/partials/workers/custom_headers.mdx
@@ -117,14 +117,14 @@ This applies the `Access-Control-Allow-Origin` header to any incoming URL. To be
 
 [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) and other search engines often support the `X-Robots-Tag` header to instruct its crawlers how your website should be indexed.
 
-For example, to prevent your <code>{props.product === 'workers' ? '\*.\*.workers.dev' : '\*.pages.dev'}</code> URLs from being indexed, add the following to your `_headers` file:
+For example, to prevent your {props.product === 'workers' ? <code>\*.\*.workers.dev</code> : <><code>\*.pages.dev</code> and <code>\*.\*.pages.dev</code></>} URLs from being indexed, add the following to your `_headers` file:
 
 <Code
 	lang="txt"
 	code={
 		props.product === "workers"
 			? `https://:version.:subdomain.workers.dev/*\n\tX-Robots-Tag: noindex`
-			: `https://*.pages.dev/*\n\tX-Robots-Tag: noindex`
+			: `https://:project.pages.dev/*\n\tX-Robots-Tag: noindex\n\nhttps://:version.:project.pages.dev/*\n\tX-Robots-Tag: noindex`
 	}
 />
 

--- a/src/content/partials/workers/custom_headers.mdx
+++ b/src/content/partials/workers/custom_headers.mdx
@@ -117,7 +117,7 @@ This applies the `Access-Control-Allow-Origin` header to any incoming URL. To be
 
 [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) and other search engines often support the `X-Robots-Tag` header to instruct its crawlers how your website should be indexed.
 
-For example, to prevent your {props.product === 'workers' ? <code>\*.\*.workers.dev</code> : <><code>\*.pages.dev</code> and <code>\*.\*.pages.dev</code></>} URLs from being indexed, add the following to your `_headers` file: 
+For example, to prevent your {props.product === 'workers' ? <code>\*.\*.workers.dev</code> : <><code>\*.pages.dev</code> and <code>\*.\*.pages.dev</code></>} URLs from being indexed, add the following to your `_headers` file:
 
 <Code
 	lang="txt"

--- a/src/content/partials/workers/custom_headers.mdx
+++ b/src/content/partials/workers/custom_headers.mdx
@@ -117,7 +117,7 @@ This applies the `Access-Control-Allow-Origin` header to any incoming URL. To be
 
 [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) and other search engines often support the `X-Robots-Tag` header to instruct its crawlers how your website should be indexed.
 
-For example, to prevent your {props.product === 'workers' ? <code>\*.\*.workers.dev</code> : <><code>\*.pages.dev</code> and <code>\*.\*.pages.dev</code></>} URLs from being indexed, add the following to your `_headers` file:
+For example, to prevent your {props.product === 'workers' ? <code>\*.\*.workers.dev</code> : <><code>\*.pages.dev</code> and <code>\*.\*.pages.dev</code></>} URLs from being indexed, add the following to your `_headers` file: 
 
 <Code
 	lang="txt"

--- a/src/content/partials/workers/custom_headers.mdx
+++ b/src/content/partials/workers/custom_headers.mdx
@@ -117,13 +117,13 @@ This applies the `Access-Control-Allow-Origin` header to any incoming URL. To be
 
 [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) and other search engines often support the `X-Robots-Tag` header to instruct its crawlers how your website should be indexed.
 
-For example, to prevent your <code>{props.product === 'workers' ? '\*.workers.dev' : '\*.pages.dev'}</code> URLs from being indexed, add the following to your `_headers` file:
+For example, to prevent your <code>{props.product === 'workers' ? '\*.\*.workers.dev' : '\*.pages.dev'}</code> URLs from being indexed, add the following to your `_headers` file:
 
 <Code
 	lang="txt"
 	code={
 		props.product === "workers"
-			? `https://*.workers.dev/*\n\tX-Robots-Tag: noindex`
+			? `https://:version.:subdomain.workers.dev/*\n\tX-Robots-Tag: noindex`
 			: `https://*.pages.dev/*\n\tX-Robots-Tag: noindex`
 	}
 />


### PR DESCRIPTION
### Summary

The previous example for matching `workers.dev` URLs under ["Prevent your workers.dev URLs showing in search results"](https://developers.cloudflare.com/workers/static-assets/headers/#prevent-your-workersdev-urls-showing-in-search-results) incorrectly used two "splats", i.e. `*`, when only one splat can be used at maximum.

Addressing the above feedback raised in https://github.com/cloudflare/cloudflare-docs/issues/23472, this PR updates the example to use a single splat wildcard with a placeholder pattern that correctly matches both `workers.dev` URLs and Preview URLs.

closes #23472 

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
