### PR TITLE
Remove comment about hashlib ssl limitations

### DIFF
--- a/src/content/docs/workers/languages/python/stdlib.mdx
+++ b/src/content/docs/workers/languages/python/stdlib.mdx
@@ -17,7 +17,6 @@ The full [Python Standard Library](https://docs.python.org/3/library/index.html)
 
 ## Modules with limited functionality
 
-* `hashlib`: Hash algorithms that depend on OpenSSL are not available by default.
 * `decimal`: The decimal module has C (\_decimal) and Python (\_pydecimal) implementations
   with the same functionality. Only the C implementation is available (compiled to WebAssembly)
 * `pydoc`: Help messages for Python builtins are not available


### PR DESCRIPTION
We include ssl by default so this isn't true.

