### PR TITLE
Update IAM role for Cloudflare access to GCS bucket

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
@@ -22,7 +22,7 @@ Cloudflare Logpush supports pushing logs directly to Google Cloud Storage (GCS) 
    - **Bucket** - GCS bucket name
    - **Path** - bucket location within the storage container
    - **Organize logs into daily subfolders** (recommended)
-   - For **Grant Cloudflare access to upload files to your bucket**, make sure your bucket has added Cloudflare’s IAM as a user with a [Storage Object Admin role](https://cloud.google.com/storage/docs/access-control/iam-roles).
+   - For **Grant Cloudflare access to upload files to your bucket**, make sure your bucket has added Cloudflare’s IAM as a user with a [Storage Object Creator role](https://cloud.google.com/storage/docs/access-control/iam-roles).
 
 When you are done entering the destination details, select **Continue**.
 
@@ -44,7 +44,7 @@ When you are done entering the destination details, select **Continue**.
 
 ## Create and get access to a GCS bucket
 
-Cloudflare uses Google Cloud Identity and Access Management (IAM) to gain access to your bucket. The Cloudflare IAM service account needs admin permission for the bucket.
+Cloudflare uses Google Cloud Identity and Access Management (IAM) to gain access to your bucket. The Cloudflare IAM service account needs object creator permission for the bucket.
 
 <Render file="enable-read-permissions" product="logs" /> <br />
 
@@ -52,4 +52,4 @@ To enable Logpush to GCS:
 
 1. Create a GCS bucket. Refer to [instructions from GCS](https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-console).
 
-2. In **Storage** > **Browser** > **Bucket** > **Permissions**, add the member `logpush@cloudflare-data.iam.gserviceaccount.com` with `Storage Object Admin` permission.
+2. In **Storage** > **Browser** > **Bucket** > **Permissions**, add the member `logpush@cloudflare-data.iam.gserviceaccount.com` with `Storage Object Creator` permission.


### PR DESCRIPTION

### Summary

There is no need for objectAdmin, when all logpush does is to push to GCS.

## Reference
https://cloud.google.com/storage/docs/access-control/iam-roles#storage.objectCreator https://cloud.google.com/storage/docs/access-control/iam-roles#storage.objectAdmin

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
