### PR TITLE
Documents module example in Python Workers

### DIFF
--- a/src/content/docs/workers/languages/python/examples.mdx
+++ b/src/content/docs/workers/languages/python/examples.mdx
@@ -11,6 +11,33 @@ Cloudflare has a wide range of Python examples in the [Workers Example gallery](
 
 In addition to those examples, consider the following ones that illustrate Python-specific behavior.
 
+## Modules in your Worker
+
+Let's say your Worker has the following structure:
+
+```
+├── src
+│   ├── module.py
+│   └── main.py
+├── uv.lock
+├── pyproject.toml
+└── wrangler.toml
+```
+
+In order to import `module.py` in `main.py`, you would use the following import statement:
+
+```python
+import module
+```
+
+In this case, the main module is set to `src/main.py` in the wrangler.toml file like so:
+
+```toml
+main = "src/main.py"
+```
+
+This means that the `src` directory does not need to be specified in the import statement.
+
 ## Parse an incoming request URL
 
 ```python


### PR DESCRIPTION
### Summary

Adds a new example designed to ensure users are aware of the intricacies of how to import modules in their Python Worker.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
