### PR TITLE
Add allowed_sender_addresses to send email binding

### DIFF
--- a/src/content/docs/email-routing/email-workers/send-email-workers.mdx
+++ b/src/content/docs/email-routing/email-workers/send-email-workers.mdx
@@ -27,11 +27,12 @@ send_email = [
 
 ## Types of bindings
 
-There are three types of bindings:
+There are several types of restrictions you can configure in the bindings:
 
 - **No attribute defined**: When you do not define an attribute, the binding has no restrictions in place. You can use it to send emails to any verified email address [through Email Routing](/email-routing/setup/email-routing-addresses/#destination-addresses).
 - **`destination_address`**: When you define the `destination_address` attribute, you create a targeted binding. This means you can only send emails to the chosen email address. For example, `{type = "send_email", name = "<NAME_FOR_BINDING>", destination_address = "<YOUR_EMAIL>@example.com"}`. <br/> For this particular binding, when you call the `send_email` function you can pass `null` or `undefined` to your Worker and it will assume the email address specified in the binding.
 - **`allowed_destination_addresses`**: When you specify this attribute, you create an allowlist, and can send emails to any email address on the list.
+- **`allowed_sender_addresses`**: When you specify this attribute, you create a sender allowlist, and can only send emails from an email address on the list.
 
 <Render file="types-bindings" product="email-routing" />
 


### PR DESCRIPTION

### Summary

Add documentation around the new "allowed_sender_addresses" attribute that allows a send email binding to be restricted in possible values of the sender of each email.

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
