### PR TITLE
[WAF] Filter/hide API permissions

### DIFF
--- a/src/content/docs/waf/account/custom-rulesets/create-api.mdx
+++ b/src/content/docs/waf/account/custom-rulesets/create-api.mdx
@@ -48,6 +48,7 @@ The following example creates a custom ruleset with a single rule in the `rules`
 		],
 		phase: "http_request_firewall_custom",
 	}}
+	roles="account"
 />
 
 Save the ruleset ID in the response for the next step.
@@ -67,6 +68,7 @@ To deploy the custom ruleset, add a rule with `"action": "execute"` to the `http
     	parameters={{
     		ruleset_phase: "http_request_firewall_custom",
     	}}
+    	roles="account"
     />
 
     ```json output {4}
@@ -110,6 +112,7 @@ To deploy the custom ruleset, add a rule with `"action": "execute"` to the `http
     		},
     		enabled: true,
     	}}
+    	roles="account"
     />
 
     :::caution
@@ -142,6 +145,7 @@ To deploy the custom ruleset, add a rule with `"action": "execute"` to the `http
     		],
     		phase: "http_request_firewall_custom",
     	}}
+    	roles="account"
     />
 
 ## Next steps

--- a/src/content/docs/waf/account/managed-rulesets/index.mdx
+++ b/src/content/docs/waf/account/managed-rulesets/index.mdx
@@ -33,7 +33,6 @@ The second rule logs any matches for PL4 rules, the most strict set of rules in 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 1. Deploy the Cloudflare OWASP Core Ruleset by following the [dashboard instructions](/waf/account/managed-rulesets/deploy-dashboard/#deploy-a-managed-ruleset), customizing the ruleset behavior using these settings:
-
    - **OWASP Anomaly Score Threshold**: _Medium - 40 and higher_
    - **OWASP Paranoia Level**: _PL3_
    - **OWASP Action**: _Managed Challenge_
@@ -41,7 +40,6 @@ The second rule logs any matches for PL4 rules, the most strict set of rules in 
 2. Select **Deploy**.
 
 3. Repeat the deployment procedure for the OWASP ruleset, but with following ruleset configuration:
-
    - **OWASP Anomaly Score Threshold**: _Medium - 40 and higher_
    - **OWASP Paranoia Level**: _PL4_
    - **OWASP Action**: _Log_
@@ -102,6 +100,7 @@ The following `POST` request for the [Create an account ruleset](/api/resources/
 			},
 		],
 	}}
+	roles="account"
 />
 
 </TabItem> </Tabs>

--- a/src/content/docs/waf/account/rate-limiting-rulesets/create-api.mdx
+++ b/src/content/docs/waf/account/rate-limiting-rulesets/create-api.mdx
@@ -64,6 +64,7 @@ The following example creates a rate limiting ruleset with a single rate limitin
 		],
 		phase: "http_ratelimit",
 	}}
