### PR TITLE
Removing duplicate link

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/sase/augment-access-with-serverless.mdx
+++ b/src/content/docs/reference-architecture/diagrams/sase/augment-access-with-serverless.mdx
@@ -187,5 +187,4 @@ Using the details in the JWT, you can use a Worker to extract the details of the
 
 - [External Evaluation rules](/cloudflare-one/policies/access/external-evaluation/)
 - [SASE reference architecture](/reference-architecture/architectures/sase/)
-- [External Evaluation rules Developer Documentation](/cloudflare-one/policies/access/external-evaluation/)
 - [External Evaluation blog post](https://blog.cloudflare.com/access-external-validation-rules/)


### PR DESCRIPTION
Cloudflare employee here, both links were pointing to the same devdoc URL

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
