### PR TITLE
PCX-14947 updating card one liners

### DIFF
--- a/src/content/products/1.1.1.1.yaml
+++ b/src/content/products/1.1.1.1.yaml
@@ -8,7 +8,7 @@ product:
 
 meta:
   title: Cloudflare 1.1.1.1 docs
-  description: A blazing fast DNS resolver built for private browsing.
+  description: A blazing fast DNS resolver built for private browsing
   author: "@cloudflare"
 
 resources:

--- a/src/content/products/access.yaml
+++ b/src/content/products/access.yaml
@@ -7,5 +7,5 @@ product:
 
 meta:
   title: Cloudflare Access docs
-  description: Determine who can reach your application using policies.
+  description: Determine who can reach your application using policies
   author: "@cloudflare"

--- a/src/content/products/account-billing.yaml
+++ b/src/content/products/account-billing.yaml
@@ -6,4 +6,5 @@ product:
   url: /fundamentals/account/
 
 meta:
-  description: Manage your Cloudflare account.
+  description: Manage your Cloudflare account and contacts
+  author: "@cloudflare"

--- a/src/content/products/aegis.yaml
+++ b/src/content/products/aegis.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Aegis docs
-  description: Lock down origin security with dedicated IPs 
+  description: Lock down origin security with dedicated IPs
   author: "@cloudflare"

--- a/src/content/products/aegis.yaml
+++ b/src/content/products/aegis.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Aegis docs
-  description: Leverage dedicated IPs to improve your origin security and implement Zero Trust.
+  description: Lock down origin security with dedicated IPs 
   author: "@cloudflare"

--- a/src/content/products/ai-audit.yaml
+++ b/src/content/products/ai-audit.yaml
@@ -5,6 +5,6 @@ product:
   group: Core platform
   additional_groups: [AI]
 meta:
-  title: AI Audit
+  title: Cloudflare AI Audit docs
   description: Analyze and control third-party AI crawlers in your website
   author: "@cloudflare"

--- a/src/content/products/ai-gateway.yaml
+++ b/src/content/products/ai-gateway.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare AI Gateway docs
-  description: Observe and control your AI applications.
+  description: Observe and control your AI applications
   author: "@cloudflare"

--- a/src/content/products/analytics.yaml
+++ b/src/content/products/analytics.yaml
@@ -8,9 +8,5 @@ product:
 
 meta:
   title: Cloudflare Analytics docs
-  description:
-    With the GraphQL Analytics API, all of your performance, security,
-    and reliability data is available from one endpoint. And you can select
-    exactly what you need, from one metric for a domain to multiple metrics
-    aggregated for your account.
-  author: "@cloudflare"
+  description: Visualize the performance, security and reliability data collected by our products
+   author: "@cloudflare"

--- a/src/content/products/analytics.yaml
+++ b/src/content/products/analytics.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Analytics docs
-  description: Visualize the performance, security and reliability data collected by our products
+  description: Visualize the performance, security, and reliability data collected by Cloudflare products
   author: "@cloudflare"

--- a/src/content/products/analytics.yaml
+++ b/src/content/products/analytics.yaml
@@ -9,4 +9,4 @@ product:
 meta:
   title: Cloudflare Analytics docs
   description: Visualize the performance, security and reliability data collected by our products
-   author: "@cloudflare"
+  author: "@cloudflare"

--- a/src/content/products/api-shield.yaml
+++ b/src/content/products/api-shield.yaml
@@ -8,6 +8,5 @@ product:
 
 meta:
   title: Cloudflare API Shield docs
-  description: Protect your APIs from simple and sophisticated attacks using
-    Cloudflare API Shield products.
+  description: Identify and address your API vulnerabilities
   author: "@cloudflare"

--- a/src/content/products/api.yaml
+++ b/src/content/products/api.yaml
@@ -8,6 +8,5 @@ product:
 meta:
   title: Cloudflare API docs
   description:
-    Cloudflare’s API tokens allow you to make calls to our API to alter
-    different settings.
+    Cloudflare's API tokens allow you to make calls to our API to alter different settings
   author: "@cloudflare"

--- a/src/content/products/argo-smart-routing.yaml
+++ b/src/content/products/argo-smart-routing.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Argo Smart Routing docs
-  description: Detect real-time congestion to route web traffic across the fastest and most reliable network paths.
+  description: Route web traffic across the fastest, most reliable network paths
   author: "@cloudflare"

--- a/src/content/products/automatic-platform-optimization.yaml
+++ b/src/content/products/automatic-platform-optimization.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Automatic Platform Optimization docs
-  description: Serve your WP site from Cloudflare's edge, ensuring improved performance.
+  description: Improve performance by serving your WordPress site from Cloudflare's edge
   author: "@cloudflare"

