### PR TITLE
[Challenges / Rules] Add back CAPTCHA_BOX

### DIFF
--- a/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
+++ b/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
@@ -16,12 +16,12 @@ To display a custom page for each error, create a separate page per error. For e
 
 The following custom error tokens are required by their respective error pages:
 
-| Token                                        | Required for                                                                                                                       |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `::CF_WIDGET_BOX::` <br /> `::CAPTCHA_BOX::`[^1] | Interactive Challenge <br/>Country Challenge (Managed Challenge)<br/>Managed Challenge / I'm Under Attack Mode (Interstitial Page) |
-| `::IM_UNDER_ATTACK_BOX::`                    | JS Challenge                                                                                                                       |
-| `::CLOUDFLARE_ERROR_500S_BOX::`              | 5XX Errors                                                                                                                         |
-| `::CLOUDFLARE_ERROR_1000S_BOX::`             | 1XXX Errors                                                                                                                        |
+| Token                            | Required for                                                                                                                       |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `::CAPTCHA_BOX::`                | Interactive Challenge <br/>Country Challenge (Managed Challenge)<br/>Managed Challenge / I'm Under Attack Mode (Interstitial Page) |
+| `::IM_UNDER_ATTACK_BOX::`        | Non-Interactive Challenge (JS Challenge)                                                                                           |
+| `::CLOUDFLARE_ERROR_500S_BOX::`  | 5XX Errors                                                                                                                         |
+| `::CLOUDFLARE_ERROR_1000S_BOX::` | 1XXX Errors                                                                                                                        |
 
 [^1]: Not used for I'm Under Attack Mode.
 

--- a/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
+++ b/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
@@ -16,12 +16,14 @@ To display a custom page for each error, create a separate page per error. For e
 
 The following custom error tokens are required by their respective error pages:
 
-| Token                            | Required for                                                                                                                       |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `::CF_WIDGET_BOX::`                | Interactive Challenge <br/>Country Challenge (Managed Challenge)<br/>Managed Challenge / I'm Under Attack Mode (Interstitial Page) |
-| `::IM_UNDER_ATTACK_BOX::`        | JS Challenge                                                                                                                       |
-| `::CLOUDFLARE_ERROR_500S_BOX::`  | 5XX Errors                                                                                                                         |
-| `::CLOUDFLARE_ERROR_1000S_BOX::` | 1XXX Errors                                                                                                                        |
+| Token                                        | Required for                                                                                                                       |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `::CF_WIDGET_BOX::` <br /> `::CAPTCHA_BOX::`[^1] | Interactive Challenge <br/>Country Challenge (Managed Challenge)<br/>Managed Challenge / I'm Under Attack Mode (Interstitial Page) |
+| `::IM_UNDER_ATTACK_BOX::`                    | JS Challenge                                                                                                                       |
+| `::CLOUDFLARE_ERROR_500S_BOX::`              | 5XX Errors                                                                                                                         |
+| `::CLOUDFLARE_ERROR_1000S_BOX::`             | 1XXX Errors                                                                                                                        |
+
+[^1] `::CAPTCHA_BOX::` is not used for I'm Under Attack Mode.
 
 Each custom error token has a default look and feel. However, you can use CSS to stylize each custom error tag using each tag's class ID. All the external resources like images, CSS, and scripts will be inlined during the process. As such, all external resources need to be available (that is, they must return `200 OK`) otherwise an error will be thrown.
 

--- a/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
+++ b/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
@@ -23,7 +23,7 @@ The following custom error tokens are required by their respective error pages:
 | `::CLOUDFLARE_ERROR_500S_BOX::`              | 5XX Errors                                                                                                                         |
 | `::CLOUDFLARE_ERROR_1000S_BOX::`             | 1XXX Errors                                                                                                                        |
 
-[^1] `::CAPTCHA_BOX::` is not used for I'm Under Attack Mode.
+[^1] Not used for I'm Under Attack Mode.
 
 Each custom error token has a default look and feel. However, you can use CSS to stylize each custom error tag using each tag's class ID. All the external resources like images, CSS, and scripts will be inlined during the process. As such, all external resources need to be available (that is, they must return `200 OK`) otherwise an error will be thrown.
 

--- a/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
+++ b/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
@@ -23,7 +23,7 @@ The following custom error tokens are required by their respective error pages:
 | `::CLOUDFLARE_ERROR_500S_BOX::`              | 5XX Errors                                                                                                                         |
 | `::CLOUDFLARE_ERROR_1000S_BOX::`             | 1XXX Errors                                                                                                                        |
 
-[^1] Not used for I'm Under Attack Mode.
+[^1]: Not used for I'm Under Attack Mode.
 
 Each custom error token has a default look and feel. However, you can use CSS to stylize each custom error tag using each tag's class ID. All the external resources like images, CSS, and scripts will be inlined during the process. As such, all external resources need to be available (that is, they must return `200 OK`) otherwise an error will be thrown.
 

--- a/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
+++ b/src/content/docs/rules/custom-errors/reference/error-tokens.mdx
@@ -23,8 +23,6 @@ The following custom error tokens are required by their respective error pages:
 | `::CLOUDFLARE_ERROR_500S_BOX::`  | 5XX Errors                                                                                                                         |
 | `::CLOUDFLARE_ERROR_1000S_BOX::` | 1XXX Errors                                                                                                                        |
 
-[^1]: Not used for I'm Under Attack Mode.
-
 Each custom error token has a default look and feel. However, you can use CSS to stylize each custom error tag using each tag's class ID. All the external resources like images, CSS, and scripts will be inlined during the process. As such, all external resources need to be available (that is, they must return `200 OK`) otherwise an error will be thrown.
 
 ## For Custom Error Assets, inline responses, and Error Pages


### PR DESCRIPTION
### Summary

Adds back default `::CAPTCHA_BOX::` token to Rules error tokens

### Documentation checklist

- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

