### PR TITLE
Fix broken link to Host selectors

### DIFF
--- a/src/content/docs/cloudflare-one/policies/gateway/egress-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/egress-policies/index.mdx
@@ -220,4 +220,4 @@ Gateway uses Rust to evaluate regular expressions. The Rust implementation is sl
 
 ### Selector prerequisites
 
-The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require configuration changes in order to be operational. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/policies/gateway/egress-policies/#host-selectors).
+The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require configuration changes in order to be operational. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/policies/gateway/egress-policies/host-selectors).


### PR DESCRIPTION
Fixes the broken link to Host selectors page in the Egress policies documentation.
