### PR TITLE
Prisma Postgres PR Suggestion

### DIFF
--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
@@ -31,7 +31,7 @@ You can connect Hyperdrive to any existing Prisma Postgres database by using you
 
 :::note
 
-Use the [`create-db`](https://www.npmjs.com/package/create-db) package to generate a quick temporary connection string.
+An alternative to the Prisma Data Platform is to use the [`create-db`](https://www.npmjs.com/package/create-db) package to generate a quick temporary connection string.
 
 ```bash
 npx create-db@latest

--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
@@ -31,7 +31,7 @@ You can connect Hyperdrive to any existing Prisma Postgres database by using you
 
 :::note
 
-An alternative to the Prisma Data Platform is to use the [`create-db`](https://www.npmjs.com/package/create-db) package. This package will generate a quick temporary database for you to use.
+An alternative to the Prisma Data Platform is to use the [`create-db`](https://www.npmjs.com/package/create-db) package. This package will generate a quick temporary Prisma Postgres database for you to use.
 
 ```bash
 npx create-db@latest

--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
@@ -29,6 +29,16 @@ You can connect Hyperdrive to any existing Prisma Postgres database by using you
    postgres://USERNAME:PASSWORD@HOSTNAME_OR_IP_ADDRESS:PORT/database_name
     ```   
 
+:::note
+
+Use the [`create-db`](https://www.npmjs.com/package/create-db) package to generate a quick temporary connection string.
+
+```bash
+npx create-db@latest
+```
+
+:::
+
 With this connection string, you can now create a Hyperdrive database configuration.
 
 ## 2. Create a database configuration

--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres.mdx
@@ -31,7 +31,7 @@ You can connect Hyperdrive to any existing Prisma Postgres database by using you
 
 :::note
 
-An alternative to the Prisma Data Platform is to use the [`create-db`](https://www.npmjs.com/package/create-db) package to generate a quick temporary connection string.
+An alternative to the Prisma Data Platform is to use the [`create-db`](https://www.npmjs.com/package/create-db) package. This package will generate a quick temporary database for you to use.
 
 ```bash
 npx create-db@latest


### PR DESCRIPTION
Added a helpful callout about using the `create-db` npm package on the `/hyperdrive/examples/connect-to-postgres/postgres-database-providers/prisma-postgres/` page. This package generates a temporary database and returns connection strings for testing Prisma Postgres. This allows users to quickly get up and running.