### PR TITLE
Adjust awkward spacing in sql string literal

### DIFF
--- a/src/content/docs/durable-objects/api/storage-api.mdx
+++ b/src/content/docs/durable-objects/api/storage-api.mdx
@@ -91,14 +91,16 @@ export class MyDurableObject extends DurableObject {
     super(ctx, env);
     this.sql = ctx.storage.sql;
 
-    this.sql.exec(`CREATE TABLE IF NOT EXISTS artist(
-      artistid    INTEGER PRIMARY KEY,
-      artistname  TEXT
-    );INSERT INTO artist (artistid, artistname) VALUES
-      (123, 'Alice'),
-      (456, 'Bob'),
-      (789, 'Charlie');`
-    );
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS artist(
+        artistid    INTEGER PRIMARY KEY,
+        artistname  TEXT
+      );
+      INSERT INTO artist (artistid, artistname) VALUES
+        (123, 'Alice'),
+        (456, 'Bob'),
+        (789, 'Charlie');
+    `);
   }
 }
 ````


### PR DESCRIPTION
I offer this change as an excuse to inquire: Is there a reason this example is written this way, to prefer starting one SQL query on the same line as the previous?