### PR TITLE
[Workers] Workers preview_urls default to workers_dev (configuration.mdx, previews.mdx)

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -45,7 +45,7 @@ New versions of a Worker are created when you run:
 - [`wrangler versions upload`](/workers/wrangler/commands/#upload)
 - Or when you make edits via the Cloudflare dashboard
 
-If Preview URLs have been enabled, they are **public by default** and available immediately after version creation.
+If Preview URLs have been enabled, they are public and available immediately after version creation.
 
 :::note
 Minimum required Wrangler version: 3.74.0. Check your version by running `wrangler --version`. To update Wrangler, refer to [Install/Update Wrangler](/workers/wrangler/install-and-update/).
@@ -112,7 +112,8 @@ To limit your preview URLs to authorized emails only:
 
 Note:
 
-- Preview URLs are disabled by default.
+- Preview URLs are enabled by default when `workers_dev` is enabled.
+- Preview URLs are disabled by default when `workers_dev` is disabled.
 - Disabling Preview URLs will disable routing to both versioned and aliased preview URLs.
 
 ### From the Dashboard
@@ -156,7 +157,7 @@ preview_urls = false
 
 </WranglerConfig>
 
-If not given, `preview_urls = false` is the default.
+If not given, `preview_urls = workers_dev` is the default.
 
 :::caution
 If you enable or disable Preview URLs in the Cloudflare dashboard, but do not update your Worker's Wrangler file accordingly, the Preview URLs status will change the next time you deploy your Worker with Wrangler.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -118,7 +118,7 @@ The `main` key is optional for assets-only Workers.
   - Enables use of `*.workers.dev` subdomain to deploy your Worker. If you have a Worker that is only for `scheduled` events, you can set this to `false`. Defaults to `true`. Refer to [types of routes](#types-of-routes).
 
 - `preview_urls` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Enables use of Preview URLs to test your Worker. Defaults to `false`. Refer to [Preview URLs](/workers/configuration/previews).
+  - Enables use of Preview URLs to test your Worker. Defaults to value of `workers_dev`. Refer to [Preview URLs](/workers/configuration/previews).
 
 - `route` <Type text="Route" /> <MetaInfo text="optional" />
   - A route that your Worker should be deployed to. Only one of `routes` or `route` is required. Refer to [types of routes](#types-of-routes).
@@ -992,7 +992,7 @@ The following options are available:
   - To specify a custom instance type, see [here](#custom-instance-types).
 
 - `max_instances` <Type text="string" /> <MetaInfo text="optional" />
-  - The maximum number of concurrent container instances you want to run at any given moment. Stopped containers do not count towards this - you may have more container instances than this number overall, but only this many actively running containers at once. If a request to start a container will exceed this limit, that request will error. 
+  - The maximum number of concurrent container instances you want to run at any given moment. Stopped containers do not count towards this - you may have more container instances than this number overall, but only this many actively running containers at once. If a request to start a container will exceed this limit, that request will error.
 
   - Defaults to 20.
 


### PR DESCRIPTION
### Summary

We're making changes in Wrangler so that `preview_urls` default to `workers_dev`.

Change the docs to reflect that.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
