### PR TITLE
WP-2220: Remove migration Pages->Workers messaging

### DIFF
--- a/src/content/docs/pages/configuration/api.mdx
+++ b/src/content/docs/pages/configuration/api.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: REST API
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { APIRequest, DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/branch-build-controls.mdx
+++ b/src/content/docs/pages/configuration/branch-build-controls.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Branch deployment controls
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/configuration/build-caching.mdx
+++ b/src/content/docs/pages/configuration/build-caching.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Build caching
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Improve Pages build times by caching dependencies and build output between builds with a project-wide shared cache.

--- a/src/content/docs/pages/configuration/build-configuration.mdx
+++ b/src/content/docs/pages/configuration/build-configuration.mdx
@@ -2,11 +2,6 @@
 pcx_content_type: concept
 title: Build configuration
 rss: https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/docs/pages/configuration/build-configuration.mdx.atom
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Details, PagesBuildPresetsTable, DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/build-image.mdx
+++ b/src/content/docs/pages/configuration/build-image.mdx
@@ -2,11 +2,6 @@
 pcx_content_type: concept
 title: Build image
 rss: https://github.com/cloudflare/cloudflare-docs/commits/production/src/content/partials/pages/_platform-language-support-and-tools.atom
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/configuration/build-watch-paths.mdx
+++ b/src/content/docs/pages/configuration/build-watch-paths.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Build watch paths
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 When you connect a git repository to Pages, by default a change to any file in the repository will trigger a Pages build. You can configure Pages to include or exclude specific paths to specify if Pages should skip a build for a given path. This can be especially helpful if you are using a monorepo project structure and want to limit the amount of builds being kicked off.

--- a/src/content/docs/pages/configuration/custom-domains.mdx
+++ b/src/content/docs/pages/configuration/custom-domains.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Custom domains
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/debugging-pages.mdx
+++ b/src/content/docs/pages/configuration/debugging-pages.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Debugging Pages
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/deploy-hooks.mdx
+++ b/src/content/docs/pages/configuration/deploy-hooks.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Deploy Hooks
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/early-hints.mdx
+++ b/src/content/docs/pages/configuration/early-hints.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Early Hints
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 [Early Hints](/cache/advanced-configuration/early-hints/) help the browser to load webpages faster. Early Hints is enabled automatically on all `pages.dev` domains and custom domains.

--- a/src/content/docs/pages/configuration/git-integration/github-integration.mdx
+++ b/src/content/docs/pages/configuration/git-integration/github-integration.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: GitHub integration
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 You can connect each Cloudflare Pages project to a GitHub repository, and Cloudflare will automatically deploy your code every time you push a change to a branch.

--- a/src/content/docs/pages/configuration/git-integration/gitlab-integration.mdx
+++ b/src/content/docs/pages/configuration/git-integration/gitlab-integration.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: GitLab integration
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 You can connect each Cloudflare Pages project to a GitLab repository, and Cloudflare will automatically deploy your code every time you push a change to a branch.

--- a/src/content/docs/pages/configuration/git-integration/index.mdx
+++ b/src/content/docs/pages/configuration/git-integration/index.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Git integration
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 You can connect each Cloudflare Pages project to a [GitHub](/pages/configuration/git-integration/github-integration) or [GitLab](/pages/configuration/git-integration/gitlab-integration) repository, and Cloudflare will automatically deploy your code every time you push a change to a branch.

--- a/src/content/docs/pages/configuration/git-integration/troubleshooting.mdx
+++ b/src/content/docs/pages/configuration/git-integration/troubleshooting.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Troubleshooting builds
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 If your git integration is experiencing issues, you may find the following banners in the Deployment page of your Pages project.

--- a/src/content/docs/pages/configuration/headers.mdx
+++ b/src/content/docs/pages/configuration/headers.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Headers
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/configuration/index.mdx
+++ b/src/content/docs/pages/configuration/index.mdx
@@ -5,11 +5,6 @@ sidebar:
   order: 5
   group:
     hideIndex: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/configuration/monorepos.mdx
+++ b/src/content/docs/pages/configuration/monorepos.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Monorepos
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 While some apps are built from a single repository, Pages also supports apps with more complex setups. A monorepo is a repository that has multiple subdirectories each containing its own application.

--- a/src/content/docs/pages/configuration/preview-deployments.mdx
+++ b/src/content/docs/pages/configuration/preview-deployments.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Preview deployments
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/configuration/redirects.mdx
+++ b/src/content/docs/pages/configuration/redirects.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Redirects
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/configuration/rollbacks.mdx
+++ b/src/content/docs/pages/configuration/rollbacks.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Rollbacks
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Rollbacks allow you to instantly revert your project to a previous production deployment.

--- a/src/content/docs/pages/configuration/serving-pages.mdx
+++ b/src/content/docs/pages/configuration/serving-pages.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: concept
 title: Serving Pages
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Cloudflare Pages includes a number of defaults for serving your Pages sites. This page details some of those decisions, so you can understand how Pages works, and how you might want to override some of the default behaviors.

--- a/src/content/docs/pages/demos.mdx
+++ b/src/content/docs/pages/demos.mdx
@@ -3,11 +3,6 @@ pcx_content_type: navigation
 title: Demos and architectures
 sidebar:
   order: 8
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-blazor-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-blazor-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Blazor
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Brunch
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Docusaurus
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-gatsby-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-gatsby-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Gatsby
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-gridsome-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-gridsome-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Gridsome
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Hexo
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Hono
 tags:
   - Hono
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Hugo
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, TabItem, Tabs } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Jekyll
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-nuxt-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-nuxt-site.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Nuxt
 head: []
 description: Web framework making Vue.js-based development simple and powerful.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Pelican
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Preact
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Qwik
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: React
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers, DashButton } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
@@ -2,11 +2,6 @@
 pcx_content_type: how-to
 title: Remix
 tags: [Remix]
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: SolidStart
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-sphinx-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-sphinx-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Sphinx
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-svelte-kit-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-svelte-kit-site.mdx
@@ -2,11 +2,6 @@
 pcx_content_type: how-to
 title: SvelteKit
 description: Learn how to create and deploy a SvelteKit application to Cloudflare Pages using the create-cloudflare CLI
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Vite 3
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, PackageManagers, DashButton } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: VitePress
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Vue
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Zola
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-analog-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-analog-site.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Analog
 head: []
 description: The fullstack Angular meta-framework
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Angular
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Astro
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Elder.js
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-eleventy-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-eleventy-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Eleventy
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-emberjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-emberjs-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Ember
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: MkDocs
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-anything.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-anything.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: how-to
 title: Static HTML
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Details, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/index.mdx
+++ b/src/content/docs/pages/framework-guides/index.mdx
@@ -6,11 +6,6 @@ sidebar:
   order: 3
   group:
     hideIndex: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/deploy-a-static-nextjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/deploy-a-static-nextjs-site.mdx
