### PR TITLE
Fix ratelimit binding to ref 4.36.0

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
@@ -18,7 +18,7 @@ You can use it to enforce:
 The Rate Limiting API is backed by the same infrastructure that serves [rate limiting rules](/waf/rate-limiting-rules/).
 
 :::note
-You must use version 3.45.0 or later of the [Wrangler CLI](/workers/wrangler).
+You must use version 4.36.0 or later of the [Wrangler CLI](/workers/wrangler).
 :::
 
 ## Get started


### PR DESCRIPTION
### Summary

Ratelimit binding was stablised in 4.36.0 which is what the docs refer to. Update the version so users are not confused their older Wranglers do not work.
