### PR TITLE
[Chore] Remove unhelpful metadata

### DIFF
--- a/src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx
+++ b/src/content/docs/d1/tutorials/import-to-d1-with-rest-api/index.mdx
@@ -4,8 +4,6 @@ difficulty: Beginner
 content_type: Tutorial
 pcx_content_type: tutorial
 title: Bulk import to D1 using REST API
-products:
-  - D1
 languages:
   - JavaScript
   - TypeScript

--- a/src/content/docs/d1/tutorials/using-read-replication-for-e-com/index.mdx
+++ b/src/content/docs/d1/tutorials/using-read-replication-for-e-com/index.mdx
@@ -4,8 +4,6 @@ difficulty: Beginner
 content_type: Tutorial
 pcx_content_type: tutorial
 title: Using D1 Read Replication for your e-commerce website
-products:
-  - D1
 languages:
   - JavaScript
   - TypeScript


### PR DESCRIPTION
### Summary

We don't need `products: [D1]` within the D1 product folder.
