### PR TITLE
Tidy up the Python durable object example

### DIFF
--- a/src/content/docs/durable-objects/get-started.mdx
+++ b/src/content/docs/durable-objects/get-started.mdx
@@ -169,13 +169,10 @@ export class MyDurableObject extends DurableObject<Env> {
 from workers import DurableObject
 
 class MyDurableObject(DurableObject):
-    def __init__(self, ctx, env):
-        super().__init__(ctx, env)
-
     async def say_hello(self):
-        result = self.ctx.storage.sql \
-            .exec("SELECT 'Hello, World!' as greeting") \
-            .one()
+        result = self.ctx.storage.sql.exec(
+            "SELECT 'Hello, World!' as greeting"
+        ).one()
 
         return result.greeting
 ```
@@ -355,13 +352,10 @@ from workers import DurableObject, handler, Response
 from urllib.parse import urlparse
 
 class MyDurableObject(DurableObject):
-    def __init__(self, ctx, env):
-        super().__init__(ctx, env)
-
     async def say_hello(self):
-        result = self.ctx.storage.sql \
-            .exec("SELECT 'Hello, World!' as greeting") \
-            .one()
+        result = self.ctx.storage.sql.exec(
+            "SELECT 'Hello, World!' as greeting"
+        ).one()
 
         return result.greeting
 


### PR DESCRIPTION
Made it a bit shorter and applied an automated formatter to it.
