### PR TITLE
document nodejs_process_v2 compat flag

### DIFF
--- a/src/content/compatibility-flags/nodejs-compat-process-v2.md
+++ b/src/content/compatibility-flags/nodejs-compat-process-v2.md
@@ -6,7 +6,7 @@ enable_flag: "enable_nodejs_process_v2"
 disable_flag: "disable_nodejs_process_v2"
 ---
 
-When enabled, the `enable_nodejs_process_v2` flag along with the [`nodejs_compat`](/workers/runtime-apis/nodejs/) compat flag
+When enabled after 2025-09-15, the `enable_nodejs_process_v2` flag along with the [`nodejs_compat`](/workers/runtime-apis/nodejs/) compat flag
 ensures a comprehensive Node.js-compatible `process` implementation, updating from the previous minimal process implementation
 that only provided the limited `nextTick`, `env`, `exit`, `getBuiltinModule`, `platform` and `features` properties.
 

--- a/src/content/compatibility-flags/nodejs-compat-process-v2.md
+++ b/src/content/compatibility-flags/nodejs-compat-process-v2.md
@@ -12,4 +12,4 @@ that only provided the limited `nextTick`, `env`, `exit`, `getBuiltinModule`, `p
 
 To continue using the previous minimal implementation after the compat date, set the `disable_nodejs_process_v2` flag instead.
 
-Most Node.js-supported process properties are implemented where possible, with undefined exports for unsupported features. See the Wo[process documentation](/workers/runtime-apis/nodejs/process/) for Workers-specific implementation details.
+Most Node.js-supported process properties are implemented where possible, with undefined exports for unsupported features. See the [process documentation](/workers/runtime-apis/nodejs/process/) for Workers-specific implementation details.

--- a/src/content/compatibility-flags/nodejs-compat-process-v2.md
+++ b/src/content/compatibility-flags/nodejs-compat-process-v2.md
@@ -1,0 +1,15 @@
+---
+name: "Enable `process` v2 implementation"
+sort_date: "2025-09-15"
+enable_date: "2025-09-15"
+enable_flag: "enable_nodejs_process_v2"
+disable_flag: "disable_nodejs_process_v2"
+---
+
+When enabled, the `enable_nodejs_process_v2` flag along with the [`nodejs_compat`](/workers/runtime-apis/nodejs/) compat flag
+ensures a comprehensive Node.js-compatible `process` implementation, updating from the previous minimal process implementation
+that only provided the limited `nextTick`, `env`, `exit`, `getBuiltinModule`, `platform` and `features` properties.
+
+To continue using the previous minimal implementation after the compat date, set the `disable_nodejs_process_v2` flag instead.
+
+Most Node.js-supported process properties are implemented where possible, with undefined exports for unsupported features. See the Wo[process documentation](/workers/runtime-apis/nodejs/process/) for Workers-specific implementation details.

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -47,20 +47,20 @@ The runtime APIs from Node.js listed below as "🟢 supported" are currently nat
 | Events                                                                               | 🟢 supported                              |
 | File system                                                                          | ⚪ coming soon                            |
 | Globals                                                                              | 🟢 supported                              |
-| HTTP                                                                                 | 🟢 supported                              |
+| [HTTP](/workers/runtime-apis/nodejs/http/)                                           | 🟢 supported                              |
 | HTTP/2                                                                               | ⚪ not yet supported                      |
-| HTTPS                                                                                | 🟢 supported                              |
+| [HTTPS](/workers/runtime-apis/nodejs/https/)                                         | 🟢 supported                              |
 | Inspector                                                                            | 🟢 supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/) |
 | [Net](/workers/runtime-apis/nodejs/net/)                                             | 🟢 supported                              |
 | OS                                                                                   | ⚪ not yet supported                      |
 | [Path](/workers/runtime-apis/nodejs/path/)                                           | 🟢 supported                              |
 | Performance hooks                                                                    | 🟡 partially supported                    |
-| Process                                                                              | 🟢 supported                              |
+| [Process](/workers/runtime-apis/nodejs/process/)                                     | 🟢 supported                              |
 | Query strings                                                                        | 🟢 supported                              |
-| Stream                                                                               | 🟢 supported                              |
+| [Stream](/workers/runtime-apis/nodejs/streams/)                                      | 🟢 supported                              |
 | [String decoder](/workers/runtime-apis/nodejs/string-decoder/)                       | 🟢 supported                              |
 | [Timers](/workers/runtime-apis/nodejs/timers/)                                       | 🟢 supported                              |
-| TLS/SSL                                                                              | 🟡 partially supported                    |
+| [TLS/SSL](/workers/runtime-apis/nodejs/tls/)                                         | 🟡 partially supported                    |
 | UDP/datagram                                                                         | ⚪ not yet supported                      |
 | [URL](/workers/runtime-apis/nodejs/url/)                                             | 🟢 supported                              |
 | [Utilities](/workers/runtime-apis/nodejs/util/)                                      | 🟢 supported                              |

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -87,8 +87,7 @@ nextTick(() => {
 ## Stdio
 
 [`process.stdout`](https://nodejs.org/docs/latest/api/process.html#processstdout), [`process.stderr`](https://nodejs.org/docs/latest/api/process.html#processstderr) and [`process.stdin`](https://nodejs.org/docs/latest/api/process.html#processstdin) are supported as streams. `stdin` is treated as an empty readable stream.
-`stdout` and `stderr` are treated as non-TTY writable streams, with line buffering when integrating with inspector and structured
-logging output.
+`stdout` and `stderr` are non-TTY writable streams, which output to normal logging output only with `stdout: ` and `stderr: ` prefixing.
 
 The line buffer works by storing writes to stdout or stderr until either a newline character `\n` is encountered or until the next microtask, when the log is then flushed to the output.
 

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -106,7 +106,7 @@ While [`process.hrtime`](https://nodejs.org/docs/latest/api/process.html#process
 
 ## Unsupported Features
 
-The following process properties are currently entirely unsupported and return `undefined`: `binding`, `channel`, `connected`, `debugPort`, `dlopen`,
+The following `process` properties are currently entirely unsupported and return `undefined`: `binding`, `channel`, `connected`, `debugPort`, `dlopen`,
 `exitCode`, `finalization`, `getActiveResourcesInfo`, `hasUncaughtExceptionCaptureCallback`, `kill`, `memoryUsage`, `noDeprecation`, `permission`,
 `ref`, `release`, `report`, `resourceUsage`, `send`, `setUncaughtExceptionCaptureCallback`, `sourceMapsEnabled`, `threadCpuUsage`,
 `throwDeprecation`, `traceDeprecation`, `unref`.

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -92,22 +92,7 @@ logging output.
 
 The line buffer works by storing writes to stdout or stderr until either a newline character `\n` is encountered or until the next microtask, when the log is then flushed to the output.
 
-This way, synchronous writes without newline characters will always remain contiguous on the same line. For example, the following will behave as if calling `console.log('one')` followed by `console.log('two')`:
-
-```js
-// equivalent to `console.log('one');`
-process.stdout.write('o');
-process.stdout.write('n');
-process.stdout.write('e');
-await 0;
-// equivalent to `console.log('two')`
-process.stdout.write('t');
-process.stdout.write('w');
-process.stdout.write('o');
-process.stdout.write('\n');
-// equivalent to `console.log('')`
-process.stdout.write('\n');
-```
+This ensures compatibility with inspector and structured logging outputs.
 
 ## Filesystem
 

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -94,7 +94,7 @@ The line buffer works by storing writes to stdout or stderr until either a newli
 
 This ensures compatibility with inspector and structured logging outputs.
 
-## Filesystem
+## Current Working Directory
 
 [`process.cwd()`](https://nodejs.org/docs/latest/api/process.html#processcwd) is the _current workding directory_, used as the default path for all filesystem operations, and is initialized to `/bundle`.
 

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -7,18 +7,14 @@ import { Render } from "~/components";
 
 <Render file="nodejs-compat-howto" product="workers" />
 
-The [`process`](https://nodejs.org/dist/latest-v19.x/docs/api/process.html) module in Node.js provides a number of useful APIs related to the current process. Within a serverless environment like Workers, most of these APIs are not relevant or meaningful, but some are useful for cross-runtime compatibility. Within Workers, the following APIs are available:
+The [`process`](https://nodejs.org/dist/latest-v22.x/docs/api/process.html) module in Node.js provides a number of useful APIs related to the current process.
 
-```js
-import { env, nextTick } from "node:process";
+Initially Workers only supported `nextTick`, `env`, `exit`, `getBuiltinModule`, `platform` and `features` on process,
+which was then updated with the [`enable_nodejs_process_v2`](/workers/configuration/compatibility-flags/#enable-process-v2-implementation) flag to include most Node.js process features.
 
-env["FOO"] = "bar";
-console.log(env["FOO"]); // Prints: bar
+Refer to the [Node.js documentation for `process`](https://nodejs.org/dist/latest-v22.x/docs/api/process.html) for more information.
 
-nextTick(() => {
-	console.log("next tick");
-});
-```
+Workers-specific implementation details apply when adapting Node.js support for a serverless environment, which are described in more detail below.
 
 ## `process.env`
 
@@ -77,5 +73,66 @@ process.env === env; // false! they are no longer the same object
 
 The Workers implementation of `process.nextTick()` is a wrapper for the standard Web Platform API [`queueMicrotask()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask).
 
-Refer to the [Node.js documentation for `process`](https://nodejs.org/dist/latest-v19.x/docs/api/process.html) for more information.
+```js
+import { env, nextTick } from "node:process";
+
+env["FOO"] = "bar";
+console.log(env["FOO"]); // Prints: bar
+
+nextTick(() => {
+	console.log("next tick");
+});
 ```
+
+## Stdio
+
+`process.stdout`, `process.stderr` and `process.stdin` are supported as streams. `stdin` is treated as an empty readable stream.
+`stdout` and `stderr` are treated as non-TTY writable streams, with line buffering when integrating with inspector and structured
+logging output.
+
+The line buffer is cleared by either a newline or the next microtask, so that synchronous writes without newline characters will always
+remain contiguous on the same line.
+
+For example, the following will behave as if calling `console.log('one')` followed by `console.log('two')`:
+
+```js
+// equivalent to `console.log('one');`
+process.stdout.write('o');
+process.stdout.write('n');
+process.stdout.write('e');
+await 0;
+// equivalent to `console.log('two')`
+process.stdout.write('t');
+process.stdout.write('w');
+process.stdout.write('o');
+process.stdout.write('\n');
+// equivalent to `console.log('')`
+process.stdout.write('\n');
+```
+
+## Filesystem
+
+`process.cwd()` is initialized to `/bundle`.
+
+`process.chdir()` may be used to alter the current working directory, and is respected by FS operations when using `enable_nodejs_fs_module`.
+
+## Hrtime
+
+`process.hrtime` is now available, but currently provides an unaccurate timer for compatiblity only.
+
+## Unsupported Features
+
+The following process properties are currently entirely unsupported and return `undefined`: `binding`, `channel`, `connected`, `debugPort`, `dlopen`,
+`exitCode`, `finalization`, `getActiveResourcesInfo`, `hasUncaughtExceptionCaptureCallback`, `kill`, `memoryUsage`, `noDeprecation`, `permission`,
+`ref`, `release`, `report`, `resourceUsage`, `send`, `setUncaughtExceptionCaptureCallback`, `sourceMapsEnabled`, `threadCpuUsage`,
+`throwDeprecation`, `traceDeprecation`, `unref`.
+
+These unimplemented features may be feature-detected via conditional gating patterns like:
+
+```js
+if (process.dlopen) {
+	// use dlopen when available
+}
+```
+
+Any of these remaining unimplemented features may be implemented in future.

--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -7,14 +7,14 @@ import { Render } from "~/components";
 
 <Render file="nodejs-compat-howto" product="workers" />
 
-The [`process`](https://nodejs.org/dist/latest-v22.x/docs/api/process.html) module in Node.js provides a number of useful APIs related to the current process.
+The [`process`](https://nodejs.org/docs/latest/api/process.html) module in Node.js provides a number of useful APIs related to the current process.
 
 Initially Workers only supported `nextTick`, `env`, `exit`, `getBuiltinModule`, `platform` and `features` on process,
 which was then updated with the [`enable_nodejs_process_v2`](/workers/configuration/compatibility-flags/#enable-process-v2-implementation) flag to include most Node.js process features.
 
-Refer to the [Node.js documentation for `process`](https://nodejs.org/dist/latest-v22.x/docs/api/process.html) for more information.
+Refer to the [Node.js documentation for `process`](https://nodejs.org/docs/latest/api/process.html) for more information.
 
-Workers-specific implementation details apply when adapting Node.js support for a serverless environment, which are described in more detail below.
+Workers-specific implementation details apply when adapting Node.js process support for a serverless environment, which are described in more detail below.
 
 ## `process.env`
 
@@ -86,14 +86,13 @@ nextTick(() => {
 
 ## Stdio
 
-`process.stdout`, `process.stderr` and `process.stdin` are supported as streams. `stdin` is treated as an empty readable stream.
+[`process.stdout`](https://nodejs.org/docs/latest/api/process.html#processstdout), [`process.stderr`](https://nodejs.org/docs/latest/api/process.html#processstderr) and [`process.stdin`](https://nodejs.org/docs/latest/api/process.html#processstdin) are supported as streams. `stdin` is treated as an empty readable stream.
 `stdout` and `stderr` are treated as non-TTY writable streams, with line buffering when integrating with inspector and structured
 logging output.
 
-The line buffer is cleared by either a newline or the next microtask, so that synchronous writes without newline characters will always
-remain contiguous on the same line.
+The line buffer works by storing writes to stdout or stderr until either a newline character `\n` is encountered or until the next microtask, when the log is then flushed to the output.
 
-For example, the following will behave as if calling `console.log('one')` followed by `console.log('two')`:
+This way, synchronous writes without newline characters will always remain contiguous on the same line. For example, the following will behave as if calling `console.log('one')` followed by `console.log('two')`:
 
 ```js
 // equivalent to `console.log('one');`
@@ -112,13 +111,13 @@ process.stdout.write('\n');
 
 ## Filesystem
 
-`process.cwd()` is initialized to `/bundle`.
+[`process.cwd()`](https://nodejs.org/docs/latest/api/process.html#processcwd) is the _current workding directory_, used as the default path for all filesystem operations, and is initialized to `/bundle`.
 
-`process.chdir()` may be used to alter the current working directory, and is respected by FS operations when using `enable_nodejs_fs_module`.
+[`process.chdir()`](https://nodejs.org/docs/latest/api/process.html#processchdirdirectory) allows modifying the `cwd` and is respected by FS operations when using `enable_nodejs_fs_module`.
 
 ## Hrtime
 
-`process.hrtime` is now available, but currently provides an unaccurate timer for compatiblity only.
+While [`process.hrtime`](https://nodejs.org/docs/latest/api/process.html#processhrtimetime) high-resolution timer is available, it provides an inaccurate timer for compatibility only.
 
 ## Unsupported Features
 
@@ -134,5 +133,3 @@ if (process.dlopen) {
 	// use dlopen when available
 }
 ```
-
-Any of these remaining unimplemented features may be implemented in future.


### PR DESCRIPTION
### Summary

This adds documentation for the new `enable_nodejs_process_v2` compat flag which will be auto-enabled on September 15.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
