### PR TITLE
[Workers] Remove experimental flag in waku framework guide

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/waku.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/waku.mdx
@@ -24,7 +24,7 @@ To use `create-cloudflare` to create a new Waku project with Workers Assets, run
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest my-waku-app"
-	args={"--framework=waku --experimental"}
+	args={"--framework=waku"}
 />
 
 <Render


### PR DESCRIPTION
### Summary

The `--experimental` flag is not needed for `create-cloudflare --framework waku`. It was removed in the final merged version of https://github.com/cloudflare/workers-sdk/pull/8314 and we missed updating these docs. When used, it results in an error:

```
Error: Unsupported framework: waku
```

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
