### PR TITLE
Update previous release notes with config warning

### DIFF
--- a/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
@@ -1,9 +1,8 @@
 releaseNotes: |-
-  This release contains three significant changes all customers should be aware of:
+  This release contains two significant changes all customers should be aware of:
   1. All DNS traffic now flows inside the WARP tunnel. Customers are no longer required to configure their local firewall rules to allow our [DoH IP addresses and domains](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#doh-ip).
   2. When using MASQUE, the connection will fall back to HTTP/2 (TCP) when we detect that HTTP/3 traffic is blocked. This allows for a much more reliable connection on some public WiFi networks.
-  3. Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
-
+  
   **Changes and improvements**
   - Fixed an issue where the managed network policies could incorrectly report network location beacons as missing.
   - Improved DEX test error reporting.
@@ -14,6 +13,10 @@ releaseNotes: |-
   - DNS over HTTPS traffic is now included in the WARP tunnel by default.
   - Improvement for WARP to check if tunnel connectivity fails or times out at device wake before attempting to reconnect.
   - Fixed an issue causing WARP connection disruptions after network changes.
+
+  **Known issues**
+  - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
 version: 2025.4.929.0
 releaseDate: 2025-05-12T23:21:47.865Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-intel/version/2025.4.929.0

--- a/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.4.929.0.yaml
@@ -1,7 +1,8 @@
 releaseNotes: |-
-  This release contains two significant changes all customers should be aware of:
+  This release contains three significant changes all customers should be aware of:
   1. All DNS traffic now flows inside the WARP tunnel. Customers are no longer required to configure their local firewall rules to allow our [DoH IP addresses and domains](/cloudflare-one/connections/connect-devices/warp/deployment/firewall/#doh-ip).
   2. When using MASQUE, the connection will fall back to HTTP/2 (TCP) when we detect that HTTP/3 traffic is blocked. This allows for a much more reliable connection on some public WiFi networks.
+  3. Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
 
   **Changes and improvements**
   - Fixed an issue where the managed network policies could incorrectly report network location beacons as missing.

--- a/src/content/warp-releases/linux/ga/2025.4.943.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.4.943.0.yaml
@@ -1,10 +1,12 @@
 releaseNotes: |-
   This release contains a hotfix for [managed networks](/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks/) for the 2025.4.929.0 release.
 
-  Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
-
   **Changes and improvements**
   - Fixed an issue where it could take up to 3 minutes for the correct device profile to be applied in some circumstances. In the worst case, it should now only take up to 40 seconds. This will be improved further in a future release.
+
+  **Known issues**
+  - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
 version: 2025.4.943.0
 releaseDate: 2025-05-22T19:22:32.439Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-intel/version/2025.4.943.0

--- a/src/content/warp-releases/linux/ga/2025.4.943.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.4.943.0.yaml
@@ -1,6 +1,8 @@
 releaseNotes: |-
   This release contains a hotfix for [managed networks](/cloudflare-one/connections/connect-devices/warp/configure-warp/managed-networks/) for the 2025.4.929.0 release.
 
+  Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
   **Changes and improvements**
   - Fixed an issue where it could take up to 3 minutes for the correct device profile to be applied in some circumstances. In the worst case, it should now only take up to 40 seconds. This will be improved further in a future release.
 version: 2025.4.943.0

--- a/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
@@ -1,6 +1,8 @@
 releaseNotes: |-
   This release contains improvements and new exciting features, including [post-quantum cryptography](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#enable_post_quantum). By tunneling your corporate network traffic over Cloudflare, you can now gain the immediate protection of post-quantum cryptography without needing to upgrade any of your individual corporate applications or systems.
 
+  Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
   **Changes and improvements**
   - Fixed a device registration issue causing WARP connection failures when changing networks.
   - Captive portal improvements and fixes:

--- a/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
@@ -1,8 +1,6 @@
 releaseNotes: |-
   This release contains improvements and new exciting features, including [post-quantum cryptography](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#enable_post_quantum). By tunneling your corporate network traffic over Cloudflare, you can now gain the immediate protection of post-quantum cryptography without needing to upgrade any of your individual corporate applications or systems.
 
-  Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
-
   **Changes and improvements**
   - Fixed a device registration issue causing WARP connection failures when changing networks.
   - Captive portal improvements and fixes:
@@ -13,6 +11,10 @@ releaseNotes: |-
   - Improvement to handle client configuration changes made by MDM while WARP is not running.
   - Fixed an issue affecting Split Tunnel Include mode, where traffic outside the tunnel was blocked when switching between Wi-Fi and Ethernet networks.
   - Added a WARP client device posture check for SAN attributes to the [client certificate check](/cloudflare-one/identity/devices/warp-client-checks/client-certificate/).
+
+  **Known issues**
+  - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
 version: 2025.5.893.0
 releaseDate: 2025-06-30T19:44:34.251Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-intel/version/2025.5.893.0

--- a/src/content/warp-releases/linux/ga/2025.7.176.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.7.176.0.yaml
@@ -12,7 +12,9 @@ releaseNotes: >-
 
   - Improvements to maintain client connectivity during network changes.
 
+
   **Known issues**
+  
   - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
 
 version: 2025.7.176.0

--- a/src/content/warp-releases/linux/ga/2025.7.176.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.7.176.0.yaml
@@ -11,6 +11,10 @@ releaseNotes: >-
   - Improvements to maintain [Global WARP override](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/#global-warp-override) settings when [switching between organizations](/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/switch-organizations/#switch-organizations-in-warp).
 
   - Improvements to maintain client connectivity during network changes.
+
+  **Known issues**
+  - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
 version: 2025.7.176.0
 releaseDate: 2025-09-30T20:20:30.460Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/fedora35-arm/version/2025.7.176.0

--- a/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
@@ -6,7 +6,9 @@ releaseNotes: >-
 
   - The MASQUE protocol is now the only protocol that can use [Proxy mode](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#proxy-mode). If you previously configured a device profile to use Proxy mode with Wireguard, you will need to select a new WARP mode or switch to the MASQUE protocol. Otherwise, all devices matching the profile will lose connectivity.
 
+
   **Known issues**
+  
   - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
 
 version: 2025.8.779.0

--- a/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
@@ -5,6 +5,10 @@ releaseNotes: >-
   **Changes and improvements**
 
   - The MASQUE protocol is now the only protocol that can use [Proxy mode](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-modes/#proxy-mode). If you previously configured a device profile to use Proxy mode with Wireguard, you will need to select a new WARP mode or switch to the MASQUE protocol. Otherwise, all devices matching the profile will lose connectivity.
+
+  **Known issues**
+  - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/connections/connect-devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
+
 version: 2025.8.779.0
 releaseDate: 2025-10-07T19:20:00.003Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/bullseye-intel/version/2025.8.779.0


### PR DESCRIPTION
### Summary

Our release notes did not consistently contain the warning that since 2025.4.929.0, there's a possibility for failure if there is not a fallback server configured. This PR ensures this warning is present in every version's release notes since the original release where this showed up.

### Screenshots (optional)

N/A

### Documentation checklist

N/A
