### PR TITLE
[Tunnel] Set config_src in Terraform deployment

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/deployment-guides/terraform.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/deployment-guides/terraform.mdx
@@ -228,7 +228,7 @@ The following configuration will modify settings in your Cloudflare account.
 		resource "cloudflare_zero_trust_tunnel_cloudflared" "gcp_tunnel" {
 			account_id = var.cloudflare_account_id
 			name       = "Terraform GCP tunnel"
-			secret     = random_bytes.tunnel_secret.base64
+			config_src = "cloudflare"
 		}
 
 		# Creates the CNAME record that routes http_app.${var.cloudflare_zone} to the tunnel.


### PR DESCRIPTION
### Summary

Terraform configuration update: The creation of a remotely-managed Cloudflare Tunnel in Terraform requires setting the config_src to 'cloudflare', because the default is 'local'.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
