### PR TITLE
Update cloudflare-tunnel.mdx

### DIFF
--- a/src/content/docs/magic-wan/zero-trust/cloudflare-tunnel.mdx
+++ b/src/content/docs/magic-wan/zero-trust/cloudflare-tunnel.mdx
@@ -20,7 +20,7 @@ To design solutions where a destination IP may match both a Cloudflare Tunnel pr
 
 To check if a `cloudflared` tunnel is working properly with your Magic WAN connection, open a browser from a host behind your customer premise equipment, and browse to the `cloudflared` tunnel endpoint.
 
-For example, imagine you have a Cloudflare Tunnel set up with a private network CIDR of `10.1.2.3/32`, a static route defined in Magic WAN for `10.1.2./24`, and the device you are trying to connect to is a web server. You can test connectivity to the web server by using a browser to load `https://10.1.2.3`. If the page loads correctly, your Cloudflare Tunnel is working properly. In this scenario, you have overlapping routes defined for Cloudflare Tunnel and Magic WAN.
+For example, imagine you have a Cloudflare Tunnel set up with a private network CIDR of `10.1.2.3/32`, a static route defined in Magic WAN for `10.1.2.3/24`, and the device you are trying to connect to is a web server. You can test connectivity to the web server by using a browser to load `https://10.1.2.3`. If the page loads correctly, your Cloudflare Tunnel is working properly. In this scenario, you have overlapping routes defined for Cloudflare Tunnel and Magic WAN.
 
 As mentioned above, if you have overlapping routes in your Magic WAN and Cloudflare Tunnel routing configurations, Cloudflare Tunnel will take precedence. This happens whenever a `cloudflared` tunnel CIDR matches a packet, regardless of prefix length. For example, a `cloudflared` tunnel with prefix `10.1.2.0/24` will take precedence over a static route configured to `10.1.2.4/32`, sending packets over a GRE tunnel.
 


### PR DESCRIPTION
Example was missing 4th octet value

### Summary

example was missing 4th octet value was 10.1.2./24 which is not valid, should be 10.1.2.3/24

### Screenshots (optional)


### Documentation checklist


- [x ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
