### PR TITLE
Fix AutoRAG sub-folder filter

### DIFF
--- a/src/content/docs/autorag/configuration/metadata.mdx
+++ b/src/content/docs/autorag/configuration/metadata.mdx
@@ -113,7 +113,7 @@ filters: {
     type: "and",
     filters: [
       {
-        type: "gt",
+        type: "gte",
         key: "folder",
         value: "customer-a/",
       },
@@ -129,7 +129,7 @@ filters: {
 This filter identifies paths starting with `customer-a/` by using:
 
 - The `and` condition to combine the effects of the `gt` and `lte` conditions.
-- The `gt` condition to include paths greater than the folder.
+- The `gte` condition to include paths greater than and including the folder itself.
 - The `lte` condition to include paths less than and including the lower case `z` ASCII character.
 
 Together, these conditions effectively select paths that begin with the provided path value.

--- a/src/content/docs/autorag/configuration/metadata.mdx
+++ b/src/content/docs/autorag/configuration/metadata.mdx
@@ -115,7 +115,7 @@ filters: {
       {
         type: "gt",
         key: "folder",
-        value: "customer-a//",
+        value: "customer-a/",
       },
       {
         type: "lte",
@@ -129,7 +129,7 @@ filters: {
 This filter identifies paths starting with `customer-a/` by using:
 
 - The `and` condition to combine the effects of the `gt` and `lte` conditions.
-- The `gt` condition to include paths greater than the `/` ASCII character.
+- The `gt` condition to include paths greater than the folder.
 - The `lte` condition to include paths less than and including the lower case `z` ASCII character.
 
 Together, these conditions effectively select paths that begin with the provided path value.

--- a/src/content/docs/autorag/configuration/metadata.mdx
+++ b/src/content/docs/autorag/configuration/metadata.mdx
@@ -128,7 +128,7 @@ filters: {
 
 This filter identifies paths starting with `customer-a/` by using:
 
-- The `and` condition to combine the effects of the `gt` and `lte` conditions.
+- The `and` condition to combine the effects of the `gte` and `lte` conditions.
 - The `gte` condition to include paths greater than and including the folder itself.
 - The `lte` condition to include paths less than and including the lower case `z` ASCII character.
 

--- a/src/content/docs/autorag/how-to/multitenancy.mdx
+++ b/src/content/docs/autorag/how-to/multitenancy.mdx
@@ -65,7 +65,7 @@ filters: {
       {
         type: "gt",
         key: "folder",
-        value: "customer-a//",
+        value: "customer-a/",
       },
       {
         type: "lte",
@@ -79,7 +79,7 @@ filters: {
 This filter identifies paths starting with `customer-a/` by using:
 
 - The `and` condition to combine the effects of the `gt` and `lte` conditions.
-- The `gt` condition to include paths greater than the `/` ASCII character.
+- The `gt` condition to include paths greater than the folder.
 - The `lte` condition to include paths less than and including the lower case `z` ASCII character.
 
 This filter captures both files `profile.md` and `contract-1.pdf`.

--- a/src/content/docs/autorag/how-to/multitenancy.mdx
+++ b/src/content/docs/autorag/how-to/multitenancy.mdx
@@ -63,7 +63,7 @@ filters: {
     type: "and",
     filters: [
       {
-        type: "gt",
+        type: "gte",
         key: "folder",
         value: "customer-a/",
       },
@@ -78,8 +78,8 @@ filters: {
 
 This filter identifies paths starting with `customer-a/` by using:
 
-- The `and` condition to combine the effects of the `gt` and `lte` conditions.
-- The `gt` condition to include paths greater than the folder.
+- The `and` condition to combine the effects of the `gte` and `lte` conditions.
+- The `gte` condition to include paths greater than and including the folder itself.
 - The `lte` condition to include paths less than and including the lower case `z` ASCII character.
 
 This filter captures both files `profile.md` and `contract-1.pdf`.


### PR DESCRIPTION
I tried the filter with `gt: "user/1//"`, however that didn't yield any files from "user/1/". When I exclude the second "/", it works as expected. I think the issue is that for files directly in the folder, the `gt` with trailing "/" doesn't catch, since the folder is exactly "user/1/", not "user/1/…".

Sample `response.data` from AutoRAG:

```ts
  [
    {
      file_id: 'cb9b94f5-cc24-410f-97b0-8a1d7eb76613',
      filename: 'user/1/summer_clothing_line.csv',
      score: 0.642221,
      attributes: {
          timestamp: 1756299780000,
          folder: "users/1/",
          filename: "summer_clothing_line.csv"
      },
      content: […]
    }
  ]
```

### Summary

<!-- Add context such as the type of documentation being updated or added -->

Fix the ["Starts with" filter for folders](https://developers.cloudflare.com/autorag/configuration/metadata/#starts-with-filter-for-folders) section for files directly in the folder.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
