### PR TITLE
IMAGES-1735: Adding segment to documentation

### DIFF
--- a/src/content/docs/images/transform-images/transform-via-url.mdx
+++ b/src/content/docs/images/transform-images/transform-via-url.mdx
@@ -115,6 +115,10 @@ You must specify at least one option. Options are comma-separated (spaces are no
 
 <Render file="saturation" product="images" />
 
+### `segment`
+
+<Render file="segment" product="images" />
+
 ### `sharpen`
 
 <Render file="sharpen" product="images" />

--- a/src/content/docs/images/transform-images/transform-via-workers.mdx
+++ b/src/content/docs/images/transform-images/transform-via-workers.mdx
@@ -103,6 +103,10 @@ The `fetch()` function accepts parameters in the second argument inside the `{cf
 
 <Render file="saturation" product="images" />
 
+### `segment`
+
+<Render file="segment" product="images" />
+
 ### `sharpen`
 
 <Render file="sharpen" product="images" />

--- a/src/content/partials/images/segment.mdx
+++ b/src/content/partials/images/segment.mdx
@@ -1,0 +1,21 @@
+---
+{}
+---
+import { Tabs, TabItem } from "~/components"
+
+Automatically isolates the subject of an image by replacing the background with transparent pixels.
+
+	This feature uses an open-source model called BiRefNet through Workers AI. Read more about Cloudflare's [approach to responsible AI](https://www.cloudflare.com/trust-hub/responsible-ai/).
+
+<Tabs>
+  <TabItem label="URL format">
+    ```js
+    segment=foreground
+    ```
+  </TabItem>
+  <TabItem label="Workers">
+  ```js
+  cf: {segment: "foreground"}
+  ```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<img width="789" height="334" alt="Screenshot 2025-08-28 at 14 27 57" src="https://github.com/user-attachments/assets/fca7a080-11a3-4787-981e-abccf182d4e2" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
