### PR TITLE
Avoid use of `any` in RateLimiter types

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
@@ -67,7 +67,7 @@ export default {
 
 ```ts
 interface Env {
-  MY_RATE_LIMITER: any;
+  MY_RATE_LIMITER: RateLimiter;
 }
 
 export default {


### PR DESCRIPTION
### Summary

Best I can tell, the types y'all provide mean this does not need to be typed as `any`

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->
