### PR TITLE
Fix uses of env and ctx in Python examples

### DIFF
--- a/src/content/changelog/workers/2025-05-14-python-worker-durable-object.mdx
+++ b/src/content/changelog/workers/2025-05-14-python-worker-durable-object.mdx
@@ -32,7 +32,7 @@ class MyDurableObject(DurableObject):
         return Response(result.greeting)
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env, ctx):
+    async def fetch(self, request):
         url = urlparse(request.url)
         id = env.MY_DURABLE_OBJECT.idFromName(url.path)
         stub = env.MY_DURABLE_OBJECT.get(id)

--- a/src/content/changelog/workers/2025-08-14-new-python-handlers.mdx
+++ b/src/content/changelog/workers/2025-08-14-new-python-handlers.mdx
@@ -16,7 +16,7 @@ Here's an example of how to now define a Worker with a fetch handler:
 from workers import Response, WorkerEntrypoint
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env, ctx):
+    async def fetch(self, request):
         return Response("Hello World!")
 ```
 

--- a/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
+++ b/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
@@ -84,11 +84,11 @@ To create a Python Worker, create an empty file at `src/entry.py`, matching the 
 from workers import Response, WorkerEntrypoint
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         # Do anything else you'd like on request here!
 
         # Query D1 - we'll list all tables in our database in this example
-        results = await env.DB.prepare("PRAGMA table_list").run()
+        results = await self.env.DB.prepare("PRAGMA table_list").run()
         # Return a JSON response
         return Response.json(results)
 

--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -228,9 +228,9 @@ from workers import handler, Response, WorkerEntrypoint
 from urllib.parse import urlparse
 
 class Default(WorkerEntrypoint):
-    async def fetch(request, env, ctx):
+    async def fetch(request):
         url = urlparse(request.url)
-        stub = env.MY_DURABLE_OBJECT.getByName(url.path)
+        stub = self.env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
 ```
@@ -366,9 +366,9 @@ class MyDurableObject(DurableObject):
         return result.greeting
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env, ctx):
+    async def fetch(self, request):
         url = urlparse(request.url)