+	roles="account"
 />
 
 The available characteristics depend on your Cloudflare plan and product subscriptions. Refer to [Availability](/waf/rate-limiting-rules/#availability) for more information.
@@ -85,6 +86,7 @@ To deploy the rate limiting ruleset, add a rule with `"action": "execute"` to th
     	parameters={{
     		ruleset_phase: "http_ratelimit",
     	}}
+    	roles="account"
     />
 
     ```json output {4}
@@ -129,6 +131,7 @@ To deploy the rate limiting ruleset, add a rule with `"action": "execute"` to th
     		},
     		enabled: true,
     	}}
+    	roles="account"
     />
 
     <Render file="account-enterprise-zones-only-api" />
@@ -159,6 +162,7 @@ To deploy the rate limiting ruleset, add a rule with `"action": "execute"` to th
     		],
     		phase: "http_ratelimit",
     	}}
+    	roles="account"
     />
 
 For examples of rate limiting rule definitions for the API, refer to the [zone-level API documentation](/waf/rate-limiting-rules/create-api/).

--- a/src/content/docs/waf/custom-rules/create-api.mdx
+++ b/src/content/docs/waf/custom-rules/create-api.mdx
@@ -44,6 +44,7 @@ The new rule, which will be the last rule in the ruleset, will challenge request
 			'(ip.src.country eq "GB" or ip.src.country eq "FR") and cf.waf.score lt 20',
 		action: "challenge",
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />
@@ -70,6 +71,7 @@ The new rule, which will be the last rule in the ruleset, includes the definitio
 			},
 		},
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />

--- a/src/content/docs/waf/custom-rules/skip/api-examples.mdx
+++ b/src/content/docs/waf/custom-rules/skip/api-examples.mdx
@@ -41,6 +41,7 @@ This example invokes the [Create a zone ruleset rule](/api/resources/rulesets/su
 		expression: 'http.request.uri.path contains "/skip-current-ruleset/"',
 		description: "",
 	}}
+	roles={false}
 />
 
 ## Skip a phase
@@ -58,6 +59,7 @@ This example invokes the [Create a zone ruleset rule](/api/resources/rulesets/su
 		expression: 'http.request.uri.path contains "/skip-phase/"',
 		description: "",
 	}}
+	roles={false}
 />
 
 Refer to [Available skip options](/waf/custom-rules/skip/options/) for the list of phases you can skip.
@@ -83,6 +85,7 @@ This example invokes the [Create a zone ruleset rule](/api/resources/rulesets/su
 		expression: 'http.request.uri.path contains "/disable-logging/"',
 		description: "",
 	}}
+	roles={false}
 />
 
 Refer to [Available skip options: Logging](/waf/custom-rules/skip/options/#logging) for more information on disabling logging for requests that match a skip rule.
@@ -102,6 +105,7 @@ This example uses the [Create a zone ruleset rule](/api/resources/rulesets/subre
 		expression: 'http.request.uri.path contains "/skip-products/"',
 		description: "",
 	}}
+	roles={false}
 />
 
 Refer to [Available skip options](/waf/custom-rules/skip/options/) for the list of products you can skip.

--- a/src/content/docs/waf/managed-rules/check-for-exposed-credentials/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/check-for-exposed-credentials/configure-api.mdx
@@ -75,6 +75,7 @@ This `POST` request example creates a new custom ruleset with a rule that checks
 		],
 		phase: "http_request_firewall_custom",
 	}}
+	roles="account"
 />
 
 The response returns the created ruleset. Note the presence of the `exposed_credential_check` object on the rule definition.
@@ -153,6 +154,7 @@ This `POST` request example creates a new custom ruleset with a rule that checks
 		],
 		phase: "http_request_firewall_custom",
 	}}
+	roles="account"
 />
 
 The response returns the created ruleset. Note the presence of the following elements in the rule definition:

--- a/src/content/docs/waf/managed-rules/payload-logging/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/payload-logging/configure-api.mdx
@@ -16,7 +16,6 @@ Use the [Rulesets API](/ruleset-engine/rulesets-api/) to configure payload loggi
 ## Configure and enable payload logging
 
 1. Use the [Get a zone entry point ruleset](/api/resources/rulesets/subresources/phases/methods/get/) operation to obtain the following IDs:
-
    - The ID of the [entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset) of the `http_request_firewall_managed` [phase](/ruleset-engine/about/phases/).
    - The ID of the `execute` rule deploying the WAF managed ruleset, for which you want to configure payload logging.
 
@@ -48,7 +47,7 @@ To configure payload logging for a managed ruleset deployed at the account level
 
 This example configures payload logging for the [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/), which is already deployed for a zone with ID `$ZONE_ID`.
 
-1. Invoke the [Get a zone entry point ruleset](/api/resources/rulesets/subresources/phases/methods/get/) operation (a `GET` request) to obtain the rules currently configured in the entry point ruleset of the `http_request_firewall_managed` phase.
+1. Invoke the [Get a zone entry point ruleset](/api/resources/rulesets/subresources/phases/methods/get/) operation to obtain the rules currently configured in the entry point ruleset of the `http_request_firewall_managed` phase.
 
    <APIRequest
    	path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
@@ -56,6 +55,7 @@ This example configures payload logging for the [Cloudflare Managed Ruleset](/wa
    	parameters={{
    		ruleset_phase: "http_request_firewall_managed",
    	}}
+   	roles={false}
    />
 
    ```json output {3,12,20}
@@ -94,7 +94,6 @@ This example configures payload logging for the [Cloudflare Managed Ruleset](/wa
    ```
 
 2. Save the following IDs for the next step:
-
    - The ID of the entry point ruleset: `060013b1eeb14c93b0dcd896537e0d2c`
    - The ID of the `execute` rule deploying the Cloudflare Managed Ruleset: `1bdb49371c1f46958fc8b985efcb79e7`
 
@@ -105,7 +104,7 @@ This example configures payload logging for the [Cloudflare Managed Ruleset](/wa
    To get the IDs of existing WAF managed rulesets, refer to [WAF Managed Rules](/waf/managed-rules/#available-managed-rulesets) or use the [List account rulesets](/api/resources/rulesets/methods/list/) operation.
    :::
 
-3. Invoke the [Update a zone ruleset rule](/api/resources/rulesets/methods/update/) operation (a `PATCH` request) to update the configuration of the rule you identified. The rule will now include the payload logging configuration (`matched_data` object).
+3. Invoke the [Update a zone ruleset rule](/api/resources/rulesets/methods/update/) operation to update the configuration of the rule you identified. The rule will now include the payload logging configuration (`matched_data` object).
 
    <APIRequest
    	path="/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}"
@@ -124,6 +123,10 @@ This example configures payload logging for the [Cloudflare Managed Ruleset](/wa
    		},
    		expression: "true",
    	}}
+   	code={{
+   		mark: [8, 9, 10],
+   	}}
+   	roles={false}
    />
 
    The response will include the complete ruleset after updating the rule.
@@ -136,11 +139,11 @@ For more information on deploying managed rulesets via API, refer to [Deploy a m
 
 To disable payload logging for a managed ruleset:
 
-1. Use the [Update a zone ruleset rule](/api/resources/rulesets/methods/update/) operation (a `PATCH` request) to update the rule deploying the managed ruleset (an `execute` rule).
+1. Use the [Update a zone ruleset rule](/api/resources/rulesets/methods/update/) operation to update the rule deploying the managed ruleset (a rule with `"action": "execute"`).
 
 2. Modify the rule definition so that there is no `matched_data` object in `action_parameters`.
 
-For example, the following `PATCH` request updates rule with ID `$RULE_ID` deploying the [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) so that payload logging is disabled:
+For example, the following `PATCH` request updates the rule with ID `$RULE_ID` deploying the [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) so that payload logging is disabled:
 
 <APIRequest
 	path="/zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}"
@@ -152,6 +155,7 @@ For example, the following `PATCH` request updates rule with ID `$RULE_ID` deplo
 		},
 		expression: "true",
 	}}
+	roles={false}
 />
 
 For details on obtaining the entry point ruleset ID and the ID of the rule to update, refer to [Configure and enable payload logging](/waf/managed-rules/payload-logging/configure-api/#configure-and-enable-payload-logging).

--- a/src/content/docs/waf/managed-rules/reference/exposed-credentials-check.mdx
+++ b/src/content/docs/waf/managed-rules/reference/exposed-credentials-check.mdx
@@ -67,6 +67,7 @@ This example deploys the Cloudflare Exposed Credentials Check Managed Ruleset to
     	parameters={{
     		ruleset_phase: "http_request_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {4}
@@ -111,6 +112,7 @@ This example deploys the Cloudflare Exposed Credentials Check Managed Ruleset to
     		description:
     			"Execute the Cloudflare Exposed Credentials Check Managed Ruleset",
     	}}
+    	roles={false}
     />
 
     ```json output
@@ -176,6 +178,7 @@ This example deploys the Cloudflare Exposed Credentials Check Managed Ruleset to
     			},
     		],
     	}}
