### PR TITLE
Add changelog for js returned content-type

### DIFF
--- a/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
+++ b/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
@@ -1,0 +1,18 @@
+---
+title: Content type returned in Workers Assets for Javascript files is now `text/javascript`
+description: Updated JavaScript asset responses to use the standardized text/javascript Content-Type header (previously `application/javascript`) for better alignment with the HTML spec and browser expectations.
+products:
+  - workers
+date: 2025-08-25
+---
+
+We updated JavaScript asset responses to use the `text/javascript` Content-Type header instead of `application/javascript`. While both MIME types are widely supported by browsers, the HTML Living Standard explicitly recommends `text/javascript` as the preferred type going forward.
+
+This change improves:
+
+- Standards alignment: Ensures consistency with the HTML spec and modern web platform guidance.
+- Interoperability: Some developer tools, validators, and proxies expect text/javascript and may warn or behave inconsistently with application/javascript.
+- Future-proofing: By following the spec-preferred MIME type, we reduce the risk of deprecation warnings or unexpected behavior in evolving browser environments.
+- Consistency: Most frameworks, CDNs, and hosting providers now default to text/javascript, so this change matches common ecosystem practice.
+
+Because all major browsers accept both MIME types, this update is backwards compatible and should not cause breakage.

--- a/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
+++ b/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
@@ -16,3 +16,5 @@ This change improves:
 - Consistency: Most frameworks, CDNs, and hosting providers now default to text/javascript, so this change matches common ecosystem practice.
 
 Because all major browsers accept both MIME types, this update is backwards compatible and should not cause breakage.
+
+Users will see this change on the next deployment of their assets.

--- a/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
+++ b/src/content/changelog/workers/2025-08-25-workers-assets-javascript-content-type.mdx
@@ -6,7 +6,7 @@ products:
 date: 2025-08-25
 ---
 
-We updated JavaScript asset responses to use the `text/javascript` Content-Type header instead of `application/javascript`. While both MIME types are widely supported by browsers, the HTML Living Standard explicitly recommends `text/javascript` as the preferred type going forward.
+JavaScript asset responses have been updated to use the `text/javascript` Content-Type header instead of `application/javascript`. While both MIME types are widely supported by browsers, the HTML Living Standard explicitly recommends `text/javascript` as the preferred type going forward.
 
 This change improves:
 


### PR DESCRIPTION
### Summary

Provide changelog to users about updated content-type returned for javascript files in Workers Assets.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [n/a] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [n/a] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [n/a] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