-        stub = env.MY_DURABLE_OBJECT.getByName(url.path)
+        stub = self.env.MY_DURABLE_OBJECT.getByName(url.path)
         greeting = await stub.say_hello()
         return Response(greeting)
 ```

--- a/src/content/docs/workers/examples/cache-api.mdx
+++ b/src/content/docs/workers/examples/cache-api.mdx
@@ -111,7 +111,7 @@ from pyodide.ffi import create_proxy
 from js import Response, Request, URL, caches, fetch
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, _env, ctx):
+    async def fetch(self, request):
         cache_url = request.url
 
         # Construct the cache key from the cache URL
@@ -133,7 +133,7 @@ class Default(WorkerEntrypoint):
             # will limit the response to be in cache for 10 seconds s-maxage
             # Any changes made to the response here will be reflected in the cached value
             response.headers.append("Cache-Control", "s-maxage=10")
-            ctx.waitUntil(create_proxy(cache.put(cache_key, response.clone())))
+            self.ctx.waitUntil(create_proxy(cache.put(cache_key, response.clone())))
         else:
             print(f"Cache hit for: {request.url}.")
         return response

--- a/src/content/docs/workers/examples/debugging-logs.mdx
+++ b/src/content/docs/workers/examples/debugging-logs.mdx
@@ -124,7 +124,7 @@ async def post_log(data):
 	await fetch(log_url, method="POST", body=data)
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, _env, ctx):
+    async def fetch(self, request):
         # Service configured to receive logs
         response = await fetch(request)
 
@@ -136,7 +136,7 @@ class Default(WorkerEntrypoint):
         except Exception as e:
             # Without ctx.waitUntil(), your fetch() to Cloudflare's
             # logging service may or may not complete
-            ctx.waitUntil(create_proxy(post_log(str(e))))
+            self.ctx.waitUntil(create_proxy(post_log(str(e))))
             # Copy the response and add to header
             response = Response.new(stack, response)
             response.headers["X-Debug-err"] = str(e)

--- a/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
+++ b/src/content/docs/workers/examples/protect-against-timing-attacks.mdx
@@ -77,9 +77,9 @@ from workers import WorkerEntrypoint, Response
 from js import TextEncoder, crypto
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         auth_token = request.headers["Authorization"] or ""
-        secret = env.MY_SECRET_VALUE
+        secret = self.env.MY_SECRET_VALUE
 
         if secret is None:
             return Response("Missing secret binding", status=500)

--- a/src/content/docs/workers/examples/signing-requests.mdx
+++ b/src/content/docs/workers/examples/signing-requests.mdx
@@ -388,74 +388,74 @@ EXPIRY = 60
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
-		# Get the secret key
-		secret_key_data = encoder.encode(self.env.SECRET_DATA if hasattr(self.env, "SECRET_DATA") else "my secret symmetric key")
+        # Get the secret key
+        secret_key_data = encoder.encode(getattr(self.env, "SECRET_DATA", None) or "my secret symmetric key")
 
-		# Import the secret as a CryptoKey for both 'sign' and 'verify' operations
-		key = await crypto.subtle.importKey(
-			"raw",
-			secret_key_data,
-			to_js({"name": "HMAC", "hash": "SHA-256"}),
-			False,
-			["sign", "verify"]
-		)
+        # Import the secret as a CryptoKey for both 'sign' and 'verify' operations
+        key = await crypto.subtle.importKey(
+            "raw",
+            secret_key_data,
+            to_js({"name": "HMAC", "hash": "SHA-256"}),
+            False,
+            ["sign", "verify"]
+        )
 
-		url = URL.new(request.url)
+        url = URL.new(request.url)
 
-		if url.pathname.startswith("/generate/"):
-			url.pathname = url.pathname.replace("/generate/", "/", 1)
+        if url.pathname.startswith("/generate/"):
+            url.pathname = url.pathname.replace("/generate/", "/", 1)
 
-			timestamp = int(Date.now() / 1000)
+            timestamp = int(Date.now() / 1000)
 
-			# Data to authenticate
-			data_to_authenticate = f"{url.pathname}{timestamp}"
+            # Data to authenticate
+            data_to_authenticate = f"{url.pathname}{timestamp}"
 
-			# Sign the data
-			mac = await crypto.subtle.sign(
-				"HMAC",
-				key,
-				encoder.encode(data_to_authenticate)
-			)
+            # Sign the data
+            mac = await crypto.subtle.sign(
+                "HMAC",
+                key,
+                encoder.encode(data_to_authenticate)
+            )
 
-			# Convert to base64
-			base64_mac = Buffer.from(mac).toString("base64")
+            # Convert to base64
+            base64_mac = Buffer.from(mac).toString("base64")
 
-			# Set the verification parameter
-			url.searchParams.set("verify", f"{timestamp}-{base64_mac}")
+            # Set the verification parameter
+            url.searchParams.set("verify", f"{timestamp}-{base64_mac}")
 
-			return Response.new(f"{url.pathname}{url.search}")
-		else:
-			# Verify the request
-			if not "verify" in url.searchParams:
-				return Response.new("Missing query parameter", status=403)
+            return Response.new(f"{url.pathname}{url.search}")
+        else:
+            # Verify the request
+            if not "verify" in url.searchParams:
+                return Response.new("Missing query parameter", status=403)
 
-			verify_param = url.searchParams.get("verify")
-			timestamp, hmac = verify_param.split("-")
+            verify_param = url.searchParams.get("verify")
+            timestamp, hmac = verify_param.split("-")
 
-			asserted_timestamp = int(timestamp)
+            asserted_timestamp = int(timestamp)
 
-			data_to_authenticate = f"{url.pathname}{asserted_timestamp}"
+            data_to_authenticate = f"{url.pathname}{asserted_timestamp}"
 
-			received_mac = Buffer.from(hmac, "base64")
+            received_mac = Buffer.from(hmac, "base64")
 
-			# Verify the signature
-			verified = await crypto.subtle.verify(
-				"HMAC",
-				key,
-				received_mac,
-				encoder.encode(data_to_authenticate)
-			)
+            # Verify the signature
+            verified = await crypto.subtle.verify(
+                "HMAC",
+                key,
+                received_mac,
+                encoder.encode(data_to_authenticate)
+            )
 
-			if not verified:
-				return Response.new("Invalid MAC", status=403)
+            if not verified:
+                return Response.new("Invalid MAC", status=403)
 
-			# Check expiration
-			if Date.now() / 1000 > asserted_timestamp + EXPIRY:
-				expiry_date = Date.new((asserted_timestamp + EXPIRY) * 1000)
-				return Response.new(f"URL expired at {expiry_date}", status=403)
+            # Check expiration
+            if Date.now() / 1000 > asserted_timestamp + EXPIRY:
+                expiry_date = Date.new((asserted_timestamp + EXPIRY) * 1000)
+                return Response.new(f"URL expired at {expiry_date}", status=403)
 
-		# Proxy to example.com if verification passes
-		return fetch(URL.new(f"https://example.com{url.pathname}"), request)
+        # Proxy to example.com if verification passes
+        return fetch(URL.new(f"https://example.com{url.pathname}"), request)
 ```
 
 </TabItem> </Tabs>

