### PR TITLE
[DO] Ensuring DO constructors call `super` if extends from DurableObject

### DIFF
--- a/src/content/docs/durable-objects/api/alarms.mdx
+++ b/src/content/docs/durable-objects/api/alarms.mdx
@@ -97,7 +97,7 @@ const SECONDS = 1000;
 
 export class AlarmExample extends DurableObject {
 	constructor(ctx, env) {
-		this.ctx = ctx;
+		super(ctx, env);
 		this.storage = ctx.storage;
 	}
 	async fetch(request) {

--- a/src/content/docs/durable-objects/examples/alarms-api.mdx
+++ b/src/content/docs/durable-objects/examples/alarms-api.mdx
@@ -30,7 +30,7 @@ const SECONDS = 10;
 // Durable Object
 export class Batcher extends DurableObject {
 	constructor(state, env) {
-		this.state = state;
+		super(state, env);
 		this.storage = state.storage;
 		this.state.blockConcurrencyWhile(async () => {
 			let vals = await this.storage.list({ reverse: true, limit: 1 });

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -34,6 +34,7 @@ async function handleRequest(request, env) {
 // Durable Object
 export class Location extends DurableObject {
 	constructor(state, env) {
+		super(state, env);
 		this.state = state;
 		// Upon construction, you do not have a location to provide.
 		// This value will be updated as people access the Durable Object.

--- a/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
+++ b/src/content/docs/durable-objects/examples/durable-object-in-memory-state.mdx
@@ -35,7 +35,6 @@ async function handleRequest(request, env) {
 export class Location extends DurableObject {
 	constructor(state, env) {
 		super(state, env);
-		this.state = state;
 		// Upon construction, you do not have a location to provide.
 		// This value will be updated as people access the Durable Object.
 		// When the Durable Object is evicted from memory, this will be reset.

--- a/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
+++ b/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
@@ -79,6 +79,7 @@ export class YourDurableObject extends DurableObject {
 		public state: DurableObjectState,
 		env: Env,
 	) {
+		super(state, env);
 		this.state = state;
 		// Ensure you pass your bindings and environmental variables into
 		// each Durable Object when it is initialized

--- a/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
+++ b/src/content/docs/durable-objects/examples/use-kv-from-durable-objects.mdx
@@ -80,10 +80,6 @@ export class YourDurableObject extends DurableObject {
 		env: Env,
 	) {
 		super(state, env);
-		this.state = state;
-		// Ensure you pass your bindings and environmental variables into
-		// each Durable Object when it is initialized
-		this.env = env;
 	}
 
 	async fetch(request: Request) {


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

1. Identified 4 instances where we extend DurableObject and has a constructor, but wasn't using `super()`.
2. Added in `super()`, and removed redundant lines, if any.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
