### PR TITLE
docs (remote-backend): fix broken link to Terraform backend documentation

### DIFF
--- a/src/content/docs/terraform/advanced-topics/remote-backend.mdx
+++ b/src/content/docs/terraform/advanced-topics/remote-backend.mdx
@@ -36,7 +36,7 @@ After your token has been successfully created, review your **Secret Access Key*
 
 ## Define R2 backend
 
-Update your [`cloudflare.tf`](/terraform/tutorial/initialize-terraform/) file to include a [backend](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) for the `<YOUR_BUCKET_NAME>` bucket you created above.
+Update your [`cloudflare.tf`](/terraform/tutorial/initialize-terraform/) file to include a [backend](https://developer.hashicorp.com/terraform/language/backend) for the `<YOUR_BUCKET_NAME>` bucket you created above.
 
 <Render file="v4-code-snippets" product="terraform" />
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

This PR updates the broken link to the Terraform document. (Store state remotely)

Old link: `https://developer.hashicorp.com/terraform/language/backend/configuration`
New link: `https://developer.hashicorp.com/terraform/language/backend`

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

<details><summary>Old link:</summary>
<p>

<img width="2014" height="1296" alt="20251022_1600_EhC9Wz4a@2x" src="https://github.com/user-attachments/assets/07da6719-9250-441f-97fb-36a407f94268" />

</p>
</details> 


<details><summary>New link:</summary>
<p>

<img width="3048" height="2092" alt="20251022_1601_w4Zceb3n@2x" src="https://github.com/user-attachments/assets/3f49cb0d-2fe8-4068-b02c-b37e018986d6" />

</p>
</details> 


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
