### PR TITLE
store-and-sync-state: use this.sql synchronously

### DIFF
--- a/src/content/docs/agents/api-reference/store-and-sync-state.mdx
+++ b/src/content/docs/agents/api-reference/store-and-sync-state.mdx
@@ -211,7 +211,7 @@ export class MyAgent extends Agent<Env> {
 		let userId = new URL(request.url).searchParams.get('userId');
 		// Supply the type parameter to the query when calling this.sql
 		// This assumes the results returns one or more User rows with "id", "name", and "email" columns
-		const user = this.sql<User>`SELECT * FROM users WHERE id = ${userId}`;
+		const [user] = this.sql<User>`SELECT * FROM users WHERE id = ${userId}`;
 		return Response.json(user)
 	}
 }

--- a/src/content/docs/agents/api-reference/store-and-sync-state.mdx
+++ b/src/content/docs/agents/api-reference/store-and-sync-state.mdx
@@ -189,7 +189,7 @@ export class MyAgent extends Agent<Env> {
 
 		// 'users' is just an example here: you can create arbitrary tables and define your own schemas
 		// within each Agent's database using SQL (SQLite syntax).
-		let user = await this.sql`SELECT * FROM users WHERE id = ${userId}`
+		let user = this.sql`SELECT * FROM users WHERE id = ${userId}`
 		return Response.json(user)
 	}
 }
@@ -211,7 +211,7 @@ export class MyAgent extends Agent<Env> {
 		let userId = new URL(request.url).searchParams.get('userId');
 		// Supply the type parameter to the query when calling this.sql
 		// This assumes the results returns one or more User rows with "id", "name", and "email" columns
-		const user = await this.sql<User>`SELECT * FROM users WHERE id = ${userId}`;
+		const user = this.sql<User>`SELECT * FROM users WHERE id = ${userId}`;
 		return Response.json(user)
 	}
 }
@@ -242,7 +242,7 @@ export class ReasoningAgent extends Agent<Env> {
 	async callReasoningModel(prompt: Prompt) {
 		let result = this.sql<History>`SELECT * FROM history WHERE user = ${prompt.userId} ORDER BY timestamp DESC LIMIT 1000`;
 		let context = [];
-		for await (const row of result) {
+		for (const row of result) {
 			context.push(row.entry);
 		}
 

--- a/src/content/docs/agents/api-reference/store-and-sync-state.mdx
+++ b/src/content/docs/agents/api-reference/store-and-sync-state.mdx
@@ -189,7 +189,7 @@ export class MyAgent extends Agent<Env> {
 
 		// 'users' is just an example here: you can create arbitrary tables and define your own schemas
 		// within each Agent's database using SQL (SQLite syntax).
-		let user = this.sql`SELECT * FROM users WHERE id = ${userId}`
+		let [user] = this.sql`SELECT * FROM users WHERE id = ${userId}`
 		return Response.json(user)
 	}
 }


### PR DESCRIPTION
### Summary

fixes https://github.com/cloudflare/cloudflare-docs/issues/25018

copying summary from there:

### Existing documentation URL(s)

https://developers.cloudflare.com/agents/api-reference/store-and-sync-state/#sql-api

The first example of the `this.sql` helper uses `await` which is functional but misleading that it's necessary(?) and doesn't showcase the value:

```ts
export class MyAgent extends Agent<Env> {
  async onRequest(request: Request) {
    let userId = new URL(request.url).searchParams.get('userId');

    // 'users' is just an example here: you can create arbitrary tables and define your own schemas
    // within each Agent's database using SQL (SQLite syntax).
    let user = await this.sql`SELECT * FROM users WHERE id = ${userId}`
    return Response.json(user)
  }
}
```

I think it's also probably misleading to imply the return value from that particular sql query is `user` given `this.sql` returns an array? Have I got this wrong?

### What changes are you suggesting?

An sync/singular example like 

```ts
let [user] = this.sql`select * from users where id = ${userId}`
```

### Additional information

Intro blog mentions it's synchronous! https://blog.cloudflare.com/sqlite-in-durable-objects/#reads-and-writes-are-synchronous

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- ~[ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).~
- ~[ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.~
- ~[ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~
- ~[ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~
