### PR TITLE
[Workers] Add changelog entry for V8 sandbox

### DIFF
--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -3,6 +3,9 @@ link: "/workers/platform/changelog/"
 productName: Workers
 productLink: "/workers/"
 entries:
+  - publish_date: "2025-08-14"
+    description: |-
+      - Enable V8 Sandbox for improved isolation and security.
   - publish_date: "2025-08-11"
     description: |-
       - The MessageChannel and MessagePort APIs are now available in Workers.


### PR DESCRIPTION
### Summary

The Workers Runtime now uses the V8 sandbox.
CC @ketanhwr

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.