### PR TITLE
[Docs Site] Sidebar tags wrap

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -19,7 +19,7 @@ const showFeedback = Astro.locals.starlightRoute.entry.data.feedback;
 					{tags.map((tag) => (
 						<a
 							href={`/search/?tags=${tag}`}
-							class="rounded-sm border border-(--sl-color-hairline) px-3 text-nowrap text-black"
+							class="overflow-hidden rounded-sm border border-(--sl-color-hairline) px-3 text-ellipsis whitespace-nowrap text-black"
 							data-tag-serp-link={true}
 						>
 							{tag}

--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -15,11 +15,11 @@ const showFeedback = Astro.locals.starlightRoute.entry.data.feedback;
 			<br />
 			<div>
 				<h2>Tags</h2>
-				<div class="flex gap-2">
+				<div class="flex flex-wrap gap-2">
 					{tags.map((tag) => (
 						<a
 							href={`/search/?tags=${tag}`}
-							class="rounded-sm border border-(--sl-color-hairline) px-3 text-black"
+							class="rounded-sm border border-(--sl-color-hairline) px-3 text-nowrap text-black"
 							data-tag-serp-link={true}
 						>
 							{tag}


### PR DESCRIPTION
### Summary

Sidebar tags wrap

### Screenshots (optional)

Before:
<img width="290" height="154" alt="image" src="https://github.com/user-attachments/assets/b6fc0854-fc1d-4755-a68a-47ea2c8de494" />

After:
<img width="291" height="113" alt="image" src="https://github.com/user-attachments/assets/1cf41eae-134a-44ec-893c-7daaa980d719" />
