### PR TITLE
[SSL] Update pqc-support.mdx

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -26,7 +26,7 @@ The list below is for reference only. Responsibility for third-party software li
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
 - Default for [OpenSSL 3.5.0+](https://www.openssl.org/)
-- Default for [Node 24.5.0+, 22.20.0+](https://nodejs.org/)
+- Default for [Node 24.5.0+](https://nodejs.org/) and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 - [GnuTLS](https://www.gnutls.org)
     - 3.8.9+ compiled with leancrypto 1.2.0+

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -14,9 +14,8 @@ The list below is for reference only. Responsibility for third-party software li
 :::
 
 ## X25519MLKEM768
-- Default for [Firefox 132+](https://www.mozilla.org/firefox/)
-    - For QUIC/HTTP3, use Firefox 135+
-    - On Android, use Firefox 145+ (Beta)
+- Default for [Firefox 132+](https://www.mozilla.org/firefox/) (Desktop) and Firefox 145+ (Android)
+    - For QUIC/HTTP3, use Firefox 135+ (Desktop)
 - Default for [Chrome 131+](https://www.google.com/chrome/)
 - Default for [Safari 26+](https://www.apple.com/safari/)
     - System-wide support in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756)

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -14,18 +14,19 @@ The list below is for reference only. Responsibility for third-party software li
 :::
 
 ## X25519MLKEM768
-- Default for [Firefox 132+](https://www.mozilla.org/firefox/) on Desktop
+- Default for [Firefox 132+](https://www.mozilla.org/firefox/)
     - For QUIC/HTTP3, use Firefox 135+
+    - On Android, use Firefox 145+ (Beta)
 - Default for [Chrome 131+](https://www.google.com/chrome/)
 - Default for [Safari 26+](https://www.apple.com/safari/)
     - System-wide support in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756)
 - Default for [Edge 131+](https://microsoft.com/edge/)
 - Default for recent [Opera](https://opera.com) and [Brave](https://brave.com)
-- Default for [Tor Browser 15.0](https://www.torproject.org/) on Desktop (Alpha)
+- Default for [Tor Browser 15.0+](https://www.torproject.org/)
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
 - Default for [OpenSSL 3.5.0+](https://www.openssl.org/)
-- Default for [Node 24.5.0+](https://nodejs.org/)
+- Default for [Node 24.5.0+, 22.20.0+](https://nodejs.org/)
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 - [GnuTLS](https://www.gnutls.org)
     - 3.8.9+ compiled with leancrypto 1.2.0+


### PR DESCRIPTION
* Mention [Firefox 145 for Android][1]

* Tor Browser 15 is stable and [enables PQC on Android][2]

* Node 22.20.0 [backports OpenSSL 3.5][3]

[1]: https://hg-edge.mozilla.org/mozilla-central/rev/ef49596c0190
[2]: https://gitlab.torproject.org/tpo/applications/tor-browser/-/commit/9ca6db00b134f710bc195bafda2092a88625f956
[3]: https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352