--- a/src/content/products/automatic-platform-optimization.yaml
+++ b/src/content/products/automatic-platform-optimization.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Automatic Platform Optimization docs
-  description: Improve performance by serving your WordPress site from Cloudflare's edge
+  description: Improve performance by serving your WordPress site from Cloudflare's global network
   author: "@cloudflare"

--- a/src/content/products/autorag.yaml
+++ b/src/content/products/autorag.yaml
@@ -8,8 +8,8 @@ product:
   tags: [AI]
 
 meta:
-  title: AutoRAG
-  description: Create fully managed RAG pipelines for your AI applications.
+  title: Cloudflare AutoRAG docs
+  description: Create fully managed RAG pipelines for your AI applications
   author: "@cloudflare"
 
 resources:

--- a/src/content/products/billing.yaml
+++ b/src/content/products/billing.yaml
@@ -6,4 +6,6 @@ product:
   group: Core platform
 
 meta:
-  description: Manage billing for your account.
+  title: Cloudflare Billing docs
+  description: Manage billing, plans, and subscriptions for your account
+  author: "@cloudflare"

--- a/src/content/products/bots.yaml
+++ b/src/content/products/bots.yaml
@@ -8,7 +8,5 @@ product:
 
 meta:
   title: Cloudflare bot solutions docs
-  description:
-    Cloudflare’s bot solutions identify and mitigate automated traffic
-    to protect your domain from bad bots.
+  description: Protect your domain from bad bot traffic
   author: "@cloudflare"

--- a/src/content/products/browser-isolation.yaml
+++ b/src/content/products/browser-isolation.yaml
@@ -6,4 +6,5 @@ product:
   url: /cloudflare-one/policies/browser-isolation/
 
 meta:
-  description: Cloudflare Browser Isolation executes active webpage content in a secure isolated browser.
+  description: Execute active webpage content in a secure, isolated browser
+  author: "@cloudflare"

--- a/src/content/products/browser-rendering.yaml
+++ b/src/content/products/browser-rendering.yaml
@@ -7,9 +7,6 @@ product:
   additional_groups: [AI]
 
 meta:
-  title: Browser Rendering docs
-  description: Control and interact with a headless browser instance programmatically.
+  title: Cloudflare Browser Rendering docs
+  description: Control and interact with headless browser instances programmatically
   author: "@cloudflare"
-
-resources:
-  community: https://community.cloudflare.com/tag/browser-rendering

--- a/src/content/products/cache-reserve.yaml
+++ b/src/content/products/cache-reserve.yaml
@@ -6,4 +6,5 @@ product:
   url: /cache/advanced-configuration/cache-reserve/
 
 meta:
-  description: Cache Reserve is a large, persistent data store implemented on top of R2.
+  description: Cache your website content on a persistent data store
+  author: "@cloudflare"

--- a/src/content/products/cache.yaml
+++ b/src/content/products/cache.yaml
@@ -7,9 +7,5 @@ product:
 
 meta:
   title: Cloudflare Cache (CDN) docs
-  description:
-    Cloudflare makes customer websites faster by storing a copy of the
-    website’s content on our servers. Caching static resources at Cloudflare
-    reduces your server load and bandwidth, with no extra charges for bandwidth
-    spikes
+  description: Make websites faster by caching content across our global server network
   author: "@cloudflare"

--- a/src/content/products/casb.yaml
+++ b/src/content/products/casb.yaml
@@ -6,4 +6,4 @@ product:
   url: /cloudflare-one/applications/casb/
 
 meta:
-  description: Scan SaaS applications for misconfigurations, unauthorized user activity, shadow IT, and other data security issues that can occur after a user has successfully logged in.
+  description: Scan SaaS applications and cloud environments for data security issues

--- a/src/content/products/china-network.yaml
+++ b/src/content/products/china-network.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare China Network docs
-  description: The Cloudflare China Network is a global network that offers a fast experience for visitors inside and outside of China.
+  description: Fast, global network serving visitors inside and outside of China
   author: "@cloudflare"

--- a/src/content/products/cloudflare-challenges.yaml
+++ b/src/content/products/cloudflare-challenges.yaml
@@ -10,4 +10,5 @@ product:
 
 meta:
   title: Cloudflare challenges docs
-  description: Verify whether a visitor is a real human using a challenge
+  description: Verify visitors aren't bots with lightweight challenges
+  author: "@cloudflare"

--- a/src/content/products/cloudflare-challenges.yaml
+++ b/src/content/products/cloudflare-challenges.yaml
@@ -10,5 +10,5 @@ product:
 
 meta:
   title: Cloudflare challenges docs
-  description: Verify visitors aren't bots with lightweight challenges
+  description: Verify visitors are not bots with lightweight challenges
   author: "@cloudflare"

