### PR TITLE
[R2 Data Catalog] Update Docs for Table-Level Compaction Commands

### DIFF
--- a/src/content/changelog/r2/2025-10-06-data-catalog-table-compaction.mdx
+++ b/src/content/changelog/r2/2025-10-06-data-catalog-table-compaction.mdx
@@ -1,0 +1,23 @@
+---
+title: R2 Data Catalog table-level compaction
+description: Control compaction settings for individual Iceberg tables
+products:
+  - r2
+date: 2025-10-06
+hidden: false
+---
+
+You can now enable compaction for individual [Apache Iceberg](https://iceberg.apache.org/) tables in [R2 Data Catalog](/r2/data-catalog/), giving you fine-grained control over different workloads.
+
+```bash
+# Enable compaction for a specific table (no token required)
+npx wrangler r2 bucket catalog compaction enable <BUCKET> <NAMESPACE> <TABLE> --target-size 256
+```
+
+This allows you to:
+
+- Apply different target file sizes per table
+- Disable compaction for specific tables
+- Optimize based on table-specific access patterns
+
+Learn more at [Manage catalogs](/r2/data-catalog/manage-catalogs/).

--- a/src/content/docs/r2/data-catalog/about-compaction.mdx
+++ b/src/content/docs/r2/data-catalog/about-compaction.mdx
@@ -21,6 +21,12 @@ Every write operation in [Apache Iceberg](https://iceberg.apache.org/), no matte
 
 R2 Data Catalog can now [manage compaction](/r2/data-catalog/manage-catalogs) for Apache Iceberg tables stored in R2. When enabled, compaction runs automatically and combines new files that have not been compacted yet.
 
+You can enable compaction at two levels:
+- **Catalog-level**: Applies to all tables in your R2 bucket
+- **Table-level**: Fine-grained control for specific tables
+
+Table-level settings allow you to customize compaction behavior for different workloads within the same bucket.
+
 Compacted files are prefixed with `compacted-` in the `/data/` directory.
 
 ### Choosing the right target file size

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -49,9 +49,9 @@ npx wrangler r2 bucket catalog enable <BUCKET_NAME>
 ```
 
 After enabling, Wrangler will return your catalog URI and warehouse name.
+
 </TabItem>
 </Tabs>
-
 
 ## Disable R2 Data Catalog on a bucket
 
@@ -74,11 +74,14 @@ To disable the catalog on your bucket, run the [`r2 bucket catalog disable comma
 ```bash
 npx wrangler r2 bucket catalog disable <BUCKET_NAME>
 ```
+
 </TabItem>
 </Tabs>
 
 ## Enable compaction
+
 Compaction improves query performance by combining the many small files created during data ingestion into fewer, larger files according to the set `target file size`. For more information about compaction and why it's valuable, refer to [About compaction](/r2/data-catalog/about-compaction/).
+
 <Tabs syncKey='CLIvDash'>
 <TabItem label='Dashboard'>
 
@@ -96,11 +99,23 @@ Compaction improves query performance by combining the many small files created 
 </TabItem>
 <TabItem label='Wrangler CLI'>
 
-To enable the compaction on your catalog, run the [`r2 bucket catalog enable command`](/workers/wrangler/commands/#r2-bucket-catalog-compaction-enable):
+To enable the compaction on your catalog, run the [`r2 bucket catalog compaction enable` command](/workers/wrangler/commands/#r2-bucket-catalog-compaction-enable):
 
 ```bash
-npx wrangler r2 bucket catalog compaction enable <BUCKET_NAME>  --target-size 128 --token <API_TOKEN>
+# Enable catalog-level compaction (all tables)
+npx wrangler r2 bucket catalog compaction enable <BUCKET_NAME> --target-size 128 --token <API_TOKEN>
+
+# Enable compaction for a specific table
+npx wrangler r2 bucket catalog compaction enable <BUCKET_NAME> <NAMESPACE> <TABLE> --target-size 128
 ```
+
+:::note[Table-level vs Catalog-level compaction]
+
+- **Catalog-level**: Applies to all tables in the bucket; requires an API token as a service credential.
+- **Table-level**: Applies to a specific table only.
+
+:::
+
 </TabItem>
 </Tabs>
 
@@ -108,11 +123,13 @@ npx wrangler r2 bucket catalog compaction enable <BUCKET_NAME>  --target-size 12
 Compaction requires a Cloudflare API token with both R2 storage and R2 Data Catalog read/write permissions to act as a service credential. The compaction process uses this token to read files, combine them, and update table metadata.
 
 Refer to [Authenticate your Iceberg engine](#authenticate-your-iceberg-engine) for details on creating a token with the required permissions.
+:::
 
-Once enabled, compaction applies retroactively to all existing tables and automatically to newly created tables. During open beta, we currently compact up to 2 GB worth of files once per hour for each table.
+Once enabled, compaction applies retroactively to all existing tables (for catalog-level compaction) or the specified table (for table-level compaction). During open beta, we currently compact up to 2 GB worth of files once per hour for each table.
 
 ## Disable compaction
-Disabling compaction will prevent the process from running for all tables managed by the catalog. You can re-enable it at any time.
+
+Disabling compaction will prevent the process from running for all tables (catalog level) or a specific table (table level). You can re-enable it at any time.
 
 <Tabs syncKey='CLIvDash'>
 <TabItem label='Dashboard'>
@@ -130,11 +147,16 @@ Disabling compaction will prevent the process from running for all tables manage
 </TabItem>
 <TabItem label='Wrangler CLI'>
 
-To disable the compaction on your catalog, run the [`r2 bucket catalog disable command`](/workers/wrangler/commands/#r2-bucket-catalog-compaction-disable):
+To disable the compaction on your catalog, run the [`r2 bucket catalog compaction disable` command](/workers/wrangler/commands/#r2-bucket-catalog-compaction-disable):
 
 ```bash
+# Disable catalog-level compaction (all tables)
 npx wrangler r2 bucket catalog compaction disable <BUCKET_NAME>
+
+# Disable compaction for a specific table
+npx wrangler r2 bucket catalog compaction disable <BUCKET_NAME> <NAMESPACE> <TABLE>
 ```
+
 </TabItem>
 </Tabs>
 

--- a/src/content/partials/workers/wrangler-commands/r2.mdx
+++ b/src/content/partials/workers/wrangler-commands/r2.mdx
@@ -112,18 +112,32 @@ wrangler r2 bucket catalog get <NAME> [OPTIONS]
 	depth={3}
 />
 
-Enable compaction on a [R2 Data Catalog](/r2/data-catalog/).
+Enable compaction on a [R2 Data Catalog](/r2/data-catalog/) or a specific table.
 
 ```txt
-wrangler r2 bucket catalog compaction enable <BUCKET> [OPTIONS]
+wrangler r2 bucket catalog compaction enable <BUCKET> [NAMESPACE] [TABLE] [OPTIONS]
 ```
 
 - `BUCKET` <Type text="string" /> <MetaInfo text="required" />
   - The name of the bucket to enable R2 Data Catalog compaction for.
-- `--token` <Type text="string" /> <MetaInfo text="required" />
-  - The R2 API token with R2 Data Catalog edit permissions
-- `--target-size` <Type text="number" /> <MetaInfo text="required" />
-  - The target file size (in MB) compaction will attempt to generate. Default: 128.
+- `NAMESPACE` <Type text="string" /> <MetaInfo text="optional" />
+  - The namespace containing the table (for table-level compaction). Must be provided together with `TABLE`.
+- `TABLE` <Type text="string" /> <MetaInfo text="optional" />
+  - The name of the table (for table-level compaction). Must be provided together with `NAMESPACE`.
+- `--token` <Type text="string" /> <MetaInfo text="optional" />
+  - The R2 API token with R2 Data Catalog edit permissions. Required for catalog-level compaction only.
+- `--target-size` <Type text="number" /> <MetaInfo text="optional" />
+  - The target file size (in MB) compaction will attempt to generate. Default: 128. Allowed values: 64, 128, 256, 512.
+
+Examples:
+
+```bash
+# Enable catalog-level compaction (requires token)
+npx wrangler r2 bucket catalog compaction enable my-bucket --token <TOKEN>
+
+# Enable table-level compaction
+npx wrangler r2 bucket catalog compaction enable my-bucket my-namespace my-table --target-size 256
+```
 
 <AnchorHeading
 	title="`catalog compaction disable`"
@@ -131,14 +145,28 @@ wrangler r2 bucket catalog compaction enable <BUCKET> [OPTIONS]
 	depth={3}
 />
 
-Disable compaction on a [R2 Data Catalog](/r2/data-catalog/).
+Disable compaction on a [R2 Data Catalog](/r2/data-catalog/) or a specific table.
 
 ```txt
-wrangler r2 bucket catalog compaction disable <BUCKET> [OPTIONS]
+wrangler r2 bucket catalog compaction disable <BUCKET> [NAMESPACE] [TABLE] [OPTIONS]
 ```
 
 - `BUCKET` <Type text="string" /> <MetaInfo text="required" />
-  - The name of the bucket to enable R2 Data Catalog compaction for.
+  - The name of the bucket to disable R2 Data Catalog compaction for.
+- `NAMESPACE` <Type text="string" /> <MetaInfo text="optional" />
+  - The namespace containing the table (for table-level compaction). Must be provided together with `TABLE`.
+- `TABLE` <Type text="string" /> <MetaInfo text="optional" />
+  - The name of the table (for table-level compaction). Must be provided together with `NAMESPACE`.
+
+Examples:
+
+```bash
+# Disable catalog-level compaction
+npx wrangler r2 bucket catalog compaction disable my-bucket
+
+# Disable table-level compaction
+npx wrangler r2 bucket catalog compaction disable my-bucket my-namespace my-table
+```
 
 <AnchorHeading title="`cors set`" slug="r2-bucket-cors-set" depth={3} />
 


### PR DESCRIPTION
### Summary

Documents new table-level compaction support in Wrangler R2 catalog commands.

Changes:
  - wrangler-commands/r2.mdx - Added optional NAMESPACE/TABLE args, changed --token to optional (catalog-level only), added examples
  - manage-catalogs.mdx - Added table-level examples and token clarification
  - about-compaction.mdx - Explained catalog vs table-level hierarchy

Fixes: https://github.com/cloudflare/workers-sdk/issues/10880

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
