### PR TITLE
Remove calls to sql.end() in Hyperdrive examples

### DIFF
--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-drivers-and-libraries/drizzle-orm.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-drivers-and-libraries/drizzle-orm.mdx
@@ -87,9 +87,6 @@ export default {
 		// Sample query to get all users
 		const allUsers = await db.select().from(users);
 
-		// Clean up the connection
-		ctx.waitUntil(sql.end());
-
 		return Response.json(allUsers);
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -233,10 +233,10 @@ export interface Env {
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
 		// Create a client using the pg driver (or any supported driver, ORM or query builder)
-    // with the Hyperdrive credentials. These credentials are only accessible from your Worker.
-    const sql = new Client({
-      connectionString: env.HYPERDRIVE.connectionString,
-    });
+        // with the Hyperdrive credentials. These credentials are only accessible from your Worker.
+        const sql = new Client({
+          connectionString: env.HYPERDRIVE.connectionString,
+        });
 
 		try {
 			// Connect to the database
@@ -244,9 +244,6 @@ export default {
 			
 			// Sample query
 			const results = await sql.query(`SELECT * FROM pg_tables`);
-
-			// Clean up the client after the response is returned, before the Worker is killed
-			ctx.waitUntil(sql.end());
 
 			// Return result rows as JSON
 			return Response.json(results.rows);

--- a/src/content/docs/hyperdrive/index.mdx
+++ b/src/content/docs/hyperdrive/index.mdx
@@ -53,10 +53,6 @@ export default {
     	try {
     		// Sample SQL query
     		const results = await sql`SELECT * FROM pg_tables`;
-
-    		// Close the client after the response is returned
-    		ctx.waitUntil(sql.end());
-
     		return Response.json(results);
     	} catch (e) {
     		return Response.json({ error: e instanceof Error ? e.message : e }, { status: 500 });

--- a/src/content/docs/workers/tutorials/postgres/index.mdx
+++ b/src/content/docs/workers/tutorials/postgres/index.mdx
@@ -206,23 +206,18 @@ export default {
 		const sql = new Client({
 			connectionString: env.DB_URL,
 		});
-		try {
-			// Connect to the PostgreSQL database
-			await sql.connect();
+        // Connect to the PostgreSQL database
+        await sql.connect();
 
-			// Query the products table
-			const result = await sql.query("SELECT * FROM products");
+        // Query the products table
+        const result = await sql.query("SELECT * FROM products");
 
-			// Return the result as JSON
-			return new Response(JSON.stringify(result.rows), {
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
-		} finally {
-			// Clean up the client connection
-			await sql.end();
-		}
+        // Return the result as JSON
+        return new Response(JSON.stringify(result.rows), {
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
 	},
 } satisfies ExportedHandler<Env>;
 ```
@@ -260,49 +255,44 @@ export default {
 		const sql = new Client({
 			connectionString: env.DB_URL,
 		});
-		try {
-			// Connect to the PostgreSQL database
-			await sql.connect();
+        // Connect to the PostgreSQL database
+        await sql.connect();
 
-			const url = new URL(request.url);
-			if (request.method === "POST" && url.pathname === "/products") {
-				// Parse the request's JSON payload
-				const productData = (await request.json()) as {
-					name: string;
-					description: string;
-					price: number;
-				};
+        const url = new URL(request.url);
+        if (request.method === "POST" && url.pathname === "/products") {
+            // Parse the request's JSON payload
+            const productData = (await request.json()) as {
+                name: string;
+                description: string;
+                price: number;
+            };
 
-				const name = productData.name,
-					description = productData.description,
-					price = productData.price;
+            const name = productData.name,
+                description = productData.description,
+                price = productData.price;
 
-				// Insert the new product into the products table
-				const insertResult = await sql.query(
-					`INSERT INTO products(name, description, price) VALUES($1, $2, $3)
-        RETURNING *`,
-					[name, description, price],
-				);
+            // Insert the new product into the products table
+            const insertResult = await sql.query(
+                `INSERT INTO products(name, description, price) VALUES($1, $2, $3)
+    RETURNING *`,
+                [name, description, price],
+            );
 
-				// Return the inserted row as JSON
-				return new Response(JSON.stringify(insertResult.rows), {
-					headers: { "Content-Type": "application/json" },
-				});
-			}
+            // Return the inserted row as JSON
+            return new Response(JSON.stringify(insertResult.rows), {
+                headers: { "Content-Type": "application/json" },
+            });
+        }
 
-			// Query the products table
-			const result = await sql.query("SELECT * FROM products");
+        // Query the products table
+        const result = await sql.query("SELECT * FROM products");
 
-			// Return the result as JSON
-			return new Response(JSON.stringify(result.rows), {
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
-		} finally {
-			// Clean up the client connection
-			await sql.end();
-		}
+        // Return the result as JSON
+        return new Response(JSON.stringify(result.rows), {
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
 	},
 } satisfies ExportedHandler<Env>;
 ```

--- a/src/content/partials/hyperdrive/use-postgres-js-to-make-query.mdx
+++ b/src/content/partials/hyperdrive/use-postgres-js-to-make-query.mdx
@@ -41,10 +41,6 @@ export default {
 			// A very simple test query
 			const result = await sql`select * from pg_tables`;
 
-			// Clean up the client, ensuring we don't kill the worker before that is
-			// completed.
-			ctx.waitUntil(sql.end());
-
 			// Return result rows as JSON
 			return Response.json({ success: true, result: result });
 		} catch (e: any) {

--- a/src/content/partials/prompts/base-prompt.txt
+++ b/src/content/partials/prompts/base-prompt.txt
@@ -541,10 +541,6 @@ const sql = postgres(env.HYPERDRIVE.connectionString)
       // Test query
       const results = await sql`SELECT * FROM pg_tables`;
 
-      // Clean up the client, ensuring we don't kill the worker before that is
-      // completed.
-      ctx.waitUntil(sql.end());
-
       // Return result rows as JSON
       return Response.json(results);
     } catch (e) {


### PR DESCRIPTION
As discussed, the workers runtime already handles closing outgoing connections as soon as a worker invocation finishes. And we have reason to believe that sql.end() can cause hangs due to a bug in postgres.js (https://github.com/porsager/postgres/issues/1097), so it's better to just not include it.

I guess I didn't have to remove it from our node-postgres examples, but it isn't needed there either, so why clutter our examples with extra code?

@thomasgauvin @ReppCodes 