### PR TITLE
Fix calling-agents.mdx code example

### DIFF
--- a/src/content/docs/agents/api-reference/calling-agents.mdx
+++ b/src/content/docs/agents/api-reference/calling-agents.mdx
@@ -97,7 +97,7 @@ export default {
 		let chatResponse = namedAgent.chat('Hello!');
 		// No need to serialize/deserialize it from a HTTP request or WebSocket
 		// message and back again
-		let agentState = getState() // agentState is of type UserHistory
+		let agentState = namedAgent.getState() // agentState is of type UserHistory
 		return namedResp
 	},
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
### Summary

getState was called globally, which is not right and may confuse readers. Fixed it by calling that method on namedAgent instance.
