### PR TITLE
[Docs builds] Move node options to package.json for viz + standardize

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -39,7 +39,6 @@ jobs:
       - run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max-old-space-size=4192"
 
       - name: Install dependencies
         run: curl https://htmltest.wjdp.uk | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       - run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max-old-space-size=6144"
           RUN_LINK_CHECK: true
 
       - run: npm run check:worker

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -33,7 +33,6 @@ jobs:
         name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --max-old-space-size=6144
       - name: Deploy to Cloudflare Workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -28,7 +28,6 @@ jobs:
         name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --max-old-space-size=6144
       - run: npx wrangler deploy
         name: Deploy to Cloudflare Workers
         env:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"astro": "npx astro",
-		"build": "npx astro build",
+		"build": "NODE_OPTIONS='--max-old-space-size=6192' npx astro build",
 		"typegen:worker": "npx wrangler types ./worker/worker-configuration.d.ts",
 		"check": "npm run check:astro && npm run check:worker",
 		"check:astro": "npx astro check",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"astro": "npx astro",
-		"build": "NODE_OPTIONS='--max-old-space-size=6192' npx astro build",
+		"build": "export NODE_OPTIONS='--max-old-space-size=6192' || set NODE_OPTIONS='--max-old-space-size=6192'&& npx astro build",
 		"typegen:worker": "npx wrangler types ./worker/worker-configuration.d.ts",
 		"check": "npm run check:astro && npm run check:worker",
 		"check:astro": "npx astro check",


### PR DESCRIPTION
Follow up of other work, we should really specify these in package.json and then remove the node options from the individual actions.

This doesn't _quite_ remove from the individual actions that matter, but will do once we confirm that this behavior works as expected in production (namely, by running [Anchor Link audit](https://github.com/cloudflare/cloudflare-docs/actions/runs/18946052941) against this branch -- TBD).