### PR TITLE
Update docs to point to CF tunnel option

### DIFF
--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -35,7 +35,7 @@ Before you begin, ensure you have completed the following:
 2. Install [`Node.js`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). Use a Node version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/) to avoid permission issues and change Node.js versions. [Wrangler](/workers/wrangler/install-and-update/) requires a Node version of `16.17.0` or later.
 3. Have PostgreSQL/MySQL (or compatible) database, accessible in one of the following ways:
 	* **Publicly Accessible**: Your database is directly reachable from the Internet.
-	* **Private Network (Beta)**: Your database is in a private network (like a VPC) and can be securely connected using [Cloudflare Tunnel](/hyperdrive/configuration/connect-to-private-database/).
+	* **Private Network**: Your database is in a private network (like a VPC) and can be securely connected using [Cloudflare Tunnel](/hyperdrive/configuration/connect-to-private-database/).
 
 
 ## 1. Log in

--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -33,7 +33,10 @@ Before you begin, ensure you have completed the following:
 
 1. Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) if you have not already.
 2. Install [`Node.js`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). Use a Node version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/) to avoid permission issues and change Node.js versions. [Wrangler](/workers/wrangler/install-and-update/) requires a Node version of `16.17.0` or later.
-3. Have **a publicly accessible** PostgreSQL/MySQL (or compatible) database.
+3. Have PostgreSQL/MySQL (or compatible) database, accessible in one of the following ways:
+	* **Publicly Accessible**: Your database is directly reachable from the Internet.
+	* **Private Network (Beta)**: Your database is in a private network (like a VPC) and can be securely connected using [Cloudflare Tunnel](/hyperdrive/configuration/connect-to-private-database/).
+
 
 ## 1. Log in
 
@@ -241,7 +244,7 @@ export default {
 		try {
 			// Connect to the database
 			await sql.connect();
-			
+
 			// Sample query
 			const results = await sql.query(`SELECT * FROM pg_tables`);
 


### PR DESCRIPTION
### Summary

I noticed that in the Hyperdrive docs we have an outdated prerequisite. You can use Hyperdrive using a private network when using Cloudflare Tunnel per https://developers.cloudflare.com/hyperdrive/configuration/connect-to-private-database/

### Screenshots (optional)

<img width="1548" height="700" alt="CleanShot 2025-10-10 at 10 36 08@2x" src="https://github.com/user-attachments/assets/124286f6-8dc7-4a13-9953-09ceb764f84a" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
