### PR TITLE
[Fundamentals] Removing redirect to Get started

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -718,7 +718,6 @@
 /fundamentals/get-started/reference/ /fundamentals/reference/ 301
 /fundamentals/get-started/reference/http-request-headers/ /fundamentals/reference/http-request-headers/ 301
 /fundamentals/get-started/reference/network-ports/ /fundamentals/reference/network-ports/ 301
-/fundamentals/get-started/ /fundamentals/setup/ 301
 /fundamentals/get-started/setup/allow-cloudflare-ip-addresses/ /fundamentals/concepts/cloudflare-ip-addresses/ 301
 
 #fundamentals revamp cont


### PR DESCRIPTION
Now that we have a Get started page again, removing the old redirect.