### PR TITLE
Add SCIM provisioning troubleshooting page

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
@@ -34,7 +34,7 @@ Expectations for user lifecycle management with SCIM:
 ## Limitations
 
 - If a user is the only Super Administrator on an Enterprise account, they will not be deprovisioned.
-- It is possible to unintentionally remove all account Super Administrators by misconfiguring SCIM groups. See [SCIM troubleshooting](/fundamentals/account/account-security/scim-setup/troubleshooting/) for more information.
+- It is possible to unintentionally remove all account Super Administrators by misconfiguring SCIM groups. Refer to [SCIM troubleshooting](/fundamentals/account/account-security/scim-setup/troubleshooting/) for more information.
 
 ## Prerequisites
 

--- a/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
@@ -34,6 +34,7 @@ Expectations for user lifecycle management with SCIM:
 ## Limitations
 
 - If a user is the only Super Administrator on an Enterprise account, they will not be deprovisioned.
+- It is possible to unintentionally remove all account Super Administrators by misconfiguring SCIM groups. See [SCIM troubleshooting](/fundamentals/account/account-security/scim-setup/troubleshooting/) for more information.
 
 ## Prerequisites
 

--- a/src/content/docs/fundamentals/account/account-security/scim-setup/troubleshooting.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/troubleshooting.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: how-to
+title: SCIM troubleshooting
+sidebar:
+  label: Troubleshooting
+---
+
+## Restore Super Administrator after group misconfiguration
+
+If you have removed all Super Administrators mistakenly, you can restore the role to account member(s) using the Account API Token you created for SCIM provisioning.
+
+First, fetch a list of account members and find the member ID for the user you want to restore Super Admin to via [list members](https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/list/)
+
+```curl
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/members" \
+  -H "Authorization: Bearer YOUR_SCIM_AOT" \
+  -H "Content-Type: application/json"
+```
+
+Then restore the Super Admin role to that member via [update member](https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/update/)
+
+```curl
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/members/{member_id}" \
+  -H "Authorization: Bearer YOUR_SCIM_AOT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "roles": ["33666b9c79b9a5273fc7344ff42f953d"]
+  }'
+```
+
+:::note
+33666b9c79b9a5273fc7344ff42f953d is the Super Administrator role ID
+:::

--- a/src/content/docs/fundamentals/account/account-security/scim-setup/troubleshooting.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/troubleshooting.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 If you have removed all Super Administrators mistakenly, you can restore the role to account member(s) using the Account API Token you created for SCIM provisioning.
 
-First, fetch a list of account members and find the member ID for the user you want to restore Super Admin to via [list members](https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/list/)
+First, fetch a list of account members and find the member ID for the user you want to restore Super Admin to via [list members].(/api/resources/accounts/subresources/members/methods/list/)
 
 ```curl
 curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/members" \
@@ -17,7 +17,7 @@ curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/members"
   -H "Content-Type: application/json"
 ```
 
-Then restore the Super Admin role to that member via [update member](https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/update/)
+Then restore the Super Admin role to that member via [update member](/api/resources/accounts/subresources/members/methods/update/)
 
 ```curl
 curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/members/{member_id}" \


### PR DESCRIPTION
### Summary

Some users unintentionally configure the groups in their IdP in a way which removes all Super Administrators from an account. This often results in support tickets, but most often customers can restore the role themselves.

**Changes:**

- Add a new SCIM troubleshooting page with restoring Super Admin instructions
- Add note in limitations that Super Administrators can be unintentionally removed with a link to the Troubleshooting page

### Screenshots (optional)

**New page**
<img width="1049" height="928" alt="Screenshot 2025-10-31 at 10 35 19 AM" src="https://github.com/user-attachments/assets/aab00adc-426d-4a98-9506-885717d968b3" />

**Sidebar displays "Troubleshooting" instead of the full page title (as it is a subpage)**
<img width="223" height="163" alt="Screenshot 2025-10-31 at 10 39 51 AM" src="https://github.com/user-attachments/assets/c8f438f4-a6a3-4b8f-bbeb-574560381521" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
