### PR TITLE
CUSTESC-53389 - Clarify configuration restrictions apply to all custom list types

### DIFF
--- a/src/content/docs/waf/rate-limiting-rules/parameters.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/parameters.mdx
@@ -229,6 +229,6 @@ To use claims inside a JSON Web Token (JWT), you must first set up a [token vali
 
 ## Configuration restrictions
 
-- If the rule expression [custom lists](/waf/tools/lists/custom-lists/), you must enable the **Also apply rate limiting to cached assets** parameter.
+- If the rule expression includes [custom lists](/waf/tools/lists/custom-lists/), you must enable the **Also apply rate limiting to cached assets** parameter.
 
 - The rule counting expression, defined in the **Increment counter when** parameter, cannot include both [HTTP response fields](/ruleset-engine/rules-language/fields/reference/?field-category=Response) and [custom lists](/waf/tools/lists/custom-lists/). If you use custom lists, you must enable the **Also apply rate limiting to cached assets** parameter.

--- a/src/content/docs/waf/rate-limiting-rules/parameters.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/parameters.mdx
@@ -229,6 +229,6 @@ To use claims inside a JSON Web Token (JWT), you must first set up a [token vali
 
 ## Configuration restrictions
 
-- If the rule expression [includes IP lists](/waf/tools/lists/use-in-expressions/), you must enable the **Also apply rate limiting to cached assets** parameter.
+- If the rule expression [custom lists](/waf/tools/lists/custom-lists/), you must enable the **Also apply rate limiting to cached assets** parameter.
 
-- The rule counting expression, defined in the **Increment counter when** parameter, cannot include both [HTTP response fields](/ruleset-engine/rules-language/fields/reference/?field-category=Response) and [IP lists](/waf/tools/lists/custom-lists/#ip-lists). If you use IP lists, you must enable the **Also apply rate limiting to cached assets** parameter.
+- The rule counting expression, defined in the **Increment counter when** parameter, cannot include both [HTTP response fields](/ruleset-engine/rules-language/fields/reference/?field-category=Response) and [custom lists](/waf/tools/lists/custom-lists/). If you use custom lists, you must enable the **Also apply rate limiting to cached assets** parameter.


### PR DESCRIPTION

### Summary

Related to CUSTESC-53389. To clarify that the configuration restrictions currently apply to all custom list types and not just IP lists.


### Screenshots (optional)


### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
