### PR TITLE
Update documented component for enabling non-production builds in WCI

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/build-branches.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-branches.mdx
@@ -22,6 +22,6 @@ Every push event made to this branch will trigger a build and execute the [build
 To enable or disable non-production branch builds:
 
 1. In **Overview**, select your Workers project.
-2. Go to **Settings** > **Build** > **Branch control**. The checkbox allows you to enable or disable builds for non-production branches.
+2. Go to **Settings** > **Build** > **Branch control**. The button under **Pull Request Previews** allows you to enable or disable builds for non-production branches.
 
 When enabled, every push event made to a non-production branch will trigger a build and execute the [build command](/workers/ci-cd/builds/configuration/#build-command), followed by the [non-production branch deploy command](/workers/ci-cd/builds/configuration/#non-production-branch-deploy-command).


### PR DESCRIPTION
### Summary

This used to be a checkbox, but recent work in dash has updated this to a button. Updated docs to reflect correct component.
