### PR TITLE
Fixing code backticks

### DIFF
--- a/src/content/changelog/workers/2025-01-28-nodejs-compat-improvements.mdx
+++ b/src/content/changelog/workers/2025-01-28-nodejs-compat-improvements.mdx
@@ -38,7 +38,7 @@ export default {
     return new Response("Wrote to server", { status: 200 });
   },
 } satisfies ExportedHandler;
-````
+```
 </TypeScriptExample>
 
 Additionally, you can now use other APIs including [`net.BlockList`](https://nodejs.org/api/net.html#class-netblocklist) and
@@ -55,8 +55,8 @@ You can use [`node:dns`](https://nodejs.org/api/dns.html) for name resolution vi
 ```ts
 import dns from 'node:dns';
 
-let responese = await dns.promises.resolve4('cloudflare.com', 'NS');
-````
+let response = await dns.promises.resolve4('cloudflare.com', 'NS');
+```
 
 </TypeScriptExample>
 

--- a/src/content/docs/ai-gateway/integrations/aig-workers-ai-binding.mdx
+++ b/src/content/docs/ai-gateway/integrations/aig-workers-ai-binding.mdx
@@ -113,7 +113,7 @@ npx wrangler dev
 
 You will be prompted to log in after you run `wrangler dev`. When you run `npx wrangler dev`, Wrangler will give you a URL (most likely `localhost:8787`) to review your Worker. After you go to the URL Wrangler provides, you will see a message that resembles the following example:
 
-````json
+```json
 {
   "response": "A fascinating question!\n\nThe phrase \"Hello, World!\" originates from a simple computer program written in the early days of programming. It is often attributed to Brian Kernighan, a Canadian computer scientist and a pioneer in the field of computer programming.\n\nIn the early 1970s, Kernighan, along with his colleague Dennis Ritchie, were working on the C programming language. They wanted to create a simple program that would output a message to the screen to demonstrate the basic structure of a program. They chose the phrase \"Hello, World!\" because it was a simple and recognizable message that would illustrate how a program could print text to the screen.\n\nThe exact code was written in the 5th edition of Kernighan and Ritchie's book \"The C Programming Language,\" published in 1988. The code, literally known as \"Hello, World!\" is as follows:\n\n```
 main()
@@ -122,7 +122,7 @@ main()
 }
 ```\n\nThis code is still often used as a starting point for learning programming languages, as it demonstrates how to output a simple message to the console.\n\nThe phrase \"Hello, World!\" has since become a catch-all phrase to indicate the start of a new program or a small test program, and is widely used in computer science and programming education.\n\nSincerely, I'm glad I could help clarify the origin of this iconic phrase for you!"
 }
-````
+```
 
 ## 5. Deploy your AI Worker
 

--- a/src/content/docs/durable-objects/api/container.mdx
+++ b/src/content/docs/durable-objects/api/container.mdx
@@ -39,7 +39,7 @@ export class MyDurableObject extends DurableObject {
 
 }
 
-````
+```
 </TypeScriptExample>
 
 
@@ -51,7 +51,7 @@ export class MyDurableObject extends DurableObject {
 
 ```js
 	this.ctx.container.running;
-````
+```
 
 ## Methods
 

--- a/src/content/docs/hyperdrive/index.mdx
+++ b/src/content/docs/hyperdrive/index.mdx
@@ -65,7 +65,7 @@ export default {
 
 } satisfies ExportedHandler<{ HYPERDRIVE: Hyperdrive }>;
 
-````
+```
 
     </TabItem>
     <TabItem label="wrangler.jsonc">
@@ -89,7 +89,7 @@ export default {
 			}
 		]
 	}
-````
+```
 
 </TabItem>
 </Tabs>
@@ -128,7 +128,7 @@ headers: {
 },
 } satisfies ExportedHandler<Env>;
 
-````
+```
 
     </TabItem>
     <TabItem label="wrangler.jsonc">
