### PR TITLE
[Hyperdrive] Fix code block language

### DIFF
--- a/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-drivers-and-libraries/prisma-orm.mdx
+++ b/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-drivers-and-libraries/prisma-orm.mdx
@@ -75,7 +75,7 @@ model User {
 
 Add your database connection string to the `.env` file created by Prisma:
 
-```env title=".env"
+```txt title=".env"
 DATABASE_URL="postgres://user:password@host:port/database"
 ```
 


### PR DESCRIPTION
### Summary

Fixes the following build warning:
```
[WARN] [astro-expressive-code] Error while highlighting code block using language "env" in document 
"/home/runner/work/cloudflare-docs/cloudflare-docs/src/content/docs/hyperdrive/examples/connect-to-postgres/postgres-drivers-and-libraries/prisma-orm.mdx". 
The language could not be found. Using "txt" instead. 
Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
```

The [PR build](https://github.com/cloudflare/cloudflare-docs/actions/runs/17760260816/job/50471207020?pr=25186) no longer includes the warning.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
