### PR TITLE
Updating sandboxes docs to not reference dockerhub

### DIFF
--- a/src/content/docs/sandbox/configuration/dockerfile.mdx
+++ b/src/content/docs/sandbox/configuration/dockerfile.mdx
@@ -68,6 +68,7 @@ When you run `wrangler dev` or `wrangler deploy`, Wrangler automatically builds 
 
 ## Related resources
 
+- [Image Management](/containers/platform-details/image-management/) - Building and pushing images to Cloudflare\'s registry
 - [Wrangler configuration](/sandbox/configuration/wrangler/) - Using custom images in wrangler.jsonc
 - [Docker documentation](https://docs.docker.com/reference/dockerfile/) - Complete Dockerfile syntax
 - [Container concepts](/sandbox/concepts/containers/) - Understanding the runtime environment

--- a/src/content/docs/sandbox/configuration/wrangler.mdx
+++ b/src/content/docs/sandbox/configuration/wrangler.mdx
@@ -18,7 +18,7 @@ The minimum required configuration for using Sandbox SDK:
 	"containers": [
 		{
 			"class_name": "Sandbox",
-			"image": "docker.io/cloudflare/sandbox:0.3.3",
+			"image": "./Dockerfile",
 		},
 	],
 	"durable_objects": {
@@ -49,7 +49,7 @@ Each container is backed by its own Durable Object. The container image contains
 	"containers": [
 		{
 			"class_name": "Sandbox",
-			"image": "docker.io/cloudflare/sandbox:0.3.3",
+			"image": "./Dockerfile",
 		},
 	],
 }
@@ -60,20 +60,7 @@ Each container is backed by its own Durable Object. The container image contains
 - **class_name** (string, required) - Must match the `class_name` of the Durable Object.
 - **image** (string, required) - The Docker image to use. Must match your npm package version.
 
-For custom images, use a Dockerfile:
-
-```jsonc
-{
-	"containers": [
-		{
-			"class_name": "Sandbox",
-			"image": "./Dockerfile",
-		},
-	],
-}
-```
-
-See [Dockerfile reference](/sandbox/configuration/dockerfile/) for customization.
+See [Dockerfile reference](/sandbox/configuration/dockerfile/) for information on customizing your Docker image.
 
 ### durable_objects.bindings
 
@@ -203,23 +190,6 @@ export default {
 			},
 		],
 	},
-}
-```
-
-### Container image pull fails
-
-**Error**: `Failed to pull container image`
-
-**Solution**: Ensure you're using the correct image version (must match npm package):
-
-```jsonc
-{
-	"containers": [
-		{
-			"class_name": "Sandbox",
-			"image": "docker.io/cloudflare/sandbox:0.3.3",
-		},
-	],
 }
 ```
 


### PR DESCRIPTION
### Summary

Fixing an issue where the docs were referencing polls from Docker Hub, which do not work yet.