### PR TITLE
adding changelog for Wrangler interactive improvement for Assets deployment

### DIFF
--- a/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
+++ b/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
@@ -1,0 +1,63 @@
+---
+title: Interactive deployment flow for static assets in Wrangler
+description: Wrangler now guides you through deploying static assets with interactive prompts and automatic configuration generation when no wrangler.jsonc file exists.
+products:
+  - workers
+date: 2025-09-09
+---
+
+Deploying static assets to Workers is now significantly easier. When you run `wrangler deploy [directory]` or `wrangler deploy --assets [directory]` without an existing configuration file, Wrangler will now guide you through the deployment process with interactive prompts.
+
+## What's new
+
+**Interactive prompts for missing configuration:**
+- Wrangler detects when you're trying to deploy a directory of static assets
+- Prompts you to confirm the deployment type
+- Asks for a project name (with smart defaults)
+- Automatically sets the compatibility date to today
+
+**Automatic configuration generation:**
+- Creates a `wrangler.jsonc` file with your deployment settings
+- Stores your choices for future deployments
+- Eliminates the need to remember complex command-line flags
+
+## Example workflow
+
+```bash
+# Deploy your built static site
+wrangler deploy dist
+
+# Wrangler will prompt:
+✔ It looks like you are trying to deploy a directory of static assets only. Is this correct? … yes
+✔ What do you want to name your project? … my-astro-site
+
+# Automatically generates wrangler.jsonc:
+{
+  "name": "my-astro-site",
+  "compatibility_date": "2025-09-09",
+  "assets": {
+    "directory": "dist"
+  }
+}
+
+# Future deployments are now simplified:
+wrangler deploy
+```
+
+## Before and after
+
+**Before:** Required remembering multiple flags and parameters
+```bash
+wrangler deploy --assets ./dist --compatibility-date 2025-09-09 --name my-project
+```
+
+**After:** Simple directory deployment with guided setup
+```bash
+wrangler deploy dist
+# Interactive prompts handle the rest as shown in the example flow above
+```
+
+## Requirements
+
+- **Wrangler 4.24.4 or higher** is required for this functionality
+

--- a/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
+++ b/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
@@ -8,6 +8,19 @@ date: 2025-09-09
 
 Deploying static site to Workers is now easier. When you run `wrangler deploy [directory]` or `wrangler deploy --assets [directory]` without an existing [configuration file](/workers/wrangler/configuration/), [Wrangler CLI](/workers/wrangler/) now guides you through the deployment process with interactive prompts.
 
+## Before and after
+
+**Before:** Required remembering multiple flags and parameters
+```bash
+wrangler deploy --assets ./dist --compatibility-date 2025-09-09 --name my-project
+```
+
+**After:** Simple directory deployment with guided setup
+```bash
+wrangler deploy dist
+# Interactive prompts handle the rest as shown in the example flow above
+```
+
 ## What's new
 
 **Interactive prompts for missing configuration:**
@@ -42,19 +55,6 @@ wrangler deploy dist
 
 # Next time you run wrangler deploy, this will use the configuration in your newly generated wrangler.jsonc file
 wrangler deploy
-```
-
-## Before and after
-
-**Before:** Required remembering multiple flags and parameters
-```bash
-wrangler deploy --assets ./dist --compatibility-date 2025-09-09 --name my-project
-```
-
-**After:** Simple directory deployment with guided setup
-```bash
-wrangler deploy dist
-# Interactive prompts handle the rest as shown in the example flow above
 ```
 
 ## Requirements

--- a/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
+++ b/src/content/changelog/workers/2025-09-09-interactive-wrangler-assets.mdx
@@ -1,12 +1,12 @@
 ---
-title: Interactive deployment flow for static assets in Wrangler
+title: Deploy static sites to Workers without a configuration file
 description: Wrangler now guides you through deploying static assets with interactive prompts and automatic configuration generation when no wrangler.jsonc file exists.
 products:
   - workers
 date: 2025-09-09
 ---
 
-Deploying static assets to Workers is now significantly easier. When you run `wrangler deploy [directory]` or `wrangler deploy --assets [directory]` without an existing configuration file, Wrangler will now guide you through the deployment process with interactive prompts.
+Deploying static site to Workers is now easier. When you run `wrangler deploy [directory]` or `wrangler deploy --assets [directory]` without an existing [configuration file](/workers/wrangler/configuration/), [Wrangler CLI](/workers/wrangler/) now guides you through the deployment process with interactive prompts.
 
 ## What's new
 
@@ -31,7 +31,7 @@ wrangler deploy dist
 ✔ It looks like you are trying to deploy a directory of static assets only. Is this correct? … yes
 ✔ What do you want to name your project? … my-astro-site
 
-# Automatically generates wrangler.jsonc:
+# Automatically generates a wrangler.jsonc file and adds it to your project:
 {
   "name": "my-astro-site",
   "compatibility_date": "2025-09-09",
@@ -40,7 +40,7 @@ wrangler deploy dist
   }
 }
 
-# Future deployments are now simplified:
+# Next time you run wrangler deploy, this will use the configuration in your newly generated wrangler.jsonc file
 wrangler deploy
 ```
 
@@ -59,5 +59,5 @@ wrangler deploy dist
 
 ## Requirements
 
-- **Wrangler 4.24.4 or higher** is required for this functionality
+- You must use Wrangler version 4.24.4 or later in order to use this feature
 


### PR DESCRIPTION
### Summary

Added changelog to announce release of: [PR](https://github.com/cloudflare/workers-sdk/pull/10016)
that creates a `wrangler.jsonc` for users by only running `wrangler deploy [directory]` instead of wrangler deploy --assets ./dist --compatibility-date 2025-09-09 --name my-project
<img width="609" height="827" alt="Screenshot 2025-09-08 at 9 47 39 PM" src="https://github.com/user-attachments/assets/b49bacbe-6637-47eb-b5d3-4ff1c182def0" />
<img width="468" height="332" alt="Screenshot 2025-09-08 at 9 47 52 PM" src="https://github.com/user-attachments/assets/b900141c-7804-400f-ac0d-7800300dc29e" />
