### PR TITLE
[Rules] Mirage deprecation notice - small tweak

### DIFF
--- a/src/content/docs/rules/configuration-rules/settings.mdx
+++ b/src/content/docs/rules/configuration-rules/settings.mdx
@@ -154,7 +154,11 @@ API configuration property name: `"fonts"` (boolean).
 
 ## Mirage
 
-[Mirage](/speed/optimization/images/mirage/) (deprecated) accelerates image delivery for your visitors based on their device.
+:::caution[Deprecation notice]
+Mirage was deprecated on September 15, 2025.
+:::
+
+[Mirage](/speed/optimization/images/mirage/) accelerates image delivery for your visitors based on their device.
 
 Use this setting to turn on or off Mirage for matching requests.
 
@@ -167,10 +171,6 @@ API configuration property name: `"mirage"` (boolean).
   "mirage": false
 }
 ```
-
-:::caution[Deprecation notice]
-Mirage was deprecated on September 15, 2025.
-:::
 
 <Render file="configuration-rule-link-to-examples" product="rules" />
 


### PR DESCRIPTION
Just tweaking the location of the deprecation notice after merging these three

https://github.com/cloudflare/cloudflare-docs/pull/25144
https://github.com/cloudflare/cloudflare-docs/pull/24199
https://github.com/cloudflare/cloudflare-docs/pull/24942 