### PR TITLE
Add example for validating JWT in a Cloudflare Worker

### DIFF
--- a/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
+++ b/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
@@ -104,7 +104,7 @@ You can now paste the AUD tag into your token validation script. The AUD tag wil
 
 ### Cloudflare Workers example
 
-When Cloudflare Access is in front of your [Worker](/workers), your Worker still needs to validate the JWT that Cloudflare Access adds to the `Cf-Access-Jwt-Assertion` header on the incoming request, to ensure that the request came from Cloudflare Access, and not a malicious third-party.
+When Cloudflare Access is in front of your [Worker](/workers), your Worker still needs to validate the JWT that Cloudflare Access adds to the `Cf-Access-Jwt-Assertion` header on the incoming request.
 
 The following code will validate the JWT using the [jose NPM package](https://www.npmjs.com/package/jose):
 
@@ -153,14 +153,8 @@ export default {
 #### Required environment variables
 
 Add these [environment variables](/workers/configuration/environment-variables/) to your Worker:
-
-1. **`POLICY_AUD`** - Your application's Audience (AUD) tag from Zero Trust dashboard
-   - Go to **Access** > **Applications** > **Configure** > **Basic information**
-   - Copy the **Application Audience (AUD) Tag**
-
-2. **`TEAM_DOMAIN`** - Your Zero Trust team domain
-   - Format: `https://<your-team-name>.cloudflareaccess.com`
-   - Replace `<your-team-name>` with your actual team name
+	- `POLICY_AUD`: Your application's [AUD tag](#get-your-aud-tag)
+	- `TEAM_DOMAIN`: `https://<your-team-name>.cloudflareaccess.com`, where `<your-team-name>` is replaced with your actual <GlossaryTooltip term="team name">team name</GlossaryTooltip>.
 
 You can set these variables by adding them to your Worker's [Wrangler configuration file](/workers/wrangler/configuration/), or via the Cloudflare dashboard under **Workers & Pages** > **your-worker** > **Settings** > **Environment Variables**.
 
@@ -354,7 +348,3 @@ app.get("/", (req, res) => {
 
 app.listen(3333);
 ```
-
-## Related resources
-
-- [Verifying JWTs in Cloudflare Workers](https://kinde.com/blog/engineering/verifying-jwts-in-cloudflare-workers/) - Implement JWT verification in Cloudflare Workers.

--- a/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
+++ b/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
@@ -102,6 +102,68 @@ To get the AUD tag:
 
 You can now paste the AUD tag into your token validation script. The AUD tag will never change unless you delete or recreate the Access application.
 
+### Cloudflare Workers example
+
+When Cloudflare Access is in front of your [Worker](/workers), your Worker still needs to validate the JWT that Cloudflare Access adds to the `Cf-Access-Jwt-Assertion` header on the incoming request, to ensure that the request came from Cloudflare Access, and not a malicious third-party.
+
+The following code will validate the JWT using the [jose NPM package](https://www.npmjs.com/package/jose):
+
+```javascript
+import { jwtVerify, createRemoteJWKSet } from 'jose';
+
+export default {
+	async fetch(request, env, ctx) {
+		// Get the JWT from the request headers
+		const token = request.headers.get('cf-access-jwt-assertion');
+
+		// Check if token exists
+		if (!token) {
+			return new Response('Missing required CF Access JWT', {
+				status: 403,
+				headers: { 'Content-Type': 'text/plain' }
+			});
+		}
+
+		try {
+			// Create JWKS from your team domain
+			const JWKS = createRemoteJWKSet(new URL(`${env.TEAM_DOMAIN}/cdn-cgi/access/certs`));
+
+			// Verify the JWT
+			const { payload } = await jwtVerify(token, JWKS, {
+				issuer: env.TEAM_DOMAIN,
+				audience: env.POLICY_AUD,
+			});
+
+			// Token is valid, proceed with your application logic
+			return new Response(`Hello ${payload.email || 'authenticated user'}!`, {
+				headers: { 'Content-Type': 'text/plain' }
+			});
+
+		} catch (error) {
+			// Token verification failed
+			return new Response(`Invalid token: ${error.message}`, {
+				status: 403,
+				headers: { 'Content-Type': 'text/plain' }
+			});
+		}
+	},
+};
+```
+
+#### Required environment variables
+
+Add these [environment variables](/workers/configuration/environment-variables/) to your Worker:
+
+1. **`POLICY_AUD`** - Your application's Audience (AUD) tag from Zero Trust dashboard
+   - Go to **Access** > **Applications** > **Configure** > **Basic information**
+   - Copy the **Application Audience (AUD) Tag**
+
+2. **`TEAM_DOMAIN`** - Your Zero Trust team domain
+   - Format: `https://<your-team-name>.cloudflareaccess.com`
+   - Replace `<your-team-name>` with your actual team name
+
+You can set these variables by adding them to your Worker's [Wrangler configuration file](/workers/wrangler/configuration/), or via the Cloudflare dashboard under **Workers & Pages** > **your-worker** > **Settings** > **Environment Variables**.
+
 ### Golang example
 
 ```go
@@ -246,7 +308,7 @@ if __name__ == '__main__':
     app.run()
 ```
 
-### JavaScript example
+### JavaScript (Node.js) example
 
 ```javascript
 const express = require("express");


### PR DESCRIPTION
https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/#javascript-example is Node.js

The page links to an external 3rd party URL to guide someone using Access and Workers together: https://kinde.com/blog/engineering/verifying-jwts-in-cloudflare-workers/

Should have something first-party here, and it should guide people more clearly (esp in advance of making it easier to one-click enable Access for a Worker)

reviewing code before moving this out of draft