### PR TITLE
Adding missing comma after name field in the Python script for creating indexes

### DIFF
--- a/src/content/docs/vectorize/best-practices/create-indexes.mdx
+++ b/src/content/docs/vectorize/best-practices/create-indexes.mdx
@@ -55,7 +55,7 @@ headers = {
 }
 
 body = {
-	"name": "demo-index"
+	"name": "demo-index",
 	"description": "some index description",
   "config": {
     "dimensions": 1024,

--- a/src/content/docs/vectorize/best-practices/create-indexes.mdx
+++ b/src/content/docs/vectorize/best-practices/create-indexes.mdx
@@ -89,7 +89,6 @@ The following table highlights some example embeddings models and their output d
 | Google Cloud - `multimodalembedding`     | 1408              | Multi-modal (text, images) |
 
 :::note[Learn more about Workers AI]
-
 Refer to the [Workers AI documentation](/workers-ai/models/#text-embeddings) to learn about its built-in embedding models.
 :::
 


### PR DESCRIPTION
### Summary

fix: add a missing comma after the name field in the [Python script for creating indexes](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/#http-api)



<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
As-is
```python

import requests

url = "https://api.cloudflare.com/client/v4/accounts/{}/vectorize/v2/indexes".format("your-account-id")

headers = {
    "Authorization": "Bearer <your-api-token>"
}

body = {
  "name": "demo-index"
  "description": "some index description",
  "config": {
    "dimensions": 1024,
    "metric": "euclidean"
  },
}

resp = requests.post(url, headers=headers, json=body)

print('Status Code:', resp.status_code)
print('Response JSON:', resp.json())

```

To-be
```python

import requests

url = "https://api.cloudflare.com/client/v4/accounts/{}/vectorize/v2/indexes".format("your-account-id")

headers = {
    "Authorization": "Bearer <your-api-token>"
}

body = {
  "name": "demo-index",
  "description": "some index description",
  "config": {
    "dimensions": 1024,
    "metric": "euclidean"
  },
}

resp = requests.post(url, headers=headers, json=body)

print('Status Code:', resp.status_code)
print('Response JSON:', resp.json())

```
<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

