### PR TITLE
[Docs] Update `cloudflare_ruleset` schema

### DIFF
--- a/src/content/docs/cache/how-to/cache-rules/terraform-example.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/terraform-example.mdx
@@ -56,7 +56,9 @@ resource "cloudflare_ruleset" "cache_rules_example" {
         cache_deception_armor      = true
         custom_key {
           query_string {
-            exclude = ["*"]
+            exclude {
+              all = true
+            }
           }
           header {
             include        = ["habc", "hdef"]


### PR DESCRIPTION
### Summary

The info at https://developers.cloudflare.com/cache/how-to/cache-rules/terraform-example/ is outdated and cause ` Inappropriate value for attribute` when apply.

Current schema at https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset#nested-schema-for-rulesaction_parameterscache_keycustom_keyquery_stringexclude requires query_string to have `all` or `list` as a key.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
