### PR TITLE
[GH] Add GH action to auto clean up codeowners file

### DIFF
--- a/.github/workflows/codeowner-cleanup.yml
+++ b/.github/workflows/codeowner-cleanup.yml
@@ -1,0 +1,22 @@
+---
+name: Weekly codeowners cleanup
+workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  cleanowners:
+    name: cleanowners
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Run cleanowners action
+        uses: github/cleanowners@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: cloudflare


### PR DESCRIPTION
### Summary

Implements https://github.com/marketplace/actions/cleanowners-action to auto-remove folks who aren't part of the CF org.