### PR TITLE
Fix typo in fs.mdx regarding fs.rm API

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/fs.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/fs.mdx
@@ -131,7 +131,7 @@ supported:
 
 - `fs.watch` and `fs.watchFile` operations for watching for file changes.
 - The `fs.globSync()` and other glob APIs have not yet been implemented.
-- The `force` option in the `fs.rm` API has not yet bee implemented.
+- The `force` option in the `fs.rm` API has not yet been implemented.
 - Timestamps for files are always set to the Unix epoch (`1970-01-01T00:00:00Z`).
 - File permissions and ownership are not supported.
 


### PR DESCRIPTION
### Summary
Fix typo in https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs
