### PR TITLE
[Docs] Fix language warnings

### DIFF
--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -121,28 +121,24 @@ To create your first D1 database:
     While Wrangler gets installed locally to your project, you can use it outside the project by using the command `npx wrangler`.
     :::
 
-   ```sh
-   npx wrangler@latest d1 create prod-d1-tutorial
-   ```
+    ```sh
+    npx wrangler@latest d1 create prod-d1-tutorial
+    ```
 
-   ```txt output
+    ```txt output
+    ✅ Successfully created DB 'prod-d1-tutorial' in region WEUR
+    Created your new D1 database.
 
-		✅ Successfully created DB 'prod-d1-tutorial' in region WEUR
-		Created your new D1 database.
-
-		{
-			"d1_databases": [
-				{
-					"binding": "DB",
-					"database_name": "prod-d1-tutorial",
-					"database_id": "<unique-ID-for-your-database>"
-				}
-			]
-		}
-
-   ```
-
-
+    {
+    	"d1_databases": [
+    		{
+    			"binding": "DB",
+    			"database_name": "prod-d1-tutorial",
+    			"database_id": "<unique-ID-for-your-database>"
+    		}
+    	]
+    }
+    ```
 
 </Steps>
 
@@ -257,7 +253,7 @@ After correctly preparing your [Wrangler configuration file](/workers/wrangler/c
     npx wrangler d1 execute prod-d1-tutorial --local --file=./schema.sql
     ```
     ```txt output
-     ⛅️ wrangler 4.13.2
+    ⛅️ wrangler 4.13.2
     -------------------
 
     🌀 Executing on local database prod-d1-tutorial (<DATABASE_ID>) from .wrangler/state/v3/d1:
@@ -442,7 +438,7 @@ To deploy your Worker to production using Wrangler, you must first repeat the [d
     npx wrangler d1 execute prod-d1-tutorial --remote --command="SELECT * FROM Customers"
     ```
     ```txt output
-     ⛅️ wrangler 4.13.2
+    ⛅️ wrangler 4.13.2
     -------------------
 
     🌀 Executing on remote database prod-d1-tutorial (<DATABASE_ID>):
@@ -467,18 +463,18 @@ To deploy your Worker to production using Wrangler, you must first repeat the [d
    npx wrangler deploy
    ```
    ```txt output
-    ⛅️ wrangler 4.13.2
-    -------------------
+   ⛅️ wrangler 4.13.2
+   -------------------
 
-    Total Upload: 0.19 KiB / gzip: 0.16 KiB
-    Your worker has access to the following bindings:
-    - D1 Databases:
-      - DB: prod-d1-tutorial (<DATABASE_ID>)
-    Uploaded d1-tutorial (3.76 sec)
-    Deployed d1-tutorial triggers (2.77 sec)
-      https://d1-tutorial.<YOUR_SUBDOMAIN>.workers.dev
-    Current Version ID: <VERSION_ID>
-    ```
+   Total Upload: 0.19 KiB / gzip: 0.16 KiB
+   Your worker has access to the following bindings:
+   - D1 Databases:
+     - DB: prod-d1-tutorial (<DATABASE_ID>)
+   Uploaded d1-tutorial (3.76 sec)
+   Deployed d1-tutorial triggers (2.77 sec)
+     https://d1-tutorial.<YOUR_SUBDOMAIN>.workers.dev
+   Current Version ID: <VERSION_ID>
+   ```
 
    You can now visit the URL for your newly created project to query your live database.
 

--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -125,7 +125,7 @@ To create your first D1 database:
    npx wrangler@latest d1 create prod-d1-tutorial
    ```
 
-   ```sh output
+   ```txt output
 
 		✅ Successfully created DB 'prod-d1-tutorial' in region WEUR
 		Created your new D1 database.
@@ -253,10 +253,10 @@ After correctly preparing your [Wrangler configuration file](/workers/wrangler/c
 
 2. Initialize your database to run and test locally first. Bootstrap your new D1 database by running:
 
-   ```sh
-   npx wrangler d1 execute prod-d1-tutorial --local --file=./schema.sql
-   ```
-    ```output
+    ```sh
+    npx wrangler d1 execute prod-d1-tutorial --local --file=./schema.sql
+    ```
+    ```txt output
      ⛅️ wrangler 4.13.2
     -------------------
 
@@ -275,7 +275,7 @@ After correctly preparing your [Wrangler configuration file](/workers/wrangler/c
    npx wrangler d1 execute prod-d1-tutorial --local --command="SELECT * FROM Customers"
    ```
 
-   ```sh output
+   ```txt output
    🌀 Mapping SQL input into an array of statements
    🌀 Executing on local database production-db-backend (<DATABASE_ID>) from .wrangler/state/v3/d1:
    ┌────────────┬─────────────────────┬───────────────────┐
@@ -424,7 +424,7 @@ To deploy your Worker to production using Wrangler, you must first repeat the [d
     ```sh
     npx wrangler d1 execute prod-d1-tutorial --remote --file=./schema.sql
     ```
-    ```sh output
+    ```txt output
     ✔ ⚠️ This process may take some time, during which your D1 database will be unavailable to serve queries.
     Ok to proceed? y
     🚣 Executed 3 queries in 0.00 seconds (5 rows read, 6 rows written)
@@ -441,7 +441,7 @@ To deploy your Worker to production using Wrangler, you must first repeat the [d
     ```sh
     npx wrangler d1 execute prod-d1-tutorial --remote --command="SELECT * FROM Customers"
     ```
-    ```sh output
+    ```txt output
      ⛅️ wrangler 4.13.2
     -------------------
 
@@ -466,7 +466,7 @@ To deploy your Worker to production using Wrangler, you must first repeat the [d
    ```sh
    npx wrangler deploy
    ```
-   ```sh output
+   ```txt output
     ⛅️ wrangler 4.13.2
     -------------------
 

--- a/src/content/docs/images/tutorials/optimize-mobile-viewing.mdx
+++ b/src/content/docs/images/tutorials/optimize-mobile-viewing.mdx
@@ -29,15 +29,17 @@ There are two possible `loading` attributes for your `<img>` tags: `lazy` and  `
 Lazy loading is recommended for most images. With Lazy loading, resources like images are deferred until they reach a certain distance from the viewport. If an image does not reach the threshold, then it does not get loaded.
 
 Example of modifying the `loading` attribute of your `<img>` tags to be `"lazy"`:
-````HTML
+
+```html
 <img src="example.com/cdn-cgi/width=300/image.png" loading="lazy">
-````
+```
 
 ### Eager loading
 
 If you have images that are in the viewport, eager loading, instead of lazy loading, is recommended. Eager loading loads the asset at the initial page load, regardless of its location on the page.
 
 Example of modifying the `loading` attribute of your `<img>` tags to be `"eager"`:
-````HTML
+
+```html
 <img src="example.com/cdn-cgi/width=300/image.png" loading="eager">
-````
+```


### PR DESCRIPTION
### Summary

Fixes the following Expressive Code warnings:

```
10:24:27 [WARN] [astro-expressive-code] Error while highlighting code block using language "output" in document "/src/content/docs/d1/get-started.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:24:43 [WARN] [astro-expressive-code] Error while highlighting code block using language "HTML" in document "/src/content/docs/images/tutorials/optimize-mobile-viewing.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:24:43 [WARN] [astro-expressive-code] Error while highlighting code block using language "HTML" in document "/src/content/docs/images/tutorials/optimize-mobile-viewing.mdx". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
```

