### PR TITLE
Add File Upload Anomaly Score Threshold effects

### DIFF
--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/concepts.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/concepts.mdx
@@ -37,4 +37,8 @@ The available score thresholds are the following:
 - _Medium – 40 and higher_ (default value)
 - _High – 25 and higher_
 
-Each threshold (_Low_, _Medium_, and _High_) has an associated value (_60_, _40_, and _25_, respectively). Configuring a _Low_ threshold means that more rules will have to match the current request for the WAF to apply the configured ruleset action. For an example, refer to [OWASP evaluation example](/waf/managed-rules/reference/owasp-core-ruleset/example/).
+Each threshold (_Low_, _Medium_, and _High_) has an associated value (_60_, _40_, and _25_, respectively). Configuring a _Low_ threshold means that more rules will have to match the current request for the WAF to apply the configured ruleset action. 
+
+When the OWASP Anomaly Score Threshold is set to _High_, file uploads may trigger the `949110: Inbound Anomaly Score Exceeded` rule due to the lower amount scoring rules needed. Consider adjusting the threshold level, individual counting rules, or making an exception if excessive false positives occur.
+
+For an example, refer to [OWASP evaluation example](/waf/managed-rules/reference/owasp-core-ruleset/example/).

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/concepts.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/concepts.mdx
@@ -39,6 +39,6 @@ The available score thresholds are the following:
 
 Each threshold (_Low_, _Medium_, and _High_) has an associated value (_60_, _40_, and _25_, respectively). Configuring a _Low_ threshold means that more rules will have to match the current request for the WAF to apply the configured ruleset action. 
 
-When the OWASP Anomaly Score Threshold is set to _High_, file uploads may trigger the `949110: Inbound Anomaly Score Exceeded` rule due to the lower amount scoring rules needed. Consider adjusting the threshold level, individual counting rules, or making an exception if excessive false positives occur.
+When the OWASP Anomaly Score Threshold is set to _High_, file uploads may trigger the `949110: Inbound Anomaly Score Exceeded` rule due to the lower amount of scoring rules needed. Consider adjusting the threshold level, [adjusting individual rules](/waf/managed-rules/deploy-zone-dashboard/#configure-a-single-rule-in-a-managed-ruleset) in the ruleset, or [creating an exception](/waf/managed-rules/waf-exceptions/) if excessive false positives occur.
 
 For an example, refer to [OWASP evaluation example](/waf/managed-rules/reference/owasp-core-ruleset/example/).


### PR DESCRIPTION
Added clarification on the impact of the OWASP Anomaly Score Threshold on file uploads and false positives.

Previously documented below 

https://developers.cloudflare.com/waf/reference/legacy/old-waf-managed-rules/#owasp-modsecurity-core-rule-set:~:text=With%20a%20high%20sensitivity%2C%20large%20file%20uploads%20will%20trigger%20the%20WAF.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
