### PR TITLE
Fixes to Python debugging-logs example

### DIFF
--- a/src/content/docs/workers/examples/debugging-logs.mdx
+++ b/src/content/docs/workers/examples/debugging-logs.mdx
@@ -116,19 +116,16 @@ export default {
 
 ```py
 from workers import WorkerEntrypoint
-import json
-import traceback
-from pyodide.ffi import create_once_callable
-from js import Response, fetch, Headers
+from pyodide.ffi import create_proxy
+from js import Response, fetch
+
+async def post_log(data):
+	log_url = "https://log-service.example.com/"
+	await fetch(log_url, method="POST", body=data)
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request, _env, ctx):
         # Service configured to receive logs
-        log_url = "https://log-service.example.com/"
-
-        async def post_log(data):
-            return await fetch(log_url, method="POST", body=data)
-
         response = await fetch(request)
 
         try:
@@ -139,12 +136,10 @@ class Default(WorkerEntrypoint):
         except Exception as e:
             # Without ctx.waitUntil(), your fetch() to Cloudflare's
             # logging service may or may not complete
-            ctx.waitUntil(create_once_callable(post_log(e)))
-            stack = json.dumps(traceback.format_exc()) or e
+            ctx.waitUntil(create_proxy(post_log(str(e))))
             # Copy the response and add to header
             response = Response.new(stack, response)
-            response.headers["X-Debug-stack"] = stack
-            response.headers["X-Debug-err"] = e
+            response.headers["X-Debug-err"] = str(e)
 
         return response
 ```


### PR DESCRIPTION
* `traceback.format_exc()` returns a string so we shouldn't json.dumps() it.
* `traceback.format_exc()` should always return a truthy value so `or e` does nothing.
* The coroutine returned by `post_log()` is not callable so it doens't make sense to call `create_once_callable()` on it. We want `create_proxy()`.
* extract post_log function to top level
* explicitly convert error to string for clarity when assigning to headers
* `str(e)` already includes a traceback so we don't need to include a separate traceback here

cc @dom96 
