### PR TITLE
Clarify inherited permissions and SCIM limitations

### DIFF
--- a/src/content/docs/fundamentals/manage-members/policies.mdx
+++ b/src/content/docs/fundamentals/manage-members/policies.mdx
@@ -15,7 +15,7 @@ Policies define what access a given user has to your account or domains, and are
 2. A `ResourceGroup` (a scope).
 3. A `PermissionGroup` (roles).
 
-An account member can have one or several of these policies to represent the most appropriate access.
+An account member can have one or several of these policies to represent the most appropriate access. A member’s effective permissions are the union of all policies assigned to them—whether directly, or through group membership.
 
 To increase the usability and flexibility of Cloudflare's role system, changes to the API have been made to expose these underlying data principles and allow users to interact with them.
 
@@ -29,3 +29,17 @@ A set of standard API endpoints is present on every account that allow access to
 * A `permissionGroup` is a unique identifier for the set of roles that are assigned to a given policy.
 
 Refer to the [API documentation](/api/) for more information.
+
+## Viewing Effective Permissions
+
+Cloudflare supports assigning permissions to members both directly and through [User Groups](../user-groups/). A member’s effective permissions are additive; they represent the union of all permissions granted directly to a member and those inherited through a member's group membership.
+
+:::note
+To understand a member’s full access, check both the **Members** and **User Groups** views:
+
+- The **Members** view shows only the permissions explicitly assigned to the user.
+- Permissions inherited through [User Groups](../user-groups/) are not shown on the Members page. To see these, go to the Groups tab, find the groups the user belongs to, and review the policies assigned to each group.
+
+Cloudflare is actively working on improvements to consolidate this view in a future update.
+:::
+

--- a/src/content/docs/fundamentals/manage-members/policies.mdx
+++ b/src/content/docs/fundamentals/manage-members/policies.mdx
@@ -32,13 +32,13 @@ Refer to the [API documentation](/api/) for more information.
 
 ## Viewing Effective Permissions
 
-Cloudflare supports assigning permissions to members both directly and through [User Groups](../user-groups/). A member’s effective permissions are additive; they represent the union of all permissions granted directly to a member and those inherited through a member's group membership.
+Cloudflare supports assigning permissions to members both directly and through [User Groups](/fundamentals/manage-members/user-groups/). A member’s effective permissions are additive; they represent the union of all permissions granted directly to a member and those inherited through a member's group membership.
 
 :::note
 To understand a member’s full access, check both the **Members** and **User Groups** views:
 
 - The **Members** view shows only the permissions explicitly assigned to the user.
-- Permissions inherited through [User Groups](../user-groups/) are not shown on the Members page. To see these, go to the Groups tab, find the groups the user belongs to, and review the policies assigned to each group.
+- Permissions inherited through [User Groups](/fundamentals/manage-members/user-groups/) are not shown on the Members page. To see these, go to the Groups tab, find the groups the user belongs to, and review the policies assigned to each group.
 
 Cloudflare is actively working on improvements to consolidate this view in a future update.
 :::

--- a/src/content/docs/fundamentals/manage-members/user-groups.mdx
+++ b/src/content/docs/fundamentals/manage-members/user-groups.mdx
@@ -12,9 +12,12 @@ import { Tabs, TabItem } from '~/components';
 User Groups are a collection of [account members](/fundamentals/manage-members/) that are treated equally from an access control perspective. User Groups can be assigned permission policies, with individual members in the group receiving all permissions of the roles assigned to the User Group.
 
 :::note
-If you use the [Cloudflare dashboard SCIM integration](/fundamentals/account/account-security/scim-setup/), you can sync Groups from an upstream Identity Provider via SCIM. This allows you to centralize user and group management at your identity provider.
+User Group permissions are inherited by each member of the group but are not currently reflected in the role field on the **Members** page. To view a member’s full set of permissions, check both:
 
-Additionally, when you manage User Groups with SCIM, you cannot change the name, members, or delete a group through either the Cloudflare dashboard or API.
+- The **Members** page for any directly assigned policies
+- The **Groups** tab to identify which groups the member belongs to, and the policies applied to those groups
+
+Cloudflare is actively working on improving this experience to make inherited and direct permissions easier to view.
 :::
 
 ## Create a User Group manually 
@@ -80,9 +83,16 @@ PAYLOAD
 
 Customers with the SCIM integration configured can sync User Groups from an upstream identity provider to Cloudflare. Cloudflare's SCIM integration requires one external application per account. 
 
+
 :::note
-Cloudflare's SCIM integration requires one external application per account.
+If you use the [Cloudflare dashboard SCIM integration](/fundamentals/account/account-security/scim-setup/), you can sync Groups from an upstream Identity Provider. This allows you to centralize user and group management at your identity provider.
+
+Note that when managing User Groups via SCIM:
+- You cannot change the name, members, or delete the group manually from the Cloudflare dashboard or API. 
+- The integration requires one external SCIM application per Cloudflare account.
+- Cloudflare does not currently support updating user profile fields (`firstName`, `lastName`, or `email`) via SCIM. If those attributes change in your IdP, they will not be updated in Cloudflare. These values are only set during initial provisioning.
 :::
+
 
 To set up a user group with SCIM, refer to the [Provisioning with SCIM guide](/fundamentals/account/account-security/scim-setup/).
 


### PR DESCRIPTION
### Summary

* Clarified that permissions inherited from User Groups aren’t shown on the Members page

* Added guidance on how to find a member's full set of permissions across Members and User Groups

* Moved the SCIM note to the appropriate section and cleaned it up

* Added a caveat that we don’t currently sync updates to firstName, lastName, or email from the IdP after initial provisioning


<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
