### PR TITLE
[Bots/Fraud] Add note on known error to sequence rules

### DIFF
--- a/src/content/docs/bots/additional-configurations/sequence-rules.mdx
+++ b/src/content/docs/bots/additional-configurations/sequence-rules.mdx
@@ -9,7 +9,9 @@ import { Render, Steps } from "~/components"
 
 <Render file="sequence-rules" product="bots" params={{ one: "Sequence rules", two: "/bots/additional-configurations/sequence-rules/" }} />
 
-Sequence rules is currently in private beta. If you would like to be included in the beta, contact your account team.
+:::caution[`431` error]
+Too many concurrent requests to your zone may add cookies that create a header that is too large, causing a `431` error.
+:::
 
 ## Prerequisites
 
@@ -128,3 +130,9 @@ not cf.sequence.msec_since_op["aaaaaaaa"] ge 1000
 ## Limitations
 
 Cloudflare only supports HTTPS requests since our cookies set the `Secure` attribute.
+
+---
+
+## Availability
+
+Sequence rules is currently in private beta. If you would like to be included in the beta, contact your account team.


### PR DESCRIPTION
### Summary

Adds note on `431` error to sequence rules page + move availability to the end.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
