### PR TITLE
Changelog for workers-rs panic recovery

### DIFF
--- a/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
+++ b/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
@@ -1,6 +1,6 @@
 ---
 title: Panic Recovery for Rust Workers
-description: Making workers-rs deployments more reliable with panic recovery
+description: Deployments on workers-rs are now more reliable with improved panic recovery
 date: 2025-09-19
 ---
 
@@ -8,17 +8,13 @@ import { WranglerConfig, Aside } from "~/components";
 
 A long-standing problem we've had with [workers-rs](https://github.com/cloudflare/workers-rs) is that its Rust panics are non-recoverable, and can put the worker into an invalid state.
 
-Working on the [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) internals, we've been able to implement a solution for panic recovery to ensure more reliable deployments.
+We've been able to implement a solution for panic recovery to ensure more reliable deployments. This new automatic panic recovery feature is enabled for all new workers-rs deployments, as of version 0.6.5, with no further configuration required.
 
 ## Fixing Rust Panics with Wasm Bindgen
 
-We use [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) to build and deploy Rust workers, but Wasm Bindgen is not designed to support recoverable panics.
+Rust Workers are built with Wasm Bindgen, which treats panics as non-recoverable - the entire Wasm application is considered to be in an invalid state, and any further function calls could result in overflows or memory exceptions.
 
-When a panic happens in Wasm Bindgen, the entire Wasm application is considered to be in an invalid state, and any further function calls could result in overflows or memory exceptions.
-
-But Wasm is a virtual machine - if we can reset all the Wasm internal state back to its initial state then we can continue to take new requests.
-
-It's possible to add a panic handler in Rust to detect immediately when a panic happens:
+We now attach a default panic handler in Rust:
 
 ```rust
 std::panic::set_hook(Box::new(move |panic_info| {
@@ -26,7 +22,7 @@ std::panic::set_hook(Box::new(move |panic_info| {
 }));
 ```
 
-With some extra wiring we can then export a registration function to JavaScript to allow a custom panic hook to be attached:
+Which is registered by default in the JS initialization:
 
 ```js
 import { setPanicHook } from "./index.js";
@@ -35,7 +31,7 @@ setPanicHook(function (err) {
 });
 ```
 
-We then call a new reset state function when a panic occurs, to reinitialize the Wasm application to back to as it was when the application first started.
+When a panic occurs, we then reset the Wasm state to reinitialize the Wasm application back to as it was when the application first started.
 
 ## Resetting VM State in Wasm Bindgen
 
@@ -48,22 +44,16 @@ One other necessary change here was associating Wasm-created JS objects with an 
 
 ## Layered Solution
 
-By implementing only the minimal primitive upstream in Wasm Bindgen necessary, we could then comprehensively solve the remaining JS state concerns for workers-rs specifically.
-
-For this a proxy wrapper was needed to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are fully reinitialized when resetting the Wasm instance. This is because
+Building on this new Wasm Bindgen feature, layered with our new default panic handler, the last piece was adding a proxy wrapper to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are fully reinitialized when resetting the Wasm instance. This is because
 the workerd runtime will instantiate exported classes, which would then be associated with the Wasm instance. So tracking and reinitializing these exported classes was necessary.
 
-This approach is then all that is needed to provide full panic recovery for Rust Workers. Requests in progress during a panic will provide 500 errors, but the worker will then instantly recover for future requests with an instant reset.
+This approach now provides full panic recovery for Rust Workers. Requests in progress during a panic will provide 500 errors, but the worker will then instantly recover for future requests with an instant reset.
 
 Of course we never want panics, but when they do happen they are isolated and can be investigated further from the error logs - avoiding broader service disruption.
 
 ## WebAssembly Exception Handling
 
