### PR TITLE
fix: added links to RealtimeKit and RealtimeKit UI API specs

### DIFF
--- a/src/content/docs/realtime/realtimekit/introduction.mdx
+++ b/src/content/docs/realtime/realtimekit/introduction.mdx
@@ -17,6 +17,11 @@ RealtimeKit is composed of three core components that work together to provide a
 
 - **Backend Infrastructure**: This is the foundation of RealtimeKit. It includes REST APIs for creating meetings, adding participants, retrieving session information, webhooks for server-side notifications, and so on. A dedicated socket server handles real-time signalling, while the [Realtime SFU](/realtime/sfu) relays media between users with low latency. The entire backend runs on Cloudflare's global network, ensuring reliability and scale.
 
+You can find the API specifications here:
+
+- [Core SDK](https://docs.realtime.cloudflare.com/web-core)
+- [UI Kit](https://docs.realtime.cloudflare.com/ui-kit)
+
 ## Use Cases
 
 RealtimeKit is designed for a variety of real-time communication needs. Here are some of the most common use cases:


### PR DESCRIPTION
### Summary

Adding links to RealtimeKit and RealtimeKit UI API specifications temporarily until https://docs.realtime.cloudflare.com is migrated https://developers.cloudflare.com

Fixes #25847

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
