### PR TITLE
[Workers] Update email routing and cron triggers local dev pages

### DIFF
--- a/src/content/docs/email-routing/email-workers/local-development.mdx
+++ b/src/content/docs/email-routing/email-workers/local-development.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Render, Type, MetaInfo, WranglerConfig } from "~/components";
 
-You can test the behavior of an Email Worker script in local development using [wrangler dev](/workers/wrangler/commands/#dev).
+You can test the behavior of an Email Worker script in local development using Wrangler with [wrangler dev](/workers/wrangler/commands/#dev), or using the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/).
 
 This is the minimal wrangler configuration required to run an Email Worker locally:
 

--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -173,7 +173,7 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 ## Test Cron Triggers locally
 
-Test Cron Triggers using Wrangler with [`wrangler dev`](/workers/wrangler/commands/#dev). This will expose a `/cdn-cgi/handler/scheduled` route which can be used to test using a HTTP request.
+Test Cron Triggers using Wrangler with [`wrangler dev`](/workers/wrangler/commands/#dev), or using the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/). This will expose a `/cdn-cgi/handler/scheduled` route which can be used to test using a HTTP request.
 
 ```sh
 curl "http://localhost:8787/cdn-cgi/handler/scheduled"


### PR DESCRIPTION
### Summary

Update email routing and cron triggers local dev pages to reflect that the local development story is now also supported by the Cloudflare vite plugin.


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
