### PR TITLE
PCX-18692: Adding page tags

### DIFF
--- a/src/content/docs/1.1.1.1/infrastructure/ipv6-networks.mdx
+++ b/src/content/docs/1.1.1.1/infrastructure/ipv6-networks.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: reference
 title: Support for IPv6-only networks
+tags:
+  - IPv6
 sidebar:
   order: 3
 slug: 1.1.1.1/infrastructure/ipv6-networks

--- a/src/content/docs/aegis/about/ips-allocation.mdx
+++ b/src/content/docs/aegis/about/ips-allocation.mdx
@@ -1,6 +1,8 @@
 ---
 title: IPs allocation
 pcx_content_type: concept
+tags:
+  - IPv6
 sidebar:
   order: 2
 head:

--- a/src/content/docs/agents/concepts/calling-llms.mdx
+++ b/src/content/docs/agents/concepts/calling-llms.mdx
@@ -1,6 +1,8 @@
 ---
 title: Calling LLMs
 pcx_content_type: concept
+tags:
+  - LLM
 sidebar:
   order: 6
 

--- a/src/content/docs/agents/concepts/what-are-agents.mdx
+++ b/src/content/docs/agents/concepts/what-are-agents.mdx
@@ -1,6 +1,9 @@
 ---
 title: Agents
 pcx_content_type: concept
+tags:
+  - AI
+  - LLM
 sidebar:
   order: 2
 

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Build a Remote MCP server
+tags:
+  - MCP
 sidebar:
   order: 4
 ---

--- a/src/content/docs/agents/guides/test-remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/test-remote-mcp-server.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Test a Remote MCP Server
+tags:
+  - MCP
 sidebar:
   order: 6
 ---

--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -1,5 +1,7 @@
 ---
 title: Authorization
+tags:
+  - MCP
 sidebar:
   order: 2
   group:

--- a/src/content/docs/agents/model-context-protocol/index.mdx
+++ b/src/content/docs/agents/model-context-protocol/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Model Context Protocol (MCP)
 pcx_content_type: navigation
+tags:
+  - MCP
 sidebar:
   order: 4
   group:

--- a/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-agent-api.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: McpAgent — API Reference
+tags:
+  - MCP
 sidebar:
   order: 6
 ---

--- a/src/content/docs/agents/model-context-protocol/mcp-servers-for-cloudflare.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-servers-for-cloudflare.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Cloudflare's own MCP servers
+tags:
+  - MCP
 sidebar:
   order: 100
 

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Transport
+tags:
+  - MCP
 sidebar:
   order: 5
 ---

--- a/src/content/docs/ai-audit/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/connect-to-stripe.mdx
+++ b/src/content/docs/ai-audit/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/connect-to-stripe.mdx
@@ -1,6 +1,8 @@
 ---
 title: Connect Stripe
 pcx_content_type: concept
+tags:
+  - Stripe
 sidebar:
   order: 4
 ---

--- a/src/content/docs/ai-audit/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/connect-to-stripe.mdx
+++ b/src/content/docs/ai-audit/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/connect-to-stripe.mdx
@@ -1,6 +1,8 @@
 ---
 title: Connect Stripe
 pcx_content_type: concept
+tags:
+  - Stripe
 sidebar:
   order: 4
 ---

--- a/src/content/docs/autorag/concepts/what-is-rag.mdx
+++ b/src/content/docs/autorag/concepts/what-is-rag.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: What is RAG
+tags:
+  - LLM
 sidebar:
   order: 1
 ---

--- a/src/content/docs/browser-rendering/how-to/ai.mdx
+++ b/src/content/docs/browser-rendering/how-to/ai.mdx
@@ -2,6 +2,7 @@
 title: Use browser rendering with AI
 tags:
   - AI
+  - LLM
 sidebar:
   order: 2
 ---

--- a/src/content/docs/browser-rendering/platform/playwright-mcp.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright-mcp.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: concept
 title: Playwright MCP
 description: Deploy a Playwright MCP server that uses Browser Rendering to provide browser automation capabilities to your agents.
+tags:
+  - MCP
 sidebar:
   order: 6
   badge: Beta

--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: /json - Capture structured data
+tags:
+  - JSON
 sidebar:
   order: 9
 ---

--- a/src/content/docs/cloudflare-one/applications/configure-apps/mcp-servers/linked-apps.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/mcp-servers/linked-apps.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Authenticate MCP server to self-hosted apps
+tags:
+  - MCP
 sidebar:
   order: 2
   label: Enable MCP OAuth to self-hosted apps

--- a/src/content/docs/cloudflare-one/applications/configure-apps/mcp-servers/saas-mcp.mdx
+++ b/src/content/docs/cloudflare-one/applications/configure-apps/mcp-servers/saas-mcp.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Secure MCP servers with Access for SaaS
+tags:
+  - MCP
 sidebar:
   order: 1
   label: Secure MCP servers with Access for SaaS

--- a/src/content/docs/cloudflare-one/connections/connect-devices/agentless/dns/locations/index.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-devices/agentless/dns/locations/index.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Locations
+tags:
+  - IPv6
 sidebar:
   order: 1
   label: Add locations

--- a/src/content/docs/cloudflare-one/policies/gateway/network-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/network-policies/index.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: configuration
 title: Network policies
+tags:
+  - Geolocation
 sidebar:
   order: 3
 ---

--- a/src/content/docs/d1/sql-api/query-json.mdx
+++ b/src/content/docs/d1/sql-api/query-json.mdx
@@ -1,6 +1,8 @@
 ---
 title: Query JSON
 pcx_content_type: concept
+tags:
+  - JSON
 sidebar:
   order: 5
 

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/api/dns-protection/json-objects.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/api/dns-protection/json-objects.mdx
@@ -1,6 +1,8 @@
 ---
 title: JSON objects
 pcx_content_type: reference
