### PR TITLE
[WAF] Highlight lines in APIRequest calls

### DIFF
--- a/src/content/docs/waf/custom-rules/create-api.mdx
+++ b/src/content/docs/waf/custom-rules/create-api.mdx
@@ -72,6 +72,9 @@ The new rule, which will be the last rule in the ruleset, includes the definitio
 			},
 		},
 	}}
+	code={{
+		mark: [{ range: "9-13" }],
+	}}
 	roles={false}
 />
 

--- a/src/content/docs/waf/managed-rules/payload-logging/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/payload-logging/configure-api.mdx
@@ -124,7 +124,7 @@ This example configures payload logging for the [Cloudflare Managed Ruleset](/wa
    		expression: "true",
    	}}
    	code={{
-   		mark: [8, 9, 10],
+   		mark: [{ range: "8-10" }],
    	}}
    	roles={false}
    />

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
@@ -138,6 +138,9 @@ This example sets the Cloudflare OWASP Core Ruleset's paranoia level for a zone 
     		expression: "true",
     		enabled: true,
     	}}
+    	code={{
+    		mark: [{ range: "8-19" }],
+    	}}
     	roles={false}
     />
 
@@ -296,6 +299,9 @@ This example configures the managed ruleset score threshold and the performed ac
    		},
    		expression: "true",
    		enabled: true,
+   	}}
+   	code={{
+   		mark: [{ range: "12-13" }],
    	}}
    	roles={false}
    />

--- a/src/content/docs/waf/rate-limiting-rules/create-api.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/create-api.mdx
@@ -91,6 +91,9 @@ The new rule defines a [custom response](/waf/rate-limiting-rules/create-zone-da
 			mitigation_timeout: 600,
 		},
 	}}
+	code={{
+		mark: [{ range: "9-13" }],
+	}}
 	roles={false}
 />
 
@@ -121,6 +124,7 @@ The new rule does not consider requests for cached assets when calculating the r
 			requests_to_origin: true,
 		},
 	}}
+	code={{ mark: [17] }}
 	roles={false}
 />
 
@@ -151,6 +155,9 @@ The new rule is a complexity-based rate limiting rule that takes the `my-score` 
 			mitigation_timeout: 600,
 			counting_expression: "",
 		},
+	}}
+	code={{
+		mark: [{ range: "13-14" }],
 	}}
 	roles={false}
 />


### PR DESCRIPTION
### Summary

Adds back highlighted lines in API requests (lost when we switched to the `APIRequest` component).

### Documentation checklist
- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
