### PR TITLE
Added line to pre reqs for creating DLP key to use prompt logging

### DIFF
--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/granular-controls.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/granular-controls.mdx
@@ -17,7 +17,7 @@ To use Application Granular Controls, you must:
 - Turn on [TLS decryption](/cloudflare-one/policies/gateway/http-policies/tls-decryption/).
 - Turn on the [Gateway proxy](/cloudflare-one/policies/gateway/proxy/#turn-on-the-gateway-proxy).
 - (Optional) If an application uses HTTP/3, turn on the [Gateway proxy for UDP traffic](/cloudflare-one/policies/gateway/http-policies/http3/#enable-http3-inspection).
-- (Optional) If you wish to enable AI Prompt logging, create a [DLP payload encryption public key](https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/dlp-policies/logging-options/#set-a-dlp-payload-encryption-public-key).
+- (Optional) To turn on [AI prompt logging](/cloudflare-one/policies/data-loss-prevention/dlp-policies/logging-options/#log-generative-ai-prompt-content), create a [DLP payload encryption public key](/cloudflare-one/policies/data-loss-prevention/dlp-policies/logging-options/#set-a-dlp-payload-encryption-public-key).
 
 ## Create a policy with Application Granular Controls
 

--- a/src/content/docs/cloudflare-one/policies/gateway/http-policies/granular-controls.mdx
+++ b/src/content/docs/cloudflare-one/policies/gateway/http-policies/granular-controls.mdx
@@ -17,6 +17,7 @@ To use Application Granular Controls, you must:
 - Turn on [TLS decryption](/cloudflare-one/policies/gateway/http-policies/tls-decryption/).
 - Turn on the [Gateway proxy](/cloudflare-one/policies/gateway/proxy/#turn-on-the-gateway-proxy).
 - (Optional) If an application uses HTTP/3, turn on the [Gateway proxy for UDP traffic](/cloudflare-one/policies/gateway/http-policies/http3/#enable-http3-inspection).
+- (Optional) If you wish to enable AI Prompt logging, create a [DLP payload encryption public key](https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/dlp-policies/logging-options/#set-a-dlp-payload-encryption-public-key).
 
 ## Create a policy with Application Granular Controls
 


### PR DESCRIPTION
Using AI Prompt logging requires a DLP public key to be created before Gateway will log prompts. Added this step to the prereqs to prevent confusion when AI prompts aren't logged due to no DLP key existing.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
