### PR TITLE
Add missing await to getRandom

### DIFF
--- a/src/content/docs/containers/examples/container-backend.mdx
+++ b/src/content/docs/containers/examples/container-backend.mdx
@@ -150,7 +150,7 @@ export default {
 		const url = new URL(request.url);
 		if (url.pathname.startsWith("/api")) {
 			// note: "getRandom" to be replaced with latency-aware routing in the near future
-			const containerInstance = getRandom(env.BACKEND, INSTANCE_COUNT);
+			const containerInstance = await getRandom(env.BACKEND, INSTANCE_COUNT);
 			return containerInstance.fetch(request);
 		}
 


### PR DESCRIPTION
### Summary

Updates the Static Frontend, Container Backend example docs. `getRandom()` returns a promise and should be awaited.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
