### PR TITLE
Update enable-proxy-protocol with MWAN note

### DIFF
--- a/src/content/docs/spectrum/how-to/enable-proxy-protocol.mdx
+++ b/src/content/docs/spectrum/how-to/enable-proxy-protocol.mdx
@@ -7,7 +7,7 @@ weight: 0
 
 Because Cloudflare intercepts packets before forwarding them to your server, if you were to look up the client IP, you would see Cloudflare's IP rather than the true client IP.
 
-Some services you run may require knowledge of the true client IP. In those cases, you can use a proxy protocol for Cloudflare to pass on the client IP to your service. Sending proxy information along is dependent on whether TCP or UDP is used. For TCP, Spectrum supports adding [Proxy Protocol v1](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt), which is the human readable version supported by Amazon ELB and [NGINX](https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/). For UDP applications, Cloudflare has developed a custom proxy protocol called Simple Proxy Protocol.
+Some services you run may require knowledge of the true client IP. In those cases, you can use a proxy protocol for Cloudflare to pass on the client IP to your service. Sending proxy information along is dependent on whether TCP or UDP is used. For TCP, Spectrum supports adding [Proxy Protocol v1](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt), which is the human readable version supported by Amazon ELB and [NGINX](https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/). For UDP applications, Cloudflare has developed a custom proxy protocol called Simple Proxy Protocol. Be aware that Proxy Protocol is not supported for Spectrum egresses to Magic WAN.
 
 :::note
 


### PR DESCRIPTION
added "Be aware that Proxy Protocol is not supported for Spectrum egresses to Magic WAN."

### Summary

added the sentence "Be aware that Proxy Protocol is not supported for Spectrum egresses to Magic WAN."
