### PR TITLE
[Workers] update workers startup limits

### DIFF
--- a/src/content/changelog/workers/2025-10-09-increased-startup-time.mdx
+++ b/src/content/changelog/workers/2025-10-09-increased-startup-time.mdx
@@ -1,0 +1,13 @@
+---
+title: Worker startup time increased to 1 second.
+description: Worker startup time has been increased from 400 ms to 1s.
+products:
+  - workers
+date: 2025-10-09
+---
+
+import { Render, TypeScriptExample, WranglerConfig } from "~/components";
+
+You can now upload a Worker that takes up 1 second to parse and execute its global scope. Previously, startup time was limited to 400 ms.
+
+For more information, see the documentation on [Workers startup limits](/workers/platform/limits/#worker-startup-time).

--- a/src/content/changelog/workers/2025-10-10-increased-startup-time.mdx
+++ b/src/content/changelog/workers/2025-10-10-increased-startup-time.mdx
@@ -3,11 +3,13 @@ title: Worker startup time increased to 1 second.
 description: Worker startup time has been increased from 400 ms to 1s.
 products:
   - workers
-date: 2025-10-09
+date: 2025-10-10
 ---
 
 import { Render, TypeScriptExample, WranglerConfig } from "~/components";
 
 You can now upload a Worker that takes up 1 second to parse and execute its global scope. Previously, startup time was limited to 400 ms.
+
+This allows you to run Workers that import more complex packages and execute more code prior to requests being handled.
 
 For more information, see the documentation on [Workers startup limits](/workers/platform/limits/#worker-startup-time).

--- a/src/content/changelog/workers/2025-10-10-increased-startup-time.mdx
+++ b/src/content/changelog/workers/2025-10-10-increased-startup-time.mdx
@@ -1,6 +1,6 @@
 ---
-title: Worker startup time increased to 1 second.
-description: Worker startup time has been increased from 400 ms to 1s.
+title: Worker startup time limit increased to 1 second
+description: Worker startup time limit has been increased from 400 ms to 1s
 products:
   - workers
 date: 2025-10-10

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -18,7 +18,7 @@ import { Render, WranglerConfig, DashButton } from "~/components";
 | [Environment variables](#environment-variables)                                  | 64/Worker    | 128/Worker   |
 | [Environment variable<br/>size](#environment-variables)                          | 5 KB         | 5 KB         |
 | [Worker size](#worker-size)                                                      | 3 MB         | 10 MB        |
-| [Worker startup time](#worker-startup-time)                                      | 400 ms       | 400 ms       |
+| [Worker startup time](#worker-startup-time)                                      | 1 second     | 1 second     |
 | [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500          |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250          |
 | Number of [Static Asset](#static-assets) files per Worker version                | 20,000       | 100,000      |
@@ -335,7 +335,7 @@ To reduce the upload size of a Worker, consider some of the following strategies
 
 ## Worker startup time
 
-A Worker must be able to be parsed and execute its global scope (top-level code outside of any handlers) within 400 ms. Worker size can impact startup because there is more code to parse and evaluate. Avoiding expensive code in the global scope can keep startup efficient as well.
+A Worker must be able to be parsed and execute its global scope (top-level code outside of any handlers) within 1 second. Worker size can impact startup because there is more code to parse and evaluate. Avoiding expensive code in the global scope can keep startup efficient as well.
 
 You can measure your Worker's startup time by deploying it to Cloudflare using [Wrangler](/workers/wrangler/). When you run `npx wrangler@latest deploy` or `npx wrangler@latest versions upload`, Wrangler will output the startup time of your Worker in the command-line output, using the `startup_time_ms` field in the [Workers Script API](/api/resources/workers/subresources/scripts/methods/update/) or [Workers Versions API](/api/resources/workers/subresources/scripts/subresources/versions/methods/create/).
 


### PR DESCRIPTION

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<img width="1155" height="368" alt="image" src="https://github.com/user-attachments/assets/a242dd52-1a25-4358-92e3-7babfd6feaa4" />
<img width="754" height="194" alt="image" src="https://github.com/user-attachments/assets/af3f8173-91fe-46c6-ad26-629cf8b2c0fa" />

