### PR TITLE
[Containers] Remove unsupported wrangler options

### DIFF
--- a/src/content/partials/workers/wrangler-commands/containers.mdx
+++ b/src/content/partials/workers/wrangler-commands/containers.mdx
@@ -14,22 +14,13 @@ wrangler containers build [PATH] [OPTIONS]
 
 - `PATH` <Type text="string" /> <MetaInfo text="optional" />
   - Path for the directory containing the Dockerfile to build.
-
-#### Options:
-
 - `-t, --tag` <Type text="string" /> <MetaInfo text="required" />
   - Name and optionally a tag (format: "name:tag").
 - `--path-to-docker` <Type text="string" /> <MetaInfo text="optional" />
-  - Path to your docker binary if it's not on $PATH.
+  - Path to your docker binary if it's not on `$PATH`.
   - Default: "docker"
 - `-p, --push` <Type text="boolean" /> <MetaInfo text="optional" />
   - Push the built image to Cloudflare's managed registry.
-  - Default: false
-- `--platform` <Type text="string" /> <MetaInfo text="optional" />
-  - Platform to build for. Defaults to the architecture supported by Workers (linux/amd64).
-  - Default: "linux/amd64"
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as clean JSON.
   - Default: false
 
 <AnchorHeading title="`delete`" slug="containers-delete" depth={3} />
@@ -42,10 +33,6 @@ wrangler containers delete <CONTAINER_ID> [OPTIONS]
 
 - `CONTAINER_ID` <Type text="string" /> <MetaInfo text="required" />
   - The ID of the Container to delete.
-- `-y, --skip-confirmation` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Skip deletion confirmation prompt.
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as JSON rather than a table.
 
 <AnchorHeading title="`images`" slug="containers-images" depth={3} />
 
@@ -58,8 +45,6 @@ List images in your containers registry.
 ```txt
 wrangler containers images list [OPTIONS]
 ```
-
-#### Options:
 
 - `--filter` <Type text="string" /> <MetaInfo text="optional" />
   - Regex to filter results.
@@ -80,13 +65,7 @@ wrangler containers images delete [IMAGE] [OPTIONS]
 ```
 
 - `IMAGE` <Type text="string" /> <MetaInfo text="required" />
-  - Image to delete.
-
-#### Options:
-
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as clean JSON.
-  - Default: false
+  - Image to delete of the form `IMAGE:TAG`
 
 <AnchorHeading title="`info`" slug="containers-info" depth={3} />
 
@@ -98,8 +77,6 @@ wrangler containers info <CONTAINER_ID> [OPTIONS]
 
 - `CONTAINER_ID` <Type text="string" /> <MetaInfo text="required" />
   - The ID of the Container to get information about.
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as JSON rather than a table.
 
 <AnchorHeading title="`list`" slug="containers-list" depth={3} />
 
@@ -108,9 +85,6 @@ List the Containers in your account.
 ```txt
 wrangler containers list [OPTIONS]
 ```
-
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as JSON rather than a table.
 
 <AnchorHeading title="`push`" slug="containers-push" depth={3} />
 
@@ -122,12 +96,6 @@ wrangler containers push [TAG] [OPTIONS]
 
 - `TAG` <Type text="string" /> <MetaInfo text="required" />
   - The name and tag of the container image to push.
-
-#### Options:
-
 - `--path-to-docker` <Type text="string" /> <MetaInfo text="optional" />
-  - Path to your docker binary if it's not on $PATH.
+  - Path to your docker binary if it's not on `$PATH`.
   - Default: "docker"
-- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Return output as clean JSON.
-  - Default: false


### PR DESCRIPTION
### Summary

- Remove the unsupported `--json` flag from wrangler containers commands
- Remove unsupported `--skip-confirmation` flag for containers delete
- Remove hidden `--platform` flag for containers build
- Remove "Options" heading as the heading is inconsistently used across containers commands

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

