### PR TITLE
Remove dangling needs: test from Workers External CI/CD GitHub Actions example (#23994)

### DIFF
--- a/src/content/docs/workers/ci-cd/external-cicd/github-actions.mdx
+++ b/src/content/docs/workers/ci-cd/external-cicd/github-actions.mdx
@@ -58,7 +58,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: test
     steps:
       - uses: actions/checkout@v4
       - name: Build & Deploy Worker


### PR DESCRIPTION
This PR removes the extraneous `needs: test` line from the “Build & Deploy Worker” snippet in the Workers CI/CD → External CI/CD (GitHub Actions) documentation. The current example references a non‑existent `test` job, causing the workflow to fail when copy‑pasted.

closes #23994.