-In future, we would like to see full support for recoverable panics without even needing reinitialization at all.
-
-With the [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md) proposal part of the newly announced [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/) specification,
-it would actually be possible to fully unwind panics as normal JS errors. Concurrent requests would no longer fail at all, and all state would remain just fine.
-
-This would be a larger Wasm Bindgen initiative, but a very useful one to explore further.
+In future, full support for recoverable panics could be implemented without needing reinitialization at all, utilizing the [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md)
+proposal, part of the newly announced [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/) specification. This would allow unwinding panics as normal JS errors, and concurrent requests would no longer fail.
 
 **We're making significant improvements to the reliability of [Rust Workers](https://github.com/cloudflare/workers-rs). Join us in `#rust-on-workers` on the [Cloudflare Developers Discord](https://discord.gg/cloudflaredev) to stay updated.**

--- a/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
+++ b/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
@@ -10,7 +10,7 @@ In [workers-rs](https://github.com/cloudflare/workers-rs), Rust panics were prev
 
 Now, when a panic occurs, in-flight requests will throw 500 errors, but the Worker will automatically and instantly recover for future requests.
 
-This ensures more reliable deployents. Automatic panic recovery is enabled for all new workers-rs deployments as of version 0.6.5, with no configuration required.
+This ensures more reliable deployments. Automatic panic recovery is enabled for all new workers-rs deployments as of version 0.6.5, with no configuration required.
 
 ## Fixing Rust Panics with Wasm Bindgen
 

--- a/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
+++ b/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
@@ -1,18 +1,20 @@
 ---
 title: Panic Recovery for Rust Workers
-description: Deployments on workers-rs are now more reliable with improved panic recovery
+description: Deployments on workers-rs are now more reliable with automatic panic recovery
 date: 2025-09-19
 ---
 
 import { WranglerConfig, Aside } from "~/components";
 
-A long-standing problem we've had with [workers-rs](https://github.com/cloudflare/workers-rs) is that its Rust panics are non-recoverable, and can put the worker into an invalid state.
+In [workers-rs](https://github.com/cloudflare/workers-rs), Rust panics were previously non-recoverable. A panic would put the Worker into an invalid state, and further function calls could result in memory overflows or exceptions.
 
-We've been able to implement a solution for panic recovery to ensure more reliable deployments. This new automatic panic recovery feature is enabled for all new workers-rs deployments, as of version 0.6.5, with no further configuration required.
+Now, when a panic occurs, requests in progress during a panic will throw 500 errors, but the Worker will then automatically and instantly recover for future requests.
+
+This ensures more reliable deployents. Automatic panic recovery feature is enabled for all new workers-rs deployments as of version 0.6.5, with no further configuration required.
 
 ## Fixing Rust Panics with Wasm Bindgen
 
-Rust Workers are built with Wasm Bindgen, which treats panics as non-recoverable - the entire Wasm application is considered to be in an invalid state, and any further function calls could result in overflows or memory exceptions.
+Rust Workers are built with Wasm Bindgen, which treats panics as non-recoverable - the entire Wasm application is considered to be in an invalid state.
 
 We now attach a default panic handler in Rust:
 
@@ -47,13 +49,13 @@ One other necessary change here was associating Wasm-created JS objects with an 
 Building on this new Wasm Bindgen feature, layered with our new default panic handler, the last piece was adding a proxy wrapper to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are fully reinitialized when resetting the Wasm instance. This is because
 the workerd runtime will instantiate exported classes, which would then be associated with the Wasm instance. So tracking and reinitializing these exported classes was necessary.
 
-This approach now provides full panic recovery for Rust Workers. Requests in progress during a panic will provide 500 errors, but the worker will then instantly recover for future requests with an instant reset.
+This approach now provides full panic recovery for Rust Workers on subsequent requests.
 
-Of course we never want panics, but when they do happen they are isolated and can be investigated further from the error logs - avoiding broader service disruption.
+Of course, we never want panics, but when they do happen they are isolated and can be investigated further from the error logs - avoiding broader service disruption.
 
 ## WebAssembly Exception Handling
 
-In future, full support for recoverable panics could be implemented without needing reinitialization at all, utilizing the [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md)
+In the future, full support for recoverable panics could be implemented without needing reinitialization at all, utilizing the [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md)
 proposal, part of the newly announced [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/) specification. This would allow unwinding panics as normal JS errors, and concurrent requests would no longer fail.
 
 **We're making significant improvements to the reliability of [Rust Workers](https://github.com/cloudflare/workers-rs). Join us in `#rust-on-workers` on the [Cloudflare Developers Discord](https://discord.gg/cloudflaredev) to stay updated.**

--- a/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
+++ b/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
@@ -1,0 +1,69 @@
+---
+title: Panic Recovery for Rust Workers
+description: Making workers-rs deployments more reliable with panic recovery
+date: 2025-09-19
+---
+
+import { WranglerConfig, Aside } from "~/components";
+
+A long-standing problem we've had with [workers-rs](https://github.com/cloudflare/workers-rs) is that its Rust panics are non-recoverable, and can put the worker into an invalid state.
+
+Working on the [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) internals, we've been able to implement a solution for panic recovery to ensure more reliable deployments.
+
+## Fixing Rust Panics with Wasm Bindgen
+
+We use [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) to build and deploy Rust workers, but Wasm Bindgen is not designed to support recoverable panics.
+
+When a panic happens in Wasm Bindgen, the entire Wasm application is considered to be in an invalid state, and any further function calls could result in overflows or memory exceptions.
+
+But Wasm is a virtual machine - if we can reset all the Wasm internal state back to its initial state then we can continue to take new requests.
+
+It's possible to add a panic handler in Rust to detect immediately when a panic happens:
+
+```rust
+std::panic::set_hook(Box::new(move |panic_info| {
+  hook_impl(panic_info);
+}));
+```
+
+With some extra wiring we can then export a registration function to JavaScript to allow a custom panic hook to be attached:
+
+```js
+import { setPanicHook } from "./index.js";
+setPanicHook(function (err) {
+	console.error("Panic handler!", err);
+});
+```
+
+We then call a new reset state function when a panic occurs, to reinitialize the Wasm application to back to as it was when the application first started.
+
+## Resetting VM State in Wasm Bindgen
+
+We worked upstream on the Wasm Bindgen project to implement a new [`--experimental-reset-state-function` compilation option](https://github.com/wasm-bindgen/wasm-bindgen/pull/4644) which outputs a new `__wbg_reset_state` function.
+
+This function clears all internal state related to the Wasm VM, and also ensures object references are uniquely associated with the Wasm instance identity. Wasm bindgen exports stateless JS wrapper functions which call into Wasm. Updating their internal
+Wasm instance binding to the new instance allows exposing the new Wasm instance without having to rebind the exported functions.
+
+One other necessary change here was associating Wasm-created JS objects with an instance identity. If a JS object created by an earlier instance is then passed into a new instance later on, a new "stale object" error is specially thrown when using this feature.
+
+## Layered Solution
+
+By implementing only the minimal primitive upstream in Wasm Bindgen necessary, we could then comprehensively solve the remaining JS state concerns for workers-rs specifically.
+
+For this a proxy wrapper was needed to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are fully reinitialized when resetting the Wasm instance. This is because
+the workerd runtime will instantiate exported classes, which would then be associated with the Wasm instance. So tracking and reinitializing these exported classes was necessary.
+
+This approach is then all that is needed to provide full panic recovery for Rust Workers. Requests in progress during a panic will provide 500 errors, but the worker will then instantly recover for future requests with an instant reset.
+
+Of course we never want panics, but when they do happen they are isolated and can be investigated further from the error logs - avoiding broader service disruption.
+
+## WebAssembly Exception Handling
+
+In future, we would like to see full support for recoverable panics without even needing reinitialization at all.
+
+With the [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md) proposal part of the newly announced [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/) specification,
+it would actually be possible to fully unwind panics as normal JS errors. Concurrent requests would no longer fail at all, and all state would remain just fine.
+
+This would be a larger Wasm Bindgen initiative, but a very useful one to explore further.
+
+**We're making significant improvements to the reliability of [Rust Workers](https://github.com/cloudflare/workers-rs). Join us in `#rust-on-workers` on the [Cloudflare Developers Discord](https://discord.gg/cloudflaredev) to stay updated.**

--- a/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
+++ b/src/content/changelog/workers/2025-09-19-workers-rs-panic-recovery.mdx
@@ -8,13 +8,13 @@ import { WranglerConfig, Aside } from "~/components";
 
 In [workers-rs](https://github.com/cloudflare/workers-rs), Rust panics were previously non-recoverable. A panic would put the Worker into an invalid state, and further function calls could result in memory overflows or exceptions.
 
-Now, when a panic occurs, requests in progress during a panic will throw 500 errors, but the Worker will then automatically and instantly recover for future requests.
+Now, when a panic occurs, in-flight requests will throw 500 errors, but the Worker will automatically and instantly recover for future requests.
 
-This ensures more reliable deployents. Automatic panic recovery feature is enabled for all new workers-rs deployments as of version 0.6.5, with no further configuration required.
+This ensures more reliable deployents. Automatic panic recovery is enabled for all new workers-rs deployments as of version 0.6.5, with no configuration required.
 
 ## Fixing Rust Panics with Wasm Bindgen
 
-Rust Workers are built with Wasm Bindgen, which treats panics as non-recoverable - the entire Wasm application is considered to be in an invalid state.
+Rust Workers are built with Wasm Bindgen, which treats panics as non-recoverable. After a panic, the entire Wasm application is considered to be in an invalid state.
 
 We now attach a default panic handler in Rust:
 
@@ -33,21 +33,20 @@ setPanicHook(function (err) {
 });
 ```
 
-When a panic occurs, we then reset the Wasm state to reinitialize the Wasm application back to as it was when the application first started.
+When a panic occurs, we reset the Wasm state to revert the Wasm application to how it was when the application started.
 
 ## Resetting VM State in Wasm Bindgen
 
 We worked upstream on the Wasm Bindgen project to implement a new [`--experimental-reset-state-function` compilation option](https://github.com/wasm-bindgen/wasm-bindgen/pull/4644) which outputs a new `__wbg_reset_state` function.
 
-This function clears all internal state related to the Wasm VM, and also ensures object references are uniquely associated with the Wasm instance identity. Wasm bindgen exports stateless JS wrapper functions which call into Wasm. Updating their internal
-Wasm instance binding to the new instance allows exposing the new Wasm instance without having to rebind the exported functions.
+This function clears all internal state related to the Wasm VM, and updates all function bindings in place to reference the new WebAssembly instance.
 
 One other necessary change here was associating Wasm-created JS objects with an instance identity. If a JS object created by an earlier instance is then passed into a new instance later on, a new "stale object" error is specially thrown when using this feature.
 
 ## Layered Solution
 
-Building on this new Wasm Bindgen feature, layered with our new default panic handler, the last piece was adding a proxy wrapper to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are fully reinitialized when resetting the Wasm instance. This is because
-the workerd runtime will instantiate exported classes, which would then be associated with the Wasm instance. So tracking and reinitializing these exported classes was necessary.
+Building on this new Wasm Bindgen feature, layered with our new default panic handler, we also added a proxy wrapper to ensure all top-level exported class instantiations (such as for Rust Durable Objects) are tracked and fully reinitialized when resetting the Wasm instance. This was necessary because
+the workerd runtime will instantiate exported classes, which would then be associated with the Wasm instance.
 
 This approach now provides full panic recovery for Rust Workers on subsequent requests.
 


### PR DESCRIPTION
### Summary

Provides a technical changelog for the new workers-rs panic recovery functionality.

It's quite nice to go into the details here, but we could cut back on the content too if this is the wrong place for it.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
