### PR TITLE
Removes sandbox start times

### DIFF
--- a/src/content/docs/sandbox/concepts/architecture.mdx
+++ b/src/content/docs/sandbox/concepts/architecture.mdx
@@ -125,12 +125,6 @@ const processes = await sandbox.listProcesses();
 // Server still running
 ```
 
-## Performance
-
-**Cold start**: 100-300ms (container initialization)  
-**Warm start**: \<10ms (reuse existing container)  
-**Network latency**: 10-50ms (edge-to-edge)
-
 ## Related resources
 
 - [Sandbox lifecycle](/sandbox/concepts/sandboxes/) - How sandboxes are created and managed


### PR DESCRIPTION
### Summary

We are reporting incorrect numbers for sandbox cold start times. Current start times are closer to ~3 seconds I believe.

Removing the sandbox performance until we can measure and report correct times.