+    	roles={false}
     />
 
 <Render

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
@@ -36,7 +36,11 @@ This example sets the Cloudflare OWASP Core Ruleset's paranoia level for a zone 
 
 1.  Get the ID of the Cloudflare OWASP Core Ruleset using the [List account rulesets](/api/resources/rulesets/methods/list/) method, since WAF's managed rulesets exist at the account level. Alternatively, use the following ruleset ID directly: <RuleID id="4814384a9e5d4991b9815dcfc25d2f1f" />.
 
-    <APIRequest path="/accounts/{account_id}/rulesets" method="GET" />
+    <APIRequest
+    	path="/accounts/{account_id}/rulesets"
+    	method="GET"
+    	roles={false}
+    />
 
     ```json output {4-5}
     {
@@ -67,6 +71,7 @@ This example sets the Cloudflare OWASP Core Ruleset's paranoia level for a zone 
     	parameters={{
     		ruleset_phase: "http_request_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {3,12,14-16}
@@ -133,6 +138,7 @@ This example sets the Cloudflare OWASP Core Ruleset's paranoia level for a zone 
     		expression: "true",
     		enabled: true,
     	}}
+    	roles={false}
     />
 
 For more information on creating overrides, refer to [Override a managed ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
@@ -150,7 +156,11 @@ This example configures the managed ruleset score threshold and the performed ac
 
 1. Get the ID of the Cloudflare OWASP Core Ruleset using the [List account rulesets](/api/resources/rulesets/methods/list/) method, since WAF's managed rulesets exist at the account level. Alternatively, use the following ruleset ID directly: <RuleID id="4814384a9e5d4991b9815dcfc25d2f1f" />.
 
-   <APIRequest path="/accounts/{account_id}/rulesets" method="GET" />
+   <APIRequest
+   	path="/accounts/{account_id}/rulesets"
+   	method="GET"
+   	roles={false}
+   />
 
    ```json output {4-5}
    {
@@ -179,6 +189,7 @@ This example configures the managed ruleset score threshold and the performed ac
    	path="/accounts/{account_id}/rulesets/{ruleset_id}"
    	method="GET"
    	parameters={{ ruleset_id: "$OWASP_RULESET_ID" }}
+   	roles={false}
    />
 
    ```json output {12,16}
@@ -220,6 +231,7 @@ This example configures the managed ruleset score threshold and the performed ac
    	parameters={{
    		ruleset_phase: "http_request_firewall_managed",
    	}}
+   	roles={false}
    />
 
    ```json output {3,12,14-16}
@@ -258,7 +270,6 @@ This example configures the managed ruleset score threshold and the performed ac
    ```
 
 4. Update the rule you identified in the entry point ruleset using the [Update a zone ruleset rule](/api/resources/rulesets/methods/update/) operation, adding a rule override for the last rule in the OWASP ruleset (identified in step 2) with the following properties and values:
-
    - `"score_threshold": 60`
    - `"action": "managed_challenge"`
 
@@ -286,6 +297,7 @@ This example configures the managed ruleset score threshold and the performed ac
    		expression: "true",
    		enabled: true,
    	}}
+   	roles={false}
    />
 
 ## More resources

--- a/src/content/docs/waf/managed-rules/reference/sensitive-data-detection.mdx
+++ b/src/content/docs/waf/managed-rules/reference/sensitive-data-detection.mdx
@@ -81,6 +81,7 @@ This example deploys the Cloudflare Sensitive Data Detection managed ruleset to 
     	parameters={{
     		ruleset_phase: "http_response_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {4}
@@ -124,6 +125,7 @@ This example deploys the Cloudflare Sensitive Data Detection managed ruleset to 
     		description:
     			"Execute the Cloudflare Sensitive Data Detection managed ruleset",
     	}}
+    	roles={false}
     />
 
     ```json output
@@ -189,6 +191,7 @@ This example deploys the Cloudflare Sensitive Data Detection managed ruleset to 
     			},
     		],
     	}}
