### PR TITLE
remove outdated note saying that RPC is not supported in remote service bindings

### DIFF
--- a/src/content/partials/workers/bindings_per_env.mdx
+++ b/src/content/partials/workers/bindings_per_env.mdx
@@ -25,11 +25,9 @@
 | **Queues**                              |        ✅         |             ✅             |
 | **R2**                                  |        ✅         |             ✅             |
 | **Rate Limiting**                       |        ✅         |             ❌             |
-| **Service Bindings (multiple Workers)** |        ✅         |          ✅ [^1]           |
+| **Service Bindings (multiple Workers)** |        ✅         |             ✅             |
 | **Vectorize**                           |        ❌         |             ✅             |
 | **Workflows**                           |        ✅         |             ❌             |
-
-[^1]: While you can make `fetch()` calls on remote service bindings, you cannot currently call RPC methods on remote service bindings.
 
 ## Remote development
 


### PR DESCRIPTION
Summary

RPC is now supported for remote bindings (https://github.com/cloudflare/workers-sdk/pull/10249), so here I am removing the note from the supported bindings list saying that it is not 🚀 (since I missed this in https://github.com/cloudflare/cloudflare-docs/pull/24903)