### PR TITLE
Add example for handling 429 responses from Browser Rendering REST API

### DIFF
--- a/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
+++ b/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
@@ -8,7 +8,7 @@ sidebar:
 ## Example: Handling 429 Rate Limits with Retry-After Header
 
 When you make too many requests in a short period of time, Browser Rendering will respond with HTTP status code `429 Too Many Requests`.
-The response includes a `Retry-After` header, which specifies how many seconds to wait before retrying. You can view your account's rate limits on the [Limits](/browser-rendering/platform/limits/) page. 
+The response includes a `Retry-After` header, which specifies how many seconds to wait before retrying. You can view your account's rate limits on the [Limits](/browser-rendering/platform/limits/) page.
 
 The example below demonstrates how to handle rate limiting gracefully by reading the `Retry-After` value and retrying the request after that delay.
 
@@ -29,5 +29,32 @@ if (response.status === 429) {
 
     // Retry the request
     const retryResponse = await fetch(/* same request as above */);
+}
+```
+
+## Workers Binding Example: Handling 429 Rate Limits with Retry-After Header
+
+```js
+import puppeteer from "@cloudflare/puppeteer";
+
+try {
+	const browser = await puppeteer.launch(env.MYBROWSER);
+
+	const page = await browser.newPage();
+	await page.goto("https://example.com");
+	const content = await page.content();
+
+	await browser.close();
+} catch (error) {
+	if (error.status === 429) {
+		const retryAfter = error.headers.get("Retry-After");
+		console.log(
+			`Browser instance limit reached. Waiting ${retryAfter} seconds...`,
+		);
+		await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+
+		// Retry launching browser
+		const browser = await puppeteer.launch(env.MYBROWSER);
+	}
 }
 ```

--- a/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
+++ b/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
@@ -7,6 +7,11 @@ sidebar:
 
 ## Example: Handling 429 Rate Limits with Retry-After Header
 
+When you make too many requests in a short period of time, Browser Rendering will respond with HTTP status code `429 Too Many Requests`.
+The response includes a `Retry-After` header, which specifies how many seconds to wait before retrying. You can view your account's rate limits on the Limits(/browser-rendering/platform/limits/) page. 
+
+The example below demonstrates how to handle rate limiting gracefully by reading the `Retry-After` value and retrying the request after that delay.
+
 ```js
 const response = await fetch('https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/content', {
     method: 'POST',

--- a/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
+++ b/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
@@ -8,7 +8,7 @@ sidebar:
 ## Example: Handling 429 Rate Limits with Retry-After Header
 
 When you make too many requests in a short period of time, Browser Rendering will respond with HTTP status code `429 Too Many Requests`.
-The response includes a `Retry-After` header, which specifies how many seconds to wait before retrying. You can view your account's rate limits on the Limits(/browser-rendering/platform/limits/) page. 
+The response includes a `Retry-After` header, which specifies how many seconds to wait before retrying. You can view your account's rate limits on the [Limits](/browser-rendering/platform/limits/) page. 
 
 The example below demonstrates how to handle rate limiting gracefully by reading the `Retry-After` value and retrying the request after that delay.
 

--- a/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
+++ b/src/content/docs/browser-rendering/how-to/rate-limiting.mdx
@@ -1,0 +1,28 @@
+---
+pcx_content_type: how-to
+title: Rate limiting REST API requests
+sidebar:
+  order: 5
+---
+
+## Example: Handling 429 Rate Limits with Retry-After Header
+
+```js
+const response = await fetch('https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/content', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer <your-token>',
+    },
+    body: JSON.stringify({ url: 'https://example.com' })
+});
+
+if (response.status === 429) {
+    const retryAfter = response.headers.get('Retry-After');
+    console.log(`Rate limited. Waiting ${retryAfter} seconds...`);
+    await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+
+    // Retry the request
+    const retryResponse = await fetch(/* same request as above */);
+}
+```


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Adding an example of handling 429 responses on the Browser Rendering REST API

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->
<img width="2727" height="1928" alt="image" src="https://github.com/user-attachments/assets/d775197c-b72c-4bdf-855e-1535b2cf6788" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

