### PR TITLE
[Workers] Delete unrelated pages configuration in react-router docs

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
@@ -198,44 +198,4 @@ As you have direct access to your Worker entry file (`workers/app.ts`), you can 
 
 </Details>
 
-### Static assets
-
-By default, the Remix template for Cloudflare Pages Functions does not handle static assets, but you can configure it to do so.
-
-First, configure your `wrangler.toml` file to serve a directory.
-
-```toml title="wrangler.toml"
-[[d1_databases]]
-binding = "DB"
-database_name = "remix-app"
-database_id = "<YOUR_DATABASE_ID>"
-
-[[r2_buckets]]
-binding = "MY_BUCKET"
-bucket_name = "my-bucket"
-
-[site]
-bucket = "./public"
-```
-
-Then, you must modify your server handler to serve static assets from that directory.
-
-```ts title="functions/[[path]].ts"
-import { createPagesFunctionHandler } from "@remix-run/cloudflare-pages";
-import { type Env } from "../app/lib/env";
-
-// @ts-ignore
-import * as build from "../build";
-
-export const onRequest = createPagesFunctionHandler<Env>({
-  build,
-  getLoadContext: (context) => ({
-    cloudflare: {
-      ...context,
-      env: { ...context.env, ASSETS: undefined },
-    },
-  }),
-});
-```
-
 <Render file="frameworks-bindings" product="workers" />


### PR DESCRIPTION
### Summary

I am not sure why we mention mention Cloudflare Pages function in a docs about Cloudflare Workers. It gets added in #24569.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
