### PR TITLE
corrected documentation at cloudflare.com/dns/foundation-dns/setup/#e…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
 	},
 	"[astro]": {
 		"editor.defaultFormatter": "astro-build.astro-vscode"
-	}
+	},
+	"vscode-corda.isCordaProject": false
 }

--- a/src/content/docs/dns/foundation-dns/setup.mdx
+++ b/src/content/docs/dns/foundation-dns/setup.mdx
@@ -103,7 +103,7 @@ To enable advanced nameservers on an existing zone:
    </TabItem> </Tabs>
 
 2. Update the authoritative nameservers at your registrar. This step depends on whether you are using [Cloudflare Registrar](/registrar/):
-   - If you are using Cloudflare Registrar, [contact Cloudflare Support](/support/contacting-cloudflare-support/) to have your nameservers updated.
+   - If you are using Cloudflare Registrar, you need to contact your Account Team to do this.
    - If you are using a different registrar or if your zone is delegated to a parent zone, [manually update your nameservers](/dns/nameservers/update-nameservers/#specific-processes).
 
      :::caution


### PR DESCRIPTION

 Summary

(FIXED) :- Misleading Directions on Foundation DNS #26163


 Screenshots (optional)


 
 Documentation checklist

Removed this confusing line:

"If you are using Cloudflare Registrar, [contact Cloudflare Support](https://developers.cloudflare.com/support/contacting-cloudflare-support/) to have your nameservers updated."
