### PR TITLE
[Workers] Updating note on the main key

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -99,6 +99,8 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 :::note
 
 At a minimum, the `name`, `main` and `compatibility_date` keys are required to deploy a Worker.
+
+If a Worker uses [static assets](/workers/static-assets/) (and therefore the Wrangler file specifies the assets directory), the `main` key is optional.
 :::
 
 - `name` <Type text="string" /> <MetaInfo text="required" />
@@ -1091,7 +1093,7 @@ The following options are available:
   - The instance type of the container. This determines the amount of memory, CPU, and disk given to the container
     instance. The current options are `"dev"`, `"basic"`, and `"standard"`. The default is `"dev"`. For more information,
     the see [instance types documentation](/containers/platform-details#instance-types).
-    
+
   - To specify a custom instance type, see [here](#custom-instance-types).
 
 - `max_instances` <Type text="string" /> <MetaInfo text="optional" />

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -100,7 +100,7 @@ Inheritable keys are configurable at the top-level, and can be inherited (or ove
 
 At a minimum, the `name`, `main` and `compatibility_date` keys are required to deploy a Worker.
 
-If a Worker uses [static assets](/workers/static-assets/) (and therefore the Wrangler file specifies the assets directory), the `main` key is optional.
+The `main` key is optional for assets-only Workers.
 :::
 
 - `name` <Type text="string" /> <MetaInfo text="required" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Specifying that the `main` key in the Wrangler file becomes optional if the Worker is using static assets, and therefore specifies the assets directory in the Wrangler file.

Closes https://github.com/cloudflare/cloudflare-docs/issues/23746.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
