### PR TITLE
docs: switch to http.request.cookies for gradual rollout

### DIFF
--- a/src/content/docs/workers/static-assets/routing/advanced/gradual-rollouts.mdx
+++ b/src/content/docs/workers/static-assets/routing/advanced/gradual-rollouts.mdx
@@ -64,7 +64,7 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 **Header name**: `Cloudflare-Workers-Version-Key`
 
-**Value**: `http.cookie["session_id"]`
+**Value**: `http.request.cookies["session_id"][0]`
 
 </Example>
 
@@ -84,7 +84,7 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 **Header name**: `Cloudflare-Workers-Version-Key`
 
-**Value**: `http.cookie["user_id"]`
+**Value**: `http.request.cookies["user_id"][0]`
 
 </Example>
 


### PR DESCRIPTION
### Summary

From this issue: https://github.com/cloudflare/cloudflare-docs/issues/25478
Documentation of fields: https://developers.cloudflare.com/ruleset-engine/rules-language/fields/reference/http.request.cookies/

This pull request updates documentation examples to use the correct syntax for accessing cookie values in Cloudflare Workers. The changes clarify how to retrieve the first value of a cookie from the request object.

Documentation corrections:

* Updated the example values for setting the `Cloudflare-Workers-Version-Key` header to use `http.request.cookies["session_id"][0]` and `http.request.cookies["user_id"][0]` instead of the incorrect `http.cookie` syntax in `src/content/docs/workers/static-assets/routing/advanced/gradual-rollouts.mdx`. [[1]](diffhunk://#diff-a145c23ff102ba083cab2bdbfa6e938d35459d706d2a42b5553d0b3077244afbL67-R67) [[2]](diffhunk://#diff-a145c23ff102ba083cab2bdbfa6e938d35459d706d2a42b5553d0b3077244afbL87-R87)

### Screenshots (optional)

**Before**
<img width="700" height="400" alt="Screenshot 2025-09-27 at 11 01 09 AM" src="https://github.com/user-attachments/assets/d49ec6ba-3b70-49ef-b43d-b7f2e13b93bc" />

**After**
<img width="600" height="450" alt="Screenshot 2025-09-27 at 11 31 40 AM" src="https://github.com/user-attachments/assets/c98e8b6a-e26f-44e9-aca7-0ab3436fb0c5" />

**Logs of CF worker**
<img width="756" height="803" alt="Screenshot 2025-09-27 at 11 48 32 AM" src="https://github.com/user-attachments/assets/4eac0135-5f58-4e72-bc5d-e5a58d307ecc" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
