### PR TITLE
Cache: Fix issue that lumps in a note with a list of headers

### DIFF
--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -169,9 +169,10 @@ Our implementation of the Cache API respects the following HTTP headers on the r
 
   * Results in a `304` response if a matching response is found with an `ETag` header with a value that matches a value in `If-None-Match`.
 
-* `cache.match()`
-  * Never sends a subrequest to the origin. If no matching response is found in cache, the promise that `cache.match()` returns is fulfilled with `undefined`.
+:::note
 
+`cache.match()` never sends a subrequest to the origin. If no matching response is found in cache, the promise that `cache.match()` returns is fulfilled with `undefined`.
+:::
 
 #### Errors
 


### PR DESCRIPTION
### Summary

The current formatting lumps what appears to be a note in with a list of headers

### Screenshots (optional)

https://developers.cloudflare.com/workers/runtime-apis/cache/#match
<img width="800" height="1291" alt="Monosnap Image 2025-10-23 08-41-17" src="https://github.com/user-attachments/assets/1aae692f-edfb-430a-8ef4-44851deaba59" />