### PR TITLE
[workers] Update release notes: V8 14.2, JSON optimization, WebSocket message size limit

### DIFF
--- a/src/content/changelog/workers/2025-10-31-increased-websocket-message-size-limit.mdx
+++ b/src/content/changelog/workers/2025-10-31-increased-websocket-message-size-limit.mdx
@@ -1,0 +1,15 @@
+---
+title: Workers WebSocket message size limit increased from 1 MiB to 32 MiB
+description: The maximum WebSocket message size limit for all Workers has been increased from 1 MiB to 32 MiB.
+products:
+  - workers
+  - durable-objects
+  - browser-rendering
+date: 2025-10-31
+---
+
+Workers, including those using [Durable Objects](/durable-objects/) and [Browser Rendering](/browser-rendering/workers-bindings/), may now process WebSocket messages up to 32 MiB in size. Previously, this limit was 1 MiB.
+
+This change allows Workers to handle use cases requiring large message sizes, such as processing Chrome Devtools Protocol messages.
+
+For more information, please see the [Durable Objects startup limits](/durable-objects/platform/limits/#SQLite-backed-Durable-Objects-general-limits).

--- a/src/content/docs/durable-objects/platform/limits.mdx
+++ b/src/content/docs/durable-objects/platform/limits.mdx
@@ -20,7 +20,7 @@ Durable Objects are a special kind of Worker, so [Workers Limits](/workers/platf
 | Storage per Durable Object     | 10 GB [^3]                                                                                                     |
 | Key size                       | Key and value combined cannot exceed 2 MB                                                                      |
 | Value size                     | Key and value combined cannot exceed 2 MB                                                                      |
-| WebSocket message size         | 1 MiB (only for received messages)                                                                             |
+| WebSocket message size         | 32 MiB (only for received messages)                                                                            |
 | CPU per request                | 30 seconds (default) / configurable to 5 minutes of [active CPU time](/workers/platform/limits/#cpu-time) [^4] |
 
 [^1]: Identical to the Workers [script limit](/workers/platform/limits/).
@@ -69,7 +69,7 @@ For Durable Object classes with [SQLite storage](/durable-objects/api/sqlite-sto
 | Storage per Durable Object     | Unlimited                                           |
 | Key size                       | 2 KiB (2048 bytes)                                  |
 | Value size                     | 128 KiB (131072 bytes)                              |
-| WebSocket message size         | 1 MiB (only for received messages)                  |
+| WebSocket message size         | 32 MiB (only for received messages)                 |
 | CPU per request                | 30s (including WebSocket messages) [^7]             |
 
 [^5]: Identical to the Workers [script limit](/workers/platform/limits/).

--- a/src/content/release-notes/durable-objects.yaml
+++ b/src/content/release-notes/durable-objects.yaml
@@ -3,6 +3,9 @@ link: "/durable-objects/release-notes/"
 productName: Durable Objects
 productLink: "/durable-objects/"
 entries:
+  - publish_date: "2025-10-25"
+    description: |-
+      - The maximum WebSocket message size limit has been increased from 1 MiB to 32 MiB.
   - publish_date: "2025-10-16"
     title: Durable Objects can access stored data with UI editor
     description: |-

--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -3,6 +3,13 @@ link: "/workers/platform/changelog/"
 productName: Workers
 productLink: "/workers/"
 entries:
+  - publish_date: "2025-10-22"
+    description: |-
+      - Warnings which were previously only visible via the devtools console in preview sessions are now also sent to the tail Worker, if one is attached.
+  - publish_date: "2025-10-17"
+    description: |-
+      - Updated v8 to version 14.2.
+      - Backported an optimization to `JSON.parse()`. More details are [available in this blog post](https://blog.cloudflare.com/unpacking-cloudflare-workers-cpu-performance-benchmarks/#json-parsing) and [the upstream patch](https://chromium-review.googlesource.com/c/v8/v8/+/7027411).
   - publish_date: "2025-09-18"
     description: |-
       - Updated v8 to version 14.1.

--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -3,6 +3,9 @@ link: "/workers/platform/changelog/"
 productName: Workers
 productLink: "/workers/"
 entries:
+  - publish_date: "2025-10-25"
+    description: |-
+      - The maximum WebSocket message size limit has been increased from 1 MiB to 32 MiB.
   - publish_date: "2025-10-22"
     description: |-
       - Warnings which were previously only visible via the devtools console in preview sessions are now also sent to the tail Worker, if one is attached.


### PR DESCRIPTION
### Summary

This brings the Workers external release notes up to date with some recent changes:

- V8 14.2
- A `JSON.parse()` optimization which we blogged about
- The WebSocket message size limit increase from 1 MiB to 32 MiB

The WebSocket message size limit, while implemented in the Workers platform, appears only to have been documented in the Durable Objects section. So, I updated the DO documentation, too.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).