### PR TITLE
Fix 2025-06-05-open-next-size.mdx

### DIFF
--- a/src/content/changelog/workers/2025-06-05-open-next-size.mdx
+++ b/src/content/changelog/workers/2025-06-05-open-next-size.mdx
@@ -15,4 +15,4 @@ This means that users will now see a decrease from 14 to 8MiB (2.3 to 1.6MiB gzi
 Users only need to update to the latest version of `@opennextjs/cloudflare` to automatically benefit from these improvements.
 
 Note that we published [CVE-2005-6087](https://github.com/opennextjs/opennextjs-cloudflare/security/advisories/GHSA-rvpw-p7vw-wj3m) for a SSRF vulnerability in the `@opennextjs/cloudflare` package.
-The vulnerability has been fixed from `@opennextjs/cloudflare` v1.3.0 onwards. Please update to any version after this one. v1.6.3 is the latest at the time of writing.
+The vulnerability has been fixed from `@opennextjs/cloudflare` v1.3.0 onwards. Please update to any version after this one. 


### PR DESCRIPTION
Fix to remove incorrect date from 2025-06-05-open-next-size.mdx introduced in https://github.com/cloudflare/cloudflare-docs/pull/23277