+    	roles={false}
     />
 
 <Render

--- a/src/content/docs/waf/managed-rules/waf-exceptions/define-api.mdx
+++ b/src/content/docs/waf/managed-rules/waf-exceptions/define-api.mdx
@@ -38,6 +38,7 @@ The following example adds a rule that skips all remaining rules in the entry po
     	parameters={{
     		ruleset_phase: "http_request_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {3}
@@ -80,6 +81,7 @@ The following example adds a rule that skips all remaining rules in the entry po
     			before: "",
     		},
     	}}
+    	roles={false}
     />
 
 For more information on skipping all remaining rules via API, refer to [Create an exception](/ruleset-engine/managed-rulesets/create-exception/#skip-all-remaining-rules) in the Ruleset Engine documentation.
@@ -96,6 +98,7 @@ The following example adds a rule that skips the [Cloudflare Managed Ruleset](/w
     	parameters={{
     		ruleset_phase: "http_request_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {3,12,20}
@@ -140,7 +143,6 @@ The following example adds a rule that skips the [Cloudflare Managed Ruleset](/w
     :::
 
     Save the following IDs for the next step:
-
     - The ID of the entry point ruleset (`060013b1eeb14c93b0dcd896537e0d2c` in this example)
     - The ID of the `execute` rule deployment the managed ruleset (`1bdb49371c1f46958fc8b985efcb79e7` in this example)
 
@@ -161,6 +163,7 @@ The following example adds a rule that skips the [Cloudflare Managed Ruleset](/w
     			before: "1bdb49371c1f46958fc8b985efcb79e7",
     		},
     	}}
+    	roles={false}
     />
 
 For more information on skipping one or more managed rulesets via API, refer to [Create an exception](/ruleset-engine/managed-rulesets/create-exception/#skip-one-or-more-managed-rulesets) in the Ruleset Engine documentation.
@@ -182,6 +185,7 @@ The following example adds a rule that skips a particular rule of the [Cloudflar
     	parameters={{
     		ruleset_id: "efb7b8c949ac4650a09736fc376e9aee",
     	}}
+    	roles={false}
     />
 
     ```json output {12}
@@ -226,6 +230,7 @@ The following example adds a rule that skips a particular rule of the [Cloudflar
     	parameters={{
     		ruleset_phase: "http_request_firewall_managed",
     	}}
+    	roles={false}
     />
 
     ```json output {3,12,20}
@@ -270,12 +275,10 @@ The following example adds a rule that skips a particular rule of the [Cloudflar
     :::
 
     Save the following IDs for the next step:
-
     - The ID of the entry point ruleset (`060013b1eeb14c93b0dcd896537e0d2c` in this example)
     - The ID of the `execute` rule deploying the Cloudflare Managed Ruleset (`1bdb49371c1f46958fc8b985efcb79e7` in this example)
 
     You will also use the following IDs:
-
     - The ID of the Cloudflare Managed Ruleset (<RuleID id="efb7b8c949ac4650a09736fc376e9aee" />)
     - The ID of the rule to skip (<RuleID id="d9e350f1b72d4730899c8a420e48a85d" /> in this example)
 
@@ -302,6 +305,7 @@ The following example adds a rule that skips a particular rule of the [Cloudflar
     			before: "1bdb49371c1f46958fc8b985efcb79e7",
     		},
     	}}
+    	roles={false}
     />
 
 The `action_parameters` > `rules` object contains the ID of the Cloudflare Managed Ruleset with an associated list of rule IDs to skip (in this case, only one rule). The [`position` object](/ruleset-engine/rulesets-api/add-rule/#define-the-rule-position-in-the-ruleset) defines the exact rule placement in the entry point ruleset (before rule `1bdb49371c1f46958fc8b985efcb79e7`).

--- a/src/content/docs/waf/rate-limiting-rules/create-api.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/create-api.mdx
@@ -54,6 +54,7 @@ This example adds a rate limiting rule to the `http_ratelimit` phase entry point
 			mitigation_timeout: 600,
 		},
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />
@@ -89,6 +90,7 @@ The new rule defines a [custom response](/waf/rate-limiting-rules/create-zone-da
 			mitigation_timeout: 600,
 		},
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />
@@ -118,6 +120,7 @@ The new rule does not consider requests for cached assets when calculating the r
 			requests_to_origin: true,
 		},
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />
@@ -148,6 +151,7 @@ The new rule is a complexity-based rate limiting rule that takes the `my-score` 
 			counting_expression: "",
 		},
 	}}