--- a/src/content/products/cloudflare-for-platforms.yaml
+++ b/src/content/products/cloudflare-for-platforms.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare for Platforms docs
-  description: Cloudflare for Platforms allows you to extend the security and performance benefits of Cloudflare's network to your customers via their own custom or vanity domains.
+  description: Build your own multi-tenant platform using Cloudflare as infrastructure
   author: "@cloudflare"

--- a/src/content/products/cloudflare-for-saas.yaml
+++ b/src/content/products/cloudflare-for-saas.yaml
@@ -9,4 +9,4 @@ product:
   preview_tryout: true
 
 meta:
-  description: Cloudflare for SaaS allows you to extend the security and performance benefits of Cloudflare’s network to your customers via their own custom or vanity domains.
+  description: Extend Cloudflare's security and performance to your customers

--- a/src/content/products/cloudflare-one.yaml
+++ b/src/content/products/cloudflare-one.yaml
@@ -9,5 +9,6 @@ product:
 
 meta:
   title: Cloudflare Zero Trust docs
-  description: Cloudflare Zero Trust replaces legacy security perimeters with Cloudflare's network, providing secure access to any application, on any device, in any location.
+  description: Replace legacy security perimeters with Cloudflare's network to protect your organization
   author: "@cloudflare"
+  

--- a/src/content/products/cloudflare-tunnel.yaml
+++ b/src/content/products/cloudflare-tunnel.yaml
@@ -6,4 +6,4 @@ product:
   url: /cloudflare-one/connections/connect-networks/
 
 meta:
-  description: Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address
+  description: Securely connect resources to Cloudflare without a publicly routable IP address

--- a/src/content/products/containers.yaml
+++ b/src/content/products/containers.yaml
@@ -6,6 +6,6 @@ product:
   group: Developer platform
 
 meta:
-  title: Containers docs
+  title: Cloudflare Containers docs
   description: Enhance your Workers with serverless containers
   author: "@cloudflare"

--- a/src/content/products/d1.yaml
+++ b/src/content/products/d1.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare D1 docs
-  description: Managed, serverless database with SQLite's SQL semantics, built-in disaster recovery, and Worker and HTTP API access.
+  description: Create managed, serverless databases with SQL semantics
   author: "@cloudflare"

--- a/src/content/products/data-localization.yml
+++ b/src/content/products/data-localization.yml
@@ -17,6 +17,6 @@ product:
     ]
 
 meta:
-  title: Data Localization Suite docs
-  description: The Data Localization Suite is a set of products that helps customers who want to maintain local control over their traffic while retaining the security benefits of a global network.
+  title: Cloudflare Data Localization Suite docs
+  description: Control where Cloudflare stores and inspects data
   author: "@cloudflare"

--- a/src/content/products/ddos-protection.yaml
+++ b/src/content/products/ddos-protection.yaml
@@ -8,7 +8,5 @@ product:
 
 meta:
   title: Cloudflare DDoS Protection docs
-  description: Cloudflare DDoS protection secures websites, applications, and
-    entire networks while ensuring the performance of legitimate traffic is not
-    compromised.
+  description: Protect against DDoS attacks automatically with uncompromised performance
   author: "@cloudflare"

--- a/src/content/products/developer-spotlight.yaml
+++ b/src/content/products/developer-spotlight.yaml
@@ -7,5 +7,6 @@ product:
 
 meta:
   title: Cloudflare Developer Spotlight
-  description: Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
+  description:  Whether you use Cloudflare in your profession, as a student or as a hobby, let us spotlight your creativity. Write a tutorial for our documentation and earn credits for your Cloudflare account along with having your name credited on your work.
   author: "@cloudflare"
+  

--- a/src/content/products/dex.yaml
+++ b/src/content/products/dex.yaml
@@ -9,4 +9,4 @@ product:
   wrap: true
 
 meta:
-  description: Digital Experience Monitoring provides visibility into device, network, and application performance across your Zero Trust organization.
+  description: Monitor device, network, and application health across your Zero Trust organization

--- a/src/content/products/dlp.yaml
+++ b/src/content/products/dlp.yaml
@@ -6,4 +6,4 @@ product:
   url: /cloudflare-one/policies/data-loss-prevention/
 
 meta:
-  description: Cloudflare Data Loss Prevention (DLP) allows you to scan your web traffic and SaaS applications for the presence of sensitive data such as social security numbers, financial information, secret keys, and source code.
+  description: Scan your web traffic and SaaS applications for sensitive data

--- a/src/content/products/dmarc-management.yml
+++ b/src/content/products/dmarc-management.yml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare DMARC Management docs
-  description: Stop brand impersonation.
+  description: Protect your email domain and stop brand impersonation
   author: "@cloudflare"

--- a/src/content/products/dns.yaml
+++ b/src/content/products/dns.yaml
@@ -7,6 +7,5 @@ product:
 
 meta:
   title: Cloudflare DNS docs
