### PR TITLE
add version_metadata as non-inheritable key

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -249,6 +249,10 @@ Non-inheritable keys are configurable at the top-level, but cannot be inherited 
 
   - A list of the Tail Workers your Worker sends data to. Refer to [Tail Workers](/workers/observability/logs/tail-workers/).
 
+- `version_metadata` <Type text="object" /> <MetaInfo text="optional" />
+
+  - Binding for metadata associated with a version from inside the Workers runtime. Refer to [Version metadata](/workers/runtime-apis/bindings/version-metadata/).
+
 ## Types of routes
 
 There are three types of [routes](/workers/configuration/routing/): [Custom Domains](/workers/configuration/routing/custom-domains/), [routes](/workers/configuration/routing/routes/), and [`workers.dev`](/workers/configuration/routing/workers-dev/).


### PR DESCRIPTION
### Summary

`version_metadata` is not an inheritable key (tested locally) - updating docs accordingly

<!-- Add context such as the type of documentation being updated or added -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

