### PR TITLE
Add Python example to d1 tutorial

### DIFF
--- a/src/content/docs/d1/get-started.mdx
+++ b/src/content/docs/d1/get-started.mdx
@@ -324,7 +324,8 @@ After you have set up your database, run an SQL query from within your Worker.
 2. Clear the content of `index.ts`.
 3. Paste the following code snippet into your `index.ts` file:
 
-    <TypeScriptExample filename="index.ts">
+    <Tabs syncKey="workersExamples">
+    <TypeScriptExample filename="index.ts" omitTabs={true}>
     ```typescript
     export interface Env {
     	// If you set another name in the Wrangler config file for the value for 'binding',
@@ -353,6 +354,29 @@ After you have set up your database, run an SQL query from within your Worker.
     } satisfies ExportedHandler<Env>;
     ```
     </TypeScriptExample>
+    <TabItem label="Python" icon="seti:python">
+    ```python title="entry.py"
+    from workers import Response, WorkerEntrypoint
+    from urllib.parse import urlparse
+
+    class Default(WorkerEntrypoint):
+        async def fetch(self, request):
+            pathname = urlparse(request.url).path
+            if pathname == "/api/beverages":
+                query = (
+                    await self.env.DB.prepare(
+                        "SELECT * FROM Customers WHERE CompanyName = ?",
+                    )
+                    .bind("Bs Beverages")
+                    .run()
+                )
+                return Response.json(query.results)
+            return Response(
+                "Call /api/beverages to see everyone who works at Bs Beverages"
+            )
+    ```
+    </TabItem>
+    </Tabs>
 
     In the code above, you:
 


### PR DESCRIPTION
### Summary

Added Python code to the tab switcher for the d1 tutorial.

### Screenshots (optional)

<img width="756" height="588" alt="image" src="https://github.com/user-attachments/assets/63518258-96ca-44a0-9b1f-c1705708b3b7" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
