### PR TITLE
Clarify that Cloudflare SSL/TLS will only work for a subdomain if the DNS record is proxied

### DIFF
--- a/src/content/docs/dns/proxy-status/index.mdx
+++ b/src/content/docs/dns/proxy-status/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render, Example, Details, GlossaryTooltip } from "~/components";
 
-While your [DNS records](/dns/manage-dns-records/) make your website or application available to visitors and other web services, the **Proxy status** of a DNS record defines how Cloudflare treats incoming DNS queries for that record.
+While your [DNS records](/dns/manage-dns-records/) make your website or application available to visitors and other web services, the proxy status of a DNS record defines how Cloudflare treats incoming DNS queries for that record.
 
 The records you can proxy through Cloudflare are [records used for IP address resolution](/dns/manage-dns-records/reference/dns-record-types/#ip-address-resolution) — meaning A, AAAA, or CNAME records.
 

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -14,6 +14,10 @@ import { GlossaryTooltip } from "~/components"
 
 Universal SSL certificates present some limitations.
 
+## Proxy Status
+
+Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [Proxy Status](/dns/proxy-status/) to Proxied. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
+
 ## Hostname coverage
 
 ### Full setup

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -16,7 +16,7 @@ Universal SSL certificates present some limitations.
 
 ## Proxy Status
 
-Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [Proxy Status](/dns/proxy-status/) to Proxied. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
+Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [proxy status](/dns/proxy-status/) to **Proxied**. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
 
 ## Hostname coverage
 

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -14,7 +14,7 @@ import { GlossaryTooltip } from "~/components"
 
 Universal SSL certificates present some limitations.
 
-## Proxy Status
+## Proxy status
 
 Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [proxy status](/dns/proxy-status/) to **Proxied**. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
 

--- a/src/content/partials/dns/ssltls-subdomains.mdx
+++ b/src/content/partials/dns/ssltls-subdomains.mdx
@@ -3,10 +3,10 @@
 
 ---
 
-:::note
-Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [proxy status](/dns/proxy-status/) to **Proxied**. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
-:::
-
 If your main domain is using Cloudflare's [Universal SSL certificate](/ssl/edge-certificates/universal-ssl/), that certificate also covers all first-level subdomains (`blog.example.com`).
 
 For deeper subdomains (`dev.blog.example.com`), use a [different type of certificate](/ssl/edge-certificates/universal-ssl/limitations/#full-setup).
+
+:::note[Proxy status]
+Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [proxy status](/dns/proxy-status/) to **Proxied**. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
+:::

--- a/src/content/partials/dns/ssltls-subdomains.mdx
+++ b/src/content/partials/dns/ssltls-subdomains.mdx
@@ -3,6 +3,10 @@
 
 ---
 
+:::note
+Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [Proxy Status](/dns/proxy-status/) to Proxied. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
+:::
+
 If your main domain is using Cloudflare's [Universal SSL certificate](/ssl/edge-certificates/universal-ssl/), that certificate also covers all first-level subdomains (`blog.example.com`).
 
 For deeper subdomains (`dev.blog.example.com`), use a [different type of certificate](/ssl/edge-certificates/universal-ssl/limitations/#full-setup).

--- a/src/content/partials/dns/ssltls-subdomains.mdx
+++ b/src/content/partials/dns/ssltls-subdomains.mdx
@@ -4,7 +4,7 @@
 ---
 
 :::note
-Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [Proxy Status](/dns/proxy-status/) to Proxied. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
+Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set the record's [proxy status](/dns/proxy-status/) to **Proxied**. If you do not do this, the origin server your record points to will be responsible for supporting SSL/TLS connections.
 :::
 
 If your main domain is using Cloudflare's [Universal SSL certificate](/ssl/edge-certificates/universal-ssl/), that certificate also covers all first-level subdomains (`blog.example.com`).


### PR DESCRIPTION
### Summary

Clarify that Cloudflare SSL/TLS will only work for a subdomain if the DNS record is proxied
