### PR TITLE
[Docs site] Update UsageList links

### DIFF
--- a/src/components/UsageList.astro
+++ b/src/components/UsageList.astro
@@ -29,6 +29,7 @@ const { usage } = props.parse(Astro.props);
 						"/" +
 						path
 							.replace("src/content/docs/", "")
+							.replace("/index.mdx", "")
 							.replace(".mdx", "")
 							.split("/")
 							.map((segment) => {
@@ -42,10 +43,7 @@ const { usage } = props.parse(Astro.props);
 
 					return (
 						<li>
-							<a
-								href={"https://developers.cloudflare.com" + slugified}
-								target="_blank"
-							>
+							<a href={slugified} target="_blank">
 								{slugified}
 							</a>
 							<span>


### PR DESCRIPTION
### Summary

- Removes hostname + port from usage links so that they can be used in GH previews and with the local dev server.
- Removes unnecessary `index/` path segment at the end of some links.
