### PR TITLE
[Images] Update local images binding docs with vite support

### DIFF
--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -114,16 +114,31 @@ Wrangler supports two different versions of the Images API:
 
 To test the high-fidelity version of Images, you can run `wrangler dev`:
 
-```txt
+```sh
 npx wrangler dev
 ```
 
 This creates a local-only environment that mirrors the production environment where Cloudflare runs the Images API. You can test your Worker with all available transformation features before deploying to production.
 
-To test the low-fidelity offline version of Images, add the `--experimental-images-local-mode` flag:
+To test the low-fidelity offline version of Images, add the `--experimental-images-local-mode` flag when running `wrangler dev`:
 
-```txt
+```sh
 npx wrangler dev --experimental-images-local-mode
+```
+
+Or, set the `imagesLocalMode` experimental option to `true` in your Vite config if you are using the Cloudflare Vite plugin:
+
+```ts
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			experimental: { imagesLocalMode: true },
+		}),
+	],
+});
 ```
 
 Currently, this version supports only `width`, `height`, `rotate`, and `format`.


### PR DESCRIPTION
### Summary

We are adding experimental image local mode support with the vite plugin in https://github.com/cloudflare/workers-sdk/pull/10687.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
