### PR TITLE
Fix wrong env global variable reference

### DIFF
--- a/src/content/docs/containers/examples/env-vars-and-secrets.mdx
+++ b/src/content/docs/containers/examples/env-vars-and-secrets.mdx
@@ -96,9 +96,9 @@ export class MyContainer extends Container {
   defaultPort = 8080;
   sleepAfter = '10s';
   envVars = {
-    ACCOUNT_NAME: env.ACCOUNT_NAME,
-		ACCOUNT_API_KEY: env.SECRET_STORE.ACCOUNT_API_KEY,
-		CONTAINER_SECRET_KEY: env.CONTAINER_SECRET_KEY,
+    ACCOUNT_NAME: this.env.ACCOUNT_NAME,
+		ACCOUNT_API_KEY: this.env.SECRET_STORE.ACCOUNT_API_KEY,
+		CONTAINER_SECRET_KEY: this.env.CONTAINER_SECRET_KEY,
 	};
 }
 ```


### PR DESCRIPTION
### Summary

In the containers doc, the `env` variable reference is not right. It looks like `env` is a global magic variable and the example fails outright. It has been corrected to use `this.env` instead.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

