### PR TITLE
fix(docs/cache): fix typo for "Wil" to "Will"

### DIFF
--- a/src/content/docs/cache/concepts/cache-control.mdx
+++ b/src/content/docs/cache/concepts/cache-control.mdx
@@ -141,7 +141,7 @@ The table below lists directives and their behaviors when Origin Cache Control i
 | `no-transform`            | May (un)Gzip, Polish, email filter, etc.          | Does not transform body.                                                                                                                        |
 | `s-maxage=delta, delta>1` | Same as `max-age`.                                | `Max-age` and `proxy-revalidate`.                                                                                                               |
 | `immutable`               | Not proxied downstream.                           | Proxied downstream. Browser facing, does not impact caching proxies.                                                                            |
-| `no-store`                | Will not cache.                                   | Wil not cache.                                                                                                                                  |
+| `no-store`                | Will not cache.                                   | Will not cache.                                                                                                                                  |
 
 ### Conditions
 


### PR DESCRIPTION
### Summary

I found a typo on the docs for caching.