### PR TITLE
[Style Guide] Merge GraphQL API Explorer info from README into Style Guide

### DIFF
--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -115,32 +115,13 @@ export default {
 
 ## GraphQL API explorer
 
-If you add the `graphql-api-explorer` option to the opening code fence for a `graphql` code block, it will
-add a "Run in GraphQL API Explorer" link that will take the user to the [GraphQL API explorer](https://graphql.cloudflare.com/explorer).
+Add `graphql-api-explorer` to the opening code fence to create a `graphql` code block with a **Run in GraphQL API Explorer** button that leads to [GraphQL API Explorer](https://graphql.cloudflare.com/explorer).
 
-### Live demo
+:::note
+This button only works if the person selecting it is logged in or has an API token saved.
+:::
 
-```graphql graphql-api-explorer title="A GraphQL query"
-query ASingleDatasetExample($zoneTag: string, $start: Time, $end: Time) {
-	viewer {
-		zones(filter: { zoneTag: $zoneTag }) {
-			firewallEventsAdaptive(
-				filter: { datetime_gt: $start, datetime_lt: $end }
-				limit: 2
-				orderBy: [datetime_DESC]
-			) {
-				action
-				datetime
-				host: clientRequestHTTPHost
-			}
-		}
-	}
-}
-```
-
-### How to use
-
-````mdx "graphql-api-explorer"
+````mdx live
 ```graphql graphql-api-explorer title="A GraphQL query"
 query ASingleDatasetExample($zoneTag: string, $start: Time, $end: Time) {
 	viewer {
@@ -159,3 +140,34 @@ query ASingleDatasetExample($zoneTag: string, $start: Time, $end: Time) {
 }
 ```
 ````
+
+## Variables
+
+In the GraphQL API Explorer, the Variables section is automatically filled based on the names and types of the variables defined in your query:
+- Variables that include `start` and are of type `Time` are set to six hours before the current time
+- Variables that include `end` and are of type `Time` are set to the current time
+- Variables that include `start` and are of type `Date` are set to 24 hours before the current date
+- Variables that include `end` and are of type `Date` are set to the current date
+- Variables that include `zoneTag` and are of type `string` are set to "ZONE_ID"
+- Variables that include `accountTag` and are of type `string` are set to "ACCOUNT_ID"
+- Variables that include `id` and are of type `string` are set to "REPLACE_WITH_ID"
+- Variables that include `limit` and are of type `int` are set to 100
+- Any variable with a type of `string` is set to "REPLACE_WITH_STRING"
+
+You can also add custom variables by setting their values as a JSON string in the `graphql-api-explorer` metadata. The custom variables will be merged with the automatically populated variables. For example:
+
+```graphql graphql-api-explorer='{"uID": "custom-variable"}' title="A GraphQL query"
+query GraphqlExample($zoneTag: string, $start: Time, $end: Time) {
+ viewer {
+   zones(filter: { zoneTag: $zoneTag }) {
+     ...
+   }
+ }
+}
+```
+
+Variables:
+
+```
+{"zoneTag":"ZONE_ID", "start":"2025-09-11T14:00:00Z", "end":"2025-09-11T20:00:00Z", "uId": "custom-variable"}
+```

--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -143,7 +143,7 @@ query ASingleDatasetExample($zoneTag: string, $start: Time, $end: Time) {
 
 ## Variables
 
-In the GraphQL API Explorer, the Variables section is automatically filled based on the names and types of the variables defined in your query:
+In the GraphQL API Explorer, the **Variables** section is automatically filled based on the names and types of the variables defined in your query:
 - Variables that include `start` and are of type `Time` are set to six hours before the current time
 - Variables that include `end` and are of type `Time` are set to the current time
 - Variables that include `start` and are of type `Date` are set to 24 hours before the current date
@@ -152,10 +152,13 @@ In the GraphQL API Explorer, the Variables section is automatically filled based
 - Variables that include `accountTag` and are of type `string` are set to "ACCOUNT_ID"
 - Variables that include `id` and are of type `string` are set to "REPLACE_WITH_ID"
 - Variables that include `limit` and are of type `int` are set to 100
-- Any variable with a type of `string` is set to "REPLACE_WITH_STRING"
+- Any other variable with a type of `string` is set to "REPLACE_WITH_STRING"
 
-You can also add custom variables by setting their values as a JSON string in the `graphql-api-explorer` metadata. The custom variables will be merged with the automatically populated variables. For example:
+You can also add custom variables by setting their values as a JSON string in the `graphql-api-explorer` metadata. The custom variables will be merged with the automatically populated variables.
 
+For example, here the custom value is `custom-variable`:
+
+````mdx
 ```graphql graphql-api-explorer='{"uID": "custom-variable"}' title="A GraphQL query"
 query GraphqlExample($zoneTag: string, $start: Time, $end: Time) {
  viewer {
@@ -165,8 +168,9 @@ query GraphqlExample($zoneTag: string, $start: Time, $end: Time) {
  }
 }
 ```
+````
 
-Variables:
+So, the **Variables** would look something like this:
 
 ```
 {"zoneTag":"ZONE_ID", "start":"2025-09-11T14:00:00Z", "end":"2025-09-11T20:00:00Z", "uId": "custom-variable"}

--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -113,7 +113,7 @@ export default {
 ```
 ````
 
-## GraphQL API explorer
+## GraphQL API Explorer
 
 Add `graphql-api-explorer` to the opening code fence to create a `graphql` code block with a **Run in GraphQL API Explorer** button that leads to [GraphQL API Explorer](https://graphql.cloudflare.com/explorer).
 
@@ -141,7 +141,7 @@ query ASingleDatasetExample($zoneTag: string, $start: Time, $end: Time) {
 ```
 ````
 
-## Variables
+### Variables
 
 In the GraphQL API Explorer, the **Variables** section is automatically filled based on the names and types of the variables defined in your query:
 - Variables that include `start` and are of type `Time` are set to six hours before the current time
@@ -156,7 +156,7 @@ In the GraphQL API Explorer, the **Variables** section is automatically filled b
 
 You can also add custom variables by setting their values as a JSON string in the `graphql-api-explorer` metadata. The custom variables will be merged with the automatically populated variables.
 
-For example, here the custom value is `custom-variable`:
+In the following example, the custom value is `custom-variable`:
 
 ````mdx
 ```graphql graphql-api-explorer='{"uID": "custom-variable"}' title="A GraphQL query"


### PR DESCRIPTION
We recently deprecated the "Contributing" README tab and redirected to the new Contributing section in the Style Guide. This extra information needed a new home so I merged it here into the existing GraphQL API Explorer section.

For reference, below is the content from the old "Contributing" README tab that I merged in. (You can also view it here: https://github.com/cloudflare/cloudflare-docs/pull/25049 )




GraphQL API Explorer
If you are adding a code snippet to the documentation that is an executable GraphQL query, you can add graphql-api-explorer right after graphql in the code block metadata (both must be present). This will render a button that allows users to open the query in the [GraphQL API Explorer](https://graphql.cloudflare.com/explorer). For example:
```graphql graphql-api-explorer title="A GraphQL query"
query GraphqlExample($zoneTag: string, $start: Time, $end: Time) {
	viewer {
		zones(filter: { zoneTag: $zoneTag }) {
			firewallEventsAdaptive(
				filter: { datetime_gt: $start, datetime_lt: $end }
				limit: 2
				orderBy: [datetime_DESC]
			) {
				action
				datetime
				host: clientRequestHTTPHost
			}
		}
	}
}
```
When a user selects the Run in GraphQL API Explorer button, the following variables will be pre-populated in the GraphQL API Explorer along with the query.
:::note The user must be logged in or have an API token saved to see the query and variables pre-populated. :::
{"zoneTag":"ZONE_ID", "start":"2025-05-07T14:54:36Z", "end":"2025-05-07T20:54:36Z"}
Conventions to auto populate Variables section in the GraphQL API Explorer
By default, the Variables section will be automatically populated based on the variables used in the GraphQL query.
Any variable name that includes start and has a type of Time --> start: "2025-05-09T14:58:06Z" (6 hours from the current time)
e.g. datetimeStart also has start keyword, so it will be recognized for a start time (or date)
Any variable name that includes end and has a type of Time --> end: "2025-05-09T20:58:06Z" (current time)
Any variable name that includes start and has a type of Date --> start: "2025-05-07" (24 hours from the current date)
Any variable name that includes end and has a type of Date --> end: "2025-05-08" (current date)
zoneTag and has a type of string --> zoneTag: "ZONE_ID"
accountTag and has a type of string --> accountTag: "ACCOUNT_ID"
Any variable name that includes id and has a type of string --> id: "REPLACE_WITH_ID"
Any variable name and has a type of string --> anyString: "REPLACE_WITH_STRING"
limit with type *int* --> limit: 100
In addition to the variables that are automatically populated, you can add custom variables by setting their values as a JSON string in the graphql-api-explorer metadata.
```graphql graphql-api-explorer='{"uID": "something"}' title="A GraphQL query"
query GraphqlExample($zoneTag: string, $start: Time, $end: Time) {
	viewer {
		zones(filter: { zoneTag: $zoneTag }) {
			...
		}
	}
}
The variables added via the metadata value will be merged with the automatically populated variables.
{"zoneTag":"ZONE_ID", "start":"2025-05-07T14:54:36Z", "end":"2025-05-07T20:54:36Z", "uId": "something"}
