### PR TITLE
fix realtime kit dead link

### DIFF
--- a/src/content/docs/realtime/realtimekit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/index.mdx
@@ -22,9 +22,6 @@ Powerful yet simple to use, RealtimeKit is built on top of WebRTC and provides a
 
 Learn more about the [concepts](/realtime/realtimekit/concepts/) behind RealtimeKit, [how it works](/realtime/realtimekit/introduction/#how-realtimekit-works), and [use cases](/realtime/realtimekit/introduction/#use-cases).
 
-<LinkButton variant="primary" href="/realtime/realtimekit/getting-started/">
-	Get started
-</LinkButton>
 <LinkButton
 	variant="secondary"
 	href="https://dash.cloudflare.com/?to=/:account/realtime/kit"


### PR DESCRIPTION
### Summary

Remove getting started button from realtimekit
