### PR TITLE
Allow new security dash docs in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@ Disallow: /client-ip-geolocation
 Disallow: /plans/
 Disallow: /constellation
 Disallow: /cdn-cgi/
-Disallow: /security/
 Disallow: /email-security/
 
 Sitemap: https://developers.cloudflare.com/sitemap-index.xml


### PR DESCRIPTION
### Summary

Allow the new security dash docs to be searched by removing the disallow from robots.txt
