### PR TITLE
Document the images features fit: squeeze and trim: border

### DIFF
--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -16,7 +16,8 @@ Affects interpretation of `width` and `height`. All resizing modes preserve aspe
   Image will be shrunk and cropped to fit within the area specified by `width` and `height`. The image will not be enlarged. For images smaller than the given dimensions, it is the same as `scale-down`. For images larger than the given dimensions, it is the same as `cover`. See also [`trim`](#trim)
 - `pad`\
   Resizes to the maximum size that fits within the given `width` and `height`, and then fills the remaining area with a `background` color (white by default). This mode is not recommended, since you can achieve the same effect more efficiently with the `contain` mode and the CSS `object-fit: contain` property.
-
+- `squeeze`
+  Resizes the image to the exact width and height specified. This mode does not preserve the original aspect ratio and will cause the image to appear stretched or squashed.
 <Tabs>
   <TabItem label="URL format">
     ```js

--- a/src/content/partials/images/trim.mdx
+++ b/src/content/partials/images/trim.mdx
@@ -21,3 +21,37 @@ Specifies a number of pixels to cut off on each side. Allows removal of borders 
   ```
   </TabItem>
 </Tabs>
+
+The API also supports automatic border removal based on color. This can be enabled by setting `trim=border` for automatic color detection, or customized with the parameters below.
+
+`trim.border.color`
+The border color to trim. Accepts any CSS color using CSS4 modern syntax, such as `rgb(255 255 0)`. If omitted, the color is detected automatically.
+
+`trim.border.tolerance`
+The matching tolerance for the color, on a scale of 0 to 255.
+
+`trim.border.keep`
+The number of pixels of the original border to leave untrimmed.
+
+<Tabs>
+  <TabItem label="URL format">
+    ```js
+    trim=border
+
+    OR
+
+    trim.border.color=%23000000
+    trim.border.tolerance=5
+    trim.border.keep=10
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+    ```js
+    cf: {image: {trim: "border"}}
+
+    OR
+
+    cf: {image: {trim: {border: {color: "#000000", tolerance: 5, keep: 10}}}}
+    ```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
### Summary

This adds documentation for a couple of additional features in images:
- fit: `squeeze`
- trimming the border automatically by colour

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
