### PR TITLE
Improvements to Python rewrite-links example

### DIFF
--- a/src/content/docs/workers/examples/rewrite-links.mdx
+++ b/src/content/docs/workers/examples/rewrite-links.mdx
@@ -111,22 +111,29 @@ from workers import WorkerEntrypoint
 from pyodide.ffi import create_proxy
 from js import HTMLRewriter, fetch
 
+
+class AttributeRewriter:
+    old_url = "developer.mozilla.org"
+    new_url = "mynewdomain.com"
+
+    def __init__(self, attr_name):
+        self.attr_name = attr_name
+
+    def element(self, element):
+        attr = element.getAttribute(self.attr_name)
+        if attr:
+            element.setAttribute(
+                self.attr_name, attr.replace(self.old_url, self.new_url)
+            )
+
+
+href = create_proxy(AttributeRewriter("href"))
+src = create_proxy(AttributeRewriter("src"))
+rewriter = HTMLRewriter.new().on("a", href).on("img", src)
+
+
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
-        old_url = "developer.mozilla.org"
-        new_url = "mynewdomain.com"
-
-        class AttributeRewriter:
-            def __init__(self, attr_name):
-                self.attr_name = attr_name
-            def element(self, element):
-                attr = element.getAttribute(self.attr_name)
-                if attr:
-                    element.setAttribute(self.attr_name, attr.replace(old_url, new_url))
-
-        href = create_proxy(AttributeRewriter("href"))
-        src = create_proxy(AttributeRewriter("src"))
-        rewriter = HTMLRewriter.new().on("a", href).on("img", src)
         res = await fetch(request)
         content_type = res.headers["Content-Type"]
 


### PR DESCRIPTION
Extract the definition of the HtmlRewriter() to top level. This avoids leaking stuff on every request.

cc @dom96 