### PR TITLE
[Workers] fix wrong command in wrangler/commands.mdx

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1531,7 +1531,7 @@ wrangler versions secret put <KEY> [OPTIONS]
 Delete a secret for a Worker. Creates a new [version](/workers/configuration/versions-and-deployments/#versions) with modified secrets without [deploying](/workers/configuration/versions-and-deployments/#deployments) the Worker.
 
 ```txt
-wrangler versions delete <KEY> [OPTIONS]
+wrangler versions secret delete <KEY> [OPTIONS]
 ```
 
 - `KEY` <Type text="string" /> <MetaInfo text="required" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Fixed the wrong commands in `wrangler/commands.mdx`. For reference, here is the actual Wrangler CLI help:

```
❯ yarn wrangler versions secret --help
wrangler versions secret

Generate a secret that can be referenced in a Worker

COMMANDS
  wrangler versions secret put [key]     Create or update a secret variable for a Worker
  wrangler versions secret bulk [file]   Create or update a secret variable for a Worker
  wrangler versions secret delete [key]  Delete a secret variable from a Worker
  wrangler versions secret list          List the secrets currently deployed

GLOBAL FLAGS
  -c, --config   Path to Wrangler configuration file  [string]
      --cwd      Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
  -e, --env      Environment to use for operations, and for selecting .env and .dev.vars files  [string]
  -h, --help     Show help  [boolean]
  -v, --version  Show version number  [boolean]
```


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
