### PR TITLE
[WAF] Add links between zone/account sections

### DIFF
--- a/src/content/docs/waf/account/custom-rulesets/create-api.mdx
+++ b/src/content/docs/waf/account/custom-rulesets/create-api.mdx
@@ -173,4 +173,6 @@ Use the different operations in the [Rulesets API](/ruleset-engine/rulesets-api/
 
 ## More resources
 
+For instructions on creating a custom rule at the zone level via API, refer to [Create a custom rule via API](/waf/custom-rules/create-api/).
+
 For more information on working with custom rulesets, refer to [Work with custom rulesets](/ruleset-engine/custom-rulesets/) in the Ruleset Engine documentation.

--- a/src/content/docs/waf/account/managed-rulesets/deploy-api.mdx
+++ b/src/content/docs/waf/account/managed-rulesets/deploy-api.mdx
@@ -35,4 +35,6 @@ Exceptions have priority over overrides.
 
 ## More resources
 
+For instructions on deploying a managed ruleset at the zone level via API, refer to [Deploy a WAF managed ruleset via API (zone)](/waf/managed-rules/deploy-api/).
+
 For more information on working with managed rulesets via API, refer to [Work with managed rulesets](/ruleset-engine/managed-rulesets/) in the Ruleset Engine documentation.

--- a/src/content/docs/waf/account/rate-limiting-rulesets/create-api.mdx
+++ b/src/content/docs/waf/account/rate-limiting-rulesets/create-api.mdx
@@ -196,4 +196,6 @@ Use the different operations in the [Rulesets API](/ruleset-engine/rulesets-api/
 
 ## More resources
 
+For instructions on deploying a rate limiting rule at the zone level via API, refer to [Create a rate limiting rule via API](/waf/rate-limiting-rules/create-api/).
+
 For more information on the different rate limiting parameters you can configure in your rate limiting rules, refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/).

--- a/src/content/docs/waf/custom-rules/create-api.mdx
+++ b/src/content/docs/waf/custom-rules/create-api.mdx
@@ -7,12 +7,12 @@ sidebar:
   label: Create via API
 head:
   - tag: title
-    content: Create a custom rule via API
+    content: Create a custom rule via API for a zone
 ---
 
 import { GlossaryTooltip, Render, APIRequest } from "~/components";
 
-Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a custom rule via API.
+Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a custom rule via API at the zone level.
 
 You must deploy custom rules to the `http_request_firewall_custom` [phase entry point ruleset](/ruleset-engine/about/rulesets/#entry-point-ruleset).
 
@@ -94,3 +94,7 @@ Use the different operations in the [Rulesets API](/ruleset-engine/rulesets-api/
 		phaseName: "http_request_firewall_custom",
 	}}
 />
+
+## More resources
+
+For instructions on deploying custom rules at the account level via API, refer to [Create a custom ruleset using the API](/waf/account/custom-rulesets/create-api/).

--- a/src/content/docs/waf/managed-rules/deploy-api.mdx
+++ b/src/content/docs/waf/managed-rules/deploy-api.mdx
@@ -1,17 +1,17 @@
 ---
 pcx_content_type: configuration
-title: Deploy a WAF managed ruleset via API
+title: Deploy a WAF managed ruleset via API (zone)
 sidebar:
   order: 2
   label: Deploy via API
 head:
   - tag: title
-    content: Deploy a WAF managed ruleset via API
+    content: Deploy a WAF managed ruleset via API for a zone
 ---
 
 import { Render } from "~/components";
 
-Use the [Rulesets API](/ruleset-engine/rulesets-api/) to deploy a managed ruleset at the account level or at the zone level.
+Use the [Rulesets API](/ruleset-engine/rulesets-api/) to deploy a managed ruleset at the zone level.
 
 Deploy WAF managed rulesets to the `http_request_firewall_managed` phase. Other managed rulesets, like DDoS Attack Protection managed rulesets, must be deployed to a different phase. Refer to the specific managed ruleset documentation for details.
 
@@ -32,5 +32,7 @@ To skip the execution of WAF managed rulesets or some of their rules, [create an
 Exceptions have priority over overrides.
 
 ## More resources
+
+For instrucitons on deploying a managed ruleset at the account level via API, refer to [Deploy a WAF managed ruleset via API (account)](/waf/account/managed-rulesets/deploy-api/).
 
 For more information on working with managed rulesets via API, refer to [Work with managed rulesets](/ruleset-engine/managed-rulesets/) in the Ruleset Engine documentation.

--- a/src/content/docs/waf/managed-rules/deploy-api.mdx
+++ b/src/content/docs/waf/managed-rules/deploy-api.mdx
@@ -33,6 +33,6 @@ Exceptions have priority over overrides.
 
 ## More resources
 
-For instrucitons on deploying a managed ruleset at the account level via API, refer to [Deploy a WAF managed ruleset via API (account)](/waf/account/managed-rulesets/deploy-api/).
+For instructions on deploying a managed ruleset at the account level via API, refer to [Deploy a WAF managed ruleset via API (account)](/waf/account/managed-rulesets/deploy-api/).
 
 For more information on working with managed rulesets via API, refer to [Work with managed rulesets](/ruleset-engine/managed-rulesets/) in the Ruleset Engine documentation.

--- a/src/content/docs/waf/rate-limiting-rules/create-api.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/create-api.mdx
@@ -6,12 +6,12 @@ sidebar:
   label: Create via API
 head:
   - tag: title
-    content: Create a rate limiting rule via API
+    content: Create a rate limiting rule via API for a zone
 ---
 
 import { Render, APIRequest } from "~/components";
 
-Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a rate limiting rule via API.
+Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a rate limiting rule via API at the zone level.
 
 A rate limiting rule is similar to a regular rule handled by the Ruleset Engine, but contains an additional `ratelimit` object with the rate limiting configuration. Refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/) for more information on this field and its parameters.
 
@@ -175,3 +175,7 @@ Use the different operations in the [Rulesets API](/ruleset-engine/rulesets-api/
 	product="waf"
 	params={{ rulesType: "rate limiting rules", phaseName: "http_ratelimit" }}
 />
+
+## More resources
+
+For instructions on deploying rate limiting rules at the account level via API, refer to [Create a rate limiting ruleset via API](/waf/account/rate-limiting-rulesets/create-api/).


### PR DESCRIPTION
### Summary

Improve linking between API instructions for zone and account levels.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
