### PR TITLE
Update create-via-api.mdx

### DIFF
--- a/src/content/docs/fundamentals/api/how-to/create-via-api.mdx
+++ b/src/content/docs/fundamentals/api/how-to/create-via-api.mdx
@@ -12,7 +12,7 @@ Generate new API tokens on the fly via the API. Before you can do this, you must
 
 :::note
 
-The API Token Template ["Create additional tokens"](/fundamentals/api/reference/template/) **must** be used to generate this token. The option for **API Tokens::Edit** is not available in any other template, or in the Custom Token builder.
+The API Token Template [**Create additional tokens**](/fundamentals/api/reference/template/) must be used to generate the token. The option for **API Tokens::Edit** is not available in any other template or in the Custom Token builder.
 :::
 
 ## Generating the initial token

--- a/src/content/docs/fundamentals/api/how-to/create-via-api.mdx
+++ b/src/content/docs/fundamentals/api/how-to/create-via-api.mdx
@@ -10,6 +10,11 @@ import { Render, Tabs, TabItem, APIRequest } from "~/components";
 
 Generate new API tokens on the fly via the API. Before you can do this, you must create an API token in the Cloudflare dashboard that can create subsequent tokens.
 
+:::note
+
+The API Token Template ["Create additional tokens"](/fundamentals/api/reference/template/) **must** be used to generate this token. The option for **API Tokens::Edit** is not available in any other template, or in the Custom Token builder.
+:::
+
 ## Generating the initial token
 
 Before you can create tokens via the API, you need to [generate the initial token](/fundamentals/api/get-started/create-token/) via the Cloudflare dashboard.


### PR DESCRIPTION
### Summary

Added a Note under the initial overview specifying that the "Create additional tokens" template MUST be used as it is the only option which lets a user create this special token. This language is not stated anywhere in the API token documentation, nor on the existing page.

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
