### PR TITLE
fix: add warnings for realtime agents

### DIFF
--- a/src/content/docs/realtime/agents/getting-started.mdx
+++ b/src/content/docs/realtime/agents/getting-started.mdx
@@ -11,6 +11,10 @@ description: Deploy your first Realtime Agent using the CLI.
 
 import { Render, PackageManagers, WranglerConfig, TypeScriptExample } from "~/components";
 
+:::caution
+This guide is experimental, Realtime agents will be consolidated into the [Agents SDK](/agents/) in a future release
+:::
+
 This guide will instruct you through setting up and deploying your first Realtime Agents project. You will use [Workers](/workers/), the Realtime Agents SDK, a Workers AI binding, and a large language model (LLM) to deploy your first AI-powered application on the Cloudflare global network.
 
 <Render file="prereqs" product="workers" />


### PR DESCRIPTION
Add warning "This guide is experimental, Realtime agents will be consolidated into the Agents SDK in a future release" to Realtime Agents