### PR TITLE
Document virtual networks limit per account

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -66,8 +66,9 @@ This page lists the default account limits for rules, applications, fields, and 
 | ---------------------------------------- | ----- |
 | `cloudflared` tunnels per account        | 1,000 |
 | WARP Connectors per account              | 10    |
-| Routes per tunnel                       | 1,000 |
+| Routes per tunnel                        | 1,000 |
 | Active `cloudflared` replicas per tunnel | 25    |
+| Virtual networks per account             | 1,000 |
 
 ## Digital Experience Monitoring (DEX)
 


### PR DESCRIPTION
### Summary
PCX-19781: there is a limit of a number of vnets per account that we should publicly document.