### PR TITLE
set http and https modules as partially supported

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -47,9 +47,9 @@ The runtime APIs from Node.js listed below as "🟢 supported" are currently nat
 | Events                                                                               | 🟢 supported                              |
 | File system                                                                          | ⚪ coming soon                            |
 | Globals                                                                              | 🟢 supported                              |
-| HTTP                                                                                 | ⚪ not yet supported                      |
+| HTTP                                                                                 | 🟡 partially supported                    |
 | HTTP/2                                                                               | ⚪ not yet supported                      |
-| HTTPS                                                                                | ⚪ not yet supported                      |
+| HTTPS                                                                                | 🟡 partially supported                    |
 | Inspector                                                                            | 🟢 supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/) |
 | [Net](/workers/runtime-apis/nodejs/net/)                                             | 🟢 supported                              |
 | OS                                                                                   | ⚪ not yet supported                      |


### PR DESCRIPTION
These modules have documentation but we forgot to set it as "partially supported"