### PR TITLE
workers: Request.clone does not return a Promise

### DIFF
--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -343,7 +343,7 @@ These methods are only available on an instance of a `Request` object or through
 
 
 
-* `clone()` : Promise\<Request>
+* `clone()` : Request
 
   * Creates a copy of the `Request` object.
 


### PR DESCRIPTION
### Summary

Incorrect type in docs for Request.clone result.
