### PR TITLE
update Wrangler env-vars to include WRANGLER_LOG_SANITIZE and WRANGLER_SEND_ERROR_REPORTS

### DIFF
--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -61,8 +61,11 @@ Wrangler supports the following environment variables:
 - `NODE_ENV` <Type text="string" /> <MetaInfo text="optional" />
   - Sets the value of `process.env.NODE_ENV` in your Worker code. Defaults to `"development"` for `wrangler dev` and `"production"` for `wrangler deploy` and `wrangler versions upload`. Refer to [Bundling](/workers/wrangler/bundling/#node_env) for more information.
 
-- `WRANGLER_SEND_METRICS` <Type text="string" /> <MetaInfo text="optional" />
+- `WRANGLER_SEND_METRICS` <Type text="boolean" /> <MetaInfo text="optional" />
   - Options for this are `true` and `false`. Defaults to `true`. Controls whether Wrangler can send anonymous usage data to Cloudflare for this project. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
+
+- `WRANGLER_SEND_ERROR_REPORTS` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Options for this are `true` and `false`. Defaults to `undefined`. Controls whether Wrangler can send non-user error reports to Cloudflare for this project. If `undefined`, Wrangler will ask the user whether to send an error report each time there is a non-user error.
 
 - `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING_NAME>`<Type text="string" /> <MetaInfo text="optional" />
   - The [local connection string](/hyperdrive/configuration/local-development/) for your database to use in local development with [Hyperdrive](/hyperdrive/). For example, if the binding for your Hyperdrive is named `PROD_DB`, this would be `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_PROD_DB="postgres://user:password@127.0.0.1:5432/testdb"`. Each Hyperdrive is uniquely distinguished by the binding name.
@@ -75,6 +78,9 @@ Wrangler supports the following environment variables:
 
 - `WRANGLER_LOG_PATH` <Type text="string" /> <MetaInfo text="optional" />
   - A file or directory path where Wrangler will write debug logs. If the path ends in `.log`, Wrangler will consider this the path to a file where all logs will be written. Otherwise, Wrangler will treat the path as a directory where it will write one or more log files using a timestamp for the filenames.
+
+- `WRANGLER_LOG_SANITIZE` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Options for this are `true` and `false`. Defaults to `true`. Controls whether Wrangler will sanitize any sensitive information from logs written to the console or to a log file. Sensitive information includes API tokens, email addresses, account IDs, and more.
 
 - `FORCE_COLOR` <Type text="string" /> <MetaInfo text="optional" />
   - By setting this to `0`, you can disable Wrangler's colorised output, which makes it easier to read with some terminal setups. For example, `FORCE_COLOR=0`.


### PR DESCRIPTION
### Summary

Add docs about the new WRANGLER_SEND_ERROR_REPORTS env-var for Wrangler.

This was only really added to help non-interactive tooling (such as AIs) avoid having to deal with unwanted confirmation dialogs.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/25605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
