### PR TITLE
Remove unsafe from Rate Limiting API bindings

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
@@ -30,7 +30,7 @@ First, add a [binding](/workers/runtime-apis/bindings) to your Worker that gives
 ```toml
 main = "src/index.js"
 
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "MY_RATE_LIMITER"
 type = "ratelimit"
 # An identifier you define, that is unique to your Cloudflare account.
@@ -104,14 +104,14 @@ For example, here is how you can define two rate limiting configurations for fre
 main = "src/index.js"
 
 # Free user rate limiting
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "FREE_USER_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 100, period = 60 }
 
 # Paid user rate limiting
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "PAID_USER_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1002"
@@ -135,7 +135,7 @@ For example, to apply a rate limit of 1500 requests per minute, you would define
 <WranglerConfig>
 
 ```toml
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "MY_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1001"


### PR DESCRIPTION
### Summary

[Rate Limiting in Workers ](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) is now generally available. `ratelimit` binding is now stable and does not require unsafe annotation.

Old unsafe bindings should continue to work as before for now.  
### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