-  description: Cloudflare DNS provides the fastest, most resilient, and simplest
-    managed DNS platform to meet your needs.
+  description: Deliver excellent performance and reliability to your domain
   author: "@cloudflare"

--- a/src/content/products/durable-objects.yaml
+++ b/src/content/products/durable-objects.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Durable Objects docs
-  description: A special kind of Cloudflare Worker which uniquely combines compute with storage.
+  description: A special kind of Cloudflare Worker combining compute with storage
   author: "@cloudflare"

--- a/src/content/products/email-routing.yaml
+++ b/src/content/products/email-routing.yaml
@@ -7,9 +7,5 @@ product:
 
 meta:
   title: Cloudflare Email Routing docs
-  description:
-    Simplify the way you create and manage email addresses. Create any
-    number of custom email addresses to use in situations where you do not want
-    to share your primary email address, and Email Routing will forward your
-    email messages for you.
+  description:  Create and manage email addresses and route to your preferred inbox
   author: "@cloudflare"

--- a/src/content/products/email-security-cf1.yaml
+++ b/src/content/products/email-security-cf1.yaml
@@ -6,4 +6,4 @@ product:
   group: Cloudflare One
 
 meta:
-  description: Cloudflare Email Security is a cloud based service that stops phishing attacks, the biggest cybersecurity threat, across all traffic vectors - email, web and network.
+  description: Protect your email, web, and network from phishing and malware attacks

--- a/src/content/products/fraud-detection.yaml
+++ b/src/content/products/fraud-detection.yaml
@@ -3,7 +3,11 @@ name: Fraud Detection
 product:
   title: Fraud Detection
   group: Application security
-  url: /bots/concepts/sequence-rules/
+  url: /bots/additional-configurations/sequence-rules/
 
 meta:
-  description: Sequence rules uses cookies to track the order of requests a user has made and the time between requests and makes them available via Cloudflare Rules.
+
+  title: Cloudflare Fraud Detection docs
+  description: Sequence rules use cookies to track the order and timing of requests
+  author: "@cloudflare"
+  

--- a/src/content/products/fundamentals.yml
+++ b/src/content/products/fundamentals.yml
@@ -9,6 +9,5 @@ product:
 
 meta:
   title: Cloudflare Fundamentals docs
-  description: Cloudflare Fundamentals provides information about features that
-    span Cloudflare products.
+  description: Learn about using Cloudflare and features that span across Cloudflare products
   author: "@cloudflare"

--- a/src/content/products/gateway.yaml
+++ b/src/content/products/gateway.yaml
@@ -6,4 +6,4 @@ product:
   url: /cloudflare-one/policies/gateway/
 
 meta:
-  description: Cloudflare Gateway, our comprehensive Secure Web Gateway, allows you to set up policies to inspect DNS, Network, HTTP, and Egress traffic.
+  description: Set up policies to inspect DNS, Network, HTTP, and Egress traffic

--- a/src/content/products/geokey-manager.yaml
+++ b/src/content/products/geokey-manager.yaml
@@ -6,4 +6,4 @@ product:
   url: /ssl/edge-certificates/geokey-manager/
 
 meta:
-  description: Restrict where the private keys used for TLS certificates are stored and managed.
+  description: Control SSL/TLS key storage for compliance and security

--- a/src/content/products/google-tag-gateway.yaml
+++ b/src/content/products/google-tag-gateway.yaml
@@ -7,5 +7,5 @@ product:
 
 meta:
   title: Google tag gateway for advertisers docs
-  description: Google tag gateway for advertisers allows website owners using Google Tag Manager and Cloudflare as a CDN to add a layer of data security and enables additional data privacy controls.
+  description: Add a layer of data security and privacy controls when using Google Tag Manager
   author: "@cloudflare"

--- a/src/content/products/graphql-api.yaml
+++ b/src/content/products/graphql-api.yaml
@@ -8,4 +8,4 @@ product:
   wrap: true
 
 meta:
-  description: The GraphQL Analytics API provides data regarding HTTP requests passing through Cloudflare’s network, as well as data from specific products, such as Firewall or Load Balancing.
+  description: Access data on HTTP requests and Cloudflare products

--- a/src/content/products/health-checks.yaml
+++ b/src/content/products/health-checks.yaml
@@ -7,5 +7,5 @@ product:
 
 meta:
   title: Cloudflare Health Checks docs
-  description: Standalone Health Checks monitors an IP address or hostname for origin servers or applications.
+  description: Monitor IPs or hostnames and get notified of issues
   author: "@cloudflare"

--- a/src/content/products/hyperdrive.yaml
+++ b/src/content/products/hyperdrive.yaml
@@ -7,6 +7,6 @@ product:
   additional_groups: [Storage]
 
 meta:
-  title: Hyperdrive docs
-  description: Service which accelerates queries you make to existing databases.
+  title: Cloudflare Hyperdrive docs
+  description: Accelerate database queries to make databases fast globally
   author: "@cloudflare"

