### PR TITLE
deepgram models - edited pricing

### DIFF
--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -81,8 +81,9 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/openai/whisper                    | $0.0005 per audio minute                                   | 41.14 neurons per audio minute                                           |
 | @cf/openai/whisper-large-v3-turbo     | $0.0005 per audio minute                                   | 46.63 neurons per audio minute                                           |
 | @cf/myshell-ai/melotts                | $0.0002 per audio minute                                   | 18.63 neurons per audio minute                                           |
-| @cf/deepgram/aura-1          | $0.015 per 1k characters input <br/>                | 1.36 neurons per 1k characters input <br/>                   |
-| @cf/deepgram/nova-3          | $0.0052 per audio minute output <br/>               | 7.88 neurons per audio minute output <br/>                   |
+| @cf/deepgram/aura-1          | $0.015 per 1k characters input <br/>                | 1,363.64 neurons per 1k characters input <br/>                   |
+| @cf/deepgram/nova-3          | $0.0052 per audio minute output <br/>               | 472.73 neurons per audio minute output <br/>                   |
+| @cf/deepgram/nova-3 (WebSocket)| $0.0092 per audio minute output <br/>               | 836.36 neurons per audio minute output <br/>                   |
 | @cf/pipecat-ai/smart-turn-v2 | $0.00033795 per audio minute input <br/>            | 0.51 neurons per audio minute output <br/>                   |
 
 ## Other model pricing

--- a/src/pages/workers-ai/models/[name].astro
+++ b/src/pages/workers-ai/models/[name].astro
@@ -125,10 +125,9 @@ const isBeta = model.properties.find(
 let hasPlayground = model.task.name === "Text Generation";
 
 // temporary workaround for playground limitations
-if (model.name.includes("@cf/openai/gpt-oss") ) {
+if (model.name.includes("@cf/openai/gpt-oss")) {
 	hasPlayground = false;
 }
-
 
 const author = (authorData as any)[model.name.split("/")[1]];
 
@@ -213,6 +212,28 @@ const starlightPageProps = {
 	}
 
 	<ModelFeatures model={model} />
+	{
+		model.name === "@cf/deepgram/nova-3" && (
+			<Aside>
+				<p>
+					The <a href="/workers-ai/platform/pricing">pricing of this model</a>{" "}
+					is different based on transport.
+				</p>
+				<p>
+					<ul>
+						<li>
+							WebSocket: $0.0092 per audio minute output (836.36 neurons per
+							audio minute output)
+						</li>
+						<li>
+							Regular HTTP: $0.0052 per audio minute output (472.73 neurons per
+							audio minute output)
+						</li>
+					</ul>
+				</p>
+			</Aside>
+		)
+	}
 
 	{
 		hasPlayground && (


### PR DESCRIPTION
fixed neuron pricing
added websocket streaming pricing

TODO
- [x] add note on deepgram nova-3 page explaining websocket pricing is different 

WebSocket: $0.0092 per audio minute output == 836.36 neurons per audio minute output
Regular HTTP: $0.0052 per audio minute output == 472.73 neurons per audio minute output
