### PR TITLE
Add $schema to Wrangler jsonc config

### DIFF
--- a/src/components/WranglerConfig.astro
+++ b/src/components/WranglerConfig.astro
@@ -38,7 +38,10 @@ let toml, json;
 
 if (language === "toml") {
 	toml = code;
-	json = JSON.stringify(TOML.parse(code), null, 2);
+	json = JSON.stringify({
+		"$schema": "./node_modules/wrangler/config-schema.json",
+		...TOML.parse(code),
+	}, null, 2);
 } else {
 	json = code;
 	toml = TOML.stringify(jsoncParse(code));


### PR DESCRIPTION
### Summary

When rendering Wrangler config, it's commonly provided in TOML. When we do this, we convert it to JSON to render as an option. That's great but in TOML we don't specify a schema but on JSONC we want to. So, add the `$schema` at the top with the expected value.

### Screenshots (optional)
Before:
<img width="548" height="263" alt="image" src="https://github.com/user-attachments/assets/61dee55f-3880-4b91-b779-988593e4dc44" />

After:
<img width="506" height="250" alt="image" src="https://github.com/user-attachments/assets/4b8a38ee-904f-41f9-a8d1-6dcd9cb4fcb8" />

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
