### PR TITLE
Update setInnerContent syntax in html-rewriter.mdx

### DIFF
--- a/src/content/docs/workers/runtime-apis/html-rewriter.mdx
+++ b/src/content/docs/workers/runtime-apis/html-rewriter.mdx
@@ -169,9 +169,7 @@ The `element` argument, used only in element handlers, is a representation of a 
   Element
   - Removes the element and inserts content in place of it.
 
-- <code>
-  	setInnerContent(contentContent, contentOptionsContentOptionsoptional)
-  </code>
+- `setInnerContent(contentContent, contentOptionsContentOptionsoptional)`  
   : Element
   - Replaces content of the element.
 


### PR DESCRIPTION

### Summary

`<code>` doesn't seem to work over multiple lines 

broken during a reformatting refactor?

https://github.com/cloudflare/cloudflare-docs/commit/933987a2ff6298fc1f53c35419461a0027f65dc8#diff-fa5863d597bafb036dee58cc25456f938afcf47db163e9ce658b76fb040b136cR173

### Screenshots (optional)

<img width="719" height="376" alt="image" src="https://github.com/user-attachments/assets/782a2650-76d1-4495-b437-7c44cfad90be" />


<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
