### PR TITLE
[fix] Fix the run command in Getting Started

### DIFF
--- a/src/content/docs/sandbox/get-started.mdx
+++ b/src/content/docs/sandbox/get-started.mdx
@@ -99,7 +99,8 @@ export default {
 Start the development server:
 
 ```sh
-npm run dev. If you expect to have multiple sandbox instances, you can increase `max_instances`.
+npm run dev
+# If you expect to have multiple sandbox instances, you can increase `max_instances`.
 ```
 
 :::note


### PR DESCRIPTION
### Summary

Fixes the run command in the getting started guide.