### PR TITLE
Refine Zone Deletion Conditions

### DIFF
--- a/src/content/docs/dns/zone-setups/reference/domain-status.mdx
+++ b/src/content/docs/dns/zone-setups/reference/domain-status.mdx
@@ -86,14 +86,14 @@ Your domain has failed multiple DNS checks, where either the Cloudflare nameserv
 
 ### Expected behavior for different plans
 
-If your domain is on the Free plan, it will be automatically deleted after 7 days after it entered the moved status.
+If your domain is on the Free plan, it will be automatically deleted 7 days after it entered the moved status.
 
 For moved zones with a paid plan (Pro, Business, Enterprise), deletion will occur after 7 days if any of the following is observed:
 
 - The paid plan is removed.
 - The domain is activated in another Cloudflare account.
 
-Domain can also be [manually removed](/fundamentals/manage-domains/remove-domain/) from Cloudflare.
+You can also [manually remove](/fundamentals/manage-domains/remove-domain/) your domain from Cloudflare.
 
 ## Deleted
 

--- a/src/content/docs/dns/zone-setups/reference/domain-status.mdx
+++ b/src/content/docs/dns/zone-setups/reference/domain-status.mdx
@@ -86,13 +86,14 @@ Your domain has failed multiple DNS checks, where either the Cloudflare nameserv
 
 ### Expected behavior for different plans
 
-If your domain is on the Free plan, it will be automatically deleted after 7 days.
+If your domain is on the Free plan, it will be automatically deleted after 7 days after it entered the moved status.
 
-For moved zones with a paid plan (Pro, Business, Enterprise), deletion will occur if any of the following is observed:
+For moved zones with a paid plan (Pro, Business, Enterprise), deletion will occur after 7 days if any of the following is observed:
 
 - The paid plan is removed.
 - The domain is activated in another Cloudflare account.
-- The domain is [manually removed](/fundamentals/manage-domains/remove-domain/) from Cloudflare.
+
+Domain can also be [manually removed](/fundamentals/manage-domains/remove-domain/) from Cloudflare.
 
 ## Deleted
 


### PR DESCRIPTION
### Summary

This change is based on feedback from both customers and the DNS Team based on the internal logic used to determine when a zone is transitioned from Moved to Deleted.
