### PR TITLE
[doc] Python Worker handler/dict fixes

### DIFF
--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -24,7 +24,8 @@ async def on_fetch(request, env):
     params = parse_qs(url.query)
 
     if "name" in params:
-        greeting = "Hello there, {name}".format(name=params["name"][0])
+				name = params["name"][0]
+        greeting = f"Hello there, {name}"
         return Response(greeting)
 
 
@@ -40,8 +41,8 @@ async def on_fetch(request, env):
 from workers import Response
 
 async def on_fetch(request):
-    name = (await request.json()).name
-    return Response("Hello, {name}".format(name=name))
+    name = (await request.json())["name"]
+    return Response(f"Hello, {name}")
 ```
 
 ## Emit logs from your Python Worker

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -14,9 +14,10 @@ In addition to those examples, consider the following ones that illustrate Pytho
 ## Parse an incoming request URL
 
 ```python
-from workers import Response
+from workers import handler, Response
 from urllib.parse import urlparse, parse_qs
 
+@handler
 async def on_fetch(request, env):
     # Parse the incoming request URL
     url = urlparse(request.url)
@@ -38,8 +39,9 @@ async def on_fetch(request, env):
 ## Parse JSON from the incoming request
 
 ```python
-from workers import Response
+from workers import handle, Response
 
+@handler
 async def on_fetch(request):
     name = (await request.json())["name"]
     return Response(f"Hello, {name}")
@@ -50,10 +52,11 @@ async def on_fetch(request):
 ```python
 # To use the JavaScript console APIs
 from js import console
-from workers import Response
+from workers import handler, Response
 # To use the native Python logging
 import logging
 
+@handler
 async def on_fetch(request):
     # Use the console APIs from JavaScript
     # https://developer.mozilla.org/en-US/docs/Web/API/console
@@ -78,14 +81,11 @@ async def on_fetch(request):
 
 ```python
 from js import Object
-from pyodide.ffi import to_js as _to_js
+import json
 
-from workers import Response
+from workers import handler, Response
 
-# to_js converts between Python dictionaries and JavaScript Objects
-def to_js(obj):
-   return _to_js(obj, dict_converter=Object.fromEntries)
-
+@handler
 async def on_fetch(request, env):
     # Bindings are available on the 'env' parameter
     # https://developers.cloudflare.com/queues/
@@ -94,7 +94,7 @@ async def on_fetch(request, env):
     # We can also pass plain text strings
     await env.QUEUE.send("hello", contentType="text")
     # Send a JSON payload
-    await env.QUEUE.send(to_js({"hello": "world"}))
+    await env.QUEUE.send(json.dumps({"hello": "world"}))
 
     # Return a response
     return Response.json({"write": "success"})
@@ -103,8 +103,9 @@ async def on_fetch(request, env):
 ## Query a D1 Database
 
 ```python
-from workers import Response
+from workers import handler, Response
 
+@handler
 async def on_fetch(request, env):
     results = await env.DB.prepare("PRAGMA table_list").all()
     # Return a JSON response

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -39,7 +39,7 @@ async def on_fetch(request, env):
 ## Parse JSON from the incoming request
 
 ```python
-from workers import handle, Response
+from workers import handler, Response
 
 @handler
 async def on_fetch(request):

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -24,7 +24,7 @@ async def on_fetch(request, env):
     params = parse_qs(url.query)
 
     if "name" in params:
-				name = params["name"][0]
+        name = params["name"][0]
         greeting = f"Hello there, {name}"
         return Response(greeting)
 

--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -67,7 +67,7 @@ Python workers can be split across multiple files. Let's create a new Python fil
 
 ```python
 def hello(name):
-    return "Hello, " + name + "!"
+    return f"Hello, {name}!"
 ```
 
 Now, we can modify `src/entry.py` to make use of the new module.
@@ -97,7 +97,7 @@ from workers import Response
 from hello import hello
 
 async def on_fetch(request):
-    name = (await request.json()).name
+    name = (await request.json())["name"]
     return Response(hello(name))
 ```
 

--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -38,16 +38,22 @@ cd python-workers-examples/01-hello
 npx wrangler@latest dev
 ```
 
-A Python Worker can be as simple as three lines of code:
+A Python Worker can be as simple as four lines of code:
 
 ```python
-from workers import Response
+from workers import handler, Response
 
+@handler
 def on_fetch(request):
     return Response("Hello World!")
 ```
 
 Similar to Workers written in [JavaScript](/workers/languages/javascript), [TypeScript](/workers/languages/typescript), or [Rust](/workers/languages/rust/), the main entry point for a Python worker is the [`fetch` handler](/workers/runtime-apis/handlers/fetch). In a Python Worker, this handler is named `on_fetch`.
+
+Additionally there is a `@handler` wrapper function used to nativize the on_fetch handler; the inline documentation states:
+> When applied to handlers such as `on_fetch` it will rewrite arguments passed in to native Python
+> types defined in this module. For example, the `request` argument to `on_fetch` gets converted
+> to an instance of the Request class defined in this module.
 
 To run a Python Worker locally, you use [Wrangler](/workers/wrangler/), the CLI for Cloudflare Workers:
 
@@ -74,8 +80,9 @@ Now, we can modify `src/entry.py` to make use of the new module.
 
 ```python
 from hello import hello
-from workers import Response
+from workers import handler, Response
 
+@handler
 def on_fetch(request):
     return Response(hello("World"))
 ```
@@ -93,9 +100,10 @@ Let's try editing the worker to accept a POST request. We know from the
 JSON. In a Python Worker, you would write:
 
 ```python
-from workers import Response
+from workers import handler, Response
 from hello import hello
 
+@handler
 async def on_fetch(request):
     name = (await request.json())["name"]
     return Response(hello(name))
@@ -142,8 +150,9 @@ API_HOST = "example.com"
 Then, you can access the `API_HOST` environment variable via the `env` parameter:
 
 ```python
-from workers import Response
+from workers import handler, Response
 
+@handler
 async def on_fetch(request, env):
     return Response(env.API_HOST)
 ```


### PR DESCRIPTION
### Summary
Confirmed with @dom96 that the examples should use the `@handler` wrapper. 

Python worker examples used dot notation for json objects converted to dicts, which doesn't work out of the box. In order to keep the examples simple, changed dot notation to key notation. Also removed string concatenation using plus signs and string.format() to both be f-strings as the current releases of pyodide all target support for python > 3.6

Updated the queue example to remove the unused import, and alter the example to be more pythonic with json.dumps() 

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.