### PR TITLE
CUSTESC-55739 - Document /.well-known/ is treated as static resource

### DIFF
--- a/src/content/docs/bots/additional-configurations/static-resources.mdx
+++ b/src/content/docs/bots/additional-configurations/static-resources.mdx
@@ -55,3 +55,5 @@ To exclude static resources, you would need to include `not (cf.bot_management.s
 Static resources are files with the following extensions:
 
 `ico|jpg|png|jpeg|gif|css|js|tif|tiff|bmp|pict|webp|svg|svgz|class|jar|txt|csv|doc|docx|xls|xlsx|pdf|ps|pls|ppt|pptx|ttf|otf|woff|woff2|eot|eps|ejs|swf|torrent|midi|mid|m3u8|m4a|mp3|ogg|ts`
+
+Additionally, the `/.well-known/` URL path and all elements in it are considered a static resource, regardless of file extension.


### PR DESCRIPTION
### Summary

CUSTESC-55739 
Document /.well-known/ is treated as static resource.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.