### PR TITLE
Add packages info to Python docs

### DIFF
--- a/src/content/docs/workers/languages/python/packages/index.mdx
+++ b/src/content/docs/workers/languages/python/packages/index.mdx
@@ -46,6 +46,15 @@ Your dependencies will get bundled with your worker automatically on deployment.
 
 The `pywrangler` CLI also supports all commands supported by the `wrangler` tool, for the full list of commands run `uv run pywrangler --help`.
 
+## Supported Libraries
+
+Python Workers support pure Python packages on [PyPI](https://pypi.org/),
+as well as [packages that are included in Pyodide](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
+
+If you would like to use a package that is not pure Python and not yet supported in Pyodide, request support via
+the [Python Packages Discussions](https://github.com/cloudflare/workerd/discussions/categories/python-packages) on the
+Cloudflare Workers Runtime GitHub repository.
+
 ## HTTP Client Libraries
 
 Only HTTP libraries that are able to make requests asynchronously are supported. Currently, these include [`aiohttp`](https://docs.aiohttp.org/en/stable/index.html) and [`httpx`](https://www.python-httpx.org/). You can also use the [`fetch()` API](/workers/runtime-apis/fetch/) from JavaScript, using Python Workers' [foreign function interface](/workers/languages/python/ffi) to make HTTP requests.


### PR DESCRIPTION
### Summary

Adds some explanation as to which Python Packages we support.

