### PR TITLE
ZTIA-882: remove beta tag from browser-based RDP

### DIFF
--- a/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/connections/connect-networks/use-cases/rdp/rdp-browser.mdx
@@ -4,8 +4,6 @@ title: Connect to RDP in a browser
 sidebar:
   order: 2
   label: Browser-based RDP
-  badge:
-    text: Beta
 ---
 
 import { Render, GlossaryTooltip, Details } from "~/components";


### PR DESCRIPTION
Remove beta tag from browser-based RDP after GA

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
