### PR TITLE
Fix handler function syntax in container-backend.mdx

### DIFF
--- a/src/content/docs/containers/examples/container-backend.mdx
+++ b/src/content/docs/containers/examples/container-backend.mdx
@@ -185,7 +185,7 @@ import (
 	"net/http"
 )
 
-func handler(w http.ResponseWriter, r \*http.Request) {
+func handler(w http.ResponseWriter, r *http.Request) {
     widgets := []map[string]interface{}{
         {"id": 1, "name": "Widget A"},
         {"id": 2, "name": "Sprocket B"},


### PR DESCRIPTION
Fix syntax error in docs: superfluous escape

<img width="506" height="398" alt="Screenshot 2025-09-10 at 22 07 02" src="https://github.com/user-attachments/assets/2936a5bf-f20f-4cb8-ac50-8b2989d4919e" />
