### PR TITLE
[BRAPI]: add storage state example for playwright

### DIFF
--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -238,7 +238,7 @@ await using page = await context.newPage();
 // gets updated storage state: cookies, localStorage, and IndexedDB
 const updatedStorageState = await context.storageState({ indexedDB: true });
 
-// persist updated storage state in KV
+// persists updated storage state in KV
 await env.KV.put('storageState', JSON.stringify(updatedStorageState));
 ```
 

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -215,6 +215,8 @@ npx wrangler kv namespace create KV
 }
 ```
 
+</WranglerConfig>
+
 - Now, you can use the storage state to persist cookies and other storage data in KV:
 
 ```ts title="src/index.ts"

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -181,6 +181,54 @@ export default {
 };
 ```
 
+### Storage state
+
+Playwright supports [storage state](https://playwright.dev/docs/api/class-browsercontext#browsercontext-storage-state) to obtain and persist cookies and other storage data.
+
+Here's an example that uses storage state to persist cookies and other storage data in [KV](https://developers.cloudflare.com/kv):
+
+<WranglerConfig>
+
+```jsonc
+{
+	"name": "storage-state-examples",
+	"main": "src/index.ts",
+	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_date": "2025-09-17",
+	"browser": {
+		"binding": "MYBROWSER"
+	},
+	"kv_namespaces": [
+		{
+			"binding": "KV",
+			"id": "<YOUR-KV-NAMESPACE-ID>"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+```ts title="src/index.ts"
+// gets persisted storage state from KV or undefined if it doesn't exist
+const storageStateJson = await env.KV.get('storageState');
+const storageState = storageStateJson ? await JSON.parse(storageStateJson) as BrowserContextOptions['storageState'] : undefined;
+
+await using browser = await launch(env.MYBROWSER);
+// creates a new context with storage state persisted in KV
+await using context = await browser.newContext({ storageState });
+
+await using page = await context.newPage();
+
+// do some actions on the page that may update client-side storage
+
+// gets updated storage state: cookies, localStorage and IndexedDB
+const updatedStorageState = await context.storageState({ indexedDB: true });
+
+// persist updated storage state in KV
+await env.KV.put('storageState', JSON.stringify(updatedStorageState));
+```
+
 ### Keep Alive
 
 If users omit the `browser.close()` statement, the browser instance will stay open, ready to be connected to again and [re-used](/browser-rendering/workers-bindings/reuse-sessions/) but it will, by default, close automatically after 1 minute of inactivity. Users can optionally extend this idle time up to 10 minutes, by using the `keep_alive` option, set in milliseconds:

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -189,7 +189,6 @@ export default {
 
 Playwright supports [storage state](https://playwright.dev/docs/api/class-browsercontext#browsercontext-storage-state) to obtain and persist cookies and other storage data.
 
-Here's an example that uses storage state to persist cookies and other storage data in [KV](/kv):
 
 First, ensure you have a KV namespace. You can create a new one with:
 

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -187,7 +187,7 @@ export default {
 
 ### Storage state
 
-Playwright supports [storage state](https://playwright.dev/docs/api/class-browsercontext#browsercontext-storage-state) to obtain and persist cookies and other storage data.
+Playwright supports [storage state](https://playwright.dev/docs/api/class-browsercontext#browsercontext-storage-state) to obtain and persist cookies and other storage data. In this example, you will use storage state to persist cookies and other storage data in [Workers KV](/kv).
 
 
 First, ensure you have a KV namespace. You can create a new one with:

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -235,7 +235,7 @@ await using page = await context.newPage();
 
 // do some actions on the page that may update client-side storage
 
-// gets updated storage state: cookies, localStorage and IndexedDB
+// gets updated storage state: cookies, localStorage, and IndexedDB
 const updatedStorageState = await context.storageState({ indexedDB: true });
 
 // persist updated storage state in KV

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -36,6 +36,10 @@ If you want to skip the steps and get started quickly, select **Deploy to Cloudf
 
 Make sure you have the [browser binding](/browser-rendering/platform/wrangler/#bindings) configured in your `wrangler.toml` file:
 
+:::note
+To use the latest version of `@cloudflare/playwright`, your Worker configuration must include the `nodejs_compat` compatibility flag and a `compatibility_date` of 2025-09-15 or later. This change is necessary because the library's functionality requires the native `node.fs` API.
+:::
+
 <WranglerConfig>
 
 ```toml
@@ -185,15 +189,15 @@ export default {
 
 Playwright supports [storage state](https://playwright.dev/docs/api/class-browsercontext#browsercontext-storage-state) to obtain and persist cookies and other storage data.
 
-Here's an example that uses storage state to persist cookies and other storage data in [KV](https://developers.cloudflare.com/kv):
+Here's an example that uses storage state to persist cookies and other storage data in [KV](/kv):
 
-- First, ensure you have a KV namespace. You can create a new one with:
+First, ensure you have a KV namespace. You can create a new one with:
 
 ```bash
 npx wrangler kv namespace create KV
 ```
 
-- Ensure you add the KV namespace to your `wrangler.toml` file:
+Ensure you add the KV namespace to your `wrangler.toml` file:
 
 <WranglerConfig>
 
@@ -217,7 +221,7 @@ npx wrangler kv namespace create KV
 
 </WranglerConfig>
 
-- Now, you can use the storage state to persist cookies and other storage data in KV:
+Now, you can use the storage state to persist cookies and other storage data in KV:
 
 ```ts title="src/index.ts"
 // gets persisted storage state from KV or undefined if it doesn't exist

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -196,7 +196,7 @@ First, ensure you have a KV namespace. You can create a new one with:
 npx wrangler kv namespace create KV
 ```
 
-Ensure you add the KV namespace to your `wrangler.toml` file:
+Then, add the KV namespace to your `wrangler.toml` file:
 
 <WranglerConfig>
 

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -187,6 +187,14 @@ Playwright supports [storage state](https://playwright.dev/docs/api/class-browse
 
 Here's an example that uses storage state to persist cookies and other storage data in [KV](https://developers.cloudflare.com/kv):
 
+- First, ensure you have a KV namespace. You can create a new one with:
+
+```bash
+npx wrangler kv namespace create KV
+```
+
+- Ensure you add the KV namespace to your `wrangler.toml` file:
+
 <WranglerConfig>
 
 ```jsonc
@@ -207,7 +215,7 @@ Here's an example that uses storage state to persist cookies and other storage d
 }
 ```
 
-</WranglerConfig>
+- Now, you can use the storage state to persist cookies and other storage data in KV:
 
 ```ts title="src/index.ts"
 // gets persisted storage state from KV or undefined if it doesn't exist

--- a/src/content/docs/browser-rendering/platform/playwright.mdx
+++ b/src/content/docs/browser-rendering/platform/playwright.mdx
@@ -223,7 +223,7 @@ Then, add the KV namespace to your `wrangler.toml` file:
 Now, you can use the storage state to persist cookies and other storage data in KV:
 
 ```ts title="src/index.ts"
-// gets persisted storage state from KV or undefined if it doesn't exist
+// gets persisted storage state from KV or undefined if it does not exist
 const storageStateJson = await env.KV.get('storageState');
 const storageState = storageStateJson ? await JSON.parse(storageStateJson) as BrowserContextOptions['storageState'] : undefined;
 


### PR DESCRIPTION
### Summary

Add storage state example for playwright
 
### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
