### PR TITLE
remove text stating we have no support for heic

### DIFF
--- a/src/content/docs/images/transform-images/index.mdx
+++ b/src/content/docs/images/transform-images/index.mdx
@@ -80,7 +80,7 @@ GIF/WebP animations are limited to a total of 50 megapixels (the sum of sizes of
 
 :::caution[Important]
 
-SVG files are passed through without resizing. This format is inherently scalable and does not need resizing. Cloudflare does not support the HEIC (HEIF) format and does not plan to support it.
+SVG files are passed through without resizing. This format is inherently scalable and does not need resizing.
 
 AVIF format is supported on a best-effort basis. Images that cannot be compressed as AVIF will be served as WebP instead.
 


### PR DESCRIPTION
### Summary

While we will continue to not support outputting HEIC, we now support the input format of HEIC which makes this sentence somewhat misleading.
