### PR TITLE
Update prerequisites for JavaScript detections

### DIFF
--- a/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
@@ -56,7 +56,7 @@ When adding this field to WAF custom rules, it is used on endpoints expecting br
 
 ### Prerequisites
 
-- You must have [Enterprise Bot Management](/bots/plans/bm-subscription/) entitled.
+- You must have an [Enterprise Bot Management](/bots/plans/bm-subscription/) subscription.
 - You must have JavaScript Detections enabled on your zone.
 - You must have [updated your Content Security Policy headers](/cloudflare-challenges/challenge-types/javascript-detections/#if-you-have-a-content-security-policy-csp) for JavaScript detections.
 - You must not run this field on websocket endpoints.

--- a/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
@@ -56,6 +56,7 @@ When adding this field to WAF custom rules, it is used on endpoints expecting br
 
 ### Prerequisites
 
+- You must have [Enterprise Bot Management](/bots/plans/bm-subscription/) entitled.
 - You must have JavaScript Detections enabled on your zone.
 - You must have [updated your Content Security Policy headers](/cloudflare-challenges/challenge-types/javascript-detections/#if-you-have-a-content-security-policy-csp) for JavaScript detections.
 - You must not run this field on websocket endpoints.


### PR DESCRIPTION
PCX-19832

Clarify that the Bots Fields (like `cf.bot_management.js_detection.passed`) require the Enterprise Bot Management subscription.