### PR TITLE
[Starlight] Add scroll to top button

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,6 +4,7 @@ import starlightDocSearch from "@astrojs/starlight-docsearch";
 import starlightImageZoom from "starlight-image-zoom";
 import liveCode from "astro-live-code";
 import starlightLinksValidator from "starlight-links-validator";
+import starlightScrollToTop from "starlight-scroll-to-top";
 import icon from "astro-icon";
 import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
@@ -162,6 +163,14 @@ export default defineConfig({
 					clientOptionsModule: "./src/plugins/docsearch/index.ts",
 				}),
 				starlightImageZoom(),
+				starlightScrollToTop({
+					tooltipText: "Back to top",
+					showTooltip: true,
+					svgPath: "M12 6L6 12M12 6L18 12M12 12L6 18M12 12L18 18",
+					showProgressRing: true,
+					progressRingColor: "white",
+					showOnHomepage: false, // Hide on homepage (default)
+				}),
 			],
 			lastUpdated: true,
 			markdown: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
 				"starlight-image-zoom": "0.13.0",
 				"starlight-links-validator": "0.17.2",
 				"starlight-package-managers": "0.11.0",
+				"starlight-scroll-to-top": "0.4.0",
 				"starlight-showcases": "0.3.0",
 				"strip-markdown": "6.0.0",
 				"suf-log": "2.5.3",
@@ -18157,6 +18158,19 @@
 			},
 			"peerDependencies": {
 				"@astrojs/starlight": ">=0.22.0"
+			}
+		},
+		"node_modules/starlight-scroll-to-top": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/starlight-scroll-to-top/-/starlight-scroll-to-top-0.4.0.tgz",
+			"integrity": "sha512-lxsW5Sv+oKCI8CYZQ6Ue957cExiHMozK73LmmbsvpBKWryW+AKU4OXmX/1bTQNx+mVLZcpm2qTwKa1KX5VdEaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+			},
+			"peerDependencies": {
+				"@astrojs/starlight": ">=0.35"
 			}
 		},
 		"node_modules/starlight-showcases": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
 		"starlight-image-zoom": "0.13.0",
 		"starlight-links-validator": "0.17.2",
 		"starlight-package-managers": "0.11.0",
+		"starlight-scroll-to-top": "0.4.0",
 		"starlight-showcases": "0.3.0",
 		"strip-markdown": "6.0.0",
 		"suf-log": "2.5.3",


### PR DESCRIPTION
### Summary

Adds [scroll to top button](https://frostybee.github.io/starlight-scroll-to-top/getting-started/) from Starlight plugins.

<img width="1170" height="888" alt="image" src="https://github.com/user-attachments/assets/5e751b2e-e636-437a-b178-7305ad48f6ac" />

