### PR TITLE
[Workers] changelog for wrangler dev multi config cross command support

### DIFF
--- a/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
@@ -9,17 +9,14 @@ date: 2025-08-22
 You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev`:
 
 ```sh
-# Terminal 1 - Main Application
 wrangler dev --config ./app/wrangler.jsonc --config ./api/wrangler.jsonc
 ```
 
 Previously, these Workers could not communicate with Workers running in separate dev commands. Now service bindings and tail consumers work across dev commands:
 
 ```sh
-# Terminal 2 - Other Workers (e.g. auth)
+# Start another Workers (e.g. auth) on a new terminal
 wrangler dev --config ./auth/wrangler.jsonc
 ```
 
-These Workers can now communicate with each other across separate dev commands, regardless of your development setup.
-
-Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.
+These Workers can now communicate with each other across separate dev commands, regardless of your development setup. Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
@@ -6,14 +6,20 @@ products:
 date: 2025-08-22
 ---
 
-You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev` (e.g., `wrangler dev --config api.toml --config frontend.toml`). Previously, these Workers could not communicate with Workers running in separate dev commands. Now service bindings and tail consumers work across dev commands:
+You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev`:
 
 ```sh
 # Terminal 1 - Main Application
-wrangler dev --config ./api/wrangler.jsonc --config ./app/wrangler.jsonc
+wrangler dev --config ./app/wrangler.jsonc --config ./api/wrangler.jsonc
+```
 
-# Terminal 2 - Shared Worker (e.g. auth)
+Previously, these Workers could not communicate with Workers running in separate dev commands. Now service bindings and tail consumers work across dev commands:
+
+```sh
+# Terminal 2 - Other Workers (e.g. auth)
 wrangler dev --config ./auth/wrangler.jsonc
 ```
 
-Workers can now communicate with each other across separate dev commands, regardless of your development setup. Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.
+These Workers can now communicate with each other across separate dev commands, regardless of your development setup.
+
+Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
@@ -1,0 +1,23 @@
+---
+title: Wrangler dev with multiple config files now supports worker bindings across dev commands
+description: Workers running with wrangler dev using multiple config files can now communicate with Workers running in separate dev commands.
+products:
+  - workers
+date: 2025-08-22
+---
+
+Workers using `wrangler dev` with multiple config files can now communicate with Workers running in separate dev commands using service bindings and tail consumers.
+
+Previously, cross-command communication only worked when using a single config file. Now it works with multiple configs:
+
+```sh
+# Terminal 1
+wrangler dev
+
+# Terminal 2
+wrangler dev --config ./api/wrangler.jsonc --config ./app/wrangler.jsonc
+```
+
+This means Workers can now communicate with each other across separate dev commands, regardless of your development setup.
+
+Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
@@ -6,18 +6,14 @@ products:
 date: 2025-08-22
 ---
 
-Workers using `wrangler dev` with multiple config files can now communicate with Workers running in separate dev commands using service bindings and tail consumers.
-
-Previously, cross-command communication only worked when using a single config file. Now it works with multiple configs:
+You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev` (e.g., `wrangler dev --config api.toml --config frontend.toml`). Previously, these Workers could not communicate with Workers running in separate dev commands. Now service bindings and tail consumers work across dev commands:
 
 ```sh
-# Terminal 1
-wrangler dev
-
-# Terminal 2
+# Terminal 1 - Main Application
 wrangler dev --config ./api/wrangler.jsonc --config ./app/wrangler.jsonc
+
+# Terminal 2 - Shared Worker (e.g. auth)
+wrangler dev --config ./auth/wrangler.jsonc
 ```
 
-This means Workers can now communicate with each other across separate dev commands, regardless of your development setup.
-
-Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.
+Workers can now communicate with each other across separate dev commands, regardless of your development setup. Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-08-22-wrangler-dev-multi-config-cross-command-support.mdx
@@ -19,4 +19,6 @@ Previously, these Workers could not communicate with Workers running in separate
 wrangler dev --config ./auth/wrangler.jsonc
 ```
 
-These Workers can now communicate with each other across separate dev commands, regardless of your development setup. Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.
+These Workers can now communicate with each other across separate dev commands, regardless of your development setup.
+
+Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
@@ -1,5 +1,5 @@
 ---
-title: Wrangler dev with multiple config files now supports worker bindings across dev commands
+title: Improved support for running multiple Workers with `wrangler dev`
 description: Workers running with wrangler dev using multiple config files can now communicate with Workers running in separate dev commands.
 products:
   - workers
@@ -9,16 +9,36 @@ date: 2025-09-23
 You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev`:
 
 ```sh
-wrangler dev --config ./app/wrangler.jsonc --config ./api/wrangler.jsonc
+wrangler dev --config ./web/wrangler.jsonc --config ./api/wrangler.jsonc
 ```
 
-Previously, these Workers could not communicate with Workers running in separate dev commands. Now service bindings and tail consumers work across dev commands:
+Previously, if you ran the command above and then also ran wrangler dev for a different Worker, the Workers running in separate wrangler dev sessions could not communicate with each other. This prevented you from being able to use [Service Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) and [Tail Workers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) in local development, when running separate wrangler dev sessions.
+	
+Now, the following works as expected:
 
 ```sh
-# Start another Workers (e.g. auth) on a new terminal
+# Terminal 1: Run your application that includes both Web and API workers
+wrangler dev --config ./web/wrangler.jsonc --config ./api/wrangler.jsonc
+
+# Terminal 2: Run your auth worker separately
 wrangler dev --config ./auth/wrangler.jsonc
 ```
 
 These Workers can now communicate with each other across separate dev commands, regardless of your development setup.
+
+```js title="./api/src/index.ts"
+export default {
+  async fetch(request, env) {
+    // Call the auth worker using a service binding
+    const authorized = await env.AUTH.isAuthorized(request);
+
+    if (!authorized) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    return new Response('Hello from API Worker!', { status: 200 });
+  },
+};
+```
 
 Check out the [Developing with multiple Workers](/workers/development-testing/multi-workers) guide to learn more about the different approaches and when to use each one.

--- a/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
@@ -3,7 +3,7 @@ title: Wrangler dev with multiple config files now supports worker bindings acro
 description: Workers running with wrangler dev using multiple config files can now communicate with Workers running in separate dev commands.
 products:
   - workers
-date: 2025-08-22
+date: 2025-09-23
 ---
 
 You can run multiple Workers in a single dev command by passing multiple config files to `wrangler dev`:

--- a/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
+++ b/src/content/changelog/workers/2025-09-23-wrangler-dev-multi-config-cross-command-support.mdx
@@ -29,7 +29,7 @@ These Workers can now communicate with each other across separate dev commands, 
 ```js title="./api/src/index.ts"
 export default {
   async fetch(request, env) {
-    // Call the auth worker using a service binding
+    // This service binding call now works across dev commands
     const authorized = await env.AUTH.isAuthorized(request);
 
     if (!authorized) {


### PR DESCRIPTION
### Summary

We are about to make Worker bindings on `wrangler dev` with multi config works across commands in https://github.com/cloudflare/workers-sdk/pull/10354.

DEVX-2127

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