@@ -152,7 +152,7 @@ headers: {
 			}
 		]
 	}
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/kv/examples/cache-data-with-workers-kv.mdx
+++ b/src/content/docs/kv/examples/cache-data-with-workers-kv.mdx
@@ -107,7 +107,7 @@ if (!bodyMatch) return 'No content found';
 
 }
 
-````
+```
 </TabItem>
 <TabItem label="wrangler.jsonc">
 ```json
@@ -126,7 +126,7 @@ if (!bodyMatch) return 'No content found';
 		}
 	]
 }
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/kv/examples/distributed-configuration-with-workers-kv.mdx
+++ b/src/content/docs/kv/examples/distributed-configuration-with-workers-kv.mdx
@@ -87,7 +87,7 @@ syncPreviewStatus()
 .catch(console.error)
 .finally(() => process.exit(0));
 
-````
+```
 </TabItem>
 <TabItem label=".env">
 ```md title=".env"
@@ -96,7 +96,7 @@ CLOUDFLARE_EMAIL = <CLOUDFLARE_EMAIL_HERE>
 CLOUDFLARE_API_KEY = <CLOUDFLARE_API_KEY_HERE>
 CLOUDFLARE_ACCOUNT_ID = <CLOUDFLARE_ACCOUNT_ID_HERE>
 CLOUDFLARE_WORKERS_KV_NAMESPACE_ID = <CLOUDFLARE_WORKERS_KV_NAMESPACE_ID_HERE>
-````
+```
 
 </TabItem>
 <TabItem label="db.sql">
@@ -115,7 +115,7 @@ INSERT INTO users (username, email, preview_features_enabled) VALUES
 ('bob', 'bob@example.com', false),
 ('charlie', 'charlie@example.com', true);
 
-````
+```
 </TabItem>
 </Tabs>
 
@@ -216,7 +216,7 @@ export default {
 		}
 	]
 }
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/kv/examples/routing-with-workers-kv.mdx
+++ b/src/content/docs/kv/examples/routing-with-workers-kv.mdx
@@ -111,7 +111,7 @@ export default {
 }
 } satisfies ExportedHandler<Env>;
 
-````
+```
 </TabItem>
 <TabItem label="wrangler.jsonc">
 ```json
@@ -130,7 +130,7 @@ export default {
 		}
 	]
 }
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
+++ b/src/content/docs/kv/examples/workers-kv-to-serve-assets.mdx
@@ -13,7 +13,7 @@ import { Render, PackageManagers, TabItem, Tabs } from "~/components";
 By storing static assets in Workers KV, you can retrieve these assets globally with low-latency and high throughput. You can then serve these assets directly, or use them to dynamically generate responses. This can be useful when serving files such as custom scripts, small images that fit within [KV limits](/kv/platform/limits/), or when generating dynamic HTML responses from static assets such as translations.
 
 :::note[Note]
-If you need to **host a front-end or full-stack web application**, **use [Cloudflare Workers static assets](/workers/static-assets/) or [Cloudflare Pages](/pages/)**, which provide a purpose-built deployment experience for web applications and their assets. 
+If you need to **host a front-end or full-stack web application**, **use [Cloudflare Workers static assets](/workers/static-assets/) or [Cloudflare Pages](/pages/)**, which provide a purpose-built deployment experience for web applications and their assets.
 
 [Workers KV](/kv/) provides a more flexible API which allows you to access, edit, and store assets directly from your [Worker](/workers/) without requiring deployments. This can be helpful for serving custom assets that are not included in your deployment bundle, such as uploaded media assets or custom scripts and files generated at runtime.
 :::
@@ -96,7 +96,7 @@ export default {
 
 } satisfies ExportedHandler<Env>;
 
-````
+```
 </TabItem>
 <TabItem label="wrangler.jsonc">
 ```json
@@ -115,7 +115,7 @@ export default {
 		}
 	]
 }
