### PR TITLE
Update API Rate Limit Headers to reflect IETF Proposal

### DIFF
--- a/src/content/changelog/fundamentals/2025-09-03-rate-limiting-improvement.mdx
+++ b/src/content/changelog/fundamentals/2025-09-03-rate-limiting-improvement.mdx
@@ -15,15 +15,14 @@ As always, if you need any help with rate limits, please contact Support.
 #### New Headers
 
 **Headers that are always returned:**
-- X-RateLimit-Limit: Total Number of requests the caller can make
-- X-RateLimit-Remaining: Number of requests before Rate Limit kicks in
+- `Ratelimit`: List of service limit items, composed of the limit name, the remaining quota (`r`) and the time next window resets (`t`). For example: `"default";r=50;t=30`
+- `Ratelimit-Policy`: List of quota policy items, composed of the policy name, the total quota (`q`) and the time window the quota applies to (`w`). For example: `"burst";q=100;w=60`
 
 **Returned only when a rate limit has been reached (error code: 429):**
 - Retry-After: Number of Seconds until more capacity is available, rounded up
-- X-RateLimit-Reset: RFC 1123 Formatted Date as to when more capacity is available
 
 #### SDK Back offs
-- All SDKs will automatically respond to the headers, instituting a backoff when limits are approached. 
+- All of Cloudflare's latest SDKs will automatically respond to the headers, instituting a backoff when limits are approached. 
 
 ### GraphQL and Edge APIs
 These new headers and back offs are only available for Cloudflare REST APIs, and will not affect GraphQL. 

--- a/src/content/docs/fundamentals/api/reference/limits.mdx
+++ b/src/content/docs/fundamentals/api/reference/limits.mdx
@@ -13,9 +13,8 @@ import { Render } from "~/components";
 
 The following headers are returned when calling REST APIs:
 
-- `ratelimit-limit`: The total number of requests a caller can make.
-- `ratelimit-remaining`: The number of remaining requests before the rate limit takes effect.
-- `retry-after`: The number of seconds, rounded up, until more capacity is available.
-- `ratelimit-reset`: The `RFC 1123` formatted date when more capacity is available.
+- `Ratelimit`: List of service limit items, composed of the limit name, the remaining quota (`r`) and the time next window resets (`t`). For example: `"default";r=50;t=30`
+- `Ratelimit-Policy`: List of quota policy items, composed of the policy name, the total quota (`q`) and the time window the quota applies to (`w`). For example: `"burst";q=100;w=60`
+- `retry-after`: The number of seconds, rounded up, until more capacity is available. Note, this header is only returned when the request has exceeded the rate limit.
 
 Cloudflare's SDKs will also automatically work with the headers and back off in response to rate limits.


### PR DESCRIPTION
### Summary

The underlying services were updated one to two weeks ago to use the IETF proposed `Ratelimit` and `Ratelimit-Policy` headers. This change updates the relevant Changelog announcing the new headers and the Fundamentals section to more accurately reflect the response headers that relate to rate limiting.

Full draft IETF proposal: https://ietf-wg-httpapi.github.io/ratelimit-headers/draft-ietf-httpapi-ratelimit-headers.html#name-introduction

### Screenshots (optional)

N/A

### Documentation checklist

N/A
