### PR TITLE
[doc] Python worker doc dict fix

### DIFF
--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -24,7 +24,8 @@ async def on_fetch(request, env):
     params = parse_qs(url.query)
 
     if "name" in params:
-        greeting = "Hello there, {name}".format(name=params["name"][0])
+				name = params["name"][0]
+        greeting = f"Hello there, {name}"
         return Response(greeting)
 
 
@@ -40,8 +41,8 @@ async def on_fetch(request, env):
 from workers import Response
 
 async def on_fetch(request):
-    name = (await request.json()).name
-    return Response("Hello, {name}".format(name=name))
+    name = (await request.json())["name"]
+    return Response(f"Hello, {name}")
 ```
 
 ## Emit logs from your Python Worker

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -24,7 +24,7 @@ async def on_fetch(request, env):
     params = parse_qs(url.query)
 
     if "name" in params:
-				name = params["name"][0]
+        name = params["name"][0]
         greeting = f"Hello there, {name}"
         return Response(greeting)
 

--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -67,7 +67,7 @@ Python workers can be split across multiple files. Let's create a new Python fil
 
 ```python
 def hello(name):
-    return "Hello, " + name + "!"
+    return f"Hello, {name}!"
 ```
 
 Now, we can modify `src/entry.py` to make use of the new module.
@@ -97,7 +97,7 @@ from workers import Response
 from hello import hello
 
 async def on_fetch(request):
-    name = (await request.json()).name
+    name = (await request.json())["name"]
     return Response(hello(name))
 ```
 


### PR DESCRIPTION
### Summary

Python worker examples used dot notation for json objects converted to dicts, which doesn't work out of the box. In order to keep the examples simple, changed dot notation to key notation. Also removed string concatenation using plus signs and string.format() to both be f-strings as the current releases of pyodide all target support for python > 3.6

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