--- a/src/content/products/images.yaml
+++ b/src/content/products/images.yaml
@@ -10,5 +10,5 @@ product:
 
 meta:
   title: Cloudflare Images docs
-  description: Store, transform, optimize, and deliver images at scale.
+  description: Store, transform, optimize, and deliver images at scale
   author: "@cloudflare"

--- a/src/content/products/internal-dns.yaml
+++ b/src/content/products/internal-dns.yaml
@@ -6,4 +6,4 @@ product:
   url: /dns/internal-dns/
 
 meta:
-  description: Use Cloudflare DNS for your internal resources.
+  description: Simplify private network management with Cloudflare DNS for internal resources

--- a/src/content/products/key-transparency.yaml
+++ b/src/content/products/key-transparency.yaml
@@ -7,6 +7,6 @@ product:
   additional_groups: [Privacy]
 
 meta:
-  title: Key Transparency Auditor docs
-  description: Secure the distribution of public keys in your end-to-end encrypted messaging systems.
+  title: Cloudflare Key Transparency Auditor docs
+  description: Secure the distribution of public keys in E2EE messaging systems
   author: "@cloudflare"

--- a/src/content/products/keyless-ssl.yaml
+++ b/src/content/products/keyless-ssl.yaml
@@ -7,4 +7,4 @@ product:
   url: /ssl/keyless-ssl/
 
 meta:
-  description: Keyless SSL allows security-conscious clients to upload their own custom certificates and benefit from Cloudflare, but without exposing their TLS private keys.
+  description: Use Cloudflare SSL while keeping exclusive access to your private keys

--- a/src/content/products/kv.yaml
+++ b/src/content/products/kv.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Workers KV docs
-  description: Global, low-latency, key-value data store.
+  description: Global, low-latency, key-value data storage
   author: "@cloudflare"

--- a/src/content/products/leaked-credentials.yaml
+++ b/src/content/products/leaked-credentials.yaml
@@ -7,4 +7,4 @@ product:
   wrap: true
 
 meta:
-  description: The leaked credentials traffic detection scans incoming requests for previously leaked credentials (usernames and passwords) previously leaked from data breaches.
+  description: Detect previously leaked credentials in incoming requests

--- a/src/content/products/learning-paths.yaml
+++ b/src/content/products/learning-paths.yaml
@@ -7,5 +7,5 @@ product:
 
 meta:
   title: Cloudflare Learning Paths
-  description: Learning paths guide you through modules and projects so you can get started with Cloudflare as quickly as possible.
+  description: Guided modules and projects to help you get started with Cloudflare
   author: "@cloudflare"

--- a/src/content/products/load-balancing.yaml
+++ b/src/content/products/load-balancing.yaml
@@ -8,6 +8,5 @@ product:
 
 meta:
   title: Cloudflare Load Balancing docs
-  description: Balance traffic loads, manage failovers, monitor server and pool
-    health, and apply geographic control with Cloudflare Load Balancing
+  description: Maximize application performance and availability
   author: "@cloudflare"

--- a/src/content/products/log-explorer.yaml
+++ b/src/content/products/log-explorer.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Log Explorer docs
-  description: Store and explore your Cloudflare logs directly within the Cloudflare dashboard or API.
+  description: Store and explore your logs in the Cloudflare dashboard or API
   author: '@cloudflare'

--- a/src/content/products/logs.yaml
+++ b/src/content/products/logs.yaml
@@ -8,8 +8,5 @@ product:
 
 meta:
   title: Cloudflare Logs docs
-  description:
-    Cloudflare Logs contain detailed information on requests and events
-    processed by our network. Find out about the connecting client, Cloudflare's
-    actions, and the response from the origin server
+  description: Access detailed logs with metadata from our products
   author: "@cloudflare"

--- a/src/content/products/magic-cloud-networking.yaml
+++ b/src/content/products/magic-cloud-networking.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Magic Cloud Networking docs
-  description: Documentation for Cloudflare Magic Cloud Networking, a way to automate resource discovery, and reduce management burden when connecting to your public cloud.
+  description: Automate resource discovery and simplify managing your public cloud infrastructure
   author: "@cloudflare"

--- a/src/content/products/magic-firewall.yaml
+++ b/src/content/products/magic-firewall.yaml
@@ -8,6 +8,5 @@ product:
 
 meta:
   title: Cloudflare Magic Firewall docs
-  description: Magic Firewall a network-level firewall delivered through
-    Cloudflare to secure your enterprise.
+  description: Protect your enterprise network with advanced firewall-as-a-service protection
   author: "@cloudflare"

--- a/src/content/products/magic-network-monitoring.yaml
+++ b/src/content/products/magic-network-monitoring.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Magic Network Monitoring docs
-  description: Magic Network Monitoring provides visibility into your network traffic by analyzing network flow data sent from a customer's routers.
+  description: Visibility into your network and cloud traffic by analyzing network flow data
   author: "@cloudflare"

