### PR TITLE
[WAF] Update example to use APIRequest component

### DIFF
--- a/src/content/docs/waf/tools/replace-insecure-js-libraries.mdx
+++ b/src/content/docs/waf/tools/replace-insecure-js-libraries.mdx
@@ -6,7 +6,13 @@ head:
     content: Replace insecure JavaScript libraries
 ---
 
-import { GlossaryTooltip, Tabs, TabItem, Steps } from "~/components";
+import {
+	GlossaryTooltip,
+	Tabs,
+	TabItem,
+	Steps,
+	APIRequest,
+} from "~/components";
 
 This feature, when turned on, automatically rewrites URLs to external JavaScript libraries to point to Cloudflare-hosted libraries instead. This change improves security and performance, and reduces the risk of malicious code being injected.
 
@@ -50,13 +56,16 @@ The feature is available in all Cloudflare plans, and is turned on by default on
 
 Issue a `PATCH` request similar to the following:
 
-```bash
-curl --request PATCH \
-"https://api.cloudflare.com/client/v4/zones/{zone_id}/settings/replace_insecure_js" \
---header "Authorization: Bearer <API_TOKEN>" \
---header "Content-Type: application/json" \
---data '{ "value": "on" }'
-```
+<APIRequest
+	path="/zones/{zone_id}/settings/{setting_id}"
+	parameters={{
+		setting_id: "replace_insecure_js",
+	}}
+	method="PATCH"
+	json={{
+		value: "on",
+	}}
+/>
 
 </TabItem> </Tabs>
 


### PR DESCRIPTION
### Summary

Switch API example from a code block to the `APIRequest` component, now that the schema includes the corresponding API operation.

### Documentation checklist

- [X] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
