### PR TITLE
Closes #24819 : Network Solutions link is dead

### DIFF
--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -35,7 +35,7 @@ To begin, complete the following steps in your current registrar to transfer you
 - [GoDaddy](https://www.godaddy.com/help/transfer-my-domain-away-from-godaddy-3560)
 - [Ionos by 1&1](https://www.ionos.com/help/domains/domain-transfers/#acc4514)
 - [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/258/84/what-should-i-do-to-transfer-a-domain-from-namecheap/)
-- [Network Solutions](https://customerservice.networksolutions.com/prweb/PRAuth/webkm/help/article/KC-474/networksolutions)
+- [Network Solutions](https://www.networksolutions.com/help/article/domain-transfer-process)
 - [Squarespace](https://support.squarespace.com/hc/articles/205812338-Transferring-a-domain-away-from-Squarespace)
 
 ### 1. Log in to your registrar account

--- a/src/content/docs/workers-ai/features/prompting.mdx
+++ b/src/content/docs/workers-ai/features/prompting.mdx
@@ -56,8 +56,18 @@ Typically, the role can be one of three options:
   use them to set rules and how you expect the AI to behave.
 - <strong>user</strong> - User messages are where you actually query the AI by
   providing a question or a conversation.
-- <strong>assistant</strong> - Assistant messages hint to the AI about the
-  desired output format. Not all models support this role.
+- **assistant** – Assistant messages can be used to guide the AI toward a desired output format 
+  (for example, enforcing JSON structure or Markdown formatting). 
+
+  ⚠️ **Model support:** Not all Workers AI text-generation models currently support the `assistant` role. 
+  Models based on chat-style templates (such as LLaMA 2 Chat or Mistral-Instruct) are more likely to respect it, 
+  while some base instruct models may ignore these messages. 
+
+  If you include `assistant` in your prompt with a model that doesn’t support it, the message will simply be ignored.  
+
+  ✅ **Recommendation:** For best results, use **scoped prompts**, which provide a unified interface across models. 
+  This way, your application logic doesn’t depend on which roles each model implements. 
+
 
 OpenAI has a [good explanation](https://platform.openai.com/docs/guides/text-generation#messages-and-roles) of how they use these roles with their GPT models. Even though chat templates are flexible, other text generation models tend to follow the same conventions.
 


### PR DESCRIPTION
### Summary
Closes #24819 : Network Solutions link is dead
This PR updates the broken external link to Network Solutions in the Domain transfer to Cloudflare Registrar documentation. The original link returned a 410 Gone error, so it has been replaced with the current working Network Solutions support page.


Please note: this contains the fix for Issue #24821 as well, a separate PR has been opened for that.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
