### PR TITLE
[wrangler] Document missing environment variables

### DIFF
--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -74,7 +74,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_HTTPS_KEY_PATH` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Path to a custom certificate key.
+  * Path to a custom HTTPS certificate key when running `wrangler dev`, to be used with `WRANGLER_HTTPS_CERT_PATH`.
 
 * `WRANGLER_HTTPS_CERT_PATH` <Type text="string" /> <MetaInfo text="optional" />
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -78,7 +78,7 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_HTTPS_CERT_PATH` <Type text="string" /> <MetaInfo text="optional" />
 
-  * Path to a custom certificate.
+  * Path to a custom HTTPS certificate when running `wrangler dev`, to be used with `WRANGLER_HTTPS_KEY_PATH`.
 
 
 

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -72,6 +72,14 @@ Wrangler supports the following environment variables:
   * Defaults to `unix:///var/run/docker.sock`. Set this to the socket path your container engine is listening at if you are using another container tool besides Docker, such as `colima`, or if your Docker engine is configured to listen at a path other than `unix:///var/run/docker.sock`.
     You can also set this via `container_engine` config option.
 
+* `WRANGLER_HTTPS_KEY_PATH` <Type text="string" /> <MetaInfo text="optional" />
+
+  * Path to a custom certificate key.
+
+* `WRANGLER_HTTPS_CERT_PATH` <Type text="string" /> <MetaInfo text="optional" />
+
+  * Path to a custom certificate.
+
 
 
 ## Example `.env` file


### PR DESCRIPTION
### Summary

Document `WRANGLER_HTTPS_KEY_PATH` and `WRANGLER_HTTPS_CERT_PATH` environment variables.

Fixes https://github.com/cloudflare/workers-sdk/issues/9812

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
