### PR TITLE
D1 tutorial: Clarify that bindings step is automated by CLI

### DIFF
--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -176,7 +176,9 @@ To bind your D1 database to your Worker:
 
 <Tabs syncKey='CLIvDash'> <TabItem label='CLI'>
 
-You create bindings by updating your Wrangler file.
+The CLI in step 2 will automatically add bindings to the Wrangler config file,
+so you can skip this step. You can also update the Wrangler file manually as
+follows:
 
 <Steps>
 


### PR DESCRIPTION
### Summary

If you used the CLI in step 2, it says 
```
✔ Would you like Wrangler to add it on your behalf? › 
```
and if you say yes (the default) it automatically updates the config. So then I get to step 3 and there is nothing to do. I think this helps clarify.