### PR TITLE
[Style Guide] Interlink between code block guidance

### DIFF
--- a/src/content/docs/style-guide/components/code.mdx
+++ b/src/content/docs/style-guide/components/code.mdx
@@ -5,7 +5,9 @@ styleGuide:
 ---
 
 Code blocks are powered by [Expressive Code](https://expressive-code.com/), a project by Astro.
-This is just a small showcase of functionality, it has a lot of options!
+This is just a small showcase of the wide functionality of this component.
+
+Learn more about formatting in the [code block formatting guide](/style-guide/formatting/code-conventions-and-format/).
 
 ````mdx live
 ```powershell title="PowerShell"

--- a/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
+++ b/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
@@ -12,6 +12,8 @@ To define the syntax highlighting language used for the code block, enter a lang
 
 Use the `txt` language when there is no appropriate syntax highlighting (for example, a fragment of an Apache configuration file).
 
+Learn more about what you can do with code blocks in the [code block component guide](/style-guide/components/code/).
+
 ## JSON example
 
 ````

--- a/src/content/docs/style-guide/formatting/code-conventions-and-format.mdx
+++ b/src/content/docs/style-guide/formatting/code-conventions-and-format.mdx
@@ -6,6 +6,10 @@ title: Code conventions and format
 
 Use the conventions described below throughout Cloudflare product content.
 
+[Learn about code block formatting guidelines](/style-guide/formatting/code-block-guidelines/).
+
+[Learn about the code block component](/style-guide/components/code/).
+
 ## Angle brackets ( `<` and `>` )
 
 Use angle brackets to denote placeholders for variables you want the user to enter (except in [API URLs and API authentication headers](/style-guide/api-content-strategy/guidelines-for-curl-commands/#request-guidelines), where you should use the `$ZONE_ID` / `$CLOUDFLARE_API_TOKEN` format). Placeholder text should have all capital letters and use underscores (`_`) to separate words.


### PR DESCRIPTION
The eventual plan is to reduce the content redundancy between these and refine what each is for - but as a short-term fix in the meantime, I'm just interlinking between them.