### PR TITLE
Fix Wrangler CLI usage in queue docs

### DIFF
--- a/src/content/docs/queues/configuration/configure-queues.mdx
+++ b/src/content/docs/queues/configuration/configure-queues.mdx
@@ -30,7 +30,7 @@ Below are options for queues, refer to the Wrangler documentation for a full ref
 The following queue level settings can be configured using Wrangler:
 
 ```sh
-$ npx run wrangler queues update <QUEUE-NAME> --delivery-delay-secs 60 --message-retention-period-secs 3000
+$ npx wrangler queues update <QUEUE-NAME> --delivery-delay-secs 60 --message-retention-period-secs 3000
 ```
 
 * `--delivery-delay-secs` <Type text="number" /> <Type text="optional" />

--- a/src/content/docs/queues/configuration/pause-purge.mdx
+++ b/src/content/docs/queues/configuration/pause-purge.mdx
@@ -19,7 +19,7 @@ Pausing affects both [push-based consumer Workers](/queues/reference/how-queues-
 The following command will pause message delivery from your queue:
 
 ```sh
-$ npx run wrangler queues pause-delivery <QUEUE-NAME>
+$ npx wrangler queues pause-delivery <QUEUE-NAME>
 ```
 
 - `queue-name` <Type text="string" /> <MetaInfo text="required" />
@@ -28,7 +28,7 @@ $ npx run wrangler queues pause-delivery <QUEUE-NAME>
 The following command will resume message delivery:
 
 ```sh
-$ npx run wrangler queues resume-delivery <QUEUE-NAME>
+$ npx wrangler queues resume-delivery <QUEUE-NAME>
 ```
 
 - `queue-name` <Type text="string" /> <MetaInfo text="required" />
@@ -49,7 +49,7 @@ Purging a queue is an irreversible operation. Make sure to use this operation ca
 ### Purge queue using Wrangler
 The following command will purge messages from your queue. You will be prompted to enter the queue name to confirm the operation.
 ```sh
-$ npx run wrangler queues purge <QUEUE-NAME>
+$ npx wrangler queues purge <QUEUE-NAME>
 
 This operation will permanently delete all the messages in Queue <QUEUE-NAME>. Type <QUEUE-NAME> to proceed.
 ```


### PR DESCRIPTION
Replaces incorrect 'npx run wrangler' commands with 'npx wrangler' in queue configuration and management documentation for clarity and accuracy.

### Summary

This pull request updates several Wrangler CLI commands in the documentation to remove the unnecessary `run` keyword from the `npx` commands. This change prevents the literal [`run`](http://npmjs.com/package/run) package from being ran instead of `wrangler` itself

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
