### PR TITLE
WAF: add directory based hmac example

### DIFF
--- a/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
@@ -166,7 +166,7 @@ You will need to append this parameter to the URL you are protecting:
 The authentication token parameter (`verify=<VALUE>` in the example) must be the last parameter in the query string.
 :::
 
-### Testing the generated token parameter
+### Test the generated token parameter
 
 If you are on an Enterprise plan, you can test if URLs are being generated correctly on the origin server by doing the following:
 
@@ -175,7 +175,7 @@ If you are on an Enterprise plan, you can test if URLs are being generated corre
 
 ---
 
-## Protecting several paths using the same secret
+## Protect several paths using the same secret
 
 You can use the same secret key to protect several URI paths.
 
@@ -185,17 +185,26 @@ Since `http.request.uri` includes the path to the asset and that value is extrac
 
 Note that while you can use the same secret key to authenticate several paths, you must generate an HMAC token for each unique message you want to authenticate.
 
-## Protecting an entire directory with a single signature
+## Protect an entire URI path prefix with a single signature
 
-You can dynamically [concatenate the MessageMAC](/ruleset-engine/rules-language/functions/#concatenated-messagemac-argument) argument to the `is_timed_hmac_valid_v0()` function to protect an entire directory with a single signature.
+You can protect an entire URI path prefix with a fixed length using a single HMAC signature. To achieve this, supply a URI path prefix (instead of the full URI path) and the original query string as the [`MessageMAC`](/ruleset-engine/rules-language/functions/#messagemac) argument for the [`is_timed_hmac_valid_v0()`](/ruleset-engine/rules-language/functions/#hmac-validation) function.
 
-This example assumes that the directory name is always the same length (for example, `/images/12345678-90ab-4cde-f012-3456789abcde/cat.jpg`).
+Use the [`substring()`](/ruleset-engine/rules-language/functions/#substring) function to obtain the prefix from the full URI path.
 
-To protect an entire directory, you can use the `substring()` function to extract the directory name from the request URI path.
-The length of the directory name is 45 characters here, so you do `substring(http.request.uri.path, 0, 45)` to extract the first 45 characters of the path which corresponds to the directory name.
+The following example assumes that the prefix is always 50 characters long.
 
-Then you need to concatenate the directory name with the query string and pass it to the `is_timed_hmac_valid_v0()` function like this:
+Example URI path of an incoming request:
 
 ```txt
-(http.host eq "downloads.example.com" and not is_timed_hmac_valid_v0("mysecrettoken", concat(substring(http.request.uri.path, 0, 45), "?", http.request.uri.query), 10800, http.request.timestamp.sec))
+/case-studies/12345678-90ab-4cde-f012-3456789abcde/foobar-report.pdf?1755795722-21riMY6ELx6nI5dOPPHFHn2D4o0ZmEMa1UtoCo%2Bqe%2Bk%3D
 ```
+
+If you wanted to block requests failing the HMAC validation for this path prefix, you could create a custom rule similar to the following:
+
+- Rule expression:
+
+  ```txt
+  (http.host eq "downloads.example.com" and not is_timed_hmac_valid_v0("mysecrettoken", concat(substring(http.request.uri.path, 0, 50), "?", http.request.uri.query), 10800, http.request.timestamp.sec, 1))
+  ```
+
+- Action: Block

--- a/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
@@ -184,3 +184,18 @@ This is illustrated in the previous example, where `http.request.uri` is passed 
 Since `http.request.uri` includes the path to the asset and that value is extracted for each request, the validation function evaluates all request URIs to `downloads.example.com` using the same secret key.
 
 Note that while you can use the same secret key to authenticate several paths, you must generate an HMAC token for each unique message you want to authenticate.
+
+## Protecting an entire directory with a single signature
+
+You can dynamically [concatenate the MessageMAC](/ruleset-engine/rules-language/functions/#concatenated-messagemac-argument) argument to the `is_timed_hmac_valid_v0()` function to protect an entire directory with a single signature.
+
+This example assumes that the directory name is always the same length (for example, `/images/12345678-90ab-4cde-f012-3456789abcde/cat.jpg`).
+
+To protect an entire directory, you can use the `substring()` function to extract the directory name from the request URI path.
+The length of the directory name is 45 characters here, so you do `substring(http.request.uri.path, 0, 45)` to extract the first 45 characters of the path which corresponds to the directory name.
+
+Then you need to concatenate the directory name with the query string and pass it to the `is_timed_hmac_valid_v0()` function like this:
+
+```txt
+(http.host eq "downloads.example.com" and not is_timed_hmac_valid_v0("mysecrettoken", concat(substring(http.request.uri.path, 0, 45), "?", http.request.uri.query), 10800, http.request.timestamp.sec))
+```

--- a/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
@@ -223,6 +223,6 @@ Example URI paths of valid incoming requests:
 /case-studies/768bf477-22d5-4545-857d-b155510119ff/another-company-report.pdf?1755878057-jeMS5S1F3MIgxvL61UmiX4vODiWtuLfcPV6q%2B0Y3Rig%3D
 ```
 
-The first two URI paths could use the same HMAC signature because they share the same 51-character prefix (`/case-studies/12345678-90ab-4cde-f012-3456789abcde/`) that is validated by the custom rule.
+The first two URI paths can use the same HMAC signature because they share the same 51-character prefix (`/case-studies/12345678-90ab-4cde-f012-3456789abcde/`) that is validated by the custom rule.
 
-The third URI path would need a different HMAC signature, since the prefix is different.
+The third URI path needs a different HMAC signature, since the prefix is different.

--- a/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/configure-token-authentication.mdx
@@ -187,24 +187,42 @@ Note that while you can use the same secret key to authenticate several paths, y
 
 ## Protect an entire URI path prefix with a single signature
 
-You can protect an entire URI path prefix with a fixed length using a single HMAC signature. To achieve this, supply a URI path prefix (instead of the full URI path) and the original query string as the [`MessageMAC`](/ruleset-engine/rules-language/functions/#messagemac) argument for the [`is_timed_hmac_valid_v0()`](/ruleset-engine/rules-language/functions/#hmac-validation) function.
+You can protect an entire fixed-length URI path prefix with a single HMAC signature (it would also use the same secret). To achieve this, supply a URI path prefix (instead of the full URI path) and the original query string as the [`MessageMAC`](/ruleset-engine/rules-language/functions/#messagemac) argument for the [`is_timed_hmac_valid_v0()`](/ruleset-engine/rules-language/functions/#hmac-validation) function.
 
 Use the [`substring()`](/ruleset-engine/rules-language/functions/#substring) function to obtain the prefix from the full URI path.
 
-The following example assumes that the prefix is always 50 characters long.
-
-Example URI path of an incoming request:
+In the following example, the URI path prefix requiring a single HMAC signature is always 51 characters long (`x` is a character placeholder):
 
 ```txt
-/case-studies/12345678-90ab-4cde-f012-3456789abcde/foobar-report.pdf?1755795722-21riMY6ELx6nI5dOPPHFHn2D4o0ZmEMa1UtoCo%2Bqe%2Bk%3D
+/case-studies/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/
 ```
 
-If you wanted to block requests failing the HMAC validation for this path prefix, you could create a custom rule similar to the following:
+In this case, you would need to use a different HMAC signature for every different URI path prefix of length 51.
 
-- Rule expression:
+If you wanted to block requests for case study files failing the HMAC validation, you could create a custom rule similar to the following:
 
-  ```txt
-  (http.host eq "downloads.example.com" and not is_timed_hmac_valid_v0("mysecrettoken", concat(substring(http.request.uri.path, 0, 50), "?", http.request.uri.query), 10800, http.request.timestamp.sec, 1))
-  ```
+<Example>
 
-- Action: Block
+Rule expression:
+
+```txt
+  (http.host eq "downloads.example.com" and starts_with(http.request.uri.path, "/case-studies") and not is_timed_hmac_valid_v0("mysecrettoken", concat(substring(http.request.uri.path, 0, 51), "?", http.request.uri.query), 10800, http.request.timestamp.sec, 1))
+```
+
+Action:
+
+- Block
+
+</Example>
+
+Example URI paths of valid incoming requests:
+
+```txt
+/case-studies/12345678-90ab-4cde-f012-3456789abcde/foobar-report.pdf?1755877101-5WOroVcDINdl2%2BQZxZFHJcJ6l%2Fep4HGIrX3DtSXzWO0%3D
+/case-studies/12345678-90ab-4cde-f012-3456789abcde/acme-corp.pdf?1755877101-5WOroVcDINdl2%2BQZxZFHJcJ6l%2Fep4HGIrX3DtSXzWO0%3D
+/case-studies/768bf477-22d5-4545-857d-b155510119ff/another-company-report.pdf?1755878057-jeMS5S1F3MIgxvL61UmiX4vODiWtuLfcPV6q%2B0Y3Rig%3D
+```
+
+The first two URI paths could use the same HMAC signature because they share the same 51-character prefix (`/case-studies/12345678-90ab-4cde-f012-3456789abcde/`) that is validated by the custom rule.
+
+The third URI path would need a different HMAC signature, since the prefix is different.


### PR DESCRIPTION
### Summary

*This summary is Copilot generated*

This pull request adds documentation for a new use case to the custom token authentication rules, specifically describing how to protect an entire directory with a single HMAC signature. The update provides a practical example and step-by-step instructions for extracting a directory name from a request URI and using it in authentication.

New use case documentation:

* Added a section explaining how to protect an entire directory with a single signature by concatenating the directory name and query string as the `MessageMAC` argument for the `is_timed_hmac_valid_v0()` function.
* Included an example using the `substring()` function to extract a fixed-length directory name from the URI path and demonstrated how to construct the authentication logic using `concat()` and the relevant WAF functions.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) --><img width="765" height="537" alt="image" src="https://github.com/user-attachments/assets/80c7818a-dd9b-472e-9e61-bb921ecc36aa" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
