### PR TITLE
Workflows: update limits and added notes

### DIFF
--- a/src/content/docs/workflows/get-started/cli-quick-start.mdx
+++ b/src/content/docs/workflows/get-started/cli-quick-start.mdx
@@ -144,6 +144,12 @@ Workflows are deployed via [`wrangler`](/workers/wrangler/install-and-update/), 
 npx wrangler@latest deploy
 ```
 
+:::note
+
+Workflows cannot be deployed to Workers for Platforms namespaces, as Workflows do not support Workers for Platforms.
+
+:::
+
 ## 3. Run a Workflow
 
 You can run a Workflow via the `wrangler` CLI, via a Worker binding, or via the Workflows [REST API](/api/resources/workflows/methods/list/).

--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -385,6 +385,12 @@ Showing last 1 workflow:
 └───────────────────┴───────────────────┴────────────┴─────────────────────────┴─────────────────────────┘
 ```
 
+:::note
+
+Workflows cannot be deployed to Workers for Platforms namespaces, as Workflows do not support Workers for Platforms.
+
+:::
+
 ## 6. Run and observe your Workflow
 
 With your Workflow deployed, you can now run it.

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -24,8 +24,8 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum `step.sleep` duration             | 365 days (1 year) | 365 days (1 year) |
 | Maximum steps per Workflow [^5]           | 1024 | 1024 |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |
-| Concurrent Workflow instances (executions) per account   | 25 | 4500 |
-| Maximum Workflow instance creation rate | 100 per 10 seconds [^6] | 100 per 10 seconds [^6] |
+| Concurrent Workflow instances (executions) per account   | 25 | 10,000 |
+| Maximum Workflow instance creation rate | 100 per second [^6] | 100 per second [^6] |
 | Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 | 100,000 |
 | Retention limit for completed Workflow state | 3 days | 30 days [^2] |
 | Maximum length of a Workflow name [^4]         | 64 characters | 64 characters |


### PR DESCRIPTION
### Summary

Updated the following information regarding Workflows:
- add note referring that Workflows do not support Workers for Platforms
- updated creation rate and concurrency limits

Closes WOR-940 and WOR-729.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
