### PR TITLE
Update delete-account.mdx

### DIFF
--- a/src/content/docs/fundamentals/user-profiles/delete-account.mdx
+++ b/src/content/docs/fundamentals/user-profiles/delete-account.mdx
@@ -38,7 +38,8 @@ Your user profile can be invited to other Cloudflare accounts, so you may have a
 
 When you delete your profile, the account associated with your profile and any accounts where you are the last active member will also deleted. Deleting your account is permanent. Any accounts where you are the primary owner will also be deleted and any other users on those accounts will be removed.
 
-After you delete your profile, you cannot use the email address used with your profile to create a new account.
+After you delete your profile, you can use the email address with your profile to create a new account. In most cases, your email should be freed up to be used in a new signup right away.
+However, this may not be the same for users who have a lock on their account (for legal purposes).
 
 All domains, subscriptions, and billing information on your account will be removed from Cloudflare.
 


### PR DESCRIPTION
### Summary
On this Cloudflare document, it says - After you delete your profile, you cannot use the email address used with your profile to create a new account. 

However, after checking Cloudflare wiki, Our macro for account deletion, Cloudflare community posts, and confirming in the Cloudflare IAM chat, I realized that this is not true and it is confusing a lot of customers.

I changed this sentence with the one that explicitly mentions that for most user deletes, the email will be freed up to be used in a new signup right away, except for users who have a lock on their account (for legal reasons).

I want to propose this change so that the users can clarify there doubts regarding account deletion by themselves and don't have to make multiple support cases and wait in queues for it.

Thank you.

<!-- Add context such as the type of documentation being updated or added -->

The document being updated is "Delete your Cloudflare account" on Cloudflare docs.