+tags:
+  - JSON
 sidebar:
   order: 3
 head:

--- a/src/content/docs/learning-paths/workers/get-started/first-application.mdx
+++ b/src/content/docs/learning-paths/workers/get-started/first-application.mdx
@@ -1,6 +1,8 @@
 ---
 title: First application
 pcx_content_type: learning-unit
+tags:
+  - Hono
 sidebar:
   order: 3
 

--- a/src/content/docs/magic-transit/how-to/ipv6.mdx
+++ b/src/content/docs/magic-transit/how-to/ipv6.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Configure IPv6 (beta)
+tags:
+  - IPv6
 sidebar:
   order: 4
   badge:

--- a/src/content/docs/network/ip-geolocation.mdx
+++ b/src/content/docs/network/ip-geolocation.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: concept
 source: https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation
 title: IP geolocation
+tags:
+  - Geolocation
 ---
 
 import { FeatureTable, TabItem, Tabs } from "~/components";

--- a/src/content/docs/network/ipv6-compatibility.mdx
+++ b/src/content/docs/network/ipv6-compatibility.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: concept
 source: https://support.cloudflare.com/hc/en-us/articles/229666767-Understanding-and-configuring-Cloudflare-s-IPv6-support
 title: IPv6 compatibility
+tags:
+  - IPv6
 ---
 
 import { FeatureTable, TabItem, Tabs } from "~/components";

--- a/src/content/docs/reference-architecture/design-guides/securing-guest-wireless-networks.mdx
+++ b/src/content/docs/reference-architecture/design-guides/securing-guest-wireless-networks.mdx
@@ -4,6 +4,8 @@ pcx_content_type: design-guide
 products:
   - Gateway
   - Magic WAN
+tags:
+  - IPv6
 sidebar:
   label: Securing guest wireless networks
 updated: 2024-12-17

--- a/src/content/docs/ruleset-engine/rulesets-api/json-object.mdx
+++ b/src/content/docs/ruleset-engine/rulesets-api/json-object.mdx
@@ -1,6 +1,8 @@
 ---
 title: JSON object
 pcx_content_type: reference
+tags:
+  - JSON
 sidebar:
   order: 2
 ---

--- a/src/content/docs/vectorize/reference/what-is-a-vector-database.mdx
+++ b/src/content/docs/vectorize/reference/what-is-a-vector-database.mdx
@@ -1,6 +1,8 @@
 ---
 title: Vector databases
 pcx_content_type: concept
+tags:
+  - LLM
 sidebar:
   order: 2
 ---

--- a/src/content/docs/waf/tools/lists/lists-api/json-object.mdx
+++ b/src/content/docs/waf/tools/lists/lists-api/json-object.mdx
@@ -1,6 +1,8 @@
 ---
 title: JSON object
 pcx_content_type: reference
+tags:
+  - JSON
 sidebar:
   order: 1
 head:

--- a/src/content/docs/waiting-room/how-to/json-response.mdx
+++ b/src/content/docs/waiting-room/how-to/json-response.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Get JSON response for mobile and other non-browser traffic
+tags:
+  - JSON
 sidebar:
   order: 6
 ---

--- a/src/content/docs/workers-ai/features/function-calling/index.mdx
+++ b/src/content/docs/workers-ai/features/function-calling/index.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: navigation
 title: Function calling
+tags:
+  - LLM
 sidebar:
   order: 1
   badge:

--- a/src/content/docs/workers-ai/features/json-mode.mdx
+++ b/src/content/docs/workers-ai/features/json-mode.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: navigation
 title: JSON Mode
+tags:
+  - JSON
 sidebar:
   order: 2
 ---

--- a/src/content/docs/workers-ai/features/prompting.mdx
+++ b/src/content/docs/workers-ai/features/prompting.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Prompting
+tags:
+  - AI
 sidebar:
   order: 4
 ---

--- a/src/content/docs/workers-ai/guides/tutorials/fine-tune-models-with-autotrain.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/fine-tune-models-with-autotrain.mdx
@@ -5,6 +5,7 @@ pcx_content_type: tutorial
 title: Fine Tune Models With AutoTrain from HuggingFace
 tags:
   - AI
+  - LLM
 description: Fine-tuning AI models with LoRA adapters on Workers AI allows adding custom training data, like for LLM finetuning.
 ---
 

--- a/src/content/docs/workers/framework-guides/web-apps/astro.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/astro.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: Astro
 sidebar:
   order: 2
-tags: ["ssg", "full-stack"]
+tags: ["ssg", "full-stack", "Astro"]
 description: Create an Astro application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 

--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/angular.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/angular.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: how-to
 title: Angular
 tags: ["full-stack"]
+tags:
+  - Angular
 description: Create an Angular application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 

--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/angular.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/angular.mdx
@@ -1,9 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Angular
-tags: ["full-stack"]
-tags:
-  - Angular
+tags: ["full-stack", "Angular"]
 description: Create an Angular application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 

--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/hono.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/hono.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: how-to
 title: Hono
 head: []
+tags:
+  - Hono
 description: Create a Hono application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 

--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/nuxt.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/nuxt.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Nuxt
-tags: ["full-stack"]
+tags: ["full-stack", "Nuxt"]
 description: Create a Nuxt application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 

--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -1,6 +1,9 @@
 ---
 title: Prompting
 pcx_content_type: concept
+tags:
+  - AI
+  - LLM
 sidebar:
   order: 3
 ---


### PR DESCRIPTION
### Summary

Adding descriptive tags that display in the right panel of docs pages and in the search results page.
Additions include tags: AI, LLM, MCP, as well as Hono, JSON, and IPv6.