### PR TITLE
[Zero Trust] Update GitHub identity

### DIFF
--- a/src/content/docs/cloudflare-one/identity/idp-integration/github.mdx
+++ b/src/content/docs/cloudflare-one/identity/idp-integration/github.mdx
@@ -3,6 +3,8 @@ pcx_content_type: how-to
 title: GitHub
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Cloudflare Zero Trust allows your team to connect to your applications using their GitHub login. You do not need to have a GitHub organization to use the integration.
 
 ## Set up GitHub Access
@@ -47,6 +49,11 @@ To configure GitHub access in both GitHub and Cloudflare Zero Trust:
 
 To test that your connection is working, go to [Zero Trust](https://one.dash.cloudflare.com) > **Authentication** > **Login methods** and select **Test** next to your GitHub login method.
 If you have GitHub two-factor authentication enabled, you will need to first login to GitHub directly and return to Access.
+
+
+<Aside title="Troubleshooting Organization Policies">
+When using a GitHub organization policy, if a user joins the required organization *after* a failed login attempt, they will remain blocked. To fix this, they must **revoke the application's access in their GitHub settings** and log in again to update their permissions.
+</Aside>
 
 ## Example API Configuration
 

--- a/src/content/docs/cloudflare-one/identity/idp-integration/github.mdx
+++ b/src/content/docs/cloudflare-one/identity/idp-integration/github.mdx
@@ -3,8 +3,6 @@ pcx_content_type: how-to
 title: GitHub
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 Cloudflare Zero Trust allows your team to connect to your applications using their GitHub login. You do not need to have a GitHub organization to use the integration.
 
 ## Set up GitHub Access
@@ -51,9 +49,9 @@ To test that your connection is working, go to [Zero Trust](https://one.dash.clo
 If you have GitHub two-factor authentication enabled, you will need to first login to GitHub directly and return to Access.
 
 
-<Aside title="Troubleshooting Organization Policies">
+:::note[Troubleshooting Organization Policies]
 When using a GitHub organization policy, if a user joins the required organization *after* a failed login attempt, they will remain blocked. To fix this, they must **revoke the application's access in their GitHub settings** and log in again to update their permissions.
-</Aside>
+:::
 
 ## Example API Configuration
 


### PR DESCRIPTION
### Summary

When working with Zero Trust, I added a GitHub identity /w organization policy and kept getting access denied. It turns out that I tried to authenticate before being part of the organization, which caused access denied even after I become part of it. 

This call-out is to hopefully prevent someone else from suffering the same mistake. Even though it's quite the edge case. 

### Screenshots (optional)

<img width="843" height="505" alt="Screenshot 2025-10-08 at 7 33 16 AM" src="https://github.com/user-attachments/assets/6fc991c0-9644-41f0-a814-6ea914bf0132" />
<img width="831" height="456" alt="Screenshot 2025-10-08 at 7 38 33 AM" src="https://github.com/user-attachments/assets/141ec4e8-4ac0-47f8-9a52-135a4988ea6b" />


### Documentation checklist

I don't think this is changelog worthy but please correct me if I am wrong.

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
