### PR TITLE
[Workflows] Fix Workflow instance id and name lengths

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -79,7 +79,7 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 - <code>step.do(name: string, callback: (): RpcSerializable): Promise&lt;T&gt;</code>
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: ():
   	RpcSerializable): Promise&lt;T&gt;</code>
-  - `name` - the name of the step.
+  - `name` - the name of the step, up to 256 characters.
   - `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
   - `callback` - an asynchronous function that optionally returns serializable state for the Workflow to persist.
 
@@ -250,7 +250,7 @@ Create (trigger) a new instance of the given Workflow.
 - <code>create(options?: WorkflowInstanceCreateOptions): Promise&lt;WorkflowInstance&gt;</code>
   - `options` - optional properties to pass when creating an instance, including a user-provided ID and payload parameters.
 
-An ID is automatically generated, but a user-provided ID can be specified (up to 64 characters [^1]). This can be useful when mapping Workflows to users, merchants or other identifiers in your system. You can also provide a JSON object as the `params` property, allowing you to pass data for the Workflow instance to act on as its [`WorkflowEvent`](/workflows/build/events-and-parameters/).
+An ID is automatically generated, but a user-provided ID can be specified (up to 100 characters [^1]). This can be useful when mapping Workflows to users, merchants or other identifiers in your system. You can also provide a JSON object as the `params` property, allowing you to pass data for the Workflow instance to act on as its [`WorkflowEvent`](/workflows/build/events-and-parameters/).
 
 ```ts
 // Create a new Workflow instance with your own ID and pass params to the Workflow instance

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -28,7 +28,8 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum Workflow instance creation rate | 100 per 10 seconds [^6] | 100 per 10 seconds [^6] |
 | Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 | 100,000 |
 | Retention limit for completed Workflow state | 3 days | 30 days [^2] |
-| Maximum length of a Workflow ID [^4]         | 64 characters | 64 characters |
+| Maximum length of a Workflow name [^4]         | 64 characters | 64 characters |
+| Maximum length of a Workflow instance ID [^4]         | 100 characters | 100 characters |
 | Maximum number of subrequests per Workflow instance | 50/request | 1000/request |
 
 [^2]: Workflow state and logs will be retained for 3 days on the Workers Free plan and for 7 days on the Workers Paid plan.


### PR DESCRIPTION
### Summary

Updated lengths to match production behavior:
- Workflow instance id limit is 100 chars and not 64 as previously stated
- Workflow name (and not id) limit is 64 chars
- Workflow instance step name limit is 256 chars 


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
