### PR TITLE
Update Websocket Example

### DIFF
--- a/src/content/docs/durable-objects/examples/websocket-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-server.mdx
@@ -108,20 +108,20 @@ export class WebSocketServer extends DurableObject {
         const connection = this.sessions.get(ws)!;
 
         // Reply back with the same message to the connection
-        ws.send(`[Durable Object] message: ${message}, from: ${connection.id}`);
+        ws.send(`[Durable Object] message: ${message}, from: ${connection.id}, to: the initiating client. Total connections: ${this.sessions.size}`);
 
         // Broadcast the message to all the connections,
         // except the one that sent the message.
-        this.sessions.forEach((k, session) => {
+        this.sessions.forEach((_, session) => {
             if (session !== ws) {
-                session.send(`[Durable Object] message: ${message}, from: ${connection.id}`);
+                session.send(`[Durable Object] message: ${message}, from: ${connection.id}, to: all clients except the initiating client. Total connections: ${this.sessions.size}`);
             }
         });
 
         // Broadcast the message to all the connections,
         // including the one that sent the message.
-        this.sessions.forEach((k, session) => {
-            session.send(`[Durable Object] message: ${message}, from: ${connection.id}`);
+        this.sessions.forEach((_, session) => {
+            session.send(`[Durable Object] message: ${message}, from: ${connection.id}, to: all clients. Total connections: ${this.sessions.size}`);
         });
     }
 


### PR DESCRIPTION
This updates the example in several ways:
- Send back the number of live connections. The docs say this WS server will send back the number of live connections and now it does.
- Removing the confusing `k` lambda parameter. The `k` in this case is unused and _not_ a key.
- Update the message contents so they are not the same in all cases.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
