### PR TITLE
[Tunnel] Document WARP Connector limit per account

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -63,7 +63,8 @@ This page lists the default account limits for rules, applications, fields, and 
 
 | Feature                                  | Limit |
 | ---------------------------------------- | ----- |
-| Tunnels per account                      | 1,000 |
+| `cloudflared` tunnels per account        | 1,000 |
+| WARP Connectors per account              | 10    |
 | IP routes per account                    | 1,000 |
 | Active `cloudflared` replicas per tunnel | 25    |
 


### PR DESCRIPTION
### Summary

WARP Connector has a limit of 10 tunnels per account in beta.