--- a/src/content/products/magic-transit.yaml
+++ b/src/content/products/magic-transit.yaml
@@ -7,7 +7,5 @@ product:
 
 meta:
   title: Cloudflare Magic Transit docs
-  description: Magic Transit delivers network functions at Cloudflare scale—DDoS
-    protection, traffic acceleration, and much more from every Cloudflare data
-    center—for on-premise, cloud-hosted, and hybrid networks.
+  description: Network functions at Cloudflare scale for on-premise, cloud-hosted, and hybrid networks
   author: "@cloudflare"

--- a/src/content/products/magic-wan.yaml
+++ b/src/content/products/magic-wan.yaml
@@ -8,7 +8,5 @@ product:
 
 meta:
   title: Cloudflare Magic WAN docs
-  description: Magic WAN replaces legacy WAN architectures with Cloudflare’s
-    network, providing global connectivity, cloud-based security, performance,
-    and control through one simple user interface.
+  description: Replace legacy WAN and securely connect any traffic source to Cloudflare's network
   author: "@cloudflare"

--- a/src/content/products/network-error-logging.yml
+++ b/src/content/products/network-error-logging.yml
@@ -10,8 +10,6 @@ product:
 
 meta:
   title: Cloudflare Network Error Logging docs
-  description: Network Error Logging allows you to take a peek into connectivity
-    issues on the Internet to provide answers to when and where incident is
-    happening, who is impacted, and how they're impacted.
+  description: Review connectivity issues to learn when and where an incident is happening and impact
   author: "@cloudflare"
   image: data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=

--- a/src/content/products/network-error-logging.yml
+++ b/src/content/products/network-error-logging.yml
@@ -10,6 +10,6 @@ product:
 
 meta:
   title: Cloudflare Network Error Logging docs
-  description: Review connectivity issues to learn when and where an incident is happening and impact
+  description: Review connectivity issues to learn when and where an incident is happening and its impact
   author: "@cloudflare"
   image: data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII=

--- a/src/content/products/network-interconnect.yaml
+++ b/src/content/products/network-interconnect.yaml
@@ -8,6 +8,5 @@ product:
 
 meta:
   title: Cloudflare Network Interconnect docs
-  description: For a faster, more reliable, and more secure experience than
-    connecting over the Internet.
+  description: Faster, more reliable, and more secure than connecting over the Internet
   author: "@cloudflare"

--- a/src/content/products/network.yml
+++ b/src/content/products/network.yml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Network settings docs
-  description: Manage the Cloudflare network settings for your website.
+  description: Manage Cloudflare network settings for your website
   author: "@cloudflare"

--- a/src/content/products/notifications.yml
+++ b/src/content/products/notifications.yml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Notifications docs
-  description: Cloudflare Notifications help you stay up to date with your Cloudflare account. Manage your Notifications to define what you want to be warned about and how, be it a denial-of-service attack or an issue with your server.
+  description: Define what you want to be notified about and how
   author: "@cloudflare"

--- a/src/content/products/page-shield.yml
+++ b/src/content/products/page-shield.yml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Page Shield docs
-  description: Provide client-side protection as part of your domain's firewall
+  description: Provide client-side protection for your website visitors
   author: "@cloudflare"

--- a/src/content/products/pages.yaml
+++ b/src/content/products/pages.yaml
@@ -7,6 +7,5 @@ product:
 
 meta:
   title: Cloudflare Pages docs
-  description: Documentation for Cloudflare Pages, the best way to deploy your
-    static and JAMstack sites
+  description: Build full-stack, serverless applications globally with minimal configuration
   author: "@cloudflare"

--- a/src/content/products/privacy-gateway.yml
+++ b/src/content/products/privacy-gateway.yml
@@ -9,7 +9,5 @@ product:
 
 meta:
   title: Cloudflare Privacy Gateway docs
-  description:
-    A managed gateway service that implements the Oblivious HTTP IETF standard
-    and improves client privacy.
+  description: Implement the Oblivious HTTP IETF standard to improve client privacy
   author: "@cloudflare"

--- a/src/content/products/pub-sub.yml
+++ b/src/content/products/pub-sub.yml
@@ -9,7 +9,7 @@ product:
 
 meta:
   title: Cloudflare Pub/Sub docs
-  description: Connect any MQTT-capable device directly to Cloudflare's edge
+  description: Connect any MQTT-capable device directly to Cloudflare's global network
   author: "@cloudflare"
 
 resources:

--- a/src/content/products/pub-sub.yml
+++ b/src/content/products/pub-sub.yml
@@ -9,7 +9,7 @@ product:
 
 meta:
   title: Cloudflare Pub/Sub docs
