### PR TITLE
Document the quality parameter when outputting an image using the Images Binding

### DIFF
--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -78,6 +78,7 @@ return response;
 ### `.output()`
 
 - Defines the [output format](/images/transform-images/) for the transformed image such as AVIF, WebP, and JPEG.
+- Image [quality](/images/transform-images/transform-via-url/#quality) can be altered by specifying `quality` on a 1-100 scale.
 
 For example, to rotate, resize, and blur an image, then output the image as AVIF:
 


### PR DESCRIPTION
### Summary

A small change to document the optional quality parameter available in `output()` in the Images Binding.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
