### PR TITLE
Add DO and Workflow remote resources local usage instructions

### DIFF
--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -295,7 +295,8 @@ Certain bindings are not supported for remote connections during local developme
 
 If `experimental_remote: true` is specified in Wrangler configuration for any of the following unsupported binding types, Cloudflare **will issue an error**. See [all supported and unsupported bindings for remote bindings](/workers/development-testing/bindings-per-env/).
 
-- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally.
+- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. Using Durable Objects in combination with remote bindings is however possible
+  as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
 
 - [**RPC on service bindings**](/workers/runtime-apis/bindings/service-bindings/rpc/): While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
@@ -318,6 +319,31 @@ If `experimental_remote: true` is specified in Wrangler configuration for any of
 :::note
 If you have use-cases for connecting to any of the remote resources above, please [open a feature request](https://github.com/cloudflare/workers-sdk/issues) in our [`workers-sdk` repository](https://github.com/cloudflare/workers-sdk).
 :::
+
+#### Durable Objects Usage with Remote Resources
+
+While Durable Objects cannot currently run in remote mode, you can still use them during local development and have them interact with remote resources.
+
+There are two main approaches for this:
+
+- **Local Durable Objects with remote bindings:**
+
+	When you enable remote mode for a binding in your [Wrangler configuration](/workers/wrangler/configuration), both your main Worker and any local Durable Object
+	can make use of it. This allows Durable Objects to interact with remote resources during local development.
+
+- **Remote Durable Objects with local Workers:**
+
+	You can run Durable Objects remotely from a Worker using [`wrangler dev --remote`](/workers/wrangler/commands/#dev) and have them interact with local Workers
+	running on your machine by leveraging Wrangler's [Multiple dev commands](./multi-workers/#multiple-dev-commands) feature.
+
+	To do this:
+
+	- Start your remote Worker (which contains the Durable Object) using `wrangler dev --remote`.
+
+	- In your local Workers' configuration, set the Durable Object's [`script_name`](/workers/wrangler/configuration/#durable-objects) to the name of the remote Worker.
+
+	- Run your local Workers with `wrangler dev` to connect to the remote Durable Object.
+
 
 ### Important Considerations
 

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -319,21 +319,21 @@ If `experimental_remote: true` is specified in Wrangler configuration for any of
 If you have use-cases for connecting to any of the remote resources above, please [open a feature request](https://github.com/cloudflare/workers-sdk/issues) in our [`workers-sdk` repository](https://github.com/cloudflare/workers-sdk).
 :::
 
-#### Durable Objects Usage with Remote Resources
+#### Using remote resources with Durable Objects and Workflows
 
-While Durable Object bindings cannot currently be remote, you can still use them during local development and have them interact with remote resources.
+While Durable Object and Workflow bindings cannot currently be remote, you can still use them during local development and have them interact with remote resources.
 
-There are two main approaches for this:
+There are two recommended patterns for this:
 
-- **Local Durable Objects with remote bindings:**
+- **Local Durable Objects/Workflows with remote bindings:**
 
-	When you enable remote mode for a binding in your [Wrangler configuration](/workers/wrangler/configuration), both your main Worker and any local Durable Objects can make use of it. This allows Durable Objects to interact with remote resources during local development.
+	When you enable remote bindings in your [Wrangler configuration](/workers/wrangler/configuration), your locally running Durable Objects and Workflows can access those remote resources.
+	This allows such bindings, although run locally to interact with remote resources during local development.
 
-- **Connection to remote Durable Objects via remote Workers:**
+- **Accessing remote Durable Objects/Workflows via service bindings:**
 
-	Although remote bindings for Durable Objects are not currently supported, you can still interact with remote Durable Objects during local development by using remote service bindings.
-
-	To do this, deploy a Worker that has a binding to the target Durable Object. Then, configure a remote service binding in your local Worker to point to this deployed Worker. Your local Worker will be able to interact with the Durable Object via the remote service binding, effectively using the deployed Worker as a proxy interface to the Durable Object during local development.
+	To interact with remote Durable Object or Workflow instances, deploy a Worker that defines those. Then, in your local Worker, configure a remote [service binding](/workers/runtime-apis/bindings/service-bindings/) pointing to the deployed Worker.
+	Your local Worker will be then able to interact with the remote deployed Worker which in turn can communicate with the remote Durable Objects/Workflows. In such a manner you can create a communication channel via the remote service binding, effectively using the deployed Worker as a proxy interface to the remote bindings during local development.
 
 
 ### Important Considerations

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -295,8 +295,7 @@ Certain bindings are not supported for remote connections during local developme
 
 If `experimental_remote: true` is specified in Wrangler configuration for any of the following unsupported binding types, Cloudflare **will issue an error**. See [all supported and unsupported bindings for remote bindings](/workers/development-testing/bindings-per-env/).
 
-- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. Using Durable Objects in combination with remote bindings is however possible
-  as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
+- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
 
 - [**RPC on service bindings**](/workers/runtime-apis/bindings/service-bindings/rpc/): While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
@@ -322,14 +321,13 @@ If you have use-cases for connecting to any of the remote resources above, pleas
 
 #### Durable Objects Usage with Remote Resources
 
-While Durable Objects cannot currently run in remote mode, you can still use them during local development and have them interact with remote resources.
+While Durable Object bindings cannot currently be remote, you can still use them during local development and have them interact with remote resources.
 
 There are two main approaches for this:
 
 - **Local Durable Objects with remote bindings:**
 
-	When you enable remote mode for a binding in your [Wrangler configuration](/workers/wrangler/configuration), both your main Worker and any local Durable Object
-	can make use of it. This allows Durable Objects to interact with remote resources during local development.
+	When you enable remote mode for a binding in your [Wrangler configuration](/workers/wrangler/configuration), both your main Worker and any local Durable Objects can make use of it. This allows Durable Objects to interact with remote resources during local development.
 
 - **Remote Durable Objects with local Workers:**
 

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -295,11 +295,11 @@ Certain bindings are not supported for remote connections during local developme
 
 If `experimental_remote: true` is specified in Wrangler configuration for any of the following unsupported binding types, Cloudflare **will issue an error**. See [all supported and unsupported bindings for remote bindings](/workers/development-testing/bindings-per-env/).
 
-- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible, as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
+- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible, as illustrated in the [relative section](#using-remote-resources-with-durable-objects-and-workflows) below.
 
 - [**RPC on service bindings**](/workers/runtime-apis/bindings/service-bindings/rpc/): While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
-- [**Workflows**](/workflows/): Enabling remote connections for Workflows may be supported in the future, but currently will only run locally.
+- [**Workflows**](/workflows/): Enabling remote connections for Workflows may be supported in the future, but currently will only run locally. However, using Workflows in combination with remote bindings is possible, as illustrated in the [relative section](#using-remote-resources-with-durable-objects-and-workflows) below.
 
 - [**Environment Variables (`vars`)**](/workers/wrangler/configuration/#environment-variables): Environment variables are intended to be distinct between local development and deployed environments. They are easily configurable locally (such as in a `.dev.vars` file or directly in Wrangler configuration).
 

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -312,6 +312,7 @@ If `experimental_remote: true` is specified in Wrangler configuration for any of
 - [**Analytics Engine**](/analytics/analytics-engine/): Local development sessions typically don't contribute data directly to production Analytics Engine.
 
 - [**Hyperdrive**](/workers/wrangler/configuration/#hyperdrive): This is being actively worked on, but is currently unsupported.
+
 - [**Rate Limiting**](/workers/runtime-apis/bindings/rate-limit/#configuration): Local development sessions typically should not share or affect rate limits of your deployed Workers. Rate limiting logic should be tested against local simulations.
 
 :::note

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -295,11 +295,11 @@ Certain bindings are not supported for remote connections during local developme
 
 If `experimental_remote: true` is specified in Wrangler configuration for any of the following unsupported binding types, Cloudflare **will issue an error**. See [all supported and unsupported bindings for remote bindings](/workers/development-testing/bindings-per-env/).
 
-- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible, as illustrated in the [relative section](#using-remote-resources-with-durable-objects-and-workflows) below.
+- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible. Refer to [Using remote resources with Durable Objects and Workflows](#using-remote-resources-with-durable-objects-and-workflows) below.
 
 - [**RPC on service bindings**](/workers/runtime-apis/bindings/service-bindings/rpc/): While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
-- [**Workflows**](/workflows/): Enabling remote connections for Workflows may be supported in the future, but currently will only run locally. However, using Workflows in combination with remote bindings is possible, as illustrated in the [relative section](#using-remote-resources-with-durable-objects-and-workflows) below.
+- [**Workflows**](/workflows/): Enabling remote connections for Workflows may be supported in the future, but currently will only run locally. However, using Workflows in combination with remote bindings is possible. Refer to [Using remote resources with Durable Objects and Workflows](#using-remote-resources-with-durable-objects-and-workflows) below.
 
 - [**Environment Variables (`vars`)**](/workers/wrangler/configuration/#environment-variables): Environment variables are intended to be distinct between local development and deployed environments. They are easily configurable locally (such as in a `.dev.vars` file or directly in Wrangler configuration).
 

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -331,16 +331,9 @@ There are two main approaches for this:
 
 - **Remote Durable Objects with local Workers:**
 
-	You can run Durable Objects remotely from a Worker using [`wrangler dev --remote`](/workers/wrangler/commands/#dev) and have them interact with local Workers
-	running on your machine by leveraging Wrangler's [Multiple dev commands](./multi-workers/#multiple-dev-commands) feature.
+	Although remote bindings for Durable Objects are not currently supported, you can still interact with remote Durable Objects during local development by using remote service bindings.
 
-	To do this:
-
-	- Start your remote Worker (which contains the Durable Object) using `wrangler dev --remote`.
-
-	- In your local Workers' configuration, set the Durable Object's [`script_name`](/workers/wrangler/configuration/#durable-objects) to the name of the remote Worker.
-
-	- Run your local Workers with `wrangler dev` to connect to the remote Durable Object.
+	To do this, deploy a Worker that has a binding to the target Durable Object. Then, configure a remote service binding in your local Worker to point to this deployed Worker. Your local Worker will be able to interact with the Durable Object via the remote service binding, effectively using the deployed Worker as a proxy interface to the Durable Object during local development.
 
 
 ### Important Considerations

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -329,7 +329,7 @@ There are two main approaches for this:
 
 	When you enable remote mode for a binding in your [Wrangler configuration](/workers/wrangler/configuration), both your main Worker and any local Durable Objects can make use of it. This allows Durable Objects to interact with remote resources during local development.
 
-- **Remote Durable Objects with local Workers:**
+- **Connection to remote Durable Objects via remote Workers:**
 
 	Although remote bindings for Durable Objects are not currently supported, you can still interact with remote Durable Objects during local development by using remote service bindings.
 

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -295,7 +295,7 @@ Certain bindings are not supported for remote connections during local developme
 
 If `experimental_remote: true` is specified in Wrangler configuration for any of the following unsupported binding types, Cloudflare **will issue an error**. See [all supported and unsupported bindings for remote bindings](/workers/development-testing/bindings-per-env/).
 
-- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
+- [**Durable Objects**](/workers/wrangler/configuration/#durable-objects): Enabling remote connections for Durable Objects may be supported in the future, but currently will always run locally. However, using Durable Objects in combination with remote bindings is possible, as illustrated in the [Durable Objects usage section](#durable-objects-usage-with-remote-resources) below.
 
 - [**RPC on service bindings**](/workers/runtime-apis/bindings/service-bindings/rpc/): While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
@@ -327,13 +327,12 @@ There are two recommended patterns for this:
 
 - **Local Durable Objects/Workflows with remote bindings:**
 
-	When you enable remote bindings in your [Wrangler configuration](/workers/wrangler/configuration), your locally running Durable Objects and Workflows can access those remote resources.
-	This allows such bindings, although run locally to interact with remote resources during local development.
+	When you enable remote bindings in your [Wrangler configuration](/workers/wrangler/configuration), your locally running Durable Objects and Workflows can access remote resources. This allows such bindings, although run locally, to interact with remote resources during local development.
 
 - **Accessing remote Durable Objects/Workflows via service bindings:**
 
 	To interact with remote Durable Object or Workflow instances, deploy a Worker that defines those. Then, in your local Worker, configure a remote [service binding](/workers/runtime-apis/bindings/service-bindings/) pointing to the deployed Worker.
-	Your local Worker will be then able to interact with the remote deployed Worker which in turn can communicate with the remote Durable Objects/Workflows. In such a manner you can create a communication channel via the remote service binding, effectively using the deployed Worker as a proxy interface to the remote bindings during local development.
+	Your local Worker will be then able to interact with the remote deployed Worker, which in turn can communicate with the remote Durable Objects/Workflows. Using this method, you can create a communication channel via the remote service binding, effectively using the deployed Worker as a proxy interface to the remote bindings during local development.
 
 
 ### Important Considerations

--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -240,10 +240,8 @@ To verify that the certificate exchange and validation process work as expected.
 			"binding": "MY_CLIENT_CERT_FETCHER",
 			"certificate_id": "<YOUR_UPLOADED_CERT_ID>",
 			"experimental_remote": true
-
-    	}
-    ]
-
+			}
+	]
 }
 
 ```
@@ -256,10 +254,10 @@ To connect to a high-fidelity version of the Images API, and verify that all tra
 <WranglerConfig>
 ```jsonc title="wrangler.jsonc"
 {
-  "images": {
-    "binding": "IMAGES" ,
+	"images": {
+		"binding": "IMAGES" ,
 		"experimental_remote": true
-  }
+	}
 }
 ```
 
@@ -278,13 +276,13 @@ Workers for Platforms users can configure `experimental_remote: true` in dispatc
 <WranglerConfig>
 ```jsonc title="wrangler.jsonc"
 {
-  "dispatch_namespaces": [
-    {
-      "binding": "DISPATCH_NAMESPACE",
-      "namespace": "testing",
-      "experimental_remote":true
+	"dispatch_namespaces": [
+		{
+			"binding": "DISPATCH_NAMESPACE",
+			"namespace": "testing",
+			"experimental_remote":true
 		}
-  ]
+	]
 }
 ```
 </WranglerConfig>


### PR DESCRIPTION
Internal reference: DEVX-2053

This PR adds a section on how developers can locally have Durable Objects interact with remote resources,
alongside some very minor formatting fixes.