### PR TITLE
[Logpush] Updated "Enable Datadog" page with Limitations section, outlining Datadog's hard limits.

### DIFF
--- a/src/content/docs/logs/changelog/logs.mdx
+++ b/src/content/docs/logs/changelog/logs.mdx
@@ -11,10 +11,14 @@ import { ProductChangelog } from "~/components";
 
 <ProductChangelog product="logs" />
 
+## 2025-10-01
+
+Logpush documentation has been updated for enabling Datadog, which outlines the Datadog hardcoded limitations, and how they apply to Logpush.
+
 ## 2024-10-08
 
 Cloudflare has introduced new fields two Gateway-related datasets in Cloudflare Logs:
 
-  * **Gateway HTTP**: `ApplicationIDs`, `ApplicationNames`, `CategoryIDs`, `CategoryNames`, `DestinationIPContinentCode`, `DestinationIPCountryCode`, `ProxyEndpoint`, `SourceIPContinentCode`, `SourceIPCountryCode`, `VirtualNetworkID`, and `VirtualNetworkName`.
+- **Gateway HTTP**: `ApplicationIDs`, `ApplicationNames`, `CategoryIDs`, `CategoryNames`, `DestinationIPContinentCode`, `DestinationIPCountryCode`, `ProxyEndpoint`, `SourceIPContinentCode`, `SourceIPCountryCode`, `VirtualNetworkID`, and `VirtualNetworkName`.
 
-  * **Gateway Network**: `ApplicationIDs`, `ApplicationNames`, `DestinationIPContinentCode`, `DestinationIPCountryCode`, `ProxyEndpoint`, `SourceIPContinentCode`, `SourceIPCountryCode`, `TransportProtocol`, `VirtualNetworkID`, and `VirtualNetworkName`.
+- **Gateway Network**: `ApplicationIDs`, `ApplicationNames`, `DestinationIPContinentCode`, `DestinationIPCountryCode`, `ProxyEndpoint`, `SourceIPContinentCode`, `SourceIPCountryCode`, `TransportProtocol`, `VirtualNetworkID`, and `VirtualNetworkName`.

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
@@ -16,17 +16,18 @@ Cloudflare Logpush supports pushing logs directly to Datadog via the Cloudflare 
 
 Please note the following Logpush sending limitations, as described in the Datadog documentation, [here](https://docs.datadoghq.com/api/latest/logs/).
 
-> Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
+> Send your logs to your Datadog platform over HTTP. **Limits per HTTP request are:**
+>
+> - Maximum content size per payload (uncompressed): 5MB
+> - Maximum size for a single log: 1MB
+> - Maximum array size if sending multiple logs in an array: 1000 entries
 
-> * Maximum content size per payload (uncompressed): 5MB
-> * Maximum size for a single log: 1MB
-> * Maximum array size if sending multiple logs in an array: 1000 entries
+:::caution[Warning]
 
-!!! warning
-The above limits are hardcoded defaults. It is not possible to override these limitations using the Logpush configuration values, `max_upload_records` or `max_upload_bytes`. 
+The above limits are hardcoded defaults. It is not possible to override these limitations using the Logpush configuration values, `max_upload_records` or `max_upload_bytes`.
 
-Note that these limitations may result in noticeable log ingestion delay within Datadog. Logpush will not drop unsent logs, so all logs will be uploaded to Datadog in due time.
-!!!
+These limitations may result in noticeable log ingestion delay within Datadog following high traffic events. Logpush will not drop unsent logs, so all logs will be uploaded to Datadog in due time.
+:::
 
 ## Manage via the Cloudflare dashboard
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
@@ -12,6 +12,22 @@ import { Render, TabItem, Tabs, APIRequest } from "~/components";
 
 Cloudflare Logpush supports pushing logs directly to Datadog via the Cloudflare dashboard or via API.
 
+## Limitations
+
+Please note the following Logpush sending limitations, as described in the Datadog documentation, [here](https://docs.datadoghq.com/api/latest/logs/).
+
+> Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
+
+> * Maximum content size per payload (uncompressed): 5MB
+> * Maximum size for a single log: 1MB
+> * Maximum array size if sending multiple logs in an array: 1000 entries
+
+!!! warning
+The above limits are hardcoded defaults. It is not possible to override these limitations using the Logpush configuration values, `max_upload_records` or `max_upload_bytes`. 
+
+Note that these limitations may result in noticeable log ingestion delay within Datadog. Logpush will not drop unsent logs, so all logs will be uploaded to Datadog in due time.
+!!!
+
 ## Manage via the Cloudflare dashboard
 
 <Render file="enable-logpush-job" product="logs" />


### PR DESCRIPTION
### Summary

A Limitations section has been added to the "Enable Datadog" provider page, under Logpush Job Setup. The Datadog limitations have been a noticeable Support Case driver, in the form of multiple cases concerned about Logpush lag to the destination. I feel it is critical to add this to our documentation, as it is more likely that our steps will be read and followed to integrate Datadog, before Datadog's documentation will be consulted.


### Screenshots (optional)

<img width="753" height="517" alt="datadog-limitations" src="https://github.com/user-attachments/assets/bd3c4da3-abe3-42bb-b471-60fe96335b36" />


### Documentation checklist

- [X] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? 
- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
