### PR TITLE
Add separate bullet points for cert types

### DIFF
--- a/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/client-certificate.mdx
+++ b/src/content/docs/cloudflare-one/identity/devices/warp-client-checks/client-certificate.mdx
@@ -69,7 +69,8 @@ To generate a sample root CA for testing, refer to [Generate mTLS certificates](
    2. **Operating system**: Select your operating system.
    3. **OS locations**: Specify the location(s) where the client certificate is installed.
       <Details header="Windows">
-      	- Local machine trust store - User trust store
+      	- Local machine trust store
+        - User trust store
       </Details>
       <Details header="macOS">
       


### PR DESCRIPTION
### Summary

On Windows, the WARP client searches for certificates in both the local machine cert store and the user store. This PR adds a change to display the store types as separate bullet points rather than the previous one-liner

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
