### PR TITLE
Update pfsense.mdx

### DIFF
--- a/src/content/docs/magic-wan/configuration/manually/third-party/pfsense.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/pfsense.mdx
@@ -49,6 +49,7 @@ Use the Cloudflare dashboard or API to [configure two IPsec tunnels](/magic-wan/
    - **Health check rate**: _Medium_
    - **Health check type**: _Request_
    - **Health check direction**: _Bidirectional_
+	- **Turn on replay protection**: Select
 2. Select **Add pre-shared key later** > **Add tunnels**.
 3. Repeat the process to create a second IPsec tunnel with the following options:
    - **Tunnel name**: `PF_TUNNEL_02`
@@ -58,6 +59,7 @@ Use the Cloudflare dashboard or API to [configure two IPsec tunnels](/magic-wan/
    - **Health check rate**: _Medium_
    - **Health check type**: _Request_
    - **Health check direction**: _Bidirectional_
+   - **Turn on replay protection**: Select
 4. Select **Add pre-shared key later** > **Add tunnels**.
 
 :::note

--- a/src/content/docs/magic-wan/configuration/manually/third-party/pfsense.mdx
+++ b/src/content/docs/magic-wan/configuration/manually/third-party/pfsense.mdx
@@ -49,7 +49,7 @@ Use the Cloudflare dashboard or API to [configure two IPsec tunnels](/magic-wan/
    - **Health check rate**: _Medium_
    - **Health check type**: _Request_
    - **Health check direction**: _Bidirectional_
-	- **Turn on replay protection**: Select
+	- **Turn on replay protection**: Enable
 2. Select **Add pre-shared key later** > **Add tunnels**.
 3. Repeat the process to create a second IPsec tunnel with the following options:
    - **Tunnel name**: `PF_TUNNEL_02`
@@ -59,7 +59,7 @@ Use the Cloudflare dashboard or API to [configure two IPsec tunnels](/magic-wan/
    - **Health check rate**: _Medium_
    - **Health check type**: _Request_
    - **Health check direction**: _Bidirectional_
-   - **Turn on replay protection**: Select
+   - **Turn on replay protection**: Enable
 4. Select **Add pre-shared key later** > **Add tunnels**.
 
 :::note


### PR DESCRIPTION
PFsense devices can not disable Anti-replay protection, so replay protection must be enabled on the cloudflare side.

### Summary

Pfsense doc currently does not mention enabling replay protection, this is required since the setting can not be disabled on the pfsense side. 


### Documentation checklist




- [ x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.


