### PR TITLE
fix code snippet by removing useless async

### DIFF
--- a/src/content/docs/workers/examples/respond-with-another-site.mdx
+++ b/src/content/docs/workers/examples/respond-with-another-site.mdx
@@ -34,7 +34,7 @@ import { Render, TabItem, Tabs } from "~/components";
 ```ts
 export default {
 	async fetch(request): Promise<Response> {
-		async function MethodNotAllowed(request) {
+		function MethodNotAllowed(request) {
 			return new Response(`Method ${request.method} not allowed.`, {
 				status: 405,
 				headers: {

--- a/src/content/partials/workers/respond-another-site-example-js.mdx
+++ b/src/content/partials/workers/respond-another-site-example-js.mdx
@@ -6,7 +6,7 @@
 ```js playground
 export default {
   async fetch(request) {
-    async function MethodNotAllowed(request) {
+    function MethodNotAllowed(request) {
       return new Response(`Method ${request.method} not allowed.`, {
         status: 405,
         headers: {


### PR DESCRIPTION
### Summary

remove `async` because the function is sync.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
