### PR TITLE
[Docs] Catch more redirects and partials

### DIFF
--- a/.github/workflows/potential-redirects-or-partials.yml
+++ b/.github/workflows/potential-redirects-or-partials.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           files=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" | \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" | \
             jq -r '.[] | select(.status=="renamed" or .status=="removed") | select (.filename | startswith("src/content/docs")) | select(.filename | endswith(".mdx")) | if .status == "renamed" then .previous_filename else .filename end' | \
             sed -e 's|^src/content/docs||' -e 's|/index\.mdx$|/|' -e 's|\.mdx$|/|')
           # Use random delimiter for security reasons
@@ -43,7 +43,7 @@ jobs:
         run: |
           files=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" | \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" | \
             jq -r '.[] | select(.status=="modified") | select (.filename | startswith("src/content/partials")) | select(.filename | endswith(".mdx")) | .filename' | \
             sed -e 's|^src/content/partials||' -e 's|\.mdx$|/|')
           # Use random delimiter for security reasons


### PR DESCRIPTION
### Summary

Updates the action to catch more potentially needed redirects and changed partials.
Max items per page is `100` ([source](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files--parameters)).