### PR TITLE
[Bugfix] Vendored Markdown - exclude llms.txt files

### DIFF
--- a/bin/generate-index-md.ts
+++ b/bin/generate-index-md.ts
@@ -14,7 +14,12 @@ import YAML from "yaml";
 const files = await glob("dist/**/*.html");
 
 for (const file of files) {
-	if (file === "dist/index.html" || file === "dist/404.html") {
+	if (
+		file === "dist/index.html" ||
+		file === "dist/404.html" ||
+		file === "dist/llms.txt" ||
+		file.includes("llms-full.txt")
+	) {
 		continue;
 	}
 


### PR DESCRIPTION
### Summary

Recently a lot of the Vendored markdown uploads have failed, specifically when uploading [llms.txt](https://github.com/cloudflare/cloudflare-docs/actions/runs/17955504713/job/51065595739#step:10:11708).

This excludes those files from vendored markdown more generally, which also should make sense given that -- if someone's using this export -- they wouldn't need the llms.txt version.
