### PR TITLE
remove beta label from Workers Builds

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/index.mdx
+++ b/src/content/docs/workers/ci-cd/builds/index.mdx
@@ -3,8 +3,7 @@ pcx_content_type: concept
 title: Builds
 description: Use Workers Builds to integrate with Git and automatically build and deploy your Worker when pushing a change
 sidebar:
-    badge:
-      text: Beta
+  order: 1
 ---
 import { DashButton } from "~/components";
 


### PR DESCRIPTION
Removed beta label from Workers Builds per GA announcement.
