### PR TITLE
remove outdated docs for workers free-tier burst and workers anti-abuse rate limits

### DIFF
--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -138,32 +138,6 @@ The size of chunked response bodies (`Transfer-Encoding: chunked`) is not known 
 
 Workers automatically scale onto thousands of Cloudflare global network servers around the world. There is no general limit to the number of requests per second Workers can handle.
 
-Cloudflare’s abuse protection methods do not affect well-intentioned traffic. However, if you send many thousands of requests per second from a small number of client IP addresses, you can inadvertently trigger Cloudflare’s abuse protection. If you expect to receive `1015` errors in response to traffic or expect your application to incur these errors, [contact Cloudflare support](/support/contacting-cloudflare-support/) to increase your limit. Cloudflare's anti-abuse Workers Rate Limiting does not apply to Enterprise customers.
-
-You can also confirm if you have been rate limited by anti-abuse Worker Rate Limiting by logging into the Cloudflare dashboard, selecting your account and zone, and going to **Security** > **Events**. Find the event and expand it. If the **Rule ID** is `worker`, this confirms that it is the anti-abuse Worker Rate Limiting.
-
-The burst rate and daily request limits apply at the account level, meaning that requests on your `*.workers.dev` subdomain count toward the same limit as your zones.
-
-:::caution
-
-If you are currently being rate limited, in the Cloudflare dashboard go to the **Workers plans** page to update to a Workers Paid plan to lift burst rate and daily request limits.
-
-<DashButton url="/?to=/:account/workers/plans" />
-
-:::
-
-### Burst rate
-
-Accounts using the Workers Free plan are subject to a burst rate limit of 1,000 requests per minute. Users visiting a rate limited site will receive a Cloudflare `1015` error page. However if you are calling your Worker programmatically, you can detect the rate limit page and handle it yourself by looking for HTTP status code `429`.
-
-Workers being rate-limited by Anti-Abuse Protection are also visible from the Cloudflare dashboard:
-1. In the Cloudflare dashboard, go to the **Security events** page.
-
-   <DashButton url="/?to=/:account/security-center/events" />
-
-2. Scroll to **Sampled logs**.
-3. Review the log for a Web Application Firewall block event with a `ruleID` of `worker`.
-
 ### Daily request
 
 Accounts using the Workers Free plan are subject to a daily request limit of 100,000 requests. Free plan daily requests counts reset at midnight UTC. A Worker that fails as a result of daily request limit errors can be configured by toggling its corresponding [route](/workers/configuration/routing/routes/) in two modes: 1) Fail open and 2) Fail closed.


### PR DESCRIPTION
These limits are no longer active and don't manifest in the same way, continuing to document them will confuse customers.