### PR TITLE
Update Next.js notes about PPR and "use cache" directives. 

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
@@ -51,9 +51,9 @@ Most Next.js features are supported by the Cloudflare OpenNext adapter:
 | Response streaming                    | 🟢 supported         |                                                                              |
 | asynchronous work with `next/after`   | 🟢 supported         |                                                                              |
 | Middleware                            | 🟢 supported         |                                                                              |
-| Image optimization                    | 🟢 supported         | Supported via [Cloudflare Images](/images/) |
-| Partial Prerendering (PPR)            | 🟢 supported         | PPR is experimental in Next.js                                               |
-| Composable Caching ('use cache')      | 🟢 supported         | Composable Caching is experimental in Next.js                                |
+| Image optimization                    | 🟢 supported         | Supported via [Cloudflare Images](/images/)                                  |
+| Partial Prerendering (PPR)            | 🟢 supported         |                                                                              |
+| Composable Caching ('use cache')      | 🟢 supported         |                                                                              |
 | Node.js in Middleware                 | ⚪ not yet supported | Node.js middleware introduced in 15.2 are not yet supported                  |
 
 ## Deploy a new Next.js project on Workers


### PR DESCRIPTION
Updated support status for Partial Prerendering and Composable Caching.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

With the new version of Next.js 16, PPR and "use cache" are no longer experimental features. This Pull Requests updates notes about these experimental features.  You can take a look here on the new [Next.js 16 release](https://nextjs.org/blog/next-16)

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->


- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

