### PR TITLE
Remove Python packages warning from main Python docs

### DIFF
--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -21,11 +21,9 @@ Cloudflare Workers provides first-class support for Python, including support fo
 - A robust [foreign function interface (FFI)](/workers/languages/python/ffi) that lets you use JavaScript objects and functions directly from Python — including all [Runtime APIs](/workers/runtime-apis/)
 - [Built-in packages](/workers/languages/python/packages), including [FastAPI](https://fastapi.tiangolo.com/), [Langchain](https://pypi.org/project/langchain/), [httpx](https://www.python-httpx.org/) and more.
 
-:::caution[Python Workers are in beta. Packages do not run in production.]
+:::caution[Python Workers are in beta.]
 
-Currently, you can only deploy Python Workers that use the standard library. [Packages](/workers/languages/python/packages/#supported-packages) **cannot be deployed** and will only work in local development for the time being.
-
-You must add the `python_workers` compatibility flag to your Worker, while Python Workers are in open beta.
+You must add the `python_workers` compatibility flag to your Worker, while Python Workers are in open beta. Packages are supported using the [pywrangler](/workers/languages/python/packages) tool.
 
 We'd love your feedback. Join the #python-workers channel in the [Cloudflare Developers Discord](https://discord.cloudflare.com/) and let us know what you'd like to see next.
 :::
@@ -152,4 +150,4 @@ async def on_fetch(request, env):
 
 - Understand which parts of the [Python Standard Library](/workers/languages/python/stdlib) are supported in Python Workers.
 - Learn about Python Workers' [foreign function interface (FFI)](/workers/languages/python/ffi), and how to use it to work with [bindings](/workers/runtime-apis/bindings) and [Runtime APIs](/workers/runtime-apis/).
-- Explore the [Built-in Python packages](/workers/languages/python/packages) that the Workers runtime provides.
+- Explore the [packages](/workers/languages/python/packages) docs for instructions on how to use packages with Python Workers.


### PR DESCRIPTION
### Summary

Python packages are now supported using the pywrangler tool and are no longer behind a closed beta.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.