### PR TITLE
Render Markdown if we get an Accept text/markdown header

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -14,7 +14,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					"accept-encoding": "identity",
 				},
 			});
-		} else if (pathname.endsWith("/index.md")) {
+		} else if (
+			pathname.endsWith("/index.md") ||
+			context.request.headers.get("accept")?.includes("text/markdown")
+		) {
 			const htmlUrl = new URL(pathname.replace("index.md", ""), context.url);
 			const html = await (await fetch(htmlUrl)).text();
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -33,7 +33,10 @@ export default class extends WorkerEntrypoint<Env> {
 			});
 		}
 
-		if (request.url.endsWith("/index.md")) {
+		if (
+			request.url.endsWith("/index.md") ||
+			request.headers.get("accept")?.includes("text/markdown")
+		) {
 			const htmlUrl = request.url.replace("index.md", "");
 			const res = await this.env.ASSETS.fetch(htmlUrl, request);
 


### PR DESCRIPTION
### Summary

If an incoming request says they accept Markdown, render that instead of the usual HTML page. This can help reduce token usage for LLMs.

Test with:
```
$ curl https://walshy-accept-markdown.preview.developers.cloudflare.com/workers/static-assets/binding/ -H 'Accept: text/markdown' -v
```

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
