### PR TITLE
[Bug] GPT oss not currently supported in playground

### DIFF
--- a/src/pages/workers-ai/models/[name].astro
+++ b/src/pages/workers-ai/models/[name].astro
@@ -122,7 +122,13 @@ const isBeta = model.properties.find(
 	({ property_id, value }) => property_id === "beta" && value === "true",
 );
 
-const hasPlayground = model.task.name === "Text Generation";
+let hasPlayground = model.task.name === "Text Generation";
+
+// temporary workaround for playground limitations
+if (model.name.includes("@cf/openai/gpt-oss") ) {
+	hasPlayground = false;
+}
+
 
 const author = (authorData as any)[model.name.split("/")[1]];
 


### PR DESCRIPTION
### Summary

closes #24197

Removes the playground links only from gpt-oss.

**Preview**
<img width="980" height="728" alt="image" src="https://github.com/user-attachments/assets/d57b56a2-4f46-495e-b1d2-7ea23f5e3660" />

**Current**
<img width="980" height="728" alt="image" src="https://github.com/user-attachments/assets/2525e1f1-2792-43f8-8779-f88a4cc41fea" />