@@ -7,11 +7,6 @@ head:
   - tag: title
     content: Get started | Static site | Next.js apps
 description: Deploy a static site built using Next.js to Cloudflare Pages
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/index.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/index.mdx
@@ -4,11 +4,6 @@ pcx_content_type: navigation
 title: Next.js
 head: []
 description: React framework for building full-stack web applications.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing, YouTube } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/resources.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/resources.mdx
@@ -7,11 +7,6 @@ sidebar:
 head:
   - tag: title
     content: Additional resources | Next.js
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { ResourcesBySelector, ExternalResources } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/advanced.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/advanced.mdx
@@ -6,11 +6,6 @@ sidebar:
 head:
   - tag: title
     content: Advanced Usage
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 ## Custom Worker Entrypoint

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/bindings.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/bindings.mdx
@@ -6,11 +6,6 @@ sidebar:
 head:
   - tag: title
     content: Using bindings in your Next.js app
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Once you have [set up next-on-pages](/pages/framework-guides/nextjs/ssr/get-started/), you can access [bindings](/workers/runtime-apis/bindings/) from any route of your Next.js app via `getRequestContext`:

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/caching.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/caching.mdx
@@ -4,11 +4,6 @@ title: Caching
 head:
   - tag: title
     content: Caching and data revalidation in your Next.js app
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 [`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages) supports [caching](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#caching-data) and [revalidating](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#revalidating-data) data returned by subrequests you make in your app by calling [`fetch()`](/workers/runtime-apis/fetch/).

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/get-started.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/get-started.mdx
@@ -7,11 +7,6 @@ head:
   - tag: title
     content: Get started | Full-stack (SSR) | Next.js apps
 description: Deploy a full-stack Next.js app to Cloudflare Pages
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers, WranglerConfig } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/index.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/index.mdx
@@ -4,11 +4,6 @@ pcx_content_type: navigation
 title: Full-stack (SSR)
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/static-assets.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/static-assets.mdx
@@ -4,11 +4,6 @@ title: Routing static assets
 head:
   - tag: title
     content: Routing static assets | Full-stack (SSR) | Next.js apps
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 When you use a JavaScript framework like Next.js on Cloudflare Pages, the framework adapter (ex: `@cloudflare/next-on-pages`) automatically generates a [`_routes.json` file](/pages/functions/routing/#create-a-_routesjson-file), which defines specific paths of your app's static assets. This file tells Cloudflare, `for these paths, don't run the Worker, you can just serve the static asset on this path` (an image, a chunk of client-side JavaScript, etc.)

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/supported-features.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/supported-features.mdx
@@ -4,11 +4,6 @@ title: Supported features
 head:
   - tag: title
     content: Supported features
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Details } from "~/components";

