### PR TITLE
[Docs] Fix component/partial usage on Windows

### DIFF
--- a/src/util/components.ts
+++ b/src/util/components.ts
@@ -33,7 +33,11 @@ export async function getComponentsUsage(
 		);
 
 		for (const file of files) {
-			const fullName = file.parentPath + "/" + file.name;
+			const parentPath =
+				process.platform === "win32"
+					? file.parentPath.replaceAll("\\", "/")
+					: file.parentPath;
+			const fullName = parentPath + "/" + file.name;
 			const content = await readFile(fullName, "utf8");
 
 			if (!content.includes("import")) continue;
@@ -85,7 +89,11 @@ export async function getPartialsUsage(): Promise<Record<string, Usage>> {
 		);
 
 		for (const file of files) {
-			const fullName = file.parentPath + "/" + file.name;
+			const parentPath =
+				process.platform === "win32"
+					? file.parentPath.replaceAll("\\", "/")
+					: file.parentPath;
+			const fullName = parentPath + "/" + file.name;
 			const content = await readFile(fullName, "utf8");
 
 			if (!content.includes("import")) continue;


### PR DESCRIPTION
### Summary

Usage lists for components and partials are empty on Windows platforms (local Astro server).
This PR handles Windows folder separators to make it work.

Before:

<img width="885" height="279" alt="image" src="https://github.com/user-attachments/assets/8f93aaac-fb48-4bff-b234-84a57f2f4c63" />

After:

<img width="850" height="256" alt="image" src="https://github.com/user-attachments/assets/53548c8c-5540-4ee4-8ab1-3037f9049130" />