-````
+```
 
 </TabItem>
 </Tabs>
@@ -272,7 +272,7 @@ export default {
 },
 } satisfies ExportedHandler<Env>;
 
-````
+```
 </TabItem>
 <TabItem label="wrangler.jsonc">
 ```json
@@ -291,7 +291,7 @@ export default {
 		}
 	]
 }
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/learning-paths/mtls/mtls-workers/index.mdx
+++ b/src/content/docs/learning-paths/mtls/mtls-workers/index.mdx
@@ -44,7 +44,7 @@ export default {
 }
 }
 
-````
+```
 
 </TabItem>
 <TabItem label="Service Worker" icon="seti:javascript">
@@ -79,7 +79,7 @@ addEventListener('fetch', event => {
     })(event.request)
   );
 });
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -91,7 +91,7 @@ else:
 
 A common use case is to complete the code for the user after they provide a descriptive comment.
 
-````python
+```python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 prompt = "# A function that checks if a given word is a palindrome"
@@ -112,7 +112,7 @@ display(Markdown(f"""
     {code.strip()}
     ```
 """))
-````
+```
 
 ```python
 # A function that checks if a given word is a palindrome
@@ -240,7 +240,7 @@ A common use case in Developer Tools is to autocomplete based on context. DeepSe
 
 Warning: The tokens are prefixed with `<｜` and suffixed with `｜>` make sure to copy and paste them.
 
-````python
+```python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 code = """
@@ -270,7 +270,7 @@ display(Markdown(f"""
     ```
 """))
 
-````
+```
 
 ```python
 is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
@@ -280,7 +280,7 @@ is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
 
 No need to threaten the model or bring grandma into the prompt. Get back JSON in the format you want.
 
-````python
+```python
 model = "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
 
 # Learn more at https://json-schema.org/
@@ -342,7 +342,7 @@ display(Markdown(f"""
     {response.strip()}
     ```
 """))
-````
+```
 
 ```json
 {

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -247,7 +247,7 @@ To verify that the certificate exchange and validation process work as expected.
 
 }
 
-````
+```
 </WranglerConfig>
 
 #### [Images](/workers/wrangler/configuration/#images):
@@ -262,7 +262,7 @@ To connect to a high-fidelity version of the Images API, and verify that all tra
 		"experimental_remote": true
   }
 }
-````
+```
 
 </WranglerConfig>
 

--- a/src/content/docs/workers/examples/security-headers.mdx
+++ b/src/content/docs/workers/examples/security-headers.mdx
@@ -347,6 +347,6 @@ app.all('*', async (c) => {
 });
 
 export default app;
-````
+```
 
 </TabItem> </Tabs>

--- a/src/content/partials/images/background.mdx
+++ b/src/content/partials/images/background.mdx
@@ -19,7 +19,7 @@ OR
 
 background=rgb%28240%2C40%2C145%29
 
-````
+```
 </TabItem>
 <TabItem label="Workers">
 ```js
@@ -28,7 +28,7 @@ cf: {image: {background: "#RRGGBB"}}
 OR
 
 cf:{image: {background: "rgba(240,40,145,0)"}}
-````
+```
 
   </TabItem>
 </Tabs>

--- a/src/content/partials/images/quality.mdx
+++ b/src/content/partials/images/quality.mdx
@@ -12,9 +12,9 @@ We also allow setting one of the perceptual quality levels `high|medium-high|med
   <TabItem label="URL format">
     ```js
     quality=50
-    
+
     OR
-    
+
     quality=low
     ```
   </TabItem>
@@ -26,7 +26,7 @@ OR
 
 q=medium-high
 
-````
+```
 </TabItem>
 <TabItem label="Workers">
 ```js
@@ -35,7 +35,7 @@ cf: {image: {quality: 50}}
 OR
 
 cf: {image: {quality: "high"}}
-````
+```
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Found instances where the code blocks didn't match the number of backticks. The opening and closing backticks should be consistent (three backticks, unless we're wrapping code inside something larger).

This PR fixes mismatched backticks.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
