### PR TITLE
[Docs Site] Fix CopyPageButton height on small viewports

### DIFF
--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -140,7 +140,7 @@ export default function CopyPageButton() {
 			<button
 				ref={refs.setReference}
 				{...getReferenceProps()}
-				className="inline-flex h-8 min-w-32 cursor-pointer items-center justify-center gap-2 rounded-sm border border-(--sl-color-hairline) bg-transparent px-3 text-sm text-black hover:bg-(--sl-color-bg-nav)"
+				className="inline-flex min-h-8 min-w-32 cursor-pointer items-center justify-center gap-2 rounded-sm border border-(--sl-color-hairline) bg-transparent px-3 text-sm text-black hover:bg-(--sl-color-bg-nav)"
 			>
 				{getButtonContent()}
 			</button>


### PR DESCRIPTION
### Summary

Fix CopyPageButton height on small viewports

### Screenshots (optional)

Before:

<img width="158" height="80" alt="image" src="https://github.com/user-attachments/assets/8dac965d-d2ca-4be2-8f38-2fa0ecf0c7b4" />

After:

<img width="150" height="79" alt="image" src="https://github.com/user-attachments/assets/2ca7da28-d6a9-44a7-b7aa-711122fd6757" />
