### PR TITLE
[Images] fix: npm is used instead of npx for offline wrangler example

### DIFF
--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -122,7 +122,7 @@ This creates a local-only environment that mirrors the production environment wh
 To test the low-fidelity offline version of Images, add the `--experimental-images-local-mode` flag:
 
 ```txt
-npm wrangler dev --experimental-images-local-mode
+npx wrangler dev --experimental-images-local-mode
 ```
 
 Currently, this version supports only `width`, `height`, `rotate`, and `format`.


### PR DESCRIPTION
### Summary

Very minor fix, changes "npm" to be "npx" on https://developers.cloudflare.com/images/transform-images/bindings/#interact-with-your-images-binding-locally. 
<img width="766" height="452" alt="image" src="https://github.com/user-attachments/assets/0a53a5ab-9bf8-4ba8-b311-5211fe5d1b4a" />


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.