### PR TITLE
fix: update AI Gateway docs for Replicate provider

### DIFF
--- a/src/content/docs/ai-gateway/usage/providers/replicate.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/replicate.mdx
@@ -21,8 +21,8 @@ When making requests to Replicate, ensure you have the following:
 
 - Your AI Gateway Account ID.
 - Your AI Gateway gateway name.
-- An active Replicate API token.
-- The name of the Replicate model you want to use.
+- An active Replicate API token. You can create one at [replicate.com/settings/api-tokens](https://replicate.com/settings/api-tokens)
+- The name of the Replicate model you want to use, like `anthropic/claude-4.5-haiku` or `google/nano-banana`.
 
 ## Example
 
@@ -36,7 +36,7 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/replicate/pr
     "version": "anthropic/claude-4.5-haiku",
     "input":
       {
-        "prompt": "What is Cloudflare?"
+        "prompt": "Write a haiku about Cloudflare"
       }
     }'
 ```

--- a/src/content/docs/ai-gateway/usage/providers/replicate.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/replicate.mdx
@@ -30,9 +30,10 @@ When making requests to Replicate, ensure you have the following:
 
 ```bash title="Request"
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/replicate/predictions \
-  --header 'Authorization: Token {replicate_api_token}' \
+  --header 'Authorization: Bearer {replicate_api_token}' \
   --header 'Content-Type: application/json' \
   --data '{
+    "version": "anthropic/claude-4.5-haiku",
     "input":
       {
         "prompt": "What is Cloudflare?"


### PR DESCRIPTION
This PR fixes two issues in the [AI Gateway documentation for Replicate](https://developers.cloudflare.com/ai-gateway/usage/providers/replicate/):

1. **Authorization header**: Changes from `Authorization: Token r8_...` to `Authorization: Bearer r8_...`, which is the correct format that actually works. The old format works, but is deprecated.
2. **Missing version field**: Adds the required `version` field to the request body with [anthropic/claude-4.5-haiku](https://replicate.com/anthropic/claude-4.5-haiku) as an example.

These corrections were discovered through hands-on testing with the Cloudflare AI Gateway and Replicate API.

A working example repository is available at https://github.com/replicate/cloudflare-ai-gateway-replicate-test