### PR TITLE
Adding Turnstile Updates for China Network

### DIFF
--- a/src/content/docs/china-network/faq.mdx
+++ b/src/content/docs/china-network/faq.mdx
@@ -7,13 +7,13 @@ head: []
 description: Review FAQs for Cloudflare's China Network.
 ---
 
-## Requirements
+## Prerequisites & Onboarding
 
 ### What are the requirements to enable the Cloudflare China Network service from Cloudflare?
 
 Refer to [Get started](/china-network/get-started/) for more information.
 
-### Can I use my current account to access the Cloudflare China Network service or do I need a separate account?
+### Can I use my current account to access the Cloudflare China Network service?
 
 Yes, you can use your current Cloudflare account and dashboard.
 
@@ -27,7 +27,7 @@ Cloudflare requires that you have a valid [ICP (Internet Content Provider)](/chi
 
 Cloudflare has taken numerous steps to ensure your security and the integrity of your data in China. Your identification information such as email addresses, password hashes, and billing information are never stored on the Cloudflare China Network or shared with the Cloudflare partner except for Zone configuration information and bindings with Cloudflare’s Developer Suite which are stored on the China Network operated by our partners in China upon your enabling the China Service for a particular Zone.
 
-## Licensing and onboarding
+## Compliance
 
 ### Does Cloudflare have an MIIT license to provide CDN services in China?
 
@@ -39,7 +39,7 @@ No, neither Cloudflare nor JD Cloud is responsible for [ICP (Internet Content Pr
 
 ### Why is my ICP filing/license revoked?
 
-The application and revocation of ICP filings or licenses is managed by China's local authorities. Usually either the customer or the agency processing the ICP application receive a notification with more details. Cloudflare cannot provide the ICP revocation reasons.
+The application and revocation of ICP filings or licenses is managed by China's local authorities. Usually, either the customer or the agency processing the ICP application receive a notification with more details. Cloudflare cannot provide the ICP revocation reasons.
 
 ### What would happen if my ICP filing/license got revoked?
 
@@ -50,8 +50,12 @@ To mitigate the impact on your Internet properties, Cloudflare would reroute the
 
 The JD Cloud network is proxying content inside of China for customers who have purchased the Cloudflare China Network subscription. To ensure compliance with China’s regulation on Internet information services and with [JD Cloud's service terms](https://docs.jdcloud.com/cn/product-service-agreement/starshield-terms-of-service), JD Cloud must review the content of all the domains before onboarding those domains to their network. They can approve or reject any domain based on the nature of its content. For more information, contact your sales team.
 
-## Technical questions
+## Products & Features
 
 ### How does IPv6 work on the Cloudflare China Network?
 
 All sites hosted in Mainland China must have IPv6 enabled. The Cloudflare China Network feature automatically enables IPv6 for domains to fulfill this requirement and it is not possible to disable it. According to Cloudflare's tests, IPv6 connections in Mainland China are more reliable and offer better latency.
+
+### Is Turnstile available in Mainland China?
+
+[Turnstile](/turnstile/) is not supported in Mainland China. Therefore, both China Network zones AND [global zones](/fundamentals/concepts/accounts-and-zones/#zones) with users visiting their content from Mainland China may experience issues with Turnstile.

--- a/src/content/docs/china-network/faq.mdx
+++ b/src/content/docs/china-network/faq.mdx
@@ -7,7 +7,7 @@ head: []
 description: Review FAQs for Cloudflare's China Network.
 ---
 
-## Prerequisites & Onboarding
+## Prerequisites and onboarding
 
 ### What are the requirements to enable the Cloudflare China Network service from Cloudflare?
 
@@ -50,7 +50,7 @@ To mitigate the impact on your Internet properties, Cloudflare would reroute the
 
 The JD Cloud network is proxying content inside of China for customers who have purchased the Cloudflare China Network subscription. To ensure compliance with China’s regulation on Internet information services and with [JD Cloud's service terms](https://docs.jdcloud.com/cn/product-service-agreement/starshield-terms-of-service), JD Cloud must review the content of all the domains before onboarding those domains to their network. They can approve or reject any domain based on the nature of its content. For more information, contact your sales team.
 
-## Products & Features
+## Products and features
 
 ### How does IPv6 work on the Cloudflare China Network?
 
@@ -58,4 +58,4 @@ All sites hosted in Mainland China must have IPv6 enabled. The Cloudflare China 
 
 ### Is Turnstile available in Mainland China?
 
-[Turnstile](/turnstile/) is not supported in Mainland China. Therefore, both China Network zones AND [global zones](/fundamentals/concepts/accounts-and-zones/#zones) with users visiting their content from Mainland China may experience issues with Turnstile.
+[Turnstile](/turnstile/) is not supported in Mainland China. Therefore, both China Network zones and [global zones](/fundamentals/concepts/accounts-and-zones/#zones) with users visiting their content from Mainland China may experience issues with Turnstile.

--- a/src/content/docs/china-network/reference/available-products.mdx
+++ b/src/content/docs/china-network/reference/available-products.mdx
@@ -1,5 +1,5 @@
 ---
-title: Available products and features
+title: Available Products and Features
 pcx_content_type: reference
 sidebar:
   order: 2
@@ -26,28 +26,26 @@ The following products and features are available on the Cloudflare China Networ
 
 ## Developer Services
 
-| Product/Feature                                                           | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Workers](/workers/)                                                      | A serverless execution environment running on the Cloudflare global network.                                                                                                   |
-| [Workers KV](/kv/)                                                        | Configuration data, service routing metadata, personalization (A/B testing).                                                                                                   |
-| [R2](/r2/)[^2]                                                            | Object storage for all your data.                                                                                                                                              |
-| [KV](/kv/)                                                                | Configuration data, service routing metadata, personalization (A/B testing).                                                                                                   |
-| [Assets](/workers/static-assets/)                                         | Upload static assets (HTML, CSS, images and other files) as part of your Worker — Cloudflare will handle caching and serving them to web browsers.                             |
-| [Environment variables](/workers/configuration/environment-variables/)    | Attach text strings or JSON values to your Worker.                                                                                                                             |
-| [Images](/images/transform-images/bindings/)[^3]                          | Store, transform, optimize, and deliver images at scale.                                                                                                                       |
-| [mTLS](/workers/runtime-apis/bindings/mtls/)                              | Securely connect to backend servers over [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/).                                                    |
-| [Rate Limiting](/workers/runtime-apis/bindings/rate-limit/)               | Define rate limits and write code around them in your Worker.                                                                                                                  |
-| [Secrets](/workers/configuration/secrets/)                                | Attach encrypted text values to your Worker.                                                                                                                                   |
-| [Service bindings](/workers/runtime-apis/bindings/service-bindings/)      | Service bindings allow one Worker to call into another, without going through a publicly-accessible URL.                                                                       |
-| [Tail Workers](/workers/observability/logs/tail-workers/)                 | Receives information about the execution of other Workers.                                                                                                                     |
-| [Version metadata](/workers/runtime-apis/bindings/version-metadata/)      | Access metadata associated with a version from inside the Workers runtime.                                                                                                     |
-| [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) | Deploy custom code on behalf of your users or let your users directly deploy their own code to your platform, managing infrastructure.                                         |
-| [Pages](/pages/)                                                          | Deploy dynamic front-end applications in record time.                                                                                                                          |
+| Product/Feature                                                           | Description                                                                                                                                        |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Workers](/workers/)                                                      | A serverless execution environment running on the Cloudflare global network.                                                                       |
+| [Workers KV](/kv/)                                                        | Configuration data, service routing metadata, personalization (A/B testing).                                                                       |
+| [R2](/r2/)[^2]                                                            | Object storage for all your data.                                                                                                                  |
+| [KV](/kv/)                                                                | Configuration data, service routing metadata, personalization (A/B testing).                                                                       |
+| [Assets](/workers/static-assets/)                                         | Upload static assets (HTML, CSS, images and other files) as part of your Worker — Cloudflare will handle caching and serving them to web browsers. |
+| [Environment variables](/workers/configuration/environment-variables/)    | Attach text strings or JSON values to your Worker.                                                                                                 |
+| [Images](/images/transform-images/bindings/)[^3]                          | Store, transform, optimize, and deliver images at scale.                                                                                           |
+| [mTLS](/workers/runtime-apis/bindings/mtls/)                              | Securely connect to backend servers over [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/).                        |
+| [Rate Limiting](/workers/runtime-apis/bindings/rate-limit/)               | Define rate limits and write code around them in your Worker.                                                                                      |
+| [Secrets](/workers/configuration/secrets/)                                | Attach encrypted text values to your Worker.                                                                                                       |
+| [Service bindings](/workers/runtime-apis/bindings/service-bindings/)      | Service bindings allow one Worker to call into another, without going through a publicly-accessible URL.                                           |
+| [Tail Workers](/workers/observability/logs/tail-workers/)                 | Receives information about the execution of other Workers.                                                                                         |
+| [Version metadata](/workers/runtime-apis/bindings/version-metadata/)      | Access metadata associated with a version from inside the Workers runtime.                                                                         |
+| [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) | Deploy custom code on behalf of your users or let your users directly deploy their own code to your platform, managing infrastructure.             |
+| [Pages](/pages/)                                                          | Deploy dynamic front-end applications in record time.                                                                                              |
 
-[^1]: Turnstile is not available within Mainland China.
-
+[^1]: [Turnstile](/turnstile/) is not available within Mainland China.
 [^2]: R2 buckets cannot be created within Mainland China and [custom domains](/r2/buckets/public-buckets/#add-your-domain-to-cloudflare) are not supported within Mainland China. However, R2 can be extended into Mainland China through [Global Acceleration](/china-network/concepts/global-acceleration/).
-
 [^3]: Image Resizing works [within Workers](/images/transform-images/transform-via-workers/), but may not be available [through URL format](/images/transform-images/transform-via-url/).
 
 ## Network Services
@@ -66,4 +64,4 @@ The following products and features are available on the Cloudflare China Networ
 | [Instant Logs](/logs/instant-logs/) | Live Tail your Cloudflare HTTP logs in the Cloudflare dashboard. |
 | [Logpush](/logs/logpush/)           | Push your Cloudflare HTTP logs to a storage service.             |
 
-For more details or specific product features, contact your account team.
+For more details or specific product features, please visit our [FAQ](/china-network/faq/) page or contact your account team.

--- a/src/content/docs/china-network/reference/available-products.mdx
+++ b/src/content/docs/china-network/reference/available-products.mdx
@@ -64,4 +64,4 @@ The following products and features are available on the Cloudflare China Networ
 | [Instant Logs](/logs/instant-logs/) | Live Tail your Cloudflare HTTP logs in the Cloudflare dashboard. |
 | [Logpush](/logs/logpush/)           | Push your Cloudflare HTTP logs to a storage service.             |
 
-For more details or specific product features, please visit our [FAQ](/china-network/faq/) page or contact your account team.
+For more details or specific product features, refer to the [FAQ](/china-network/faq/) page or contact your account team.

--- a/src/content/docs/china-network/reference/available-products.mdx
+++ b/src/content/docs/china-network/reference/available-products.mdx
@@ -1,5 +1,5 @@
 ---
-title: Available Products and Features
+title: Available products and features
 pcx_content_type: reference
 sidebar:
   order: 2


### PR DESCRIPTION
### Summary

Customers are unclear whether Turnstile works in Mainland China. Therefore, content has been added for clarification.

### Documentation checklist
- [ x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
