### PR TITLE
disable vscode formatting for mdx files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,11 @@
 	"astro.content-intellisense": true,
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[mdx]": {
+		// MDX prettier formatting is quite broken and simply breaks
+		// formatting, so we don't auto format MDX files
+		"editor.defaultFormatter": null
+	},
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"cSpell.enableFiletypes": ["mdx"],
 	"files.associations": { "__redirects": "plaintext", "_headers": "plaintext" }


### PR DESCRIPTION
Since `formatOnSave` is enabled by default, whenever I save an MDX file I get vscode formatting the file, this would generally be ideal, the problem being that the formatting is pretty broken, if the file contains any js/ts snippet the indentation of those gets completely broken, three backticks also get added at the end of the MDX files and I am pretty sure that I noticed other weird results as well.

So as far as I can tell formatting on the MDX files doesn't really work, thus why I am proposing to disable it here.

(Currently the way I work around the current broken formatting is by disabling temporarily `formatOnSave` or saving without formatting via the command palette, neither is really ideal)

I have seen this issue occur to other people other than me so I am making the assumption that this is a general issue, if not and there is some configuration that I am missing on my machine please let me know 🙂
