### PR TITLE
[Chore] Update partials count to remove overcounting

### DIFF
--- a/src/util/components.ts
+++ b/src/util/components.ts
@@ -98,7 +98,7 @@ export async function getPartialsUsage(): Promise<Record<string, Usage>> {
 				process.platform === "win32"
 					? file.parentPath.replaceAll("\\", "/")
 					: file.parentPath;
-			const folderPath = parentPath.split("/").splice(3,).join("/");
+			const folderPath = parentPath.split("/").splice(3).join("/");
 			const partialName = `${folderPath}/${file.name.replace(".mdx", "")}`;
 			partials[partialName] = { count: 0, pages: new Set() };
 		}

--- a/src/util/components.ts
+++ b/src/util/components.ts
@@ -98,8 +98,8 @@ export async function getPartialsUsage(): Promise<Record<string, Usage>> {
 				process.platform === "win32"
 					? file.parentPath.replaceAll("\\", "/")
 					: file.parentPath;
-			const product = parentPath.split("/")[3];
-			const partialName = `${product}/${file.name.replace(".mdx", "")}`;
+			const folderPath = parentPath.split("/").splice(3,).join("/");
+			const partialName = `${folderPath}/${file.name.replace(".mdx", "")}`;
 			partials[partialName] = { count: 0, pages: new Set() };
 		}
 


### PR DESCRIPTION
### Summary

Should fix incorrect matching (and flagging of zero-use partials) that was previously caused in nested folders.