-  description: Cloudflare Pub/Sub allows developers to connect any MQTT-capable device – an ecosystem of tens of millions of devices — directly to Cloudflare's edge using the industry-standard MQTT protocol.
+  description: Connect any MQTT-capable device directly to Cloudflare's edge
   author: "@cloudflare"
 
 resources:

--- a/src/content/products/pulumi.yaml
+++ b/src/content/products/pulumi.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Pulumi docs
-  description: Create, deploy, and manage Cloudflare resources in various programming languages.
+  description: Create, deploy, and manage Cloudflare resources in various programming languages
   author: "@cloudflare"

--- a/src/content/products/queues.yaml
+++ b/src/content/products/queues.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Queues docs
-  description: Reliably send and receive messages without the egress fees.
+  description: Reliably send and receive messages without the egress fees
   author: "@cloudflare"

--- a/src/content/products/r2-data-catalog.yaml
+++ b/src/content/products/r2-data-catalog.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare R2 Data Catalog docs
-  description: Create, manage, and query Iceberg tables stored in R2.
+  description: Create, manage, and query Iceberg tables stored in R2
   author: "@cloudflare"

--- a/src/content/products/r2.yaml
+++ b/src/content/products/r2.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare R2 docs
-  description: Store large amounts of unstructured data without egress fees.
+  description: Store large amounts of unstructured data without egress fees
   author: "@cloudflare"

--- a/src/content/products/radar.yml
+++ b/src/content/products/radar.yml
@@ -8,7 +8,7 @@ product:
 
 meta:
   title: Cloudflare Radar docs
-  description: Investigate Internet usage around the world using Cloudflare's data.
+  description: Investigate Internet usage around the world using Cloudflare's data
   author: "@CloudflareRadar"
 
 resources:

--- a/src/content/products/randomness-beacon.yml
+++ b/src/content/products/randomness-beacon.yml
@@ -9,6 +9,5 @@ product:
 
 meta:
   title: Cloudflare Randomness Beacon docs
-  description: "Explore drand: a distributed service providing public randomness
-    in an application-agnostic, secure, and efficient way."
+  description: Explore drand, a distributed service providing randomness to applications
   author: "@cloudflare"

--- a/src/content/products/rate-limiting.yaml
+++ b/src/content/products/rate-limiting.yaml
@@ -7,4 +7,4 @@ product:
   preview_tryout: true
 
 meta:
-  description: Rate limiting rules allow you to define rate limits for requests matching an expression, and the action to perform when those rate limits are reached.
+  description: Control the rate of incoming requests matching an expression

--- a/src/content/products/realtime.yaml
+++ b/src/content/products/realtime.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Realtime docs
-  description: Documentation for Cloudflare Realtime.
+  description: Infrastructure for real-time serverless video, audio, and data applications
   author: "@cloudflare"

--- a/src/content/products/reference-architecture.yml
+++ b/src/content/products/reference-architecture.yml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Reference Architecture docs
-  description: Review best practices and diagrams explaining how to address common Internet security and performance challenges using Cloudflare products.
+  description: Guides and diagrams explain Cloudflare products and how to integrate with IT architectures
   author: "@cloudflare"

--- a/src/content/products/rules.yml
+++ b/src/content/products/rules.yml
@@ -10,5 +10,5 @@ product:
 
 meta:
   title: Cloudflare Rules docs
-  description: Create rules that adjust incoming requests, change Cloudflare settings, or trigger actions.
+  description: Modify incoming requests, change Cloudflare settings, or trigger actions
   author: "@cloudflare"

--- a/src/content/products/ruleset-engine.yml
+++ b/src/content/products/ruleset-engine.yml
@@ -10,6 +10,5 @@ product:
 
 meta:
   title: Cloudflare Ruleset Engine docs
-  description: Create and deploy rules and rulesets in different Cloudflare
-    products using the same basic syntax.
+  description: Create rulesets and rules for different Cloudflare products
   author: "@cloudflare"

--- a/src/content/products/security-center.yaml
+++ b/src/content/products/security-center.yaml
@@ -9,8 +9,5 @@ product:
 meta:
   title: Cloudflare Security Center docs
   description:
-    Cloudflare Security Center allows you to manage your IT assets in a
-    single dashboard, warning you about possible security risks and
-    vulnerabilities, and providing a one-click solution for Cloudflare
-    configuration issues.
+    Enhance your security posture with a range of security products and one-click solutions
   author: "@cloudflare"

--- a/src/content/products/spectrum.yaml
+++ b/src/content/products/spectrum.yaml
@@ -8,5 +8,5 @@ product:
 
 meta:
   title: Cloudflare Spectrum docs
-  description: DDoS protection for everything.
+  description: Secure and accelerate any TCP or UDP-based application
   author: "@cloudflare"

--- a/src/content/products/speed.yaml
+++ b/src/content/products/speed.yaml
@@ -7,5 +7,5 @@ product:
 
 meta:
   title: Cloudflare Speed docs
