### PR TITLE
Remove "type" from proper rate limit binding

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
@@ -32,7 +32,6 @@ main = "src/index.js"
 
 [[ratelimits]]
 name = "MY_RATE_LIMITER"
-type = "ratelimit"
 # An identifier you define, that is unique to your Cloudflare account.
 # Must be an integer.
 namespace_id = "1001"
@@ -106,14 +105,12 @@ main = "src/index.js"
 # Free user rate limiting
 [[ratelimits]]
 name = "FREE_USER_RATE_LIMITER"
-type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 100, period = 60 }
 
 # Paid user rate limiting
 [[ratelimits]]
 name = "PAID_USER_RATE_LIMITER"
-type = "ratelimit"
 namespace_id = "1002"
 simple = { limit = 1000, period = 60 }
 ```
@@ -130,14 +127,11 @@ A rate limiting binding has three settings:
 
 For example, to apply a rate limit of 1500 requests per minute, you would define a rate limiting configuration as follows:
 
-
-
 <WranglerConfig>
 
 ```toml
 [[ratelimits]]
 name = "MY_RATE_LIMITER"
-type = "ratelimit"
 namespace_id = "1001"
 
 # 1500 requests - calls to limit() increment this


### PR DESCRIPTION
### Summary

This was needed when it needed unsafe.bindings but now it has a properly binding in Wrangler, this throws a warning that it is an unknown property. So fix that.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
