### PR TITLE
Fix 'Deploy your bucket' copy that should be 'Deploy your Worker'

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-usage.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-usage.mdx
@@ -268,7 +268,7 @@ Enter the secret text you'd like assigned to the variable AUTH_KEY_SECRET on the
 
 This secret is now available as `AUTH_KEY_SECRET` on the `env` parameter in your Worker.
 
-## 6. Deploy your bucket
+## 6. Deploy your Worker
 
 With your Worker and bucket set up, run the `npx wrangler deploy` [command](/workers/wrangler/commands/#deploy) to deploy to Cloudflare's global network:
 


### PR DESCRIPTION
### Summary

This copy should be "Deploy your Worker".

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [na] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [na] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [na] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [na] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