+	roles={false}
 />
 
 <Render file="api-create-ruleset-with-rule" />

--- a/src/content/partials/waf/managed-rulesets/api-account-example.mdx
+++ b/src/content/partials/waf/managed-rulesets/api-account-example.mdx
@@ -2,7 +2,7 @@
 {}
 ---
 
-import { Render, RuleID } from "~/components";
+import { Render, RuleID, APIRequest } from "~/components";
 
 The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) to the `http_request_firewall_managed` phase of a given account (`{account_id}`) by creating a rule that executes the managed ruleset. The rules in the managed ruleset are executed when the zone name matches one of `example.com` or `anotherexample.com`.
 
@@ -12,10 +12,14 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	params={{ phaseName: "http_request_firewall_managed" }}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
-    --header "Authorization: Bearer <API_TOKEN>"
-    ```
+    <APIRequest
+    	path="/accounts/{account_id}/rulesets/phases/{ruleset_phase}/entrypoint"
+    	method="GET"
+    	parameters={{
+    		ruleset_phase: "http_request_firewall_managed",
+    	}}
+    	roles="account"
+    />
 
     ```json output {4}
     {
@@ -47,19 +51,20 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	}}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{ruleset_id}/rules" \
-    --header "Authorization: Bearer <API_TOKEN>" \
-    --header "Content-Type: application/json" \
-    --data '{
-    	"action": "execute",
-    	"action_parameters": {
-    		"id": "efb7b8c949ac4650a09736fc376e9aee"
-    	},
-    	"expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and cf.zone.plan eq \"ENT\"",
-    	"description": "Execute the Cloudflare Managed Ruleset"
-    }'
-    ```
+    <APIRequest
+    	path="/accounts/{account_id}/rulesets/{ruleset_id}/rules"
+    	method="POST"
+    	json={{
+    		action: "execute",
+    		action_parameters: {
+    			id: "efb7b8c949ac4650a09736fc376e9aee",
+    		},
+    		expression:
+    			'(cf.zone.name in {"example.com" "anotherexample.com"}) and cf.zone.plan eq "ENT"',
+    		description: "Execute the Cloudflare Managed Ruleset",
+    	}}
+    	roles="account"
+    />
 
     ```json output
     {
@@ -110,24 +115,25 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	}}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets" \
-    --header "Authorization: Bearer <API_TOKEN>" \
-    --header "Content-Type: application/json" \
-    --data '{
-      "name": "My ruleset",
-      "description": "Entry point ruleset for WAF managed rulesets",
-      "kind": "root",
-      "phase": "http_request_firewall_managed",
-      "rules": [
-        {
-          "action": "execute",
-          "action_parameters": {
-            "id": "efb7b8c949ac4650a09736fc376e9aee"
-          },
-          "expression": "(cf.zone.name in {\"example.com\" \"anotherexample.com\"}) and cf.zone.plan eq \"ENT\"",
-          "description": "Execute the Cloudflare Managed Ruleset"
-        }
-      ]
-    }'
-    ```
+    <APIRequest
+    	path="/accounts/{account_id}/rulesets"
+    	method="POST"
+    	json={{
+    		name: "My ruleset",
+    		description: "Entry point ruleset for WAF managed rulesets",
+    		kind: "root",
+    		phase: "http_request_firewall_managed",
+    		rules: [
+    			{
+    				action: "execute",
+    				action_parameters: {
+    					id: "efb7b8c949ac4650a09736fc376e9aee",
+    				},
+    				expression:
+    					'(cf.zone.name in {"example.com" "anotherexample.com"}) and cf.zone.plan eq "ENT"',
+    				description: "Execute the Cloudflare Managed Ruleset",
+    			},
+    		],
+    	}}
+    	roles="account"
+    />

--- a/src/content/partials/waf/managed-rulesets/api-zone-example.mdx
+++ b/src/content/partials/waf/managed-rulesets/api-zone-example.mdx
@@ -2,7 +2,7 @@
 {}
 ---
 
-import { Render, RuleID } from "~/components";
+import { Render, RuleID, APIRequest } from "~/components";
 
 The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) to the `http_request_firewall_managed` phase of a given zone (`{zone_id}`) by creating a rule that executes the managed ruleset.
 
@@ -12,10 +12,14 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	params={{ phaseName: "http_request_firewall_managed" }}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_request_firewall_managed/entrypoint" \
-    --header "Authorization: Bearer <API_TOKEN>"
-    ```
+    <APIRequest
+    	path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
+    	method="GET"
+    	parameters={{
+    		ruleset_phase: "http_request_firewall_managed",
+    	}}
+    	roles={false}
+    />
 
     ```json output {4}
     {
@@ -47,19 +51,19 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	}}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/{ruleset_id}/rules" \
-    --header "Authorization: Bearer <API_TOKEN>" \
-    --header "Content-Type: application/json" \
-    --data '{
-    "action": "execute",
-    "action_parameters": {
-    "id": "efb7b8c949ac4650a09736fc376e9aee"
-    },
-    "expression": "true",
-    "description": "Execute the Cloudflare Managed Ruleset"
-    }'
-    ```
+    <APIRequest
+    	path="/zones/{zone_id}/rulesets/{ruleset_id}/rules"
+    	method="POST"
+    	json={{
+    		action: "execute",
+    		action_parameters: {
+    			id: "efb7b8c949ac4650a09736fc376e9aee",
+    		},
+    		expression: "true",
+    		description: "Execute the Cloudflare Managed Ruleset",
+    	}}
+    	roles={false}
+    />
 
     ```json output
     {
@@ -105,24 +109,24 @@ The following example deploys the [Cloudflare Managed Ruleset](/waf/managed-rule
     	}}
     />
 
-    ```bash
-    curl "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets" \
-    --header "Authorization: Bearer <API_TOKEN>" \
-    --header "Content-Type: application/json" \
-    --data '{
-      "name": "My ruleset",
-      "description": "Entry point ruleset for WAF managed rulesets",
-      "kind": "zone",
-      "phase": "http_request_firewall_managed",
-      "rules": [
-        {
-    			"action": "execute",
-    			"action_parameters": {
-    				"id": "efb7b8c949ac4650a09736fc376e9aee"
+    <APIRequest
+    	path="/zones/{zone_id}/rulesets"
+    	method="POST"
+    	json={{
+    		name: "My ruleset",
+    		description: "Entry point ruleset for WAF managed rulesets",
+    		kind: "zone",
+    		phase: "http_request_firewall_managed",
+    		rules: [
+    			{
+    				action: "execute",
+    				action_parameters: {
+    					id: "efb7b8c949ac4650a09736fc376e9aee",
+    				},
+    				expression: "true",
+    				description: "Execute the Cloudflare Managed Ruleset",
     			},
-    			"expression": "true",
-    			"description": "Execute the Cloudflare Managed Ruleset"
-    		}
-      ]
-    }'
-    ```
+    		],
+    	}}
+    	roles={false}
+    />


### PR DESCRIPTION
### Summary

Hide API permissions that may cause confusion (for Rulesets API endpoints).
Account-level ones are OK.

Also adds a few missing implementations of the `APIRequest` component.