### PR TITLE
fix indent issue in nextjs docs

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
@@ -165,8 +165,10 @@ You can convert an existing Next.js application to run on Cloudflare
     <Details header="Usage">
     	- `preview`: Builds your app and serves it locally, allowing you to
     	quickly preview your app running locally in the Workers runtime, via a
-    	single command. - `deploy`: Builds your app, and then deploys it to
-    	Cloudflare - `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the
+    	single command. 
+			- `deploy`: Builds your app, and then deploys it to
+    	Cloudflare 
+			- `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the
     	root of your project containing the types for the env.
     </Details>
 

--- a/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
@@ -165,10 +165,10 @@ You can convert an existing Next.js application to run on Cloudflare
     <Details header="Usage">
     	- `preview`: Builds your app and serves it locally, allowing you to
     	quickly preview your app running locally in the Workers runtime, via a
-    	single command. 
-			- `deploy`: Builds your app, and then deploys it to
-    	Cloudflare 
-			- `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the
+    	single command.
+		- `deploy`: Builds your app, and then deploys it to
+    	Cloudflare
+		- `cf-typegen`: Generates a `cloudflare-env.d.ts` file at the
     	root of your project containing the types for the env.
     </Details>
 


### PR DESCRIPTION
### Summary

The indent in https://developers.cloudflare.com/workers/framework-guides/web-apps/nextjs/ is wrong.

### Screenshots (optional)

<img width="936" height="527" alt="image" src="https://github.com/user-attachments/assets/411207a3-d24f-411b-90a7-96f6bfac558f" />

### Documentation checklist

NA