--- a/src/content/docs/workers/examples/signing-requests.mdx
+++ b/src/content/docs/workers/examples/signing-requests.mdx
@@ -387,9 +387,9 @@ encoder = TextEncoder.new()
 EXPIRY = 60
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
 		# Get the secret key
-		secret_key_data = encoder.encode(env.SECRET_DATA if hasattr(env, "SECRET_DATA") else "my secret symmetric key")
+		secret_key_data = encoder.encode(self.env.SECRET_DATA if hasattr(self.env, "SECRET_DATA") else "my secret symmetric key")
 
 		# Import the secret as a CryptoKey for both 'sign' and 'verify' operations
 		key = await crypto.subtle.importKey(

--- a/src/content/docs/workers/examples/turnstile-html-rewriter.mdx
+++ b/src/content/docs/workers/examples/turnstile-html-rewriter.mdx
@@ -217,9 +217,9 @@ from pyodide.ffi import create_proxy
 from js import HTMLRewriter, fetch
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
-        site_key = env.SITE_KEY
-        attr_name = env.TURNSTILE_ATTR_NAME
+    async def fetch(self, request):
+        site_key = self.env.SITE_KEY
+        attr_name = self.env.TURNSTILE_ATTR_NAME
         res = await fetch(request)
 
         class Append:
@@ -264,7 +264,7 @@ async function handlePost(request, env) {
     let formData = new FormData();
 
     // `secret_key` here is the Turnstile Secret key, which should be set using Wrangler secrets
-    formData.append('secret', env.SECRET_KEY);
+    formData.append('secret', self.env.SECRET_KEY);
     formData.append('response', token);
     formData.append('remoteip', ip); //This is optional.
 

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -18,7 +18,7 @@ from workers import WorkerEntrypoint, Response
 from urllib.parse import urlparse, parse_qs
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         # Parse the incoming request URL
         url = urlparse(request.url)
         # Parse the query parameters into a Python dictionary
@@ -89,7 +89,7 @@ def to_js(obj):
    return _to_js(obj, dict_converter=Object.fromEntries)
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         # Bindings are available on the 'env' parameter
         # https://developers.cloudflare.com/queues/
 
@@ -109,7 +109,7 @@ class Default(WorkerEntrypoint):
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         results = await env.DB.prepare("PRAGMA table_list").run()
         # Return a JSON response
         return Response.json(results)

--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -90,14 +90,14 @@ def to_js(obj):
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
-        # Bindings are available on the 'env' parameter
+        # Bindings are available on the 'env' attribute
         # https://developers.cloudflare.com/queues/
 
         # The default contentType is "json"
         # We can also pass plain text strings
-        await env.QUEUE.send("hello", contentType="text")
+        await self.env.QUEUE.send("hello", contentType="text")
         # Send a JSON payload
-        await env.QUEUE.send(to_js({"hello": "world"}))
+        await self.env.QUEUE.send(to_js({"hello": "world"}))
 
         # Return a response
         return Response.json({"write": "success"})
@@ -110,7 +110,7 @@ from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
-        results = await env.DB.prepare("PRAGMA table_list").run()
+        results = await self.env.DB.prepare("PRAGMA table_list").run()
         # Return a JSON response
         return Response.json(results)
 ```

--- a/src/content/docs/workers/languages/python/ffi.mdx
+++ b/src/content/docs/workers/languages/python/ffi.mdx
@@ -41,9 +41,9 @@ kv_namespaces = [
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
-        await env.FOO.put("bar", "baz")
-        bar = await env.FOO.get("bar")
+    async def fetch(self, request):
+        await self.env.FOO.put("bar", "baz")
+        bar = await self.env.FOO.get("bar")
         return Response(bar) # returns "baz"
 ```
 

--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -146,8 +146,8 @@ Then, you can access the `API_HOST` environment variable via the `env` parameter
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
-        return Response(env.API_HOST)
+    async def fetch(self, request):
+        return Response(self.env.API_HOST)
 ```
 
 ## Further Reading

--- a/src/content/docs/workers/languages/python/packages/fastapi.mdx
+++ b/src/content/docs/workers/languages/python/packages/fastapi.mdx
@@ -35,10 +35,10 @@ from fastapi import FastAPI, Request
 from pydantic import BaseModel
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         import asgi
 
-        return await asgi.fetch(app, request, env)
+        return await asgi.fetch(app, request, self.env)
 
 app = FastAPI()
 

--- a/src/content/docs/workers/languages/python/packages/langchain.mdx
+++ b/src/content/docs/workers/languages/python/packages/langchain.mdx
@@ -37,9 +37,9 @@ from langchain_core.prompts import PromptTemplate
 from langchain_openai import OpenAI
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
+    async def fetch(self, request):
         prompt = PromptTemplate.from_template("Complete the following sentence: I am a {profession} and ")
-        llm = OpenAI(api_key=env.API_KEY)
+        llm = OpenAI(api_key=self.env.API_KEY)
         chain = prompt | llm
 
         res = await chain.ainvoke({"profession": "electrician"})

--- a/src/content/docs/workers/platform/infrastructure-as-code.mdx
+++ b/src/content/docs/workers/platform/infrastructure-as-code.mdx
@@ -158,8 +158,8 @@ curl https://api.cloudflare.com/client/v4/accounts/<account_id>/workers/scripts/
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env):
-        return Response(env.MESSAGE)
+    async def fetch(self, request):
+        return Response(self.env.MESSAGE)
 EOF
 ```
 

--- a/src/content/partials/workers/service-binding-rpc-example.mdx
+++ b/src/content/partials/workers/service-binding-rpc-example.mdx
@@ -41,7 +41,7 @@ export default class extends WorkerEntrypoint {
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env, ctx):
+    async def fetch(self, request):
         return Response("Hello from Worker B")
 
     def add(self, a: int, b: int) -> int:
@@ -91,8 +91,8 @@ export default {
 from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
-    async def fetch(self, request, env, ctx):
-        result = await env.WORKER_B.add(1, 2)
+    async def fetch(self, request):
+        result = await self.env.WORKER_B.add(1, 2)
 		return Response(f"Result: {result}")
 ```
 


### PR DESCRIPTION
### Summary

Since #24392, most of the Python examples use env and ctx incorrectly. This fixes it.

I also replaced all tabs with spaces in signing-requests.mdx.