-  description: Speed up your website or application using built-in Cloudflare settings.
+  description: Improve the performance of your website or web application
   author: "@cloudflare"

--- a/src/content/products/ssl.yaml
+++ b/src/content/products/ssl.yaml
@@ -8,7 +8,5 @@ product:
 
 meta:
   title: Cloudflare SSL/TLS docs
-  description: Cloudflare wants to encrypt as much web traffic as possible to
-    prevent data theft and other tampering. We are the first Internet
-    performance and security company to offer free SSL/TLS protection.
+  description: Encrypt your web traffic to prevent data theft and other tampering
   author: "@cloudflare"

--- a/src/content/products/stream.yaml
+++ b/src/content/products/stream.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Stream docs
-  description: Store, encode, deliver, and play videos on your sites and applications.
+  description: Store, encode, deliver, and play videos on sites and applications
   author: "@cloudflare"

--- a/src/content/products/turn.yaml
+++ b/src/content/products/turn.yaml
@@ -8,4 +8,4 @@ product:
   url: /realtime/turn/
 
 meta:
-  description: Separately from Cloudflare Realtime's SFU, Realtime offers a managed TURN service.
+  description: Ensure connectivity with a relay point for traffic between WebRTC clients

--- a/src/content/products/vectorize.yaml
+++ b/src/content/products/vectorize.yaml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Vectorize docs
-  description: Documentation for Vectorize, Cloudflare's vector database
+  description: Store, query, and manage high-dimensional vector databases
   author: "@cloudflare"

--- a/src/content/products/version-management.yml
+++ b/src/content/products/version-management.yml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Version Management docs
-  description: Safely manage configurations on the edge with versioning, staging, and rollbacks
+  description: Safely manage configurations on Cloudflare's global network with versioning, staging, and rollbacks
   author: "@cloudflare"

--- a/src/content/products/version-management.yml
+++ b/src/content/products/version-management.yml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Version Management docs
-  description: Cloudflare Version Management lets you safely manage configurations on the edge with versioning, staging, and rollbacks.
+  description: Safely manage configurations on the edge with versioning, staging, and rollbacks
   author: "@cloudflare"

--- a/src/content/products/waf.yaml
+++ b/src/content/products/waf.yaml
@@ -7,6 +7,5 @@ product:
 
 meta:
   title: Cloudflare Web Application Firewall (WAF) docs
-  description: Protect against web application vulnerabilities with Cloudflare’s
-    Web Application Firewall (WAF).
+  description: Filter incoming traffic and protect against web app vulnerabilities
   author: "@cloudflare"

--- a/src/content/products/waiting-room.yaml
+++ b/src/content/products/waiting-room.yaml
@@ -9,7 +9,5 @@ product:
 
 meta:
   title: Cloudflare Waiting Room docs
-  description:
-    Cloudflare Waiting Room redirects visitors to virtual waiting rooms
-    when they are trying to access web pages that have high volumes of traffic.
+  description: Create a virtual waiting room to manage peak traffic
   author: "@cloudflare"

--- a/src/content/products/web-analytics.yml
+++ b/src/content/products/web-analytics.yml
@@ -9,5 +9,5 @@ product:
 
 meta:
   title: Cloudflare Web Analytics docs
-  description: Cloudflare Web Analytics helps you understand the performance of your web pages as experienced by your site visitors.
+  description: Get vital web analytics for your website
   author: "@cloudflare"

--- a/src/content/products/workers.yaml
+++ b/src/content/products/workers.yaml
@@ -8,7 +8,5 @@ product:
 
 meta:
   title: Cloudflare Workers docs
-  description: Documentation for Cloudflare Workers, a serverless execution
-    environment that allows you to create entirely new applications or augment
-    existing ones without configuring or maintaining infrastructure.
+  description: Build, deploy, and scale serverless applications globally with low latency and minimal configuration
   author: "@cloudflare"

--- a/src/content/products/zero-trust-warp.yaml
+++ b/src/content/products/zero-trust-warp.yaml
@@ -7,4 +7,4 @@ product:
   wrap: true
 
 meta:
-  description: The Cloudflare WARP client allows you to protect corporate devices by securely and privately sending traffic from those devices to Cloudflare’s global network, where Cloudflare Gateway can apply advanced web filtering.
+  description: Connect corporate devices to your Zero Trust organization


### PR DESCRIPTION
### Summary
Updating the tile one-liners in the Docs /products/ directory to be consistently shorter so that they can fit in the display, remove repeating the product name, remove end period, and replace with versions edited by team. Also updated the title tag when it was missing 'Cloudflare'.
Note: the url change in Fraud Detection is something that was changed elsewhere since i started working on this file. the new url here that displays as a change is the currently live url.

### Documentation checklist
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.