### PR TITLE
Add checks for POLICY_AUD

### DIFF
--- a/src/content/changelog/workers/2025-10-03-one-click-access-for-workers.mdx
+++ b/src/content/changelog/workers/2025-10-03-one-click-access-for-workers.mdx
@@ -34,6 +34,14 @@ import { jwtVerify, createRemoteJWKSet } from "jose";
 
 export default {
 	async fetch(request, env, ctx) {
+		// Verify the POLICY_AUD environment variable is set
+		if (!env.POLICY_AUD) {
+			return new Response('Missing required audience', {
+				status: 403,
+				headers: { 'Content-Type': 'text/plain' }
+			});
+		}
+
 		// Get the JWT from the request headers
 		const token = request.headers.get("cf-access-jwt-assertion");
 

--- a/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
+++ b/src/content/docs/cloudflare-one/identity/authorization-cookie/validating-json.mdx
@@ -113,6 +113,14 @@ import { jwtVerify, createRemoteJWKSet } from 'jose';
 
 export default {
 	async fetch(request, env, ctx) {
+		// Verify the POLICY_AUD environment variable is set
+		if (!env.POLICY_AUD) {
+			return new Response('Missing required audience', {
+				status: 403,
+				headers: { 'Content-Type': 'text/plain' }
+			});
+		}
+
 		// Get the JWT from the request headers
 		const token = request.headers.get('cf-access-jwt-assertion');
 
@@ -268,6 +276,10 @@ def verify_token(f):
     Decorator that wraps a Flask API call to verify the CF Access JWT
     """
     def wrapper():
+				# Check for the POLICY_AUD environment variable
+				if not POLICY_AUD:
+					return "missing required audience", 403
+
         token = ''
         if 'CF_Authorization' in request.cookies:
             token = request.cookies['CF_Authorization']
@@ -319,6 +331,14 @@ const JWKS = jose.createRemoteJWKSet(new URL(CERTS_URL));
 
 // verifyToken is a middleware to verify a CF authorization token
 const verifyToken = async (req, res, next) => {
+	// Check for the AUD environment variable
+	if (!AUD) {
+		return res.status(403).send({
+			status: false,
+			message: "missing required audience",
+		});
+	}
+
 	const token = req.headers["cf-access-jwt-assertion"];
 
 	// Make sure that the incoming request has our token header
@@ -329,13 +349,20 @@ const verifyToken = async (req, res, next) => {
 		});
 	}
 
-	const result = await jose.jwtVerify(token, JWKS, {
-		issuer: TEAM_DOMAIN,
-		audience: AUD,
-	});
+	try {
+		const result = await jose.jwtVerify(token, JWKS, {
+			issuer: TEAM_DOMAIN,
+			audience: AUD,
+		});
 
-	req.user = result.payload;
-	next();
+		req.user = result.payload;
+		next();
+	} catch (err) {
+		return res.status(403).send({
+			status: false,
+			message: "invalid token",
+		});
+	}
 };
 
 const app = express();


### PR DESCRIPTION
### Summary

I followed https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/#cloudflare-workers-example without setting the AUD environment variable on accident. That ends up omitting the audience verification entirely. It only verifies if the audience value is set to a truthy value. Even an empty string gets skipped (thanks JavaScript) 

I skipped to Go example, because instead of reading from an environment variable, the audience is hard-coded in. 

There is also https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/changelog/workers/2025-10-03-one-click-access-for-workers.mdx -- which has the same example. I did **not** update that yet because I don't know how we feel about retroactively updating changelogs. Happy to update that too. 

### Screenshots (optional)

<img width="1566" height="1010" alt="CleanShot 2025-10-10 at 13 24 27@2x" src="https://github.com/user-attachments/assets/9d0cb0cb-4492-45eb-8798-5d8ca516c416" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