--- a/src/content/docs/pages/framework-guides/nextjs/ssr/troubleshooting.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/ssr/troubleshooting.mdx
@@ -4,11 +4,6 @@ title: Troubleshooting
 head:
   - tag: title
     content: Troubleshooting | Full-stack (SSR) | Next.js apps
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Learn more about troubleshooting issues with your Full-stack (SSR) Next.js apps using Cloudflare.

--- a/src/content/docs/pages/functions/advanced-mode.mdx
+++ b/src/content/docs/pages/functions/advanced-mode.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Advanced mode
 sidebar:
   order: 9
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { TabItem, Tabs } from "~/components";

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -5,11 +5,6 @@ sidebar:
   order: 3
 head: []
 description: Learn about the APIs used within Pages Functions.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 The following methods can be used to configure your Pages Function.

--- a/src/content/docs/pages/functions/bindings.mdx
+++ b/src/content/docs/pages/functions/bindings.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Bindings
 sidebar:
   order: 7
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, TabItem, Tabs, WranglerConfig, DashButton } from "~/components";

--- a/src/content/docs/pages/functions/debugging-and-logging.mdx
+++ b/src/content/docs/pages/functions/debugging-and-logging.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Debugging and logging
 sidebar:
   order: 12
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/functions/examples/ab-testing.mdx
+++ b/src/content/docs/pages/functions/examples/ab-testing.mdx
@@ -10,11 +10,6 @@ sidebar:
 description: Set up an A/B test by controlling what page is served based on
   cookies. This version supports passing the request through to test and control
   on the origin.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 ```js

--- a/src/content/docs/pages/functions/examples/cors-headers.mdx
+++ b/src/content/docs/pages/functions/examples/cors-headers.mdx
@@ -8,11 +8,6 @@ title: Adding CORS headers
 sidebar:
   order: 1002
 description: A Pages Functions for appending CORS headers.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 This example is a snippet from our Cloudflare Pages Template repo.

--- a/src/content/docs/pages/functions/examples/index.mdx
+++ b/src/content/docs/pages/functions/examples/index.mdx
@@ -6,11 +6,6 @@ sidebar:
   order: 4
   group:
     hideIndex: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/functions/get-started.mdx
+++ b/src/content/docs/pages/functions/get-started.mdx
@@ -6,11 +6,6 @@ sidebar:
 head:
   - tag: title
     content: Functions - Get started
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 This guide will instruct you on creating and deploying a Pages Function.

--- a/src/content/docs/pages/functions/index.mdx
+++ b/src/content/docs/pages/functions/index.mdx
@@ -3,11 +3,6 @@ pcx_content_type: navigation
 title: Functions
 sidebar:
   order: 6
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/functions/local-development.mdx
+++ b/src/content/docs/pages/functions/local-development.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Local development
 sidebar:
   order: 6
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Run your Pages application locally with our Wrangler Command Line Interface (CLI).

--- a/src/content/docs/pages/functions/metrics.mdx
+++ b/src/content/docs/pages/functions/metrics.mdx
@@ -3,11 +3,6 @@ pcx_content_type: reference
 title: Metrics
 sidebar:
   order: 11
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/functions/middleware.mdx
+++ b/src/content/docs/pages/functions/middleware.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Middleware
 sidebar:
   order: 5
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Middleware is reusable logic that can be run before your [`onRequest`](/pages/functions/api-reference/#onrequests) function. Middlewares are typically utility functions. Error handling, user authentication, and logging are typical candidates for middleware within an application.

--- a/src/content/docs/pages/functions/module-support.mdx
+++ b/src/content/docs/pages/functions/module-support.mdx
@@ -3,11 +3,6 @@ pcx_content_type: reference
 title: Module support
 sidebar:
   order: 13
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Pages Functions provide support for several module types, much like [Workers](https://blog.cloudflare.com/workers-javascript-modules/). This means that you can import and use external modules such as WebAssembly (Wasm), `text` and `binary` files inside your Functions code.

--- a/src/content/docs/pages/functions/plugins/cloudflare-access.mdx
+++ b/src/content/docs/pages/functions/plugins/cloudflare-access.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Cloudflare Access
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/community-plugins.mdx
+++ b/src/content/docs/pages/functions/plugins/community-plugins.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Community Plugins
 sidebar:
   order: 2
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 The following are some of the community-maintained Pages Plugins. If you have created a Pages Plugin and would like to share it with developers, create a PR to add it to this alphabeticallly-ordered list using the link in the footer.

--- a/src/content/docs/pages/functions/plugins/google-chat.mdx
+++ b/src/content/docs/pages/functions/plugins/google-chat.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Google Chat
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/graphql.mdx
+++ b/src/content/docs/pages/functions/plugins/graphql.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: GraphQL
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/hcaptcha.mdx
+++ b/src/content/docs/pages/functions/plugins/hcaptcha.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: hCaptcha
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/honeycomb.mdx
+++ b/src/content/docs/pages/functions/plugins/honeycomb.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Honeycomb
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/index.mdx
+++ b/src/content/docs/pages/functions/plugins/index.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Pages Plugins
 sidebar:
   order: 9
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DirectoryListing, Render } from "~/components";

--- a/src/content/docs/pages/functions/plugins/sentry.mdx
+++ b/src/content/docs/pages/functions/plugins/sentry.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Sentry
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/static-forms.mdx
+++ b/src/content/docs/pages/functions/plugins/static-forms.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Static Forms
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/stytch.mdx
+++ b/src/content/docs/pages/functions/plugins/stytch.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Stytch
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/turnstile.mdx
+++ b/src/content/docs/pages/functions/plugins/turnstile.mdx
@@ -3,11 +3,6 @@ pcx_content_type: concept
 title: Turnstile
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/plugins/vercel-og.mdx
+++ b/src/content/docs/pages/functions/plugins/vercel-og.mdx
@@ -1,11 +1,6 @@
 ---
 pcx_content_type: reference
 title: vercel/og
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers } from "~/components";

--- a/src/content/docs/pages/functions/pricing.mdx
+++ b/src/content/docs/pages/functions/pricing.mdx
@@ -3,11 +3,6 @@ pcx_content_type: reference
 title: Pricing
 sidebar:
   order: 12
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 Requests to your Functions are billed as Cloudflare Workers requests. Workers plans and pricing can be found [in the Workers documentation](/workers/platform/pricing/).

--- a/src/content/docs/pages/functions/routing.mdx
+++ b/src/content/docs/pages/functions/routing.mdx
@@ -3,11 +3,6 @@ pcx_content_type: reference
 title: Routing
 sidebar:
   order: 2
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Details, FileTree, PagesBuildPresetsTable, DashButton } from "~/components";

--- a/src/content/docs/pages/functions/smart-placement.mdx
+++ b/src/content/docs/pages/functions/smart-placement.mdx
@@ -4,11 +4,6 @@ title: Smart Placement
 sidebar:
   badge:
     text: Beta
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/functions/source-maps.mdx
+++ b/src/content/docs/pages/functions/source-maps.mdx
@@ -3,11 +3,6 @@ pcx_content_type: configuration
 title: Source maps and stack traces
 head: []
 description: Adding source maps and generating stack traces for Pages.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { Render, WranglerConfig } from "~/components";

--- a/src/content/docs/pages/functions/typescript.mdx
+++ b/src/content/docs/pages/functions/typescript.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: TypeScript
 sidebar:
   order: 8
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { PackageManagers, Render } from "~/components";

--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -3,11 +3,6 @@ pcx_content_type: how-to
 title: Configuration
 sidebar:
   order: 6
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/get-started/c3.mdx
+++ b/src/content/docs/pages/get-started/c3.mdx
@@ -8,11 +8,7 @@ description: Use C3 (`create-cloudflare` CLI) to set up and deploy new
   applications using framework-specific setup guides to ensure each new
   application follows Cloudflare and any third-party best practices for
   deployment.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import {

--- a/src/content/docs/pages/get-started/direct-upload.mdx
+++ b/src/content/docs/pages/get-started/direct-upload.mdx
@@ -6,11 +6,7 @@ head:
     content: Direct Upload
 description: Upload your prebuilt assets to Pages and deploy them via the
   Wrangler CLI or the Cloudflare dashboard.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render, DashButton } from "~/components";

--- a/src/content/docs/pages/get-started/git-integration.mdx
+++ b/src/content/docs/pages/get-started/git-integration.mdx
@@ -5,11 +5,7 @@ head:
   - tag: title
     content: Git integration guide
 description: Connect your Git provider to Pages.
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Details, Render } from "~/components";

--- a/src/content/docs/pages/get-started/index.mdx
+++ b/src/content/docs/pages/get-started/index.mdx
@@ -3,11 +3,7 @@ pcx_content_type: navigation
 title: Getting started
 sidebar:
   order: 2
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/how-to/add-custom-http-headers.mdx
+++ b/src/content/docs/pages/how-to/add-custom-http-headers.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Add custom HTTP headers
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/docs/pages/how-to/build-commands-branches.mdx
+++ b/src/content/docs/pages/how-to/build-commands-branches.mdx
@@ -2,11 +2,7 @@
 reviewed: 2022-07-27
 pcx_content_type: how-to
 title: Set build commands per branch
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/custom-branch-aliases.mdx
+++ b/src/content/docs/pages/how-to/custom-branch-aliases.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Add a custom domain to a branch
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
+++ b/src/content/docs/pages/how-to/deploy-a-wordpress-site.mdx
@@ -5,11 +5,7 @@ pcx_content_type: tutorial
 title: Deploy a static WordPress site
 tags:
   - WordPress
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/enable-zaraz.mdx
+++ b/src/content/docs/pages/how-to/enable-zaraz.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Enable Zaraz
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/how-to/index.mdx
+++ b/src/content/docs/pages/how-to/index.mdx
@@ -6,11 +6,7 @@ sidebar:
   order: 8
   group:
     hideIndex: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/how-to/npm-private-registry.mdx
+++ b/src/content/docs/pages/how-to/npm-private-registry.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Install private packages
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 Cloudflare Pages supports custom package registries, allowing you to include private dependencies in your application. While this walkthrough focuses specifically on [npm](https://www.npmjs.com/), the Node package manager and registry, the same approach can be applied to other registry tools.

--- a/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
+++ b/src/content/docs/pages/how-to/preview-with-cloudflare-tunnel.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Preview Local Projects with Cloudflare Tunnel
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) runs a lightweight daemon (`cloudflared`) in your infrastructure that establishes outbound connections (Tunnels) between your origin web server and the Cloudflare global network. In practical terms, you can use Cloudflare Tunnel to allow remote access to services running on your local machine. It is an alternative to popular tools like [Ngrok](https://ngrok.com), and provides free, long-running tunnels via the [TryCloudflare](/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/) service.

--- a/src/content/docs/pages/how-to/redirect-to-custom-domain.mdx
+++ b/src/content/docs/pages/how-to/redirect-to-custom-domain.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Redirecting *.pages.dev to a Custom Domain
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Example, DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/refactor-a-worker-to-pages-functions.mdx
+++ b/src/content/docs/pages/how-to/refactor-a-worker-to-pages-functions.mdx
@@ -3,11 +3,7 @@ pcx_content_type: how-to
 title: Refactor a Worker to a Pages Function
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/how-to/use-direct-upload-with-continuous-integration.mdx
+++ b/src/content/docs/pages/how-to/use-direct-upload-with-continuous-integration.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Use Direct Upload with continuous integration
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/use-worker-for-ab-testing-in-pages.mdx
+++ b/src/content/docs/pages/how-to/use-worker-for-ab-testing-in-pages.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Use Pages Functions for A/B testing
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/web-analytics.mdx
+++ b/src/content/docs/pages/how-to/web-analytics.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Enable Web Analytics
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render, DashButton } from "~/components";

--- a/src/content/docs/pages/how-to/www-redirect.mdx
+++ b/src/content/docs/pages/how-to/www-redirect.mdx
@@ -1,11 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Redirecting www to domain apex
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Example, DashButton } from "~/components";

--- a/src/content/docs/pages/index.mdx
+++ b/src/content/docs/pages/index.mdx
@@ -7,11 +7,6 @@ sidebar:
 head:
   - tag: title
     content: Overview
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import {

--- a/src/content/docs/pages/migrations/index.mdx
+++ b/src/content/docs/pages/migrations/index.mdx
@@ -5,11 +5,7 @@ title: Migration guides
 sidebar:
   hidden: true
   order: 4
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/migrations/migrating-from-firebase.mdx
+++ b/src/content/docs/pages/migrations/migrating-from-firebase.mdx
@@ -5,11 +5,7 @@ pcx_content_type: tutorial
 title: Migrating from Firebase
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 In this tutorial, you will learn how to migrate an existing Firebase application to Cloudflare Pages. You should already have an existing project deployed on Firebase that you would like to host on Cloudflare Pages.

--- a/src/content/docs/pages/migrations/migrating-from-netlify/index.mdx
+++ b/src/content/docs/pages/migrations/migrating-from-netlify/index.mdx
@@ -7,11 +7,7 @@ tags:
   - JavaScript
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 In this tutorial, you will learn how to migrate your Netlify application to Cloudflare Pages.

--- a/src/content/docs/pages/migrations/migrating-from-vercel/index.mdx
+++ b/src/content/docs/pages/migrations/migrating-from-vercel/index.mdx
@@ -5,11 +5,7 @@ pcx_content_type: tutorial
 title: Migrating from Vercel to Pages
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/migrations/migrating-from-workers/index.mdx
+++ b/src/content/docs/pages/migrations/migrating-from-workers/index.mdx
@@ -5,11 +5,7 @@ pcx_content_type: tutorial
 title: Migrating from Workers Sites to Pages
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
+++ b/src/content/docs/pages/migrations/migrating-jekyll-from-github-pages.mdx
@@ -7,11 +7,7 @@ tags:
   - Ruby
 sidebar:
   hidden: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/platform/changelog.mdx
+++ b/src/content/docs/pages/platform/changelog.mdx
@@ -5,11 +5,6 @@ release_notes_file_name:
   - pages
 sidebar:
   order: 3
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
 ---
 
 import { ProductReleaseNotes } from "~/components";

--- a/src/content/docs/pages/platform/index.mdx
+++ b/src/content/docs/pages/platform/index.mdx
@@ -5,11 +5,7 @@ sidebar:
   order: 9
   group:
     hideIndex: true
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -3,11 +3,7 @@ pcx_content_type: concept
 title: Known issues
 sidebar:
   order: 4
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/pages/platform/limits.mdx
+++ b/src/content/docs/pages/platform/limits.mdx
@@ -3,11 +3,7 @@ pcx_content_type: concept
 title: Limits
 sidebar:
   order: 1
-banner:
-  content: We recommend using <strong>Cloudflare Workers</strong> for new projects. For existing Pages projects, see our <a href="/workers/static-assets/migrate-from-pages/">migration guide</a> and <a href="/workers/static-assets/migrate-from-pages/#compatibility-matrix">compatibility matrix</a>.
-  type: note
-  dismissible:
-    id: pages-migrate-to-workers
+
 ---
 
 import { Render } from "~/components";


### PR DESCRIPTION
### Summary

Removing notice to migrate Pages->Workers because it is causing a lot of customer concern. We'd like to take a step back and reevaluate.

### Screenshots (optional)
<img width="754" height="172" alt="Screenshot 2025-09-15 at 2 34 12 PM" src="https://github.com/user-attachments/assets/135af240-2301-48ed-8efc-17b78c5fe1a6" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
