### PR TITLE
[D1] Fixing instances of D1 all() to run()

### DIFF
--- a/src/content/docs/d1/best-practices/local-development.mdx
+++ b/src/content/docs/d1/best-practices/local-development.mdx
@@ -151,7 +151,7 @@ You can then use the `getD1Database()` method to retrieve the simulated database
 const db = await mf.getD1Database("DB");
 
 const stmt = db.prepare("SELECT name, age FROM users LIMIT 3");
-const { results } = await stmt.all();
+const { results } = await stmt.run();
 
 console.log(results);
 ```

--- a/src/content/docs/d1/best-practices/remote-development.mdx
+++ b/src/content/docs/d1/best-practices/remote-development.mdx
@@ -39,7 +39,7 @@ Use the following Worker script to verify that the Worker has access to the boun
 ```js
 export default {
   async fetch(request, env, ctx) {
-    const res = await env.DB.prepare("SELECT 1;").all();
+    const res = await env.DB.prepare("SELECT 1;").run();
     return new Response(JSON.stringify(res, null, 2));
   },
 };

--- a/src/content/docs/d1/examples/d1-and-hono.mdx
+++ b/src/content/docs/d1/examples/d1-and-hono.mdx
@@ -48,7 +48,7 @@ app.get("/query/users/:id", async (c) => {
 			"SELECT * FROM users WHERE user_id = ?",
 		)
 			.bind(userId)
-			.all();
+			.run();
 		return c.json(results);
 	} catch (e) {
 		return c.json({ err: e.message }, 500);
@@ -76,7 +76,7 @@ app.get("/query/users/:id", async (c) => {
 			"SELECT * FROM users WHERE user_id = ?",
 		)
 			.bind(userId)
-			.all();
+			.run();
 		return c.json(results);
 	} catch (e) {
 		return c.json({ err: e.message }, 500);

--- a/src/content/docs/d1/examples/d1-and-remix.mdx
+++ b/src/content/docs/d1/examples/d1-and-remix.mdx
@@ -39,7 +39,7 @@ interface Env {
 export const loader: LoaderFunction = async ({ context, params }) => {
   let env = context.cloudflare.env as Env;
 
-  let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").all();
+  let { results } = await env.DB.prepare("SELECT * FROM users LIMIT 5").run();
   return json(results);
 };
 

--- a/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
+++ b/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
@@ -87,7 +87,7 @@ async def on_fetch(request, env):
     # Do anything else you'd like on request here!
 
     # Query D1 - we'll list all tables in our database in this example
-    results = await env.DB.prepare("PRAGMA table_list").all()
+    results = await env.DB.prepare("PRAGMA table_list").run()
     # Return a JSON response
     return Response.json(results)
 

--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -342,7 +342,7 @@ After you have set up your database, run an SQL query from within your Worker.
     				"SELECT * FROM Customers WHERE CompanyName = ?",
     			)
     				.bind("Bs Beverages")
-    				.all();
+    				.run();
     			return Response.json(results);
     		}
 
@@ -387,7 +387,7 @@ You can query your D1 database using your Worker.
     				"SELECT * FROM Customers WHERE CompanyName = ?"
     			)
     				.bind("Bs Beverages")
-    				.all();
+    				.run();
     			return new Response(JSON.stringify(results), {
     				headers: { 'Content-Type': 'application/json' }
     			});

--- a/src/content/docs/d1/sql-api/sql-statements.mdx
+++ b/src/content/docs/d1/sql-api/sql-statements.mdx
@@ -64,7 +64,7 @@ const { results } = await env.DB.prepare(
 	"SELECT * FROM Customers WHERE CompanyName LIKE ?",
 )
 	.bind("%eve%")
-	.all();
+	.run();
 console.log("results: ", results);
 ```
 ```js output

