### PR TITLE
Encourage changelogs to be written as part of docs PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 <!-- Remove items that do not apply -->
 
-- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to: https://x.com/CFchangelog
+- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
 - [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
 - [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
 - [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 
 <!-- Remove items that do not apply -->
 
+- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to: https://x.com/CFchangelog
 - [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
 - [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
 - [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).


### PR DESCRIPTION
Nudge people contributing to the developer docs to add changelogs.

- anything that's a new feature
- anything that's an important fix or improvement

We miss too many shots on goal today to share new things that have improved, too much good stuff happens and docs get updated but we don't share the news. Should encourage here as part of this template. Open to suggestions on framing.
