### PR TITLE
[Agents] Add zod import to example

### DIFF
--- a/src/content/docs/agents/model-context-protocol/tools.mdx
+++ b/src/content/docs/agents/model-context-protocol/tools.mdx
@@ -17,6 +17,7 @@ For example, the following code from [this example MCP server](https://github.co
 ```ts title="src/index.ts"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { McpAgent } from "agents/mcp";
+import { z } from "zod";
 
 export class MyMCP extends McpAgent {
 	server = new McpServer({ name: "Demo", version: "1.0.0" });

--- a/src/content/docs/agents/x402.mdx
+++ b/src/content/docs/agents/x402.mdx
@@ -96,6 +96,7 @@ x402 supercharges your MCP servers so they can include paid tools.
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpAgent } from "agents/mcp";
 import { withX402, type X402Config } from "agents/x402";
+import { z } from "zod";
 
 const X402_CONFIG: X402Config = {
 	network: "base",


### PR DESCRIPTION
### Summary

Added the missing `zod` import to the tools example. The example in docs is a reference to [this example](https://github.com/cloudflare/ai/blob/main/demos/remote-mcp-server/src/index.ts) which correctly imports `zod` .

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).