### PR TITLE
Document prefered method getByName for creating Durable Object stubs

### DIFF
--- a/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
@@ -107,8 +107,7 @@ import puppeteer from "@cloudflare/puppeteer";
 
 export default {
 	async fetch(request, env) {
-		let id = env.BROWSER.idFromName("browser");
-		let obj = env.BROWSER.get(id);
+		let obj = env.BROWSER.getByName("browser");
 
 		// Send a request to the Durable Object, then await its response.
 		let resp = await obj.fetch(request.url);

--- a/src/content/docs/containers/examples/env-vars-and-secrets.mdx
+++ b/src/content/docs/containers/examples/env-vars-and-secrets.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Pass in environment variables and secrets to your container
 pcx_content_type: example
 title: Env Vars and Secrets
@@ -125,11 +124,8 @@ export class MyContainer extends Container {
 export default {
 	async fetch(request, env) {
 		if (new URL(request.url).pathname === "/launch-instances") {
-			let idOne = env.MY_CONTAINER.idFromName("foo");
-			let instanceOne = env.MY_CONTAINER.get(idOne);
-
-			let idTwo = env.MY_CONTAINER.idFromName("foo");
-			let instanceTwo = env.MY_CONTAINER.get(idTwo);
+			let instanceOne = env.MY_CONTAINER.getByName("foo");
+			let instanceTwo = env.MY_CONTAINER.getByName("foo");
 
 			// Each instance gets a different set of environment variables
 

--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -27,8 +27,6 @@ the `docker info` command will hang or return an error including the message "Ca
 
 ## Deploy your first Container
 
-
-
 Run the following command to create and deploy a new Worker with a container, from the starter template:
 
 ```sh
@@ -101,7 +99,6 @@ on container status changes, and more.
 
 See the [documentation for Durable Object container methods](/durable-objects/api/container/) and the
 [`Container` class repository](https://github.com/cloudflare/containers) for more details.
-
 
 ### Configuration
 
@@ -204,9 +201,8 @@ When a request enters Cloudflare, your Worker's [`fetch` handler](/workers/runti
 
   ```js
   if (pathname.startsWith("/container")) {
-  	const id = env.MY_CONTAINER.idFromName(pathname);
-		const container = env.MY_CONTAINER.get(id);
-		return await container.fetch(request);
+  	const container = env.MY_CONTAINER.getByName(pathname);
+  	return await container.fetch(request);
   }
   ```
 

--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -39,7 +39,10 @@ Alarms can be used to build distributed primitives, like queues or batching of w
 
 ### `setAlarm`
 
-- <code>{" "}setAlarm(scheduledTimeMs <Type text="number" />)</code>
+- <code>
+  	{" "}
+  	setAlarm(scheduledTimeMs <Type text="number" />)
+  </code>
   : <Type text="void" />
 
   - Set the time for the alarm to run. Specify the time as the number of milliseconds elapsed since the UNIX epoch.
@@ -63,11 +66,16 @@ This is due to the fact that, if the Durable Object wakes up after being inactiv
 
 ### `alarm`
 
-- <code>alarm(`alarmInfo`<Type text="Object"/>)</code>: <Type text='void' />
+- <code>
+  	alarm(`alarmInfo`
+  	<Type text="Object" />)
+  </code>
+  : <Type text="void" />
 
   - Called by the system when a scheduled alarm time is reached.
 
   - The optional parameter `alarmInfo` object has two properties:
+
     - `retryCount` <Type text="number"/>: The number of times this alarm event has been retried.
     - `isRetry` <Type text="boolean"/>: A boolean value to indicate if the alarm has been retried. This value is `true` if this alarm event is a retry.
 
@@ -89,8 +97,7 @@ import { DurableObject } from "cloudflare:workers";
 
 export default {
 	async fetch(request, env) {
-		let id = env.ALARM_EXAMPLE.idFromName("foo");
-		return await env.ALARM_EXAMPLE.get(id).fetch(request);
+		return await env.ALARM_EXAMPLE.getByName("foo").fetch(request);
 	},
 };
 
@@ -120,11 +127,13 @@ The following example shows how to use the `alarmInfo` property to identify if t
 
 ```js
 class MyDurableObject extends DurableObject {
-  async alarm(alarmInfo) {
-    if (alarmInfo?.retryCount != 0) {
-      console.log("This alarm event has been attempted ${alarmInfo?.retryCount} times before.");
-    }
-  }
+	async alarm(alarmInfo) {
+		if (alarmInfo?.retryCount != 0) {
+			console.log(
+				"This alarm event has been attempted ${alarmInfo?.retryCount} times before.",
+			);
+		}
+	}
 }
 ```
 

--- a/src/content/docs/durable-objects/api/namespace.mdx
+++ b/src/content/docs/durable-objects/api/namespace.mdx
@@ -28,11 +28,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
   async fetch(request, env) {
-    // Every unique ID refers to an individual instance of the Durable Object class
-    const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
     // A stub is a client Object used to invoke methods defined by the Durable Object
-    const stub = env.MY_DURABLE_OBJECT.get(id);
+    const stub = env.MY_DURABLE_OBJECT.getByName("foo);
     ...
   }
 }
@@ -55,11 +52,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
   async fetch(request, env) {
-    // Every unique ID refers to an individual instance of the Durable Object class
-    const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
     // A stub is a client Object used to invoke methods defined by the Durable Object
-    const stub = env.MY_DURABLE_OBJECT.get(id);
+    const stub = env.MY_DURABLE_OBJECT.getByName("foo");
     ...
   }
 } satisfies ExportedHandler<Env>;
@@ -145,13 +139,32 @@ const stub = env.MY_DURABLE_OBJECT.get(id);
 
 - A [`DurableObjectStub`](/durable-objects/api/stub) referring to an instance of a Durable Object class.
 
+### `getByName`
+
+`getByName` obtains a [`DurableObjectStub`](/durable-objects/api/stub) from a provided name which can be used to invoke methods on a Durable Object.
+
+This method returns the <GlossaryTooltip term="stub">stub</GlossaryTooltip> immediately, often before a connection has been established to the Durable Object. This allows requests to be sent to the instance right away, without waiting for a network round trip.
+
+```js
+const fooStub = env.MY_DURABLE_OBJECT.getByName("foo");
+const barStub = env.MY_DURABLE_OBJECT.getByName("bar");
+```
+
+#### Parameters
+
+- A required string to be used to generate a [`DurableObjectStub`](/durable-objects/api/stub) corresponding to an instance of the Durable Object class with the provided name.
+
+#### Return values
+
+- A [`DurableObjectStub`](/durable-objects/api/stub) referring to an instance of a Durable Object class.
+
 ### `jurisdiction`
 
 `jurisdiction` creates a subnamespace from a namespace where all Durable Object IDs and references created from that subnamespace will be restricted to the specified [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction).
 
 ```js
 const subnamespace = env.MY_DURABLE_OBJECT.jurisdiction("eu");
-const euId = subnamespace.idFromName("foo");
+const euStub = subnamespace.getByName("foo");
 ```
 
 #### Parameters

--- a/src/content/docs/durable-objects/api/namespace.mdx
+++ b/src/content/docs/durable-objects/api/namespace.mdx
@@ -29,7 +29,7 @@ export class MyDurableObject extends DurableObject {
 export default {
   async fetch(request, env) {
     // A stub is a client Object used to invoke methods defined by the Durable Object
-    const stub = env.MY_DURABLE_OBJECT.getByName("foo);
+    const stub = env.MY_DURABLE_OBJECT.getByName("foo");
     ...
   }
 }
@@ -141,7 +141,7 @@ const stub = env.MY_DURABLE_OBJECT.get(id);
 
 ### `getByName`
 
-`getByName` obtains a [`DurableObjectStub`](/durable-objects/api/stub) from a provided name which can be used to invoke methods on a Durable Object.
+`getByName` obtains a [`DurableObjectStub`](/durable-objects/api/stub) from a provided name, which can be used to invoke methods on a Durable Object.
 
 This method returns the <GlossaryTooltip term="stub">stub</GlossaryTooltip> immediately, often before a connection has been established to the Durable Object. This allows requests to be sent to the instance right away, without waiting for a network round trip.
 

--- a/src/content/docs/durable-objects/api/stub.mdx
+++ b/src/content/docs/durable-objects/api/stub.mdx
@@ -31,11 +31,10 @@ console.assert(id.equals(stub.id), "This should always be true");
 
 ### `name`
 
-`name` is an optional property of a `DurableObjectStub`, which returns the name that was used to create the [`DurableObjectId`](/durable-objects/api/id) via [`DurableObjectNamespace::idFromName`](/durable-objects/api/namespace/#idfromname) which was then used to create the `DurableObjectStub`. This value is undefined if the [`DurableObjectId`](/durable-objects/api/id) used to create the `DurableObjectStub` was constructed using [`DurableObjectNamespace::newUniqueId`](/durable-objects/api/namespace/#newuniqueid).
+`name` is an optional property of a `DurableObjectStub`, which returns a name if it was provided upon stub creation either directly via [`DurableObjectNamespace::getByName`](/durable-objects/api/namespace/#getbyname) or indirectly via a [`DurableObjectId`](/durable-objects/api/id) created by [`DurableObjectNamespace::idFromName`](/durable-objects/api/namespace/#idfromname). This value is undefined if the [`DurableObjectId`](/durable-objects/api/id) used to create the `DurableObjectStub` was constructed using [`DurableObjectNamespace::newUniqueId`](/durable-objects/api/namespace/#newuniqueid).
 
 ```js
-const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-const stub = env.MY_DURABLE_OBJECT.get(id);
+const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 console.assert(stub.name === "foo", "This should always be true");
 ```
 

--- a/src/content/docs/durable-objects/best-practices/create-durable-object-stubs-and-send-requests.mdx
+++ b/src/content/docs/durable-objects/best-practices/create-durable-object-stubs-and-send-requests.mdx
@@ -50,11 +50,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(request, env) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Methods on the Durable Object are invoked via the stub
 		const response = await stub.fetch(request);
@@ -87,11 +84,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(request, env) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Methods on the Durable Object are invoked via the stub
 		const response = await stub.fetch(request);
@@ -147,11 +141,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(_request, env, _ctx) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Invoke the fetch handler on the Durable Object stub
 		let response = await stub.fetch("http://do/hello?name=World");
@@ -205,11 +196,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(_request, env, _ctx) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Invoke the fetch handler on the Durable Object stub
 		let response = await stub.fetch("http://do/hello?name=World");

--- a/src/content/docs/durable-objects/best-practices/error-handling.mdx
+++ b/src/content/docs/durable-objects/best-practices/error-handling.mdx
@@ -7,7 +7,6 @@ sidebar:
 
 import { GlossaryTooltip } from "~/components";
 
-
 Any uncaught exceptions thrown by a <GlossaryTooltip term="Durable Object">Durable Object</GlossaryTooltip> or thrown by Durable Objects' infrastructure (such as overloads or network errors) will be propagated to the callsite of the client. Catching these exceptions allows you to retry creating the [`DurableObjectStub`](/durable-objects/api/stub) and sending requests.
 
 JavaScript Errors with the property `.retryable` set to True are suggested to be retried if requests to the Durable Object are idempotent, or can be applied multiple times without changing the response. If requests are not idempotent, then you will need to decide what is best for your application.
@@ -39,7 +38,6 @@ export interface Env {
 export default {
 	async fetch(request, env, ctx) {
 		let userId = new URL(request.url).searchParams.get("userId") || "";
-		const id = env.ErrorThrowingObject.idFromName(userId);
 
 		// Retry behavior can be adjusted to fit your application.
 		let maxAttempts = 3;
@@ -52,7 +50,7 @@ export default {
 			try {
 				// Create a Durable Object stub for each attempt, because certain types of
 				// errors will break the Durable Object stub.
-				const doStub = env.ErrorThrowingObject.get(id);
+				const doStub = env.ErrorThrowingObject.getByName(userId);
 				const resp = await doStub.fetch("http://your-do/");
 
 				return Response.json(resp);

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -168,7 +168,11 @@ The following are methods available on the **Native Durable Object WebSocket API
 
 #### `WebSocket.serializeAttachment()`
 
-- <code> serializeAttachment(value <Type text="any" />)</code>: <Type text="void" />
+- <code>
+  	{" "}
+  	serializeAttachment(value <Type text="any" />)
+  </code>
+  : <Type text="void" />
 
   - Keeps a copy of `value` associated with the WebSocket to survive hibernation. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. If the value needs to be durable please use [Durable Object Storage](/durable-objects/api/storage-api/).
 
@@ -179,7 +183,6 @@ The following are methods available on the **Native Durable Object WebSocket API
 - `deserializeAttachment()`: <Type text='any' />
 
   - Retrieves the most recent value passed to `serializeAttachment()`, or `null` if none exists.
-
 
 ## WebSocket Standard API
 
@@ -213,8 +216,7 @@ export default {
 
 			// This example will refer to a single Durable Object instance, since the name "foo" is
 			// hardcoded
-			let id = env.WEBSOCKET_SERVER.idFromName("foo");
-			let stub = env.WEBSOCKET_SERVER.get(id);
+			let stub = env.WEBSOCKET_SERVER.getByName("foo");
 
 			// The Durable Object's fetch handler will accept the server side connection and return
 			// the client
@@ -254,8 +256,7 @@ export default {
 
 			// This example will refer to a single Durable Object instance, since the name "foo" is
 			// hardcoded
-			let id = env.WEBSOCKET_SERVER.idFromName("foo");
-			let stub = env.WEBSOCKET_SERVER.get(id);
+			let stub = env.WEBSOCKET_SERVER.getByName("foo");
 
 			// The Durable Object's fetch handler will accept the server side connection and return
 			// the client

--- a/src/content/docs/durable-objects/concepts/durable-object-lifecycle.mdx
+++ b/src/content/docs/durable-objects/concepts/durable-object-lifecycle.mdx
@@ -14,8 +14,7 @@ Simply creating the Durable Object Stub does not send a request to the Durable O
 A request is sent to the Durable Object and its lifecycle begins only once a method is invoked on the Durable Object Stub.
 
 ```js
-const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-const stub = env.MY_DURABLE_OBJECT.get(id);
+const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 // Now the request is sent to the remote Durable Object.
 const rpcResponse = await stub.sayHello();
 ```

--- a/src/content/docs/durable-objects/examples/alarms-api.mdx
+++ b/src/content/docs/durable-objects/examples/alarms-api.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Use the Durable Objects Alarms API to batch requests to a Durable Object.
 pcx_content_type: example
 title: Use the Alarms API
@@ -22,8 +21,7 @@ import { DurableObject } from "cloudflare:workers";
 // Worker
 export default {
 	async fetch(request, env) {
-		let id = env.BATCHER.idFromName("foo");
-		return await env.BATCHER.get(id).fetch(request);
+		return await env.BATCHER.getByName("foo").fetch(request);
 	},
 };
 

--- a/src/content/docs/durable-objects/examples/build-a-counter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-counter.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Build a counter using Durable Objects and Workers with RPC methods.
 pcx_content_type: example
 title: Build a counter
@@ -29,15 +28,8 @@ export default {
 			);
 		}
 
-		// Every unique ID refers to an individual instance of the Counter class that
-		// has its own state. `idFromName()` always returns the same ID when given the
-		// same string as input (and called on the same class), but never the same
-		// ID for two different strings (or for different classes).
-		let id = env.COUNTERS.idFromName(name);
-
-		// Construct the stub for the Durable Object using the ID.
 		// A stub is a client Object used to send messages to the Durable Object.
-		let stub = env.COUNTERS.get(id);
+		let stub = env.COUNTERS.getByName(name);
 
 		// Send a request to the Durable Object using RPC methods, then await its response.
 		let count = null;
@@ -107,15 +99,8 @@ export default {
 			);
 		}
 
-		// Every unique ID refers to an individual instance of the Counter class that
-		// has its own state. `idFromName()` always returns the same ID when given the
-		// same string as input (and called on the same class), but never the same
-		// ID for two different strings (or for different classes).
-		let id = env.COUNTERS.idFromName(name);
-
-		// Construct the stub for the Durable Object using the ID.
 		// A stub is a client Object used to send messages to the Durable Object.
-		let stub = env.COUNTERS.get(id);
+		let stub = env.COUNTERS.get(name);
 
 		let count = null;
 		switch (url.pathname) {

--- a/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
+++ b/src/content/docs/durable-objects/examples/build-a-rate-limiter.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Build a rate limiter using Durable Objects and Workers.
 pcx_content_type: example
 title: Build a rate limiter
@@ -16,7 +15,7 @@ This example also discusses some decisions that need to be made when designing a
 
 The Worker creates a `RateLimiter` Durable Object on a per IP basis to protect upstream resources. IP based rate limiting can be effective without negatively impacting latency because any given IP will remain within a small geographic area colocated with the `RateLimiter` Durable Object. Furthermore, throughput is also improved because each IP gets its own Durable Object.
 
-It might seem simpler to implement a global rate limiter, `const id = env.RATE_LIMITER.idFromName("global");`, which can provide better guarantees on the request rate to the upstream resource. However:
+It might seem simpler to implement a global rate limiter, `const stub = env.RATE_LIMITER.getByName("global");`, which can provide better guarantees on the request rate to the upstream resource. However:
 
 - This would require all requests globally to make a sub-request to a single Durable Object.
 - Implementing a global rate limiter would add additional latency for requests not colocated with the Durable Object, and global throughput would be capped to the throughput of a single Durable Object.
@@ -52,11 +51,8 @@ export default {
 			return new Response("Could not determine client IP", { status: 400 });
 		}
 
-		// Obtain an identifier for a Durable Object based on the client's IP address
-		const id = env.RATE_LIMITER.idFromName(ip);
-
 		try {
-			const stub = env.RATE_LIMITER.get(id);
+			const stub = env.RATE_LIMITER.getByName(ip);
 			const milliseconds_to_next_request =
 				await stub.getMillisecondsToNextRequest();
 			if (milliseconds_to_next_request > 0) {
@@ -137,11 +133,8 @@ export default {
 			return new Response("Could not determine client IP", { status: 400 });
 		}
 
-		// Obtain an identifier for a Durable Object based on the client's IP address
-		const id = env.RATE_LIMITER.idFromName(ip);
-
 		try {
-			const stub = env.RATE_LIMITER.get(id);
+			const stub = env.RATE_LIMITER.getByName(ip);
 			const milliseconds_to_next_request =
 				await stub.getMillisecondsToNextRequest();
 			if (milliseconds_to_next_request > 0) {

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Create a Durable Object that stores the last location it was accessed
   from in-memory.
 pcx_content_type: example
@@ -25,10 +24,9 @@ export default {
 };
 
 async function handleRequest(request, env) {
-	let id = env.LOCATION.idFromName("A");
-	let obj = env.LOCATION.get(id);
+	let stub = env.LOCATION.getByName("A");
 	// Forward the request to the remote Durable Object.
-	let resp = await obj.fetch(request);
+	let resp = await stub.fetch(request);
 	// Return the response to the client.
 	return new Response(await resp.text());
 }

--- a/src/content/docs/durable-objects/examples/durable-object-ttl.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-ttl.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Implement a Time To Live (TTL) for Durable Object instances.
 pcx_content_type: example
 title: Durable Object Time To Live
@@ -46,8 +45,7 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
   async fetch(request, env) {
-    const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-        const stub = env.MY_DURABLE_OBJECT.get(id)
+    const stub = env.MY_DURABLE_OBJECT.getByName("foo");
     return await stub.fetch(request);
   },
 };
@@ -85,8 +83,7 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
   async fetch(request, env) {
-    const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-        const stub = env.MY_DURABLE_OBJECT.get(id)
+    const stub = env.MY_DURABLE_OBJECT.getByName("foo");
     return await stub.fetch(request);
   },
 } satisfies ExportedHandler<Env>;

--- a/src/content/docs/durable-objects/examples/readable-stream.mdx
+++ b/src/content/docs/durable-objects/examples/readable-stream.mdx
@@ -25,7 +25,7 @@ This example demonstrates:
 import { DurableObject } from 'cloudflare:workers';
 
 // Send incremented counter value every second
-async function\* dataSource(signal: AbortSignal) {
+async function* dataSource(signal: AbortSignal) {
 let counter = 0;
 while (!signal.aborted) {
 yield counter++;
@@ -33,7 +33,6 @@ await new Promise((resolve) => setTimeout(resolve, 1_000));
 }
 
     console.log('Data source cancelled');
-
 }
 
 export class MyDurableObject extends DurableObject<Env> {
@@ -111,4 +110,3 @@ export default {
 In a setup where a Durable Object returns a readable stream to a Worker, if the Worker cancels the Durable Object's readable stream, the cancellation propagates to the Durable Object.
 
 :::
-```

--- a/src/content/docs/durable-objects/examples/readable-stream.mdx
+++ b/src/content/docs/durable-objects/examples/readable-stream.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Stream ReadableStream from Durable Objects.
 pcx_content_type: example
 title: Use ReadableStream with Durable Object and Workers
@@ -8,7 +7,11 @@ sidebar:
 description: Stream ReadableStream from Durable Objects.
 ---
 
-import { GlossaryTooltip, WranglerConfig, TypeScriptExample } from "~/components";
+import {
+	GlossaryTooltip,
+	WranglerConfig,
+	TypeScriptExample,
+} from "~/components";
 
 This example demonstrates:
 
@@ -22,14 +25,15 @@ This example demonstrates:
 import { DurableObject } from 'cloudflare:workers';
 
 // Send incremented counter value every second
-async function* dataSource(signal: AbortSignal) {
-    let counter = 0;
-    while (!signal.aborted) {
-        yield counter++;
-        await new Promise((resolve) => setTimeout(resolve, 1_000));
-    }
+async function\* dataSource(signal: AbortSignal) {
+let counter = 0;
+while (!signal.aborted) {
+yield counter++;
+await new Promise((resolve) => setTimeout(resolve, 1_000));
+}
 
     console.log('Data source cancelled');
+
 }
 
 export class MyDurableObject extends DurableObject<Env> {
@@ -60,12 +64,12 @@ export class MyDurableObject extends DurableObject<Env> {
 
         return new Response(stream, { headers });
     }
+
 }
 
 export default {
     async fetch(request, env, ctx): Promise<Response> {
-        const id: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName('my-id');
-        const stub = env.MY_DURABLE_OBJECT.get(id);
+        const stub = env.MY_DURABLE_OBJECT.getByName("foo");
         const response = await stub.fetch(request, { ...request });
         if (!response.ok || !response.body) {
             return new Response('Invalid response', { status: 500 });
@@ -96,7 +100,9 @@ export default {
 
         return Response.json(data);
     },
+
 } satisfies ExportedHandler<Env>;
+
 ```
 </TypeScriptExample>
 
@@ -105,3 +111,4 @@ export default {
 In a setup where a Durable Object returns a readable stream to a Worker, if the Worker cancels the Durable Object's readable stream, the cancellation propagates to the Durable Object.
 
 :::
+```

--- a/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
+++ b/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
@@ -8,7 +8,6 @@ head:
   - tag: title
     content: Durable Objects - Use KV within Durable Objects
 description: Read and write to/from KV within a Durable Object
-
 ---
 
 import { GlossaryTooltip, WranglerConfig } from "~/components";
@@ -17,9 +16,9 @@ The following Worker script shows you how to configure a <GlossaryTooltip term="
 
 Prerequisites:
 
-* A [KV namespace](/kv/api/) created via the Cloudflare dashboard or the [wrangler CLI](/workers/wrangler/install-and-update/).
-* A [configured binding](/kv/concepts/kv-bindings/) for the `kv_namespace` in the Cloudflare dashboard or Wrangler file.
-* A [Durable Object namespace binding](/workers/wrangler/configuration/#durable-objects).
+- A [KV namespace](/kv/api/) created via the Cloudflare dashboard or the [wrangler CLI](/workers/wrangler/install-and-update/).
+- A [configured binding](/kv/concepts/kv-bindings/) for the `kv_namespace` in the Cloudflare dashboard or Wrangler file.
+- A [Durable Object namespace binding](/workers/wrangler/configuration/#durable-objects).
 
 Configure your Wrangler file as follows:
 
@@ -42,58 +41,59 @@ bindings = [
 </WranglerConfig>
 
 ```ts
-import { DurableObject } from 'cloudflare:workers';
+import { DurableObject } from "cloudflare:workers";
 
 interface Env {
-  YOUR_KV_NAMESPACE: KVNamespace;
-  YOUR_DO_CLASS: DurableObjectNamespace;
+	YOUR_KV_NAMESPACE: KVNamespace;
+	YOUR_DO_CLASS: DurableObjectNamespace;
 }
 
 export default {
-  async fetch(req: Request, env: Env): Promise<Response> {
-    // Assume each Durable Object is mapped to a roomId in a query parameter
-    // In a production application, this will likely be a roomId defined by your application
-    // that you validate (and/or authenticate) first.
-    let url = new URL(req.url);
-    let roomIdParam = url.searchParams.get("roomId");
+	async fetch(req: Request, env: Env): Promise<Response> {
+		// Assume each Durable Object is mapped to a roomId in a query parameter
+		// In a production application, this will likely be a roomId defined by your application
+		// that you validate (and/or authenticate) first.
+		let url = new URL(req.url);
+		let roomIdParam = url.searchParams.get("roomId");
 
-    if (roomIdParam) {
-      // Create (or get) a Durable Object based on that roomId.
-      let durableObjectId = env.YOUR_DO_CLASS.idFromName(roomIdParam);
-      // Get a "stub" that allows you to call that Durable Object
-      let durableObjectStub = env.YOUR_DO_CLASS.get(durableObjectId);
+		if (roomIdParam) {
+			// Get a stub that allows you to call that Durable Object
+			let durableObjectStub = env.YOUR_DO_CLASS.getByName(roomIdParam);
 
-      // Pass the request to that Durable Object and await the response
-      // This invokes the constructor once on your Durable Object class (defined further down)
-      // on the first initialization, and the fetch method on each request.
-      //
-      // You could pass the original Request to the Durable Object's fetch method
-      // or a simpler URL with just the roomId.
-      let response = await durableObjectStub.fetch(`http://do/${roomId}`);
+			// Pass the request to that Durable Object and await the response
+			// This invokes the constructor once on your Durable Object class (defined further down)
+			// on the first initialization, and the fetch method on each request.
+			//
+			// You could pass the original Request to the Durable Object's fetch method
+			// or a simpler URL with just the roomId.
+			let response = await durableObjectStub.fetch(`http://do/${roomId}`);
 
-      // This would return the value you read from KV *within* the Durable Object.
-      return response;
-    }
-  }
-}
+			// This would return the value you read from KV *within* the Durable Object.
+			return response;
+		}
+	},
+};
 
 export class YourDurableObject extends DurableObject {
-  constructor(public state: DurableObjectState, env: Env) {
-    this.state = state;
-    // Ensure you pass your bindings and environmental variables into
-    // each Durable Object when it is initialized
-    this.env = env;
-  }
+	constructor(
+		public state: DurableObjectState,
+		env: Env,
+	) {
+		this.state = state;
+		// Ensure you pass your bindings and environmental variables into
+		// each Durable Object when it is initialized
+		this.env = env;
+	}
 
-  async fetch(request: Request) {
-    // Error handling elided for brevity.
-    // Write to KV
-    await this.env.YOUR_KV_NAMESPACE.put("some-key");
+	async fetch(request: Request) {
+		// Error handling elided for brevity.
+		// Write to KV
+		await this.env.YOUR_KV_NAMESPACE.put("some-key");
 
-    // Fetch from KV
-    let val = await this.env.YOUR_KV_NAMESPACE.get("some-other-key");
+		// Fetch from KV
+		let val = await this.env.YOUR_KV_NAMESPACE.get("some-other-key");
 
-    return Response.json(val);
-  }
+		return Response.json(val);
+	}
 }
 ```

--- a/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
@@ -47,8 +47,7 @@ export default {
 
       // Since we are hard coding the Durable Object ID by providing the constant name 'foo',
       // all requests to this Worker will be sent to the same Durable Object instance.
-      let id = env.WEBSOCKET_HIBERNATION_SERVER.idFromName('foo');
-      let stub = env.WEBSOCKET_HIBERNATION_SERVER.get(id);
+      let stub = env.WEBSOCKET_HIBERNATION_SERVER.getByName("foo");
 
       return stub.fetch(request);
     }

--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -5,7 +5,14 @@ sidebar:
   order: 2
 ---
 
-import { Render, TabItem, Tabs, PackageManagers, WranglerConfig, TypeScriptExample } from "~/components";
+import {
+	Render,
+	TabItem,
+	Tabs,
+	PackageManagers,
+	WranglerConfig,
+	TypeScriptExample,
+} from "~/components";
 
 This guide will instruct you through:
 
@@ -81,9 +88,7 @@ To add a Durable Object to an existing Worker, you need to:
 
   export default {
     async fetch(request, env, ctx): Promise<Response> {
-      const id:DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
-
-      const stub = env.MY_DURABLE_OBJECT.get(id);
+      const stub = env.MY_DURABLE_OBJECT.getByName(new URL(request.url).pathname);
 
       {/* Access your Durable Object methods here */}
 
@@ -146,14 +151,16 @@ export class MyDurableObject extends DurableObject<Env> {
 		super(ctx, env)
 	}
 
-	async sayHello(): Promise<string> {
-		let result = this.ctx.storage.sql
-			.exec("SELECT 'Hello, World!' as greeting")
-			.one();
-		return result.greeting;
-	}
+    async sayHello(): Promise<string> {
+    	let result = this.ctx.storage.sql
+    		.exec("SELECT 'Hello, World!' as greeting")
+    		.one();
+    	return result.greeting;
+    }
+
 }
-```
+
+````
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -171,7 +178,7 @@ class MyDurableObject(DurableObject):
             .one()
 
         return result.greeting
-```
+````
 
 </TabItem>
 
@@ -196,23 +203,22 @@ A Worker is used to [access Durable Objects](/durable-objects/best-practices/cre
 
 To communicate with a Durable Object, the Worker's fetch handler should look like the following:
 
-
 <Tabs syncKey="workersExamples">
 
 <TypeScriptExample omitTabs={true}>
 ```ts
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const id:DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+    	const stub = env.MY_DURABLE_OBJECT.getByName(new URL(request.url).pathname);
 
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+    	const greeting = await stub.sayHello();
 
-		const greeting = await stub.sayHello();
+    	return new Response(greeting);
+    },
 
-		return new Response(greeting);
-	},
 } satisfies ExportedHandler<Env>;
-```
+
+````
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -224,11 +230,10 @@ from urllib.parse import urlparse
 class Default(WorkerEntrypoint):
     async def fetch(request, env, ctx):
         url = urlparse(request.url)
-        id = env.MY_DURABLE_OBJECT.idFromName(url.path)
-        stub = env.MY_DURABLE_OBJECT.get(id)
+        stub = env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
-```
+````
 
 </TabItem>
 
@@ -237,11 +242,10 @@ class Default(WorkerEntrypoint):
 In the code above, you have:
 
 1. Exported your Worker's main event handlers, such as the `fetch()` handler for receiving HTTP requests.
-2. Passed `env` into the `fetch()` handler. Bindings are delivered as a property of the environment object passed as the second parameter when an event handler or class constructor is invoked. By calling the `idFromName()` function on the binding, you use a string-derived object ID. You can also ask the system to [generate random unique IDs](/durable-objects/api/namespace/#newuniqueid). System-generated unique IDs have better performance characteristics, but require you to store the ID somewhere to access the Object again later.
-3. Derived an object ID from the URL path. `MY_DURABLE_OBJECT.idFromName()` always returns the same ID when given the same string as input (and called on the same class), but never the same ID for two different strings (or for different classes). In this case, you are creating a new object for each unique path.
-4. Constructed the stub for the Durable Object using the ID. A stub is a client object used to send messages to the Durable Object.
-5. Called a Durable Object by invoking a RPC method, `sayHello()`, on the Durable Object, which returns a `Hello, World!` string greeting.
-6. Received an HTTP response back to the client by constructing a HTTP Response with `return new Response()`.
+2. Passed `env` into the `fetch()` handler. Bindings are delivered as a property of the environment object passed as the second parameter when an event handler or class constructor is invoked.
+3. Constructed a stub for a Durable Object instance based on the provided name. A stub is a client object used to send messages to the Durable Object.
+4. Called a Durable Object by invoking a RPC method, `sayHello()`, on the Durable Object, which returns a `Hello, World!` string greeting.
+5. Received an HTTP response back to the client by constructing a HTTP Response with `return new Response()`.
 
 Refer to [Access a Durable Object from a Worker](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) to learn more about communicating with a Durable Object.
 
@@ -311,7 +315,6 @@ Preview your Durable Object Worker at `<YOUR_WORKER>.<YOUR_SUBDOMAIN>.workers.de
 
 Your final code should look like this:
 
-
 <Tabs syncKey="workersExamples">
 
 <TypeScriptExample omitTabs={true}>
@@ -323,25 +326,26 @@ export class MyDurableObject extends DurableObject<Env> {
 		super(ctx, env)
 	}
 
-	async sayHello():Promise<string> {
-		let result = this.ctx.storage.sql
-			.exec("SELECT 'Hello, World!' as greeting")
-			.one();
-		return result.greeting;
-	}
+    async sayHello():Promise<string> {
+    	let result = this.ctx.storage.sql
+    		.exec("SELECT 'Hello, World!' as greeting")
+    		.one();
+    	return result.greeting;
+    }
+
 }
 export default {
-	async fetch(request, env, ctx): Promise<Response> {
-		const id:DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+async fetch(request, env, ctx): Promise<Response> {
+const stub = env.MY_DURABLE_OBJECT.getByName(new URL(request.url).pathname);
 
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+    	const greeting = await stub.sayHello();
 
-		const greeting = await stub.sayHello();
+    	return new Response(greeting);
+    },
 
-		return new Response(greeting);
-	},
 } satisfies ExportedHandler<Env>;
-```
+
+````
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -364,11 +368,10 @@ class MyDurableObject(DurableObject):
 class Default(WorkerEntrypoint):
     async def fetch(self, request, env, ctx):
         url = urlparse(request.url)
-        id = env.MY_DURABLE_OBJECT.idFromName(url.path)
-        stub = env.MY_DURABLE_OBJECT.get(id)
+        stub = env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
-```
+````
 
 </TabItem>
 

--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -160,7 +160,7 @@ export class MyDurableObject extends DurableObject<Env> {
 
 }
 
-````
+```
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -178,7 +178,7 @@ class MyDurableObject(DurableObject):
             .one()
 
         return result.greeting
-````
+```
 
 </TabItem>
 
@@ -218,7 +218,7 @@ export default {
 
 } satisfies ExportedHandler<Env>;
 
-````
+```
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -233,7 +233,7 @@ class Default(WorkerEntrypoint):
         stub = env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
-````
+```
 
 </TabItem>
 
@@ -345,7 +345,7 @@ const stub = env.MY_DURABLE_OBJECT.getByName(new URL(request.url).pathname);
 
 } satisfies ExportedHandler<Env>;
 
-````
+```
 </TypeScriptExample>
 
 <TabItem label="Python" icon="seti:python">
@@ -371,7 +371,7 @@ class Default(WorkerEntrypoint):
         stub = env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
-````
+```
 
 </TabItem>
 

--- a/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
+++ b/src/content/docs/durable-objects/tutorials/build-a-seat-booking-app/index.mdx
@@ -374,8 +374,7 @@ export default {
 			);
 		}
 
-		const id = env.FLIGHT.idFromName(flightId);
-		const stub = env.FLIGHT.get(id);
+		const stub = env.FLIGHT.getByName(flightId);
 		return stub.fetch(request);
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/content/docs/queues/examples/use-queues-with-durable-objects.mdx
+++ b/src/content/docs/queues/examples/use-queues-with-durable-objects.mdx
@@ -66,10 +66,8 @@ export default {
     let userIdParam = url.searchParams.get("userId")
 
     if (userIdParam) {
-      // Create (or get) a Durable Object based on that userId.
-      let durableObjectId = env.YOUR_DO_CLASS.idFromName(userIdParam);
-      // Get a "stub" that allows you to call that Durable Object
-      let durableObjectStub = env.YOUR_DO_CLASS.get(durableObjectId);
+      // Get a stub that allows you to call that Durable Object
+      let durableObjectStub = env.YOUR_DO_CLASS.getByName(userIdParam);
 
       // Pass the request to that Durable Object and await the response
       // This invokes the constructor once on your Durable Object class (defined further down)

--- a/src/content/docs/workers-ai/guides/tutorials/build-ai-interview-practice-tool.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-ai-interview-practice-tool.mdx
@@ -860,8 +860,7 @@ import { requireAuth } from "../middleware/auth";
  */
 const getInterviewDO = (ctx: HonoCtx) => {
 	const username = ctx.get("username");
-	const id = ctx.env.INTERVIEW.idFromName(username);
-	return ctx.env.INTERVIEW.get(id);
+	return ctx.env.INTERVIEW.getByName(username);
 };
 
 /**

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -205,7 +205,7 @@ When you create a new gradual deployment for a Worker with Durable Objects, each
 
 ### Example
 
-This example assumes that you have previously created 3 Durable Objects and [derived their IDs from the names](/durable-objects/api/namespace/#idfromname) "foo", "bar" and "baz".
+This example assumes that you have previously created 3 Durable Object instances with names "foo", "bar" and "baz".
 
 Your Worker is currently on a version that we will call version "A" and you want to gradually deploy a new version "B" of your Worker.
 

--- a/src/content/docs/workers/testing/miniflare/storage/durable-objects.md
+++ b/src/content/docs/workers/testing/miniflare/storage/durable-objects.md
@@ -71,7 +71,7 @@ const mf = new Miniflare({
 
   export default {
     async fetch(request, env) {
-      const stub = env.TEST_OBJECT.get(env.TEST_OBJECT.idFromName("test"));
+      const stub = env.TEST_OBJECT.getByName("test");
       return stub.fetch(request);
     }
   }
@@ -79,8 +79,7 @@ const mf = new Miniflare({
 });
 
 const ns = await mf.getDurableObjectNamespace("TEST_OBJECT");
-const id = ns.idFromName("test");
-const stub = ns.get(id);
+const stub = ns.getByName("test");
 const doRes = await stub.fetch("http://localhost:8787/put");
 console.log(await doRes.text()); // "1"
 

--- a/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
+++ b/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
@@ -832,8 +832,6 @@ that will be made available to the Next.js Worker using a [`WorkerEntrypoint`](/
 	```
 	:::
 
-	{" "}
-
 	<PackageManagers type="run" pkg="deploy" frame="none" />
 
 </Steps>

--- a/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
+++ b/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
@@ -17,11 +17,20 @@ tags:
   - RPC
   - TypeScript
 ---
-import { Render, PackageManagers, Steps, TabItem, Tabs, Details } from "~/components";
+
+import {
+	Render,
+	PackageManagers,
+	Steps,
+	TabItem,
+	Tabs,
+	Details,
+} from "~/components";
 
 In this tutorial, you will learn how to build a real-time [Next.js](https://nextjs.org/) app that displays the live cursor location of each connected user using [Durable Objects](/durable-objects/), the Workers' built-in [RPC (Remote Procedure Call)](/workers/runtime-apis/rpc/) system, and the [OpenNext](https://opennext.js.org/cloudflare) Cloudflare adapter.
 
 The application works like this:
+
 - An ID is generated for each user that navigates to the application, which is used for identifying the WebSocket connection in the Durable Object.
 - Once the WebSocket connection is established, the application sends a message to the WebSocket Durable Object to determine the current number of connected users.
 - A user can close all active WebSocket connections via a Next.js server action that uses an RPC method.
@@ -37,72 +46,71 @@ The application works like this:
 
 1. Run the following command to create your Next.js Worker named `next-rpc`:
 
-	<PackageManagers
-		type="create"
-		pkg="cloudflare@latest"
-		args="next-rpc --framework=next"
-	/>
+   <PackageManagers
+   	type="create"
+   	pkg="cloudflare@latest"
+   	args="next-rpc --framework=next"
+   />
 
-	<Render
-		file="c3-post-run-steps"
-		product="workers"
-		params={{
-			category: "web-framework",
-			framework: "Next.js",
-		}}
-	/>
+   <Render
+   	file="c3-post-run-steps"
+   	product="workers"
+   	params={{
+   		category: "web-framework",
+   		framework: "Next.js",
+   	}}
+   />
 
 2. Change into your new directory:
 
-	```sh
-	cd next-rpc
-	```
+   ```sh
+   cd next-rpc
+   ```
 
 3. Install [nanoid](https://www.npmjs.com/package/nanoid) so that string IDs can be generated for clients:
-	<PackageManagers type="add" pkg="nanoid" frame="none" />
+
+   <PackageManagers type="add" pkg="nanoid" frame="none" />
 
 4. Install [perfect-cursors](https://www.npmjs.com/package/perfect-cursors) to interpolate cursor positions:
-	<PackageManagers type="add" pkg="perfect-cursors" frame="none" />
+
+   <PackageManagers type="add" pkg="perfect-cursors" frame="none" />
 
 5. Define workspaces for each Worker:
 
-	<Tabs> <TabItem label="npm">
+   <Tabs> <TabItem label="npm">
 
-	Update your `package.json` file.
+   Update your `package.json` file.
 
+   ```json title="package.json" ins={14-17}
+   {
+   	"name": "next-rpc",
+   	"version": "0.1.0",
+   	"private": true,
+   	"scripts": {
+   		"dev": "next dev",
+   		"build": "next build",
+   		"start": "next start",
+   		"lint": "next lint",
+   		"deploy": "cloudflare && wrangler deploy",
+   		"preview": "cloudflare && wrangler dev",
+   		"cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts"
+   	},
+   	"workspaces": [".", "worker"]
+   	// ...
+   }
+   ```
 
-	```json title="package.json" ins={14-17}
-	{
-		"name": "next-rpc",
-		"version": "0.1.0",
-		"private": true,
-		"scripts": {
-			"dev": "next dev",
-			"build": "next build",
-			"start": "next start",
-			"lint": "next lint",
-			"deploy": "cloudflare && wrangler deploy",
-			"preview": "cloudflare && wrangler dev",
-			"cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts"
-		},
-		"workspaces": [
-			".",
-			"worker"
-		],
-		// ...
-	}
-	```
+   </TabItem> <TabItem label="pnpm">
 
-	</TabItem> <TabItem label="pnpm">
+   Create a new file `pnpm-workspace.yaml`.
 
-	Create a new file `pnpm-workspace.yaml`.
+   ```yaml title="pnpm-workspace.yaml"
+   packages:
+   	- "worker"
+   	- "."
+   ```
 
-	```yaml title="pnpm-workspace.yaml"
-	packages:
-		- "worker"
-		- "."
-	```
-	</TabItem> </Tabs>
+   </TabItem> </Tabs>
 
 </Steps>
 
@@ -114,678 +122,679 @@ that will be made available to the Next.js Worker using a [`WorkerEntrypoint`](/
 <Steps>
 1. Create another Worker named `worker` inside the Next.js directory:
 
-	<PackageManagers
-		type="create"
-		pkg="cloudflare@latest"
-		args={"worker"}
-	/>
+    <PackageManagers
+    	type="create"
+    	pkg="cloudflare@latest"
+    	args={"worker"}
+    />
 
-	<Render
-		file="c3-post-run-steps"
-		product="workers"
-		params={{
-			category: "hello-world",
-			type: "Worker + Durable Objects",
-			lang: "TypeScript",
-		}}
-	/>
+    <Render
+    	file="c3-post-run-steps"
+    	product="workers"
+    	params={{
+    		category: "hello-world",
+    		type: "Worker + Durable Objects",
+    		lang: "TypeScript",
+    	}}
+    />
+
 </Steps>
 
 ## 3. Build Durable Object Worker functionality
+
 <Steps>
 1. In your `worker/wrangler.toml` file, update the Durable Object binding:
 	```toml {4,5,9} title="worker/wrangler.toml"
 	# ... Other wrangler configuration settings
 
-	[[durable_objects.bindings]]
-	name = "CURSOR_SESSIONS"
-	class_name = "CursorSessions"
+    [[durable_objects.bindings]]
+    name = "CURSOR_SESSIONS"
+    class_name = "CursorSessions"
 
-	[[migrations]]
-	tag = "v1"
-	new_sqlite_classes = ["CursorSessions"]
-	```
+    [[migrations]]
+    tag = "v1"
+    new_sqlite_classes = ["CursorSessions"]
+    ```
+
 2. Initialize the main methods for the Durable Object and define types for WebSocket messages and cursor sessions in your `worker/src/index.ts`
-	to support type-safe interaction:
-	- `WsMessage`. Specifies the structure of WebSocket messages handled by the Durable Object.
-	- `Session`. Represents the connected user's ID and current cursor coordinates.
+   to support type-safe interaction:
 
-	```ts title="worker/src/index.ts"
-	import { DurableObject } from 'cloudflare:workers';
+   - `WsMessage`. Specifies the structure of WebSocket messages handled by the Durable Object.
+   - `Session`. Represents the connected user's ID and current cursor coordinates.
 
-	export type WsMessage =
-		| { type: "message"; data: string }
-		| { type: "quit"; id: string }
-		| { type: "join"; id: string }
-		| { type: "move"; id: string; x: number; y: number }
-		| { type: "get-cursors" }
-		| { type: "get-cursors-response"; sessions: Session[] };
+   ```ts title="worker/src/index.ts"
+   import { DurableObject } from "cloudflare:workers";
 
-	export type Session = { id: string; x: number; y: number };
+   export type WsMessage =
+   	| { type: "message"; data: string }
+   	| { type: "quit"; id: string }
+   	| { type: "join"; id: string }
+   	| { type: "move"; id: string; x: number; y: number }
+   	| { type: "get-cursors" }
+   	| { type: "get-cursors-response"; sessions: Session[] };
 
-	export class CursorSessions extends DurableObject<Env> {
-		constructor(ctx: DurableObjectState, env: Env) {}
-		broadcast(message: WsMessage, self?: string) {}
-		async webSocketMessage(ws: WebSocket, message: string) {}
-		async webSocketClose(ws: WebSocket, code: number) {}
-		closeSessions() {}
-		async fetch(request: Request) {
-			return new Response("Hello");
-		}
-	}
+   export type Session = { id: string; x: number; y: number };
 
-	export default {
-		async fetch(request, env, ctx) {
-			return new Response("Ok");
-		},
-	} satisfies ExportedHandler<Env>;
-	```
+   export class CursorSessions extends DurableObject<Env> {
+   	constructor(ctx: DurableObjectState, env: Env) {}
+   	broadcast(message: WsMessage, self?: string) {}
+   	async webSocketMessage(ws: WebSocket, message: string) {}
+   	async webSocketClose(ws: WebSocket, code: number) {}
+   	closeSessions() {}
+   	async fetch(request: Request) {
+   		return new Response("Hello");
+   	}
+   }
 
-	Now update `worker-configuration.d.ts` by running:
+   export default {
+   	async fetch(request, env, ctx) {
+   		return new Response("Ok");
+   	},
+   } satisfies ExportedHandler<Env>;
+   ```
 
-	```sh
-	cd worker && npm run cf-typegen
-	```
+   Now update `worker-configuration.d.ts` by running:
 
+   ```sh
+   cd worker && npm run cf-typegen
+   ```
 
 3. Update the Durable Object to manage WebSockets:
-	```ts title="worker/src/index.ts" {29-34,36-43,56,79,89-100}
-	// Rest of the code
 
-	export class CursorSessions extends DurableObject<Env> {
-		sessions: Map<WebSocket, Session>;
+   ```ts title="worker/src/index.ts" {29-34,36-43,56,79,89-100}
+   // Rest of the code
 
-		constructor(ctx: DurableObjectState, env: Env) {
-			super(ctx, env);
-			this.sessions = new Map();
-			this.ctx.getWebSockets().forEach((ws) => {
-				const meta = ws.deserializeAttachment();
-				this.sessions.set(ws, { ...meta });
-			});
-		}
+   export class CursorSessions extends DurableObject<Env> {
+   	sessions: Map<WebSocket, Session>;
 
-		broadcast(message: WsMessage, self?: string) {
-			this.ctx.getWebSockets().forEach((ws) => {
-				const { id } = ws.deserializeAttachment();
-				if (id !== self) ws.send(JSON.stringify(message));
-			});
-		}
+   	constructor(ctx: DurableObjectState, env: Env) {
+   		super(ctx, env);
+   		this.sessions = new Map();
+   		this.ctx.getWebSockets().forEach((ws) => {
+   			const meta = ws.deserializeAttachment();
+   			this.sessions.set(ws, { ...meta });
+   		});
+   	}
 
-		async webSocketMessage(ws: WebSocket, message: string) {
-			if (typeof message !== "string") return;
-			const parsedMsg: WsMessage = JSON.parse(message);
-			const session = this.sessions.get(ws);
-			if (!session) return;
+   	broadcast(message: WsMessage, self?: string) {
+   		this.ctx.getWebSockets().forEach((ws) => {
+   			const { id } = ws.deserializeAttachment();
+   			if (id !== self) ws.send(JSON.stringify(message));
+   		});
+   	}
 
-			switch (parsedMsg.type) {
-				case "move":
-					session.x = parsedMsg.x;
-					session.y = parsedMsg.y;
-					ws.serializeAttachment(session);
-					this.broadcast(parsedMsg, session.id);
-					break;
+   	async webSocketMessage(ws: WebSocket, message: string) {
+   		if (typeof message !== "string") return;
+   		const parsedMsg: WsMessage = JSON.parse(message);
+   		const session = this.sessions.get(ws);
+   		if (!session) return;
 
-				case "get-cursors":
-					const sessions: Session[] = [];
-					this.sessions.forEach((session) => {
-						sessions.push(session);
-					});
-					const wsMessage: WsMessage = { type: "get-cursors-response", sessions };
-					ws.send(JSON.stringify(wsMessage));
-					break;
+   		switch (parsedMsg.type) {
+   			case "move":
+   				session.x = parsedMsg.x;
+   				session.y = parsedMsg.y;
+   				ws.serializeAttachment(session);
+   				this.broadcast(parsedMsg, session.id);
+   				break;
 
-				case "message":
-					this.broadcast(parsedMsg);
-					break;
+   			case "get-cursors":
+   				const sessions: Session[] = [];
+   				this.sessions.forEach((session) => {
+   					sessions.push(session);
+   				});
+   				const wsMessage: WsMessage = {
+   					type: "get-cursors-response",
+   					sessions,
+   				};
+   				ws.send(JSON.stringify(wsMessage));
+   				break;
 
-				default:
-					break;
-			}
-		}
+   			case "message":
+   				this.broadcast(parsedMsg);
+   				break;
 
-		async webSocketClose(ws: WebSocket, code: number) {
-			const id = this.sessions.get(ws)?.id;
-			id && this.broadcast({ type: 'quit', id });
-			this.sessions.delete(ws);
-			ws.close();
-		}
+   			default:
+   				break;
+   		}
+   	}
 
-		closeSessions() {
-			this.ctx.getWebSockets().forEach((ws) => ws.close());
-		}
+   	async webSocketClose(ws: WebSocket, code: number) {
+   		const id = this.sessions.get(ws)?.id;
+   		id && this.broadcast({ type: "quit", id });
+   		this.sessions.delete(ws);
+   		ws.close();
+   	}
 
-		async fetch(request: Request) {
-			const url = new URL(request.url);
-			const webSocketPair = new WebSocketPair();
-			const [client, server] = Object.values(webSocketPair);
-			this.ctx.acceptWebSocket(server);
-			const id = url.searchParams.get("id");
-			if (!id) {
-				return new Response("Missing id", { status: 400 });
-			}
+   	closeSessions() {
+   		this.ctx.getWebSockets().forEach((ws) => ws.close());
+   	}
 
-			// Set Id and Default Position
-			const sessionInitialData: Session = { id, x: -1, y: -1 };
-			server.serializeAttachment(sessionInitialData);
-			this.sessions.set(server, sessionInitialData);
-			this.broadcast({ type: "join", id }, id);
+   	async fetch(request: Request) {
+   		const url = new URL(request.url);
+   		const webSocketPair = new WebSocketPair();
+   		const [client, server] = Object.values(webSocketPair);
+   		this.ctx.acceptWebSocket(server);
+   		const id = url.searchParams.get("id");
+   		if (!id) {
+   			return new Response("Missing id", { status: 400 });
+   		}
 
-			return new Response(null, {
-				status: 101,
-				webSocket: client,
-			});
-		}
-	}
+   		// Set Id and Default Position
+   		const sessionInitialData: Session = { id, x: -1, y: -1 };
+   		server.serializeAttachment(sessionInitialData);
+   		this.sessions.set(server, sessionInitialData);
+   		this.broadcast({ type: "join", id }, id);
 
-	export default {
-		async fetch(request, env, ctx) {
-			if (request.url.match("/ws")) {
-				const upgradeHeader = request.headers.get("Upgrade");
-				if (!upgradeHeader || upgradeHeader !== "websocket") {
-					return new Response("Durable Object expected Upgrade: websocket", {
-						status: 426,
-					});
-				}
-				const id = env.CURSOR_SESSIONS.idFromName("globalRoom");
-				const stub = env.CURSOR_SESSIONS.get(id);
-				return stub.fetch(request);
-			}
-			return new Response(null, {
-				status: 400,
-				statusText: "Bad Request",
-				headers: {
-					"Content-Type": "text/plain",
-				},
-			});
-		},
-	} satisfies ExportedHandler<Env>;
+   		return new Response(null, {
+   			status: 101,
+   			webSocket: client,
+   		});
+   	}
+   }
 
-	```
-	- The main `fetch` handler routes requests with a `/ws` URL to the `CursorSessions` Durable Object where a WebSocket connection is established.
-	- The `CursorSessions` class manages WebSocket connections, session states, and broadcasts messages to other connected clients.
-		- When a new WebSocket connection is established, the Durable Object broadcasts a `join` message to all connected clients; similarly, a `quit` message is broadcast when a client disconnects.
-		- It tracks each WebSocket client's last cursor position under the `move` message, which is broadcasted to all active clients.
-		- When a `get-cursors` message is received, it sends the number of currently active clients to the specific client that requested it.
+   export default {
+   	async fetch(request, env, ctx) {
+   		if (request.url.match("/ws")) {
+   			const upgradeHeader = request.headers.get("Upgrade");
+   			if (!upgradeHeader || upgradeHeader !== "websocket") {
+   				return new Response("Durable Object expected Upgrade: websocket", {
+   					status: 426,
+   				});
+   			}
+   			const stub = env.CURSOR_SESSIONS.getByName("globalRoom");
+   			return stub.fetch(request);
+   		}
+   		return new Response(null, {
+   			status: 400,
+   			statusText: "Bad Request",
+   			headers: {
+   				"Content-Type": "text/plain",
+   			},
+   		});
+   	},
+   } satisfies ExportedHandler<Env>;
+   ```
 
+   - The main `fetch` handler routes requests with a `/ws` URL to the `CursorSessions` Durable Object where a WebSocket connection is established.
+   - The `CursorSessions` class manages WebSocket connections, session states, and broadcasts messages to other connected clients.
+     - When a new WebSocket connection is established, the Durable Object broadcasts a `join` message to all connected clients; similarly, a `quit` message is broadcast when a client disconnects.
+     - It tracks each WebSocket client's last cursor position under the `move` message, which is broadcasted to all active clients.
+     - When a `get-cursors` message is received, it sends the number of currently active clients to the specific client that requested it.
 
 4. Extend the `WorkerEntrypoint` class for RPC:
-	:::note[Note]
-	A service binding to `SessionsRPC` is used here because Durable Object RPC is not yet supported in multiple `wrangler dev` sessions. In this case, two `wrangler dev` sessions are used: one for the Next.js Worker and one for the Durable Object Worker. In production, however, Durable Object RPC is not an issue. For convenience in local development, a service binding is used instead of directly invoking the Durable Object RPC method.
-	:::
+   :::note[Note]
+   A service binding to `SessionsRPC` is used here because Durable Object RPC is not yet supported in multiple `wrangler dev` sessions. In this case, two `wrangler dev` sessions are used: one for the Next.js Worker and one for the Durable Object Worker. In production, however, Durable Object RPC is not an issue. For convenience in local development, a service binding is used instead of directly invoking the Durable Object RPC method.
+   :::
 
+   ```ts title="worker/src/index.ts" ins={2,5-12} del={1}
+   import { DurableObject } from 'cloudflare:workers';
+   import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
+   // ... rest of the code
 
-	```ts title="worker/src/index.ts" ins={2,5-12} del={1}
-	import { DurableObject } from 'cloudflare:workers';
-	import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
-	// ... rest of the code
+   export class SessionsRPC extends WorkerEntrypoint<Env> {
+   	async closeSessions() {
+   		const stub = this.env.CURSOR_SESSIONS.getByName("globalRoom");
+   		// Invoking Durable Object RPC method. Same `wrangler dev` session.
+   		await stub.closeSessions();
+   	}
+   }
 
-	export class SessionsRPC extends WorkerEntrypoint<Env> {
-		async closeSessions() {
-			const id = this.env.CURSOR_SESSIONS.idFromName("globalRoom");
-			const stub = this.env.CURSOR_SESSIONS.get(id);
-			// Invoking Durable Object RPC method. Same `wrangler dev` session.
-			await stub.closeSessions();
-		}
-	}
-
-	export default {
-		async fetch(request, env, ctx) {
-			if (request.url.match("/ws")) {
-	// ...
-	```
+   export default {
+   	async fetch(request, env, ctx) {
+   		if (request.url.match("/ws")) {
+   // ...
+   ```
 
 5. Leave the Durable Object Worker running. It's used for RPC and serves as a local WebSocket server:
-	<PackageManagers type="run" pkg="dev" frame="none" />
+
+   <PackageManagers type="run" pkg="dev" frame="none" />
 
 6. Use the resulting address from the previous step to set the Worker host as a public environment variable in your Next.js project:
-	```text title="next-rpc/.env.local" ins={1}
-	NEXT_PUBLIC_WS_HOST=localhost:8787
-	```
+   ```text title="next-rpc/.env.local" ins={1}
+   NEXT_PUBLIC_WS_HOST=localhost:8787
+   ```
 
 </Steps>
 
 ## 4. Build Next.js Worker functionality
+
 <Steps>
 1. In your Next.js Wrangler file, declare the external Durable Object binding and the Service binding to `SessionsRPC`:
 
-	```toml title="next-rpc/wrangler.toml" ins={10-18}
-	# ... rest of the configuration
-	compatibility_flags = ["nodejs_compat"]
+    ```toml title="next-rpc/wrangler.toml" ins={10-18}
+    # ... rest of the configuration
+    compatibility_flags = ["nodejs_compat"]
 
-	# Minification helps to keep the Worker bundle size down and improve start up time.
-	minify = true
+    # Minification helps to keep the Worker bundle size down and improve start up time.
+    minify = true
 
-	# Use the new Workers + Assets to host the static frontend files
-	assets = { directory = ".worker-next/assets", binding = "ASSETS" }
+    # Use the new Workers + Assets to host the static frontend files
+    assets = { directory = ".worker-next/assets", binding = "ASSETS" }
 
-	[[durable_objects.bindings]]
-	name = "CURSOR_SESSIONS"
-	class_name = "CursorSessions"
-	script_name = "worker"
+    [[durable_objects.bindings]]
+    name = "CURSOR_SESSIONS"
+    class_name = "CursorSessions"
+    script_name = "worker"
 
-	[[services]]
-	binding = "RPC_SERVICE"
-	service = "worker"
-	entrypoint = "SessionsRPC"
-	```
+    [[services]]
+    binding = "RPC_SERVICE"
+    service = "worker"
+    entrypoint = "SessionsRPC"
+    ```
 
-2. Update your `env.d.ts` file for type-safety:
-	```ts title="next-rpc/env.d.ts" {2-5}
-	interface CloudflareEnv {
-		CURSOR_SESSIONS: DurableObjectNamespace<
-			import("./worker/src/index").CursorSessions
-		>;
-		RPC_SERVICE: Service<import("./worker/src/index").SessionsRPC>;
-		ASSETS: Fetcher;
-	}
-	```
-3. Include Next.js server side logic:
-	- Add a server action to close all active WebSocket connections.
-	- Use the RPC method `closeSessions` from the `RPC_SERVICE` Service binding instead of invoking the Durable Object RPC method because of the limitation mentioned in the note above.
-	- The server component generates unique IDs using `nanoid` to identify the WebSocket connection within the Durable Object.
-	- Set the [`dynamic`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config) value to `force-dynamic` to ensure unique ID generation and avoid static rendering
+2.  Update your `env.d.ts` file for type-safety:
+    ```ts title="next-rpc/env.d.ts" {2-5}
+    interface CloudflareEnv {
+    	CURSOR_SESSIONS: DurableObjectNamespace<
+    		import("./worker/src/index").CursorSessions
+    	>;
+    	RPC_SERVICE: Service<import("./worker/src/index").SessionsRPC>;
+    	ASSETS: Fetcher;
+    }
+    ```
+3.  Include Next.js server side logic:
 
-	```tsx title="src/app/page.tsx" {5,9-10,19,25-27,33}
-	import { getCloudflareContext } from "@opennextjs/cloudflare";
-	import { Cursors } from "./cursor";
-	import { nanoid } from "nanoid";
+    - Add a server action to close all active WebSocket connections.
+    - Use the RPC method `closeSessions` from the `RPC_SERVICE` Service binding instead of invoking the Durable Object RPC method because of the limitation mentioned in the note above.
+    - The server component generates unique IDs using `nanoid` to identify the WebSocket connection within the Durable Object.
+    - Set the [`dynamic`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config) value to `force-dynamic` to ensure unique ID generation and avoid static rendering
 
-	export const dynamic = "force-dynamic";
+    ```tsx title="src/app/page.tsx" {5,9-10,19,25-27,33}
+    import { getCloudflareContext } from "@opennextjs/cloudflare";
+    import { Cursors } from "./cursor";
+    import { nanoid } from "nanoid";
 
-	async function closeSessions() {
-		"use server";
-		const cf = await getCloudflareContext();
-		await cf.env.RPC_SERVICE.closeSessions();
+    export const dynamic = "force-dynamic";
 
-		// Note: Not supported in `wrangler dev`
-		// const id = cf.env.CURSOR_SESSIONS.idFromName("globalRoom");
-		// const stub = cf.env.CURSOR_SESSIONS.get(id);
-		// await stub.closeSessions();
-	}
+    async function closeSessions() {
+    	"use server";
+    	const cf = await getCloudflareContext();
+    	await cf.env.RPC_SERVICE.closeSessions();
 
-	export default function Home() {
-		const id = `ws_${nanoid(50)}`;
-		return (
-			<main className="flex min-h-screen flex-col items-center p-24 justify-center">
-				<div className="border border-dashed w-full">
-					<p className="pt-2 px-2">Server Actions</p>
-					<div className="p-2">
-						<form action={closeSessions}>
-							<button className="border px-2 py-1">Close WebSockets</button>
-						</form>
-					</div>
-				</div>
-				<div className="border border-dashed w-full mt-2.5">
-					<p className="py-2 px-2">Live Cursors</p>
-					<div className="px-2 space-y-2">
-						<Cursors id={id}></Cursors>
-					</div>
-				</div>
-			</main>
-		);
-	}
-	```
+    	// Note: Not supported in `wrangler dev`
+    	// const stub = cf.env.CURSOR_SESSIONS.getByName("globalRoom");
+    	// await stub.closeSessions();
+    }
 
-4. Create a client component to manage WebSocket and mouse movement events:
+    export default function Home() {
+    	const id = `ws_${nanoid(50)}`;
+    	return (
+    		<main className="flex min-h-screen flex-col items-center justify-center p-24">
+    			<div className="w-full border border-dashed">
+    				<p className="px-2 pt-2">Server Actions</p>
+    				<div className="p-2">
+    					<form action={closeSessions}>
+    						<button className="border px-2 py-1">Close WebSockets</button>
+    					</form>
+    				</div>
+    			</div>
+    			<div className="mt-2.5 w-full border border-dashed">
+    				<p className="px-2 py-2">Live Cursors</p>
+    				<div className="space-y-2 px-2">
+    					<Cursors id={id}></Cursors>
+    				</div>
+    			</div>
+    		</main>
+    	);
+    }
+    ```
 
-	<Details header="src/app/cursor.tsx">
-	```tsx title="src/app/cursor.tsx"
-	"use client";
-	import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
-	import type { Session, WsMessage } from "../../worker/src/index";
-	import { PerfectCursor } from "perfect-cursors";
+4.  Create a client component to manage WebSocket and mouse movement events:
 
-	const INTERVAL = 55;
+    <Details header="src/app/cursor.tsx">
 
-	export function Cursors(props: { id: string }) {
-		const wsRef = useRef<WebSocket | null>(null);
-		const [cursors, setCursors] = useState<Map<string, Session>>(new Map());
-		const lastSentTimestamp = useRef(0);
-		const [messageState, dispatchMessage] = useReducer(messageReducer, {
-			in: "",
-			out: "",
-		});
-		const [highlightedIn, highlightIn] = useHighlight();
-		const [highlightedOut, highlightOut] = useHighlight();
+`````tsx title="src/app/cursor.tsx"
+"use client";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
+import type { Session, WsMessage } from "../../worker/src/index";
+import { PerfectCursor } from "perfect-cursors";
 
-		function startWebSocket() {
-			const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-			const ws = new WebSocket(
-				`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
-			);
-			ws.onopen = () => {
-				highlightOut();
-				dispatchMessage({ type: "out", message: "get-cursors" });
-				const message: WsMessage = { type: "get-cursors" };
-				ws.send(JSON.stringify(message));
-			};
-			ws.onmessage = (message) => {
-				const messageData: WsMessage = JSON.parse(message.data);
-				highlightIn();
-				dispatchMessage({ type: "in", message: messageData.type });
-				switch (messageData.type) {
-					case "quit":
-						setCursors((prev) => {
-							const updated = new Map(prev);
-							updated.delete(messageData.id);
-							return updated;
-						});
-						break;
-					case "join":
-						setCursors((prev) => {
-							const updated = new Map(prev);
-							if (!updated.has(messageData.id)) {
-								updated.set(messageData.id, { id: messageData.id, x: -1, y: -1 });
-							}
-							return updated;
-						});
-						break;
-					case "move":
-						setCursors((prev) => {
-							const updated = new Map(prev);
-							const session = updated.get(messageData.id);
-							if (session) {
-								session.x = messageData.x;
-								session.y = messageData.y;
-							} else {
-								updated.set(messageData.id, messageData);
-							}
-							return updated;
-						});
-						break;
-					case "get-cursors-response":
-						setCursors(
-							new Map(
-								messageData.sessions.map((session) => [session.id, session]),
-							),
-						);
-						break;
-					default:
-						break;
-				}
-			};
-			ws.onclose = () => setCursors(new Map());
-			return ws;
-		}
+    const INTERVAL = 55;
 
-		useEffect(() => {
-			const abortController = new AbortController();
-			document.addEventListener(
-				"mousemove",
-				(ev) => {
-					const x = ev.pageX / window.innerWidth,
-						y = ev.pageY / window.innerHeight;
-					const now = Date.now();
-					if (
-						now - lastSentTimestamp.current > INTERVAL &&
-						wsRef.current?.readyState === WebSocket.OPEN
-					) {
-						const message: WsMessage = { type: "move", id: props.id, x, y };
-						wsRef.current.send(JSON.stringify(message));
-						lastSentTimestamp.current = now;
-						highlightOut();
-						dispatchMessage({ type: "out", message: "move" });
-					}
-				},
-				{
-					signal: abortController.signal,
-				},
-			);
-			return () => abortController.abort();
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, []);
+    export function Cursors(props: { id: string }) {
+	const wsRef = useRef<WebSocket | null>(null);
+	const [cursors, setCursors] = useState<Map<string, Session>>(new Map());
+	const lastSentTimestamp = useRef(0);
+	const [messageState, dispatchMessage] = useReducer(messageReducer, {
+		in: "",
+		out: "",
+	});
+	const [highlightedIn, highlightIn] = useHighlight();
+	const [highlightedOut, highlightOut] = useHighlight();
 
-		useEffect(() => {
-			wsRef.current = startWebSocket();
-			return () => wsRef.current?.close();
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [props.id]);
+        function startWebSocket() {
+        	const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+        	const ws = new WebSocket(
+        		`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
+        	);
+        	ws.onopen = () => {
+        		highlightOut();
+        		dispatchMessage({ type: "out", message: "get-cursors" });
+        		const message: WsMessage = { type: "get-cursors" };
+        		ws.send(JSON.stringify(message));
+        	};
+        	ws.onmessage = (message) => {
+        		const messageData: WsMessage = JSON.parse(message.data);
+        		highlightIn();
+        		dispatchMessage({ type: "in", message: messageData.type });
+        		switch (messageData.type) {
+        			case "quit":
+        				setCursors((prev) => {
+        					const updated = new Map(prev);
+        					updated.delete(messageData.id);
+        					return updated;
+        				});
+        				break;
+        			case "join":
+        				setCursors((prev) => {
+        					const updated = new Map(prev);
+        					if (!updated.has(messageData.id)) {
+        						updated.set(messageData.id, { id: messageData.id, x: -1, y: -1 });
+        					}
+        					return updated;
+        				});
+        				break;
+        			case "move":
+        				setCursors((prev) => {
+        					const updated = new Map(prev);
+        					const session = updated.get(messageData.id);
+        					if (session) {
+        						session.x = messageData.x;
+        						session.y = messageData.y;
+        					} else {
+        						updated.set(messageData.id, messageData);
+        					}
+        					return updated;
+        				});
+        				break;
+        			case "get-cursors-response":
+        				setCursors(
+        					new Map(
+        						messageData.sessions.map((session) => [session.id, session]),
+        					),
+        				);
+        				break;
+        			default:
+        				break;
+        		}
+        	};
+        	ws.onclose = () => setCursors(new Map());
+        	return ws;
+        }
 
-		function sendMessage() {
-			highlightOut();
-			dispatchMessage({ type: "out", message: "message" });
-			wsRef.current?.send(
-				JSON.stringify({ type: "message", data: "Ping" } satisfies WsMessage),
-			);
-		}
+        useEffect(() => {
+        	const abortController = new AbortController();
+        	document.addEventListener(
+        		"mousemove",
+        		(ev) => {
+        			const x = ev.pageX / window.innerWidth,
+        				y = ev.pageY / window.innerHeight;
+        			const now = Date.now();
+        			if (
+        				now - lastSentTimestamp.current > INTERVAL &&
+        				wsRef.current?.readyState === WebSocket.OPEN
+        			) {
+        				const message: WsMessage = { type: "move", id: props.id, x, y };
+        				wsRef.current.send(JSON.stringify(message));
+        				lastSentTimestamp.current = now;
+        				highlightOut();
+        				dispatchMessage({ type: "out", message: "move" });
+        			}
+        		},
+        		{
+        			signal: abortController.signal,
+        		},
+        	);
+        	return () => abortController.abort();
+        	// eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
 
-		const otherCursors = Array.from(cursors.values()).filter(
-			({ id, x, y }) => id !== props.id && x !== -1 && y !== -1,
-		);
+        useEffect(() => {
+        	wsRef.current = startWebSocket();
+        	return () => wsRef.current?.close();
+        	// eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [props.id]);
 
-		return (
-			<>
-				<div className="flex border">
-					<div className="px-2 py-1 border-r">WebSocket Connections</div>
-					<div className="px-2 py-1"> {cursors.size} </div>
-				</div>
-				<div className="flex border">
-					<div className="px-2 py-1 border-r">Messages</div>
-					<div className="flex flex-1">
-						<div className="px-2 py-1 border-r">↓</div>
-						<div
-							className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
-							style={{
-								backgroundColor: highlightedIn ? "#ef4444" : "transparent",
-							}}
-						>
-							{messageState.in}
-						</div>
-					</div>
-					<div className="flex flex-1">
-						<div className="px-2 py-1 border-x">↑</div>
-						<div
-							className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
-							style={{
-								backgroundColor: highlightedOut ? "#60a5fa" : "transparent",
-							}}
-						>
-							{messageState.out}
-						</div>
-					</div>
-				</div>
-				<div className="flex gap-2">
-					<button onClick={sendMessage} className="border px-2 py-1">
-						ws message
-					</button>
-					<button
-						className="border px-2 py-1 disabled:opacity-80"
-						onClick={() => {
-							wsRef.current?.close();
-							wsRef.current = startWebSocket();
-						}}
-					>
-						ws reconnect
-					</button>
-					<button
-						className="border px-2 py-1"
-						onClick={() => wsRef.current?.close()}
-					>
-						ws close
-					</button>
-				</div>
-				<div>
-					{otherCursors.map((session) => (
-						<SvgCursor
-							key={session.id}
-							point={[
-								session.x * window.innerWidth,
-								session.y * window.innerHeight,
-							]}
-						/>
-					))}
-				</div>
-			</>
-		);
-	}
+        function sendMessage() {
+        	highlightOut();
+        	dispatchMessage({ type: "out", message: "message" });
+        	wsRef.current?.send(
+        		JSON.stringify({ type: "message", data: "Ping" } satisfies WsMessage),
+        	);
+        }
 
-	function SvgCursor({ point }: { point: number[] }) {
-		const refSvg = useRef<SVGSVGElement>(null);
-		const animateCursor = useCallback((point: number[]) => {
-			refSvg.current?.style.setProperty(
-				"transform",
-				`translate(${point[0]}px, ${point[1]}px)`,
-			);
-		}, []);
-		const onPointMove = usePerfectCursor(animateCursor);
-		useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
-		const [randomColor] = useState(
-			`#${Math.floor(Math.random() * 16777215)
-				.toString(16)
-				.padStart(6, "0")}`,
-		);
-		return (
-			<svg
-				ref={refSvg}
-				height="32"
-				width="32"
-				viewBox="0 0 32 32"
-				xmlns="http://www.w3.org/2000/svg"
-				className={"absolute -top-[12px] -left-[12px] pointer-events-none"}
-			>
-				<defs>
-					<filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
-						<feDropShadow dx="1" dy="1" stdDeviation="1.2" floodOpacity="0.5" />
-					</filter>
-				</defs>
-				<g fill="none" transform="rotate(0 16 16)" filter="url(#shadow)">
-					<path
-						d="M12 24.4219V8.4069L23.591 20.0259H16.81l-.411.124z"
-						fill="white"
-					/>
-					<path
-						d="M21.0845 25.0962L17.4795 26.6312L12.7975 15.5422L16.4835 13.9892z"
-						fill="white"
-					/>
-					<path
-						d="M19.751 24.4155L17.907 25.1895L14.807 17.8155L16.648 17.04z"
-						fill={randomColor}
-					/>
-					<path
-						d="M13 10.814V22.002L15.969 19.136l.428-.139h4.768z"
-						fill={randomColor}
-					/>
-				</g>
-			</svg>
-		);
-	}
+        const otherCursors = Array.from(cursors.values()).filter(
+        	({ id, x, y }) => id !== props.id && x !== -1 && y !== -1,
+        );
 
-	function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
-		const [pc] = useState(() => new PerfectCursor(cb));
+        return (
+        	<>
+        		<div className="flex border">
+        			<div className="px-2 py-1 border-r">WebSocket Connections</div>
+        			<div className="px-2 py-1"> {cursors.size} </div>
+        		</div>
+        		<div className="flex border">
+        			<div className="px-2 py-1 border-r">Messages</div>
+        			<div className="flex flex-1">
+        				<div className="px-2 py-1 border-r">↓</div>
+        				<div
+        					className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
+        					style={{
+        						backgroundColor: highlightedIn ? "#ef4444" : "transparent",
+        					}}
+        				>
+        					{messageState.in}
+        				</div>
+        			</div>
+        			<div className="flex flex-1">
+        				<div className="px-2 py-1 border-x">↑</div>
+        				<div
+        					className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
+        					style={{
+        						backgroundColor: highlightedOut ? "#60a5fa" : "transparent",
+        					}}
+        				>
+        					{messageState.out}
+        				</div>
+        			</div>
+        		</div>
+        		<div className="flex gap-2">
+        			<button onClick={sendMessage} className="border px-2 py-1">
+        				ws message
+        			</button>
+        			<button
+        				className="border px-2 py-1 disabled:opacity-80"
+        				onClick={() => {
+        					wsRef.current?.close();
+        					wsRef.current = startWebSocket();
+        				}}
+        			>
+        				ws reconnect
+        			</button>
+        			<button
+        				className="border px-2 py-1"
+        				onClick={() => wsRef.current?.close()}
+        			>
+        				ws close
+        			</button>
+        		</div>
+        		<div>
+        			{otherCursors.map((session) => (
+        				<SvgCursor
+        					key={session.id}
+        					point={[
+        						session.x * window.innerWidth,
+        						session.y * window.innerHeight,
+        					]}
+        				/>
+        			))}
+        		</div>
+        	</>
+        );
 
-		useLayoutEffect(() => {
-			if (point) pc.addPoint(point);
-			return () => pc.dispose();
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [pc]);
+    }
 
-		useLayoutEffect(() => {
-			PerfectCursor.MAX_INTERVAL = 58;
-		}, []);
+    function SvgCursor({ point }: { point: number[] }) {
+    const refSvg = useRef<SVGSVGElement>(null);
+    const animateCursor = useCallback((point: number[]) => {
+    refSvg.current?.style.setProperty(
+    "transform",
+    `translate(${point[0]}px, ${point[1]}px)`,
+    );
+    }, []);
+    const onPointMove = usePerfectCursor(animateCursor);
+    useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
+    const [randomColor] = useState(
+    `#${Math.floor(Math.random() * 16777215)
+			.toString(16)
+			.padStart(6, "0")}`,
+    );
+    return (
+    <svg
+    ref={refSvg}
+    height="32"
+    width="32"
+    viewBox="0 0 32 32"
+    xmlns="http://www.w3.org/2000/svg"
+    className={"absolute -top-[12px] -left-[12px] pointer-events-none"} >
+    <defs>
+    <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
+    <feDropShadow dx="1" dy="1" stdDeviation="1.2" floodOpacity="0.5" />
+    </filter>
+    </defs>
+    <g fill="none" transform="rotate(0 16 16)" filter="url(#shadow)">
+    <path
+    					d="M12 24.4219V8.4069L23.591 20.0259H16.81l-.411.124z"
+    					fill="white"
+    				/>
+    <path
+    					d="M21.0845 25.0962L17.4795 26.6312L12.7975 15.5422L16.4835 13.9892z"
+    					fill="white"
+    				/>
+    <path
+    					d="M19.751 24.4155L17.907 25.1895L14.807 17.8155L16.648 17.04z"
+    					fill={randomColor}
+    				/>
+    <path
+    					d="M13 10.814V22.002L15.969 19.136l.428-.139h4.768z"
+    					fill={randomColor}
+    				/>
+    </g>
+    </svg>
+    );
+    }
 
-		const onPointChange = useCallback(
-			(point: number[]) => pc.addPoint(point),
-			[pc],
-		);
+    function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
+    const [pc] = useState(() => new PerfectCursor(cb));
 
-		return onPointChange;
-	}
+        useLayoutEffect(() => {
+        	if (point) pc.addPoint(point);
+        	return () => pc.dispose();
+        	// eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [pc]);
 
-	type MessageState = { in: string; out: string };
-	type MessageAction = { type: "in" | "out"; message: string };
-	function messageReducer(state: MessageState, action: MessageAction) {
-		switch (action.type) {
-			case "in":
-				return { ...state, in: action.message };
-			case "out":
-				return { ...state, out: action.message };
-			default:
-				return state;
-		}
-	}
+        useLayoutEffect(() => {
+        	PerfectCursor.MAX_INTERVAL = 58;
+        }, []);
 
-	function useHighlight(duration = 250) {
-		const timestampRef = useRef(0);
-		const [highlighted, setHighlighted] = useState(false);
-		function highlight() {
-			timestampRef.current = Date.now();
-			setHighlighted(true);
-			setTimeout(() => {
-				const now = Date.now();
-				if (now - timestampRef.current >= duration) {
-					setHighlighted(false);
-				}
-			}, duration);
-		}
-		return [highlighted, highlight] as const;
-	}
-	```
-	</Details>
-	The generated ID is used here and passed as a parameter to the WebSocket server:
+        const onPointChange = useCallback(
+        	(point: number[]) => pc.addPoint(point),
+        	[pc],
+        );
 
-	```ts
-	const ws = new WebSocket(
-		`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
-	);
-	```
+        return onPointChange;
 
-	The component starts the WebSocket connection and handles 4 types of WebSocket messages, which trigger updates to React's state:
-		- `join`. Received when a new WebSocket connection is established.
-		- `quit`. Received when a WebSocket connection is closed.
-		- `move`. Received when a user's cursor moves.
-		- `get-cursors-response`. Received	when a client sends a `get-cursors` message, which is triggered once the WebSocket connection is open.
+    }
 
-	It sends the user's cursor coordinates to the WebSocket server during the [`mousemove`](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousemove_event) event, which then broadcasts them to all active WebSocket clients.
+    type MessageState = { in: string; out: string };
+    type MessageAction = { type: "in" | "out"; message: string };
+    function messageReducer(state: MessageState, action: MessageAction) {
+    switch (action.type) {
+    case "in":
+    return { ...state, in: action.message };
+    case "out":
+    return { ...state, out: action.message };
+    default:
+    return state;
+    }
+    }
 
-	Although there are multiple strategies you can use together for real-time cursor synchronization (e.g., batching, interpolation, etc.), in this tutorial throttling, spline interpolation and position normalization are used:
+    function useHighlight(duration = 250) {
+    const timestampRef = useRef(0);
+    const [highlighted, setHighlighted] = useState(false);
+    function highlight() {
+    timestampRef.current = Date.now();
+    setHighlighted(true);
+    setTimeout(() => {
+    const now = Date.now();
+    if (now - timestampRef.current >= duration) {
+    setHighlighted(false);
+    }
+    }, duration);
+    }
+    return [highlighted, highlight] as const;
+    }
 
-	```ts {4-5,8-9}
-	document.addEventListener(
-		"mousemove",
-		(ev) => {
-			const x = ev.pageX / window.innerWidth,
-				y = ev.pageY / window.innerHeight;
-			const now = Date.now();
-			if (
-					now - lastSentTimestamp.current > INTERVAL &&
-					wsRef.current?.readyState === WebSocket.OPEN
-			) {
-				const message: WsMessage = { type: "move", id: props.id, x, y };
-				wsRef.current.send(JSON.stringify(message));
-				lastSentTimestamp.current = now;
-				// ...
-			}
-		}
-	);
-	```
+    ````
+    </Details>
+    The generated ID is used here and passed as a parameter to the WebSocket server:
 
-	Each animated cursor is controlled by a `PerfectCursor` instance, which animates its position along a spline curve defined by the cursor's latest positions:
-	```ts {9-11}
-	// SvgCursor react component
-	const refSvg = useRef<SVGSVGElement>(null);
-	const animateCursor = useCallback((point: number[]) => {
-		refSvg.current?.style.setProperty(
-			"transform",
-			`translate(${point[0]}px, ${point[1]}px)`,
-		);
-	}, []);
-	const onPointMove = usePerfectCursor(animateCursor);
-	// A `point` is added to the path whenever its vule updates;
-	useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
-	// ...
-	```
+    ```ts
+    const ws = new WebSocket(
+    	`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
+    );
+    ````
 
+    The component starts the WebSocket connection and handles 4 types of WebSocket messages, which trigger updates to React's state: - `join`. Received when a new WebSocket connection is established. - `quit`. Received when a WebSocket connection is closed. - `move`. Received when a user's cursor moves. - `get-cursors-response`. Received when a client sends a `get-cursors` message, which is triggered once the WebSocket connection is open.
 
-5. Run Next.js development server:
-	:::note[Note]
-	The Durable Object Worker must also be running.
-	:::
-	<PackageManagers type="run" pkg="dev" frame="none" />
+    It sends the user's cursor coordinates to the WebSocket server during the [`mousemove`](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousemove_event) event, which then broadcasts them to all active WebSocket clients.
 
-6. Open the App in the browser.
+    Although there are multiple strategies you can use together for real-time cursor synchronization (e.g., batching, interpolation, etc.), in this tutorial throttling, spline interpolation and position normalization are used:
+
+    ```ts {4-5,8-9}
+    document.addEventListener("mousemove", (ev) => {
+    	const x = ev.pageX / window.innerWidth,
+    		y = ev.pageY / window.innerHeight;
+    	const now = Date.now();
+    	if (
+    		now - lastSentTimestamp.current > INTERVAL &&
+    		wsRef.current?.readyState === WebSocket.OPEN
+    	) {
+    		const message: WsMessage = { type: "move", id: props.id, x, y };
+    		wsRef.current.send(JSON.stringify(message));
+    		lastSentTimestamp.current = now;
+    		// ...
+    	}
+    });
+    ```
+
+    Each animated cursor is controlled by a `PerfectCursor` instance, which animates its position along a spline curve defined by the cursor's latest positions:
+
+    ```ts {9-11}
+    // SvgCursor react component
+    const refSvg = useRef<SVGSVGElement>(null);
+    const animateCursor = useCallback((point: number[]) => {
+    	refSvg.current?.style.setProperty(
+    		"transform",
+    		`translate(${point[0]}px, ${point[1]}px)`,
+    	);
+    }, []);
+    const onPointMove = usePerfectCursor(animateCursor);
+    // A `point` is added to the path whenever its vule updates;
+    useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
+    // ...
+    ```
+
+5.  Run Next.js development server:
+    :::note[Note]
+    The Durable Object Worker must also be running.
+    :::
+
+    <PackageManagers type="run" pkg="dev" frame="none" />
+
+6.  Open the App in the browser.
 
 </Steps>
-
 
 ## 5. Deploy the project
 
@@ -795,38 +804,39 @@ that will be made available to the Next.js Worker using a [`WorkerEntrypoint`](/
 	cd worker
 	```
 
-	Deploy the Worker:
-	<PackageManagers type="run" pkg="deploy" frame="none" />
+    Deploy the Worker:
+    <PackageManagers type="run" pkg="deploy" frame="none" />
 
-	Copy only the host from the generated Worker URL, excluding the protocol, and set `NEXT_PUBLIC_WS_HOST` in `.env.local` to this value (e.g., `worker-unique-identifier.workers.dev`).
+    Copy only the host from the generated Worker URL, excluding the protocol, and set `NEXT_PUBLIC_WS_HOST` in `.env.local` to this value (e.g., `worker-unique-identifier.workers.dev`).
 
-	```txt title="next-rpc/.env.local" ins={2} del={1}
-	NEXT_PUBLIC_WS_HOST=localhost:8787
-	NEXT_PUBLIC_WS_HOST=worker-unique-identifier.workers.dev
-	```
+    ```txt title="next-rpc/.env.local" ins={2} del={1}
+    NEXT_PUBLIC_WS_HOST=localhost:8787
+    NEXT_PUBLIC_WS_HOST=worker-unique-identifier.workers.dev
+    ```
 
 2. Change into your root directory and deploy your Next.js app:
-	:::note[Optional Step]
-	Invoking Durable Object RPC methods between separate workers are fully supported in Cloudflare deployments. You can opt to use them instead of Service Bindings RPC:
-	```ts title="src/app/page.tsx" ins={7-9} del={4}
-	async function closeSessions() {
-		"use server";
-		const cf = await getCloudflareContext();
-		await cf.env.RPC_SERVICE.closeSessions();
+   :::note[Optional Step]
+   Invoking Durable Object RPC methods between separate workers are fully supported in Cloudflare deployments. You can opt to use them instead of Service Bindings RPC:
 
-		// Note: Not supported in `wrangler dev`
-		const id = cf.env.CURSOR_SESSIONS.idFromName("globalRoom");
-		const stub = cf.env.CURSOR_SESSIONS.get(id);
-		await stub.closeSessions();
-	}
-	```
-	:::
+   ```ts title="src/app/page.tsx" ins={7-9} del={4}
+   async function closeSessions() {
+   	"use server";
+   	const cf = await getCloudflareContext();
+   	await cf.env.RPC_SERVICE.closeSessions();
 
-	<PackageManagers type="run" pkg="deploy" frame="none" />
+   	// Note: Not supported in `wrangler dev`
+   	const stub = cf.env.CURSOR_SESSIONS.getByName("globalRoom");
+   	await stub.closeSessions();
+   }
+`````
 
+:::
+
+{" "}
+
+<PackageManagers type="run" pkg="deploy" frame="none" />
 
 </Steps>
-
 
 ## Summary
 

--- a/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
+++ b/src/content/docs/workers/tutorials/live-cursors-with-nextjs-rpc-do/index.mdx
@@ -441,309 +441,310 @@ that will be made available to the Next.js Worker using a [`WorkerEntrypoint`](/
 
 4.  Create a client component to manage WebSocket and mouse movement events:
 
-    <Details header="src/app/cursor.tsx">
+	<Details header="src/app/cursor.tsx">
 
-`````tsx title="src/app/cursor.tsx"
-"use client";
-import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
-import type { Session, WsMessage } from "../../worker/src/index";
-import { PerfectCursor } from "perfect-cursors";
+		```tsx title="src/app/cursor.tsx"
+		"use client";
+		import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
+		import type { Session, WsMessage } from "../../worker/src/index";
+		import { PerfectCursor } from "perfect-cursors";
 
-    const INTERVAL = 55;
+		const INTERVAL = 55;
 
-    export function Cursors(props: { id: string }) {
-	const wsRef = useRef<WebSocket | null>(null);
-	const [cursors, setCursors] = useState<Map<string, Session>>(new Map());
-	const lastSentTimestamp = useRef(0);
-	const [messageState, dispatchMessage] = useReducer(messageReducer, {
-		in: "",
-		out: "",
-	});
-	const [highlightedIn, highlightIn] = useHighlight();
-	const [highlightedOut, highlightOut] = useHighlight();
+			export function Cursors(props: { id: string }) {
+			const wsRef = useRef<WebSocket | null>(null);
+			const [cursors, setCursors] = useState<Map<string, Session>>(new Map());
+			const lastSentTimestamp = useRef(0);
+			const [messageState, dispatchMessage] = useReducer(messageReducer, {
+				in: "",
+				out: "",
+			});
+			const [highlightedIn, highlightIn] = useHighlight();
+			const [highlightedOut, highlightOut] = useHighlight();
 
-        function startWebSocket() {
-        	const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-        	const ws = new WebSocket(
-        		`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
-        	);
-        	ws.onopen = () => {
-        		highlightOut();
-        		dispatchMessage({ type: "out", message: "get-cursors" });
-        		const message: WsMessage = { type: "get-cursors" };
-        		ws.send(JSON.stringify(message));
-        	};
-        	ws.onmessage = (message) => {
-        		const messageData: WsMessage = JSON.parse(message.data);
-        		highlightIn();
-        		dispatchMessage({ type: "in", message: messageData.type });
-        		switch (messageData.type) {
-        			case "quit":
-        				setCursors((prev) => {
-        					const updated = new Map(prev);
-        					updated.delete(messageData.id);
-        					return updated;
-        				});
-        				break;
-        			case "join":
-        				setCursors((prev) => {
-        					const updated = new Map(prev);
-        					if (!updated.has(messageData.id)) {
-        						updated.set(messageData.id, { id: messageData.id, x: -1, y: -1 });
-        					}
-        					return updated;
-        				});
-        				break;
-        			case "move":
-        				setCursors((prev) => {
-        					const updated = new Map(prev);
-        					const session = updated.get(messageData.id);
-        					if (session) {
-        						session.x = messageData.x;
-        						session.y = messageData.y;
-        					} else {
-        						updated.set(messageData.id, messageData);
-        					}
-        					return updated;
-        				});
-        				break;
-        			case "get-cursors-response":
-        				setCursors(
-        					new Map(
-        						messageData.sessions.map((session) => [session.id, session]),
-        					),
-        				);
-        				break;
-        			default:
-        				break;
-        		}
-        	};
-        	ws.onclose = () => setCursors(new Map());
-        	return ws;
-        }
+					function startWebSocket() {
+						const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+						const ws = new WebSocket(
+							`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
+						);
+						ws.onopen = () => {
+							highlightOut();
+							dispatchMessage({ type: "out", message: "get-cursors" });
+							const message: WsMessage = { type: "get-cursors" };
+							ws.send(JSON.stringify(message));
+						};
+						ws.onmessage = (message) => {
+							const messageData: WsMessage = JSON.parse(message.data);
+							highlightIn();
+							dispatchMessage({ type: "in", message: messageData.type });
+							switch (messageData.type) {
+								case "quit":
+									setCursors((prev) => {
+										const updated = new Map(prev);
+										updated.delete(messageData.id);
+										return updated;
+									});
+									break;
+								case "join":
+									setCursors((prev) => {
+										const updated = new Map(prev);
+										if (!updated.has(messageData.id)) {
+											updated.set(messageData.id, { id: messageData.id, x: -1, y: -1 });
+										}
+										return updated;
+									});
+									break;
+								case "move":
+									setCursors((prev) => {
+										const updated = new Map(prev);
+										const session = updated.get(messageData.id);
+										if (session) {
+											session.x = messageData.x;
+											session.y = messageData.y;
+										} else {
+											updated.set(messageData.id, messageData);
+										}
+										return updated;
+									});
+									break;
+								case "get-cursors-response":
+									setCursors(
+										new Map(
+											messageData.sessions.map((session) => [session.id, session]),
+										),
+									);
+									break;
+								default:
+									break;
+							}
+						};
+						ws.onclose = () => setCursors(new Map());
+						return ws;
+					}
 
-        useEffect(() => {
-        	const abortController = new AbortController();
-        	document.addEventListener(
-        		"mousemove",
-        		(ev) => {
-        			const x = ev.pageX / window.innerWidth,
-        				y = ev.pageY / window.innerHeight;
-        			const now = Date.now();
-        			if (
-        				now - lastSentTimestamp.current > INTERVAL &&
-        				wsRef.current?.readyState === WebSocket.OPEN
-        			) {
-        				const message: WsMessage = { type: "move", id: props.id, x, y };
-        				wsRef.current.send(JSON.stringify(message));
-        				lastSentTimestamp.current = now;
-        				highlightOut();
-        				dispatchMessage({ type: "out", message: "move" });
-        			}
-        		},
-        		{
-        			signal: abortController.signal,
-        		},
-        	);
-        	return () => abortController.abort();
-        	// eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+					useEffect(() => {
+						const abortController = new AbortController();
+						document.addEventListener(
+							"mousemove",
+							(ev) => {
+								const x = ev.pageX / window.innerWidth,
+									y = ev.pageY / window.innerHeight;
+								const now = Date.now();
+								if (
+									now - lastSentTimestamp.current > INTERVAL &&
+									wsRef.current?.readyState === WebSocket.OPEN
+								) {
+									const message: WsMessage = { type: "move", id: props.id, x, y };
+									wsRef.current.send(JSON.stringify(message));
+									lastSentTimestamp.current = now;
+									highlightOut();
+									dispatchMessage({ type: "out", message: "move" });
+								}
+							},
+							{
+								signal: abortController.signal,
+							},
+						);
+						return () => abortController.abort();
+						// eslint-disable-next-line react-hooks/exhaustive-deps
+					}, []);
 
-        useEffect(() => {
-        	wsRef.current = startWebSocket();
-        	return () => wsRef.current?.close();
-        	// eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [props.id]);
+					useEffect(() => {
+						wsRef.current = startWebSocket();
+						return () => wsRef.current?.close();
+						// eslint-disable-next-line react-hooks/exhaustive-deps
+					}, [props.id]);
 
-        function sendMessage() {
-        	highlightOut();
-        	dispatchMessage({ type: "out", message: "message" });
-        	wsRef.current?.send(
-        		JSON.stringify({ type: "message", data: "Ping" } satisfies WsMessage),
-        	);
-        }
+					function sendMessage() {
+						highlightOut();
+						dispatchMessage({ type: "out", message: "message" });
+						wsRef.current?.send(
+							JSON.stringify({ type: "message", data: "Ping" } satisfies WsMessage),
+						);
+					}
 
-        const otherCursors = Array.from(cursors.values()).filter(
-        	({ id, x, y }) => id !== props.id && x !== -1 && y !== -1,
-        );
+					const otherCursors = Array.from(cursors.values()).filter(
+						({ id, x, y }) => id !== props.id && x !== -1 && y !== -1,
+					);
 
-        return (
-        	<>
-        		<div className="flex border">
-        			<div className="px-2 py-1 border-r">WebSocket Connections</div>
-        			<div className="px-2 py-1"> {cursors.size} </div>
-        		</div>
-        		<div className="flex border">
-        			<div className="px-2 py-1 border-r">Messages</div>
-        			<div className="flex flex-1">
-        				<div className="px-2 py-1 border-r">↓</div>
-        				<div
-        					className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
-        					style={{
-        						backgroundColor: highlightedIn ? "#ef4444" : "transparent",
-        					}}
-        				>
-        					{messageState.in}
-        				</div>
-        			</div>
-        			<div className="flex flex-1">
-        				<div className="px-2 py-1 border-x">↑</div>
-        				<div
-        					className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
-        					style={{
-        						backgroundColor: highlightedOut ? "#60a5fa" : "transparent",
-        					}}
-        				>
-        					{messageState.out}
-        				</div>
-        			</div>
-        		</div>
-        		<div className="flex gap-2">
-        			<button onClick={sendMessage} className="border px-2 py-1">
-        				ws message
-        			</button>
-        			<button
-        				className="border px-2 py-1 disabled:opacity-80"
-        				onClick={() => {
-        					wsRef.current?.close();
-        					wsRef.current = startWebSocket();
-        				}}
-        			>
-        				ws reconnect
-        			</button>
-        			<button
-        				className="border px-2 py-1"
-        				onClick={() => wsRef.current?.close()}
-        			>
-        				ws close
-        			</button>
-        		</div>
-        		<div>
-        			{otherCursors.map((session) => (
-        				<SvgCursor
-        					key={session.id}
-        					point={[
-        						session.x * window.innerWidth,
-        						session.y * window.innerHeight,
-        					]}
-        				/>
-        			))}
-        		</div>
-        	</>
-        );
+					return (
+						<>
+							<div className="flex border">
+								<div className="px-2 py-1 border-r">WebSocket Connections</div>
+								<div className="px-2 py-1"> {cursors.size} </div>
+							</div>
+							<div className="flex border">
+								<div className="px-2 py-1 border-r">Messages</div>
+								<div className="flex flex-1">
+									<div className="px-2 py-1 border-r">↓</div>
+									<div
+										className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
+										style={{
+											backgroundColor: highlightedIn ? "#ef4444" : "transparent",
+										}}
+									>
+										{messageState.in}
+									</div>
+								</div>
+								<div className="flex flex-1">
+									<div className="px-2 py-1 border-x">↑</div>
+									<div
+										className="w-full px-2 py-1 [word-break:break-word] transition-colors duration-500"
+										style={{
+											backgroundColor: highlightedOut ? "#60a5fa" : "transparent",
+										}}
+									>
+										{messageState.out}
+									</div>
+								</div>
+							</div>
+							<div className="flex gap-2">
+								<button onClick={sendMessage} className="border px-2 py-1">
+									ws message
+								</button>
+								<button
+									className="border px-2 py-1 disabled:opacity-80"
+									onClick={() => {
+										wsRef.current?.close();
+										wsRef.current = startWebSocket();
+									}}
+								>
+									ws reconnect
+								</button>
+								<button
+									className="border px-2 py-1"
+									onClick={() => wsRef.current?.close()}
+								>
+									ws close
+								</button>
+							</div>
+							<div>
+								{otherCursors.map((session) => (
+									<SvgCursor
+										key={session.id}
+										point={[
+											session.x * window.innerWidth,
+											session.y * window.innerHeight,
+										]}
+									/>
+								))}
+							</div>
+						</>
+					);
 
-    }
+			}
 
-    function SvgCursor({ point }: { point: number[] }) {
-    const refSvg = useRef<SVGSVGElement>(null);
-    const animateCursor = useCallback((point: number[]) => {
-    refSvg.current?.style.setProperty(
-    "transform",
-    `translate(${point[0]}px, ${point[1]}px)`,
-    );
-    }, []);
-    const onPointMove = usePerfectCursor(animateCursor);
-    useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
-    const [randomColor] = useState(
-    `#${Math.floor(Math.random() * 16777215)
-			.toString(16)
-			.padStart(6, "0")}`,
-    );
-    return (
-    <svg
-    ref={refSvg}
-    height="32"
-    width="32"
-    viewBox="0 0 32 32"
-    xmlns="http://www.w3.org/2000/svg"
-    className={"absolute -top-[12px] -left-[12px] pointer-events-none"} >
-    <defs>
-    <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
-    <feDropShadow dx="1" dy="1" stdDeviation="1.2" floodOpacity="0.5" />
-    </filter>
-    </defs>
-    <g fill="none" transform="rotate(0 16 16)" filter="url(#shadow)">
-    <path
-    					d="M12 24.4219V8.4069L23.591 20.0259H16.81l-.411.124z"
-    					fill="white"
-    				/>
-    <path
-    					d="M21.0845 25.0962L17.4795 26.6312L12.7975 15.5422L16.4835 13.9892z"
-    					fill="white"
-    				/>
-    <path
-    					d="M19.751 24.4155L17.907 25.1895L14.807 17.8155L16.648 17.04z"
-    					fill={randomColor}
-    				/>
-    <path
-    					d="M13 10.814V22.002L15.969 19.136l.428-.139h4.768z"
-    					fill={randomColor}
-    				/>
-    </g>
-    </svg>
-    );
-    }
+			function SvgCursor({ point }: { point: number[] }) {
+			const refSvg = useRef<SVGSVGElement>(null);
+			const animateCursor = useCallback((point: number[]) => {
+			refSvg.current?.style.setProperty(
+			"transform",
+			`translate(${point[0]}px, ${point[1]}px)`,
+			);
+			}, []);
+			const onPointMove = usePerfectCursor(animateCursor);
+			useLayoutEffect(() => onPointMove(point), [onPointMove, point]);
+			const [randomColor] = useState(
+			`#${Math.floor(Math.random() * 16777215)
+				.toString(16)
+				.padStart(6, "0")}`,
+			);
+			return (
+			<svg
+			ref={refSvg}
+			height="32"
+			width="32"
+			viewBox="0 0 32 32"
+			xmlns="http://www.w3.org/2000/svg"
+			className={"absolute -top-[12px] -left-[12px] pointer-events-none"} >
+			<defs>
+			<filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
+			<feDropShadow dx="1" dy="1" stdDeviation="1.2" floodOpacity="0.5" />
+			</filter>
+			</defs>
+			<g fill="none" transform="rotate(0 16 16)" filter="url(#shadow)">
+			<path
+								d="M12 24.4219V8.4069L23.591 20.0259H16.81l-.411.124z"
+								fill="white"
+							/>
+			<path
+								d="M21.0845 25.0962L17.4795 26.6312L12.7975 15.5422L16.4835 13.9892z"
+								fill="white"
+							/>
+			<path
+								d="M19.751 24.4155L17.907 25.1895L14.807 17.8155L16.648 17.04z"
+								fill={randomColor}
+							/>
+			<path
+								d="M13 10.814V22.002L15.969 19.136l.428-.139h4.768z"
+								fill={randomColor}
+							/>
+			</g>
+			</svg>
+			);
+			}
 
-    function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
-    const [pc] = useState(() => new PerfectCursor(cb));
+			function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
+			const [pc] = useState(() => new PerfectCursor(cb));
 
-        useLayoutEffect(() => {
-        	if (point) pc.addPoint(point);
-        	return () => pc.dispose();
-        	// eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [pc]);
+					useLayoutEffect(() => {
+						if (point) pc.addPoint(point);
+						return () => pc.dispose();
+						// eslint-disable-next-line react-hooks/exhaustive-deps
+					}, [pc]);
 
-        useLayoutEffect(() => {
-        	PerfectCursor.MAX_INTERVAL = 58;
-        }, []);
+					useLayoutEffect(() => {
+						PerfectCursor.MAX_INTERVAL = 58;
+					}, []);
 
-        const onPointChange = useCallback(
-        	(point: number[]) => pc.addPoint(point),
-        	[pc],
-        );
+					const onPointChange = useCallback(
+						(point: number[]) => pc.addPoint(point),
+						[pc],
+					);
 
-        return onPointChange;
+					return onPointChange;
 
-    }
+			}
 
-    type MessageState = { in: string; out: string };
-    type MessageAction = { type: "in" | "out"; message: string };
-    function messageReducer(state: MessageState, action: MessageAction) {
-    switch (action.type) {
-    case "in":
-    return { ...state, in: action.message };
-    case "out":
-    return { ...state, out: action.message };
-    default:
-    return state;
-    }
-    }
+			type MessageState = { in: string; out: string };
+			type MessageAction = { type: "in" | "out"; message: string };
+			function messageReducer(state: MessageState, action: MessageAction) {
+			switch (action.type) {
+			case "in":
+			return { ...state, in: action.message };
+			case "out":
+			return { ...state, out: action.message };
+			default:
+			return state;
+			}
+			}
 
-    function useHighlight(duration = 250) {
-    const timestampRef = useRef(0);
-    const [highlighted, setHighlighted] = useState(false);
-    function highlight() {
-    timestampRef.current = Date.now();
-    setHighlighted(true);
-    setTimeout(() => {
-    const now = Date.now();
-    if (now - timestampRef.current >= duration) {
-    setHighlighted(false);
-    }
-    }, duration);
-    }
-    return [highlighted, highlight] as const;
-    }
+			function useHighlight(duration = 250) {
+			const timestampRef = useRef(0);
+			const [highlighted, setHighlighted] = useState(false);
+			function highlight() {
+			timestampRef.current = Date.now();
+			setHighlighted(true);
+			setTimeout(() => {
+			const now = Date.now();
+			if (now - timestampRef.current >= duration) {
+			setHighlighted(false);
+			}
+			}, duration);
+			}
+			return [highlighted, highlight] as const;
+			}
 
-    ````
-    </Details>
+			```
+	</Details>
+
     The generated ID is used here and passed as a parameter to the WebSocket server:
 
     ```ts
     const ws = new WebSocket(
     	`${wsProtocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws?id=${props.id}`,
     );
-    ````
+    ```
 
     The component starts the WebSocket connection and handles 4 types of WebSocket messages, which trigger updates to React's state: - `join`. Received when a new WebSocket connection is established. - `quit`. Received when a WebSocket connection is closed. - `move`. Received when a user's cursor moves. - `get-cursors-response`. Received when a client sends a `get-cursors` message, which is triggered once the WebSocket connection is open.
 
@@ -804,37 +805,36 @@ import { PerfectCursor } from "perfect-cursors";
 	cd worker
 	```
 
-    Deploy the Worker:
-    <PackageManagers type="run" pkg="deploy" frame="none" />
+	Deploy the Worker:
+	<PackageManagers type="run" pkg="deploy" frame="none" />
 
-    Copy only the host from the generated Worker URL, excluding the protocol, and set `NEXT_PUBLIC_WS_HOST` in `.env.local` to this value (e.g., `worker-unique-identifier.workers.dev`).
+	Copy only the host from the generated Worker URL, excluding the protocol, and set `NEXT_PUBLIC_WS_HOST` in `.env.local` to this value (e.g., `worker-unique-identifier.workers.dev`).
 
-    ```txt title="next-rpc/.env.local" ins={2} del={1}
-    NEXT_PUBLIC_WS_HOST=localhost:8787
-    NEXT_PUBLIC_WS_HOST=worker-unique-identifier.workers.dev
-    ```
+	```txt title="next-rpc/.env.local" ins={2} del={1}
+	NEXT_PUBLIC_WS_HOST=localhost:8787
+	NEXT_PUBLIC_WS_HOST=worker-unique-identifier.workers.dev
+	```
 
 2. Change into your root directory and deploy your Next.js app:
-   :::note[Optional Step]
-   Invoking Durable Object RPC methods between separate workers are fully supported in Cloudflare deployments. You can opt to use them instead of Service Bindings RPC:
+	:::note[Optional Step]
+	Invoking Durable Object RPC methods between separate workers are fully supported in Cloudflare deployments. You can opt to use them instead of Service Bindings RPC:
 
-   ```ts title="src/app/page.tsx" ins={7-9} del={4}
-   async function closeSessions() {
-   	"use server";
-   	const cf = await getCloudflareContext();
-   	await cf.env.RPC_SERVICE.closeSessions();
+	```ts title="src/app/page.tsx" ins={7-9} del={4}
+	async function closeSessions() {
+		"use server";
+		const cf = await getCloudflareContext();
+		await cf.env.RPC_SERVICE.closeSessions();
 
-   	// Note: Not supported in `wrangler dev`
-   	const stub = cf.env.CURSOR_SESSIONS.getByName("globalRoom");
-   	await stub.closeSessions();
-   }
-`````
+		// Note: Not supported in `wrangler dev`
+		const stub = cf.env.CURSOR_SESSIONS.getByName("globalRoom");
+		await stub.closeSessions();
+	}
+	```
+	:::
 
-:::
+	{" "}
 
-{" "}
-
-<PackageManagers type="run" pkg="deploy" frame="none" />
+	<PackageManagers type="run" pkg="deploy" frame="none" />
 
 </Steps>
 

--- a/src/content/partials/durable-objects/example-rpc.mdx
+++ b/src/content/partials/durable-objects/example-rpc.mdx
@@ -23,11 +23,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(request, env) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Methods on the Durable Object are invoked via the stub
 		const rpcResponse = await stub.sayHello();
@@ -60,11 +57,8 @@ export class MyDurableObject extends DurableObject {
 // Worker
 export default {
 	async fetch(request, env) {
-		// Every unique ID refers to an individual instance of the Durable Object class
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
 		// A stub is a client used to invoke methods on the Durable Object
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Methods on the Durable Object are invoked via the stub
 		const rpcResponse = await stub.sayHello();

--- a/src/content/partials/prompts/base-prompt.txt
+++ b/src/content/partials/prompts/base-prompt.txt
@@ -277,8 +277,7 @@ export default {
   async fetch(request, env) {
     let url = new URL(request.url);
     let userId = url.searchParams.get("userId") || crypto.randomUUID();
-    let id = env.ALARM_EXAMPLE.idFromName(userId);
-    return await env.ALARM_EXAMPLE.get(id).fetch(request);
+    return await env.ALARM_EXAMPLE.getByName(userId).fetch(request);
   },
 };
 


### PR DESCRIPTION
### Summary

Document new method `getByName()` for getting Durable Object stubs and update references to `idFromName()` where ID is not used directly. 

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
