### PR TITLE
Clarify that wrangler check startup generates a local CPU profile

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1849,6 +1849,14 @@ Generate a CPU profile of your Worker's startup phase.
 
 After you run `wrangler check startup`, you can import the profile into Chrome DevTools or open it directly in VSCode to view a flamegraph of your Worker's startup phase. Additionally, when a Worker deployment fails with a startup time error Wrangler will automatically generate a CPU profile for easy investigation.
 
+:::note
+
+This command measures performance of your Worker locally, on your own machine — which has a different CPU than when your Worker runs on Cloudflare. This means results can vary widely.
+
+You should use the CPU profile that `wrangler check startup` generates in order to understand where time is spent at startup, but you should not expect the overall startup time in the profile to match exactly what your Worker's startup time will be when deploying to Cloudflare.
+
+:::
+
 ```sh
 wrangler check startup
 ```


### PR DESCRIPTION
Add note about CPU profile performance variability.

Without this, one might assume that the startup time shown in the profile will match what will happen when deploying to Cloudflare or running on Cloudflare.