### PR TITLE
CC-5730: remove name from container examples

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -112,7 +112,6 @@ Your [Wrangler configuration file](/workers/wrangler/configuration/) defines the
 ```toml
 [[containers]]
 max_instances = 10
-name = "hello-containers"
 class_name = "MyContainer"
 image = "./Dockerfile"
 

--- a/src/content/docs/containers/index.mdx
+++ b/src/content/docs/containers/index.mdx
@@ -78,7 +78,6 @@ async fetch(request, env) {
       "class_name": "MyContainer",
       "image": "./Dockerfile",
       "instances": 5,
-      "name": "hello-containers-go"
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
### Summary

Removes references to the `name` property in examples for containers

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
