### PR TITLE
Documented support for HTTP/3

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/index.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/index.mdx
@@ -9,6 +9,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components"
 
-With DNS over HTTPS (DoH), DNS queries and responses are encrypted and sent via the HTTP or HTTP/2 protocols. DoH ensures that attackers cannot forge or alter DNS traffic. DoH uses port 443, which is the standard HTTPS traffic port, to wrap the DNS query in an HTTPS request. DNS queries and responses are camouflaged within other HTTPS traffic, since it all comes and goes from the same port.
+With DNS over HTTPS (DoH), DNS queries and responses are encrypted and sent via the HTTP, HTTP/2 and HTTP/3 protocols. DoH ensures that attackers cannot forge or alter DNS traffic. DoH uses port 443, which is the standard HTTPS traffic port, to wrap the DNS query in an HTTPS request. DNS queries and responses are camouflaged within other HTTPS traffic, since it all comes and goes from the same port.
 
 <DirectoryListing />


### PR DESCRIPTION
Update documentation to mention DNS over HTTP/3 support.

### Summary

Cloudflare 1.1.1.1 resolver natively supports DNS over HTTP/3, but that's not mentioned in Cloudflare's documentation. I just added a small mention to this in the Overview section of DNS over HTTPS.




