### PR TITLE
docs: move XPath selector FAQ to Puppeteer page

### DIFF
--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -54,31 +54,6 @@ There is no fixed limit on the number of requests per browser session. A single 
 
 This error typically occurs because your Puppeteer launch is not receiving the Browser binding. To resolve: Pass your Browser binding into `puppeteer.launch`.
 
-### Why can't I use an XPath selector when using Browser Rendering with Puppeteer?
-
-Currently it is not possible to use Xpath to select elements since this poses a security risk to Workers.
-
-As an alternative, try to use a css selector or `page.evaluate`. For example:
-
-```ts
-const innerHtml = await page.evaluate(() => {
-	return (
-		// @ts-ignore this runs on browser context
-		new XPathEvaluator()
-			.createExpression("/html/body/div/h1")
-			// @ts-ignore this runs on browser context
-			.evaluate(document, XPathResult.FIRST_ORDERED_NODE_TYPE).singleNodeValue
-			.innerHTML
-	);
-});
-```
-
-:::note
-
-Keep in mind that `page.evaluate` can only return primitive types like strings, numbers, etc. Returning an `HTMLElement` will not work.
-
-:::
-
 ### Why is my screenshot blurry?
 
 It may be because you increased the height and width of the viewport. To fix this, increase the value of the `deviceScaleFactor` (default is 1).

--- a/src/content/docs/browser-rendering/platform/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/platform/puppeteer.mdx
@@ -68,7 +68,32 @@ await page.setUserAgent(
 ```
 
 :::note
-The `userAgent` parameter does not bypass bot protection. Requests from Browser Rendering will always be identified as a bot. 
+The `userAgent` parameter does not bypass bot protection. Requests from Browser Rendering will always be identified as a bot.
+:::
+
+## Element selection
+
+Puppeteer provides multiple methods for selecting elements on a page. While CSS selectors work as expected, XPath selectors are not supported due to security constraints in the Workers runtime.
+
+Instead of using Xpath selectors, you can use CSS selectors or `page.evaluate()` to run XPath queries in the browser context:
+
+```ts
+const innerHtml = await page.evaluate(() => {
+	return (
+		// @ts-ignore this runs on browser context
+		new XPathEvaluator()
+			.createExpression("/html/body/div/h1")
+			// @ts-ignore this runs on browser context
+			.evaluate(document, XPathResult.FIRST_ORDERED_NODE_TYPE).singleNodeValue
+			.innerHTML
+	);
+});
+```
+
+:::note
+
+`page.evaluate()` can only return primitive types like strings, numbers, and booleans. Returning complex objects like `HTMLElement` will not work.
+
 :::
 
 ## Session management


### PR DESCRIPTION
- Add Element selection section to Puppeteer documentation
- Explain XPath limitation and provide page.evaluate() workaround
- Remove duplicate XPath FAQ entry from FAQ page
- Improve information architecture by placing content in relevant context

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
