### PR TITLE
[Ruleset Engine] FieldCatalog: Clear input on Esc key

### DIFF
--- a/src/components/FieldCatalog.tsx
+++ b/src/components/FieldCatalog.tsx
@@ -95,6 +95,11 @@ const FieldCatalog = ({ fields }: { fields: Fields }) => {
 					placeholder="Search fields"
 					value={filters.search}
 					onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+					onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+						if (e.key === "Escape") {
+							setFilters({ ...filters, search: "" });
+						}
+					}}
 				/>
 
 				<div className="mb-8! hidden md:block">

--- a/src/components/FieldCatalog.tsx
+++ b/src/components/FieldCatalog.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useState, type ChangeEvent } from "react";
+import {
+	useEffect,
+	useState,
+	type ChangeEvent,
+	type KeyboardEvent,
+} from "react";
 import FieldBadges from "./fields/FieldBadges";
 import Markdown from "react-markdown";
 import type { CollectionEntry } from "astro:content";
@@ -95,7 +100,7 @@ const FieldCatalog = ({ fields }: { fields: Fields }) => {
 					placeholder="Search fields"
 					value={filters.search}
 					onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-					onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+					onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
 						if (e.key === "Escape") {
 							setFilters({ ...filters, search: "" });
 						}


### PR DESCRIPTION
### Summary

Implement similar behavior to the sidebar search input box in Fields reference (`Esc` key clears the input).

### Screenshots

<img width="1082" height="437" alt="image" src="https://github.com/user-attachments/assets/3f9a8620-29bf-46b0-8cfa-166fb6e85e26" />
