### PR TITLE
[Docs] Support for  PDF redirects in validation script

### DIFF
--- a/bin/validate-redirects.ts
+++ b/bin/validate-redirects.ts
@@ -8,7 +8,7 @@ async function main() {
 	let numDuplicateRedirects = 0;
 	let numNonSlashedRedirects = 0;
 
-	const validEndings = ["/", "*", ".xml", ".md", ".json", ".html"];
+	const validEndings = ["/", "*", ".xml", ".md", ".json", ".html", ".pdf"];
 
 	const redirectSourceUrls: string[] = [];
 


### PR DESCRIPTION
### Summary

Redirects for PDF files don't need an ending slash (`/`) in their path.
