### PR TITLE
Document Spectrum x Cloudflare Tunnel interop

### DIFF
--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -34,9 +34,9 @@ Integrating Spectrum with [Cloudflare Tunnel](/cloudflare-one/connections/connec
 To correctly route traffic from Spectrum through a Cloudflare Tunnel, you must:
 
 1.  Configure your Spectrum application with the type set to **HTTP** or **HTTPS**.
-2.  Point the Spectrum application's origin to a hostname that is already [routing traffic](/cloudflare-one/connections/connect-networks/routing-to-tunnel/) through your Cloudflare Tunnel (e.g., via a [DNS record](/cloudflare-one/connections/connect-networks/routing-to-tunnel/dns/) or [Cloudflare Load Balancer](/cloudflare-one/connections/connect-networks/routing-to-tunnel/lb/)).
+2.  Point the Spectrum application's origin to a hostname that is already [routing traffic](/cloudflare-one/connections/connect-networks/routing-to-tunnel/) through your Cloudflare Tunnel (for example, via a [DNS record](/cloudflare-one/connections/connect-networks/routing-to-tunnel/dns/) or [Cloudflare Load Balancer](/cloudflare-one/connections/connect-networks/routing-to-tunnel/lb/)).
 
-Using a Spectrum application of any other type (e.g., TCP) with a Cloudflare Tunnel origin is not supported. Pointing a Spectrum application's origin directly to your Tunnel's subdomain (`<UUID>.cfargotunnel.com`) is also not a valid configuration and will not work.
+Using a Spectrum application of any other type (for example, TCP) with a Cloudflare Tunnel origin is not supported. Pointing a Spectrum application's origin directly to your Tunnel's subdomain (`<UUID>.cfargotunnel.com`) is also not a valid configuration and will not work.
 
 ## Listen on ports configuration
 

--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -27,6 +27,17 @@ Minecraft Java Edition is supported but Minecraft Bedrock Edition is not support
 
 When using [Spectrum](/load-balancing/private-network/#on-ramps) as an on-ramp and [Magic WAN](/load-balancing/private-network/#magic-wan) as an off-ramp the [proxy protocol](/spectrum/how-to/enable-proxy-protocol/) setting in Spectrum is not supported.
 
+## Cloudflare Tunnel
+
+Integrating Spectrum with [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) is only supported for **HTTP/HTTPS** applications. This is because Spectrum must upstream the request through the [Layer 7 CDN products](/spectrum/reference/layer-7-analytics/#the-overlap-layer-7-traffic-being-proxied-through-spectrum) to reach the Tunnel service.
+
+To correctly route traffic from Spectrum through a Cloudflare Tunnel, you must:
+
+1.  Configure your Spectrum application with the type set to **HTTP** or **HTTPS**.
+2.  Point the Spectrum application's origin to a hostname that is already [routing traffic](/cloudflare-one/connections/connect-networks/routing-to-tunnel/) through your Cloudflare Tunnel (e.g., via a [DNS record](/cloudflare-one/connections/connect-networks/routing-to-tunnel/dns/) or [Cloudflare Load Balancer](/cloudflare-one/connections/connect-networks/routing-to-tunnel/lb/)).
+
+Using a Spectrum application of any other type (e.g., TCP) with a Cloudflare Tunnel origin is not supported. Pointing a Spectrum application's origin directly to your Tunnel's subdomain (`<UUID>.cfargotunnel.com`) is also not a valid configuration and will not work.
+
 ## Listen on ports configuration
 
 By default, Spectrum is configured to listen on all ports, which can raise concerns for security auditors. However, it is important to note that Spectrum will only proxy connections from edge ports that are specifically configured within Cloudflare.


### PR DESCRIPTION
### Summary

Integrating Spectrum with Tunnel is only supported for HTTP/HTTPS applications. This is because Spectrum must upstream the request through the Layer 7 CDN products to reach the Tunnel service.