### PR TITLE
[Magic] Use Telemetry for Magic WAN Connector metrics

### DIFF
--- a/src/content/docs/magic-wan/configuration/connector/device-metrics.mdx
+++ b/src/content/docs/magic-wan/configuration/connector/device-metrics.mdx
@@ -7,10 +7,10 @@ sidebar:
 
 Cloudflare customers can inspect metrics for a specific Magic WAN Connector in the Cloudflare dashboard. The Magic WAN Connector device metrics measured by Cloudflare include:
 
-- Average CPU load
-- Average temperature (this is always zero for Virtual Connector)
-- Average disk utilization
-- Average memory utilization
+- CPU load
+- System temperature (this is always zero for Virtual Connector)
+- Disk utilization
+- Memory utilization
 
 To check for Connector metrics:
 
@@ -33,22 +33,21 @@ query MagicWanDeviceMetrics(
 ) {
 	viewer {
 		accounts(filter: { accountTag: $accountTag }) {
-			MagicWANConnectorMetricsAdaptiveGroups(
+			mconnTelemetrySnapshotsAdaptiveGroups(
 				limit: 100
 				filter: {
-					mconnInterfaceType: "system"
 					datetime_geq: $datetimeStart
 					datetime_lt: $datetimeEnd
 				}
 			) {
-				avg {
-					cpuTemperature
-					cpuLoadPercentage
-					diskUsagePercentage
-					memoryUsagePercentage
+				max {
+					loadAverage1m
+					cpuCount
+					memoryFreeBytes
+					memoryTotalBytes
 				}
 				dimensions {
-					mconnInterfaceName
+					connectorId
 				}
 			}
 		}


### PR DESCRIPTION
The `mconnTelemetry*` nodes replace the soon-to-be-deprecated `MagicWANConnectorMetrics` node in GraphQL.