### PR TITLE
Add Python example to d1 tutorial

### DIFF
--- a/src/components/TypeScriptExample.astro
+++ b/src/components/TypeScriptExample.astro
@@ -1,9 +1,7 @@
 ---
 import { z } from "astro:content";
-import tsBlankSpace from "ts-blank-space";
-import { format } from "prettier";
-import { parse } from "node-html-parser";
-import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Code, Tabs } from "@astrojs/starlight/components";
+import { TypeScriptTabs  } from "~/components";
 import type { ComponentProps } from "astro/types";
 
 type Props = z.input<typeof props>;
@@ -19,44 +17,11 @@ const props = z
 
 const { filename, playground, code, omitTabs } = props.parse(Astro.props);
 
-const slot = await Astro.slots.render("default");
-
-const html = parse(slot);
-
-const copy = html.querySelector("div.copy > button");
-
-if (!copy) {
-	throw new Error(
-		`[TypeScriptExample] Unable to find copy button in rendered code block HTML.`,
-	);
-}
-
-let raw = copy.attributes["data-code"];
-
-if (!raw) {
-	throw new Error(
-		`[TypeScriptExample] Unable to find data-code attribute on copy button.`,
-	);
-}
-
-raw = raw.replace(/\u007f/g, "\n");
-
-const js = await format(tsBlankSpace(raw), { parser: "babel", useTabs: true });
-
 const Wrapper = omitTabs ? Fragment : Tabs;
 ---
 
 <Wrapper syncKey="workersExamples">
-	<TabItem label="JavaScript" icon="seti:javascript">
-		<Code
-			{...code}
-			lang="js"
-			code={js}
-			title={filename?.replace(".ts", ".js")}
-			meta={playground ? "playground" : undefined}
-		/>
-	</TabItem>
-	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code {...code} lang="ts" code={raw} title={filename} />
-	</TabItem>
+	<TypeScriptTabs filename={filename} playground={playground} code={code}>
+		<slot />
+	</TypeScriptTabs>
 </Wrapper>

--- a/src/components/TypeScriptTabs.astro
+++ b/src/components/TypeScriptTabs.astro
@@ -1,0 +1,58 @@
+---
+import { z } from "astro:content";
+import tsBlankSpace from "ts-blank-space";
+import { format } from "prettier";
+import { parse } from "node-html-parser";
+import { Code, TabItem } from "@astrojs/starlight/components";
+import type { ComponentProps } from "astro/types";
+
+type Props = z.input<typeof props>;
+
+const props = z
+	.object({
+		filename: z.string().optional(),
+		playground: z.boolean().default(false),
+		code: z.custom<ComponentProps<typeof Code>>().optional(),
+	})
+	.strict();
+
+const { filename, playground, code } = props.parse(Astro.props);
+
+const slot = await Astro.slots.render("default");
+
+const html = parse(slot);
+
+const copy = html.querySelector("div.copy > button");
+
+if (!copy) {
+	throw new Error(
+		`[TypeScriptExample] Unable to find copy button in rendered code block HTML.`,
+	);
+}
+
+let raw = copy.attributes["data-code"];
+
+if (!raw) {
+	throw new Error(
+		`[TypeScriptExample] Unable to find data-code attribute on copy button.`,
+	);
+}
+
+raw = raw.replace(/\u007f/g, "\n");
+
+const js = await format(tsBlankSpace(raw), { parser: "babel", useTabs: true });
+
+---
+
+<TabItem label="JavaScript" icon="seti:javascript">
+    <Code
+        {...code}
+        lang="js"
+        code={js}
+        title={filename?.replace(".ts", ".js")}
+        meta={playground ? "playground" : undefined}
+    />
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+    <Code {...code} lang="ts" code={raw} title={filename} />
+</TabItem>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -57,6 +57,7 @@ export { default as TagsUsage } from "./TagsUsage.astro";
 export { default as TunnelCalculator } from "./TunnelCalculator.astro";
 export { default as Type } from "./Type.astro";
 export { default as TypeScriptExample } from "./TypeScriptExample.astro";
+export { default as TypeScriptTabs } from "./TypeScriptTabs.astro";
 export { default as WranglerCommand } from "./WranglerCommand.astro";
 export { default as WranglerNamespace } from "./WranglerNamespace.astro";
 export { default as WranglerConfig } from "./WranglerConfig.astro";

--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-import { Render, PackageManagers, Steps, FileTree, Tabs, TabItem, TypeScriptExample, WranglerConfig } from "~/components";
+import { Render, PackageManagers, Steps, FileTree, Tabs, TabItem, TypeScriptTabs, WranglerConfig } from "~/components";
 
 This guide instructs you through:
 
@@ -324,7 +324,8 @@ After you have set up your database, run an SQL query from within your Worker.
 2. Clear the content of `index.ts`.
 3. Paste the following code snippet into your `index.ts` file:
 
-    <TypeScriptExample filename="index.ts">
+    <Tabs syncKey="workersExamples">
+    <TypeScriptTabs filename="index.ts">
     ```typescript
     export interface Env {
     	// If you set another name in the Wrangler config file for the value for 'binding',
@@ -352,7 +353,30 @@ After you have set up your database, run an SQL query from within your Worker.
     	},
     } satisfies ExportedHandler<Env>;
     ```
-    </TypeScriptExample>
+    </TypeScriptTabs>
+    <TabItem label="Python" icon="seti:python">
+    ```python title="entry.py"
+    from workers import Response, WorkerEntrypoint
+    from urllib.parse import urlparse
+
+    class Default(WorkerEntrypoint):
+        async def fetch(self, request):
+            pathname = urlparse(request.url).path
+            if pathname == "/api/beverages":
+                query = (
+                    await self.env.DB.prepare(
+                        "SELECT * FROM Customers WHERE CompanyName = ?",
+                    )
+                    .bind("Bs Beverages")
+                    .run()
+                )
+                return Response.json(query.results)
+            return Response(
+                "Call /api/beverages to see everyone who works at Bs Beverages"
+            )
+    ```
+    </TabItem>
+    </Tabs>
 
     In the code above, you:
 


### PR DESCRIPTION
### Summary

Added Python code to the tab switcher for the d1 tutorial.
In order to do this I had to refactor `TypeScriptExample` into `TypeScriptExample` and `TypeScriptTabs`. `TypeScriptExample` creates the `<Tabs>` and then uses `<TypeScriptTabs>` and `<TypeScriptTabs>` creates the two tab items. That way I can add a Python tab to the tab switcher.


### Screenshots (optional)

<img width="756" height="588" alt="image" src="https://github.com/user-attachments/assets/63518258-96ca-44a0-9b1f-c1705708b3b7" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
