### PR TITLE
Disable tracing

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,4 +26,4 @@ bucket_name = "vendored-markdown"
 enabled = true
 
 [observability.traces]
-enabled = true
+enabled = false


### PR DESCRIPTION
### Summary

We had to disable the tracing gate last night. Due to this is now deployments for the docs (e.g. preview or prod) are now failing.
