### PR TITLE
[Workers] Use table vs inline table toml syntax for `routes`

### DIFF
--- a/src/content/docs/workers/configuration/routing/custom-domains.mdx
+++ b/src/content/docs/workers/configuration/routing/custom-domains.mdx
@@ -56,9 +56,9 @@ To configure a Custom Domain in your [Wrangler configuration file](/workers/wran
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "shop.example.com", custom_domain = true }
-]
+[[routes]]
+pattern = "shop.example.com"
+custom_domain = true
 ```
 
 </WranglerConfig>
@@ -70,10 +70,13 @@ To configure multiple Custom Domains:
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "shop.example.com", custom_domain = true },
-	{ pattern = "shop-two.example.com", custom_domain = true }
-]
+[[routes]]
+pattern = "shop.example.com"
+custom_domain = true
+
+[[routes]]
+pattern = "shop-two.example.com"
+custom_domain = true
 ```
 
 </WranglerConfig>
@@ -167,9 +170,9 @@ To migrate the route `example.com/*` in your [Wrangler configuration file](/work
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "example.com", custom_domain = true }
-]
+[[routes]]
+pattern = "example.com"
+custom_domain = true
 ```
 
 </WranglerConfig>

--- a/src/content/docs/workers/configuration/routing/routes.mdx
+++ b/src/content/docs/workers/configuration/routing/routes.mdx
@@ -58,11 +58,15 @@ To configure a route using your [Wrangler configuration file](/workers/wrangler/
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "subdomain.example.com/*", zone_name = "example.com" },
-	# or
-	{ pattern = "subdomain.example.com/*", zone_id = "<YOUR_ZONE_ID>" }
-]
+[[routes]]
+pattern = "subdomain.example.com/*"
+zone_name = "example.com"
+
+# or
+
+[[routes]]
+pattern = "subdomain.example.com/*"
+zone_id = "<YOUR_ZONE_ID>"
 ```
 
 </WranglerConfig>
@@ -76,10 +80,13 @@ To add multiple routes:
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "subdomain.example.com/*", zone_name = "example.com" },
-	{ pattern = "subdomain-two.example.com/example", zone_id = "<YOUR_ZONE_ID>" }
-]
+[[routes]]
+pattern = "subdomain.example.com/*"
+zone_name = "example.com"
+
+[[routes]]
+pattern = "subdomain-two.example.com/example"
+zone_id = "<YOUR_ZONE_ID>"
 ```
 
 </WranglerConfig>

--- a/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
+++ b/src/content/docs/workers/tutorials/deploy-a-realtime-chat-app/index.mdx
@@ -52,9 +52,9 @@ To configure a route in your Wrangler configuration file, add the following to y
 <WranglerConfig>
 
 ```toml
-routes = [
-    { pattern = "example.com/about", zone_id = "<YOUR_ZONE_ID>" }
-]
+[[routes]]
+pattern = "example.com/about"
+zone_id = "<YOUR_ZONE_ID>"
 ```
 
 </WranglerConfig>
@@ -66,9 +66,9 @@ To configure a subdomain in your Wrangler configuration file, add the following 
 <WranglerConfig>
 
 ```toml
-routes = [
-	{ pattern = "subdomain.example.com", custom_domain = true }
-]
+[[routes]]
+pattern = "subdomain.example.com"
+custom_domain = true
 ```
 
 </WranglerConfig>

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -270,9 +270,9 @@ Example:
 <WranglerConfig>
 
 ```toml title="wrangler.toml"
-routes = [
-	{ pattern = "shop.example.com", custom_domain = true }
-]
+[[routes]]
+pattern = "shop.example.com"
+custom_domain = true
 ```
 
 </WranglerConfig>
@@ -296,9 +296,9 @@ Example:
 <WranglerConfig>
 
 ```toml title="wrangler.toml"
-routes = [
-	{ pattern = "subdomain.example.com/*", zone_id = "<YOUR_ZONE_ID>" }
-]
+[[routes]]
+pattern = "subdomain.example.com/*"
+zone_id = "<YOUR_ZONE_ID>"
 ```
 
 </WranglerConfig>
@@ -318,9 +318,9 @@ Example:
 <WranglerConfig>
 
 ```toml title="wrangler.toml"
-routes = [
-	{ pattern = "subdomain.example.com/*", zone_name = "example.com" }
-]
+[[routes]]
+pattern = "subdomain.example.com/*"
+zone_name = "example.com"
 ```
 
 </WranglerConfig>


### PR DESCRIPTION
### Summary

Convert routes config code snippets from inline table toml syntax
```
routes = [
	{ pattern = "shop.example.com", custom_domain = true }
]
```

to table syntax

```
[[routes]]
pattern = "shop.example.com"
custom_domain = true
```

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
