### PR TITLE
Add Workers Emscripten Instructions and Gotchas

### DIFF
--- a/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
+++ b/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
@@ -83,6 +83,31 @@ export default {
 
 When invoked, this Worker should log `Hello from JavaScript: 42` and return `Success: 42`, demonstrating the ability to invoke Wasm methods with arguments from JavaScript and vice versa.
 
+## Use of Emscripten Modules from Javascript
+
+WebAssembly modules compiled with Emscripten require a few considerations for use with Workers.   Specifically, they should be compiled with `MODULARIZE=1`, `EXPORT_ES6=1`, `ENVIRONMENT=web`, and `DYNAMIC_EXECUTION=0` to avoid the workers' limitations with nodejs compatibility and dynamic code execution.
+
+Then, the module can be instantiated in your worker with:
+```javascript
+import { M } from './myModule.js';
+import mod from './myModule.wasm';
+/** @typedef {import("./myModule.js").MyModuleToplevel} MyModuleToplevel */
+
+async initializeMyModule() {
+  /** @type {MyModuleToplevel} */
+  var myModule = await M({
+    instantiateWasm: (imports, callback) => {
+      const instance = new WebAssembly.Instance(mod, imports);
+      callback(instance);
+      return instance.exports;
+    }
+  });
+}
+initializeMyModule();
+```
+
+Please refer to [this example](https://github.com/cloudflare/worker-emscripten-template) for details.
+
 ## Next steps
 
 In practice, you will likely compile a language of your choice (such as Rust) to WebAssembly binaries. Many languages provide a `bindgen` to simplify the interaction between JavaScript and Wasm. These tools may integrate with your JavaScript bundler, and provide an API other than the WebAssembly API for initializing and invoking your Wasm module. As an example, refer to the [Rust `wasm-bindgen` documentation](https://rustwasm.github.io/wasm-bindgen/examples/without-a-bundler.html).

--- a/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
+++ b/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
@@ -93,9 +93,9 @@ import { M } from './myModule.js';
 import mod from './myModule.wasm';
 /** @typedef {import("./myModule.js").MyModuleToplevel} MyModuleToplevel */
 
-async initializeMyModule() {
+async function initializeMyModule() {
   /** @type {MyModuleToplevel} */
-  var myModule = await M({
+  const myModule = await M({
     instantiateWasm: (imports, callback) => {
       const instance = new WebAssembly.Instance(mod, imports);
       callback(instance);
@@ -103,7 +103,9 @@ async initializeMyModule() {
     }
   });
 }
-initializeMyModule();
+initializeMyModule().catch(error => {
+  console.error("Failed to initialize the module:", error);
+});
 ```
 
 Please refer to [this example](https://github.com/cloudflare/worker-emscripten-template) for details.

--- a/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
+++ b/src/content/docs/workers/runtime-apis/webassembly/javascript.mdx
@@ -87,23 +87,22 @@ When invoked, this Worker should log `Hello from JavaScript: 42` and return `Suc
 
 WebAssembly modules compiled with Emscripten require a few considerations for use with Workers.   Specifically, they should be compiled with `MODULARIZE=1`, `EXPORT_ES6=1`, `ENVIRONMENT=web`, and `DYNAMIC_EXECUTION=0` to avoid the workers' limitations with nodejs compatibility and dynamic code execution.
 
-Then, the module can be instantiated in your worker with:
+Then, the module can be instantiated in your Worker with:
 ```javascript
 import { M } from './myModule.js';
 import mod from './myModule.wasm';
 /** @typedef {import("./myModule.js").MyModuleToplevel} MyModuleToplevel */
 
-async function initializeMyModule() {
+M({
+  instantiateWasm: (imports, callback) => {
+    const instance = new WebAssembly.Instance(mod, imports);
+    callback(instance);
+    return instance.exports;
+  }
+}).then(instantiatedModule => {
   /** @type {MyModuleToplevel} */
-  const myModule = await M({
-    instantiateWasm: (imports, callback) => {
-      const instance = new WebAssembly.Instance(mod, imports);
-      callback(instance);
-      return instance.exports;
-    }
-  });
-}
-initializeMyModule().catch(error => {
+  const myModule = instantiatedModule;
+}).catch(error => {
   console.error("Failed to initialize the module:", error);
 });
 ```


### PR DESCRIPTION
### Summary

I spent two days figuring out how to get Emscripten WASM modules working in PartyKit, assembled from old Discord messages and abandoned example repos with out-dated WASM import mechanisms. 

The instructions here represent the cleanest and most useful way to get Emscripten modules working in Cloudflare Workers and Durable Objects.

This example can be seen in production using an Emscripten compilation of the `manifold` CSG library in a PartyKit server for doing shared multiplayer CSG operations: 
https://zalo.github.io/WorldParty/
https://github.com/zalo/WorldParty/blob/main/src/server.js#L82-L92

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
