### PR TITLE
[Workers] Workers Preview URLs now default to disabled (configuration.mdx, previews.mdx)

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -130,7 +130,7 @@ To toggle Preview URLs for a Worker:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **Workers & Pages** and in **Overview**, select your Worker.
 3. Go to **Settings** > **Domains & Routes**.
-4. On "Preview URLs" click "Enable" or "Disable".
+4. For Preview URLs, click **Enable** or **Disable**.
 5. Confirm your action.
 
 ### From the [Wrangler configuration file](/workers/wrangler/configuration/)

--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -45,7 +45,7 @@ New versions of a Worker are created when you run:
 - [`wrangler versions upload`](/workers/wrangler/commands/#upload)
 - Or when you make edits via the Cloudflare dashboard
 
-These URLs are public by default and available immediately after version creation.
+If Preview URLs have been enabled, they are **public by default** and available immediately after version creation.
 
 :::note
 Minimum required Wrangler version: 3.74.0. Check your version by running `wrangler --version`. To update Wrangler, refer to [Install/Update Wrangler](/workers/wrangler/install-and-update/).
@@ -90,7 +90,7 @@ The resulting alias would be associated with this version, and immediately avail
 
 ## Manage access to Preview URLs
 
-By default, all preview URLs are enabled and available publicly. You can use [Cloudflare Access](/cloudflare-one/policies/access/) to require visitors to authenticate before accessing preview URLs. You can limit access to yourself, your teammates, your organization, or anyone else you specify in your [access policy](/cloudflare-one/policies/access).
+When enabled, all preview URLs are available publicly. You can use [Cloudflare Access](/cloudflare-one/policies/access/) to require visitors to authenticate before accessing preview URLs. You can limit access to yourself, your teammates, your organization, or anyone else you specify in your [access policy](/cloudflare-one/policies/access).
 
 To limit your preview URLs to authorized emails only:
 
@@ -116,41 +116,51 @@ You must press enter after you input your Application domain for it to save. You
 10. Go to the next page.
 11. Add application.
 
-## Disabling Preview URLs
+## Toggle Preview URLs (Enable or Disable)
 
-Disabling Preview URLs will disable routing to both versioned and aliased preview URLs.
+Note:
 
-### Disabling Preview URLs in the dashboard
+- Preview URLs are disabled by default.
+- Disabling Preview URLs will disable routing to both versioned and aliased preview URLs.
 
-To disable Preview URLs for a Worker:
+### From the Dashboard
+
+To toggle Preview URLs for a Worker:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
 2. Go to **Workers & Pages** and in **Overview**, select your Worker.
 3. Go to **Settings** > **Domains & Routes**.
-4. On "Preview URLs" click "Disable".
-5. Confirm you want to disable.
+4. On "Preview URLs" click "Enable" or "Disable".
+5. Confirm your action.
 
-### Disabling Preview URLs in the [Wrangler configuration file](/workers/wrangler/configuration/)
+### From the [Wrangler configuration file](/workers/wrangler/configuration/)
 
 :::note
 Wrangler 3.91.0 or higher is required to use this feature.
 :::
 
-To disable Preview URLs for a Worker, include the following in your Worker's Wrangler file:
+:::note
+Older Wrangler versions will default to Preview URLs being enabled.
+:::
+
+To toggle Preview URLs for a Worker, include any of the following in your Worker's Wrangler file:
 
 <WranglerConfig>
+```toml
+preview_urls = true
+```
+</WranglerConfig>
 
+<WranglerConfig>
 ```toml
 preview_urls = false
 ```
-
 </WranglerConfig>
 
-When you redeploy your Worker with this change, Preview URLs will be disabled.
+If not given, `preview_urls = false` is the default.
 
 :::caution
-
-If you disable Preview URLs in the Cloudflare dashboard but do not update your Worker's Wrangler file with `preview_urls = false`, then Preview URLs will be re-enabled the next time you deploy your Worker with Wrangler.
+If you enable or disable Preview URLs in the Cloudflare dashboard, but do not update your Worker's Wrangler file accordingly, the Preview URLs status will change the next time you deploy your Worker with Wrangler.
 :::
 
 ## Limitations

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -118,7 +118,7 @@ The `main` key is optional for assets-only Workers.
   - Enables use of `*.workers.dev` subdomain to deploy your Worker. If you have a Worker that is only for `scheduled` events, you can set this to `false`. Defaults to `true`. Refer to [types of routes](#types-of-routes).
 
 - `preview_urls` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Enables use of Preview URLs to test your Worker. Defaults to `true`. Refer to [Preview URLs](/workers/configuration/previews).
+  - Enables use of Preview URLs to test your Worker. Defaults to `false`. Refer to [Preview URLs](/workers/configuration/previews).
 
 - `route` <Type text="Route" /> <MetaInfo text="optional" />
   - A route that your Worker should be deployed to. Only one of `routes` or `route` is required. Refer to [types of routes](#types-of-routes).


### PR DESCRIPTION
We're making changes in Wrangler and Dashboard so that Preview URLs default to disabled.

Change the docs to reflect that.

### Summary

Updates the docs about Workers Preview URLs to accurate represent their new disabled by default status.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
