### PR TITLE
Fix incorrect versions command link

### DIFF
--- a/src/content/changelog/workers/2025-10-07-fix-incorrect-versions-upload-link.mdx
+++ b/src/content/changelog/workers/2025-10-07-fix-incorrect-versions-upload-link.mdx
@@ -1,5 +1,6 @@
 ---
 title: Fix Incorrect Versions Upload Link
+description: Updates 2 links in preview URL docs to link to correct command documentation.
 date: 2025-10-07
 product:
   - workers

--- a/src/content/changelog/workers/2025-10-07-fix-incorrect-versions-upload-link.mdx
+++ b/src/content/changelog/workers/2025-10-07-fix-incorrect-versions-upload-link.mdx
@@ -1,0 +1,8 @@
+---
+title: Fix Incorrect Versions Upload Link
+date: 2025-10-07
+product:
+  - workers
+---
+
+The 2 links to the `wrangler versions upload` docs at https://developers.cloudflare.com/workers/configuration/previews/#versioned-preview-urls has been fixed to point to the correct documentation for the command.

--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -42,7 +42,7 @@ Every time you create a new [version](/workers/configuration/versions-and-deploy
 New versions of a Worker are created when you run:
 
 - [`wrangler deploy`](/workers/wrangler/commands/#deploy)
-- [`wrangler versions upload`](/workers/wrangler/commands/#upload)
+- [`wrangler versions upload`](/workers/wrangler/commands/#versions-upload)
 - Or when you make edits via the Cloudflare dashboard
 
 If Preview URLs have been enabled, they are **public by default** and available immediately after version creation.
@@ -53,7 +53,7 @@ Minimum required Wrangler version: 3.74.0. Check your version by running `wrangl
 
 #### View versioned preview URLs using Wrangler
 
-The [`wrangler versions upload`](/workers/wrangler/commands/#upload) command uploads a new [version](/workers/configuration/versions-and-deployments/#versions) of your Worker and returns a preview URL for each version uploaded.
+The [`wrangler versions upload`](/workers/wrangler/commands/#versions-upload) command uploads a new [version](/workers/configuration/versions-and-deployments/#versions) of your Worker and returns a preview URL for each version uploaded.
 
 #### View versioned preview URLs on the Workers dashboard
 


### PR DESCRIPTION
### Summary

Updates the Preview URLs docs to point to the correct `wrangler versions upload` docs rather than the `wrangler mtls-certificate upload` docs.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
