### PR TITLE
Update documented location of non-production enablement

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/build-branches.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-branches.mdx
@@ -22,6 +22,6 @@ Every push event made to this branch will trigger a build and execute the [build
 To enable or disable non-production branch builds:
 
 1. In **Overview**, select your Workers project.
-2. Go to **Settings** > **Build** > **Branch control**. The button under **Pull Request Previews** allows you to enable or disable builds for non-production branches.
+2. Go to **Settings** > **Build** > **Branch control**. The checkbox **Builds for non-production branches** allows you to enable or disable builds for non-production branches.
 
 When enabled, every push event made to a non-production branch will trigger a build and execute the [build command](/workers/ci-cd/builds/configuration/#build-command), followed by the [non-production branch deploy command](/workers/ci-cd/builds/configuration/#non-production-branch-deploy-command).


### PR DESCRIPTION
### Summary

This is no longer a button, but a checkbox. No need to change anything in https://developers.cloudflare.com/workers/ci-cd/builds/configuration/#non-production-branch-deploy-command as it does not mention anything about a button or the slider which contains the deploy command.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [na] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [na] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [na] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