--- a/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-comments-api/index.mdx
@@ -155,12 +155,12 @@ app.get("/api/posts/:slug/comments", async (c) => {
   `,
 	)
 		.bind(slug)
-		.all();
+		.run();
 	return c.json(results);
 });
 ```
 
-The above code makes use of the `prepare`, `bind`, and `all` functions on a D1 binding to prepare and execute a SQL statement. Refer to [D1 Workers Binding API](/d1/worker-api/) for a list of all methods available.
+The above code makes use of the `prepare`, `bind`, and `run` functions on a D1 binding to prepare and execute a SQL statement. Refer to [D1 Workers Binding API](/d1/worker-api/) for a list of all methods available.
 
 In this function, you accept a `slug` URL query parameter and set up a new SQL statement where you select all comments with a matching `post_slug` value to your query parameter. You can then return it as a JSON response.
 

--- a/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
+++ b/src/content/docs/d1/tutorials/build-a-staff-directory-app/index.mdx
@@ -185,7 +185,7 @@ export const findAllEmployees = async (db: D1Database) => {
       JOIN locations ON employees.location_id = locations.location_id
       JOIN departments ON employees.department_id = departments.department_id
       `;
-	const { results } = await db.prepare(query).all();
+	const { results } = await db.prepare(query).run();
 	const employees = results;
 	return employees;
 };

--- a/src/content/docs/d1/tutorials/using-read-replication-for-e-com/index.mdx
+++ b/src/content/docs/d1/tutorials/using-read-replication-for-e-com/index.mdx
@@ -748,7 +748,7 @@ app.get("/api/products", async (c) => {
 
 	try {
 		return await withRetry(async () => {
-			const { results } = await session.prepare("SELECT * FROM products").all();
+			const { results } = await session.prepare("SELECT * FROM products").run();
 
 			const latestBookmark = session.getBookmark();
 

--- a/src/content/docs/d1/worker-api/index.mdx
+++ b/src/content/docs/d1/worker-api/index.mdx
@@ -101,7 +101,7 @@ export default {
 	  const { pathname } = new URL(request.url);
 	//   if (pathname === "/api/beverages") {
 	// 	// If you did not use `DB` as your binding name, change it here
-	// 	const { results } = await env.DB.prepare("SELECT * FROM Customers WHERE CompanyName = ?",).bind("Bs Beverages").all();
+	// 	const { results } = await env.DB.prepare("SELECT * FROM Customers WHERE CompanyName = ?",).bind("Bs Beverages").run();
 	// 	return Response.json(results);
 	//   }
 		const companyName1 = `Bs Beverages`;

--- a/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
@@ -163,7 +163,7 @@ export const loader: LoaderFunction = async ({ context, params }) => {
   const { env, cf, ctx } = context.cloudflare;
   let { results } = await env.DB.prepare(
     "SELECT * FROM products where id = ?1"
-  ).bind(params.productId).all();
+  ).bind(params.productId).run();
   return json(results);
 };
 

--- a/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -370,7 +370,7 @@ app.get("/", async (c) => {
 	let notes = [];
 	if (vecId) {
 		const query = `SELECT * FROM notes WHERE id = ?`;
-		const { results } = await c.env.DB.prepare(query).bind(vecId).all();
+		const { results } = await c.env.DB.prepare(query).bind(vecId).run();
 		if (results) notes = results.map((vec) => vec.text);
 	}
 

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -105,7 +105,7 @@ async def on_fetch(request, env):
 from workers import Response
 
 async def on_fetch(request, env):
-    results = await env.DB.prepare("PRAGMA table_list").all()
+    results = await env.DB.prepare("PRAGMA table_list").run()
     # Return a JSON response
     return Response.json(results)
 ```

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/rpc.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/rpc.mdx
@@ -145,7 +145,7 @@ export class UserEntrypoint extends WorkerEntrypoint {
       "SELECT title FROM tasks WHERE user_id = ?"
     )
       .bind(userId)
-      .all();
+      .run();
   }
 
   async createTask(userId, title) {

--- a/src/content/docs/workflows/examples/send-invoices.mdx
+++ b/src/content/docs/workflows/examples/send-invoices.mdx
@@ -82,7 +82,7 @@ export class cartInvoicesWorkflow extends WorkflowEntrypoint<Env, Params> {
 					`SELECT * FROM cart WHERE id = ?`,
 				)
 					.bind(event.payload.cartId)
-					.all();
+					.run();
 				// should return { checkedOut: true, amount: 250 , account: { email: "celsomartinho@gmail.com" }};
 				if (results[0].checkedOut === false) {
 					throw new Error("cart hasn't been checked out yet");


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

D1's `all()` method is an alias to `run()`, and we recommend users to use `run()`.

This PR replaces instances of code examples which were using `all()` to `run()` for consistency with our recommendation.

Closes https://github.com/cloudflare/cloudflare-docs/issues/24137.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
