### PR TITLE
Update index.mdx about important remarks

### DIFF
--- a/src/content/docs/rules/transform/response-header-modification/index.mdx
+++ b/src/content/docs/rules/transform/response-header-modification/index.mdx
@@ -53,7 +53,7 @@ You can create a response header transform rule [in the dashboard](/rules/transf
 
 - The response header values are calculated using the field values from the corresponding HTTP request. For example, the value of `ip.src.country` will be the country of the website visitor, not the origin where the response was sent from.
 
-- You cannot modify or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.
+- You cannot add, modify or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.
 
 - You cannot modify the value of certain headers such as `server`, `eh-cache-tag`, or `eh-cdn-cache-control`.
 

--- a/src/content/docs/rules/transform/response-header-modification/index.mdx
+++ b/src/content/docs/rules/transform/response-header-modification/index.mdx
@@ -53,7 +53,7 @@ You can create a response header transform rule [in the dashboard](/rules/transf
 
 - The response header values are calculated using the field values from the corresponding HTTP request. For example, the value of `ip.src.country` will be the country of the website visitor, not the origin where the response was sent from.
 
-- You cannot add, modify or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.
+- You cannot add, modify, or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.
 
 - You cannot modify the value of certain headers such as `server`, `eh-cache-tag`, or `eh-cdn-cache-control`.
 


### PR DESCRIPTION
In Important remarks
changed 
From:
You cannot modify or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.

To:
You cannot add, modify or remove HTTP response headers whose name starts with `cf-` or `x-cf-`.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
